### PR TITLE
Set accounts-physical as machine only

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/rule.yml
@@ -103,5 +103,3 @@ fixtext: |-
     $ sudo systemctl mask --now ctrl-alt-del.target
 
 srg_requirement: 'The x86 Ctrl-Alt-Delete key sequence must be disabled on {{{ full_name }}}.'
-
-platform: machine

--- a/linux_os/guide/system/accounts/accounts-physical/group.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/group.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 title: 'Protect Physical Console Access'
 
+platform: machine
+
 description: |-
     It is impossible to fully protect a system from an
     attacker with physical access, so securing the space in which the

--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/rule.yml
@@ -80,8 +80,6 @@ ocil: |-
     <pre>$ sudo grep -r emergency.service /etc/systemd/system/</pre>
     The output should be empty.
 
-platform: machine
-
 fixtext: |-
     Configure {{{ full_name }}} to require authentication for system emergency mode.
 

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/rule.yml
@@ -89,8 +89,6 @@ ocil: |-
     There should be no output.
     {{% endif %}}
 
-platform: machine
-
 fixtext: |-
     Configure {{{ full_name }}} to require authentication in single user mode.
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/rule.yml
@@ -53,5 +53,3 @@ fixtext: |-
     $ sudo chmod 0644 /etc/tmux.conf
 
 srg_requirement: '{{{ full_name }}} must automatically lock command line user sessions after 15 minutes of inactivity.'
-
-platform: machine

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/rule.yml
@@ -55,5 +55,3 @@ fixtext: |-
     $ sudo chmod 0644 /etc/tmux.conf
 
 srg_requirement: '{{{ full_name }}} must enable a user session lock until that user re-establishes access using established identification and authentication procedures for command line sessions.'
-
-platform: machine

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/rule.yml
@@ -49,5 +49,3 @@ fixtext: |-
     Then, ensure a correct mode of /etc/tmux.conf using this command:
 
     $ sudo chmod 0644 /etc/tmux.conf
-
-platform: machine

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/no_tmux_in_shells/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/no_tmux_in_shells/rule.yml
@@ -39,6 +39,4 @@ ocil: |-
 fixtext: |-
     Edit the file "/etc/shells" and remove any line that ends in "tmux".
 
-platform: machine
-
 srg_requirement: '{{{ full_name }}} must prevent users from disabling session control mechanisms.'

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/package_screen_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/package_screen_installed/rule.yml
@@ -45,8 +45,6 @@ ocil_clause: 'the package is not installed'
 
 ocil: '{{{ ocil_package(package="screen") }}}'
 
-platform: machine
-
 template:
     name: package_installed
     vars:

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/package_tmux_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/package_tmux_installed/rule.yml
@@ -53,8 +53,6 @@ fixtext: '{{{ describe_package_install(package="tmux") }}}'
 
 srg_requirement: '{{{ srg_requirement_package_installed("tmux") }}}'
 
-platform: machine
-
 template:
     name: package_installed
     vars:

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/vlock_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/vlock_installed/rule.yml
@@ -58,5 +58,3 @@ template:
         pkgname@ubuntu1604: vlock
         pkgname@ubuntu1804: vlock
         pkgname@ubuntu2004: vlock
-
-platform: machine

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/group.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/group.yml
@@ -11,5 +11,3 @@ description: |-
     In Red Hat Enterprise Linux servers and workstations, hardware token login
     {{% endif %}}
     is not enabled by default and must be enabled in the system settings.
-
-platform: machine

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_ca/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_ca/rule.yml
@@ -46,5 +46,3 @@ ocil: |-
     <pre>cert_policy = ca, ocsp_on, signature;
     cert_policy = ca, ocsp_on, signature;
     cert_policy = ca, ocsp_on, signature;</pre>
-
-platform: machine

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/rule.yml
@@ -81,5 +81,3 @@ ocil: |-
 
     If <tt>pam_pkcs11.so</tt> is not set in <tt>etc/pam.d/common-auth</tt> this
     is a finding.
-
-platform: machine

--- a/linux_os/guide/system/accounts/accounts-physical/service_debug-shell_disabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/service_debug-shell_disabled/rule.yml
@@ -50,8 +50,6 @@ fixtext: '{{{ srg_requirement_service_disabled("debug-shell") }}}'
 
 srg_requirement: '{{{ srg_requirement_service_disabled("debug-shell") }}}'
 
-platform: machine
-
 template:
     name: service_disabled
     vars:


### PR DESCRIPTION
#### Description:

Set accounts-physical as machine only

#### Rationale:

This group's intent is to "Protect Physical Console Access" - since there is no physical console to access in containers, the group is not applicable to containers, and should only apply to actual machines.