### PR TITLE
accounts_umask_etc_bashrc: depend on bash being installed

### DIFF
--- a/components/bash.yml
+++ b/components/bash.yml
@@ -1,0 +1,5 @@
+name: bash
+packages:
+- bash
+rules:
+- accounts_umask_etc_bashrc

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/rule.yml
@@ -56,6 +56,8 @@ references:
     stigid@ol8: OL08-00-020353
     stigid@rhel8: RHEL-08-020353
 
+platform: package[bash]
+
 ocil_clause: 'the value for the "umask" parameter is not "{{{ xccdf_value("var_accounts_user_umask") }}}", or the "umask" parameter is missing or is commented out'
 
 ocil: |-

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/missing.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = bash
 
 {{% if 'sle' in product or 'ubuntu' in product %}}
 etc_bash_rc="/etc/bash.bashrc"

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/ospp_cis_correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/ospp_cis_correct.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_cis, xccdf_org.ssgproject.content_profile_ospp
+# packages = bash
 
 {{% if 'sle' in product or 'ubuntu' in product %}}
 etc_bash_rc="/etc/bash.bashrc"

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/stig_correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/stig_correct.pass.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_stig
 # platform = Oracle Linux 8,Red Hat Enterprise Linux 8
+# packages = bash
 
 sed -i '/umask/d' /etc/bashrc
 echo "umask 077" >> /etc/bashrc

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/super_compliant.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/super_compliant.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = bash
 
 {{% if 'sle' in product or 'ubuntu' in product %}}
 etc_bash_rc="/etc/bash.bashrc"

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/wrong.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/wrong.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = bash
 
 sed -i '/umask/d' /etc/bashrc
 echo "umask 000" >> /etc/bashrc

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/wrong_multiple.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/wrong_multiple.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = bash
 
 sed -i '/umask/d' /etc/bashrc
 echo "umask 000" >> /etc/bashrc

--- a/shared/applicability/package.yml
+++ b/shared/applicability/package.yml
@@ -14,6 +14,8 @@ args:
     {{% else %}}
     pkgname: auditd
     {{% endif %}}
+  bash:
+    pkgname: bash
   chrony:
     pkgname: chrony
   firewalld:


### PR DESCRIPTION
#### Description:

accounts_umask_etc_bashrc: depend on bash being installed

#### Rationale:

/etc/bashrc is only used if bash is installed.