### PR TITLE
change hardcoded value to variable in ansible of accounts_password_set_min_life_existing

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/ansible/shared.yml
@@ -17,7 +17,7 @@
     passwd -q -n {{ var_accounts_minimum_age_login_defs }} {{ item }}
 {{% else %}}
   command: >
-    chage -m 1 {{ item }}
+    chage -m {{ var_accounts_minimum_age_login_defs }} {{ item }}
 {{% endif %}}    
   with_items: "{{ user_names.stdout_lines }}"
   when: user_names.stdout_lines | length > 0


### PR DESCRIPTION
#### Description:

- the value for the chage command was hardcoded to 1, change it to use the variable

#### Rationale:


- Fixes #10853 

#### Review Hints:

1. setup a RHEL 8 VM
2. ./build_product rhel8
3. scan the VM with the datastream - the rule accounts_password_set_min_life_existing should fail
4. ansible-playbook -u root -i <hostname>, --tags accounts_password_set_min_life_existing build/ansible/rhel8-playbook-cis_workstation_l2.yml
5. Scan the VM again - the rule should pass