### PR TITLE
Implement rules for CIS OCP Section 5.4

### DIFF
--- a/controls/cis_ocp_1_4_0/section-5.yml
+++ b/controls/cis_ocp_1_4_0/section-5.yml
@@ -111,18 +111,20 @@ controls:
       levels: level_2
   - id: '5.4'
     title: Secrets Management
-    status: pending
+    status: manual
     rules: []
     controls:
     - id: 5.4.1
       title: Prefer using secrets as files over secrets as environment variables
-      status: pending
-      rules: []
+      status: manual
+      rules:
+        - secrets_no_environment_variables
       levels: level_1
     - id: 5.4.2
       title: Consider external secret storage
-      status: pending
-      rules: []
+      status: manual
+      rules:
+        - secrets_consider_external_storage
       levels: level_2
   - id: '5.5'
     title: Extensible Admission Control


### PR DESCRIPTION
Now that we have a profile and control files for CIS 1.4.0, we can start
wiring up the existing rules.

This commit ports all the existing rules we were using for the CIS
OpenShift profile into the CIS 1.4.0 version.