### PR TITLE
Adding OCP version detection helper rules for CIS OCP

### DIFF
--- a/controls/cis_ocp_1_4_0/section-1.yml
+++ b/controls/cis_ocp_1_4_0/section-1.yml
@@ -2,7 +2,11 @@ controls:
 - id: '1'
   title: Control Plane Components
   status: pending
-  rules: []
+  rules:
+    ### Helper Rules
+    ### This is a helper rule to fetch the required api resource for detecting OCP version
+    - version_detect_in_ocp
+    - version_detect_in_hypershift
   controls:
   - id: '1.1'
     title: Master Node Configuration Files

--- a/controls/cis_ocp_1_4_0/section-5.yml
+++ b/controls/cis_ocp_1_4_0/section-5.yml
@@ -2,7 +2,11 @@ controls:
 - id: '5'
   title: Policies
   status: pending
-  rules: []
+  rules:  
+    ### Helper Rules
+    ### This is a helper rule to fetch the required api resource for detecting OCP version
+    - version_detect_in_ocp
+    - version_detect_in_hypershift
   controls:
   - id: '5.1'
     title: RBAC and Service Accounts


### PR DESCRIPTION
We should have version detection helper rules in the benchmark control file so that we can identify the OCP version correctly