### PR TITLE
Implement rules for CIS OCP Section 4.1

### DIFF
--- a/controls/cis_ocp_1_4_0/section-4.yml
+++ b/controls/cis_ocp_1_4_0/section-4.yml
@@ -11,53 +11,68 @@ controls:
     controls:
     - id: 4.1.1
       title: Ensure that the kubelet service file permissions are set to 644 or more restrictive
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_permissions_worker_service
       levels: level_1
     - id: 4.1.2
       title: Ensure that the kubelet service file ownership is set to root:root
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_owner_worker_service
+        - file_groupowner_worker_service
       levels: level_1
     - id: 4.1.3
       title: If proxy kube proxy configuration file exists ensure permissions are set to 644 or more restrictive
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_permissions_proxy_kubeconfig
       levels: level_1
     - id: 4.1.4
       title: If proxy kubeconfig file exists ensure ownership is set to root:root
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_owner_proxy_kubeconfig
+        - file_groupowner_proxy_kubeconfig
       levels: level_1
     - id: 4.1.5
       title: Ensure that the --kubeconfig kubelet.conf file permissions are set to 644 or more restrictive
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_permissions_kubelet_conf
       levels: level_1
     - id: 4.1.6
       title: Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_groupowner_kubelet_conf
+        - file_owner_kubelet_conf
       levels: level_1
     - id: 4.1.7
       title: Ensure that the certificate authorities file permissions are set to 644 or more restrictive
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_permissions_worker_ca
       levels: level_1
     - id: 4.1.8
       title: Ensure that the client certificate authorities file ownership is set to root:root
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_owner_worker_ca
+        - file_groupowner_worker_ca
       levels: level_1
     - id: 4.1.9
       title: Ensure that the kubelet --config configuration file has permissions set to 600 or more restrictive
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_permissions_worker_kubeconfig
       levels: level_1
     - id: 4.1.10
       title: Ensure that the kubelet configuration file ownership is set to root:root
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_owner_worker_kubeconfig
+        - file_groupowner_worker_kubeconfig
       levels: level_1
   - id: '4.2'
     title: Kubelet


### PR DESCRIPTION
Now that we have a profile and control files for CIS 1.4.0, we can start wiring
up the existing rules.

This commit ports all the existing rules we were using for the CIS OpenShift
profile into the CIS 1.4.0 version.
