### PR TITLE
pam_faillock rules: show XCCDF variables in rule description

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
@@ -7,9 +7,19 @@ title: 'Lock Accounts After Failed Password Attempts'
 description: |-
     This rule configures the system to lock out accounts after a number of incorrect login attempts
     using <tt>pam_faillock.so</tt>.
-
     pam_faillock.so module requires multiple entries in pam files. These entries must be carefully
     defined to work as expected.
+    {{% if product in ["rhel7"] %}}
+    Ensure that pam_faillock.so module entries in
+    <tt>/etc/pam.d/password-auth</tt> and <tt>/etc/pam.d/system-auth</tt> are
+    followed by the assignment <tt>deny=&lt;count&gt;</tt> where count should be less than or equal to 
+    {{{xccdf_value("var_accounts_passwords_pam_faillock_deny") }}} and greater than 0.
+    {{% else %}}
+    Ensure that the file <tt>/etc/security/faillock.conf</tt> contains the following entry:
+    <tt>deny = &lt;count&gt;</tt>
+    Where count should be less than or equal to 
+    {{{ xccdf_value("var_accounts_passwords_pam_faillock_deny") }}} and greater than 0.
+    {{% endif %}}
     {{% if 'ubuntu' not in product %}}
     In order to avoid errors when manually editing these files, it is
     recommended to use the appropriate tools, such as <tt>authselect</tt> or <tt>authconfig</tt>,

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/rule.yml
@@ -16,6 +16,8 @@ description: |-
     recommended to use the appropriate tools, such as <tt>authselect</tt> or <tt>authconfig</tt>,
     depending on the OS version.
 
+    The chosen profile expects the directory to be <tt>{{{ xccdf_value("var_accounts_passwords_pam_faillock_dir") }}}</tt>.
+
 rationale: |-
     Locking out user accounts after a number of incorrect attempts prevents direct password
     guessing attacks. In combination with the <tt>silent</tt> option, user enumeration attacks

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
@@ -8,6 +8,21 @@ description: |-
     Utilizing <tt>pam_faillock.so</tt>, the <tt>fail_interval</tt> directive configures the system
     to lock out an account after a number of incorrect login attempts within a specified time
     period.
+    {{% if product in ["rhel7"] %}}
+    Ensure that pam_faillock.so module entries in
+    <tt>/etc/pam.d/password-auth</tt> and <tt>/etc/pam.d/system-auth</tt> are
+    followed by the assignment
+    <tt>fail_interval=&lt;interval-in-seconds&gt;</tt> where
+    <tt>interval-in-seconds</tt> is <tt>{{{xccdf_value("var_accounts_passwords_pam_faillock_fail_interval") }}}</tt> or greater.
+    {{% else %}}
+    Ensure that the file <tt>/etc/security/faillock.conf</tt> contains the following entry:
+    <tt>fail_interval = &lt;interval-in-seconds&gt;</tt> where <tt>interval-in-seconds</tt> is <tt>{{{ xccdf_value("var_accounts_passwords_pam_faillock_fail_interval") }}}</tt> or greater.
+    {{% endif %}}
+    {{% if 'ubuntu' not in product %}}
+    In order to avoid errors when manually editing these files, it is
+    recommended to use the appropriate tools, such as <tt>authselect</tt> or <tt>authconfig</tt>,
+    depending on the OS version.
+    {{% endif %}}
 
 rationale: |-
     By limiting the number of failed logon attempts the risk of unauthorized system

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
@@ -8,6 +8,18 @@ description: |-
     This rule configures the system to lock out accounts during a specified time period after a
     number of incorrect login attempts using <tt>pam_faillock.so</tt>.
 
+    {{% if product in ["rhel7"] %}}
+    Ensure that pam_faillock.so module entries in
+    <tt>/etc/pam.d/password-auth</tt> and <tt>/etc/pam.d/system-auth</tt> are
+    followed by the assignment
+    <tt>unlock_time=&lt;interval-in-seconds&gt;</tt> where
+    <tt>interval-in-seconds</tt> is <tt>{{{xccdf_value("var_accounts_passwords_pam_faillock_unlock_time") }}}</tt> or greater.
+    {{% else %}}
+    Ensure that the file <tt>/etc/security/faillock.conf</tt> contains the following entry:
+    <tt>unlock_time=&lt;interval-in-seconds&gt;</tt> where
+    <tt>interval-in-seconds</tt> is <tt>{{{xccdf_value("var_accounts_passwords_pam_faillock_unlock_time") }}}</tt> or greater.
+    {{% endif %}}
+
     pam_faillock.so module requires multiple entries in pam files. These entries must be carefully
     defined to work as expected. In order to avoid any errors when manually editing these files,
     it is recommended to use the appropriate tools, such as <tt>authselect</tt> or <tt>authconfig</tt>,


### PR DESCRIPTION
#### Description:

Modify following rules so that XCCDF variable which is used in their checks and remediations is displayed in the description:

- accounts_passwords_pam_faillock_deny
- accounts_passwords_pam_faillock_interval
- accounts_passwords_pam_faillock_dir
- accounts_passwords_pam_faillock_unlock_time

#### Rationale:

It improves customer experience. Previously, when reading the guide, an administrator could not find out what configuration value is actually correct.

#### Review Hints:

1. ./build_product rhel7 rhel8 rhel9
2. review HTML guides and verify that the appropriate variable is shown in the description section. I recommend reviewing the STIG guide.
