### PR TITLE
enhance OVAL for enable_fips_mode

### DIFF
--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/oval/shared.xml
@@ -20,6 +20,36 @@
       {{% endif %}}
     </criteria>
   </definition>
+
+  <ind:textfilecontent54_test id="test_fips_1_argument_in_boot_loader_entries_conf"
+  comment="Check if argument fips=1 is present in the line starting with 'options ' in /boot/loader/entries/.*.conf"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_fips_1_argument_in_boot_loader_entries_conf" />
+    <ind:state state_ref="state_fips_1_argument_in_boot_loader_entries_conf" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_fips_1_argument_in_boot_loader_entries_conf" version="1">
+    <ind:filepath operation="pattern match">^/boot/loader/entries/.*.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^options (.*)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_fips_1_argument_in_boot_loader_entries_conf" version="1">
+    <ind:subexpression datatype="string" operation="pattern match">^(?:.*\s)?fips=1(?:\s.*)?$</ind:subexpression>
+  </ind:textfilecontent54_state>
+  <ind:textfilecontent54_test id="test_fips_1_argument_in_etc_kernel_cmdline"
+  comment="Check if argument fips=1 is present in /etc/kernel/cmdline"
+  check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_fips_1_argument_in_etc_kernel_cmdline" />
+    <ind:state state_ref="state_fips_1_argument_in_etc_kernel_cmdline" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_fips_1_argument_in_etc_kernel_cmdline" version="1">
+    <ind:filepath operation="pattern match">^/etc/kernel/cmdline</ind:filepath>
+    <ind:pattern operation="pattern match">^(.*)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_fips_1_argument_in_etc_kernel_cmdline" version="1">
+    <ind:subexpression datatype="string" operation="pattern match">^(?:.*\s)?fips=1(?:\s.*)?$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
   <ind:variable_test check="at least one" comment="tests if var_system_crypto_policy is set to FIPS" id="test_system_crypto_policy_value" version="1">
     <ind:object object_ref="obj_system_crypto_policy_value" />
     <ind:state state_ref="ste_system_crypto_policy_value" />

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/oval/shared.xml
@@ -38,30 +38,27 @@
   comment="Check if argument fips=1 is present in the line starting with 'options ' in /boot/loader/entries/.*.conf"
   check="all" check_existence="all_exist" version="1">
     <ind:object object_ref="object_fips_1_argument_in_boot_loader_entries_conf" />
-    <ind:state state_ref="state_fips_1_argument_in_boot_loader_entries_conf" />
+    <ind:state state_ref="state_fips_1_argument_in_captured_group" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_fips_1_argument_in_boot_loader_entries_conf" version="1">
     <ind:filepath operation="pattern match">^/boot/loader/entries/.*.conf</ind:filepath>
     <ind:pattern operation="pattern match">^options (.*)$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
-  <ind:textfilecontent54_state id="state_fips_1_argument_in_boot_loader_entries_conf" version="1">
+  <ind:textfilecontent54_state id="state_fips_1_argument_in_captured_group" version="1">
     <ind:subexpression datatype="string" operation="pattern match">^(?:.*\s)?fips=1(?:\s.*)?$</ind:subexpression>
   </ind:textfilecontent54_state>
   <ind:textfilecontent54_test id="test_fips_1_argument_in_etc_kernel_cmdline"
   comment="Check if argument fips=1 is present in /etc/kernel/cmdline"
   check="all" check_existence="all_exist" version="1">
     <ind:object object_ref="object_fips_1_argument_in_etc_kernel_cmdline" />
-    <ind:state state_ref="state_fips_1_argument_in_etc_kernel_cmdline" />
+    <ind:state state_ref="state_fips_1_argument_in_captured_group" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_fips_1_argument_in_etc_kernel_cmdline" version="1">
     <ind:filepath operation="pattern match">^/etc/kernel/cmdline</ind:filepath>
     <ind:pattern operation="pattern match">^(.*)$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
-  <ind:textfilecontent54_state id="state_fips_1_argument_in_etc_kernel_cmdline" version="1">
-    <ind:subexpression datatype="string" operation="pattern match">^(?:.*\s)?fips=1(?:\s.*)?$</ind:subexpression>
-  </ind:textfilecontent54_state>
 
   <ind:variable_test check="at least one" comment="tests if var_system_crypto_policy is set to FIPS" id="test_system_crypto_policy_value" version="1">
     <ind:object object_ref="obj_system_crypto_policy_value" />

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/oval/shared.xml
@@ -7,15 +7,28 @@
       <extend_definition comment="Dracut FIPS module is enabled" definition_ref="enable_dracut_fips_module" />
       <extend_definition comment="system cryptography policy is configured" definition_ref="configure_crypto_policy" />
       <criterion comment="check if system crypto policy selection in var_system_crypto_policy in the profile is set to FIPS" test_ref="test_system_crypto_policy_value" />
-      {{% if product in ["ol8"] %}}
-      <criterion comment="check if the kernel boot parameter is configured for FIPS mode"
-      test_ref="test_grubenv_fips_mode" />
-      {{% elif product in ["rhel8"] %}}
+      <criterion comment="Check if argument fips=1 for Linux kernel is present in /etc/kernel/cmdline" test_ref="test_fips_1_argument_in_etc_kernel_cmdline" />
+      {{% if "ol" in product or "rhel" in product %}}
       <criteria operator="OR">
-        <extend_definition comment="Generic test for s390x architecture"
-        definition_ref="system_info_architecture_s390_64" />
-        <criterion comment="check if the kernel boot parameter is configured for FIPS mode"
-        test_ref="test_grubenv_fips_mode" />
+        <criteria operator="AND">
+          <extend_definition comment="Generic test for s390x architecture"
+          definition_ref="system_info_architecture_s390_64" />
+          <criterion comment="Check if argument fips=1 for Linux kernel is present in /boot/loader/entries/.*.conf"
+          test_ref="test_fips_1_argument_in_boot_loader_entries_conf" />
+        </criteria>
+        <criteria operator="AND">
+          <criteria negate="true">
+            <extend_definition comment="Generic test for NOT s390x architecture"
+            definition_ref="system_info_architecture_s390_64" />
+          </criteria>
+          {{% if product in ["ol8", "rhel8"] %}}
+          <criterion comment="check if the kernel boot parameter is configured for FIPS mode"
+          test_ref="test_grubenv_fips_mode" />
+          {{% else %}}
+          <criterion comment="Check if argument fips=1 for Linux kernel is present in /boot/loader/entries/.*.conf"
+          test_ref="test_fips_1_argument_in_boot_loader_entries_conf" />
+          {{% endif %}}
+        </criteria>
       </criteria>
       {{% endif %}}
     </criteria>


### PR DESCRIPTION
#### Description:

- add more tests to check /etc/kernel/cmdline and also /boot/loader/entries/*.conf files
- use correct check based on prodtype, inspired by grub2_template
- if we are on S390X architecture, check /boot/loader/entries/*.conf only, there is no grubenv file

#### Rationale:

- fixes https://bugzilla.redhat.com/show_bug.cgi?id=2129100



#### Review Hints:

1. provision X86 and S390X RHEL 8 and RHEL 9 machines
2. ./build_product rhel8 rhel9
3. on each machine run fips-mode-setup --enable && update-crypto-policies --set fips:ospp
4. run oscap xccdf eval --profile ospp --report result.html --rule xccdf_org.ssgproject.content_rule_enable_fips_mode <datastream.xml>
5. inspect the HTML report to see that checks are checking corect things