### PR TITLE
Add support for multiple STIG id assignments

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
@@ -54,7 +54,7 @@ references:
     stigid@ol7: OL07-00-010320
     stigid@ol8: OL08-00-020012
     stigid@rhel7: RHEL-07-010320
-    stigid@rhel8: RHEL-08-020013
+    stigid@rhel8: RHEL-08-020012,RHEL-08-020013
 
 platform: package[pam]
 

--- a/tests/unit/ssg-module/test_build_yaml.py
+++ b/tests/unit/ssg-module/test_build_yaml.py
@@ -195,10 +195,10 @@ def test_make_items_product_specific():
     assert rule.template["backends"]["anaconda"]
 
     rule.references = {
-        "stigid@rhel7": "RHEL-07-040370,RHEL-07-057364",
+        "stigid@rhel8": "RHEL-08-020012,RHEL-08-020013",
     }
-    with pytest.raises(ValueError, match="Rules can not have multiple STIG IDs."):
-        rule.make_refs_and_identifiers_product_specific("rhel7")
+    rule.normalize("rhel8")
+    assert rule.references["stigid"] == "RHEL-08-020012,RHEL-08-020013"
 
 
 def test_priority_ordering():


### PR DESCRIPTION
#### Description:

- Add support for multiple STIG id assignments.

#### Rationale:

- Ability to assign multiple STIG ids to `stigid` reference, comma separated.
- Help with testing of the feature is appreciated.

#### Review Hints:

- oscap xccdf eval --profile stig --rule xccdf_org.ssgproject.content_rule_accounts_passwords_pam_faillock_interval --results results.xml --stig-viewer results-stig.xml ssg-rhel8-ds.xml
- results-stig.xml should contain two results such as:

```
  <rule-result idref="SV-230334r627750_rule" role="full" time="2023-07-14T07:37:00-05:00" severity="medium" weight="1.000000">
    <result>fail</result>
    <ident system="https://ncp.nist.gov/cce">CCE-80669-5</ident>
    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
      <check-export export-name="oval:ssg-var_accounts_passwords_pam_faillock_fail_interval:var:1" value-id="xccdf_org.ssgproject.content_value_var_accounts_passwords_pam_faillock_fail_interval"/>
      <check-content-ref name="oval:ssg-accounts_passwords_pam_faillock_interval:def:1" href="ssg-rhel8-oval.xml"/>
    </check>
  </rule-result>
  <rule-result idref="SV-230335r743969_rule" role="full" time="2023-07-14T07:37:00-05:00" severity="medium" weight="1.000000">
    <result>fail</result>
    <ident system="https://ncp.nist.gov/cce">CCE-80669-5</ident>
    <check system="http://oval.mitre.org/XMLSchema/oval-definitions-5">
      <check-export export-name="oval:ssg-var_accounts_passwords_pam_faillock_fail_interval:var:1" value-id="xccdf_org.ssgproject.content_value_var_accounts_passwords_pam_faillock_fail_interval"/>
      <check-content-ref name="oval:ssg-accounts_passwords_pam_faillock_interval:def:1" href="ssg-rhel8-oval.xml"/>
    </check>
  </rule-result>
````

After that you can import https://github.com/ComplianceAsCode/content/raw/master/shared/references/disa-stig-rhel8-v1r10-xccdf-manual.xml into STIG viewer, create a checklist and then you can import the results-stig.xml file.

STIG viewer can be found on: https://public.cyber.mil/stigs/srg-stig-tools/