### PR TITLE
DO NOT MERGE: service_disabled template: filter out not found units

### DIFF
--- a/shared/templates/service_disabled/oval.template
+++ b/shared/templates/service_disabled/oval.template
@@ -36,7 +36,11 @@
   <linux:systemdunitproperty_object id="obj_service_loadstate_is_masked_{{{ SERVICENAME }}}" comment="Retrieve the LoadState property of {{{ SERVICENAME }}}" version="1">
     <linux:unit operation="pattern match">^{{{ SERVICENAME }}}\.(service|socket)$</linux:unit>
     <linux:property>LoadState</linux:property>
+    <filter action="exclude">state_service_loadstate_is_notfound_{{{ SERVICENAME }}}</filter>
   </linux:systemdunitproperty_object>
+  <linux:systemdunitproperty_state id="state_service_loadstate_is_notfound_{{{ SERVICENAME }}}" version="1" comment="LoadState is set to not-found">
+      <linux:value>not-found</linux:value>
+  </linux:systemdunitproperty_state>
   <linux:systemdunitproperty_state id="state_service_loadstate_is_masked_{{{ SERVICENAME }}}" version="1" comment="LoadState is set to masked">
       <linux:value>masked</linux:value>
   </linux:systemdunitproperty_state>


### PR DESCRIPTION
#### Description:

- when searching for systemd units and checking if their state is "masked", Openscap sometimes returns units which in fact do not exist. Their state is "not-found". This tries to workaround this problem by filtering out those units.

#### Rationale:

- openscap sometimes returns unit files with loadstate not-found, this happens in case of templated units.
My opinion is that this should be fixed on Openscap side.

Related to #10894 

#### Review Hints:

- try to run test scenarios of rule service_systemd-coredump-disabled with Openscap 1.3.8.
- you can also try to run some other test scenarios for other rules using service_disabled platform