### PR TITLE
OCP4: Fix instructions of scc_limit_container_allowed_capabilities

### DIFF
--- a/applications/openshift/scc/scc_limit_container_allowed_capabilities/rule.yml
+++ b/applications/openshift/scc/scc_limit_container_allowed_capabilities/rule.yml
@@ -66,7 +66,7 @@ ocil: |-
     check the variable value, e.g:
     <pre>$ oc get variable ocp4-var-sccs-with-allowed-capabilities-regex  -ojsonpath='{.value}' </pre>
     Then use following command to list the SCCs that would fail the test:
-    <pre>$ oc get scc -o json | {{{ jqfilter }}}</pre>
+    <pre>$ oc get scc -o json | jq {{{ jqfilter }}}</pre>
     Please replace the regular expression in the test command with the value read from the variable
     <pre>ocp4-var-sccs-with-allowed-capabilities-regex</pre>. You can read the variable
     value with:


### PR DESCRIPTION
#### Description:

- The OCIL was missing a JQ

#### Rationale:

- The instructions should be correct

#### Review Hints:

- Review the rule instructions
