### PR TITLE
Remove tickets from CIS control files

### DIFF
--- a/controls/cis_ocp_1_4_0/section-1.yml
+++ b/controls/cis_ocp_1_4_0/section-1.yml
@@ -388,8 +388,9 @@ controls:
       rules:
         - api_server_encryption_provider_cipher
       levels: level_1
-      tickets:
-        - https://issues.redhat.com/browse/CMP-1973
+      # Remove this comment once https://github.com/ComplianceAsCode/content/issues/10868 is fixed.
+      # tickets:
+      #   - https://issues.redhat.com/browse/CMP-1973
       notes: |-
         Ticket 1973 tracks adding the aesgcm encryption method for OCP 4.13+
     - id: 1.2.32


### PR DESCRIPTION
We attempted to use `tickets` to document WIP changes for a control, but
it appears to break content builds.

Commenting out the attribute for now so we can at least build the CIS
profile.

This is related to issue #10868.
