### PR TITLE
Enable remediations for sensitive rules

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_ol,multi_platform_fedora
 # reboot = true
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_ol,multi_platform_fedora
 
 {{{ bash_instantiate_variables("sshd_approved_ciphers") }}}
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_ol,multi_platform_fedora
 # reboot = true
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_ol,multi_platform_fedora
 
 {{{ bash_instantiate_variables("sshd_approved_ciphers") }}}
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_ol,multi_platform_fedora
 # reboot = true
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_ol,multi_platform_fedora
 
 {{{ bash_instantiate_variables("sshd_approved_macs") }}}
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_ol,multi_platform_fedora
 # reboot = true
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_ol,multi_platform_fedora
 
 {{{ bash_instantiate_variables("sshd_approved_macs") }}}
 


### PR DESCRIPTION
#### Description:

Rules that configure SSH ciphers/MACs have very tight remediations - they had a per-product granularity of prodtype. I have flipped the `multi_platform_rhel` on - those remediations are consistent with checks, and it doesn't make sense to have one, but not the another.

#### Rationale:

- Fixes #10664 

#### Review Hints:

- Superficial: Check the guides - remediations are there again!
- Thorough: Run tests for the rules - container won't do for some reason.