### PR TITLE
Fix invalid YAML in OCP CIS control file

### DIFF
--- a/controls/cis_ocp_1_4_0/section-2.yml
+++ b/controls/cis_ocp_1_4_0/section-2.yml
@@ -27,7 +27,7 @@ controls:
     title: Ensure that the --peer-cert-file and --peer-key-file arguments are set
       as appropriate
     status: automated
-    rules: []
+    rules:
       - etcd_peer_cert_file
       - etcd_peer_key_file
     level: level_1


### PR DESCRIPTION
This invalid yaml accidentally slipped into the tree and causes errors
if you use the control file to build the content.
