### PR TITLE
Stabilization: Use distributed product properties in Automatus

### DIFF
--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -264,7 +264,7 @@ def _make_file_root_owned(tarinfo):
     return tarinfo
 
 
-def get_product_context(product=None):
+def get_product_context(product_id=None):
     """
     Returns a product YAML context if any product is specified. Hard-coded to
     assume a debug build.
@@ -272,9 +272,11 @@ def get_product_context(product=None):
     # Load product's YAML file if present. This will allow us to parse
     # tests in the context of the product we're executing under.
     product_yaml = dict()
-    if product:
-        yaml_path = product_yaml_path(SSG_ROOT, product)
-        product_yaml.update(load_product_yaml(yaml_path))
+    if product_id:
+        product = load_product_yaml(product_yaml_path(SSG_ROOT, product_id))
+        product_properties_path = os.path.join(SSG_ROOT, "product_properties")
+        product.read_properties_from_directory(product_properties_path)
+        product_yaml.update(product)
 
     # We could run into a DocumentationNotComplete error when loading a
     # rule's YAML contents. However, because the test suite isn't executed


### PR DESCRIPTION
Backport of https://github.com/ComplianceAsCode/content/pull/10878 to stabilization branch.

Automatus needs to start using distributed product properties. Loading only `product.yml` will not obtain all variables that appear in rule YAML files.

Addressing:

```
[jcerny@fedora scap-security-guide{master}]$ tests/automatus.py rule --libvirt qemu:///system ssgts_rhel8 --remediate-using ansible --datastream build/ssg-rhel8-ds.xml dir_perms_world_writable_system_owned_group
Setting console output to log level INFO
INFO - The base image option has not been specified, choosing libvirt-based test environment.
INFO - Logging into /home/jcerny/work/git/scap-security-guide/logs/rule-custom-2023-07-19-1524/test_suite.log
ERROR - Terminating due to error: Error loading a Rule from /home/jcerny/work/git/scap-security-guide/linux_os/guide/system/permissions/files/dir_perms_world_writable_system_owned_group/rule.yml: 'auid' is undefined.
WARNING - Nothing has been tested!
```

Fixes: #10866

