### PR TITLE
Add version to profile element in the data stream

### DIFF
--- a/ssg/entities/profile_base.py
+++ b/ssg/entities/profile_base.py
@@ -92,6 +92,8 @@ class Profile(XCCDFEntity, SelectionHandler):
     def to_xml_element(self):
         element = ET.Element('{%s}Profile' % XCCDF12_NS)
         element.set("id", OSCAP_PROFILE + self.id_)
+        if self.metadata and 'version' in self.metadata and self.metadata['version'] is not None:
+            add_sub_element(element, "version", XCCDF12_NS, str(self.metadata["version"]))
         if self.extends:
             element.set("extends", self.extends)
         title = add_sub_element(element, "title", XCCDF12_NS, self.title)

--- a/tests/unit/ssg-module/data/ospp.xml
+++ b/tests/unit/ssg-module/data/ospp.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <ns0:Profile xmlns:ns0="http://checklists.nist.gov/xccdf/1.2" id="xccdf_org.ssgproject.content_profile_ospp">
+  <ns0:version>4.2.1</ns0:version>
   <ns0:title override="true">Protection Profile for General Purpose Operating Systems</ns0:title>
   <ns0:description override="true">This profile is part of Red Hat Enterprise Linux 9 Common Criteria Guidance
 documentation for Target of Evaluation based on Protection Profile for

--- a/tests/unit/ssg-module/test_build_yaml.py
+++ b/tests/unit/ssg-module/test_build_yaml.py
@@ -533,3 +533,25 @@ def test_rule_to_ocil(rule_accounts_tmout):
             expected_file_path = os.path.join(DATADIR, expected_filename)
             diff = xmldiff_main.diff_files(real_file_path, expected_file_path)
             assert diff == []
+
+
+@pytest.fixture()
+def profile_without_version(profile_ospp):
+    profile_ospp.metadata.pop('version', None)
+    return profile_ospp
+
+
+def test_profile_without_version(profile_without_version):
+    profile_el = profile_without_version.to_xml_element()
+    assert profile_el.find("{%s}version" % XCCDF12_NS) is None
+
+
+@pytest.fixture()
+def profile_with_version(profile_ospp):
+    profile_ospp.metadata["version"] = "3.2.1"
+    return profile_ospp
+
+
+def test_profile_with_version(profile_with_version):
+    profile_el = profile_with_version.to_xml_element()
+    assert profile_el.find("{%s}version" % XCCDF12_NS).text == "3.2.1"


### PR DESCRIPTION
#### Description:

Adds version numbers for profiles to the data stream based on the metadata version information.

#### Rationale:

To aid in future features.
#### Review Hints:
1. `./build_product -j10 rhel8`
2. `grep xccdf-1.2:version build/ssg-*-ds.xml`