### PR TITLE
Refactor Ansible remediation for dir_perms_world_writable_root_owned

### DIFF
--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/ansible/shared.yml
@@ -1,12 +1,11 @@
-# platform = Red Hat Virtualization 4,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Fedora,Oracle Linux 7,Oracle Linux 8
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low
 # disruption = medium
 
-
-- name: "Configure excluded (non local) file systems"
-  set_fact:
+- name: "{{{ rule_title }}} - Define Excluded (Non-Local) File Systems and Paths"
+  ansible.builtin.set_fact:
     excluded_fstypes:
       - afs
       - ceph
@@ -27,34 +26,57 @@
       - lustre
       - davfs
       - fuse.sshfs
-
-- name: "Create empty list of excluded paths"
-  set_fact:
     excluded_paths:
-      - /proc
+      - dev
+      - proc
+      - run
+      - sys
+    search_paths: []
+    world_writable_dirs: []
 
-- name: "Detect nonlocal file systems and add them to excluded paths"
-  set_fact:
-    excluded_paths: "{{ excluded_paths | union([item.mount]) }}"
-  loop: "{{ ansible_mounts }}"
-  when: item.fstype in excluded_fstypes
-
-- name: "Find all directories excluding non-local partitions"
-  find:
-    paths: "/"
-    excludes: excluded_paths
+- name: "{{{ rule_title }}} - Find Relevant Root Directories Ignoring Pre-Defined Excluded Paths"
+  ansible.builtin.find:
+    paths: /
     file_type: directory
-    hidden: yes
-    recurse: yes
-  register: found_dirs
+    excludes: "{{ excluded_paths }}"
+    hidden: true
+    recurse: false
+  register: result_relevant_root_dirs
 
-- name: "Create list of world writable directories"
-  set_fact:
-    world_writable_dirs: "{{ found_dirs.files | selectattr('woth') | list }}"
+- name: "{{{ rule_title }}} - Include Relevant Root Directories in a List of Paths to be Searched"
+  ansible.builtin.set_fact:
+    search_paths: "{{ search_paths | union([item.path]) }}"
+  loop: "{{ result_relevant_root_dirs.files }}"
 
-- name: "Change owner to root on directories which are world writable"
-  file:
-    path: '{{ item.path }}'
+- name: "{{{ rule_title }}} - Increment Search Paths List with Local Partitions Mount Points"
+  ansible.builtin.set_fact:
+    search_paths: "{{ search_paths | union([item.mount]) }}"
+  loop: '{{ ansible_mounts }}'
+  when:
+    - item.fstype not in excluded_fstypes
+    - item.mount != '/'
+
+- name: "{{{ rule_title }}} - Increment Search Paths List with Local NFS File System Targets"
+  ansible.builtin.set_fact:
+    search_paths: "{{ search_paths | union([item.device.split(':')[1]]) }}"
+  loop: '{{ ansible_mounts }}'
+  when:
+    - item.device is search("localhost:")
+
+- name: "{{{ rule_title }}} - Find All Uncompliant Directories in Local File Systems"
+  ansible.builtin.command:
+    cmd: find {{ item }} -xdev -type d -perm -0002 -uid +0
+  loop: "{{ search_paths }}"
+  changed_when: false
+  register: result_found_dirs
+
+- name: "{{{ rule_title }}} - Create List of World Writable Directories Not Owned by root"
+  ansible.builtin.set_fact:
+    world_writable_dirs: '{{ world_writable_dirs | union(item.stdout_lines) | list }}'
+  loop: "{{ result_found_dirs.results }}"
+
+- name: "{{{ rule_title }}} - Ensure root Ownership on Local World Writable Directories"
+  ansible.builtin.file:
+    path: '{{ item }}'
     owner: root
-  loop:  '{{ world_writable_dirs }}'
-  ignore_errors: yes
+  loop: '{{ world_writable_dirs }}'

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/bash/shared.sh
@@ -1,5 +1,14 @@
 # platform = multi_platform_all
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = medium
 
 # At least under containerized env /proc can have files w/o possilibity to
 # modify even as root. And touching /proc is not good idea anyways.
-find / -path /proc -prune -o -not -fstype afs -not -fstype ceph -not -fstype cifs -not -fstype smb3 -not -fstype smbfs -not -fstype sshfs -not -fstype ncpfs -not -fstype ncp -not -fstype nfs -not -fstype nfs4 -not -fstype gfs -not -fstype gfs2 -not -fstype glusterfs -not -fstype gpfs -not -fstype pvfs2 -not -fstype ocfs2 -not -fstype lustre -not -fstype davfs -not -fstype fuse.sshfs -type d -perm -0002 -uid +0 -exec chown root {} \;
+find / -path /proc -prune -o \
+    -not -fstype afs -not -fstype ceph -not -fstype cifs -not -fstype smb3 -not -fstype smbfs \
+    -not -fstype sshfs -not -fstype ncpfs -not -fstype ncp -not -fstype nfs -not -fstype nfs4 \
+    -not -fstype gfs -not -fstype gfs2 -not -fstype glusterfs -not -fstype gpfs \
+    -not -fstype pvfs2 -not -fstype ocfs2 -not -fstype lustre -not -fstype davfs \
+    -not -fstype fuse.sshfs -type d -perm -0002 -uid +0 -exec chown root {} \;

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/oval/shared.xml
@@ -10,7 +10,6 @@
   <unix:file_test id="test_dir_world_writable_uid_gt_zero" check="all" version="1"
     comment="check for local directories that are world writable and have uid greater than 0">
     <unix:object object_ref="all_local_directories_uid_zero"/>
-    <unix:state state_ref="state_uid_is_not_root_and_world_writable"/>
   </unix:file_test>
 
   <unix:file_object id="all_local_directories_uid_zero" version="1"

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/oval/shared.xml
@@ -1,21 +1,29 @@
 <def-group>
-  <definition class="compliance" id="dir_perms_world_writable_root_owned" version="1">
+  <definition class="compliance" id="{{{ rule_id }}}" version="2">
     {{{ oval_metadata("All world writable directories should be owned by root.") }}}
-    <criteria comment="check for local directories that are world writable and have uid greater than 0" negate="true">
-      <criterion comment="check for local directories that are world writable and have uid greater than 0" test_ref="test_dir_world_writable_uid_gt_zero" />
+    <criteria negate="true">
+      <criterion test_ref="test_dir_world_writable_uid_gt_zero"
+        comment="check for local directories that are world writable and owner is not root"/>
     </criteria>
   </definition>
-  <unix:file_test check="all" comment="check for local directories that are world writable and have uid greater than 0" id="test_dir_world_writable_uid_gt_zero" version="1">
-    <unix:object object_ref="all_local_directories_uid_zero" />
-    <unix:state state_ref="state_uid_is_not_root_and_world_writable" />
+
+  <unix:file_test id="test_dir_world_writable_uid_gt_zero" check="all" version="1"
+    comment="check for local directories that are world writable and have uid greater than 0">
+    <unix:object object_ref="all_local_directories_uid_zero"/>
+    <unix:state state_ref="state_uid_is_not_root_and_world_writable"/>
   </unix:file_test>
-  <unix:file_object comment="all local directories" id="all_local_directories_uid_zero" version="1">
-    <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
+
+  <unix:file_object id="all_local_directories_uid_zero" version="1"
+    comment="collect all local directories and filter them by uid and others write permission">
+    <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1"
+      recurse_file_system="local"/>
     <unix:path operation="equals">/</unix:path>
     <unix:filename xsi:nil="true" />
     <filter action="include">state_uid_is_not_root_and_world_writable</filter>
   </unix:file_object>
-  <unix:file_state comment="uid greater than 0 and world writable" id="state_uid_is_not_root_and_world_writable" version="1">
+
+  <unix:file_state id="state_uid_is_not_root_and_world_writable" version="1"
+    comment="uid greater than 0 and world writable">
     <unix:user_id datatype="int" operation="greater than">0</unix:user_id>
     <unix:owrite datatype="boolean">true</unix:owrite>
   </unix:file_state>

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/rule.yml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/rule.yml
@@ -2,19 +2,17 @@ documentation_complete: true
 
 prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
-title: 'Ensure All World-Writable Directories Are Owned by root user'
+title: 'Ensure All World-Writable Directories Are Owned by root User'
 
 description: |-
-    All directories in local partitions which are world-writable should be owned
-    by root. If any world-writable directories are not owned by root, this
-    should be investigated. Following this, the files should be deleted or
-    assigned to root user.
+    All directories in local partitions which are world-writable should be owned by root.
+    If any world-writable directories are not owned by root, this should be investigated.
+    Following this, the files should be deleted or assigned to root user.
 
 rationale: |-
-    Allowing a user account to own a world-writable directory is
-    undesirable because it allows the owner of that directory to remove
-    or replace any files that may be placed in the directory by other
-    users.
+    Allowing a user account to own a world-writable directory is undesirable because it allows the
+    owner of that directory to remove or replace any files that may be placed in the directory by
+    other users.
 
 severity: medium
 
@@ -31,11 +29,11 @@ references:
     srg: SRG-OS-000480-GPOS-00227,SRG-OS-000138-GPOS-00069
     stigid@rhel8: RHEL-08-010700
 
-ocil_clause: 'there is output'
+ocil_clause: 'there are world-writable directories not owned by root'
 
 ocil: |-
     The following command will discover and print world-writable directories that
-    are not owned by root.  Run it once for each local partition <i>PART</i>:
+    are not owned by root. Run it once for each local partition <i>PART</i>:
     <pre>$ sudo find <i>PART</i> -xdev -type d -perm -0002 -uid +0 -print</pre>
 
 fixtext: |-


### PR DESCRIPTION
#### Description:

During the review of https://github.com/ComplianceAsCode/content/pull/10563 it was noticed some issues in the Ansible remediation due to a misinterpretation of the `exclude` parameter used by the `find` module, as more detailed in the https://github.com/ComplianceAsCode/content/pull/10563#issuecomment-1632274582 comment.

In a deeper analysis of the remediation it was also noticed some performance issues and a corner case.

This PR complements the https://github.com/ComplianceAsCode/content/pull/10563 by refactoring the Ansible remediation so it is faster, accurate and more robust.

#### Rationale:

- More robust Ansible remediation
- Performance improvements

#### Review Hints:

Automatus tests using Bash and Ansible should be enough to confirm it is working as expected.