### PR TITLE
Implement rules for CIS OCP Section 5.5

### DIFF
--- a/applications/openshift/registry/ocp_allowed_registries/rule.yml
+++ b/applications/openshift/registry/ocp_allowed_registries/rule.yml
@@ -34,6 +34,7 @@ ocil: |-
   make sure the output is not empty and matches the registries that you wish to allow.
 
 references:
+    cis@ocp4: '5.5.1'
     nist: CM-5(3),CM-7(2),CM-7(5),CM-11
     srg: SRG-APP-000456-CTR-001125
 

--- a/applications/openshift/registry/ocp_allowed_registries_for_import/rule.yml
+++ b/applications/openshift/registry/ocp_allowed_registries_for_import/rule.yml
@@ -25,6 +25,7 @@ rationale: |-
 severity: medium
 
 references:
+    cis@ocp4: '5.5.1'
     nist: CM-5(3),CM-7(2),CM-7(5),CM-11
     srg: SRG-APP-000456-CTR-001125
 

--- a/applications/openshift/registry/ocp_insecure_allowed_registries_for_import/rule.yml
+++ b/applications/openshift/registry/ocp_insecure_allowed_registries_for_import/rule.yml
@@ -31,6 +31,7 @@ identifiers:
     cce@ocp4: CCE-86235-9
 
 references:
+    cis@ocp4: '5.5.1'
     nist: CM-5(3)
     srg: SRG-APP-000014-CTR-000035
 

--- a/applications/openshift/registry/ocp_insecure_registries/rule.yml
+++ b/applications/openshift/registry/ocp_insecure_registries/rule.yml
@@ -27,6 +27,7 @@ identifiers:
     cce@ocp4: CCE-86123-7
 
 references:
+    cis@ocp4: '5.5.1'
     nist: CM-5(3)
     srg: SRG-APP-000014-CTR-000035
 

--- a/controls/cis_ocp_1_4_0/section-5.yml
+++ b/controls/cis_ocp_1_4_0/section-5.yml
@@ -147,14 +147,18 @@ controls:
       levels: level_2
   - id: '5.5'
     title: Extensible Admission Control
-    status: pending
+    status: automated
     rules: []
     controls:
     - id: 5.5.1
       title: Configure Image Provenance using image controller configuration parameters
-      status: pending
-      rules: []
-      levels: level_2
+      status: automated
+      rules:
+        - ocp_allowed_registries
+        - ocp_allowed_registries_for_import
+        - ocp_insecure_registries
+        - ocp_insecure_allowed_registries_for_import
+      level: level_2
   - id: '5.7'
     title: General Policies
     status: partial


### PR DESCRIPTION
Now that we have a profile and control files for CIS 1.4.0, we can start
wiring up the existing rules.

This commit ports all the existing rules we were using for the CIS
OpenShift profile into the CIS 1.4.0 version.