### PR TITLE
Don't wrap titles in control files

### DIFF
--- a/controls/cis_ocp_1_4_0/section-1.yml
+++ b/controls/cis_ocp_1_4_0/section-1.yml
@@ -10,44 +10,37 @@ controls:
     rules: []
     controls:
     - id: 1.1.1
-      title: Ensure that the API server pod specification file permissions are set
-        to 600 or more restrictive
+      title: Ensure that the API server pod specification file permissions are set to 600 or more restrictive
       status: pending
       rules: []
       level: level_1
     - id: 1.1.2
-      title: Ensure that the API server pod specification file ownership is set to
-        root:root
+      title: Ensure that the API server pod specification file ownership is set to root:root
       status: pending
       rules: []
       level: level_1
     - id: 1.1.3
-      title: Ensure that the controller manager pod specification file permissions
-        are set to 600 or more restrictive
+      title: Ensure that the controller manager pod specification file permissions are set to 600 or more restrictive
       status: pending
       rules: []
       level: level_1
     - id: 1.1.4
-      title: Ensure that the controller manager pod specification file ownership is
-        set to root:root
+      title: Ensure that the controller manager pod specification file ownership is set to root:root
       status: pending
       rules: []
       level: level_1
     - id: 1.1.5
-      title: Ensure that the scheduler pod specification file permissions are set
-        to 600 or more restrictive
+      title: Ensure that the scheduler pod specification file permissions are set to 600 or more restrictive
       status: pending
       rules: []
       level: level_1
     - id: 1.1.6
-      title: Ensure that the scheduler pod specification file ownership is set to
-        root:root
+      title: Ensure that the scheduler pod specification file ownership is set to root:root
       status: pending
       rules: []
       level: level_1
     - id: 1.1.7
-      title: Ensure that the etcd pod specification file permissions are set to 600
-        or more restrictive
+      title: Ensure that the etcd pod specification file permissions are set to 600 or more restrictive
       status: pending
       rules: []
       level: level_1
@@ -57,20 +50,17 @@ controls:
       rules: []
       level: level_1
     - id: 1.1.9
-      title: Ensure that the Container Network Interface file permissions are set
-        to 600 or more restrictive
+      title: Ensure that the Container Network Interface file permissions are set to 600 or more restrictive
       status: pending
       rules: []
       level: level_1
     - id: 1.1.10
-      title: Ensure that the Container Network Interface file ownership is set to
-        root:root
+      title: Ensure that the Container Network Interface file ownership is set to root:root
       status: pending
       rules: []
       level: level_1
     - id: 1.1.11
-      title: Ensure that the etcd data directory permissions are set to 700 or more
-        restrictive
+      title: Ensure that the etcd data directory permissions are set to 700 or more restrictive
       status: pending
       rules: []
       level: level_1
@@ -90,8 +80,7 @@ controls:
       rules: []
       level: level_1
     - id: 1.1.15
-      title: Ensure that the Scheduler kubeconfig file permissions are set to 600
-        or more restrictive
+      title: Ensure that the Scheduler kubeconfig file permissions are set to 600 or more restrictive
       status: pending
       rules: []
       level: level_1
@@ -101,26 +90,22 @@ controls:
       rules: []
       level: level_1
     - id: 1.1.17
-      title: Ensure that the Controller Manager kubeconfig file permissions are set
-        to 600 or more restrictive
+      title: Ensure that the Controller Manager kubeconfig file permissions are set to 600 or more restrictive
       status: pending
       rules: []
       level: level_1
     - id: 1.1.18
-      title: Ensure that the Controller Manager kubeconfig file ownership is set to
-        root:root
+      title: Ensure that the Controller Manager kubeconfig file ownership is set to root:root
       status: pending
       rules: []
       level: level_1
     - id: 1.1.19
-      title: Ensure that the OpenShift PKI directory and file ownership is set to
-        root:root
+      title: Ensure that the OpenShift PKI directory and file ownership is set to root:root
       status: pending
       rules: []
       level: level_1
     - id: 1.1.20
-      title: Ensure that the OpenShift PKI certificate file permissions are set to
-        600 or more restrictive
+      title: Ensure that the OpenShift PKI certificate file permissions are set to 600 or more restrictive
       status: pending
       rules: []
       level: level_1
@@ -200,8 +185,7 @@ controls:
       rules: []
       level: level_1
     - id: 1.2.14
-      title: Ensure that the admission control plugin SecurityContextConstraint is
-        set
+      title: Ensure that the admission control plugin SecurityContextConstraint is set
       status: pending
       rules: []
       level: level_1
@@ -266,14 +250,12 @@ controls:
       rules: []
       level: level_1
     - id: 1.2.27
-      title: Ensure that the --etcd-certfile and --etcd-keyfile arguments are set
-        as appropriate
+      title: Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate
       status: pending
       rules: []
       level: level_1
     - id: 1.2.28
-      title: Ensure that the --tls-cert-file and --tls-private-key-file arguments
-        are set as appropriate
+      title: Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate
       status: pending
       rules: []
       level: level_1
@@ -314,15 +296,13 @@ controls:
         - rbac_debug_role_protects_pprof
       level: level_1
     - id: 1.3.2
-      title: Ensure that the --use-service-account-credentials argument is set to
-        true
+      title: Ensure that the --use-service-account-credentials argument is set to true
       status: automated
       rules:
         - controller_use_service_account
       level: level_1
     - id: 1.3.3
-      title: Ensure that the --service-account-private-key-file argument is set as
-        appropriate
+      title: Ensure that the --service-account-private-key-file argument is set as appropriate
       status: automated
       rules:
         - controller_service_account_private_key
@@ -346,8 +326,7 @@ controls:
     rules: []
     controls:
     - id: 1.4.1
-      title: Ensure that the healthz endpoints for the scheduler are protected by
-        RBAC
+      title: Ensure that the healthz endpoints for the scheduler are protected by RBAC
       status: pending
       rules: []
       level: level_1

--- a/controls/cis_ocp_1_4_0/section-2.yml
+++ b/controls/cis_ocp_1_4_0/section-2.yml
@@ -24,8 +24,7 @@ controls:
       - etcd_auto_tls
     level: level_1
   - id: '2.4'
-    title: Ensure that the --peer-cert-file and --peer-key-file arguments are set
-      as appropriate
+    title: Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate
     status: automated
     rules: []
       - etcd_peer_cert_file

--- a/controls/cis_ocp_1_4_0/section-4.yml
+++ b/controls/cis_ocp_1_4_0/section-4.yml
@@ -10,8 +10,7 @@ controls:
     rules: []
     controls:
     - id: 4.1.1
-      title: Ensure that the kubelet service file permissions are set to 644 or more
-        restrictive
+      title: Ensure that the kubelet service file permissions are set to 644 or more restrictive
       status: pending
       rules: []
       level: level_1
@@ -21,8 +20,7 @@ controls:
       rules: []
       level: level_1
     - id: 4.1.3
-      title: If proxy kube proxy configuration file exists ensure permissions are
-        set to 644 or more restrictive
+      title: If proxy kube proxy configuration file exists ensure permissions are set to 644 or more restrictive
       status: pending
       rules: []
       level: level_1
@@ -32,8 +30,7 @@ controls:
       rules: []
       level: level_1
     - id: 4.1.5
-      title: Ensure that the --kubeconfig kubelet.conf file permissions are set to
-        644 or more restrictive
+      title: Ensure that the --kubeconfig kubelet.conf file permissions are set to 644 or more restrictive
       status: pending
       rules: []
       level: level_1
@@ -43,20 +40,17 @@ controls:
       rules: []
       level: level_1
     - id: 4.1.7
-      title: Ensure that the certificate authorities file permissions are set to 644
-        or more restrictive
+      title: Ensure that the certificate authorities file permissions are set to 644 or more restrictive
       status: pending
       rules: []
       level: level_1
     - id: 4.1.8
-      title: Ensure that the client certificate authorities file ownership is set
-        to root:root
+      title: Ensure that the client certificate authorities file ownership is set to root:root
       status: pending
       rules: []
       level: level_1
     - id: 4.1.9
-      title: Ensure that the kubelet --config configuration file has permissions set
-        to 600 or more restrictive
+      title: Ensure that the kubelet --config configuration file has permissions set to 600 or more restrictive
       status: pending
       rules: []
       level: level_1
@@ -96,8 +90,7 @@ controls:
       rules: []
       level: level_1
     - id: 4.2.6
-      title: Ensure that the --streaming-connection-idle-timeout argument is not set
-        to 0
+      title: Ensure that the --streaming-connection-idle-timeout argument is not set to 0
       status: pending
       rules: []
       level: level_1
@@ -107,14 +100,12 @@ controls:
       rules: []
       level: level_1
     - id: 4.2.8
-      title: Ensure that the kubeAPIQPS [--event-qps] argument is set to 0 or a level
-        which ensures appropriate event capture
+      title: Ensure that the kubeAPIQPS [--event-qps] argument is set to 0 or a level which ensures appropriate event capture
       status: pending
       rules: []
       level: level_2
     - id: 4.2.9
-      title: Ensure that the --tls-cert-file and --tls-private-key-file arguments
-        are set as appropriate
+      title: Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate
       status: pending
       rules: []
       level: level_1

--- a/controls/cis_ocp_1_4_0/section-5.yml
+++ b/controls/cis_ocp_1_4_0/section-5.yml
@@ -50,8 +50,7 @@ controls:
       rules: []
       level: level_1
     - id: 5.2.2
-      title: Minimize the admission of containers wishing to share the host process
-        ID namespace
+      title: Minimize the admission of containers wishing to share the host process ID namespace
       status: pending
       rules: []
       level: level_1
@@ -61,8 +60,7 @@ controls:
       rules: []
       level: level_1
     - id: 5.2.4
-      title: Minimize the admission of containers wishing to share the host network
-        namespace
+      title: Minimize the admission of containers wishing to share the host network namespace
       status: pending
       rules: []
       level: level_1
@@ -148,8 +146,7 @@ controls:
         - general_namespaces_in_use
       level: level_1
     - id: 5.7.2
-      title: Ensure that the seccomp profile is set to docker/default in your pod
-        definitions
+      title: Ensure that the seccomp profile is set to docker/default in your pod definitions
       status: manual
       rules:
         - general_default_seccomp_profile

--- a/utils/generate_profile.py
+++ b/utils/generate_profile.py
@@ -220,7 +220,7 @@ class RuleGenerator(Generator):
             'warnings': self.placeholder(),
             'template': self.placeholder(),
         }
-        print(yaml.dump(output, sort_keys=False))
+        print(yaml.dump(output, sort_keys=False, width=float("inf")))
 
 
 class SectionGenerator(Generator):
@@ -229,7 +229,7 @@ class SectionGenerator(Generator):
         output = {
             'controls': self._get_controls(section=section)
         }
-        print(yaml.dump(output, sort_keys=False))
+        print(yaml.dump(output, sort_keys=False, width=float("inf")))
 
 
 class ProfileGenerator(Generator):


### PR DESCRIPTION
Previously, the generate_profile.py script would wrap line lines in
YAML, without any sort of line continuation. Feeding these control files
into the build tools breaks because it can't parse the yaml.

This commit fixes all the long lines in existing OCP control files
generated by the script and updates the script to not wrap long lines.
