### PR TITLE
Implement rules for CIS OCP Section 5.3

### DIFF
--- a/controls/cis_ocp_1_4_0/section-5.yml
+++ b/controls/cis_ocp_1_4_0/section-5.yml
@@ -101,13 +101,16 @@ controls:
     controls:
     - id: 5.3.1
       title: Ensure that the CNI in use supports Network Policies
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - configure_network_policies
       levels: level_1
     - id: 5.3.2
       title: Ensure that all Namespaces have Network Policies defined
-      status: pending
-      rules: []
+      status: partial
+      rules:
+        - configure_network_policies_namespaces
+        - configure_network_policies_hypershift_hosted
       levels: level_2
   - id: '5.4'
     title: Secrets Management


### PR DESCRIPTION
Now that we have a profile and control files for CIS 1.4.0, we can start
wiring up the existing rules.

This commit ports all the existing rules we were using for the CIS
OpenShift profile into the CIS 1.4.0 version.
