### PR TITLE
0640 permission in permissions_local_var_log should only apply to files

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_local_var_log/bash/ubuntu.sh
+++ b/linux_os/guide/system/permissions/files/permissions_local_var_log/bash/ubuntu.sh
@@ -1,6 +1,6 @@
 # platform = multi_platform_ubuntu
 
-readarray -t files < <(find /var/log/)
+readarray -t files < <(find /var/log/ -type f)
 for file in "${files[@]}"; do
     if basename $file | grep -qE '^.*$'; then
         chmod 0640 $file


### PR DESCRIPTION
#### Description:

Ubuntu remediation for permissions_local_var_log changes the permission of /var/log to 0640 as a result services like lighttpd can't access it logfiles.

#### Rationale:

Services should be able to access their logfiles.

#### Review Hints:

In the yml file for this rule the check is listet for files only.
https://github.com/ComplianceAsCode/content/blob/afbd58909cd3726c59324bbbbf9a79cd05e123ab/linux_os/guide/system/permissions/files/permissions_local_var_log/rule.yml#L52

Thank you.