### PR TITLE
Fix Redhat CVE Feed URLs

### DIFF
--- a/products/rhel7/product.yml
+++ b/products/rhel7/product.yml
@@ -20,7 +20,7 @@ aux_pkg_version: "2fa658e0"
 
 release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
 auxiliary_key_fingerprint: "43A6E49C4A38F4BE9ABF2A5345689C882FA658E0"
-oval_feed_url: "https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml.bz2"
+oval_feed_url: "https://access.redhat.com/security/data/oval/v2/RHEL7/rhel-7.oval.xml.bz2"
 
 grub2_uefi_boot_path: "/boot/efi/EFI/redhat"
 audisp_conf_path: "/etc/audisp"

--- a/products/rhel8/product.yml
+++ b/products/rhel8/product.yml
@@ -20,7 +20,7 @@ aux_pkg_version: "d4082792"
 
 release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
 auxiliary_key_fingerprint: "6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792"
-oval_feed_url: "https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2"
+oval_feed_url: "https://access.redhat.com/security/data/oval/v2/RHEL8/rhel-8.oval.xml.bz2"
 
 grub2_boot_path: "/boot/grub2"
 grub2_uefi_boot_path: "/boot/efi/EFI/redhat"

--- a/products/rhel9/product.yml
+++ b/products/rhel9/product.yml
@@ -34,7 +34,7 @@ aux_pkg_version: "5a6340b3"
 
 release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
 auxiliary_key_fingerprint: "7E4624258C406535D56D6F135054E4A45A6340B3"
-oval_feed_url: "https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL9.xml.bz2"
+oval_feed_url: "https://access.redhat.com/security/data/oval/v2/RHEL9/rhel-9.oval.xml.bz2"
 
 cpes_root: "../../shared/applicability"
 cpes:

--- a/tests/data/product_stability/rhel7.yml
+++ b/tests/data/product_stability/rhel7.yml
@@ -47,7 +47,7 @@ grub2_uefi_boot_path: /boot/efi/EFI/redhat
 init_system: systemd
 nobody_gid: 65534
 nobody_uid: 65534
-oval_feed_url: https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml.bz2
+oval_feed_url: https://access.redhat.com/security/data/oval/v2/RHEL7/rhel-7.oval.xml.bz2
 pkg_manager: yum
 pkg_manager_config_file: /etc/yum.conf
 pkg_release: 4ae0493b

--- a/tests/data/product_stability/rhel8.yml
+++ b/tests/data/product_stability/rhel8.yml
@@ -75,7 +75,7 @@ grub2_uefi_boot_path: /boot/efi/EFI/redhat
 init_system: systemd
 nobody_gid: 65534
 nobody_uid: 65534
-oval_feed_url: https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2
+oval_feed_url: https://access.redhat.com/security/data/oval/v2/RHEL8/rhel-8.oval.xml.bz2
 pkg_manager: yum
 pkg_manager_config_file: /etc/yum.conf
 pkg_release: 4ae0493b

--- a/tests/data/product_stability/rhel9.yml
+++ b/tests/data/product_stability/rhel9.yml
@@ -31,7 +31,7 @@ grub2_uefi_boot_path: /boot/grub2
 init_system: systemd
 nobody_gid: 65534
 nobody_uid: 65534
-oval_feed_url: https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL9.xml.bz2
+oval_feed_url: https://access.redhat.com/security/data/oval/v2/RHEL9/rhel-9.oval.xml.bz2
 pkg_manager: dnf
 pkg_manager_config_file: /etc/dnf/dnf.conf
 pkg_release: 4ae0493b


### PR DESCRIPTION
#### Description:

Move to OVAL V2 URLs. 


#### Rationale:


OVAL V1 was deprecated on July 1.

Fixes #10831 
Fixes #10832

