### PR TITLE
OCP4 CIS: Re-add forgotten rules

### DIFF
--- a/applications/openshift/controller/controller_rotate_kubelet_server_certs/rule.yml
+++ b/applications/openshift/controller/controller_rotate_kubelet_server_certs/rule.yml
@@ -63,7 +63,7 @@ warnings:
     of rotation yourself
 
 references:
-    cis@ocp4: 1.3.6
+    cis@ocp4: 4.2.11
     nerc-cip: CIP-003-8 R4.2,CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R5.1,CIP-007-3 R6.1
     nist: CM-6,CM-6(1),SC-8,SC-8(1)
     pcidss: Req-2.2

--- a/applications/openshift/kubelet/kubelet_configure_tls_key/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_key/rule.yml
@@ -31,7 +31,7 @@ platforms:
   - (ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12 or ocp4.13) and not ocp4-on-hypershift-hosted
 
 references:
-    cis@ocp4: 4.2.10
+    cis@ocp4: 4.2.9
     nerc-cip: CIP-003-8 R4.2,CIP-007-3 R5.1
     nist: SC-8,SC-8(1),SC-8(2)
     pcidss: Req-2.2,Req-2.2.3,Req-2.3

--- a/controls/cis_ocp_1_4_0/section-1.yml
+++ b/controls/cis_ocp_1_4_0/section-1.yml
@@ -39,7 +39,7 @@ controls:
       title: Ensure that the scheduler pod specification file permissions are set to 600 or more restrictive
       status: automated
       rules:
-        - file_permissions_kube_scheduler
+        - file_permissions_scheduler
       levels: level_1
     - id: 1.1.6
       title: Ensure that the scheduler pod specification file ownership is set to root:root

--- a/controls/cis_ocp_1_4_0/section-1.yml
+++ b/controls/cis_ocp_1_4_0/section-1.yml
@@ -26,7 +26,7 @@ controls:
       title: Ensure that the controller manager pod specification file permissions are set to 600 or more restrictive
       status: automated
       rules:
-        - file_permissions_kube_apiserver
+        - file_permissions_kube_controller_manager
       levels: level_1
     - id: 1.1.4
       title: Ensure that the controller manager pod specification file ownership is set to root:root

--- a/controls/cis_ocp_1_4_0/section-4.yml
+++ b/controls/cis_ocp_1_4_0/section-4.yml
@@ -47,6 +47,8 @@ controls:
       rules:
         - file_groupowner_kubelet_conf
         - file_owner_kubelet_conf
+        #- file_groupowner_kubelet
+        - file_owner_kubelet
       levels: level_1
     - id: 4.1.7
       title: Ensure that the certificate authorities file permissions are set to 644 or more restrictive
@@ -135,6 +137,7 @@ controls:
       status: automated
       rules:
         - kubelet_configure_tls_cert
+        - kubelet_configure_tls_key
       levels: level_1
     - id: 4.2.10
       title: Ensure that the --rotate-certificates argument is not set to false
@@ -148,6 +151,7 @@ controls:
       status: automated
       rules:
         - kubelet_enable_server_cert_rotation
+        - controller_rotate_kubelet_server_certs
       levels: level_1
     - id: 4.2.12
       title: Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers


### PR DESCRIPTION

#### Description:

- CIS: Use the correct rule for 1.1.3 - this was a copy-paste most probably
- CIS: Use the automated rule for checking kube scheduler permissions - there's two rules that differ just by one having `_kube` in the name and one of them is manual, the other is automated. Let's use the automated one.
- CIS: Additional rules for already covered controls - Just re-adds rules that were in the original hand-written CIS profile, but left out from the control files. I'll point out some questions

#### Rationale:

- OCP4 CIS coverage

#### Review Hints:

- I'll point out some questions inline
- Otherwise just check that the rules make sense and that CI passes
