### PR TITLE
Update OL variables

### DIFF
--- a/products/ol7/product.yml
+++ b/products/ol7/product.yml
@@ -25,7 +25,7 @@ groups:
   dedicated_ssh_keyowner:
     name: ssh_keys
 
-oval_feed_url: "https://linux.oracle.com/security/oval/com.oracle.elsa-all.xml.bz2"
+oval_feed_url: "https://linux.oracle.com/security/oval/com.oracle.elsa-ol7.xml.bz2"
 
 cpes_root: "../../shared/applicability"
 cpes:

--- a/products/ol7/profiles/ncp.profile
+++ b/products/ol7/profiles/ncp.profile
@@ -143,7 +143,7 @@ selections:
     - audit_rules_usergroup_modification_shadow
     - rsyslog_cron_logging
     - rsyslog_nolisten
-    - var_multiple_time_servers=rhel
+    - var_multiple_time_servers=ol
     - chronyd_or_ntpd_specify_remote_server
     - chronyd_or_ntpd_specify_multiple_servers
     - service_chronyd_or_ntpd_enabled

--- a/products/ol8/product.yml
+++ b/products/ol8/product.yml
@@ -21,7 +21,7 @@ grub2_uefi_boot_path: "/boot/efi/EFI/redhat"
 
 faillock_path: "/var/log/faillock"
 
-oval_feed_url: "https://linux.oracle.com/security/oval/com.oracle.elsa-all.xml.bz2"
+oval_feed_url: "https://linux.oracle.com/security/oval/com.oracle.elsa-ol8.xml.bz2"
 
 groups:
   dedicated_ssh_keyowner:

--- a/products/ol9/product.yml
+++ b/products/ol9/product.yml
@@ -23,7 +23,7 @@ aux_pkg_version: "8b4efbe6"
 release_key_fingerprint: "3E6D826D3FBAB389C2F38E34BC4D06A08D8B756F"
 auxiliary_key_fingerprint: "982231759C7467065D0CE9B2A7DD07088B4EFBE6"
 
-oval_feed_url: "https://linux.oracle.com/security/oval/com.oracle.elsa-all.xml.bz2"
+oval_feed_url: "https://linux.oracle.com/security/oval/com.oracle.elsa-ol9.xml.bz2"
 
 groups:
   dedicated_ssh_keyowner:


### PR DESCRIPTION
#### Description:

- Fix selection of `var_multiple_time_servers` for OL7 in ncp profile
- Update `oval_feed_url` in all OL products

#### Rationale:

- `var_multiple_time_servers` update is about being more aligned with oracle's requirements
- `oval_feed_url` update is a workaround to https://github.com/OpenSCAP/openscap/issues/1796. Reducing the size of OVAL  being processed makes harder to run out of memory

#### Review Hints:

- Test in a OL machine with `--fetch-remote-resources ` flag and try to generate a few reports, (arf, html etc). With existing oval url the process is killed, in my case, just adding html report