### PR TITLE
Remove rules from the RHEL9 STIG profile

### DIFF
--- a/controls/srg_gpos/SRG-OS-000250-GPOS-00093.yml
+++ b/controls/srg_gpos/SRG-OS-000250-GPOS-00093.yml
@@ -10,6 +10,4 @@ controls:
             - configure_openssl_crypto_policy
             - configure_openssl_tls_crypto_policy
             - configure_ssh_crypto_policy
-            - harden_sshd_ciphers_opensshserver_conf_crypto_policy
-            - harden_sshd_macs_opensshserver_conf_crypto_policy
         status: automated


### PR DESCRIPTION
Those rules aren't even RHEL9-compatible

The RHEL9 SSHD Crypto Policies implementation is different than the RHEL8 one, and it now has an sshd config format vs the former CLI argument format.

Unfortunately, we can't just remove prodtypes from those rules because of tailoring compatibility, so we have to pay attention not to include them again.