### PR TITLE
Sanitize lines for clean YAML output when generating profiles

### DIFF
--- a/utils/generate_profile.py
+++ b/utils/generate_profile.py
@@ -25,7 +25,14 @@ class LiteralUnicode(str):
 
 
 def literal_unicode_representer(dumper, data):
-    return dumper.represent_scalar(u'tag:yaml.org,2002:str', data, style='|')
+    # NOTE(rhmdnd): pyyaml will not format a string using the style we define for the scalar below
+    # if any strings in the data end with a space (e.g., 'some text ' instead of 'some text'). This
+    # has been reported upstream in https://github.com/yaml/pyyaml/issues/121. This particular code
+    # goes through every line of data and strips any whitespace characters from the end of the
+    # string, and reconstructs the string with newlines so that it will format properly.
+    text = [line.rstrip() for line in data.splitlines()]
+    sanitized = '\n'.join(text)
+    return dumper.represent_scalar(u'tag:yaml.org,2002:str', sanitized, style='|')
 
 
 yaml.add_representer(LiteralUnicode, literal_unicode_representer)


### PR DESCRIPTION
There is an issue with how pyyaml dumps lines, where if the line ends
with whitespace, styling won't matter.

  https://github.com/yaml/pyyaml/issues/121

This was affecting our ability to generate YAML output where audit
procedures (with many long lines) would get rendered as a single line
with escaped newlines. Instead, we want to render newlines as a block.

This commit parse each line of the data before it is dumped to make sure
trailing whitespace is removed as a workaround for this issue in pyyaml.
