### PR TITLE
Set package_rng-tools_installed as machine only

### DIFF
--- a/linux_os/guide/system/software/system-tools/package_rng-tools_installed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_rng-tools_installed/rule.yml
@@ -32,6 +32,7 @@ fixtext: '{{{ fixtext_package_installed("rng-tools") }}}'
 
 srg_requirement: '{{{ srg_requirement_package_installed("rng-tools") }}}'
 
+platform: machine
 
 template:
     name: package_installed


### PR DESCRIPTION
#### Description:

Set package_rng-tools_installed as machine only

#### Rationale:

Entropy gathering should be done on the host, not in each container.
