### PR TITLE
A correction in the rule pam_disable_automatic_configuration

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/pam_disable_automatic_configuration/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/pam_disable_automatic_configuration/oval/shared.xml
@@ -8,8 +8,7 @@
       <description>Verify the SUSE operating system is configured to not overwrite Pluggable
     Authentication Modules (PAM) configuration on package changes.</description>
     </metadata>
-    <criteria comment="package pam_apparmor is installed and automatic configuration is disabled" operator="AND">
-        <extend_definition comment="package package pam_apparmor installed" definition_ref="package_pam_apparmor_installed" />
+    <criteria>
         <criterion comment="/etc/pam.d/common-* are not symbolic links" test_ref="test_pam_disable_automatic_configuration" />
     </criteria>
   </definition>

--- a/linux_os/guide/system/accounts/accounts-pam/pam_disable_automatic_configuration/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/pam_disable_automatic_configuration/oval/shared.xml
@@ -8,7 +8,8 @@
       <description>Verify the SUSE operating system is configured to not overwrite Pluggable
     Authentication Modules (PAM) configuration on package changes.</description>
     </metadata>
-    <criteria>
+    <criteria comment="package pam_apparmor is installed and automatic configuration is disabled" operator="AND">
+        <extend_definition comment="package package pam_apparmor installed" definition_ref="package_pam_apparmor_installed" />
         <criterion comment="/etc/pam.d/common-* are not symbolic links" test_ref="test_pam_disable_automatic_configuration" />
     </criteria>
   </definition>

--- a/linux_os/guide/system/accounts/accounts-pam/pam_disable_automatic_configuration/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/pam_disable_automatic_configuration/rule.yml
@@ -37,3 +37,5 @@ ocil: |-
     <pre># find /etc/pam.d/ -type l -iname "common-*"</pre>
 
     If any results are returned, this is a finding.
+
+platform: package[pam_apparmor]

--- a/shared/applicability/package.yml
+++ b/shared/applicability/package.yml
@@ -49,6 +49,8 @@ args:
     {{% else %}}
       pkgname: libpam-runtime
     {{% endif %}}
+  pam_apparmor:
+    pkgname: pam_apparmor
   polkit:
     pkgname: polkit
   postfix:


### PR DESCRIPTION
#### Description:

- _The correction corrects the recommendation pam_disable_automatic_configuration_

#### Rationale:

- At the moment after the build in the resulting remediation files (bash/ansible) we have first the rule  pam_disable_automatic_configuration and after this  we have the rule package_pam_apparmor_installed, instead of opposite order. There is a dependency between both rules because  pam_disable_automatic_configuration removes soft links, but these links are created during the execution of the rule package_pam_apparmor_installed. With this correction the rule pam_disable_automatic_configuration will not make changes in our system when the  module pam_apparmor is not installed.   
