### PR TITLE
Fix association of nfs-utils package with rpcbind service

### DIFF
--- a/components/nfs-utils.yml
+++ b/components/nfs-utils.yml
@@ -5,7 +5,6 @@ rules:
 - package_nfs-utils_removed
 - service_nfs_disabled
 - service_nfslock_disabled
-- service_rpcbind_disabled
 - service_rpcgssd_disabled
 - service_rpcidmapd_disabled
 - service_rpcsvcgssd_disabled

--- a/components/rpcbind.yml
+++ b/components/rpcbind.yml
@@ -3,3 +3,4 @@ packages:
 - rpcbind
 rules:
 - package_rpcbind_removed
+- service_rpcbind_disabled

--- a/linux_os/guide/services/nfs_and_rpc/disabling_nfs/disabling_nfs_services/service_rpcbind_disabled/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/disabling_nfs/disabling_nfs_services/service_rpcbind_disabled/rule.yml
@@ -40,4 +40,3 @@ template:
     name: service_disabled
     vars:
         servicename: rpcbind
-        packagename: nfs-utils


### PR DESCRIPTION
#### Description:

When investigating #10901 it was noticed that the `nfs-utils` package was associated with the `rpcbind` service when calling the `service_disabled` template in the `service_rpcbind_disabled rule`.

This association is not correct and has been fixed in this PR.

#### Rationale:

Bugfix