### PR TITLE
Fix invalid yaml in CIS section 4

### DIFF
--- a/controls/cis_ocp_1_4_0/section-4.yml
+++ b/controls/cis_ocp_1_4_0/section-4.yml
@@ -139,7 +139,7 @@ controls:
     - id: 4.2.10
       title: Ensure that the --rotate-certificates argument is not set to false
       status: automated
-      rules: []
+      rules:
         - kubelet_enable_client_cert_rotation
         - kubelet_enable_cert_rotation
       levels: level_1


### PR DESCRIPTION
The empty rule list wasn't removed when we filled in the rules for the
section 4 implementation. This commit removes the empty list so we can
build the content.
