### PR TITLE
Sysctl template remediations do not modify package files

### DIFF
--- a/shared/templates/sysctl/ansible.template
+++ b/shared/templates/sysctl/ansible.template
@@ -19,7 +19,7 @@
       - "/run/sysctl.d/"
       - "/usr/local/lib/sysctl.d/"
 {{% endif %}}
-{{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel7", "rhel8", "rhel9"] %}}
+{{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel7", "rhel8", "rhel9", "sle12", "sle15"] %}}
       - "/usr/lib/sysctl.d/"
 {{% endif %}}
     contains: '^[\s]*{{{ SYSCTLVAR }}}.*$'

--- a/shared/templates/sysctl/bash.template
+++ b/shared/templates/sysctl/bash.template
@@ -6,7 +6,7 @@
 
 # Comment out any occurrences of {{{ SYSCTLVAR }}} from /etc/sysctl.d/*.conf files
 {{% if product in [ "sle12", "sle15"] %}}
-for f in /run/sysctl.d/*.conf /etc/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf; do
+for f in /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf; do
 {{% elif product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel7", "rhel8", "rhel9"] %}}
 for f in /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf; do
 {{% else %}}


### PR DESCRIPTION
#### Description:

- Remediations should not coment settings in `/usr/lib/sysctl.d/`

#### Rationale:

Those files belong to the packages and as such this is considered as modification of the system package.
 SYSCTL.D(5) manual page states that priority of sysctl configuration file is:
 
 ```   
    /etc/sysctl.d/*.conf
    /run/sysctl.d/*.conf
    /usr/lib/sysctl.d/*.conf
 ```
 So if there is conflict between a setting in /usr/lib/sysctl.d/ and /etc/sysctl.d/, the latter will win
 In this context current remediation code that modifies only /etc/sysctl.d/ files is good enough since even, if we do not comment out setting in /usr/lib/sysctl.d/ it will be ignored by the system

### Review Hints:

@freddieRv you might want to consider if for your platform the changes are valid also