### PR TITLE
Refactor Ansible remediations that search local file systems

### DIFF
--- a/linux_os/guide/services/obsolete/r_services/no_host_based_files/ansible/shared.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_host_based_files/ansible/shared.yml
@@ -4,65 +4,12 @@
 # complexity = low
 # disruption = low
 
-- name: "{{{ rule_title }}} - Define Excluded (Non-Local) File Systems and Paths"
+{{{ ansible_create_list_of_local_paths(list_name="search_paths") }}}
+
+- name: "{{{ rule_title }}} - Define Rule Specific Facts"
   ansible.builtin.set_fact:
-    excluded_fstypes:
-      - afs
-      - ceph
-      - cifs
-      - smb3
-      - smbfs
-      - sshfs
-      - ncpfs
-      - ncp
-      - nfs
-      - nfs4
-      - gfs
-      - gfs2
-      - glusterfs
-      - gpfs
-      - pvfs2
-      - ocfs2
-      - lustre
-      - davfs
-      - fuse.sshfs
-    excluded_paths:
-      - dev
-      - proc
-      - run
-      - sys
-    search_paths: []
     shosts_equiv_files:
       - /shosts.equiv
-
-- name: "{{{ rule_title }}} - Find Relevant Root Directories Ignoring Pre-Defined Excluded Paths"
-  ansible.builtin.find:
-    paths: /
-    file_type: directory
-    excludes: "{{ excluded_paths }}"
-    hidden: true
-    recurse: false
-  register: result_relevant_root_dirs
-
-- name: "{{{ rule_title }}} - Include Relevant Root Directories in a List of Paths to be Searched"
-  ansible.builtin.set_fact:
-    search_paths: "{{ search_paths | union([item.path]) }}"
-  loop: "{{ result_relevant_root_dirs.files }}"
-
-- name: "{{{ rule_title }}} - Increment Search Paths List with Local Partitions Mount Points"
-  ansible.builtin.set_fact:
-    search_paths: "{{ search_paths | union([item.mount]) }}"
-  loop: '{{ ansible_mounts }}'
-  when:
-    - item.fstype not in excluded_fstypes
-    - item.mount != '/'
-
-- name: "{{{ rule_title }}} - Increment Search Paths List with Local NFS File System Targets"
-  ansible.builtin.set_fact:
-    search_paths: "{{ search_paths | union([item.device.split(':')[1]]) }}"
-  loop: '{{ ansible_mounts }}'
-  when:
-    - item.device is search("localhost:")
 
 - name: "{{{ rule_title }}} - Find All shosts.equiv Files in Local File Systems"
   ansible.builtin.command:

--- a/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/ansible/shared.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/ansible/shared.yml
@@ -3,26 +3,28 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: "Find local mount points"
-  shell: |
-      set -o pipefail
-      df --local | awk '{print $6}' | grep -v Mounted | grep -v '^/dev' || true
-  register: local_mount_points
 
-- name: "Detect the .shosts files on the system"
-  find:
-      paths: "{{ item }}"
-      recurse: yes
-      patterns: [".shosts"]
-      hidden: yes
-      file_type: "file"
-  check_mode: no
-  with_items: "{{ local_mount_points.stdout_lines }}"
-  register: shosts_locations
+{{{ ansible_create_list_of_local_paths(list_name="search_paths") }}}
 
-- name: "Remove .shosts Files"
-  file:
-      path: "{{ item.path }}"
-      state: absent
-  with_items: "{{ shosts_locations.results | map(attribute='files') | list }}"
-  when: shosts_locations is success
+- name: "{{{ rule_title }}} - Define Rule Specific Facts"
+  ansible.builtin.set_fact:
+    user_shosts_files:
+      - /.shosts
+
+- name: "{{{ rule_title }}} - Find All .shosts Files in Local File Systems"
+  ansible.builtin.command:
+    cmd: find {{ item }} -xdev -type f -name ".shosts"
+  loop: "{{ search_paths }}"
+  changed_when: false
+  register: result_found_shosts_files
+
+- name: "{{{ rule_title }}} - Create List of .shosts Files Present in Local File Systems"
+  ansible.builtin.set_fact:
+    user_shosts_files: '{{ user_shosts_files | union(item.stdout_lines) | list }}'
+  loop: "{{ result_found_shosts_files.results }}"
+
+- name: "{{{ rule_title }}} - Ensure No .shosts Files Are Present in the System"
+  ansible.builtin.file:
+    path: '{{ item }}'
+    state: absent
+  loop: '{{ user_shosts_files }}'

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/ansible/shared.yml
@@ -4,28 +4,16 @@
 # complexity = low
 # disruption = low
 
-- name: Ensure SHA_CRYPT_MIN_ROUNDS has minimum value of 5000
-  replace:
+- name: "{{{ rule_title }}} - Ensure SHA_CRYPT_MIN_ROUNDS has Minimum Value of 5000"
+  ansible.builtin.replace:
     path: /etc/login.defs
     regexp: '(^\s*SHA_CRYPT_MIN_ROUNDS\s+)(?!(?:[5-9]\d{3,}|\d{5,}))\S*(\s*$)'
     replace: '\g<1>5000\g<2>'
     backup: no
 
-- name: Check to see if SHA_CRYPT_MIN_ROUNDS is explicitly configured
-  shell: |
-    set -o pipefail
-    grep -e '^\s*SHA_CRYPT_MIN_ROUNDS\s\+' /etc/login.defs || true
-  register: check_sha_crypt_min_rounds_result
-
-# NOTE(gyee): there's a possibility that the value of SHA_CRYPT_MIN_ROUNDS is
-# greater than the value of SHA_CRYPT_MAX_ROUNDS. But as far as we're,
-# concerned, this is not a problem as per login.defs,
-# if SHA_CRYPT_MIN_ROUNDS > SHA_CRYPT_MAX_ROUNDS, the highest value will be
-# used. In that case, we don't need to touch SHA_CRYPT_MAX_ROUNDS.
-- name: Ensure SHA_CRYPT_MAX_ROUNDS has minimum value of 5000
-  replace:
+- name: "{{{ rule_title }}} - Ensure SHA_CRYPT_MAX_ROUNDS has Minimum Value of 5000"
+  ansible.builtin.replace:
     path: /etc/login.defs
     regexp: '(^\s*SHA_CRYPT_MAX_ROUNDS\s+)(?!(?:[5-9]\d{3,}|\d{5,}))\S*(\s*$)'
     replace: '\g<1>5000\g<2>'
     backup: no
-  when: '"SHA_CRYPT_MIN_ROUNDS" not in check_sha_crypt_min_rounds_result.stdout'

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/tests/argument_missing.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/tests/argument_missing.pass.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-source common.sh

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/tests/common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/tests/common.sh
@@ -1,2 +1,0 @@
-
-truncate -s 0 "/etc/login.defs"

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/tests/correct_values.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/tests/correct_values.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-source common.sh
-
 echo "SHA_CRYPT_MIN_ROUNDS 5000" > "/etc/login.defs"
+echo "SHA_CRYPT_MAX_ROUNDS 5000" >> "/etc/login.defs"

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/tests/missing_max_parameter.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/tests/missing_max_parameter.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Default values are 5000 if the parameters are not defined.
+echo "SHA_CRYPT_MIN_ROUNDS 5000" > "/etc/login.defs"

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/tests/missing_min_parameter.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/tests/missing_min_parameter.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Default values are 5000 if the parameters are not defined.
+echo "SHA_CRYPT_MAX_ROUNDS 5000" > "/etc/login.defs"

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/tests/missing_parameters.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/tests/missing_parameters.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Default values are 5000 if the parameters are not defined.
+truncate -s 0 "/etc/login.defs"

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/tests/only_max_value_wrong.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/tests/only_max_value_wrong.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "SHA_CRYPT_MIN_ROUNDS 5000" > "/etc/login.defs"
+echo "SHA_CRYPT_MAX_ROUNDS 4999" >> "/etc/login.defs"

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/tests/only_min_value_wrong.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/tests/only_min_value_wrong.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-source common.sh
-
 echo "SHA_CRYPT_MIN_ROUNDS 4999" > "/etc/login.defs"
+echo "SHA_CRYPT_MAX_ROUNDS 5000" >> "/etc/login.defs"

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/tests/wrong_values.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/tests/wrong_values.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "SHA_CRYPT_MIN_ROUNDS 4999" > "/etc/login.defs"
+echo "SHA_CRYPT_MAX_ROUNDS 4999" >> "/etc/login.defs"

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/ansible/shared.yml
@@ -4,64 +4,11 @@
 # complexity = low
 # disruption = medium
 
-- name: "{{{ rule_title }}} - Define Excluded (Non-Local) File Systems and Paths"
+{{{ ansible_create_list_of_local_paths(list_name="search_paths") }}}
+
+- name: "{{{ rule_title }}} - Define Rule Specific Facts"
   ansible.builtin.set_fact:
-    excluded_fstypes:
-      - afs
-      - ceph
-      - cifs
-      - smb3
-      - smbfs
-      - sshfs
-      - ncpfs
-      - ncp
-      - nfs
-      - nfs4
-      - gfs
-      - gfs2
-      - glusterfs
-      - gpfs
-      - pvfs2
-      - ocfs2
-      - lustre
-      - davfs
-      - fuse.sshfs
-    excluded_paths:
-      - dev
-      - proc
-      - run
-      - sys
-    search_paths: []
     world_writable_dirs: []
-
-- name: "{{{ rule_title }}} - Find Relevant Root Directories Ignoring Pre-Defined Excluded Paths"
-  ansible.builtin.find:
-    paths: /
-    file_type: directory
-    excludes: "{{ excluded_paths }}"
-    hidden: true
-    recurse: false
-  register: result_relevant_root_dirs
-
-- name: "{{{ rule_title }}} - Include Relevant Root Directories in a List of Paths to be Searched"
-  ansible.builtin.set_fact:
-    search_paths: "{{ search_paths | union([item.path]) }}"
-  loop: "{{ result_relevant_root_dirs.files }}"
-
-- name: "{{{ rule_title }}} - Increment Search Paths List with Local Partitions Mount Points"
-  ansible.builtin.set_fact:
-    search_paths: "{{ search_paths | union([item.mount]) }}"
-  loop: '{{ ansible_mounts }}'
-  when:
-    - item.fstype not in excluded_fstypes
-    - item.mount != '/'
-
-- name: "{{{ rule_title }}} - Increment Search Paths List with Local NFS File System Targets"
-  ansible.builtin.set_fact:
-    search_paths: "{{ search_paths | union([item.device.split(':')[1]]) }}"
-  loop: '{{ ansible_mounts }}'
-  when:
-    - item.device is search("localhost:")
 
 - name: "{{{ rule_title }}} - Find All Uncompliant Directories in Local File Systems"
   ansible.builtin.command:

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1670,3 +1670,73 @@ Part of the grub2_bootloader_argument_absent template.
 {{%- macro ansible_mount_conditional(path) -%}}
 '"{{{ path }}}" in ansible_mounts | map(attribute="mount") | list'
 {{%- endmacro -%}}
+
+{{#
+    Create a list of paths composed by root directories and mount points representing local file systems.
+    This list excludes all local directories and mount points using known remote file systems.
+    It also excludes local directories and mount points with pseudo file systems. The list of paths
+    created by this macro can be used to efficiently locate local files or directories in a system.
+
+:param list_name:       Prefered list name to be used in subsequent tasks.
+:type pam_file: str
+
+#}}
+{{%- macro ansible_create_list_of_local_paths(list_name="search_paths") -%}}
+- name: "{{{ rule_title }}} - Define Excluded (Non-Local) File Systems and Paths"
+  ansible.builtin.set_fact:
+    excluded_fstypes:
+      - afs
+      - ceph
+      - cifs
+      - smb3
+      - smbfs
+      - sshfs
+      - ncpfs
+      - ncp
+      - nfs
+      - nfs4
+      - gfs
+      - gfs2
+      - glusterfs
+      - gpfs
+      - pvfs2
+      - ocfs2
+      - lustre
+      - davfs
+      - fuse.sshfs
+    excluded_paths:
+      - dev
+      - proc
+      - run
+      - sys
+    {{{ list_name }}}: []
+
+- name: "{{{ rule_title }}} - Find Relevant Root Directories Ignoring Pre-Defined Excluded Paths"
+  ansible.builtin.find:
+    paths: /
+    file_type: directory
+    excludes: "{{ excluded_paths }}"
+    hidden: true
+    recurse: false
+  register: result_relevant_root_dirs
+
+- name: "{{{ rule_title }}} - Include Relevant Root Directories in a List of Paths to be Searched"
+  ansible.builtin.set_fact:
+    {{{ list_name }}}: "{{ {{{ list_name }}} | union([item.path]) }}"
+  loop: "{{ result_relevant_root_dirs.files }}"
+
+- name: "{{{ rule_title }}} - Increment Search Paths List with Local Partitions Mount Points"
+  ansible.builtin.set_fact:
+    {{{ list_name }}}: "{{ {{{ list_name }}} | union([item.mount]) }}"
+  loop: '{{ ansible_mounts }}'
+  when:
+    - item.fstype not in excluded_fstypes
+    - item.mount != '/'
+
+- name: "{{{ rule_title }}} - Increment Search Paths List with Local NFS File System Targets"
+  ansible.builtin.set_fact:
+    {{{ list_name }}}: "{{ {{{ list_name }}} | union([item.device.split(':')[1]]) }}"
+  loop: '{{ ansible_mounts }}'
+  when:
+    - item.device is search("localhost:")
+{{%- endmacro -%}}


### PR DESCRIPTION
#### Description:

There are some rules which need to locate files and directories in a system but should only consider local files and directories, ignoring remote file systems and some known local directories with pseudo file systems.
Recently the Ansible approach in `dir_perms_world_writable_root_owned` and `no_host_based_files` was refactored in order to make the remediation more robust and more efficient.
A third rule (`no_user_host_based_files`) was discovered with the same issue.
Therefore a macro was created to make the remediation aligned among all relevant rules and to make the same approach easier to be adopted by future rules.

This PR also refactors the Ansible remediation in `set_password_hashing_min_rounds_logindefs` rule by removing unnecessary tasks and align the playbook to the project Style Guides. Finally, the test scenarios were also improved.

#### Rationale:

- More robust, efficient and scalable Ansible remediation.
- Fixes #10893

#### Review Hints:

Automatus tests using Ansible remediation should be enough.