### PR TITLE
Implement rules for CIS OCP Section 3

### DIFF
--- a/controls/cis_ocp_1_4_0/section-3.yml
+++ b/controls/cis_ocp_1_4_0/section-3.yml
@@ -6,27 +6,31 @@ controls:
   controls:
   - id: '3.1'
     title: Authentication and Authorization
-    status: pending
+    status: automated
     rules: []
     controls:
     - id: 3.1.1
       title: Client certificate authentication should not be used for users
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - idp_is_configured
+        - kubeadmin_removed
       levels: level_2
   - id: '3.2'
     title: Logging
-    status: pending
+    status: automated
     rules: []
     controls:
     - id: 3.2.1
       title: Ensure that a minimal audit policy is created
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - audit_profile_set
       levels: level_1
     - id: 3.2.2
       title: Ensure that the audit policy covers key security concerns
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - audit_profile_set
       levels: level_2
 


### PR DESCRIPTION
Now that we have a profile and control files for CIS 1.4.0, we can start
wiring up the existing rules.

This commit ports all the existing rules we were using for the CIS
OpenShift profile into the CIS 1.4.0 version.
