### PR TITLE
Create runtime_kernel_fips_enabled cpe and apply it to service_rngd_enabled for OL8 

### DIFF
--- a/linux_os/guide/services/rng/service_rngd_enabled/rule.yml
+++ b/linux_os/guide/services/rng/service_rngd_enabled/rule.yml
@@ -25,6 +25,10 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-010471
 
+{{% if product == "ol8" %}}
+platform: os_linux[ol]<8.4 or not runtime_kernel_fips_enabled
+{{% endif %}}
+
 ocil_clause: '{{{ ocil_clause_service_enabled("rngd") }}}'
 
 ocil: |-

--- a/shared/applicability/oval/runtime_kernel_fips_enabled.xml
+++ b/shared/applicability/oval/runtime_kernel_fips_enabled.xml
@@ -1,0 +1,30 @@
+<def-group>
+  <definition class="inventory" id="runtime_kernel_fips_enabled" version="1">
+    <metadata>
+      <title>Running kernel has fips mode enabled</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Check if sysctl crypto.fips_enabled = 1</description>
+      <reference ref_id="cpe:/a:runtime-kernel-fips-enabled" source="CPE" />
+    </metadata>
+    <criteria>
+      <criterion test_ref="test_runtime_kernel_fips_enabled" comment="check if sysctl crypto.fips_enabled = 1" />
+    </criteria>
+  </definition>
+
+  <unix:sysctl_test check="all" check_existence="all_exist" comment="kernel runtime parameter crypto.fips_enabled set to 1"
+  id="test_runtime_kernel_fips_enabled" version="1">
+    <unix:object object_ref="obj_runtime_kernel_fips_enabled" />
+    <unix:state state_ref="state_runtime_kernel_fips_enabled" />
+  </unix:sysctl_test>
+
+  <unix:sysctl_object id="obj_runtime_kernel_fips_enabled" version="1">
+    <unix:name>crypto.fips_enabled</unix:name>
+  </unix:sysctl_object>
+
+  <unix:sysctl_state id="state_runtime_kernel_fips_enabled" version="1">
+    <unix:value datatype="int" operation="equals">1</unix:value>
+  </unix:sysctl_state>
+
+</def-group>

--- a/shared/applicability/runtime_kernel_fips_enabled.yml
+++ b/shared/applicability/runtime_kernel_fips_enabled.yml
@@ -1,0 +1,4 @@
+name: cpe:/a:runtime-kernel-fips-enabled
+title: Running kernel has fips mode enabled
+check_id: runtime_kernel_fips_enabled
+bash_conditional: '[ $(sysctl -a | grep -c fips_enabled.*1) -eq 1 ]'


### PR DESCRIPTION
#### Description:

- Introduce the cpe `runtime_kernel_fips_enabled`
- Update platform in `service_rngd_enabled` rule to restrict the usage depending on OL version and   `runtime_kernel_fips_enabled` cpe

#### Rationale:

- With new OL8 STIG V1R7 it was updated the applicability of the requirement implemented by `service_rngd_enabled`:

> Note: For OL versions 8.4 and above running with kernel FIPS mode enabled as specified by OL08-00-010020, this requirement is not applicable.

- It is known that the kernel parameter is not enough to declare a system in FIPS mode, however in this case as rngd is related to kernel entropy, this should be enough to validate applicability.