### PR TITLE
Set package_iptables_installed as machine only

### DIFF
--- a/linux_os/guide/system/network/network-iptables/package_iptables_installed/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/package_iptables_installed/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: alinux2,alinux3,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhv4,sle12,sle15,ubuntu2004,ubuntu2204
 
-platform: not rhcos4-rhel9
+platform: machine and not rhcos4-rhel9
 
 title: 'Install iptables Package'
 


### PR DESCRIPTION
#### Description:

Set package_iptables_installed as machine only

#### Rationale:

This aligns the rule with service_iptables_enabled.
