### PR TITLE
New applicability platform to check IPv6 state

### DIFF
--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/group.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/group.yml
@@ -9,3 +9,5 @@ description: |-
     perspective, manually configuring important configuration
     information is preferable to accepting it from the network
     in an unauthenticated fashion.
+
+platform: ipv6[enabled]

--- a/shared/applicability/ipv6.yml
+++ b/shared/applicability/ipv6.yml
@@ -1,0 +1,11 @@
+name: "cpe:/a:ipv6-{arg}"
+title: "IPv6 is {arg} on system"
+template:
+  name: platform_ipv6_state
+args:
+  enabled:
+    state: enabled
+    ipv6_disable_value: 0
+  disabled:
+    state: disabled
+    ipv6_disable_value: 1

--- a/shared/templates/platform_ipv6_state/cpe-oval.template
+++ b/shared/templates/platform_ipv6_state/cpe-oval.template
@@ -1,0 +1,38 @@
+<def-group>
+    <definition class="inventory" id="{{{ _RULE_ID }}}" version="1">
+        {{{ oval_metadata("", title="IPv6 is " + STATE + " on system", affected_platforms=[full_name]) }}}
+        <criteria operator="OR">
+            <criterion test_ref="test_grub2_ipv6_disable_is_correct"
+                comment="check if ipv6.disable argument is correct in GRUB_CMDLINE_LINUX"/>
+            {{%- if STATE == "enabled" -%}}
+            <criterion test_ref="test_grub2_ipv6_disable_is_absent"
+                comment="check if ipv6.disable parameter is defined in /etc/default/grub"/>
+            {{%- endif -%}}
+        </criteria>
+    </definition>
+
+    <ind:textfilecontent54_test id="test_grub2_ipv6_disable_is_correct" version="1"
+        check="all" check_existence="all_exist"
+        comment="check GRUB_CMDLINE_LINUX parameters in /etc/default/grub">
+        <ind:object object_ref="object_grub2_ipv6_disable_parameter"/>
+        <ind:state state_ref="state_grub2_ipv6_disable_argument"/>
+    </ind:textfilecontent54_test>
+
+    <ind:textfilecontent54_object id="object_grub2_ipv6_disable_parameter" version="1">
+        <ind:filepath>/etc/default/grub</ind:filepath>
+        <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX=".*ipv6\.disable=(\d).*$</ind:pattern>
+        <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    </ind:textfilecontent54_object>
+
+    <ind:textfilecontent54_state id="state_grub2_ipv6_disable_argument" version="1">
+        <ind:subexpression datatype="int" operation="equals">{{{ IPV6_DISABLE_VALUE }}}</ind:subexpression>
+    </ind:textfilecontent54_state>
+
+    {{%- if STATE == "enabled" -%}}
+    <ind:textfilecontent54_test id="test_grub2_ipv6_disable_is_absent" version="1"
+        check="all" check_existence="none_exist"
+        comment="ipv6.disable is not defined in /etc/default/grub">
+        <ind:object object_ref="object_grub2_ipv6_disable_parameter"/>
+    </ind:textfilecontent54_test>
+    {{%- endif -%}}
+</def-group>

--- a/shared/templates/platform_ipv6_state/template.yml
+++ b/shared/templates/platform_ipv6_state/template.yml
@@ -1,0 +1,2 @@
+supported_languages:
+  - cpe-oval


### PR DESCRIPTION
#### Description:

Create a new applicability platform to check IPv6 state and include a `platform: ipv6[enabled]` in for the group of rules that configure IPv6.

#### Rationale:

- Many IPv6 settings defined by `sysctl` even report error if IPv6 is disabled
- Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2210276

#### Review Hints:

1. ./build_product rhel9
2. Test some IPv6 related rules. e.g.:
```./tests/automatus.py rule --libvirt qemu:///session rhel9 --datastream build/ssg-rhel9-ds.xml --dontclean --remediate-using bash sysctl_net_ipv6_conf_all_accept_ra```
3. The rule should be checked normally if the IPv6 is enabled in the system (default)
4. Disable the IPv6 with this command: `grubby --update-kernel=ALL --args=ipv6.disable=1`
5. Test the rule again and now it should report `notapplicable`

Here are examples of other rules which could be tested:

- sysctl_net_ipv6_conf_all_accept_redirects
- sysctl_net_ipv6_conf_all_accept_source_route
- sysctl_net_ipv6_conf_default_accept_redirects