### PR TITLE
Add rule logind_session_timeout to OL8 STIG

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/logind_session_timeout/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/logind_session_timeout/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhel9
+prodtype: ol8,rhel8,rhel9
 
 title: "Configure Logind to terminate idle sessions after certain time of inactivity"
 
@@ -20,6 +20,7 @@ severity: medium
 
 platforms:
     - os_linux[rhel]>=8.7 and os_linux[rhel]!=9.0
+    - os_linux[ol]>=8.7
 
 identifiers:
     cce@rhel8: CCE-90784-0
@@ -39,6 +40,7 @@ references:
     nist-csf: DE.CM-1,DE.CM-3,PR.AC-1,PR.AC-4,PR.AC-6,PR.AC-7,PR.IP-2
     ospp: FMT_SMF_EXT.1.1
     pcidss: Req-8.1.8
+    stigid@ol8: OL08-00-020035
 
 ocil_clause: "the option is not configured"
 

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -527,6 +527,10 @@ selections:
     # OL08-00-020032
     - dconf_gnome_disable_user_list
 
+    # OL08-00-020035
+    - logind_session_timeout
+    - var_logind_session_timeout=15_minutes
+
     # OL08-00-020039
     - package_tmux_installed
 


### PR DESCRIPTION
#### Description:

- Add ol8 prodtype and STIG ID to the rule `logind_session_timeout`, and add the rule to the STIG profile

#### Rationale:

- Keep OL8 STIG profile up to date with DISA's STIG V1R7
