### PR TITLE
Add audit_rules_login_events_faillock to RHEL 8 STIG

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/rule.yml
@@ -65,9 +65,9 @@ ocil_clause: 'the command does not return a line, or the line is commented out'
 ocil: |-
     Verify {{{ full_name }}} generates audit records for all account creations, modifications, disabling, and termination events that affect "/etc/security/opasswd" with the following command:
 
-    $ sudo auditctl -l | grep /var/run/faillock
+    $ sudo auditctl -l | grep {{{ faillock_path }}}
 
-    -w /var/run/faillock -p wa -k logins
+    -w {{{ faillock_path }}} -p wa -k logins
 
 template:
     name: audit_rules_login_events

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -885,9 +885,7 @@ selections:
     - audit_rules_privileged_commands_kmod
 
     # RHEL-08-030590
-    # This one needs to be updated to use /var/log/faillock, but first RHEL-08-020017 should be
-    # implemented as it is the one that configures a different path for the events of failing locks
-    # - audit_rules_login_events_faillock
+    - audit_rules_login_events_faillock
 
     # RHEL-08-030600
     - audit_rules_login_events_lastlog

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -112,6 +112,7 @@ selections:
 - audit_rules_kernel_module_loading_delete
 - audit_rules_kernel_module_loading_finit
 - audit_rules_kernel_module_loading_init
+- audit_rules_login_events_faillock
 - audit_rules_login_events_lastlog
 - audit_rules_media_export
 - audit_rules_privileged_commands_chage

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -123,6 +123,7 @@ selections:
 - audit_rules_kernel_module_loading_delete
 - audit_rules_kernel_module_loading_finit
 - audit_rules_kernel_module_loading_init
+- audit_rules_login_events_faillock
 - audit_rules_login_events_lastlog
 - audit_rules_media_export
 - audit_rules_privileged_commands_chage


### PR DESCRIPTION
The selection of the rule audit_rules_login_events_faillock has been commented out with a comment that the RHEL-08-020017 needs to be implemented first. But, the RHEL-08-020017 is now implemented by rule accounts_passwords_pam_faillock_dir, which didn't exist before. Therefore, we can uncomment the rule selection.

The rule "accounts_passwords_pam_faillock_dir" sets the value of the `dir` configuration option to `/var/log/faillock` which is the value of the `faillock_path` product property. So, we only need to use the product property in the rule.yml.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2167999

