### PR TITLE
Add validation for Keys in Controls

### DIFF
--- a/controls/srg_ctr/SRG-APP-000290-CTR-000670.yml
+++ b/controls/srg_ctr/SRG-APP-000290-CTR-000670.yml
@@ -4,7 +4,7 @@ controls:
   - medium
   title: {{{ full_name }}} must use cryptographic mechanisms to protect the integrity
     of audit tools.
-  related:rules:
+  related_rules:
   - audit_log_forwarding_uses_tls
   status: inherently met
   status_justification: |-
@@ -14,7 +14,7 @@ controls:
 
     The file that contains the checksums of the installer tooling and listing of container image manifest hashes is signed and the signature, validatable with Red Hat's product security GPG key, is published alongside the listing. See, for example, https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.8/sha256sum.txt.gpg
 
-    Included in the release of the base platform are the components that index the available installation sources for additional components, delivered as Operators, from Red Hat. The images for the OpenShift Logging Operator, which are the only supported mechanism for exporting audit logs from the cluster and forwarding to an external log aggregation solution, 
+    Included in the release of the base platform are the components that index the available installation sources for additional components, delivered as Operators, from Red Hat. The images for the OpenShift Logging Operator, which are the only supported mechanism for exporting audit logs from the cluster and forwarding to an external log aggregation solution,
   artifact_description: |-
     Supporting evidence is in the following documentation
 

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -147,15 +147,6 @@ class Control(ssg.entities.common.SelectionHandler, ssg.entities.common.XCCDFEnt
         control.notes = control_dict.get("notes", "")
         selections = control_dict.get("rules", {})
 
-        product = None
-        product_dir = None
-        benchmark_root = None
-        if env_yaml:
-            product = env_yaml.get('product', None)
-            product_dir = env_yaml.get('product_dir', None)
-            benchmark_root = env_yaml.get('benchmark_root', None)
-            content_dir = os.path.join(product_dir, benchmark_root)
-
         control.selections = selections
 
         control.related_rules = control_dict.get("related_rules", [])

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -115,7 +115,14 @@ class Control(ssg.entities.common.SelectionHandler, ssg.entities.common.XCCDFEnt
         return hash(self.id)
 
     @classmethod
+    def _check_keys(cls, control_dict):
+        for key in control_dict.keys():
+            if key not in cls.KEYS.keys() and key not in ['rules', 'related_rules', 'controls', ]:
+                raise ValueError("Key %s is not a valid for a control." % key)
+
+    @classmethod
     def from_control_dict(cls, control_dict, env_yaml=None, default_level=["default"]):
+        cls._check_keys(control_dict)
         control = cls()
         control.id = ssg.utils.required_key(control_dict, "id")
         control.title = control_dict.get("title")

--- a/tests/unit/ssg-module/test_controls.py
+++ b/tests/unit/ssg-module/test_controls.py
@@ -2,8 +2,6 @@ import pytest
 import logging
 import os
 
-import pytest
-
 import ssg.controls
 import ssg.build_yaml
 from ssg.environment import open_environment
@@ -492,3 +490,13 @@ def test_policy_parse_from_referenced(minimal_empty_controls, one_simple_subcont
     assert control.title == "control"
     assert control.controls == ["s"]
     assert subcontrol.title == "subcontrol"
+
+
+def test_control_with_bad_key():
+    control = {'id': 'abcd', 'badval': 'should not be here', }
+    control_obj = None
+    try:
+        control_obj = ssg.controls.Control.from_control_dict(control)
+    except ValueError as e:
+        assert type(e) is ValueError
+    assert control_obj is None


### PR DESCRIPTION
#### Description:

This adds test before import a control dict to ensure that it only have supported keys. To prevent unfortunate event like using `rule` vs `rules`. 

#### Rationale:
Closes #9772 

#### Review Hints:
Add an valid key like `badval` to a control in a control file and the build should fail.