### PR TITLE
.github/workflows/gate.yaml:Add anolis8 product.

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -21,6 +21,7 @@ jobs:
               alinux2 \
               alinux3 \
               anolis23 \
+              anolis8 \
               chromium \
               fedora \
               firefox \
@@ -45,7 +46,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build
-        run: ./build_product alinux2 alinux3 anolis23 chromium fedora firefox rhcos4 rhel7 rhel8 rhel9 sle12 sle15 ubuntu2004 ubuntu2204 uos20
+        run: ./build_product alinux2 alinux3 anolis23 anolis8 chromium fedora firefox rhcos4 rhel7 rhel8 rhel9 sle12 sle15 ubuntu2004 ubuntu2204 uos20
       - name: Test
         run: ctest -j2 --output-on-failure -E unique-stigids
         working-directory: ./build
@@ -89,6 +90,7 @@ jobs:
               alinux2 \
               alinux3 \
               anolis23 \
+              anolis8 \
               chromium \
               fedora \
               firefox \
@@ -142,6 +144,7 @@ jobs:
               alinux2 \
               alinux3 \
               anolis23 \
+              anolis8 \
               chromium \
               fedora \
               firefox \
@@ -193,6 +196,7 @@ jobs:
                 alinux2 \
                 alinux3 \
                 anolis23 \
+                anolis8 \
                 chromium \
                 fedora \
                 firefox \


### PR DESCRIPTION
Signed-off-by: YuQing yangyuqing6@qq.com
Signed-off-by: YiLin.Li YiLin.Li@linux.alibaba.com

Description:
.github/workflows/gate.yaml: Add anolis8 product.

Rationale:
Anolis OS 8 products have been merged before, this PR  is to fix the problem that there is no anolis8 in file .github/workflows/gate.yaml.