### PR TITLE
no_rsh_trust_files: depend on rsh-server being installed

### DIFF
--- a/components/rsh.yml
+++ b/components/rsh.yml
@@ -3,6 +3,7 @@ packages:
 - rsh
 - rsh-server
 rules:
+- no_rsh_trust_files
 - package_rsh-server_removed
 - package_rsh_removed
 - service_rexec_disabled

--- a/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/rule.yml
@@ -45,6 +45,8 @@ references:
     nist: CM-7(a),CM-7(b),CM-6(a)
     nist-csf: PR.AC-3,PR.IP-1,PR.PT-3,PR.PT-4
 
+platform: package[rsh-server]
+
 ocil_clause: 'these files exist'
 
 ocil: |-

--- a/shared/applicability/package.yml
+++ b/shared/applicability/package.yml
@@ -53,6 +53,8 @@ args:
     pkgname: polkit
   postfix:
     pkgname: postfix
+  rsh-server:
+    pkgname: rsh-server
   shadow-utils:
     {{% if pkg_system == "rpm" %}}
     {{% if product in ["sle12", "sle15"] %}}


### PR DESCRIPTION
#### Description:

no_rsh_trust_files: depend on rsh-server being installed

#### Rationale:

no_rsh_trust_files is only applicable if rsh-server is installed.