### PR TITLE
service_apport_disabled: depend on apport being installed

### DIFF
--- a/linux_os/guide/services/apport/service_apport_disabled/rule.yml
+++ b/linux_os/guide/services/apport/service_apport_disabled/rule.yml
@@ -20,6 +20,8 @@ severity: unknown
 references:
     cis@ubuntu2204: 1.5.3
 
+platform: package[apport]
+
 template:
     name: service_disabled
     vars:

--- a/shared/applicability/package.yml
+++ b/shared/applicability/package.yml
@@ -4,6 +4,8 @@ versioned: true
 template:
   name: platform_package
 args:
+  apport:
+    pkgname: apport
   audit:
     {{% if pkg_system == "rpm" %}}
     pkgname: audit


### PR DESCRIPTION
#### Description:

service_apport_disabled is only applicable if apport is installed.

#### Rationale:

service_apport_disabled is only applicable if apport is installed.
