### PR TITLE
Update ssh stig HMACS and Ciphers allowed in OL8 STIG

### DIFF
--- a/linux_os/guide/services/ssh/sshd_approved_ciphers.var
+++ b/linux_os/guide/services/ssh/sshd_approved_ciphers.var
@@ -12,6 +12,7 @@ interactive: false
 
 options:
     stig: aes256-ctr,aes192-ctr,aes128-ctr
+    stig_extended: aes256-ctr,aes192-ctr,aes128-ctr,aes256-gcm@openssh.com,aes128-gcm@openssh.com
     default: aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc,rijndael-cbc@lysator.liu.se
     cis_rhel7: chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,aes128-cbc,aes192-cbc,aes256-cbc,blowfish-cbc,cast128-cbc,3des-cbc
     cis_sle12: chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/tests/rhel8_stig_correct.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/tests/rhel8_stig_correct.pass.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # platform = Oracle Linux 8,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_stig
+# variables = sshd_approved_ciphers=aes256-ctr,aes192-ctr,aes128-ctr,aes256-gcm@openssh.com,aes128-gcm@openssh.com
 
-sshd_approved_ciphers=aes256-ctr,aes192-ctr,aes128-ctr
+sshd_approved_ciphers=aes256-ctr,aes192-ctr,aes128-ctr,aes256-gcm@openssh.com,aes128-gcm@openssh.com
+
 configfile=/etc/crypto-policies/back-ends/opensshserver.config
 correct_value="-oCiphers=${sshd_approved_ciphers}"
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/tests/rhel8_stig_empty_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/tests/rhel8_stig_empty_policy.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # platform = Oracle Linux 8,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_stig
+# variables = sshd_approved_ciphers=aes256-ctr,aes192-ctr,aes128-ctr,aes256-gcm@openssh.com,aes128-gcm@openssh.com
 
 configfile=/etc/crypto-policies/back-ends/opensshserver.config
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/tests/rhel8_stig_incorrect_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/tests/rhel8_stig_incorrect_policy.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # platform = Oracle Linux 8,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_stig
+# variables = sshd_approved_ciphers=aes256-ctr,aes192-ctr,aes128-ctr,aes256-gcm@openssh.com,aes128-gcm@openssh.com
 
 configfile=/etc/crypto-policies/back-ends/opensshserver.config
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/tests/rhel8_stig_missing_file.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/tests/rhel8_stig_missing_file.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # platform = Oracle Linux 8,Red Hat Enterprise Linux 8
-# profiles = xccdf_org.ssgproject.content_profile_stig
+# variables = sshd_approved_ciphers=aes256-ctr,aes192-ctr,aes128-ctr,aes256-gcm@openssh.com,aes128-gcm@openssh.com
 
 configfile=/etc/crypto-policies/back-ends/opensshserver.config
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/rule.yml
@@ -12,7 +12,7 @@ description: |-
     To check that Crypto Policies settings are configured correctly, ensure that
     <tt>/etc/crypto-policies/back-ends/openssh.config</tt> contains the following
     line and is not commented out:
-    <tt>MACs hmac-sha2-512,hmac-sha2-256</tt>
+    <tt>MACs {{{ xccdf_value("sshd_approved_macs") }}}</tt>
 
 rationale: |-
     Overriding the system crypto policy makes the behavior of the OpenSSH
@@ -38,7 +38,7 @@ ocil: |-
     To verify if the OpenSSH client uses defined MACs in the Crypto Policy, run:
     <pre>$ grep -i macs /etc/crypto-policies/back-ends/openssh.config</pre>
     and verify that the line matches:
-    <pre>MACs hmac-sha2-512,hmac-sha2-256</pre>
+    <pre>MACs {{{ xccdf_value("sshd_approved_macs") }}}</pre>
 
 warnings:
     - general: |-

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_correct.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_correct.pass.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_stig
+# variables = sshd_approved_macs=hmac-sha2-512,hmac-sha2-256,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com
 
-sshd_approved_macs=hmac-sha2-512,hmac-sha2-256
+sshd_approved_macs=hmac-sha2-512,hmac-sha2-256,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com
+
 configfile=/etc/crypto-policies/back-ends/openssh.config
 
 # Ensure directory + file is there

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_correct_commented.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_correct_commented.fail.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_stig
+# variables = sshd_approved_macs=hmac-sha2-512,hmac-sha2-256,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com
 
-sshd_approved_macs=hmac-sha2-512,hmac-sha2-256
+sshd_approved_macs=hmac-sha2-512,hmac-sha2-256,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com
+
 configfile=/etc/crypto-policies/back-ends/openssh.config
 
 # Ensure directory + file is there

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_correct_followed_by_incorrect_commented.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_correct_followed_by_incorrect_commented.pass.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_stig
+# variables = sshd_approved_macs=hmac-sha2-512,hmac-sha2-256,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com
 
-sshd_approved_macs=hmac-sha2-512,hmac-sha2-256
+sshd_approved_macs=hmac-sha2-512,hmac-sha2-256,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com
+
 configfile=/etc/crypto-policies/back-ends/openssh.config
 
 # Ensure directory + file is there

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_incorrect_followed_by_correct_commented.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_incorrect_followed_by_correct_commented.fail.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_stig
+# variables = sshd_approved_macs=hmac-sha2-512,hmac-sha2-256,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com
 
-sshd_approved_macs=hmac-sha2-512,hmac-sha2-256
+sshd_approved_macs=hmac-sha2-512,hmac-sha2-256,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com
+
 incorrect_sshd_approved_macs=hmac-sha2-256-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha1,umac-128@openssh.com,hmac-sha2-512
 configfile=/etc/crypto-policies/back-ends/openssh.config
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/rule.yml
@@ -12,7 +12,7 @@ description: |-
     To check that Crypto Policies settings are configured correctly, ensure that
     <tt>/etc/crypto-policies/back-ends/opensshserver.config</tt> contains the following
     text and is not commented out:
-    <tt>-oMACS=hmac-sha2-512,hmac-sha2-256,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com</tt>
+    <tt>-oMACS={{{ xccdf_value("sshd_approved_macs") }}}</tt>
 
 rationale: |-
     Overriding the system crypto policy makes the behavior of the OpenSSH
@@ -38,7 +38,7 @@ ocil: |-
     To verify if the OpenSSH server uses defined MACs in the Crypto Policy, run:
     <pre>$ grep -Po '(-oMACs=\S+)' /etc/crypto-policies/back-ends/opensshserver.config</pre>
     and verify that the line matches:
-    <pre>-oMACS=hmac-sha2-512,hmac-sha2-256,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com</pre>
+    <pre>-oMACS={{{ xccdf_value("sshd_approved_macs") }}}</pre>
 
 warnings:
     - general: |-

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -38,7 +38,7 @@ selections:
     - var_password_pam_retry=3
     - var_password_pam_minlen=15
     - var_sshd_set_keepalive=0
-    - sshd_approved_macs=stig
+    - sshd_approved_macs=stig_extended
     - sshd_approved_ciphers=stig
     - sshd_idle_timeout_value=10_minutes
     - var_accounts_authorized_local_users_regex=ol8

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -39,7 +39,7 @@ selections:
     - var_password_pam_minlen=15
     - var_sshd_set_keepalive=0
     - sshd_approved_macs=stig_extended
-    - sshd_approved_ciphers=stig
+    - sshd_approved_ciphers=stig_extended
     - sshd_idle_timeout_value=10_minutes
     - var_accounts_authorized_local_users_regex=ol8
     - var_accounts_passwords_pam_faillock_deny=3


### PR DESCRIPTION
#### Description:

- Update HMAC algorithms selection for OL8 STIG
- Add new cipher selection in `sshd_approved_ciphers` in a similar approach as in taken in HMACs
- Apply this new selection in OL8 STIG

#### Rationale:

- This is to keep up to date OL8 STIG with DISA's V1R7

**Note:** The Cipher update also applies to RHEL8, let me know if you want me to apply it there also