### PR TITLE
Fix `levels` key in general_profile script

### DIFF
--- a/controls/cis_ocp_1_4_0/section-1.yml
+++ b/controls/cis_ocp_1_4_0/section-1.yml
@@ -14,121 +14,121 @@ controls:
         to 600 or more restrictive
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.1.2
       title: Ensure that the API server pod specification file ownership is set to
         root:root
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.1.3
       title: Ensure that the controller manager pod specification file permissions
         are set to 600 or more restrictive
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.1.4
       title: Ensure that the controller manager pod specification file ownership is
         set to root:root
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.1.5
       title: Ensure that the scheduler pod specification file permissions are set
         to 600 or more restrictive
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.1.6
       title: Ensure that the scheduler pod specification file ownership is set to
         root:root
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.1.7
       title: Ensure that the etcd pod specification file permissions are set to 600
         or more restrictive
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.1.8
       title: Ensure that the etcd pod specification file ownership is set to root:root
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.1.9
       title: Ensure that the Container Network Interface file permissions are set
         to 600 or more restrictive
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.1.10
       title: Ensure that the Container Network Interface file ownership is set to
         root:root
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.1.11
       title: Ensure that the etcd data directory permissions are set to 700 or more
         restrictive
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.1.12
       title: Ensure that the etcd data directory ownership is set to etcd:etcd
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.1.13
       title: Ensure that the kubeconfig file permissions are set to 600 or more restrictive
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.1.14
       title: Ensure that the kubeconfig file ownership is set to root:root
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.1.15
       title: Ensure that the Scheduler kubeconfig file permissions are set to 600
         or more restrictive
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.1.16
       title: Ensure that the Scheduler kubeconfig file ownership is set to root:root
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.1.17
       title: Ensure that the Controller Manager kubeconfig file permissions are set
         to 600 or more restrictive
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.1.18
       title: Ensure that the Controller Manager kubeconfig file ownership is set to
         root:root
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.1.19
       title: Ensure that the OpenShift PKI directory and file ownership is set to
         root:root
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.1.20
       title: Ensure that the OpenShift PKI certificate file permissions are set to
         600 or more restrictive
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.1.21
       title: Ensure that the OpenShift PKI key file permissions are set to 600
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
   - id: '1.2'
     title: API Server
     status: pending
@@ -138,170 +138,170 @@ controls:
       title: Ensure that anonymous requests are authorized
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.2
       title: Ensure that the --basic-auth-file argument is not set
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.3
       title: Ensure that the --token-auth-file parameter is not set
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.4
       title: Use https for kubelet connections
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.5
       title: Ensure that the kubelet uses certificates to authenticate
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.6
       title: Verify that the kubelet certificate authority is set as appropriate
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.7
       title: Ensure that the --authorization-mode argument is not set to AlwaysAllow
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.8
       title: Verify that RBAC is enabled
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.9
       title: Ensure that the APIPriorityAndFairness feature gate is enabled
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.10
       title: Ensure that the admission control plugin AlwaysAdmit is not set
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.11
       title: Ensure that the admission control plugin AlwaysPullImages is not set
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.12
       title: Ensure that the admission control plugin ServiceAccount is set
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.13
       title: Ensure that the admission control plugin NamespaceLifecycle is set
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.14
       title: Ensure that the admission control plugin SecurityContextConstraint is
         set
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.15
       title: Ensure that the admission control plugin NodeRestriction is set
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.16
       title: Ensure that the --insecure-bind-address argument is not set
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.17
       title: Ensure that the --insecure-port argument is set to 0
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.18
       title: Ensure that the --secure-port argument is not set to 0
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.19
       title: Ensure that the healthz endpoint is protected by RBAC
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.20
       title: Ensure that the --audit-log-path argument is set
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.21
       title: Ensure that the audit logs are forwarded off the cluster for retention
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.22
       title: Ensure that the maximumRetainedFiles argument is set to 10 or as appropriate
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.23
       title: Ensure that the maximumFileSizeMegabytes argument is set to 100
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.24
       title: Ensure that the --request-timeout argument is set
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.25
       title: Ensure that the --service-account-lookup argument is set to true
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.26
       title: Ensure that the --service-account-key-file argument is set as appropriate
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.27
       title: Ensure that the --etcd-certfile and --etcd-keyfile arguments are set
         as appropriate
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.28
       title: Ensure that the --tls-cert-file and --tls-private-key-file arguments
         are set as appropriate
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.29
       title: Ensure that the --client-ca-file argument is set as appropriate
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.30
       title: Ensure that the --etcd-cafile argument is set as appropriate
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.31
       title: Ensure that encryption providers are appropriately configured
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.32
       title: Ensure that the API Server only makes use of Strong Cryptographic Ciphers
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.2.33
       title: Ensure unsupported configuration overrides are not used
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
   - id: '1.3'
     title: Controller Manager
     status: pending
@@ -312,34 +312,34 @@ controls:
       status: automated
       rules:
         - rbac_debug_role_protects_pprof
-      level: level_1
+      levels: level_1
     - id: 1.3.2
       title: Ensure that the --use-service-account-credentials argument is set to
         true
       status: automated
       rules:
         - controller_use_service_account
-      level: level_1
+      levels: level_1
     - id: 1.3.3
       title: Ensure that the --service-account-private-key-file argument is set as
         appropriate
       status: automated
       rules:
         - controller_service_account_private_key
-      level: level_1
+      levels: level_1
     - id: 1.3.4
       title: Ensure that the --root-ca-file argument is set as appropriate
       status: automated
       rules:
         - controller_service_account_ca
-      level: level_1
+      levels: level_1
     - id: 1.3.5
       title: Ensure that the --bind-address argument is set to 127.0.0.1
       status: automated
       rules:
         - controller_secure_port
         - controller_insecure_port_disabled
-      level: level_1
+      levels: level_1
   - id: '1.4'
     title: Scheduler
     status: pending
@@ -350,10 +350,10 @@ controls:
         RBAC
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 1.4.2
       title: Verify that the scheduler API service is protected by RBAC
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
 

--- a/controls/cis_ocp_1_4_0/section-2.yml
+++ b/controls/cis_ocp_1_4_0/section-2.yml
@@ -10,19 +10,19 @@ controls:
     rules:
       - etcd_cert_file
       - etcd_key_file
-    level: level_1
+    levels: level_1
   - id: '2.2'
     title: Ensure that the --client-cert-auth argument is set to true
     status: automated
     rules:
       - etcd_client_cert_auth
-    level: level_1
+    levels: level_1
   - id: '2.3'
     title: Ensure that the --auto-tls argument is not set to true
     status: automated
     rules:
       - etcd_auto_tls
-    level: level_1
+    levels: level_1
   - id: '2.4'
     title: Ensure that the --peer-cert-file and --peer-key-file arguments are set
       as appropriate
@@ -30,23 +30,23 @@ controls:
     rules: []
       - etcd_peer_cert_file
       - etcd_peer_key_file
-    level: level_1
+    levels: level_1
   - id: '2.5'
     title: Ensure that the --peer-client-cert-auth argument is set to true
     status: automated
     rules:
       - etcd_peer_client_cert_auth
-    level: level_1
+    levels: level_1
   - id: '2.6'
     title: Ensure that the --peer-auto-tls argument is not set to true
     status: automated
     rules:
       - etcd_peer_auto_tls
-    level: level_1
+    levels: level_1
   - id: '2.7'
     title: Ensure that a unique Certificate Authority is used for etcd
     status: automated
     rules:
       - etcd_unique_ca
-    level: level_2
+    levels: level_2
 

--- a/controls/cis_ocp_1_4_0/section-3.yml
+++ b/controls/cis_ocp_1_4_0/section-3.yml
@@ -13,7 +13,7 @@ controls:
       title: Client certificate authentication should not be used for users
       status: pending
       rules: []
-      level: level_2
+      levels: level_2
   - id: '3.2'
     title: Logging
     status: pending
@@ -23,10 +23,10 @@ controls:
       title: Ensure that a minimal audit policy is created
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 3.2.2
       title: Ensure that the audit policy covers key security concerns
       status: pending
       rules: []
-      level: level_2
+      levels: level_2
 

--- a/controls/cis_ocp_1_4_0/section-4.yml
+++ b/controls/cis_ocp_1_4_0/section-4.yml
@@ -14,57 +14,57 @@ controls:
         restrictive
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 4.1.2
       title: Ensure that the kubelet service file ownership is set to root:root
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 4.1.3
       title: If proxy kube proxy configuration file exists ensure permissions are
         set to 644 or more restrictive
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 4.1.4
       title: If proxy kubeconfig file exists ensure ownership is set to root:root
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 4.1.5
       title: Ensure that the --kubeconfig kubelet.conf file permissions are set to
         644 or more restrictive
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 4.1.6
       title: Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 4.1.7
       title: Ensure that the certificate authorities file permissions are set to 644
         or more restrictive
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 4.1.8
       title: Ensure that the client certificate authorities file ownership is set
         to root:root
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 4.1.9
       title: Ensure that the kubelet --config configuration file has permissions set
         to 600 or more restrictive
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 4.1.10
       title: Ensure that the kubelet configuration file ownership is set to root:root
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
   - id: '4.2'
     title: Kubelet
     status: pending
@@ -74,63 +74,63 @@ controls:
       title: Activate Garbage collection in OpenShift Container Platform 4, as appropriate
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 4.2.2
       title: Ensure that the --anonymous-auth argument is set to false
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 4.2.3
       title: Ensure that the --authorization-mode argument is not set to AlwaysAllow
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 4.2.4
       title: Ensure that the --client-ca-file argument is set as appropriate
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 4.2.5
       title: Verify that the read only port is not used or is set to 0
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 4.2.6
       title: Ensure that the --streaming-connection-idle-timeout argument is not set
         to 0
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 4.2.7
       title: Ensure that the --make-iptables-util-chains argument is set to true
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 4.2.8
       title: Ensure that the kubeAPIQPS [--event-qps] argument is set to 0 or a level
         which ensures appropriate event capture
       status: pending
       rules: []
-      level: level_2
+      levels: level_1
     - id: 4.2.9
       title: Ensure that the --tls-cert-file and --tls-private-key-file arguments
         are set as appropriate
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 4.2.10
       title: Ensure that the --rotate-certificates argument is not set to false
       status: pending
       rules: []
-      level: level_2
+      levels: level_1
     - id: 4.2.11
       title: Verify that the RotateKubeletServerCertificate argument is set to true
       status: pending
       rules: []
-      level: level_2
+      levels: level_1
     - id: 4.2.12
       title: Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
 

--- a/controls/cis_ocp_1_4_0/section-5.yml
+++ b/controls/cis_ocp_1_4_0/section-5.yml
@@ -13,32 +13,32 @@ controls:
       title: Ensure that the cluster-admin role is only used where required
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 5.1.2
       title: Minimize access to secrets
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 5.1.3
       title: Minimize wildcard use in Roles and ClusterRoles
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 5.1.4
       title: Minimize access to create pods
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 5.1.5
       title: Ensure that default service accounts are not actively used.
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 5.1.6
       title: Ensure that Service Account Tokens are only mounted where necessary
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
   - id: '5.2'
     title: Security Context Constraints
     status: pending
@@ -48,54 +48,54 @@ controls:
       title: Minimize the admission of privileged containers
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 5.2.2
       title: Minimize the admission of containers wishing to share the host process
         ID namespace
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 5.2.3
       title: Minimize the admission of containers wishing to share the host IPC namespace
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 5.2.4
       title: Minimize the admission of containers wishing to share the host network
         namespace
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 5.2.5
       title: Minimize the admission of containers with allowPrivilegeEscalation
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 5.2.6
       title: Minimize the admission of root containers
       status: pending
       rules: []
-      level: level_2
+      levels: level_2
     - id: 5.2.7
       title: Minimize the admission of containers with the NET_RAW capability
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 5.2.8
       title: Minimize the admission of containers with added capabilities
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 5.2.9
       title: Minimize the admission of containers with capabilities assigned
       status: pending
       rules: []
-      level: level_2
+      levels: level_2
     - id: 5.2.10
       title: Minimize access to privileged Security Context Constraints
       status: pending
       rules: []
-      level: level_2
+      levels: level_2
   - id: '5.3'
     title: Network Policies and CNI
     status: pending
@@ -105,12 +105,12 @@ controls:
       title: Ensure that the CNI in use supports Network Policies
       status: pending
       rules: []
-      level: level_1
+      levels: level_1
     - id: 5.3.2
       title: Ensure that all Namespaces have Network Policies defined
       status: pending
       rules: []
-      level: level_2
+      levels: level_2
   - id: '5.4'
     title: Secrets Management
     status: pending
@@ -120,12 +120,12 @@ controls:
       title: Prefer using secrets as files over secrets as environment variables
       status: pending
       rules: []
-      level: level_2
+      levels: level_1
     - id: 5.4.2
       title: Consider external secret storage
       status: pending
       rules: []
-      level: level_2
+      levels: level_2
   - id: '5.5'
     title: Extensible Admission Control
     status: pending
@@ -135,7 +135,7 @@ controls:
       title: Configure Image Provenance using image controller configuration parameters
       status: pending
       rules: []
-      level: level_2
+      levels: level_2
   - id: '5.7'
     title: General Policies
     status: partial
@@ -146,24 +146,24 @@ controls:
       status: manual
       rules:
         - general_namespaces_in_use
-      level: level_1
+      levels: level_1
     - id: 5.7.2
       title: Ensure that the seccomp profile is set to docker/default in your pod
         definitions
       status: manual
       rules:
         - general_default_seccomp_profile
-      level: level_2
+      levels: level_2
     - id: 5.7.3
       title: Apply Security Context to Your Pods and Containers
       status: manual
       rules:
         - general_apply_scc
-      level: level_2
+      levels: level_2
     - id: 5.7.4
       title: The default namespace should not be used
       status: manual
       rules:
         - general_default_namespace_use
-      level: level_2
+      levels: level_2
 

--- a/utils/generate_profile.py
+++ b/utils/generate_profile.py
@@ -186,7 +186,7 @@ class Generator:
             'rules': []
         }
         if hasattr(node, 'level'):
-            d['level'] = node.level.replace(' ', '_').lower()
+            d['levels'] = node.level.replace(' ', '_').lower()
         if node.children:
             d['controls'] = []
         for node in node.children:


### PR DESCRIPTION
The script we have for generating profiles was using the wrong key for
levels (it was using `level` instead of `levels`). This caused the
content build process to fail when you build the ocp content.

This commit updates the script to use the right key and also updates the
CIS OpenShift benchmark to use the right key.
