### PR TITLE
Deprecate account_emergency_expire_date

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_emergency_expire_date/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_emergency_expire_date/rule.yml
@@ -60,6 +60,7 @@ warnings:
     - general: |-
         Due to the unique requirements of each system, automated
         remediation is not available for this configuration check.
+{{{ warning_rule_deprecated_by("account_temp_expire_date", release='0.1.69') | indent(4) }}}
 
 vuldiscussion: |-
     If emergency user accounts remain active when no longer needed or for

--- a/products/rhel7/profiles/stig.profile
+++ b/products/rhel7/profiles/stig.profile
@@ -340,7 +340,7 @@ selections:
     - package_aide_installed
     - selinux_context_elevation_for_sudo
     - audit_rules_kernel_module_loading_create
-    - account_emergency_expire_date
+    - account_temp_expire_date
     - package_screen_installed
     - sysctl_kernel_dmesg_restrict
     - aide_build_database


### PR DESCRIPTION
#### Description:

Deprecate account_emergency_expire_date

#### Rationale:

This rule was required by STIG but wording in the STIG is now moving to `account_temp_expire_date`.

