### PR TITLE
configure_openssl_cryptopolicy: align remediations with rule description

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/ansible/shared.yml
@@ -3,10 +3,12 @@
 # strategy = unknown
 # complexity = low
 # disruption = medium
+
+{{% set openssl_cnf_file="openssl.cnf" %}}
 {{% if 'sle' in product %}}
-  {{% set openssl_cnf_path="/etc/ssl/openssl.cnf" %}}
+  {{% set openssl_cnf_dir="/etc/ssl" %}}
 {{% else %}}
-  {{%- set openssl_cnf_path="/etc/pki/tls/openssl.cnf" %}}
+  {{%- set openssl_cnf_dir="/etc/pki/tls" %}}
 {{% endif %}}
 
 {{% if product in ["fedora", "ol9", "rhel9"] %}}
@@ -17,28 +19,34 @@
 {{% set full_config_section = "[crypto_policy]\n" + ansible_openssl_include_directive %}}
 
 
-- name: "Test for crypto_policy group"
-  command: grep '^\s*\[\s*crypto_policy\s*]' {{{ openssl_cnf_path }}}
+- name: "{{{ rule_title }}} - Test for crypto_policy group"
+  ansible.builtin.find:
+    paths: "{{{ openssl_cnf_dir }}}"
+    patterns: "{{{ openssl_cnf_file }}}"
+    contains: '^\s*\[\s*crypto_policy\s*]'
   register: test_crypto_policy_group
-  failed_when: test_crypto_policy_group.rc not in [0, 1]
-  changed_when: False
-  check_mode: no
 
-- name: "Add .include for opensslcnf.config to crypto_policy section"
-  lineinfile:
+- name: "{{{ rule_title }}} - test for crypto policy section together with include directive"
+  ansible.builtin.find:
+    paths: "{{{ openssl_cnf_dir }}}"
+    patterns: "{{{ openssl_cnf_file }}}"
+    contains: '^\s*\.include\s*(?:=\s*)?/etc/crypto-policies/back-ends/opensslcnf.config$'
+  register: test_crypto_policy_include_directive
+
+- name: "{{ rule_title }} - Add .include for opensslcnf.config to crypto_policy section"
+  ansible.builtin.lineinfile:
     create: yes
     insertafter: '^\s*\[\s*crypto_policy\s*]\s*'
     line: {{{ ansible_openssl_include_directive }}}
-    path: {{{ openssl_cnf_path }}}
+    path: "{{{ openssl_cnf_dir }}}/{{{ openssl_cnf_file }}}"
   when:
-    - test_crypto_policy_group.stdout is defined
-    - test_crypto_policy_group.stdout | length > 0
+    - test_crypto_policy_group.matched > 0
+    - test_crypto_policy_include_directive.matched == 0
 
-- name: "Add crypto_policy group and set include opensslcnf.config"
-  lineinfile:
+- name: "{{{ rule_title }}} - Add crypto_policy group and set include opensslcnf.config"
+  ansible.builtin.lineinfile:
     create: yes
     line: "[crypto_policy]\n{{{ ansible_openssl_include_directive }}}"
-    path: {{{ openssl_cnf_path }}}
+    path: "{{{ openssl_cnf_dir }}}/{{{ openssl_cnf_file }}}"
   when:
-    - test_crypto_policy_group.stdout is defined
-    - test_crypto_policy_group.stdout | length < 1
+    - test_crypto_policy_group.matched == 0

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/ansible/shared.yml
@@ -19,21 +19,21 @@
 {{% set full_config_section = "[crypto_policy]\n" + ansible_openssl_include_directive %}}
 
 
-- name: "{{{ rule_title }}} - Test for crypto_policy group"
+- name: "{{{ rule_title }}} - Search for crypto_policy Section"
   ansible.builtin.find:
     paths: "{{{ openssl_cnf_dir }}}"
     patterns: "{{{ openssl_cnf_file }}}"
     contains: '^\s*\[\s*crypto_policy\s*]'
   register: test_crypto_policy_group
 
-- name: "{{{ rule_title }}} - test for crypto policy section together with include directive"
+- name: "{{{ rule_title }}} - Search for crypto_policy Section Together With .include Directive"
   ansible.builtin.find:
     paths: "{{{ openssl_cnf_dir }}}"
     patterns: "{{{ openssl_cnf_file }}}"
     contains: '^\s*\.include\s*(?:=\s*)?/etc/crypto-policies/back-ends/opensslcnf.config$'
   register: test_crypto_policy_include_directive
 
-- name: "{{ rule_title }} - Add .include for opensslcnf.config to crypto_policy section"
+- name: "{{ rule_title }} - Add .include Line for opensslcnf.config File in crypto_policy Section"
   ansible.builtin.lineinfile:
     create: yes
     insertafter: '^\s*\[\s*crypto_policy\s*]\s*'
@@ -43,7 +43,7 @@
     - test_crypto_policy_group.matched > 0
     - test_crypto_policy_include_directive.matched == 0
 
-- name: "{{{ rule_title }}} - Add crypto_policy group and set include opensslcnf.config"
+- name: "{{{ rule_title }}} - Add crypto_policy Section With .include for opensslcnf.config File"
   ansible.builtin.lineinfile:
     create: yes
     line: "[crypto_policy]\n{{{ ansible_openssl_include_directive }}}"

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/ansible/shared.yml
@@ -9,6 +9,14 @@
   {{%- set openssl_cnf_path="/etc/pki/tls/openssl.cnf" %}}
 {{% endif %}}
 
+{{% if product in ["fedora", "ol9", "rhel9"] %}}
+    {{% set ansible_openssl_include_directive = ".include = /etc/crypto-policies/back-ends/opensslcnf.config" %}}
+{{% else %}}
+    {{% set ansible_openssl_include_directive = ".include /etc/crypto-policies/back-ends/opensslcnf.config" %}}
+{{% endif %}}
+{{% set full_config_section = "[crypto_policy]\n" + ansible_openssl_include_directive %}}
+
+
 - name: "Test for crypto_policy group"
   command: grep '^\s*\[\s*crypto_policy\s*]' {{{ openssl_cnf_path }}}
   register: test_crypto_policy_group
@@ -20,7 +28,7 @@
   lineinfile:
     create: yes
     insertafter: '^\s*\[\s*crypto_policy\s*]\s*'
-    line: ".include = /etc/crypto-policies/back-ends/opensslcnf.config"
+    line: {{{ ansible_openssl_include_directive }}}
     path: {{{ openssl_cnf_path }}}
   when:
     - test_crypto_policy_group.stdout is defined
@@ -29,7 +37,7 @@
 - name: "Add crypto_policy group and set include opensslcnf.config"
   lineinfile:
     create: yes
-    line: "[crypto_policy]\n.include = /etc/crypto-policies/back-ends/opensslcnf.config"
+    line: "[crypto_policy]\n{{{ ansible_openssl_include_directive }}}"
     path: {{{ openssl_cnf_path }}}
   when:
     - test_crypto_policy_group.stdout is defined

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/bash/shared.sh
@@ -2,8 +2,14 @@
 
 OPENSSL_CRYPTO_POLICY_SECTION='[ crypto_policy ]'
 OPENSSL_CRYPTO_POLICY_SECTION_REGEX='\[\s*crypto_policy\s*\]'
+{{% if product in ["fedora", "ol9", "rhel9"] %}}
 OPENSSL_CRYPTO_POLICY_INCLUSION='.include = /etc/crypto-policies/back-ends/opensslcnf.config'
-OPENSSL_CRYPTO_POLICY_INCLUSION_REGEX='^\s*\.include\s*(?:=\s*)?/etc/crypto-policies/back-ends/opensslcnf.config$'
+OPENSSL_CRYPTO_POLICY_INCLUSION_REGEX='^\s*\.include\s*=\s*/etc/crypto-policies/back-ends/opensslcnf.config$'
+{{% else %}}
+OPENSSL_CRYPTO_POLICY_INCLUSION='.include /etc/crypto-policies/back-ends/opensslcnf.config'
+OPENSSL_CRYPTO_POLICY_INCLUSION_REGEX='^\s*\.include\s*/etc/crypto-policies/back-ends/opensslcnf.config$'
+{{%endif %}}
+
 
 {{% if 'sle' in product %}}
   {{% set openssl_cnf_path="/etc/ssl/openssl.cnf" %}}

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/bash/shared.sh
@@ -4,11 +4,10 @@ OPENSSL_CRYPTO_POLICY_SECTION='[ crypto_policy ]'
 OPENSSL_CRYPTO_POLICY_SECTION_REGEX='\[\s*crypto_policy\s*\]'
 {{% if product in ["fedora", "ol9", "rhel9"] %}}
 OPENSSL_CRYPTO_POLICY_INCLUSION='.include = /etc/crypto-policies/back-ends/opensslcnf.config'
-OPENSSL_CRYPTO_POLICY_INCLUSION_REGEX='^\s*\.include\s*=\s*/etc/crypto-policies/back-ends/opensslcnf.config$'
 {{% else %}}
 OPENSSL_CRYPTO_POLICY_INCLUSION='.include /etc/crypto-policies/back-ends/opensslcnf.config'
-OPENSSL_CRYPTO_POLICY_INCLUSION_REGEX='^\s*\.include\s*/etc/crypto-policies/back-ends/opensslcnf.config$'
 {{%endif %}}
+OPENSSL_CRYPTO_POLICY_INCLUSION_REGEX='^\s*\.include\s*(?:=\s*)?/etc/crypto-policies/back-ends/opensslcnf.config$'
 
 
 {{% if 'sle' in product %}}


### PR DESCRIPTION
#### Description:

- change the ".include"  line which is used in remediations to be coherent with rule descriptions for different products

#### Rationale:

- remediations were always using the include statement without the "=" sign, whereas rule description used different statements for different products. This PR aligns remediations with the description.


#### Review Hints:

1. ./build_product rhel8 rhel9
2. compare Bash and Ansible remediations for configure_openssl_crypto_policy between rhel8 and rhel9 products
3. compare rule descriptions of configure_openssl_crypto_policy between rhel8 and rhel9 product
4. descriptions should match remediations in respective products