### PR TITLE
Fix invalid yaml in CIS OCP section 5

### DIFF
--- a/controls/cis_ocp_1_4_0/section-5.yml
+++ b/controls/cis_ocp_1_4_0/section-5.yml
@@ -77,7 +77,7 @@ controls:
     - id: 5.2.5
       title: Minimize the admission of containers with allowPrivilegeEscalation
       status: manual
-      rules: []
+      rules:
         - scc_limit_privilege_escalation
       levels: level_1
     - id: 5.2.6


### PR DESCRIPTION
We'll need to fix this before we can include it in the actual OCP
profile.
