### PR TITLE
Check only local users home directories

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/oval/shared.xml
@@ -7,19 +7,21 @@
     </criteria>
   </definition>
 
-  {{%- set interactive_users_object = "object_" ~ rule_id ~ "_objects" -%}}
-  {{{ create_interactive_users_list_object(interactive_users_object) }}}
+  {{%- set interactive_users_home_dirs_object = "object_" ~ rule_id ~ "_home_dirs" -%}}
+  {{{ create_local_interactive_users_home_dirs_list_object(interactive_users_home_dirs_object) }}}
+  {{%- set interactive_users_gids_object = "object_" ~ rule_id ~ "_gids" -%}}
+  {{{ create_local_interactive_users_gids_list_object(interactive_users_gids_object) }}}
 
   <local_variable id="var_accounts_user_dot_group_ownership_dirs" datatype="string" version="1"
                   comment="Variable including all home dirs from interactive users">
-    <object_component item_field="home_dir"
-                      object_ref="{{{ interactive_users_object }}}"/>
+    <object_component item_field="subexpression"
+                      object_ref="{{{ interactive_users_home_dirs_object }}}"/>
   </local_variable>
 
   <local_variable id="var_accounts_user_dot_group_ownership_gids" datatype="int" version="1"
                   comment="List of interactive users gids">
-    <object_component item_field="group_id"
-                      object_ref="{{{ interactive_users_object }}}"/>
+    <object_component item_field="subexpression"
+                      object_ref="{{{ interactive_users_gids_object }}}"/>
   </local_variable>
 
   <!-- #### creation of object #### -->

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/oval/shared.xml
@@ -7,19 +7,21 @@
     </criteria>
   </definition>
 
-  {{%- set interactive_users_object = "object_" ~ rule_id ~ "_objects" -%}}
-  {{{ create_interactive_users_list_object(interactive_users_object) }}}
+  {{%- set interactive_users_home_dirs_object = "object_" ~ rule_id ~ "_home_dirs" -%}}
+  {{{ create_local_interactive_users_home_dirs_list_object(interactive_users_home_dirs_object) }}}
+  {{%- set interactive_users_uids_object = "object_" ~ rule_id ~ "_uids" -%}}
+  {{{ create_local_interactive_users_uids_list_object(interactive_users_uids_object) }}}
 
   <local_variable id="var_accounts_user_dot_user_ownership_dirs" datatype="string" version="1"
                   comment="Variable including all home dirs from interactive users">
-    <object_component item_field="home_dir"
-                      object_ref="{{{ interactive_users_object }}}"/>
+    <object_component item_field="subexpression"
+                      object_ref="{{{ interactive_users_home_dirs_object }}}"/>
   </local_variable>
 
   <local_variable id="var_accounts_user_dot_user_ownership_uids" datatype="int" version="1"
                   comment="List of interactive users uids">
-    <object_component item_field="user_id"
-                      object_ref="{{{ interactive_users_object }}}"/>
+    <object_component item_field="subexpression"
+                      object_ref="{{{ interactive_users_uids_object }}}"/>
   </local_variable>
 
   <!-- #### creation of object #### -->

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/oval/shared.xml
@@ -10,13 +10,13 @@
   </definition>
 
   {{%- set interactive_users_object = "object_" ~ rule_id ~ "_objects" -%}}
-  {{{ create_interactive_users_list_object(interactive_users_object) }}}
+  {{{ create_local_interactive_users_home_dirs_list_object(interactive_users_object) }}}
 
   <!-- #### create a local variable composed by the list of home dirs from /etc/passwd #### -->
   <local_variable id="var_accounts_user_interactive_home_directory_exists_dirs_list"
                   datatype="string" version="1"
                   comment="Variable including all home dirs from interactive users">
-    <object_component item_field="home_dir"
+    <object_component item_field="subexpression"
                       object_ref="{{{ interactive_users_object }}}"/>
   </local_variable>
 

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/rule.yml
@@ -5,7 +5,7 @@ prodtype: alinux2,alinux3,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15,
 title: 'All Interactive Users Home Directories Must Exist'
 
 description: |-
-    Create home directories to all interactive users that currently do not
+    Create home directories to all local interactive users that currently do not
     have a home directory assigned. Use the following commands to create the user
     home directory assigned in <tt>/etc/passwd</tt>:
     <pre>$ sudo mkdir /home/<i>USER</i></pre>

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/oval/shared.xml
@@ -7,19 +7,21 @@
     </criteria>
   </definition>
 
-  {{%- set interactive_users_object = "object_" ~ rule_id ~ "_objects" -%}}
-  {{{ create_interactive_users_list_object(interactive_users_object) }}}
+  {{%- set interactive_users_home_dirs_object = "object_" ~ rule_id ~ "_home_dirs" -%}}
+  {{{ create_local_interactive_users_home_dirs_list_object(interactive_users_home_dirs_object) }}}
+  {{%- set interactive_users_gids_object = "object_" ~ rule_id ~ "_gids" -%}}
+  {{{ create_local_interactive_users_gids_list_object(interactive_users_gids_object) }}}
 
   <local_variable id="var_accounts_users_home_files_groupownership_dirs" datatype="string" version="1"
                   comment="Variable including all home dirs from interactive users">
-    <object_component item_field="home_dir"
-                      object_ref="{{{ interactive_users_object }}}"/>
+    <object_component item_field="subexpression"
+                      object_ref="{{{ interactive_users_home_dirs_object }}}"/>
   </local_variable>
 
   <local_variable id="var_accounts_users_home_files_groupownership_gids" datatype="int" version="1"
                   comment="List of interactive users gids">
-    <object_component item_field="group_id"
-                      object_ref="{{{ interactive_users_object }}}"/>
+    <object_component item_field="subexpression"
+                      object_ref="{{{ interactive_users_gids_object }}}"/>
   </local_variable>
 
   <!-- #### creation of object #### -->

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/oval/shared.xml
@@ -7,17 +7,20 @@
     </criteria>
   </definition>
 
-  {{%- set interactive_users_object = "object_" ~ rule_id ~ "_objects" -%}}
-  {{{ create_interactive_users_list_object(interactive_users_object) }}}
+  {{%- set interactive_users_home_dirs_object = "object_" ~ rule_id ~ "_home_dirs" -%}}
+  {{{ create_local_interactive_users_home_dirs_list_object(interactive_users_home_dirs_object) }}}
+  {{%- set interactive_users_uids_object = "object_" ~ rule_id ~ "_uids" -%}}
+  {{{ create_local_interactive_users_uids_list_object(interactive_users_uids_object) }}}
+
 
   <local_variable id="var_accounts_users_home_files_ownership_dirs" datatype="string" version="1"
                   comment="Variable including all home dirs from interactive users">
-    <object_component item_field="home_dir" object_ref="{{{ interactive_users_object }}}"/>
+    <object_component item_field="subexpression" object_ref="{{{ interactive_users_home_dirs_object }}}"/>
   </local_variable>
 
   <local_variable id="var_accounts_users_home_files_ownership_uids" datatype="int" version="1"
                   comment="List of interactive users uids">
-    <object_component item_field="user_id" object_ref="{{{ interactive_users_object }}}"/>
+    <object_component item_field="subexpression" object_ref="{{{ interactive_users_uids_object }}}"/>
   </local_variable>
 
   <!-- #### creation of object #### -->

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_permissions/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_permissions/oval/shared.xml
@@ -9,13 +9,13 @@
     </criteria>
   </definition>
 
-  {{%- set interactive_users_object = "object_" ~ rule_id ~ "_objects" -%}}
-  {{{ create_interactive_users_list_object(interactive_users_object) }}}
+  {{%- set interactive_users_home_dirs_object = "object_" ~ rule_id ~ "_home_dirs" -%}}
+  {{{ create_local_interactive_users_home_dirs_list_object(interactive_users_home_dirs_object) }}}
 
   <!-- #### prepare for test_file_permissions_home_directories #### -->
   <local_variable id="var_accounts_users_home_files_permissions_dirs" datatype="string" version="1"
                   comment="Variable including all home dirs from interactive users">
-    <object_component item_field="home_dir" object_ref="{{{ interactive_users_object }}}"/>
+    <object_component item_field="subexpression" object_ref="{{{ interactive_users_home_dirs_object }}}"/>
   </local_variable>
   <!-- #### creation of object #### -->
   <unix:file_object id="object_accounts_users_home_files_permissions_dirs" version="1">

--- a/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/oval/shared.xml
@@ -7,18 +7,20 @@
     </criteria>
   </definition>
 
-  {{%- set interactive_users_object = "object_" ~ rule_id ~ "_objects" -%}}
-  {{{ create_interactive_users_list_object(interactive_users_object) }}}
+  {{%- set interactive_users_home_dirs_object = "object_" ~ rule_id ~ "_home_dirs" -%}}
+  {{{ create_local_interactive_users_home_dirs_list_object(interactive_users_home_dirs_object) }}}
+  {{%- set interactive_users_gids_object = "object_" ~ rule_id ~ "_gids" -%}}
+  {{{ create_local_interactive_users_gids_list_object(interactive_users_gids_object) }}}
 
   <!-- #### prepare for test_file_groupownership_home_directories #### -->
   <local_variable id="var_file_groupownership_home_directories_dirs" datatype="string" version="1"
                   comment="Variable including all home dirs from primary interactive groups">
-    <object_component item_field="home_dir" object_ref="{{{ interactive_users_object }}}"/>
+    <object_component item_field="subexpression" object_ref="{{{ interactive_users_home_dirs_object  }}}"/>
   </local_variable>
 
   <local_variable id="var_file_groupownership_home_directories_gids" datatype="int" version="1"
                   comment="Variable including all gids from primary interactive group">
-    <object_component item_field="group_id" object_ref="{{{ interactive_users_object }}}"/>
+    <object_component item_field="subexpression" object_ref="{{{ interactive_users_gids_object }}}"/>
   </local_variable>
 
   <!-- #### creation of object #### -->

--- a/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/oval/shared.xml
@@ -13,8 +13,10 @@
     </criteria>
   </definition>
 
-  {{%- set interactive_users_object = "object_" ~ rule_id ~ "_objects" -%}}
-  {{{ create_interactive_users_list_object(interactive_users_object) }}}
+  {{%- set interactive_users_home_dirs_object = "object_" ~ rule_id ~ "_home_dirs" -%}}
+  {{{ create_local_interactive_users_home_dirs_list_object(interactive_users_home_dirs_object) }}}
+  {{%- set interactive_users_uids_object = "object_" ~ rule_id ~ "_uids" -%}}
+  {{{ create_local_interactive_users_uids_list_object(interactive_users_uids_object) }}}
 
   <!-- 
     #### prepare for test_file_groupownership_home_directories ####
@@ -22,7 +24,7 @@
   -->
   <local_variable id="var_file_ownership_home_directories_dirs" datatype="string" version="1"
                   comment="Variable including all home dirs from interactive users">
-    <object_component item_field="home_dir" object_ref="{{{ interactive_users_object }}}"/>
+    <object_component item_field="subexpression" object_ref="{{{ interactive_users_home_dirs_object }}}"/>
   </local_variable>
 
   <!-- 
@@ -30,7 +32,7 @@
   -->
   <local_variable id="var_file_ownership_home_directories_uids" datatype="int" version="1"
                   comment="List of interactive users uids">
-    <object_component item_field="user_id" object_ref="{{{ interactive_users_object }}}"/>
+    <object_component item_field="subexpression" object_ref="{{{ interactive_users_uids_object }}}"/>
   </local_variable>
 
   <!-- 

--- a/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/oval/shared.xml
@@ -8,12 +8,12 @@
   </definition>
 
   {{%- set interactive_users_object = "object_" ~ rule_id ~ "_objects" -%}}
-  {{{ create_interactive_users_list_object(interactive_users_object) }}}
+  {{{ create_local_interactive_users_home_dirs_list_object(interactive_users_object) }}}
 
   <!-- #### prepare for test_file_permissions_home_directories #### -->
   <local_variable id="var_file_permissions_home_directories_dirs" datatype="string" version="1"
                   comment="Variable including all home dirs from interactive users">
-    <object_component item_field="home_dir" object_ref="{{{ interactive_users_object }}}"/>
+    <object_component item_field="subexpression" object_ref="{{{ interactive_users_object }}}"/>
   </local_variable>
 
   <!-- #### creation of object #### -->

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/oval/shared.xml
@@ -8,11 +8,11 @@
   </definition>
 
   {{%- set interactive_users_object = "object_" ~ rule_id ~ "_objects" -%}}
-  {{{ create_interactive_users_list_object(interactive_users_object) }}}
+  {{{ create_local_interactive_users_home_dirs_list_object(interactive_users_object) }}}
 
   <local_variable id="var_accounts_umask_interactive_users_dirs" datatype="string" version="1"
                   comment="Variable including all home dirs from interactive users">
-    <object_component item_field="home_dir"
+    <object_component item_field="subexpression"
                       object_ref="{{{ interactive_users_object }}}"/>
   </local_variable>
 

--- a/shared/macros/10-oval.jinja
+++ b/shared/macros/10-oval.jinja
@@ -1077,8 +1077,9 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
 
 
 {{#
-  Extract from /etc/passwd a list composed of password objects related to non-system UIDs.
+  Extract from system password database a list composed of password objects related to non-system UIDs.
   This list is then filtered to exclude some special usernames and users with /sbin/nologin shell.
+  The list includes non-local (LDAP) users, because the implementation of "unix:password_object" in OpenSCAP makes use of getpwent(), which browses all users provided by the NSS.
 
   The macro receives a string as parameter, which is used as the password_object id in the rule.
 
@@ -1109,6 +1110,51 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
   </unix:password_state>
 {{%- endmacro %}}
 
+{{#
+  Extract from /etc/passwd a list of home directories of local interactive users.
+  The list contains only items related to non-system UIDs and is filtered to exclude some special usernames and users with /sbin/nologin shell.
+
+  Unlike macro create_interactive_users_list_object, this macro gives list that contains only local users, because it doesn't use the OVAL "unix:password_object" element, but it merely parses /etc/passwd using "ind:textfilecontent54_object".
+
+  The macro receives a string as parameter, which is used as the textfilecontent54_object ID in the rule.
+
+:param object_id: Object ID to be created.
+:type object_id: str
+
+#}}
+{{%- macro create_local_interactive_users_home_dirs_list_object(object_id) -%}}
+
+  <!-- OVAL object to collect home directories of local interactive users -->
+  <ind:textfilecontent54_object id="{{{ object_id }}}" version="1">
+    <ind:filepath>/etc/passwd</ind:filepath>
+    <!-- Home directories from /etc/passwd (6th column) captured as subexpression of this object -->
+    <ind:pattern operation="pattern match" var_ref="variable_{{{ rule_id }}}_local_interactive_users_regex" var_check="at least one"/>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+
+  <local_variable id="variable_{{{ rule_id }}}_local_interactive_users_regex" datatype="int" version="1" comment="usernames rows retrieved from /etc/passwd">
+    <concat>
+      <literal_component>^(?:</literal_component>
+      <object_component item_field="subexpression" object_ref="object_{{{ rule_id }}}_local_interactive_users" />
+      <literal_component>:)(?:[^:]*:){4}([^:]+):[^:]*$</literal_component>
+    </concat>
+  </local_variable>
+
+  <!-- OVAL object to collect user names of local interactive users -->
+  <ind:textfilecontent54_object id="object_{{{ rule_id }}}_local_interactive_users" version="1">
+    <ind:filepath>/etc/passwd</ind:filepath>
+    <ind:pattern operation="pattern match">^([^:]*):[^:]*:\d{4,}:(?:[^:]*:){3}(?!\/sbin\/nologin)[^:]*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    <filter action="exclude">state_{{{ rule_id }}}_users_ignored</filter>
+  </ind:textfilecontent54_object>
+
+  {{%- set ignored_users_list="(nobody|nfsnobody)" %}}
+  <ind:textfilecontent54_state id="state_{{{ rule_id }}}_users_ignored" version="1">
+    <ind:subexpression operation="pattern match">^{{{ ignored_users_list }}}$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+{{%- endmacro %}}
 
 {{#
   Extract from /etc/passwd a list composed of password objects related to system UIDs.

--- a/shared/macros/10-oval.jinja
+++ b/shared/macros/10-oval.jinja
@@ -1111,6 +1111,55 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
 {{%- endmacro %}}
 
 {{#
+  Extract from /etc/passwd a list of specified fields of local interactive users.
+  The list contains only items related to non-system UIDs and is filtered to exclude some special usernames and users with /sbin/nologin shell.
+
+  Unlike macro create_interactive_users_list_object, this macro gives list that contains only local users, because it doesn't use the OVAL "unix:password_object" element, but it merely parses /etc/passwd using "ind:textfilecontent54_object".
+
+  The macro receives a string as parameter, which is used as the textfilecontent54_object ID in the rule.
+
+:param object_id: Object ID to be created.
+:type object_id: str
+:param second_literal_component_regex: regex in the second literal_component of the concat element of the local variable that forms the regex describing an username row
+:type second_literal_component_regex: str
+
+#}}
+{{%- macro create_local_interactive_users_object(object_id, second_literal_component_regex) -%}}
+
+
+  <!-- OVAL object to collect home directories of local interactive users -->
+  <ind:textfilecontent54_object id="{{{ object_id }}}" version="1">
+    <ind:filepath>/etc/passwd</ind:filepath>
+    <!-- Home directories from /etc/passwd (6th column) captured as subexpression of this object -->
+    <ind:pattern operation="pattern match" var_ref="variable_{{{ object_id }}}_regex" var_check="at least one"/>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+
+  <local_variable id="variable_{{{ object_id }}}_regex" datatype="string" version="1" comment="usernames rows retrieved from /etc/passwd">
+    <concat>
+      <literal_component>^(?:</literal_component>
+      <object_component item_field="subexpression" object_ref="{{{ object_id }}}_local_interactive_users" />
+      <literal_component>{{{ second_literal_component_regex }}}</literal_component>
+    </concat>
+  </local_variable>
+
+  <!-- OVAL object to collect user names of local interactive users -->
+  <ind:textfilecontent54_object id="{{{ object_id }}}_local_interactive_users" version="1">
+    <ind:filepath>/etc/passwd</ind:filepath>
+    <ind:pattern operation="pattern match">^([^:]*):[^:]*:\d{4,}:(?:[^:]*:){3}(?!\/sbin\/nologin)[^:]*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    <filter action="exclude">state_{{{ object_id }}}_users_ignored</filter>
+  </ind:textfilecontent54_object>
+
+  {{%- set ignored_users_list="(nobody|nfsnobody)" %}}
+  <ind:textfilecontent54_state id="state_{{{ object_id }}}_users_ignored" version="1">
+    <ind:subexpression operation="pattern match">^{{{ ignored_users_list }}}$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+{{%- endmacro %}}
+
+{{#
   Extract from /etc/passwd a list of home directories of local interactive users.
   The list contains only items related to non-system UIDs and is filtered to exclude some special usernames and users with /sbin/nologin shell.
 
@@ -1123,37 +1172,47 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
 
 #}}
 {{%- macro create_local_interactive_users_home_dirs_list_object(object_id) -%}}
-
-  <!-- OVAL object to collect home directories of local interactive users -->
-  <ind:textfilecontent54_object id="{{{ object_id }}}" version="1">
-    <ind:filepath>/etc/passwd</ind:filepath>
-    <!-- Home directories from /etc/passwd (6th column) captured as subexpression of this object -->
-    <ind:pattern operation="pattern match" var_ref="variable_{{{ rule_id }}}_local_interactive_users_regex" var_check="at least one"/>
-    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
-  </ind:textfilecontent54_object>
+{{{ create_local_interactive_users_object(
+  object_id=object_id,
+  second_literal_component_regex="):(?:[^:]*:){4}([^:]+):[^:]*$") }}}
+{{%- endmacro %}}
 
 
-  <local_variable id="variable_{{{ rule_id }}}_local_interactive_users_regex" datatype="string" version="1" comment="usernames rows retrieved from /etc/passwd">
-    <concat>
-      <literal_component>^(?:</literal_component>
-      <object_component item_field="subexpression" object_ref="object_{{{ rule_id }}}_local_interactive_users" />
-      <literal_component>:)(?:[^:]*:){4}([^:]+):[^:]*$</literal_component>
-    </concat>
-  </local_variable>
+{{#
+  Extract from /etc/passwd a list of User IDs of local interactive users.
+  The list contains only items related to non-system UIDs and is filtered to exclude some special usernames and users with /sbin/nologin shell.
 
-  <!-- OVAL object to collect user names of local interactive users -->
-  <ind:textfilecontent54_object id="object_{{{ rule_id }}}_local_interactive_users" version="1">
-    <ind:filepath>/etc/passwd</ind:filepath>
-    <ind:pattern operation="pattern match">^([^:]*):[^:]*:\d{4,}:(?:[^:]*:){3}(?!\/sbin\/nologin)[^:]*$</ind:pattern>
-    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
-    <filter action="exclude">state_{{{ rule_id }}}_users_ignored</filter>
-  </ind:textfilecontent54_object>
+  Unlike macro create_interactive_users_list_object, this macro gives list that contains only local users, because it doesn't use the OVAL "unix:password_object" element, but it merely parses /etc/passwd using "ind:textfilecontent54_object".
 
-  {{%- set ignored_users_list="(nobody|nfsnobody)" %}}
-  <ind:textfilecontent54_state id="state_{{{ rule_id }}}_users_ignored" version="1">
-    <ind:subexpression operation="pattern match">^{{{ ignored_users_list }}}$</ind:subexpression>
-  </ind:textfilecontent54_state>
+  The macro receives a string as parameter, which is used as the textfilecontent54_object ID in the rule.
 
+:param object_id: Object ID to be created.
+:type object_id: str
+
+#}}
+{{%- macro create_local_interactive_users_uids_list_object(object_id) -%}}
+{{{ create_local_interactive_users_object(
+  object_id=object_id,
+  second_literal_component_regex=":)(?:[^:]*:)([^:]+):(?:[^:]*:){3}[^:]*$") }}}
+{{%- endmacro %}}
+
+
+{{#
+  Extract from /etc/passwd a list of Group IDs of local interactive users.
+  The list contains only items related to non-system UIDs and is filtered to exclude some special usernames and users with /sbin/nologin shell.
+
+  Unlike macro create_interactive_users_list_object, this macro gives list that contains only local users, because it doesn't use the OVAL "unix:password_object" element, but it merely parses /etc/passwd using "ind:textfilecontent54_object".
+
+  The macro receives a string as parameter, which is used as the textfilecontent54_object ID in the rule.
+
+:param object_id: Object ID to be created.
+:type object_id: str
+
+#}}
+{{%- macro create_local_interactive_users_gids_list_object(object_id) -%}}
+{{{ create_local_interactive_users_object(
+  object_id=object_id,
+  second_literal_component_regex=":)(?:[^:]*:){2}([^:]+):(?:[^:]*:){2}[^:]*$") }}}
 {{%- endmacro %}}
 
 {{#

--- a/shared/macros/10-oval.jinja
+++ b/shared/macros/10-oval.jinja
@@ -1147,6 +1147,12 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
   <!-- OVAL object to collect user names of local interactive users -->
   <ind:textfilecontent54_object id="{{{ object_id }}}_local_interactive_users" version="1">
     <ind:filepath>/etc/passwd</ind:filepath>
+    <!-- The regex matches only user entries with UID greater than or
+      equal 1000. The users whose UID is greater than or equal 1000 are
+      considered interactive users. This is achieved by ':\d{4,}:' in the
+      regular expression which ensures that the third field in the entry
+      contains at least 4 digits (or more) and therefore the regular
+      expression doesn't match entries with values 999 or less. -->
     <ind:pattern operation="pattern match">^([^:]*):[^:]*:\d{4,}:(?:[^:]*:){3}(?!\/sbin\/nologin)[^:]*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
     <filter action="exclude">state_{{{ object_id }}}_users_ignored</filter>

--- a/shared/macros/10-oval.jinja
+++ b/shared/macros/10-oval.jinja
@@ -1133,7 +1133,7 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
   </ind:textfilecontent54_object>
 
 
-  <local_variable id="variable_{{{ rule_id }}}_local_interactive_users_regex" datatype="int" version="1" comment="usernames rows retrieved from /etc/passwd">
+  <local_variable id="variable_{{{ rule_id }}}_local_interactive_users_regex" datatype="string" version="1" comment="usernames rows retrieved from /etc/passwd">
     <concat>
       <literal_component>^(?:</literal_component>
       <object_component item_field="subexpression" object_ref="object_{{{ rule_id }}}_local_interactive_users" />


### PR DESCRIPTION
The rule `accounts_user_interactive_home_directory_exists` states in rationale that we need to ensure that home directories of interactive users exist. The text indicates that this requirement is relevant to local interactive users.

However, the current implementation of the OVAL check uses the `unix:password_object` element, which also returns non-local (LDAP) users, because the implementation of OpenSCAP makes use of the `getpwent()` system call, which browses all users provides by the NSS.

In this commit, we will change the implementation so that only local interactive users will be considered. We will achieve this by parsing the data directly from `/etc/passwd` using the OVAL `ind:textfilecontent54_object` instead of using the `unix:password_object`.

Also, the rule description is clarified.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2203791


Then, a similar change has been done also in these rules:

-  accounts_users_home_files_groupownership
-  accounts_user_dot_group_ownership
-  accounts_users_home_files_permissions
-  accounts_umask_interactive_users
-  accounts_user_dot_user_ownership 
-  file_permissions_home_directories
-  file_groupownership_home_directories
-  file_ownership_home_directories
-  accounts_users_home_files_ownership

