### PR TITLE
Fix run_scapval.py Python 2 syntax errors

### DIFF
--- a/tests/run_scapval.py
+++ b/tests/run_scapval.py
@@ -115,7 +115,7 @@ def main():
     else:
         build_dir = args.build_dir
         files = os.listdir(build_dir)
-    print(f"Build dir: {build_dir}")
+    print("Build dir: %s" % build_dir)
     if args.scap_version == "1.2":
         ds_suffix = "-ds-1.2.xml"
     elif args.scap_version == "1.3":


### PR DESCRIPTION
#### Description:

Python 2 is still a thing on RHEL 7, make tests/run_scapval.py work with Python 2.

#### Rationale:
Backport of #10873