### PR TITLE
Allow default permission for user.cfg file in UEFI systems

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/uefi/file_permissions_efi_user_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/file_permissions_efi_user_cfg/rule.yml
@@ -45,4 +45,4 @@ template:
     name: file_permissions
     vars:
         filepath: {{{ grub2_uefi_boot_path }}}/user.cfg
-        filemode: '0600'
+        filemode: '0700'

--- a/linux_os/guide/system/bootloader-grub2/uefi/group.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/group.yml
@@ -6,3 +6,10 @@ description: |-
     UEFI GRUB2 bootloader configuration
 
 platform: uefi
+
+warnings:
+    - functionality: |-
+        UEFI generally uses vfat file systems, which does not support Unix-style permissions
+        managed by chmod command. In this case, in order to change file permissions for files
+        within /boot/efi it is necessary to update the mount options in /etc/fstab file and
+        reboot the system.


### PR DESCRIPTION
#### Description:

This rule was asking `0600` permission for `user.cfg` file even in a UEFI boot partition.
However, UEFI usually uses a `vfat` file system, which makes the `chmod` command ineffective if the file system "umask" mount option is set to `0077`, as it is by default.
If the permissions of files in `/boot/efi` using `vfat` needs to be changed, the `umask` value should be updated in fstab.

#### Rationale:

CIS allows `0700` permission for `/boot/efi` and currently it is the only profile using this rule.
This PR makes 0700 permission accepted.

- Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2184487