### PR TITLE
Implement rules for CIS OCP Section 1.3

### DIFF
--- a/applications/openshift/controller/controller_insecure_port_disabled/rule.yml
+++ b/applications/openshift/controller/controller_insecure_port_disabled/rule.yml
@@ -55,7 +55,7 @@ ocil: |-
     Verify that it's true in the console output (the value will be true if the insecure port is bind to loopback address or disabled) .
 
 references:
-    cis@ocp4: 1.3.7
+    cis@ocp4: 1.3.5
     nerc-cip: CIP-003-8 R4.2,CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R5.1,CIP-007-3 R6.1
     nist: CM-6,CM-6(1),SC-8,SC-8(1)
     pcidss: Req-2.2

--- a/applications/openshift/controller/controller_secure_port/rule.yml
+++ b/applications/openshift/controller/controller_secure_port/rule.yml
@@ -49,7 +49,7 @@ ocil: |-
     Verify that it's using an appropriate port (the value is not <pre>0</pre>).
 
 references:
-    cis@ocp4: 1.3.7
+    cis@ocp4: 1.3.5
     nerc-cip: CIP-003-8 R4.2,CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R5.1,CIP-007-3 R6.1
     nist: CM-6,CM-6(1),SC-8,SC-8(1)
     pcidss: Req-2.2

--- a/applications/openshift/controller/controller_service_account_ca/rule.yml
+++ b/applications/openshift/controller/controller_service_account_ca/rule.yml
@@ -39,7 +39,7 @@ identifiers:
 severity: medium
 
 references:
-    cis@ocp4: 1.3.5
+    cis@ocp4: 1.3.4
     nerc-cip: CIP-003-8 R4.2,CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R5.1,CIP-007-3 R6.1
     nist: CM-6,CM-6(1),SC-8,SC-8(1)
     pcidss: Req-2.2

--- a/applications/openshift/controller/controller_service_account_private_key/rule.yml
+++ b/applications/openshift/controller/controller_service_account_private_key/rule.yml
@@ -41,7 +41,7 @@ identifiers:
 severity: medium
 
 references:
-    cis@ocp4: 1.3.4
+    cis@ocp4: 1.3.3
     nerc-cip: CIP-003-8 R4.2,CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R5.1,CIP-007-3 R6.1
     nist: CM-6,CM-6(1),SC-8,SC-8(1)
     pcidss: Req-2.2,Req-2.2.3,Req-2.3
@@ -69,6 +69,6 @@ template:
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '[:]'
     values:
-    - value: 'true'      
+    - value: 'true'
       type: "string"
       entity_check: "at least one"

--- a/applications/openshift/controller/controller_use_service_account/rule.yml
+++ b/applications/openshift/controller/controller_use_service_account/rule.yml
@@ -43,7 +43,7 @@ identifiers:
     cce@ocp4: CCE-84208-8
 
 references:
-    cis@ocp4: 1.3.3
+    cis@ocp4: 1.3.2
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     pcidss: Req-2.2

--- a/applications/openshift/rbac/rbac_debug_role_protects_pprof/rule.yml
+++ b/applications/openshift/rbac/rbac_debug_role_protects_pprof/rule.yml
@@ -22,7 +22,7 @@ identifiers:
   cce@ocp4: CCE-84182-5
 
 references:
-  cis@ocp4: 1.3.2,1.4.1
+  cis@ocp4: 1.3.1,1.4.1
   nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
   nist: CM-6,CM-6(1)
   pcidss: Req-2.2

--- a/controls/cis_ocp_1_4_0/section-1.yml
+++ b/controls/cis_ocp_1_4_0/section-1.yml
@@ -309,30 +309,36 @@ controls:
     controls:
     - id: 1.3.1
       title: Ensure that controller manager healthz endpoints are protected by RBAC
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - rbac_debug_role_protects_pprof
       level: level_1
     - id: 1.3.2
       title: Ensure that the --use-service-account-credentials argument is set to
         true
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - controller_use_service_account
       level: level_1
     - id: 1.3.3
       title: Ensure that the --service-account-private-key-file argument is set as
         appropriate
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - controller_service_account_private_key
       level: level_1
     - id: 1.3.4
       title: Ensure that the --root-ca-file argument is set as appropriate
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - controller_service_account_ca
       level: level_1
     - id: 1.3.5
       title: Ensure that the --bind-address argument is set to 127.0.0.1
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - controller_secure_port
+        - controller_insecure_port_disabled
       level: level_1
   - id: '1.4'
     title: Scheduler


### PR DESCRIPTION
Now that we have a profile and control files for CIS 1.4.0, we can start
wiring up the existing rules.

This commit ports all the existing rules we were using for the CIS
OpenShift profile into the CIS 1.4.0 version.
