### PR TITLE
Fix invalid levels key in section 5

### DIFF
--- a/controls/cis_ocp_1_4_0/section-5.yml
+++ b/controls/cis_ocp_1_4_0/section-5.yml
@@ -158,7 +158,7 @@ controls:
         - ocp_allowed_registries_for_import
         - ocp_insecure_registries
         - ocp_insecure_allowed_registries_for_import
-      level: level_2
+      levels: level_2
   - id: '5.7'
     title: General Policies
     status: partial


### PR DESCRIPTION
We recently started filling in the implementation for CIS OpenShift
1.4.0, but missed a case where we were using `level` instead of
`levels` as a control key. This causes errors building the product when
we render the profile from the control files.
