### PR TITLE
Prevent quoting issues in rule firewalld-backend

### DIFF
--- a/linux_os/guide/system/network/network-firewalld/firewalld-backend/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld-backend/rule.yml
@@ -55,3 +55,4 @@ template:
         path: /etc/firewalld/firewalld.conf
         parameter: FirewallBackend
         value: nftables
+        no_quotes: 'true'

--- a/linux_os/guide/system/network/network-firewalld/firewalld-backend/tests/extra_quotes.fail.sh
+++ b/linux_os/guide/system/network/network-firewalld/firewalld-backend/tests/extra_quotes.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+sed -i '/FirewallBackend/d' "/etc/firewalld/firewalld.conf"
+echo "FirewallBackend='nftables'" >> "/etc/firewalld/firewalld.conf"


### PR DESCRIPTION
We will set the no_quotes parameter of the template to avoid issues that can be caused by extra quotes in the configuration file.

For example, setting `CleanupOnExit='no'` causes this problem:

```
Jul 11 10:22:20 fedora firewalld[117694]: WARNING: CleanupOnExit ''no'' is not valid, using default value True
```

The default for the `FirewallBackend` option is `nftables`, adding quotes will not cause a problem, until firewalld decides in future to change the defaults.

```
Jul 11 10:25:18 fedora firewalld[118127]: WARNING: FirewallBackend ''nftables'' is not valid, using default value nftables
```

We have seen similar things with journald rules, where it actually caused troubles, check:
https://bugzilla.redhat.com/show_bug.cgi?id=2193169
