### PR TITLE
Update expected result of e2e tests for sysctls already defined in `/usr/lib/sysctl.d`

### DIFF
--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_source_route/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_source_route/tests/ocp4/e2e.yml
@@ -1,3 +1,3 @@
 ---
-default_result: FAIL
+default_result: PASS
 result_after_remediation: PASS

--- a/linux_os/guide/system/permissions/files/sysctl_fs_protected_hardlinks/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/permissions/files/sysctl_fs_protected_hardlinks/tests/ocp4/e2e.yml
@@ -1,3 +1,3 @@
 ---
-default_result: FAIL
+default_result: PASS
 result_after_remediation: PASS

--- a/linux_os/guide/system/permissions/files/sysctl_fs_protected_symlinks/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/permissions/files/sysctl_fs_protected_symlinks/tests/ocp4/e2e.yml
@@ -1,3 +1,3 @@
 ---
-default_result: FAIL
+default_result: PASS
 result_after_remediation: PASS

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/tests/ocp4/e2e.yml
@@ -1,3 +1,3 @@
 ---
-default_result: FAIL
+default_result: PASS
 result_after_remediation: PASS


### PR DESCRIPTION
#### Description:
- Update `default_result` of OCP e2e tests to `PASS` in the following rules:
  - `sysctl_net_ipv4_conf_default_accept_source_route`
  - `sysctl_fs_protected_hardlinks`
  - `sysctl_fs_protected_symlinks`
  - `sysctl_kernel_kptr_restrict`

#### Rationale:

- After https://github.com/ComplianceAsCode/content/pull/10637 the sysctls that are defined in `/usr/lib/sysctl.d` started to be taken into account.
Previously, the files in that directory were not checked but now they are. And they set up compliant sysctls for these rules.

-Fixes failures in weekly OCP CI 
