### PR TITLE
Allow verify_references.py to identify RH OVALv2 feed IDs as remote

### DIFF
--- a/build-scripts/verify_references.py
+++ b/build-scripts/verify_references.py
@@ -132,6 +132,7 @@ def get_profileruleids(xccdftree, profile_name):
 def is_remote_feed(href):
     return href.startswith("http://") or \
             href.startswith("https://") or \
+            href.startswith("security-data-oval-v2-") or \
             href.startswith("security-data-oval-com.redhat.rhsa-") or \
             href.startswith("security-oval-com.oracle") or \
             href.startswith("-ubuntu-security-oval-com.ubuntu") or \


### PR DESCRIPTION
#### Description:

- Switch to RH OVALv2 feeds caused verify_references.py to fail because new ID template has not been filtered out as a remote source.

#### Rationale:

- Merging of https://github.com/ComplianceAsCode/content/pull/10842 caused `verify_references.py` to fail over new OVAL feed IDs.