### PR TITLE
use_pam_wheel_group_for_su: depend on pam being installed

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_group_for_su/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_group_for_su/rule.yml
@@ -29,6 +29,8 @@ references:
     cis@ubuntu2004: '5.6'
     cis@ubuntu2204: 5.3.7
 
+platform: package[pam]
+
 ocil_clause: 'the line is not in the file or it is commented'
 
 ocil: |-


### PR DESCRIPTION
#### Description:

use_pam_wheel_group_for_su: depend on pam being installed

#### Rationale:

This rule, which checks pam configuration, only makes sense when pam is installed.
