### PR TITLE
Set ensure_root_password_configured as machine only

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_root_password_configured/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_root_password_configured/rule.yml
@@ -18,6 +18,8 @@ severity: medium
 identifiers:
     cce@rhel9: CCE-87101-2
 
+platform: machine
+
 references:
     cis@rhel9: 5.6.6
     cis@ubuntu2004: 1.5.3


### PR DESCRIPTION
#### Description:

Set ensure_root_password_configured as machine only

#### Rationale:

The rationale for this rule is:
> Requiring authentication in single user mode prevents an unauthorized user from rebooting the system into single user to gain root privileges without credentials.

Single user mode isn't applicable to containers, only actual machines.
