### PR TITLE
Implement rules for CIS OCP Section 4.2

### DIFF
--- a/applications/openshift/kubelet/kubelet_anonymous_auth/rule.yml
+++ b/applications/openshift/kubelet/kubelet_anonymous_auth/rule.yml
@@ -37,7 +37,7 @@ severity: medium
 
 references:
     cis@eks: 3.2.1
-    cis@ocp4: 4.2.1
+    cis@ocp4: 4.2.2
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325

--- a/applications/openshift/kubelet/kubelet_authorization_mode/rule.yml
+++ b/applications/openshift/kubelet/kubelet_authorization_mode/rule.yml
@@ -36,7 +36,7 @@ severity: medium
 
 references:
     cis@eks: 3.2.2
-    cis@ocp4: 4.2.2
+    cis@ocp4: 4.2.3
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325

--- a/applications/openshift/kubelet/kubelet_configure_client_ca/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_client_ca/rule.yml
@@ -49,7 +49,7 @@ identifiers:
 
 references:
     cis@eks: 3.2.3
-    cis@ocp4: 4.2.3
+    cis@ocp4: 4.2.4
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325

--- a/applications/openshift/kubelet/kubelet_configure_event_creation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_event_creation/rule.yml
@@ -51,7 +51,7 @@ ocil: |-
     The output should return <tt>{{{ xccdf_value("var_event_record_qps") }}}</tt>.
 
 references:
-    cis@ocp4: 4.2.9
+    cis@ocp4: 4.2.8
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325

--- a/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
@@ -31,7 +31,7 @@ platforms:
   - (ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12 or ocp4.13) and not ocp4-on-hypershift-hosted
 
 references:
-    cis@ocp4: 4.2.10
+    cis@ocp4: 4.2.9
     nerc-cip: CIP-003-8 R4.2,CIP-007-3 R5.1
     nist: SC-8,SC-8(1),SC-8(2)
     pcidss: Req-2.2,Req-2.2.3,Req-2.3

--- a/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/rule.yml
@@ -43,7 +43,7 @@ identifiers:
     cce@ocp4: CCE-86030-4
 
 references:
-  cis@ocp4: 4.2.13
+  cis@ocp4: 4.2.12
   nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
   nist: CM-6,CM-6(1)
   srg: SRG-APP-000516-CTR-001325

--- a/applications/openshift/kubelet/kubelet_disable_readonly_port/rule.yml
+++ b/applications/openshift/kubelet/kubelet_disable_readonly_port/rule.yml
@@ -44,7 +44,7 @@ identifiers:
     cce@ocp4: CCE-83427-5
 
 references:
-    cis@ocp4: 4.2.4
+    cis@ocp4: 4.2.5
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     pcidss: Req-2.2

--- a/applications/openshift/kubelet/kubelet_enable_cert_rotation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_cert_rotation/rule.yml
@@ -40,7 +40,7 @@ identifiers:
 
 references:
     cis@eks: 3.2.10
-    cis@ocp4: 4.2.11
+    cis@ocp4: 4.2.10
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325

--- a/applications/openshift/kubelet/kubelet_enable_client_cert_rotation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_client_cert_rotation/rule.yml
@@ -41,7 +41,7 @@ identifiers:
 
 references:
     cis@eks: 3.2.10
-    cis@ocp4: 4.2.11
+    cis@ocp4: 4.2.10
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325

--- a/applications/openshift/kubelet/kubelet_enable_server_cert_rotation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_server_cert_rotation/rule.yml
@@ -41,7 +41,7 @@ identifiers:
 
 references:
     cis@eks: 3.2.11
-    cis@ocp4: 4.2.12
+    cis@ocp4: 4.2.11
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325

--- a/applications/openshift/kubelet/kubelet_enable_streaming_connections/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_streaming_connections/rule.yml
@@ -44,7 +44,7 @@ identifiers:
 
 references:
     cis@eks: 3.2.5
-    cis@ocp4: 4.2.5
+    cis@ocp4: 4.2.6
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_available/rule.yml
@@ -54,7 +54,7 @@ identifiers:
   cce@ocp4: CCE-84144-5
 
 references:
-  cis@ocp4: 1.3.1
+  cis@ocp4: 1.3.1,4.2.1
   nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
   nist: CM-6,CM-6(1)
   srg: SRG-APP-000516-CTR-001325

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_memory_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_memory_available/rule.yml
@@ -55,7 +55,7 @@ identifiers:
   cce@ocp4: CCE-84135-3
 
 references:
-  cis@ocp4: 1.3.1
+  cis@ocp4: 1.3.1,4.2.1
   nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
   nist: CM-6,CM-6(1)
   srg: SRG-APP-000516-CTR-001325

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_available/rule.yml
@@ -54,7 +54,7 @@ identifiers:
   cce@ocp4: CCE-84138-7
 
 references:
-  cis@ocp4: 1.3.1
+  cis@ocp4: 1.3.1,4.2.1
   nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
   nist: CM-6,CM-6(1)
   srg: SRG-APP-000516-CTR-001325

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_inodesfree/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_inodesfree/rule.yml
@@ -54,7 +54,7 @@ identifiers:
   cce@ocp4: CCE-84141-1
 
 references:
-  cis@ocp4: 1.3.1
+  cis@ocp4: 1.3.1,4.2.1
   nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
   nist: CM-6,CM-6(1)
   srg: SRG-APP-000516-CTR-001325

--- a/controls/cis_ocp_1_4_0/section-4.yml
+++ b/controls/cis_ocp_1_4_0/section-4.yml
@@ -66,62 +66,78 @@ controls:
     controls:
     - id: 4.2.1
       title: Activate Garbage collection in OpenShift Container Platform 4, as appropriate
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - kubelet_eviction_thresholds_set_hard_memory_available
+        - kubelet_eviction_thresholds_set_hard_nodefs_available
+        - kubelet_eviction_thresholds_set_hard_nodefs_inodesfree
+        - kubelet_eviction_thresholds_set_hard_imagefs_available
       levels: level_1
     - id: 4.2.2
       title: Ensure that the --anonymous-auth argument is set to false
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - kubelet_anonymous_auth
       levels: level_1
     - id: 4.2.3
       title: Ensure that the --authorization-mode argument is not set to AlwaysAllow
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - kubelet_authorization_mode
       levels: level_1
     - id: 4.2.4
       title: Ensure that the --client-ca-file argument is set as appropriate
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - kubelet_configure_client_ca
       levels: level_1
     - id: 4.2.5
       title: Verify that the read only port is not used or is set to 0
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - kubelet_disable_readonly_port
       levels: level_1
     - id: 4.2.6
       title: Ensure that the --streaming-connection-idle-timeout argument is not set to 0
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - kubelet_enable_streaming_connections
       levels: level_1
     - id: 4.2.7
       title: Ensure that the --make-iptables-util-chains argument is set to true
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - kubelet_enable_iptables_util_chains
       levels: level_1
     - id: 4.2.8
       title: Ensure that the kubeAPIQPS [--event-qps] argument is set to 0 or a level which ensures appropriate event capture
-      status: pending
-      rules: []
-      levels: level_1
+      status: automated
+      rules:
+        - kubelet_configure_event_creation
+      levels: level_2
     - id: 4.2.9
       title: Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - kubelet_configure_tls_cert
       levels: level_1
     - id: 4.2.10
       title: Ensure that the --rotate-certificates argument is not set to false
-      status: pending
+      status: automated
       rules: []
+        - kubelet_enable_client_cert_rotation
+        - kubelet_enable_cert_rotation
       levels: level_1
     - id: 4.2.11
       title: Verify that the RotateKubeletServerCertificate argument is set to true
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - kubelet_enable_server_cert_rotation
       levels: level_1
     - id: 4.2.12
       title: Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - kubelet_configure_tls_cipher_suites
       levels: level_1
 


### PR DESCRIPTION
Now that we have a profile and control files for CIS 1.4.0, we can start
wiring up the existing rules.

This commit ports all the existing rules we were using for the CIS
OpenShift profile into the CIS 1.4.0 version.
