### PR TITLE
Update OL8 hipaa profile

### DIFF
--- a/products/ol8/profiles/hipaa.profile
+++ b/products/ol8/profiles/hipaa.profile
@@ -54,6 +54,8 @@ selections:
     - service_xinetd_disabled
     - service_zebra_disabled
     - use_kerberos_security_all_exports
+    - var_authselect_profile=sssd
+    - enable_authselect
     - disable_host_auth
     - sshd_allow_only_protocol2
     - sshd_disable_compression


### PR DESCRIPTION
#### Description:

- Add rule `enable_authselect` to OL8 hippa profile

#### Rationale:

- Harden this profile with this kind of new rule

#### Review Hints:

- This doesn't affect any functionality, only updates rule selection in one profile in OL8