### PR TITLE
A change into sudoers_validate_passwd

### DIFF
--- a/linux_os/guide/system/software/sudo/sudoers_validate_passwd/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudoers_validate_passwd/rule.yml
@@ -63,3 +63,5 @@ fixtext: |-
 
 srg_requirement: |-
   {{{ full_name }}} must use the invoking user's password for privilege escalation when using "sudo".
+
+platform: package[sudo]


### PR DESCRIPTION
#### Description:

- _A change into sudoers_validate_passwd_

#### Rationale:

- The current version of the rules does not return notapplicable when the sudo module is not installed.
