### PR TITLE
Add rule to verify protection of profiling data

### DIFF
--- a/applications/openshift/api-server/api_server_profiling_protected_by_rbac/rule.yml
+++ b/applications/openshift/api-server/api_server_profiling_protected_by_rbac/rule.yml
@@ -10,7 +10,7 @@ description: |-
 rationale: |-
   Profiling allows for the identification of specific performance bottlenecks.
   It generates a significant amount of program data that could potentially be
-  exploited to uncover system and program details. 
+  exploited to uncover system and program details.
   To ensure the collected data is not exploited, profiling endpoints are secured
   via RBAC (see cluster-debugger role). By default, the profiling endpoints are
   accessible only by users bound to cluster-admin or cluster-debugger role.
@@ -20,7 +20,7 @@ identifiers:
   cce@ocp4: CCE-84212-0
 
 references:
-  cis@ocp4: 1.2.21
+  cis@ocp4: 1.2.19
   nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
   nist: CM-6,CM-6(1)
   pcidss: Req-2.2

--- a/controls/cis_ocp_1_4_0/section-1.yml
+++ b/controls/cis_ocp_1_4_0/section-1.yml
@@ -234,8 +234,9 @@ controls:
       levels: level_1
     - id: 1.2.19
       title: Ensure that the healthz endpoint is protected by RBAC
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_profiling_protected_by_rbac
       levels: level_1
     - id: 1.2.20
       title: Ensure that the --audit-log-path argument is set


### PR DESCRIPTION
We had an OpenShift rule for verifying that profiling data was protected
by RBAC, but this wasn't pulled over to the new OpenShift profile.

This commit updates the control files for section 1 to include a rule
that verifies profiling data is protected using RBAC.
