### PR TITLE
Avoid Ansible shell module if not necessary

### DIFF
--- a/linux_os/guide/services/obsolete/r_services/no_host_based_files/ansible/shared.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_host_based_files/ansible/shared.yml
@@ -3,25 +3,81 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: "Find local mount points"
-  shell: |
-      set -o pipefail
-      df --local | awk '{print $6}' | grep -v Mounted | grep -v '^/dev' || true
-  register: local_mount_points
 
-- name: "Detect the shosts.equiv files on the system"
-  find:
-      paths: "{{ item }}"
-      recurse: yes
-      patterns: ["shosts.equiv"]
-      file_type: "file"
-  check_mode: no
-  with_items: "{{ local_mount_points.stdout_lines }}"
-  register: shosts_equiv_locations
+- name: "{{{ rule_title }}} - Define Excluded (Non-Local) File Systems and Paths"
+  ansible.builtin.set_fact:
+    excluded_fstypes:
+      - afs
+      - ceph
+      - cifs
+      - smb3
+      - smbfs
+      - sshfs
+      - ncpfs
+      - ncp
+      - nfs
+      - nfs4
+      - gfs
+      - gfs2
+      - glusterfs
+      - gpfs
+      - pvfs2
+      - ocfs2
+      - lustre
+      - davfs
+      - fuse.sshfs
+    excluded_paths:
+      - dev
+      - proc
+      - run
+      - sys
+    search_paths: []
+    shosts_equiv_files:
+      - /shosts.equiv
 
-- name: "Remove shosts.equiv Files"
-  file:
-      path: "{{ item.path }}"
-      state: absent
-  with_items: "{{ shosts_equiv_locations.results | map(attribute='files') | list }}"
-  when: shosts_equiv_locations is success
+- name: "{{{ rule_title }}} - Find Relevant Root Directories Ignoring Pre-Defined Excluded Paths"
+  ansible.builtin.find:
+    paths: /
+    file_type: directory
+    excludes: "{{ excluded_paths }}"
+    hidden: true
+    recurse: false
+  register: result_relevant_root_dirs
+
+- name: "{{{ rule_title }}} - Include Relevant Root Directories in a List of Paths to be Searched"
+  ansible.builtin.set_fact:
+    search_paths: "{{ search_paths | union([item.path]) }}"
+  loop: "{{ result_relevant_root_dirs.files }}"
+
+- name: "{{{ rule_title }}} - Increment Search Paths List with Local Partitions Mount Points"
+  ansible.builtin.set_fact:
+    search_paths: "{{ search_paths | union([item.mount]) }}"
+  loop: '{{ ansible_mounts }}'
+  when:
+    - item.fstype not in excluded_fstypes
+    - item.mount != '/'
+
+- name: "{{{ rule_title }}} - Increment Search Paths List with Local NFS File System Targets"
+  ansible.builtin.set_fact:
+    search_paths: "{{ search_paths | union([item.device.split(':')[1]]) }}"
+  loop: '{{ ansible_mounts }}'
+  when:
+    - item.device is search("localhost:")
+
+- name: "{{{ rule_title }}} - Find All shosts.equiv Files in Local File Systems"
+  ansible.builtin.command:
+    cmd: find {{ item }} -xdev -type f -name "shosts.equiv"
+  loop: "{{ search_paths }}"
+  changed_when: false
+  register: result_found_shosts_equiv_files
+
+- name: "{{{ rule_title }}} - Create List of shosts.equiv Files Present in Local File Systems"
+  ansible.builtin.set_fact:
+    shosts_equiv_files: '{{ shosts_equiv_files | union(item.stdout_lines) | list }}'
+  loop: "{{ result_found_shosts_equiv_files.results }}"
+
+- name: "{{{ rule_title }}} - Ensure No shosts.equiv Files Are Present in the System"
+  ansible.builtin.file:
+    path: '{{ item }}'
+    state: absent
+  loop: '{{ shosts_equiv_files }}'

--- a/linux_os/guide/services/obsolete/r_services/no_host_based_files/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_host_based_files/rule.yml
@@ -5,18 +5,15 @@ prodtype: ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 title: 'Remove Host-Based Authentication Files'
 
 description: |-
-    The <tt>shosts.equiv</tt> file list remote hosts
-    and users that are trusted by the local system.
-    To remove these files, run the following command to delete them from any
-    location:
+    The <tt>shosts.equiv</tt> file lists remote hosts and users that are trusted by the local
+    system. To remove these files, run the following command to delete them from any location:
     <pre>$ sudo rm /[path]/[to]/[file]/shosts.equiv</pre>
 
 rationale: |-
-    The shosts.equiv files are used to configure host-based authentication for the
-    system via SSH. Host-based authentication is not sufficient for preventing
-    unauthorized access to the system, as it does not require interactive
-    identification and authentication of a connection request, or for the use of
-    two-factor authentication.
+    The shosts.equiv files are used to configure host-based authentication for the system via SSH.
+    Host-based authentication is not sufficient for preventing unauthorized access to the system,
+    as it does not require interactive identification and authentication of a connection request,
+    or for the use of two-factor authentication.
 
 severity: high
 
@@ -40,8 +37,7 @@ references:
 ocil_clause: 'shosts.equiv files exist'
 
 ocil: |-
-    Verify that there are no <tt>shosts.equiv</tt> files
-    on the system, run the following command:
+    Verify that there are no <tt>shosts.equiv</tt> files on the system, run the following command:
     <pre>$ find / -name shosts.equiv</pre>
 
 fixtext: |-

--- a/linux_os/guide/system/software/gnome/dconf_db_up_to_date/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/dconf_db_up_to_date/ansible/shared.yml
@@ -4,6 +4,5 @@
 # complexity = low
 # disruption = medium
 - name: "Run dconf update"
-  shell: |
-    set -o pipefail
-    dconf update
+  ansible.builtin.command:
+    cmd: dconf update


### PR DESCRIPTION
#### Description:

The Ansible remediation of two rules was updated in this PR:

- dconf_db_up_to_date
  - `shell` module simply replaced by `command` module and simplified.
- no_host_based_files
  - Ansible remediation was refactored to improve efficiency on detecting local partitions and performance on searching files.

#### Rationale:

- Fixes #10852

#### Review Hints:

automatus tests with these rules should be enough. The same result is expected after the improvements.