### PR TITLE
Introduce secure_boot & kernel_uek cpes and use them in sysctl_kernel_kexec_load_disabled

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_kexec_load_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_kexec_load_disabled/rule.yml
@@ -30,7 +30,11 @@ references:
 
 srg_requirement: '{{{ full_name }}} must prevent the loading of a new kernel for later execution.'
 
+{{% if product == "ol8" %}}
+platform: machine and not (secure_boot and kernel_uek)
+{{% else %}}
 platform: machine
+{{% endif %}}
 
 template:
     name: sysctl

--- a/shared/applicability/kernel_uek.yml
+++ b/shared/applicability/kernel_uek.yml
@@ -1,0 +1,5 @@
+name: cpe:/a:kernel-uek
+title: System is running on uek kernel
+check_id: kernel_uek
+bash_conditional: '[[ $(uname -r) == *"uek"* ]]'
+ansible_conditional: '"uek" in ansible_kernel'

--- a/shared/applicability/oval/kernel_uek.xml
+++ b/shared/applicability/oval/kernel_uek.xml
@@ -1,0 +1,25 @@
+<def-group>
+  <definition class="inventory" id="kernel_uek" version="1">
+    <metadata>
+      <title>System runs on UEK kernel</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Check if System is running on UEK kernel.</description>
+      <reference ref_id="cpe:/a:kernel-uek" source="CPE" />
+    </metadata>
+    <criteria operator="AND">
+      <criterion comment="Runing kernel is UEK" test_ref="test_kernel_uek" />
+    </criteria>
+  </definition>
+  <unix:uname_test check_existence="all_exist" check="all"
+  comment="Runing kernel is UEK"
+  id="test_kernel_uek" version="1">
+    <unix:object object_ref="obj_kernel_uek" />
+    <unix:state state_ref="state_kernel_uek" />
+  </unix:uname_test>
+  <unix:uname_object id="obj_kernel_uek" version="1"/>
+  <unix:uname_state id="state_kernel_uek" version="1">
+      <unix:os_release operation="pattern match">^.*uek.*</unix:os_release>
+  </unix:uname_state>
+</def-group>

--- a/shared/applicability/oval/secureboot_enabled.xml
+++ b/shared/applicability/oval/secureboot_enabled.xml
@@ -1,0 +1,33 @@
+<def-group>
+  <definition class="inventory" id="secure_boot_enabled" version="1">
+    <metadata>
+      <title>Secure Boot status check</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Check if System has Secure Boot enabled.</description>
+      <reference ref_id="cpe:/a:secure-boot" source="CPE" />
+    </metadata>
+    <criteria operator="AND"> 
+      <extend_definition definition_ref="system_boot_mode_is_uefi" comment="Pass if System boot mode is UEFI" />
+      <criterion comment="Scure Boot is enabled" test_ref="test_secure_boot_enabled" />
+    </criteria>
+  </definition>
+  <ind:filehash58_test check_existence="all_exist" check="all"
+  comment="Scure Boot is enabled"
+  id="test_secure_boot_enabled" version="1">
+    <ind:object object_ref="obj_secure_boot_enabled" />
+    <ind:state state_ref="state_secure_boot_enabled" />
+  </ind:filehash58_test>
+  <ind:filehash58_object id="obj_secure_boot_enabled" version="1">
+    <ind:filepath operation="pattern match">^/sys/firmware/efi/efivars/SecureBoot-.*</ind:filepath>
+    <ind:hash_type>SHA-256</ind:hash_type>
+  </ind:filehash58_object>
+  <ind:filehash58_state id="state_secure_boot_enabled" version="1">
+      <!-- OVAL doesn't support binary file reading so using hash instead this works as the
+           efivar file contains 4 bytes of var attributes + var data. So it is expected that
+           the only change in the file would be the byte indicating if it is enabled or not -->
+      <!-- Hash of a file with this hexdump: 0006 0000 0001 -->
+      <ind:hash>b401b4bd7e4f321db95fcae00d274ab8aa2cf1852d1495c382356d981f63d771</ind:hash>
+  </ind:filehash58_state>
+</def-group>

--- a/shared/applicability/secure_boot.yml
+++ b/shared/applicability/secure_boot.yml
@@ -1,0 +1,5 @@
+name: cpe:/a:secure-boot
+title: System secure boot is enabled
+check_id: secure_boot_enabled
+bash_conditional: "[ $(mokutil --sb-state | awk '{print $NF}') == 'enabled' ]"
+


### PR DESCRIPTION
#### Description:

- Introduce `secure_boot` cpe
- Introduce `kernel_uek` cpe
- Add these cpes in platform of `sysctl_kernel_kexec_load_disabled` for OL8

#### Rationale:

- This is to comply with latest DISA STIG V1R7 applicability text in `OL08-00-010372` requirement

> Note: For OL 8 systems using the Oracle Unbreakable Enterprise Kernel (UEK) Release 6 or above and with secureboot enabled, this requirement is not applicable.

#### References

Since the `secure_boot` CPE could be polemical I share my reasoning to implement it in that way. The efivar is formed by attributes bytes + var value bytes [1] and the secure boot has to have a 1 in last byte for enabled and a 0 for disabled [2]. So the only byte expected to change is the value, this way the hash should be a good indicator of the system having the secureboot enabled

[1] - https://wiki.archlinux.org/title/Unified_Extensible_Firmware_Interface/Secure_Boot
[2] - https://docs.kernel.org/filesystems/efivarfs.html
