### PR TITLE
Add a two rules to RHEL 9 STIG  - Stable

### DIFF
--- a/controls/srg_gpos/SRG-OS-000023-GPOS-00006.yml
+++ b/controls/srg_gpos/SRG-OS-000023-GPOS-00006.yml
@@ -8,6 +8,5 @@ controls:
             - sshd_enable_warning_banner
             - banner_etc_issue
             - dconf_gnome_banner_enabled
-            # Might be needed, its in all the other STIGs
-            #- dconf_gnome_login_banner_text
+            - dconf_gnome_login_banner_text
         status: automated

--- a/controls/srg_gpos/SRG-OS-000059-GPOS-00029.yml
+++ b/controls/srg_gpos/SRG-OS-000059-GPOS-00029.yml
@@ -7,8 +7,7 @@ controls:
             - audit_rules_immutable
             - directory_group_ownership_var_log_audit
             - directory_ownership_var_log_audit
-            # Not in the current drafts but in RHEL 8
-            # - directory_permissions_var_log_audit
+            - directory_permissions_var_log_audit
             - file_group_ownership_var_log_audit
             - file_ownership_var_log_audit_stig
             - file_permissions_var_log_audit


### PR DESCRIPTION
#### Description:

Adds the following rules to the RHEL 9 STIG

* dconf_gnome_login_banner_text
* directory_permissions_var_log_audit


#### Rationale:
Backport #10910