### PR TITLE
Update platform on bios_enable_execution_restrictions

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/enable_nx/bios_enable_execution_restrictions/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_nx/bios_enable_execution_restrictions/rule.yml
@@ -43,7 +43,8 @@ references:
     stigid@rhel8: RHEL-08-010420
     stigid@ubuntu2004: UBTU-20-010447
 
-platform: machine
+# In aarch64 cpus the bit is XN and it is not disableable
+platform: machine and not aarch64_arch
 
 ocil: |-
     Verify the NX (no-execution) bit flag is set on the system.


### PR DESCRIPTION
#### Description:

- Update platform of `bios_enable_execution_restrictions`

#### Rationale:

- The nx flag in the cpu is not applicable to aarch64 systems. Since, first of all there the flag is called XN, but also it is not disableable

#### Review Hints:

- The rule `bios_enable_execution_restrictions` should be marked as notapplicable in an aarch64 system