### PR TITLE
New control file for CCN policy

### DIFF
--- a/controls/ccn_rhel9.yml
+++ b/controls/ccn_rhel9.yml
@@ -41,7 +41,8 @@ controls:
 
   #[A.3] Manipulación de los registros de actividad (log).
   - id: A.3.SEC-RHEL1
-    title: Se auditan los inicios de sesión.
+    title: Session initiation is audited
+    original_title: Se auditan los inicios de sesión.
     levels:
       - basic
       - intermediate
@@ -53,7 +54,8 @@ controls:
       - audit_rules_login_events_lastlog
 
   - id: A.3.SEC-RHEL2
-    title: Se controla quien puede acceder a los registros de seguridad y auditoría.
+    title: Control who can access security and audit logs
+    original_title: Se controla quien puede acceder a los registros de seguridad y auditoría.
     levels:
       - intermediate
       - advanced
@@ -65,7 +67,8 @@ controls:
       - directory_permissions_var_log_audit
 
   - id: A.3.SEC-RHEL3
-    title: Se controla el cambio de hora del sistema.
+    title: System time change is controlled
+    original_title: Se controla el cambio de hora del sistema.
     levels:
       - intermediate
       - advanced
@@ -77,7 +80,8 @@ controls:
       - var_multiple_time_servers=rhel
 
   - id: A.3.SEC-RHEL4
-    title: Se controla quién puede generar o modificar reglas de audit.
+    title: Control who can generate or modify audit rules
+    original_title: Se controla quién puede generar o modificar reglas de audit.
     levels:
       - intermediate
       - advanced
@@ -88,14 +92,16 @@ controls:
       - file_groupownership_audit_configuration
 
   - id: A.3.SEC-RHEL5
-    title: Se ha implementado la auditoría detallada basada en subcategorías.
+    title: It is implemented a detailed audit based on subcategories
+    original_title: Se ha implementado la auditoría detallada basada en subcategorías.
     levels:
       - intermediate
       - advanced
     status: pending
 
   - id: A.3.SEC-RHEL6
-    title: Se garantiza al menos 90 días de registros de actividad.
+    title: At least 90 days of activity logs are guaranteed
+    original_title: Se garantiza al menos 90 días de registros de actividad.
     levels:
       - basic
       - intermediate
@@ -106,7 +112,8 @@ controls:
       - var_auditd_max_log_file_action=keep_logs
 
   - id: A.3.SEC-RHEL7
-    title: Se auditan las modificaciones del fichero sudoers, así como los cambios en permisos, usuarios, grupos y contraseñas.
+    title: Modifications to the sudoers file are audited, as are changes to permissions, users, groups, and passwords
+    original_title: Se auditan las modificaciones del fichero sudoers, así como los cambios en permisos, usuarios, grupos y contraseñas.
     levels:
       - basic
       - intermediate
@@ -135,7 +142,8 @@ controls:
       - audit_rules_dac_modification_setxattr
 
   - id: A.3.SEC-RHEL8
-    title: Se auditan los cambios en la configuración de Cron y en tareas programadas incluyendo los de scripts de inicio.
+    title: Changes to cron settings and scheduled tasks including startup scripts are audited
+    original_title: Se auditan los cambios en la configuración de Cron y en tareas programadas incluyendo los de scripts de inicio.
     levels:
       - advanced
     status: pending
@@ -147,7 +155,8 @@ controls:
       - audit_rules_time_watch_localtime
 
   - id: A.3.SEC-RHEL9
-    title: Se auditan los intentos de acceso a elementos críticos.
+    title: Attempts to access critical items are audited
+    original_title: Se auditan los intentos de acceso a elementos críticos.
     levels:
       - advanced
     status: planned
@@ -159,7 +168,8 @@ controls:
       - audit_rules_unsuccessful_file_modification_truncate
 
   - id: A.3.SEC-RHEL10
-    title: Se audita toda operación de montaje en el sistema y modificaciones en la memoria de intercambio.
+    title: All mount operations on the system and changes to the swap are audited
+    original_title: Se audita toda operación de montaje en el sistema y modificaciones en la memoria de intercambio.
     levels:
       - intermediate
       - advanced
@@ -168,14 +178,16 @@ controls:
       - audit_rules_media_export
 
   - id: A.3.SEC-RHEL11
-    title: Se auditan modificaciones en ficheros PAM.
+    title: Modifications in PAM files are audited
+    original_title: Se auditan modificaciones en ficheros PAM.
     levels:
       - advanced
     status: pending
 
   #[A.4] Manipulación de los ficheros de configuración
   - id: A.4.SEC-RHEL1
-    title: Los usuarios estándar no disponen de permisos de administrador local ni se encuentran incluidos en un grupo sudoer.
+    title: Common users do not have local administrator permissions or are included in a sudo group
+    original_title: Los usuarios estándar no disponen de permisos de administrador local ni se encuentran incluidos en un grupo sudoer.
     levels:
       - basic
       - intermediate
@@ -183,7 +195,8 @@ controls:
     status: pending
 
   - id: A.4.SEC-RHEL2
-    title: El sistema tiene un antivirus y este está actualizado.
+    title: The system has an updated antivirus
+    original_title: El sistema tiene un antivirus y este está actualizado.
     levels:
       - basic
       - intermediate
@@ -191,7 +204,8 @@ controls:
     status: pending
 
   - id: A.4.SEC-RHEL3
-    title: Se modifican los permisos por particiones.
+    title: Permissions by partitions are modified
+    original_title: Se modifican los permisos por particiones.
     levels:
       - basic
       - intermediate
@@ -202,7 +216,8 @@ controls:
 
   #[A.5] Suplantación de la identidad.
   - id: A.5.SEC-RHEL1
-    title: Se controlan los permisos de inicio de sesión y suplantación de identidad.
+    title: Control login and impersonation permissions
+    original_title: Se controlan los permisos de inicio de sesión y suplantación de identidad.
     levels:
       - intermediate
       - advanced
@@ -212,7 +227,8 @@ controls:
       - use_pam_wheel_for_su
 
   - id: A.5.SEC-RHEL2
-    title: Se controlan los intentos de elevación mediante definición de usuarios y grupos sudoers.
+    title: Elevation attempts are controlled by defining sudoers users and groups
+    original_title: Se controlan los intentos de elevación mediante definición de usuarios y grupos sudoers.
     levels:
       - basic
       - intermediate
@@ -223,7 +239,8 @@ controls:
       - sudo_require_reauthentication
 
   - id: A.5.SEC-RHEL3
-    title: Se controla el acceso a las claves de cifrado.
+    title: Access to encryption keys is controlled
+    original_title: Se controla el acceso a las claves de cifrado.
     levels:
       - basic
       - intermediate
@@ -231,7 +248,8 @@ controls:
     status: pending
 
   - id: A.5.SEC-RHEL4
-    title: Se han deshabilitado los algoritmos de cifrado inseguros.
+    title: Disable insecure encryption algorithms
+    original_title: Se han deshabilitado los algoritmos de cifrado inseguros.
     levels:
       - basic
       - intermediate
@@ -242,7 +260,8 @@ controls:
       - var_system_crypto_policy=default_policy
 
   - id: A.5.SEC-RHEL5
-    title: Se exige el cambio de contraseña de forma recurrente.
+    title: Recurring password change required
+    original_title: Se exige el cambio de contraseña de forma recurrente.
     levels:
       - basic
       - intermediate
@@ -260,7 +279,8 @@ controls:
       - accounts_password_set_warn_age_existing
 
   - id: A.5.SEC-RHEL6
-    title: Se hace uso de protocolos seguros para los procesos de autenticación de red.
+    title: Secure protocols are used for network authentication processes
+    original_title: Se hace uso de protocolos seguros para los procesos de autenticación de red.
     levels:
       - basic
       - intermediate
@@ -270,7 +290,8 @@ controls:
       - configure_ssh_crypto_policy
 
   - id: A.5.SEC-RHEL7
-    title: Se controla la inactividad de la sesión de red.
+    title: Control network session inactivity
+    original_title: Se controla la inactividad de la sesión de red.
     levels:
       - basic
       - intermediate
@@ -283,7 +304,8 @@ controls:
       - var_sshd_set_keepalive=0
 
   - id: A.5.SEC-RHEL8
-    title: Se controla la inactividad de consola local y remota.
+    title: Control local and remote console inactivity
+    original_title: Se controla la inactividad de consola local y remota.
     levels:
       - advanced
     status: planned
@@ -293,7 +315,8 @@ controls:
 
   #[A.6] Abuso de privilegios de acceso.
   - id: A.6.SEC-RHEL1
-    title: Se refuerza la seguridad de los objetos sensibles del sistema.
+    title: The security of sensitive system objects is reinforced
+    original_title: Se refuerza la seguridad de los objetos sensibles del sistema.
     levels:
       - intermediate
       - advanced
@@ -307,7 +330,8 @@ controls:
       - selinux_state
 
   - id: A.6.SEC-RHEL2
-    title: Se restringen accesos en modo recuperación incluido el modo modificación de inicio de grub.
+    title: Access in recovery mode including grub boot modification mode is restricted
+    original_title: Se restringen accesos en modo recuperación incluido el modo modificación de inicio de grub.
     levels:
       - basic
       - intermediate
@@ -322,17 +346,21 @@ controls:
       - file_permissions_user_cfg
 
   - id: A.6.SEC-RHEL3
-    title: Se limita la shell de usuarios de servicio a "/bin/false".
+    title: Service users shell is limited to "/bin/false"
+    original_title: Se limita la shell de usuarios de servicio a "/bin/false".
     levels:
       - intermediate
       - advanced
     status: planned
+    notes: |-
+      "/sbin/nologin" might be a better option
     related_rules:
       - no_password_auth_for_systemaccounts
       - no_shelllogin_for_systemaccounts
 
   - id: A.6.SEC-RHEL4
-    title: Se restringe el uso de sesiones con usuario "root".
+    title: The use of sessions with the "root" user is restricted
+    original_title: Se restringe el uso de sesiones con usuario "root".
     levels:
       - intermediate
       - advanced
@@ -342,7 +370,8 @@ controls:
       - no_empty_passwords_etc_shadow
 
   - id: A.6.SEC-RHEL5
-    title: Se modifica la máscara global del sistema para ser más restrictiva.
+    title: The global system mask is modified to be more restrictive
+    original_title: Se modifica la máscara global del sistema para ser más restrictiva.
     levels:
       - advanced
     status: planned
@@ -353,7 +382,8 @@ controls:
       - var_accounts_user_umask=027
 
   - id: A.6.SEC-RHEL6
-    title: Se eliminan los grupos y usuarios innecesarios del sistema.
+    title: Unnecessary groups and users are removed from the system
+    original_title: Se eliminan los grupos y usuarios innecesarios del sistema.
     levels:
       - basic
       - intermediate
@@ -362,7 +392,8 @@ controls:
 
   #[A.8] Difusión de software dañino.
   - id: A.8.SEC-RHEL1
-    title: Se controla quién puede instalar software en el sistema.
+    title: Control who can install software on the system
+    original_title: Se controla quién puede instalar software en el sistema.
     levels:
       - basic
       - intermediate
@@ -370,7 +401,8 @@ controls:
     status: pending
 
   - id: A.8.SEC-RHEL2
-    title: El sistema operativo está actualizado.
+    title: The operating system is updated
+    original_title: El sistema operativo está actualizado.
     levels:
       - basic
       - intermediate
@@ -380,7 +412,8 @@ controls:
       - security_patches_up_to_date
 
   - id: A.8.SEC-RHEL3
-    title: El sistema tiene un firewall local activado.
+    title: The system has a local firewall activated
+    original_title: El sistema tiene un firewall local activado.
     levels:
       - basic
       - intermediate
@@ -394,7 +427,8 @@ controls:
       - firewalld_loopback_traffic_restricted
 
   - id: A.8.SEC-RHEL4
-    title: Se deshabilitan servicios innecesarios, reduciendo la superficie de exposición.
+    title: Unnecessary services are disabled, reducing the attack surface
+    original_title: Se deshabilitan servicios innecesarios, reduciendo la superficie de exposición.
     levels:
       - intermediate
       - advanced
@@ -412,13 +446,15 @@ controls:
       - kernel_module_udf_disabled
 
   - id: A.8.SEC-RHEL5
-    title: Se controla la ejecución de aplicaciones.
+    title: Control application execution
+    original_title: Se controla la ejecución de aplicaciones.
     levels:
       - advanced
     status: pending
 
   - id: A.8.SEC-RHEL6
-    title: Se dispone de medidas anti ransomware habilitadas.
+    title: Anti-ransomware measures are enabled
+    original_title: Se dispone de medidas anti ransomware habilitadas.
     levels:
       - basic
       - intermediate
@@ -457,7 +493,8 @@ controls:
       - sysctl_net_ipv4_conf_default_rp_filter
 
   - id: A.8.SEC-RHEL7
-    title: Está habilitado el arranque cifrado con contraseña que evite modificaciones (GRUB protegido).
+    title: Password encrypted boot that prevents modification is enabled (protected GRUB)
+    original_title: Está habilitado el arranque cifrado con contraseña que evite modificaciones (GRUB protegido).
     levels:
       - basic
       - intermediate
@@ -467,12 +504,13 @@ controls:
       - grub2_password
 
   - id: A.8.SEC-RHEL8
-    title: Se audita la descarga de archivos.
+    title: File download is audited
+    original_title: Se audita la descarga de archivos.
     levels:
       - basic
       - intermediate
       - advanced
-    status: planned
+    status: pending
     related_rules:
       - audit_rules_file_deletion_events_rename
       - audit_rules_file_deletion_events_renameat
@@ -480,7 +518,8 @@ controls:
       - audit_rules_file_deletion_events_unlinkat
 
   - id: A.8.SEC-RHEL9
-    title: Están deshabilitados los compiladores del sistema.
+    title: System compilers are disabled
+    original_title: Están deshabilitados los compiladores del sistema.
     levels:
       - basic
       - intermediate
@@ -489,7 +528,8 @@ controls:
 
   #[A.11] Acceso no autorizado.
   - id: A.11.SEC-RHEL1
-    title: Se controla el inicio de sesión local en el sistema.
+    title: Control local logon to the system
+    original_title: Se controla el inicio de sesión local en el sistema.
     levels:
       - basic
       - intermediate
@@ -497,7 +537,8 @@ controls:
     status: pending
 
   - id: A.11.SEC-RHEL2
-    title: Se ha reforzado la seguridad del protocolo SSH.
+    title: The security of the SSH protocol is strengthened
+    original_title: Se ha reforzado la seguridad del protocolo SSH.
     levels:
       - basic
       - intermediate
@@ -507,7 +548,8 @@ controls:
       - sshd_limit_user_access
 
   - id: A.11.SEC-RHEL3
-    title: Se dispone de una política de credenciales robusta.
+    title: A robust credential policy is in place
+    original_title: Se dispone de una política de credenciales robusta.
     levels:
       - basic
       - intermediate
@@ -523,7 +565,8 @@ controls:
       - no_empty_passwords_etc_shadow
 
   - id: A.11.SEC-RHEL4
-    title: Durante el inicio de sesión, el sistema muestra un texto en cumplimiento con las normas o directivas de la organización.
+    title: During login, the system displays a text in compliance with the organization's standards or policies
+    original_title: Durante el inicio de sesión, el sistema muestra un texto en cumplimiento con las normas o directivas de la organización.
     levels:
       - basic
       - intermediate
@@ -542,7 +585,8 @@ controls:
       - remote_login_banner_text=cis_banners
 
   - id: A.11.SEC-RHEL5
-    title: Se controla el acceso al sistema a través de la red.
+    title: Control network access to the system
+    original_title: Se controla el acceso al sistema a través de la red.
     levels:
       - basic
       - intermediate
@@ -552,7 +596,8 @@ controls:
       - configure_firewalld_ports
 
   - id: A.11.SEC-RHEL6
-    title: Sólo se permiten algoritmos de cifrado robustos en accesos al sistema.
+    title: Only strong encryption algorithms are allowed in accesses to the system
+    original_title: Sólo se permiten algoritmos de cifrado robustos en accesos al sistema.
     levels:
       - basic
       - intermediate
@@ -562,7 +607,8 @@ controls:
       - configure_ssh_crypto_policy
 
   - id: A.11.SEC-RHEL7
-    title: Se limita el tiempo de inactividad del GUI.
+    title: GUI idle time is limited
+    original_title: Se limita el tiempo de inactividad del GUI.
     levels:
       - intermediate
       - advanced
@@ -574,14 +620,18 @@ controls:
       - var_screensaver_lock_delay=immediate
 
   - id: A.11.SEC-RHEL8
-    title: Se muestra un banner disuasorio.
+    title: A dissuasive banner is displayed
+    original_title: Se muestra un banner disuasorio.
     levels:
       - intermediate
       - advanced
     status: pending
+    notes: |-
+      It seems to duplicate the A.11.SEC-RHEL4 requirement
 
   - id: A.11.SEC-RHEL9
-    title: Se deshabilita la lista de usuarios.
+    title: The user list is disabled
+    original_title: Se deshabilita la lista de usuarios.
     levels:
       - intermediate
       - advanced
@@ -590,21 +640,24 @@ controls:
       - dconf_gnome_disable_user_list
 
   - id: A.11.SEC-RHEL10
-    title: Se deshabilita recordar el historial de ficheros.
+    title: Disable remember file history
+    original_title: Se deshabilita recordar el historial de ficheros.
     levels:
       - intermediate
       - advanced
     status: pending
 
   - id: A.11.SEC-RHEL11
-    title: Se deshabilita combinación de teclas para iniciar el inspector GTK
+    title: Key combination to launch GTK inspector is disabled
+    original_title: Se deshabilita combinación de teclas para iniciar el inspector GTK
     levels:
       - intermediate
       - advanced
     status: pending
 
   - id: A.11.SEC-RHEL12
-    title: Se deshabilita el auto montaje de dispositivos extraíbles en el sistema.
+    title: Disable auto-mounting of removable devices on the system
+    original_title: Se deshabilita el auto montaje de dispositivos extraíbles en el sistema.
     levels:
       - intermediate
       - advanced
@@ -616,7 +669,8 @@ controls:
 
   #[A.15] Modificación de la información.
   - id: A.15.SEC-RHEL1
-    title: Se controla el uso de medios de almacenamiento extraíbles.
+    title: Control the use of removable storage media
+    original_title: Se controla el uso de medios de almacenamiento extraíbles.
     levels:
       - intermediate
       - advanced
@@ -626,7 +680,8 @@ controls:
 
   #[A.19] Revelación de información.
   - id: A.19.SEC-RHEL1
-    title: Se controla el acceso al árbol de carpetas y ficheros.
+    title: Control access to the folder and file tree
+    original_title: Se controla el acceso al árbol de carpetas y ficheros.
     levels:
       - basic
       - intermediate
@@ -634,7 +689,8 @@ controls:
     status: pending
 
   - id: A.19.SEC-RHEL2
-    title: Se aplican medidas para la protección de las cuentas.
+    title: Measures are applied to protect accounts
+    original_title: Se aplican medidas para la protección de las cuentas.
     levels:
       - basic
       - intermediate
@@ -682,14 +738,16 @@ controls:
 
   #[A.24] Denegación de servicio.
   - id: A.24.SEC-RHEL1
-    title: Se controlan los privilegios que afectan al rendimiento del sistema.
+    title: Privileges that affect system performance are controlled
+    original_title: Se controlan los privilegios que afectan al rendimiento del sistema.
     levels:
       - intermediate
       - advanced
     status: pending
 
   - id: A.24.SEC-RHEL2
-    title: Se controla quien puede apagar el sistema.
+    title: Control who can turn off the system
+    original_title: Se controla quien puede apagar el sistema.
     levels:
       - intermediate
       - advanced
@@ -697,20 +755,23 @@ controls:
 
   #[A.25] Robo de equipos.
   - id: A.25.SEC-RHEL1
-    title: El disco del sistema está cifrado.
+    title: System disk is encrypted
+    original_title: El disco del sistema está cifrado.
     levels:
       - advanced
     status: pending
 
   - id: A.25.SEC-RHEL2
-    title: El disco de datos está cifrado.
+    title: The data disk is encrypted
+    original_title: El disco de datos está cifrado.
     levels:
       - advanced
     status: pending
 
   #[A.30] Ingeniería social.
   - id: A.30.SEC-RHEL1
-    title: Existe una política de bloqueo de cuentas ante inicios de sesión incorrectos.
+    title: There is an account lockout policy for incorrect logins
+    original_title: Existe una política de bloqueo de cuentas ante inicios de sesión incorrectos.
     levels:
       - advanced
     status: planned

--- a/controls/ccn_rhel9.yml
+++ b/controls/ccn_rhel9.yml
@@ -15,7 +15,7 @@ levels:
 
 controls:
   - id: reload_dconf_db
-    title: Reload Dconf database
+    title: Reload Dconf Database
     levels:
       - basic
       - intermediate
@@ -40,7 +40,7 @@ controls:
       - enable_authselect
 
   - id: A.3.SEC-RHEL1
-    title: Session initiation is audited
+    title: Session Initiation is Audited
     original_title: Se auditan los inicios de sesión.
     levels:
       - basic
@@ -53,7 +53,7 @@ controls:
       - audit_rules_login_events_lastlog
 
   - id: A.3.SEC-RHEL2
-    title: Control who can access security and audit logs
+    title: Control Who Can Access Security and Audit Logs
     original_title: Se controla quien puede acceder a los registros de seguridad y auditoría.
     levels:
       - intermediate
@@ -66,7 +66,7 @@ controls:
       - directory_permissions_var_log_audit
 
   - id: A.3.SEC-RHEL3
-    title: System time change is controlled
+    title: System Time Change is Controlled
     original_title: Se controla el cambio de hora del sistema.
     levels:
       - intermediate
@@ -79,7 +79,7 @@ controls:
       - var_multiple_time_servers=rhel
 
   - id: A.3.SEC-RHEL4
-    title: Control who can generate or modify audit rules
+    title: Control Who Can Generate or Modify Audit Rules
     original_title: Se controla quién puede generar o modificar reglas de audit.
     levels:
       - intermediate
@@ -91,7 +91,7 @@ controls:
       - file_groupownership_audit_configuration
 
   - id: A.3.SEC-RHEL5
-    title: A detailed audit has been implemented based on subcategories
+    title: A Detailed Audit Has Been Implemented Based on Subcategories
     original_title: Se ha implementado la auditoría detallada basada en subcategorías.
     levels:
       - intermediate
@@ -103,7 +103,7 @@ controls:
       we can select the proper rules.
 
   - id: A.3.SEC-RHEL6
-    title: At least 90 days of activity logs are guaranteed
+    title: At Least 90 Days of Activity Logs Are Guaranteed
     original_title: Se garantiza al menos 90 días de registros de actividad.
     levels:
       - basic
@@ -115,7 +115,7 @@ controls:
       - var_auditd_max_log_file_action=keep_logs
 
   - id: A.3.SEC-RHEL7
-    title: Modifications to the sudoers file are audited, as are changes to permissions, users, groups, and passwords
+    title: Modifications to the Sudoers File Are Audited, As Are Changes to Permissions, Users, Groups, and Passwords
     original_title: Se auditan las modificaciones del fichero sudoers, así como los cambios en permisos, usuarios, grupos y contraseñas.
     levels:
       - basic
@@ -145,7 +145,7 @@ controls:
       - audit_rules_dac_modification_setxattr
 
   - id: A.3.SEC-RHEL8
-    title: Changes to cron settings and scheduled tasks including startup scripts are audited
+    title: Changes to Cron Settings and Scheduled Tasks Including Startup Scripts Are Audited
     original_title: Se auditan los cambios en la configuración de Cron y en tareas programadas incluyendo los de scripts de inicio.
     levels:
       - advanced
@@ -162,7 +162,7 @@ controls:
       - audit_rules_time_watch_localtime
 
   - id: A.3.SEC-RHEL9
-    title: Attempts to access critical items are audited
+    title: Attempts to Access Critical Items Are Audited
     original_title: Se auditan los intentos de acceso a elementos críticos.
     levels:
       - advanced
@@ -175,7 +175,7 @@ controls:
       - audit_rules_unsuccessful_file_modification_truncate
 
   - id: A.3.SEC-RHEL10
-    title: All mount operations on the system and changes to the swap are audited
+    title: All Mount Operations on the System and Changes to the Swap Are Audited
     original_title: Se audita toda operación de montaje en el sistema y modificaciones en la memoria de intercambio.
     levels:
       - intermediate
@@ -188,7 +188,7 @@ controls:
       - audit_rules_media_export
 
   - id: A.3.SEC-RHEL11
-    title: Modifications in PAM files are audited
+    title: Modifications in PAM Files Are Audited
     original_title: Se auditan modificaciones en ficheros PAM.
     levels:
       - advanced
@@ -198,7 +198,7 @@ controls:
       this assumption and get more context.
 
   - id: A.4.SEC-RHEL1
-    title: Common users do not have local administrator permissions and are not included in a sudo group
+    title: Common Users Do Dot Have Local Administrator Permissions and Are Not Included in a Sudo Group
     original_title: Los usuarios estándar no disponen de permisos de administrador local ni se encuentran incluidos en un grupo sudoer.
     levels:
       - basic
@@ -211,7 +211,7 @@ controls:
       performed only by the root user. I am not sure if this is the intetion here.
 
   - id: A.4.SEC-RHEL2
-    title: The system has an updated antivirus
+    title: The System Has an Updated Antivirus
     original_title: El sistema tiene un antivirus y este está actualizado.
     levels:
       - basic
@@ -224,7 +224,7 @@ controls:
       leastthe partial status after the templated rule.
 
   - id: A.4.SEC-RHEL3
-    title: Permissions by partitions are modified
+    title: Permissions by Partitions Are Modified
     original_title: Se modifican los permisos por particiones.
     levels:
       - basic
@@ -235,7 +235,7 @@ controls:
       Related to nosuid, noexec and nodev options but in /boot. More context is needed.
 
   - id: A.5.SEC-RHEL1
-    title: Login and impersonation permissions are controlled
+    title: Login and Impersonation Permissions Are Controlled
     original_title: Se controlan los permisos de inicio de sesión y suplantación de identidad.
     levels:
       - intermediate
@@ -246,7 +246,7 @@ controls:
       - use_pam_wheel_for_su
 
   - id: A.5.SEC-RHEL2
-    title: Elevation attempts are controlled by defining users and sudoer groups
+    title: Elevation Attempts Are Controlled by Defining Users and Sudoer Groups
     original_title: Se controlan los intentos de elevación mediante definición de usuarios y grupos sudoers.
     levels:
       - basic
@@ -258,7 +258,7 @@ controls:
       - sudo_require_reauthentication
 
   - id: A.5.SEC-RHEL3
-    title: Access to encryption keys is controlled
+    title: Access to Encryption Keys is Controlled
     original_title: Se controla el acceso a las claves de cifrado.
     levels:
       - basic
@@ -269,7 +269,7 @@ controls:
       There are rules for ssh_keys, for example. We need to confirm the scope of this requirement
 
   - id: A.5.SEC-RHEL4
-    title: Disable insecure encryption algorithms
+    title: Disable Insecure Encryption Algorithms
     original_title: Se han deshabilitado los algoritmos de cifrado inseguros.
     levels:
       - basic
@@ -281,7 +281,7 @@ controls:
       - var_system_crypto_policy=default_policy
 
   - id: A.5.SEC-RHEL5
-    title: Recurring password change is required
+    title: Recurring Password Change is Required
     original_title: Se exige el cambio de contraseña de forma recurrente.
     levels:
       - basic
@@ -300,7 +300,7 @@ controls:
       - accounts_password_set_warn_age_existing
 
   - id: A.5.SEC-RHEL6
-    title: Secure protocols are used for the network authentication processes
+    title: Secure Protocols Are Used For the Network Authentication Processes
     original_title: Se hace uso de protocolos seguros para los procesos de autenticación de red.
     levels:
       - basic
@@ -311,7 +311,7 @@ controls:
       - configure_ssh_crypto_policy
 
   - id: A.5.SEC-RHEL7
-    title: Network session inactivity is controlled
+    title: Network Session Inactivity is Controlled
     original_title: Se controla la inactividad de la sesión de red.
     levels:
       - basic
@@ -325,7 +325,7 @@ controls:
       - var_sshd_set_keepalive=0
 
   - id: A.5.SEC-RHEL8
-    title: Local and remote console inactivity is controlled
+    title: Local and Remote Console Inactivity is Controlled
     original_title: Se controla la inactividad de consola local y remota.
     levels:
       - advanced
@@ -335,7 +335,7 @@ controls:
       - var_accounts_tmout=5_min
 
   - id: A.6.SEC-RHEL1
-    title: The security of sensitive system objects is reinforced
+    title: The Security of Sensitive System Objects is Reinforced
     original_title: Se refuerza la seguridad de los objetos sensibles del sistema.
     levels:
       - intermediate
@@ -350,7 +350,7 @@ controls:
       - selinux_state
 
   - id: A.6.SEC-RHEL2
-    title: Access in recovery mode including grub boot modification mode is restricted
+    title: Access in Recovery Mode Including Grub Boot Modification Mode is Restricted
     original_title: Se restringen accesos en modo recuperación incluido el modo modificación de inicio de grub.
     levels:
       - basic
@@ -366,7 +366,7 @@ controls:
       - file_permissions_user_cfg
 
   - id: A.6.SEC-RHEL3
-    title: Service users shell is limited to "/bin/false"
+    title: Service Users Shell is Limited to "/bin/false"
     original_title: Se limita la shell de usuarios de servicio a "/bin/false".
     levels:
       - intermediate
@@ -379,7 +379,7 @@ controls:
       - no_shelllogin_for_systemaccounts
 
   - id: A.6.SEC-RHEL4
-    title: The use of sessions with the "root" user is restricted
+    title: The Use of Sessions With the "root" User is Restricted
     original_title: Se restringe el uso de sesiones con usuario "root".
     levels:
       - intermediate
@@ -390,7 +390,7 @@ controls:
       - no_empty_passwords_etc_shadow
 
   - id: A.6.SEC-RHEL5
-    title: The global system mask is modified to be more restrictive
+    title: The Global System Mask is Modified To Be More Restrictive
     original_title: Se modifica la máscara global del sistema para ser más restrictiva.
     levels:
       - advanced
@@ -402,7 +402,7 @@ controls:
       - var_accounts_user_umask=027
 
   - id: A.6.SEC-RHEL6
-    title: Unnecessary groups and users are removed from the system
+    title: Unnecessary Groups and Users are Removed From the System
     original_title: Se eliminan los grupos y usuarios innecesarios del sistema.
     levels:
       - basic
@@ -411,7 +411,7 @@ controls:
     status: manual
 
   - id: A.8.SEC-RHEL1
-    title: Control who can install software on the system
+    title: Control Who Can Install Software on the System
     original_title: Se controla quién puede instalar software en el sistema.
     levels:
       - basic
@@ -420,7 +420,7 @@ controls:
     status: pending
 
   - id: A.8.SEC-RHEL2
-    title: The operating system is updated
+    title: The Operating System is Updated
     original_title: El sistema operativo está actualizado.
     levels:
       - basic
@@ -431,7 +431,7 @@ controls:
       - security_patches_up_to_date
 
   - id: A.8.SEC-RHEL3
-    title: The system has an activated local firewall
+    title: The System Has an Activated Local Firewall
     original_title: El sistema tiene un firewall local activado.
     levels:
       - basic
@@ -446,7 +446,7 @@ controls:
       - firewalld_loopback_traffic_restricted
 
   - id: A.8.SEC-RHEL4
-    title: Unnecessary services are disabled, reducing the attack surface
+    title: Unnecessary Services are Disabled, Reducing the Attack Surface
     original_title: Se deshabilitan servicios innecesarios, reduciendo la superficie de exposición.
     levels:
       - intermediate
@@ -465,17 +465,17 @@ controls:
       - kernel_module_udf_disabled
 
   - id: A.8.SEC-RHEL5
-    title: Application execution is controlled
+    title: Application Execution is Controlled
     original_title: Se controla la ejecución de aplicaciones.
     levels:
       - advanced
     status: pending
     notes: |-
-      This might be related to SELinux.
+      This might be related to SELinux or fapolicyd.
       We need more context to confirm the intention of this requirement
 
   - id: A.8.SEC-RHEL6
-    title: Anti-ransomware measures are enabled
+    title: Anti-Ransomware Measures are Enabled
     original_title: Se dispone de medidas anti ransomware habilitadas.
     levels:
       - basic
@@ -515,7 +515,7 @@ controls:
       - sysctl_net_ipv4_conf_default_rp_filter
 
   - id: A.8.SEC-RHEL7
-    title: Password encrypted boot that prevents modification is enabled (protected GRUB)
+    title: Password Encrypted Boot That Prevents Modification is Enabled (Protected GRUB)
     original_title: Está habilitado el arranque cifrado con contraseña que evite modificaciones (GRUB protegido).
     levels:
       - basic
@@ -526,7 +526,7 @@ controls:
       - grub2_password
 
   - id: A.8.SEC-RHEL8
-    title: File download is audited
+    title: File Download is Audited
     original_title: Se audita la descarga de archivos.
     levels:
       - basic
@@ -543,7 +543,7 @@ controls:
       - audit_rules_file_deletion_events_unlinkat
 
   - id: A.8.SEC-RHEL9
-    title: System compilers are disabled
+    title: System Compilers are Disabled
     original_title: Están deshabilitados los compiladores del sistema.
     levels:
       - basic
@@ -554,7 +554,7 @@ controls:
       Maybe simply removing the packages is enough.
 
   - id: A.11.SEC-RHEL1
-    title: Local log on to the system is controlled
+    title: Local Log On To the System is Controlled
     original_title: Se controla el inicio de sesión local en el sistema.
     levels:
       - basic
@@ -566,7 +566,7 @@ controls:
       It is not not clear the scope.
 
   - id: A.11.SEC-RHEL2
-    title: The security of the SSH protocol is strengthened
+    title: The Security of the SSH Protocol is Strengthened
     original_title: Se ha reforzado la seguridad del protocolo SSH.
     levels:
       - basic
@@ -577,7 +577,7 @@ controls:
       - sshd_limit_user_access
 
   - id: A.11.SEC-RHEL3
-    title: A robust credential policy is in place
+    title: A Robust Credential Policy is In Place
     original_title: Se dispone de una política de credenciales robusta.
     levels:
       - basic
@@ -594,7 +594,7 @@ controls:
       - no_empty_passwords_etc_shadow
 
   - id: A.11.SEC-RHEL4
-    title: During login, the system displays a text in compliance with the organization's standards or directives
+    title: During Login, the System Displays a Text in Compliance With the Organization's Standards or Directives
     original_title: Durante el inicio de sesión, el sistema muestra un texto en cumplimiento con las normas o directivas de la organización.
     levels:
       - basic
@@ -614,7 +614,7 @@ controls:
       - remote_login_banner_text=cis_banners
 
   - id: A.11.SEC-RHEL5
-    title: Network access to the system is controlled
+    title: Network Acess to the System is Controlled
     original_title: Se controla el acceso al sistema a través de la red.
     levels:
       - basic
@@ -625,7 +625,7 @@ controls:
       - configure_firewalld_ports
 
   - id: A.11.SEC-RHEL6
-    title: Only strong encryption algorithms are allowed in accesses to the system
+    title: Only Strong Encryption Algorithms are Allowed in Accesses to the System
     original_title: Sólo se permiten algoritmos de cifrado robustos en accesos al sistema.
     levels:
       - basic
@@ -636,7 +636,7 @@ controls:
       - configure_ssh_crypto_policy
 
   - id: A.11.SEC-RHEL7
-    title: GUI idle time is limited
+    title: GUI Idle Time is Limited
     original_title: Se limita el tiempo de inactividad del GUI.
     levels:
       - intermediate
@@ -649,7 +649,7 @@ controls:
       - var_screensaver_lock_delay=immediate
 
   - id: A.11.SEC-RHEL8
-    title: A dissuasive banner is displayed
+    title: A Dissuasive Banner is Displayed
     original_title: Se muestra un banner disuasorio.
     levels:
       - intermediate
@@ -659,7 +659,7 @@ controls:
       It seems to duplicate the A.11.SEC-RHEL4 requirement
 
   - id: A.11.SEC-RHEL9
-    title: The user list is disabled
+    title: The User List is Disabled
     original_title: Se deshabilita la lista de usuarios.
     levels:
       - intermediate
@@ -669,7 +669,7 @@ controls:
       - dconf_gnome_disable_user_list
 
   - id: A.11.SEC-RHEL10
-    title: File history is disabled
+    title: File History is Disabled
     original_title: Se deshabilita recordar el historial de ficheros.
     levels:
       - intermediate
@@ -679,7 +679,7 @@ controls:
       New rules might be necessary.
 
   - id: A.11.SEC-RHEL11
-    title: Key combination to launch GTK inspector is disabled
+    title: Key Combination to Launch GTK Inspector is Disabled
     original_title: Se deshabilita combinación de teclas para iniciar el inspector GTK
     levels:
       - intermediate
@@ -689,7 +689,7 @@ controls:
       New rules might be necessary.
 
   - id: A.11.SEC-RHEL12
-    title: Auto-mounting of removable devices on the system is disabled
+    title: Auto-Mounting of Removable Devices on the System is Disabled
     original_title: Se deshabilita el auto montaje de dispositivos extraíbles en el sistema.
     levels:
       - intermediate
@@ -701,7 +701,7 @@ controls:
       - dconf_gnome_disable_autorun
 
   - id: A.15.SEC-RHEL1
-    title: The use of removable storage media is controlled
+    title: The Use of Removable Storage Media is Controlled
     original_title: Se controla el uso de medios de almacenamiento extraíbles.
     levels:
       - intermediate
@@ -711,7 +711,7 @@ controls:
       - kernel_module_usb-storage_disabled
 
   - id: A.19.SEC-RHEL1
-    title: Access to the folder and file tree is controlled
+    title: Access to the Folder and File Tree is Controlled
     original_title: Se controla el acceso al árbol de carpetas y ficheros.
     levels:
       - basic
@@ -722,7 +722,7 @@ controls:
       More context should be provided to clarify this requirement
 
   - id: A.19.SEC-RHEL2
-    title: Measures are applied to protect accounts
+    title: Measures Are Applied to Protect Accounts
     original_title: Se aplican medidas para la protección de las cuentas.
     levels:
       - basic
@@ -733,7 +733,7 @@ controls:
       This is already covered by other requirements. Maybe more rules could be included here.
 
   - id: A.19.SEC-RHEL3
-    title: A robust algorithm and password complexity are enabled
+    title: A Robust Algorithm and Password Complexity Are Enabled
     original_title: Está habilitado un algoritmo robusto y la complejidad de contraseñas.
     levels:
       - basic
@@ -747,7 +747,7 @@ controls:
       - var_password_hashing_algorithm=SHA512
 
   - id: A.23.SEC-RHEL1
-    title: The installation and use of any device connected to the equipment is controlled
+    title: The Installation And Use of Any Device Connected to the Equipment is Controlled
     original_title: Se controla la instalación y uso de cualquier dispositivo conectado al equipo.
     levels:
       - basic
@@ -760,7 +760,7 @@ controls:
       - usbguard_generate_policy
 
   - id: A.23.SEC-RHEL2
-    title: The dynamic mounting and unmounting of file systems is restricted
+    title: The Dynamic Mounting and Unmounting of File Systems is Restricted
     original_title: Se restringe el montaje y desmontaje dinámico de sistemas de archivos.
     levels:
       - basic
@@ -771,7 +771,7 @@ controls:
       It seems to duplicate the A.11.SEC-RHEL12 requirement.
 
   - id: A.24.SEC-RHEL1
-    title: Privileges that affect system performance are controlled
+    title: Privileges That Affect System Performance Are Controlled
     original_title: Se controlan los privilegios que afectan al rendimiento del sistema.
     levels:
       - intermediate
@@ -781,7 +781,7 @@ controls:
       Is it about system limits?
 
   - id: A.24.SEC-RHEL2
-    title: Control who can turn off the system
+    title: Control Who Can Turn Off the System
     original_title: Se controla quien puede apagar el sistema.
     levels:
       - intermediate
@@ -792,7 +792,7 @@ controls:
       - disable_ctrlaltdel_reboot
 
   - id: A.25.SEC-RHEL1
-    title: System disk is encrypted
+    title: System Disk is Encrypted
     original_title: El disco del sistema está cifrado.
     levels:
       - advanced
@@ -802,7 +802,7 @@ controls:
       - encrypt_partitions
 
   - id: A.25.SEC-RHEL2
-    title: The data disk is encrypted
+    title: The Data Disk is Encrypted
     original_title: El disco de datos está cifrado.
     levels:
       - advanced
@@ -812,7 +812,7 @@ controls:
       - encrypt_partitions
 
   - id: A.30.SEC-RHEL1
-    title: There is an account lockout policy for incorrect logins
+    title: There Is an Account Lockout Policy for Incorrect Logins
     original_title: Existe una política de bloqueo de cuentas ante inicios de sesión incorrectos.
     levels:
       - advanced

--- a/controls/ccn_rhel9.yml
+++ b/controls/ccn_rhel9.yml
@@ -1,0 +1,507 @@
+---
+policy: CCN-STIC-610A22
+title: Security Profile Application Guide for Red Hat Enterprise Linux 9
+id: ccn_rhel9
+version: '2022-10'
+source: https://www.ccn-cert.cni.es/pdf/guias/series-ccn-stic/guias-de-acceso-publico-ccn-stic/6768-ccn-stic-610a22-perfilado-de-seguridad-red-hat-enterprise-linux-9-0/file.html
+levels:
+  - id: basic
+  - id: intermediate
+    inherits_from:
+      - basic
+  - id: advanced
+    inherits_from:
+      - intermediate
+
+controls:
+  - id: reload_dconf_db
+    title: Reload Dconf database
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    notes: |-
+      This is a helper rule to reload Dconf database correctly.
+    status: automated
+    rules:
+      - dconf_db_up_to_date
+
+  - id: enable_authselect
+    title: Enable Authselect
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    notes: |-
+      The policy doesn't have any section where this would fit better.
+    status: automated
+    rules:
+      - var_authselect_profile=sssd
+      - enable_authselect
+
+  #[A.3] Manipulación de los registros de actividad (log).
+  - id: A.3.SEC-RHEL1
+    title: Se auditan los inicios de sesión.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.3.SEC-RHEL2
+    title: Se controla quien puede acceder a los registros de seguridad y auditoría.
+    levels:
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.3.SEC-RHEL3
+    title: Se controla el cambio de hora del sistema.
+    levels:
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.3.SEC-RHEL4
+    title: Se controla quién puede generar o modificar reglas de audit.
+    levels:
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.3.SEC-RHEL5
+    title: Se ha implementado la auditoría detallada basada en subcategorías.
+    levels:
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.3.SEC-RHEL6
+    title: Se garantiza al menos 90 días de registros de actividad.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.3.SEC-RHEL7
+    title: Se auditan las modificaciones del fichero sudoers, así como los cambios en permisos, usuarios, grupos y contraseñas.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.3.SEC-RHEL8
+    title: Se auditan los cambios en la configuración de Cron y en tareas programadas incluyendo los de scripts de inicio.
+    levels:
+      - advanced
+    status: pending
+
+  - id: A.3.SEC-RHEL9
+    title: Se auditan los intentos de acceso a elementos críticos.
+    levels:
+      - advanced
+    status: pending
+
+  - id: A.3.SEC-RHEL10
+    title: Se audita toda operación de montaje en el sistema y modificaciones en la memoria de intercambio.
+    levels:
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.3.SEC-RHEL11
+    title: Se auditan modificaciones en ficheros PAM.
+    levels:
+      - advanced
+    status: pending
+
+  #[A.4] Manipulación de los ficheros de configuración
+  - id: A.4.SEC-RHEL1
+    title: Los usuarios estándar no disponen de permisos de administrador local ni se encuentran incluidos en un grupo sudoer.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.4.SEC-RHEL2
+    title: El sistema tiene un antivirus y este está actualizado.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.4.SEC-RHEL3
+    title: Se modifican los permisos por particiones.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  #[A.5] Suplantación de la identidad.
+  - id: A.5.SEC-RHEL1
+    title: Se controlan los permisos de inicio de sesión y suplantación de identidad.
+    levels:
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.5.SEC-RHEL2
+    title: Se controlan los intentos de elevación mediante definición de usuarios y grupos sudoers.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.5.SEC-RHEL3
+    title: Se controla el acceso a las claves de cifrado.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.5.SEC-RHEL4
+    title: Se han deshabilitado los algoritmos de cifrado inseguros.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.5.SEC-RHEL5
+    title: Se exige el cambio de contraseña de forma recurrente.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.5.SEC-RHEL6
+    title: Se hace uso de protocolos seguros para los procesos de autenticación de red.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.5.SEC-RHEL7
+    title: Se controla la inactividad de la sesión de red.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.5.SEC-RHEL8
+    title: Se controla la inactividad de consola local y remota.
+    levels:
+      - advanced
+    status: pending
+
+  #[A.6] Abuso de privilegios de acceso.
+  - id: A.6.SEC-RHEL1
+    title: Se refuerza la seguridad de los objetos sensibles del sistema.
+    levels:
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.6.SEC-RHEL2
+    title: Se restringen accesos en modo recuperación incluido el modo modificación de inicio de grub.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.6.SEC-RHEL3
+    title: Se limita la shell de usuarios de servicio a "/bin/false".
+    levels:
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.6.SEC-RHEL4
+    title: Se restringe el uso de sesiones con usuario "root".
+    levels:
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.6.SEC-RHEL5
+    title: Se modifica la máscara global del sistema para ser más restrictiva.
+    levels:
+      - advanced
+    status: pending
+
+  - id: A.6.SEC-RHEL6
+    title: Se eliminan los grupos y usuarios innecesarios del sistema.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  #[A.8] Difusión de software dañino.
+  - id: A.8.SEC-RHEL1
+    title: Se controla quién puede instalar software en el sistema.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.8.SEC-RHEL2
+    title: El sistema operativo está actualizado.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.8.SEC-RHEL3
+    title: El sistema tiene un firewall local activado.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.8.SEC-RHEL4
+    title: Se deshabilitan servicios innecesarios, reduciendo la superficie de exposición.
+    levels:
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.8.SEC-RHEL5
+    title: Se controla la ejecución de aplicaciones.
+    levels:
+      - advanced
+    status: pending
+
+  - id: A.8.SEC-RHEL6
+    title: Se dispone de medidas anti ransomware habilitadas.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.8.SEC-RHEL7
+    title: Está habilitado el arranque cifrado con contraseña que evite modificaciones (GRUB protegido).
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.8.SEC-RHEL8
+    title: Se audita la descarga de archivos.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.8.SEC-RHEL9
+    title: Están deshabilitados los compiladores del sistema.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  #[A.11] Acceso no autorizado.
+  - id: A.11.SEC-RHEL1
+    title: Se controla el inicio de sesión local en el sistema.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.11.SEC-RHEL2
+    title: Se ha reforzado la seguridad del protocolo SSH.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.11.SEC-RHEL3
+    title: Se dispone de una política de credenciales robusta.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.11.SEC-RHEL4
+    title: Durante el inicio de sesión, el sistema muestra un texto en cumplimiento con las normas o directivas de la organización.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.11.SEC-RHEL5
+    title: Se controla el acceso al sistema a través de la red.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.11.SEC-RHEL6
+    title: Sólo se permiten algoritmos de cifrado robustos en accesos al sistema.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.11.SEC-RHEL7
+    title: Se limita el tiempo de inactividad del GUI.
+    levels:
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.11.SEC-RHEL8
+    title: Se muestra un banner disuasorio.
+    levels:
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.11.SEC-RHEL9
+    title: Se deshabilita la lista de usuarios.
+    levels:
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.11.SEC-RHEL10
+    title: Se deshabilita recordar el historial de ficheros.
+    levels:
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.11.SEC-RHEL11
+    title: Se deshabilita combinación de teclas para iniciar el inspector GTK
+    levels:
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.11.SEC-RHEL12
+    title: Se deshabilita el auto montaje de dispositivos extraíbles en el sistema.
+    levels:
+      - intermediate
+      - advanced
+    status: pending
+
+  #[A.15] Modificación de la información.
+  - id: A.15.SEC-RHEL1
+    title: Se controla el uso de medios de almacenamiento extraíbles.
+    levels:
+      - intermediate
+      - advanced
+    status: pending
+
+  #[A.19] Revelación de información.
+  - id: A.19.SEC-RHEL1
+    title: Se controla el acceso al árbol de carpetas y ficheros.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.19.SEC-RHEL2
+    title: Se aplican medidas para la protección de las cuentas.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.19.SEC-RHEL3
+    title: A robust algorithm and password complexity are enabled
+    original_title: Está habilitado un algoritmo robusto y la complejidad de contraseñas.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: planned
+    related_rules:
+      - set_password_hashing_algorithm_systemauth
+      - set_password_hashing_algorithm_passwordauth
+      - set_password_hashing_algorithm_logindefs
+      - var_password_hashing_algorithm=SHA512
+
+  #[A.23] Manipulación del hardware.
+  - id: A.23.SEC-RHEL1
+    title: Control the installation and use of any device connected to the equipment
+    original_title: Se controla la instalación y uso de cualquier dispositivo conectado al equipo.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: planned
+    related_rules:
+      - package_usbguard_installed
+      - service_usbguard_enabled
+      - usbguard_generate_policy
+
+  - id: A.23.SEC-RHEL2
+    title: Restrict dynamic mounting and unmounting of file systems
+    original_title: Se restringe el montaje y desmontaje dinámico de sistemas de archivos.
+    levels:
+      - basic
+      - intermediate
+      - advanced
+    status: pending
+
+  #[A.24] Denegación de servicio.
+  - id: A.24.SEC-RHEL1
+    title: Se controlan los privilegios que afectan al rendimiento del sistema.
+    levels:
+      - intermediate
+      - advanced
+    status: pending
+
+  - id: A.24.SEC-RHEL2
+    title: Se controla quien puede apagar el sistema.
+    levels:
+      - intermediate
+      - advanced
+    status: pending
+
+  #[A.25] Robo de equipos.
+  - id: A.25.SEC-RHEL1
+    title: El disco del sistema está cifrado.
+    levels:
+      - advanced
+    status: pending
+
+  - id: A.25.SEC-RHEL2
+    title: El disco de datos está cifrado.
+    levels:
+      - advanced
+    status: pending
+
+  #[A.30] Ingeniería social.
+  - id: A.30.SEC-RHEL1
+    title: Existe una política de bloqueo de cuentas ante inicios de sesión incorrectos.
+    levels:
+      - advanced
+    status: pending

--- a/controls/ccn_rhel9.yml
+++ b/controls/ccn_rhel9.yml
@@ -98,6 +98,10 @@ controls:
       - intermediate
       - advanced
     status: pending
+    notes: |-
+      It is not clear the intention of this requirement since there is no definition of these
+      subcategories. The project has many audit related rules. Clarifying these subcategories
+      we can select the proper rules.
 
   - id: A.3.SEC-RHEL6
     title: At least 90 days of activity logs are guaranteed
@@ -147,6 +151,10 @@ controls:
     levels:
       - advanced
     status: pending
+    notes: |-
+      Some possible rules were included here but it is not clear if the requirement intends to
+      check more than these rules. We can se if more related rules are available in the project
+      and include everything that makes sense in the context of cron and chrony.
     related_rules:
       - audit_rules_time_adjtimex
       - audit_rules_time_settimeofday
@@ -174,6 +182,9 @@ controls:
       - intermediate
       - advanced
     status: pending
+    notes: |-
+      We probably have audit related rule to monitor mount related syscalls, but it is not clear
+      about the swap. Is the intention to monitor when swap is changed?
     related_rules:
       - audit_rules_media_export
 
@@ -183,6 +194,9 @@ controls:
     levels:
       - advanced
     status: pending
+    notes: |-
+      The intention here is probably to audit changes in /etc/pam.d files, but we need to confirm
+      this assumption and get more context.
 
   #[A.4] Manipulación de los ficheros de configuración
   - id: A.4.SEC-RHEL1
@@ -193,6 +207,10 @@ controls:
       - intermediate
       - advanced
     status: pending
+    notes: |-
+      It is a little tricky to interpret this requirement. Assuming the "Common users" are actually
+      interactive users, this requirement would automatically enforce all admin actions to be
+      performed only by the root user. I am not sure if this is the intetion here.
 
   - id: A.4.SEC-RHEL2
     title: The system has an updated antivirus
@@ -202,6 +220,10 @@ controls:
       - intermediate
       - advanced
     status: pending
+    notes: |-
+      New templated rule is necessary to install the package. But to ensure the chosen antivirus
+      is actually updated would demand a more complex rule. Maybe this requirement can have at
+      leastthe partial status after the templated rule.
 
   - id: A.4.SEC-RHEL3
     title: Permissions by partitions are modified
@@ -212,7 +234,7 @@ controls:
       - advanced
     status: pending
     notes: |-
-      Related to nosuid, noexec and nodev options but in /boot.
+      Related to nosuid, noexec and nodev options but in /boot. More context is needed.
 
   #[A.5] Suplantación de la identidad.
   - id: A.5.SEC-RHEL1
@@ -246,6 +268,8 @@ controls:
       - intermediate
       - advanced
     status: pending
+    notes: |-
+      There are rules for ssh_keys, for example. We need to confirm the scope of this requirement
 
   - id: A.5.SEC-RHEL4
     title: Disable insecure encryption algorithms
@@ -451,6 +475,9 @@ controls:
     levels:
       - advanced
     status: pending
+    notes: |-
+      This might be related to SELinux.
+      We need more context to confirm the intention of this requirement
 
   - id: A.8.SEC-RHEL6
     title: Anti-ransomware measures are enabled
@@ -511,6 +538,9 @@ controls:
       - intermediate
       - advanced
     status: pending
+    notes: |-
+      Is it related to downloads from the Internet to the system or from the system to an external
+      storage, for example?
     related_rules:
       - audit_rules_file_deletion_events_rename
       - audit_rules_file_deletion_events_renameat
@@ -525,6 +555,8 @@ controls:
       - intermediate
       - advanced
     status: pending
+    notes: |-
+      Maybe simply removing the packages is enough.
 
   #[A.11] Acceso no autorizado.
   - id: A.11.SEC-RHEL1
@@ -535,6 +567,9 @@ controls:
       - intermediate
       - advanced
     status: pending
+    notes: |-
+      Is it related to TTY access, physical access, local users authentication, etc?
+      It is not not clear the scope.
 
   - id: A.11.SEC-RHEL2
     title: The security of the SSH protocol is strengthened
@@ -646,6 +681,8 @@ controls:
       - intermediate
       - advanced
     status: pending
+    notes: |-
+      New rules might be necessary.
 
   - id: A.11.SEC-RHEL11
     title: Key combination to launch GTK inspector is disabled
@@ -654,6 +691,8 @@ controls:
       - intermediate
       - advanced
     status: pending
+    notes: |-
+      New rules might be necessary.
 
   - id: A.11.SEC-RHEL12
     title: Disable auto-mounting of removable devices on the system
@@ -687,6 +726,8 @@ controls:
       - intermediate
       - advanced
     status: pending
+    notes: |-
+      More context should be provided to clarify this requirement
 
   - id: A.19.SEC-RHEL2
     title: Measures are applied to protect accounts
@@ -696,6 +737,8 @@ controls:
       - intermediate
       - advanced
     status: pending
+    notes: |-
+      This is already covered by other requirements. Maybe more rules could be included here.
 
   - id: A.19.SEC-RHEL3
     title: A robust algorithm and password complexity are enabled
@@ -744,6 +787,8 @@ controls:
       - intermediate
       - advanced
     status: pending
+    notes: |-
+      Is it about system limits?
 
   - id: A.24.SEC-RHEL2
     title: Control who can turn off the system
@@ -759,14 +804,20 @@ controls:
     original_title: El disco del sistema está cifrado.
     levels:
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - package_cryptsetup-luks_installed
+      - encrypt_partitions
 
   - id: A.25.SEC-RHEL2
     title: The data disk is encrypted
     original_title: El disco de datos está cifrado.
     levels:
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - package_cryptsetup-luks_installed
+      - encrypt_partitions
 
   #[A.30] Ingeniería social.
   - id: A.30.SEC-RHEL1

--- a/controls/ccn_rhel9.yml
+++ b/controls/ccn_rhel9.yml
@@ -46,28 +46,46 @@ controls:
       - basic
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - audit_rules_session_events
+      - audit_rules_login_events_faillock
+      - audit_rules_login_events_lastlog
 
   - id: A.3.SEC-RHEL2
     title: Se controla quien puede acceder a los registros de seguridad y auditoría.
     levels:
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - file_permissions_var_log_audit
+      - file_ownership_var_log_audit
+      - file_group_ownership_var_log_audit
+      - directory_permissions_var_log_audit
 
   - id: A.3.SEC-RHEL3
     title: Se controla el cambio de hora del sistema.
     levels:
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - package_chrony_installed
+      - chronyd_specify_remote_server
+      - chronyd_run_as_chrony_user
+      - var_multiple_time_servers=rhel
 
   - id: A.3.SEC-RHEL4
     title: Se controla quién puede generar o modificar reglas de audit.
     levels:
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - file_permissions_audit_configuration
+      - file_ownership_audit_configuration
+      - file_groupownership_audit_configuration
 
   - id: A.3.SEC-RHEL5
     title: Se ha implementado la auditoría detallada basada en subcategorías.
@@ -82,7 +100,10 @@ controls:
       - basic
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - auditd_data_retention_max_log_file_action
+      - var_auditd_max_log_file_action=keep_logs
 
   - id: A.3.SEC-RHEL7
     title: Se auditan las modificaciones del fichero sudoers, así como los cambios en permisos, usuarios, grupos y contraseñas.
@@ -90,19 +111,52 @@ controls:
       - basic
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - audit_sudo_log_events
+      - audit_rules_usergroup_modification_group
+      - audit_rules_usergroup_modification_gshadow
+      - audit_rules_usergroup_modification_opasswd
+      - audit_rules_usergroup_modification_passwd
+      - audit_rules_usergroup_modification_shadow
+      - audit_rules_sysadmin_actions
+      - audit_rules_dac_modification_chmod
+      - audit_rules_dac_modification_chown
+      - audit_rules_dac_modification_fchmod
+      - audit_rules_dac_modification_fchmodat
+      - audit_rules_dac_modification_fchown
+      - audit_rules_dac_modification_fchownat
+      - audit_rules_dac_modification_fremovexattr
+      - audit_rules_dac_modification_fsetxattr
+      - audit_rules_dac_modification_lchown
+      - audit_rules_dac_modification_lremovexattr
+      - audit_rules_dac_modification_lsetxattr
+      - audit_rules_dac_modification_removexattr
+      - audit_rules_dac_modification_setxattr
 
   - id: A.3.SEC-RHEL8
     title: Se auditan los cambios en la configuración de Cron y en tareas programadas incluyendo los de scripts de inicio.
     levels:
       - advanced
     status: pending
+    related_rules:
+      - audit_rules_time_adjtimex
+      - audit_rules_time_settimeofday
+      - audit_rules_time_clock_settime
+      - audit_rules_time_stime
+      - audit_rules_time_watch_localtime
 
   - id: A.3.SEC-RHEL9
     title: Se auditan los intentos de acceso a elementos críticos.
     levels:
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - audit_rules_unsuccessful_file_modification_creat
+      - audit_rules_unsuccessful_file_modification_ftruncate
+      - audit_rules_unsuccessful_file_modification_open
+      - audit_rules_unsuccessful_file_modification_openat
+      - audit_rules_unsuccessful_file_modification_truncate
 
   - id: A.3.SEC-RHEL10
     title: Se audita toda operación de montaje en el sistema y modificaciones en la memoria de intercambio.
@@ -110,6 +164,8 @@ controls:
       - intermediate
       - advanced
     status: pending
+    related_rules:
+      - audit_rules_media_export
 
   - id: A.3.SEC-RHEL11
     title: Se auditan modificaciones en ficheros PAM.
@@ -141,6 +197,8 @@ controls:
       - intermediate
       - advanced
     status: pending
+    notes: |-
+      Related to nosuid, noexec and nodev options but in /boot.
 
   #[A.5] Suplantación de la identidad.
   - id: A.5.SEC-RHEL1
@@ -148,7 +206,10 @@ controls:
     levels:
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - sudo_add_use_pty
+      - use_pam_wheel_for_su
 
   - id: A.5.SEC-RHEL2
     title: Se controlan los intentos de elevación mediante definición de usuarios y grupos sudoers.
@@ -156,7 +217,10 @@ controls:
       - basic
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - sudo_require_authentication
+      - sudo_require_reauthentication
 
   - id: A.5.SEC-RHEL3
     title: Se controla el acceso a las claves de cifrado.
@@ -172,7 +236,10 @@ controls:
       - basic
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - configure_crypto_policy
+      - var_system_crypto_policy=default_policy
 
   - id: A.5.SEC-RHEL5
     title: Se exige el cambio de contraseña de forma recurrente.
@@ -180,7 +247,17 @@ controls:
       - basic
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - accounts_minimum_age_login_defs
+      - var_accounts_minimum_age_login_defs=2
+      - accounts_password_set_min_life_existing
+      - accounts_maximum_age_login_defs
+      - var_accounts_maximum_age_login_defs=45
+      - accounts_password_set_max_life_existing
+      - accounts_password_warn_age_login_defs
+      - var_accounts_password_warn_age_login_defs=10
+      - accounts_password_set_warn_age_existing
 
   - id: A.5.SEC-RHEL6
     title: Se hace uso de protocolos seguros para los procesos de autenticación de red.
@@ -188,7 +265,9 @@ controls:
       - basic
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - configure_ssh_crypto_policy
 
   - id: A.5.SEC-RHEL7
     title: Se controla la inactividad de la sesión de red.
@@ -196,13 +275,21 @@ controls:
       - basic
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - sshd_idle_timeout_value=15_minutes
+      - sshd_set_idle_timeout
+      - sshd_set_keepalive
+      - var_sshd_set_keepalive=0
 
   - id: A.5.SEC-RHEL8
     title: Se controla la inactividad de consola local y remota.
     levels:
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - accounts_tmout
+      - var_accounts_tmout=5_min
 
   #[A.6] Abuso de privilegios de acceso.
   - id: A.6.SEC-RHEL1
@@ -210,7 +297,14 @@ controls:
     levels:
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - package_libselinux_installed
+      - grub2_enable_selinux
+      - var_selinux_policy_name=targeted
+      - selinux_policytype
+      - var_selinux_state=enforcing
+      - selinux_state
 
   - id: A.6.SEC-RHEL2
     title: Se restringen accesos en modo recuperación incluido el modo modificación de inicio de grub.
@@ -218,27 +312,45 @@ controls:
       - basic
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - file_groupowner_grub2_cfg
+      - file_owner_grub2_cfg
+      - file_permissions_grub2_cfg
+      - file_groupowner_user_cfg
+      - file_owner_user_cfg
+      - file_permissions_user_cfg
 
   - id: A.6.SEC-RHEL3
     title: Se limita la shell de usuarios de servicio a "/bin/false".
     levels:
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - no_password_auth_for_systemaccounts
+      - no_shelllogin_for_systemaccounts
 
   - id: A.6.SEC-RHEL4
     title: Se restringe el uso de sesiones con usuario "root".
     levels:
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - ensure_root_password_configured
+      - no_empty_passwords_etc_shadow
 
   - id: A.6.SEC-RHEL5
     title: Se modifica la máscara global del sistema para ser más restrictiva.
     levels:
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - accounts_umask_etc_bashrc
+      - accounts_umask_etc_login_defs
+      - accounts_umask_etc_profile
+      - var_accounts_user_umask=027
 
   - id: A.6.SEC-RHEL6
     title: Se eliminan los grupos y usuarios innecesarios del sistema.
@@ -246,7 +358,7 @@ controls:
       - basic
       - intermediate
       - advanced
-    status: pending
+    status: manual
 
   #[A.8] Difusión de software dañino.
   - id: A.8.SEC-RHEL1
@@ -263,7 +375,9 @@ controls:
       - basic
       - intermediate
       - advanced
-    status: pending
+    status: manual
+    related_rules:
+      - security_patches_up_to_date
 
   - id: A.8.SEC-RHEL3
     title: El sistema tiene un firewall local activado.
@@ -271,14 +385,31 @@ controls:
       - basic
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - service_firewalld_enabled
+      - service_nftables_disabled
+      - set_firewalld_default_zone
+      - firewalld_loopback_traffic_trusted
+      - firewalld_loopback_traffic_restricted
 
   - id: A.8.SEC-RHEL4
     title: Se deshabilitan servicios innecesarios, reduciendo la superficie de exposición.
     levels:
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - package_bind_removed
+      - package_cyrus-imapd_removed
+      - package_dovecot_removed
+      - package_net-snmp_removed
+      - package_squid_removed
+      - package_telnet-server_removed
+      - package_tftp-server_removed
+      - package_vsftpd_removed
+      - kernel_module_squashfs_disable
+      - kernel_module_udf_disabled
 
   - id: A.8.SEC-RHEL5
     title: Se controla la ejecución de aplicaciones.
@@ -292,7 +423,38 @@ controls:
       - basic
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    notes: |-
+      These are mentioned to be reviewed but not enforced:
+      #net.ipv4.icmp_echo_ignore_all = 1
+      #net.ipv4.tcp_timestamps = 0
+      #net.ipv4.tcp_max_syn_backlog = 1280
+      #sysctl_net_ipv6_conf_all_disable_ipv6
+      #sysctl_net_ipv6_conf_default_disable_ipv6
+    related_rules:
+      - sysctl_net_ipv4_conf_all_send_redirects
+      - sysctl_net_ipv4_conf_all_accept_redirects
+      - sysctl_net_ipv4_conf_all_secure_redirects
+      - sysctl_net_ipv4_conf_all_accept_source_route
+      - sysctl_net_ipv4_conf_all_log_martians
+      - sysctl_net_ipv4_conf_default_send_redirects
+      - sysctl_net_ipv4_conf_default_accept_redirects
+      - sysctl_net_ipv4_conf_default_secure_redirects
+      - sysctl_net_ipv4_conf_default_accept_source_route
+      - sysctl_net_ipv4_conf_default_log_martians
+      - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
+      - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+      - sysctl_net_ipv4_tcp_syncookies
+      - sysctl_net_ipv6_conf_all_accept_source_route
+      - sysctl_net_ipv6_conf_all_accept_redirects
+      - sysctl_net_ipv6_conf_all_accept_ra
+      - sysctl_net_ipv6_conf_default_accept_source_route
+      - sysctl_net_ipv6_conf_default_accept_redirects
+      - sysctl_net_ipv6_conf_default_accept_ra
+      - sysctl_fs_suid_dumpable
+      - sysctl_net_ipv4_ip_forward
+      - sysctl_net_ipv4_conf_all_rp_filter
+      - sysctl_net_ipv4_conf_default_rp_filter
 
   - id: A.8.SEC-RHEL7
     title: Está habilitado el arranque cifrado con contraseña que evite modificaciones (GRUB protegido).
@@ -300,7 +462,9 @@ controls:
       - basic
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - grub2_password
 
   - id: A.8.SEC-RHEL8
     title: Se audita la descarga de archivos.
@@ -308,7 +472,12 @@ controls:
       - basic
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - audit_rules_file_deletion_events_rename
+      - audit_rules_file_deletion_events_renameat
+      - audit_rules_file_deletion_events_unlink
+      - audit_rules_file_deletion_events_unlinkat
 
   - id: A.8.SEC-RHEL9
     title: Están deshabilitados los compiladores del sistema.
@@ -333,7 +502,9 @@ controls:
       - basic
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - sshd_limit_user_access
 
   - id: A.11.SEC-RHEL3
     title: Se dispone de una política de credenciales robusta.
@@ -341,7 +512,15 @@ controls:
       - basic
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - accounts_password_pam_minclass
+      - accounts_password_pam_minlen
+      - accounts_password_pam_retry
+      - var_password_pam_minclass=4
+      - var_password_pam_minlen=14
+      - ensure_root_password_configured
+      - no_empty_passwords_etc_shadow
 
   - id: A.11.SEC-RHEL4
     title: Durante el inicio de sesión, el sistema muestra un texto en cumplimiento con las normas o directivas de la organización.
@@ -349,7 +528,18 @@ controls:
       - basic
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - dconf_gnome_banner_enabled
+      - dconf_gnome_login_banner_text
+      - login_banner_text=cis_default
+      - sshd_enable_warning_banner_net
+      - banner_etc_motd
+      - motd_banner_text=cis_banners
+      - banner_etc_issue
+      - login_banner_text=cis_banners
+      - banner_etc_issue_net
+      - remote_login_banner_text=cis_banners
 
   - id: A.11.SEC-RHEL5
     title: Se controla el acceso al sistema a través de la red.
@@ -357,7 +547,9 @@ controls:
       - basic
       - intermediate
       - advanced
-    status: pending
+    status: manual
+    related_rules:
+      - configure_firewalld_ports
 
   - id: A.11.SEC-RHEL6
     title: Sólo se permiten algoritmos de cifrado robustos en accesos al sistema.
@@ -365,14 +557,21 @@ controls:
       - basic
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - configure_ssh_crypto_policy
 
   - id: A.11.SEC-RHEL7
     title: Se limita el tiempo de inactividad del GUI.
     levels:
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - dconf_gnome_screensaver_idle_delay
+      - dconf_gnome_screensaver_lock_delay
+      - inactivity_timeout_value=5_minutes
+      - var_screensaver_lock_delay=immediate
 
   - id: A.11.SEC-RHEL8
     title: Se muestra un banner disuasorio.
@@ -386,7 +585,9 @@ controls:
     levels:
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - dconf_gnome_disable_user_list
 
   - id: A.11.SEC-RHEL10
     title: Se deshabilita recordar el historial de ficheros.
@@ -407,7 +608,11 @@ controls:
     levels:
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - dconf_gnome_disable_automount
+      - dconf_gnome_disable_automount_open
+      - dconf_gnome_disable_autorun
 
   #[A.15] Modificación de la información.
   - id: A.15.SEC-RHEL1
@@ -415,7 +620,9 @@ controls:
     levels:
       - intermediate
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - kernel_module_usb-storage_disabled
 
   #[A.19] Revelación de información.
   - id: A.19.SEC-RHEL1
@@ -470,6 +677,8 @@ controls:
       - intermediate
       - advanced
     status: pending
+    notes: |-
+      It seems to duplicate the A.11.SEC-RHEL12 requirement.
 
   #[A.24] Denegación de servicio.
   - id: A.24.SEC-RHEL1
@@ -504,4 +713,9 @@ controls:
     title: Existe una política de bloqueo de cuentas ante inicios de sesión incorrectos.
     levels:
       - advanced
-    status: pending
+    status: planned
+    related_rules:
+      - accounts_passwords_pam_faillock_deny
+      - var_accounts_passwords_pam_faillock_deny=8
+      - accounts_passwords_pam_faillock_unlock_time
+      - var_accounts_passwords_pam_faillock_unlock_time=0

--- a/controls/ccn_rhel9.yml
+++ b/controls/ccn_rhel9.yml
@@ -92,7 +92,7 @@ controls:
       - file_groupownership_audit_configuration
 
   - id: A.3.SEC-RHEL5
-    title: It is implemented a detailed audit based on subcategories
+    title: A detailed audit has been implemented based on subcategories
     original_title: Se ha implementado la auditoría detallada basada en subcategorías.
     levels:
       - intermediate
@@ -200,7 +200,7 @@ controls:
 
   #[A.4] Manipulación de los ficheros de configuración
   - id: A.4.SEC-RHEL1
-    title: Common users do not have local administrator permissions or are included in a sudo group
+    title: Common users do not have local administrator permissions and are not included in a sudo group
     original_title: Los usuarios estándar no disponen de permisos de administrador local ni se encuentran incluidos en un grupo sudoer.
     levels:
       - basic
@@ -238,7 +238,7 @@ controls:
 
   #[A.5] Suplantación de la identidad.
   - id: A.5.SEC-RHEL1
-    title: Control login and impersonation permissions
+    title: Login and impersonation permissions are controlled
     original_title: Se controlan los permisos de inicio de sesión y suplantación de identidad.
     levels:
       - intermediate
@@ -249,7 +249,7 @@ controls:
       - use_pam_wheel_for_su
 
   - id: A.5.SEC-RHEL2
-    title: Elevation attempts are controlled by defining sudoers users and groups
+    title: Elevation attempts are controlled by defining users and sudoer groups
     original_title: Se controlan los intentos de elevación mediante definición de usuarios y grupos sudoers.
     levels:
       - basic
@@ -284,7 +284,7 @@ controls:
       - var_system_crypto_policy=default_policy
 
   - id: A.5.SEC-RHEL5
-    title: Recurring password change required
+    title: Recurring password change is required
     original_title: Se exige el cambio de contraseña de forma recurrente.
     levels:
       - basic
@@ -303,7 +303,7 @@ controls:
       - accounts_password_set_warn_age_existing
 
   - id: A.5.SEC-RHEL6
-    title: Secure protocols are used for network authentication processes
+    title: Secure protocols are used for the network authentication processes
     original_title: Se hace uso de protocolos seguros para los procesos de autenticación de red.
     levels:
       - basic
@@ -314,7 +314,7 @@ controls:
       - configure_ssh_crypto_policy
 
   - id: A.5.SEC-RHEL7
-    title: Control network session inactivity
+    title:Network session inactivity is controlled
     original_title: Se controla la inactividad de la sesión de red.
     levels:
       - basic
@@ -328,7 +328,7 @@ controls:
       - var_sshd_set_keepalive=0
 
   - id: A.5.SEC-RHEL8
-    title: Control local and remote console inactivity
+    title: Local and remote console inactivity is controlled
     original_title: Se controla la inactividad de consola local y remota.
     levels:
       - advanced
@@ -436,7 +436,7 @@ controls:
       - security_patches_up_to_date
 
   - id: A.8.SEC-RHEL3
-    title: The system has a local firewall activated
+    title: The system has an activated local firewall
     original_title: El sistema tiene un firewall local activado.
     levels:
       - basic
@@ -470,7 +470,7 @@ controls:
       - kernel_module_udf_disabled
 
   - id: A.8.SEC-RHEL5
-    title: Control application execution
+    title: Application execution is controlled
     original_title: Se controla la ejecución de aplicaciones.
     levels:
       - advanced
@@ -560,7 +560,7 @@ controls:
 
   #[A.11] Acceso no autorizado.
   - id: A.11.SEC-RHEL1
-    title: Control local logon to the system
+    title: Local log on to the system is controlled
     original_title: Se controla el inicio de sesión local en el sistema.
     levels:
       - basic
@@ -600,7 +600,7 @@ controls:
       - no_empty_passwords_etc_shadow
 
   - id: A.11.SEC-RHEL4
-    title: During login, the system displays a text in compliance with the organization's standards or policies
+    title: During login, the system displays a text in compliance with the organization's standards or directives
     original_title: Durante el inicio de sesión, el sistema muestra un texto en cumplimiento con las normas o directivas de la organización.
     levels:
       - basic
@@ -620,7 +620,7 @@ controls:
       - remote_login_banner_text=cis_banners
 
   - id: A.11.SEC-RHEL5
-    title: Control network access to the system
+    title: Network access to the system is controlled
     original_title: Se controla el acceso al sistema a través de la red.
     levels:
       - basic
@@ -675,7 +675,7 @@ controls:
       - dconf_gnome_disable_user_list
 
   - id: A.11.SEC-RHEL10
-    title: Disable remember file history
+    title: File history is disabled
     original_title: Se deshabilita recordar el historial de ficheros.
     levels:
       - intermediate
@@ -695,7 +695,7 @@ controls:
       New rules might be necessary.
 
   - id: A.11.SEC-RHEL12
-    title: Disable auto-mounting of removable devices on the system
+    title: Auto-mounting of removable devices on the system is disabled
     original_title: Se deshabilita el auto montaje de dispositivos extraíbles en el sistema.
     levels:
       - intermediate
@@ -708,7 +708,7 @@ controls:
 
   #[A.15] Modificación de la información.
   - id: A.15.SEC-RHEL1
-    title: Control the use of removable storage media
+    title: The use of removable storage media is controlled
     original_title: Se controla el uso de medios de almacenamiento extraíbles.
     levels:
       - intermediate
@@ -719,7 +719,7 @@ controls:
 
   #[A.19] Revelación de información.
   - id: A.19.SEC-RHEL1
-    title: Control access to the folder and file tree
+    title: Access to the folder and file tree is controlled
     original_title: Se controla el acceso al árbol de carpetas y ficheros.
     levels:
       - basic
@@ -756,7 +756,7 @@ controls:
 
   #[A.23] Manipulación del hardware.
   - id: A.23.SEC-RHEL1
-    title: Control the installation and use of any device connected to the equipment
+    title: The installation and use of any device connected to the equipment is controlled
     original_title: Se controla la instalación y uso de cualquier dispositivo conectado al equipo.
     levels:
       - basic
@@ -769,7 +769,7 @@ controls:
       - usbguard_generate_policy
 
   - id: A.23.SEC-RHEL2
-    title: Restrict dynamic mounting and unmounting of file systems
+    title: The dynamic mounting and unmounting of file systems is restricted
     original_title: Se restringe el montaje y desmontaje dinámico de sistemas de archivos.
     levels:
       - basic

--- a/controls/ccn_rhel9.yml
+++ b/controls/ccn_rhel9.yml
@@ -39,7 +39,6 @@ controls:
       - var_authselect_profile=sssd
       - enable_authselect
 
-  #[A.3] Manipulación de los registros de actividad (log).
   - id: A.3.SEC-RHEL1
     title: Session initiation is audited
     original_title: Se auditan los inicios de sesión.
@@ -198,7 +197,6 @@ controls:
       The intention here is probably to audit changes in /etc/pam.d files, but we need to confirm
       this assumption and get more context.
 
-  #[A.4] Manipulación de los ficheros de configuración
   - id: A.4.SEC-RHEL1
     title: Common users do not have local administrator permissions and are not included in a sudo group
     original_title: Los usuarios estándar no disponen de permisos de administrador local ni se encuentran incluidos en un grupo sudoer.
@@ -236,7 +234,6 @@ controls:
     notes: |-
       Related to nosuid, noexec and nodev options but in /boot. More context is needed.
 
-  #[A.5] Suplantación de la identidad.
   - id: A.5.SEC-RHEL1
     title: Login and impersonation permissions are controlled
     original_title: Se controlan los permisos de inicio de sesión y suplantación de identidad.
@@ -314,7 +311,7 @@ controls:
       - configure_ssh_crypto_policy
 
   - id: A.5.SEC-RHEL7
-    title:Network session inactivity is controlled
+    title: Network session inactivity is controlled
     original_title: Se controla la inactividad de la sesión de red.
     levels:
       - basic
@@ -337,7 +334,6 @@ controls:
       - accounts_tmout
       - var_accounts_tmout=5_min
 
-  #[A.6] Abuso de privilegios de acceso.
   - id: A.6.SEC-RHEL1
     title: The security of sensitive system objects is reinforced
     original_title: Se refuerza la seguridad de los objetos sensibles del sistema.
@@ -414,7 +410,6 @@ controls:
       - advanced
     status: manual
 
-  #[A.8] Difusión de software dañino.
   - id: A.8.SEC-RHEL1
     title: Control who can install software on the system
     original_title: Se controla quién puede instalar software en el sistema.
@@ -558,7 +553,6 @@ controls:
     notes: |-
       Maybe simply removing the packages is enough.
 
-  #[A.11] Acceso no autorizado.
   - id: A.11.SEC-RHEL1
     title: Local log on to the system is controlled
     original_title: Se controla el inicio de sesión local en el sistema.
@@ -706,7 +700,6 @@ controls:
       - dconf_gnome_disable_automount_open
       - dconf_gnome_disable_autorun
 
-  #[A.15] Modificación de la información.
   - id: A.15.SEC-RHEL1
     title: The use of removable storage media is controlled
     original_title: Se controla el uso de medios de almacenamiento extraíbles.
@@ -717,7 +710,6 @@ controls:
     related_rules:
       - kernel_module_usb-storage_disabled
 
-  #[A.19] Revelación de información.
   - id: A.19.SEC-RHEL1
     title: Access to the folder and file tree is controlled
     original_title: Se controla el acceso al árbol de carpetas y ficheros.
@@ -754,7 +746,6 @@ controls:
       - set_password_hashing_algorithm_logindefs
       - var_password_hashing_algorithm=SHA512
 
-  #[A.23] Manipulación del hardware.
   - id: A.23.SEC-RHEL1
     title: The installation and use of any device connected to the equipment is controlled
     original_title: Se controla la instalación y uso de cualquier dispositivo conectado al equipo.
@@ -779,7 +770,6 @@ controls:
     notes: |-
       It seems to duplicate the A.11.SEC-RHEL12 requirement.
 
-  #[A.24] Denegación de servicio.
   - id: A.24.SEC-RHEL1
     title: Privileges that affect system performance are controlled
     original_title: Se controlan los privilegios que afectan al rendimiento del sistema.
@@ -801,7 +791,6 @@ controls:
       - disable_ctrlaltdel_burstaction
       - disable_ctrlaltdel_reboot
 
-  #[A.25] Robo de equipos.
   - id: A.25.SEC-RHEL1
     title: System disk is encrypted
     original_title: El disco del sistema está cifrado.
@@ -822,7 +811,6 @@ controls:
       - package_cryptsetup-luks_installed
       - encrypt_partitions
 
-  #[A.30] Ingeniería social.
   - id: A.30.SEC-RHEL1
     title: There is an account lockout policy for incorrect logins
     original_title: Existe una política de bloqueo de cuentas ante inicios de sesión incorrectos.

--- a/controls/ccn_rhel9.yml
+++ b/controls/ccn_rhel9.yml
@@ -797,6 +797,9 @@ controls:
       - intermediate
       - advanced
     status: pending
+    related_rules:
+      - disable_ctrlaltdel_burstaction
+      - disable_ctrlaltdel_reboot
 
   #[A.25] Robo de equipos.
   - id: A.25.SEC-RHEL1

--- a/docs/manual/developer/03_creating_content.md
+++ b/docs/manual/developer/03_creating_content.md
@@ -983,9 +983,10 @@ This is a complete schema of the YAML file format.
 ```
 id: policy ID (required key)
 title: short title (required key)
+original_title: used as a reference for policies not yet available in english
 source: a link to the original policy, eg. a URL of a PDF document
 controls_dir: a directory containing files representing controls that will be imported into this policy
-levels: a list of levels, the first one is default.
+levels: a list of levels, the first one is default
   - id: level ID (required key)
     inherits_from: a list of IDs of levels inheriting from
 
@@ -993,10 +994,10 @@ controls: a list of controls (required key)
   - id: control ID (required key)
     title: control title
     description: description of the control in a few sentences
-    levels: The list of policy levels that the control belongs to.
+    levels: The list of policy levels that the control belongs to
     notes: a short paragraph of text
     rules: a list of rule IDs that cover this control
-    related_rules: a list of related rules
+    related_rules: a list of related rules only for reference
     controls: a (nested) list of either control definitions, or of control references in the policy:id format
     status: a keyword that reflects the current status of the implementation of this control
     tickets: a list of URLs reflecting the work that still needs to be done to address this control

--- a/docs/manual/developer/03_creating_content.md
+++ b/docs/manual/developer/03_creating_content.md
@@ -983,7 +983,7 @@ This is a complete schema of the YAML file format.
 ```
 id: policy ID (required key)
 title: short title (required key)
-original_title: used as a reference for policies not yet available in english
+original_title: used as a reference for policies not yet available in English
 source: a link to the original policy, eg. a URL of a PDF document
 controls_dir: a directory containing files representing controls that will be imported into this policy
 levels: a list of levels, the first one is default

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -117,7 +117,8 @@ class Control(ssg.entities.common.SelectionHandler, ssg.entities.common.XCCDFEnt
     @classmethod
     def _check_keys(cls, control_dict):
         for key in control_dict.keys():
-            if key not in cls.KEYS.keys() and key not in ['rules', 'related_rules', 'controls', ]:
+            if key not in cls.KEYS.keys() and key not in [
+                    'controls', 'original_title', 'related_rules', 'rules']:
                 raise ValueError("Key %s is not a valid for a control." % key)
 
     @classmethod


### PR DESCRIPTION
#### Description:

This PR introduces an initial control file for CCN-STIC-610A22.
It is a Benchmark developed by National Cryptological Center of Spain, in alignment to the National Security Schema (ENS)

This control file is not used in any profile at this moment.
The intention is to already bring this initial version to the project so we can collaborate to improve it.

#### Rationale:

New control file for CCN-STIC-610A22.

#### Review Hints:

The `pending` requirements are those which demands more collaboration mainly about the interpretation of the requirement. Sometimes it is not clear the intention of the requirement or multiple interpretations are possible.
It would be great to have more context from people involved with CCN-STIC-610A22 development or use.

All the `planned` requirements were interpreted and some candidate rules were selected.
For these requirements a review of the rules is necessary to move them from `related_rules` to `rules`.