### PR TITLE
Remove deprecated rules from STIG control file for RHEL9

### DIFF
--- a/controls/srg_gpos/SRG-OS-000021-GPOS-00005.yml
+++ b/controls/srg_gpos/SRG-OS-000021-GPOS-00005.yml
@@ -18,6 +18,4 @@ controls:
             - account_password_pam_faillock_system_auth
             - account_password_pam_faillock_password_auth
             - audit_rules_login_events_faillock
-            - account_passwords_pam_faillock_audit
-            - account_passwords_pam_faillock_dir
         status: automated

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/rule.yml
@@ -17,7 +17,6 @@ identifiers:
 references:
     disa: CCI-000044
     nist: AC-7 (a)
-    srg: SRG-OS-000021-GPOS-00005
 
 ocil_clause: 'the "audit" option is not set, is missing or commented out'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_dir/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_dir/rule.yml
@@ -18,7 +18,6 @@ identifiers:
 references:
     disa: CCI-000044 
     nist: 'AC-7 (ia)'
-    srg: SRG-OS-000021-GPOS-00005
 
 ocil_clause: 'the "dir" option is not set to a non-default documented tally log directory, is missing or commented out'
 


### PR DESCRIPTION
#### Description:

Some rules related to `pam_faillock.so` were defined twice in `SRG-OS-000021-GPOS-00005.yml` while some were already deprecated in favor of other already defined in the same file.

#### Rationale:

Polish STIG for RHEL9
Cleanup

#### Review Hints:

1. ./build_product rhel9
2. Review the STIG HTML guides for RHEL9