### PR TITLE
Remove quotes from journald config parameters

### DIFF
--- a/linux_os/guide/system/logging/journald/journald_compress/rule.yml
+++ b/linux_os/guide/system/logging/journald/journald_compress/rule.yml
@@ -50,3 +50,4 @@ template:
         path: /etc/systemd/journald.conf
         parameter: Compress
         value: yes
+        no_quotes: 'true'

--- a/linux_os/guide/system/logging/journald/journald_forward_to_syslog/rule.yml
+++ b/linux_os/guide/system/logging/journald/journald_forward_to_syslog/rule.yml
@@ -50,3 +50,4 @@ template:
         path: /etc/systemd/journald.conf
         parameter: ForwardToSyslog
         value: yes
+        no_quotes: 'true'

--- a/linux_os/guide/system/logging/journald/journald_storage/rule.yml
+++ b/linux_os/guide/system/logging/journald/journald_storage/rule.yml
@@ -49,3 +49,4 @@ template:
         path: /etc/systemd/journald.conf
         parameter: Storage
         value: persistent
+        no_quotes: 'true'


### PR DESCRIPTION
#### Description:

- The quotes may lead to unexpected behaviour such as config not being applied.

#### Rationale:

- The default journald config does not use quotes around the parameter values.
