### PR TITLE
Add a test for rule journald_storage

### DIFF
--- a/linux_os/guide/system/logging/journald/journald_storage/tests/correct_value_in_quotes.fail.sh
+++ b/linux_os/guide/system/logging/journald/journald_storage/tests/correct_value_in_quotes.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# This scenario is a regression test for https://bugzilla.redhat.com/show_bug.cgi?id=2169857
+
+echo "Storage='persistent'" > "/etc/systemd/journald.conf"


### PR DESCRIPTION
This scenario is a regression test for https://bugzilla.redhat.com/show_bug.cgi?id=2169857

The bug has been fixed in https://github.com/ComplianceAsCode/content/pull/10790, but that PR doesn't add any test scenario.

Other testing is already done by templated test scenarios.