### PR TITLE
Implement rules for CIS OCP Section 5.5

### DIFF
--- a/controls/cis_ocp_1_4_0/section-5.yml
+++ b/controls/cis_ocp_1_4_0/section-5.yml
@@ -128,13 +128,14 @@ controls:
       level: level_2
   - id: '5.5'
     title: Extensible Admission Control
-    status: pending
+    status: partial
     rules: []
     controls:
     - id: 5.5.1
       title: Configure Image Provenance using image controller configuration parameters
-      status: pending
-      rules: []
+      status: partial
+      rules:
+        - general_configure_imagepolicywebhook
       level: level_2
   - id: '5.7'
     title: General Policies

--- a/ssg/content_diff.py
+++ b/ssg/content_diff.py
@@ -99,9 +99,9 @@ class StandardContentDiffer(object):
             for cpe_p in cpe_platforms:
                 ET.dump(cpe_p)
         for cpe_platform in cpe_platforms:
-            fact_refs = cpe_platform.find_all_fact_ref_elements()
-            for fact_ref in fact_refs:
-                cpe_list.append(fact_ref.get("name"))
+            check_fact_refs = cpe_platform.find_all_check_fact_ref_elements()
+            for check_fact_ref in check_fact_refs:
+                cpe_list.append(check_fact_ref.get("id-ref"))
         return cpe_list
 
     def compare_platforms(self, old_rule, new_rule, old_benchmark, new_benchmark, identifier):

--- a/ssg/xml.py
+++ b/ssg/xml.py
@@ -444,5 +444,5 @@ class XMLCPEPlatform(XMLElement):
     def __init__(self, root):
         super(XMLCPEPlatform, self).__init__(root)
 
-    def find_all_fact_ref_elements(self):
-        return self.root.findall(".//cpe-lang:fact-ref", self.ns)
+    def find_all_check_fact_ref_elements(self):
+        return self.root.findall(".//cpe-lang:check-fact-ref", self.ns)

--- a/utils/compare_ds.py
+++ b/utils/compare_ds.py
@@ -24,8 +24,7 @@ def parse_args():
     )
     parser.add_argument(
         "--no-diffs", action="store_true",
-        help="Do not perform detailed comparison of checks and "
-        "remediations contents."
+        help="Do not perform detailed comparison of checks and remediations contents."
     )
     parser.add_argument(
         "--only-rules", action="store_true",


### PR DESCRIPTION
Now that we have a profile and control files for CIS 1.4.0, we can start
wiring up the existing rules.

This commit ports all the existing rules we were using for the CIS
OpenShift profile into the CIS 1.4.0 version.