### PR TITLE
ensure_pam_wheel_group_empty: depend on pam being installed

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/rule.yml
@@ -27,6 +27,8 @@ references:
     cis@ubuntu2004: '5.6'
     cis@ubuntu2204: 5.3.7
 
+platform: package[pam]
+
 ocil_clause: 'group {{{ var_pam_wheel_group_for_su }}} exists and has no user members'
 
 ocil: |-


### PR DESCRIPTION
#### Description:

ensure_pam_wheel_group_empty: depend on pam being installed

#### Rationale:

This rule, which checks pam configuration, only makes sense when pam is installed.
