### PR TITLE
SLE15 audit rules mac modification usr share depends on selinux policy packages

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification_usr_share/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification_usr_share/oval/shared.xml
@@ -31,8 +31,8 @@
   </definition>
 
 {{%- if 'sle15' in product -%}}
-  {{{ oval_test_package_installed(package="selinux-policy-devel", evr=EVR, test_id="check_selinux_policy_devel_installed") }}}
-  {{{ oval_test_package_installed(package="selinux-policy-targeted", evr=EVR, test_id="check_selinux_policy_targeted_installed") }}}
+  {{{ oval_test_package_installed(package="selinux-policy-devel", evr="", test_id="check_selinux_policy_devel_installed") }}}
+  {{{ oval_test_package_installed(package="selinux-policy-targeted", evr="", test_id="check_selinux_policy_targeted_installed") }}}
 {{%- endif -%}}
 
   <ind:textfilecontent54_test id="test_armm_selinux_watch_augenrules_usr_share" version="1"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification_usr_share/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification_usr_share/oval/shared.xml
@@ -4,6 +4,14 @@
       mandatory access controls (SELinux) in usr/share/selinux are enabled.") }}}
 
     <criteria operator="OR">
+{{%- if 'sle15' in product -%}}
+      <criteria operator="AND">
+        <criterion test_ref="check_selinux_policy_devel_installed"
+          comment="Check no selinux-policy-devel package installed" negate="true"/>
+        <criterion test_ref="check_selinux_policy_targeted_installed"
+          comment="Check no selinux-policy-targeted package installed" negate="true"/>
+      </criteria>
+{{%- endif -%}}
       <!-- Test the augenrules_usr_share case -->
       <criteria operator="AND">
         <extend_definition definition_ref="audit_rules_augenrules"
@@ -21,6 +29,11 @@
       </criteria>
     </criteria>
   </definition>
+
+{{%- if 'sle15' in product -%}}
+  {{{ oval_test_package_installed(package="selinux-policy-devel", evr=EVR, test_id="check_selinux_policy_devel_installed") }}}
+  {{{ oval_test_package_installed(package="selinux-policy-targeted", evr=EVR, test_id="check_selinux_policy_targeted_installed") }}}
+{{%- endif -%}}
 
   <ind:textfilecontent54_test id="test_armm_selinux_watch_augenrules_usr_share" version="1"
     check="all" comment="audit selinux changes augenrules in usr/share">

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification_usr_share/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification_usr_share/oval/shared.xml
@@ -4,7 +4,7 @@
       mandatory access controls (SELinux) in usr/share/selinux are enabled.") }}}
 
     <criteria operator="OR">
-{{%- if 'sle15' in product -%}}
+{{%- if product in ["sle15"] -%}}
       <criteria operator="AND">
         <criterion test_ref="check_selinux_policy_devel_installed"
           comment="Check no selinux-policy-devel package installed" negate="true"/>
@@ -30,7 +30,7 @@
     </criteria>
   </definition>
 
-{{%- if 'sle15' in product -%}}
+{{%- if product in ["sle15"] -%}}
   {{{ oval_test_package_installed(package="selinux-policy-devel", evr="", test_id="check_selinux_policy_devel_installed") }}}
   {{{ oval_test_package_installed(package="selinux-policy-targeted", evr="", test_id="check_selinux_policy_targeted_installed") }}}
 {{%- endif -%}}


### PR DESCRIPTION
#### Description:

- In SLE15 environment we have separate package for selinux policy

#### Rationale:

- In order rules that audit selinux policy configuration to be relevant we need one of the dedicated selinux-policy packages to be installed otherwise the rule is irrelevant