### PR TITLE
Set package_nftables_installed as machine only

### DIFF
--- a/linux_os/guide/system/network/network-nftables/package_nftables_installed/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/package_nftables_installed/rule.yml
@@ -36,6 +36,8 @@ ocil_clause: 'the package is not installed'
 
 ocil: '{{{ ocil_package(package="nftables") }}}'
 
+platform: machine
+
 template:
     name: package_installed
     vars:


### PR DESCRIPTION
#### Description:

Set package_nftables_installed as machine only.

This aligns the rule with service_nftables_disabled.

#### Rationale:

This aligns the rule with service_nftables_disabled and the other nftables rules.
