### PR TITLE
Remove protect kernel default and sysctl rules from CIS

### DIFF
--- a/applications/openshift/kubelet/kubelet_enable_protect_kernel_defaults/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_protect_kernel_defaults/rule.yml
@@ -100,8 +100,6 @@ ocil: |-
 #   cce@ocp4: 
 
 references:
-  cis@eks: 3.2.6
-  cis@ocp4: 4.2.6
   nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
   nist: CM-6,CM-6(1)
   srg: SRG-APP-000516-CTR-001325

--- a/applications/openshift/kubelet/kubelet_enable_protect_kernel_sysctl/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_protect_kernel_sysctl/rule.yml
@@ -117,7 +117,6 @@ identifiers:
    cce@ocp4: CCE-86688-9
 
 references:
-  cis@ocp4: 4.2.6
   nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
   nist: CM-6,CM-6(1)
   srg: SRG-APP-000516-CTR-001325

--- a/applications/openshift/kubelet/kubelet_enable_protect_kernel_sysctl_file_exist/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_protect_kernel_sysctl_file_exist/rule.yml
@@ -86,7 +86,6 @@ ocil: |-
 #   cce@ocp4: 
 
 references:
-  cis@ocp4: 4.2.6
   nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
   nist: CM-6,CM-6(1)
   srg: SRG-APP-000516-CTR-001325

--- a/applications/openshift/kubelet/kubelet_enable_protect_kernel_sysctl_kernel_keys_root_maxbytes/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_protect_kernel_sysctl_kernel_keys_root_maxbytes/rule.yml
@@ -97,7 +97,6 @@ identifiers:
    cce@ocp4: CCE-86066-8
 
 references:
-  cis@ocp4: 4.2.6
   nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
   nist: CM-6,CM-6(1)
   srg: SRG-APP-000516-CTR-001325

--- a/applications/openshift/kubelet/kubelet_enable_protect_kernel_sysctl_kernel_keys_root_maxkeys/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_protect_kernel_sysctl_kernel_keys_root_maxkeys/rule.yml
@@ -98,7 +98,6 @@ identifiers:
   cce@ocp4: CCE-86139-3
 
 references:
-  cis@ocp4: 4.2.6
   nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
   nist: CM-6,CM-6(1)
   srg: SRG-APP-000516-CTR-001325

--- a/applications/openshift/kubelet/kubelet_enable_protect_kernel_sysctl_kernel_panic/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_protect_kernel_sysctl_kernel_panic/rule.yml
@@ -98,7 +98,6 @@ identifiers:
    cce@ocp4: CCE-86124-5
 
 references:
-  cis@ocp4: 4.2.6
   nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
   nist: CM-6,CM-6(1)
   srg: SRG-APP-000516-CTR-001325

--- a/applications/openshift/kubelet/kubelet_enable_protect_kernel_sysctl_kernel_panic_on_oops/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_protect_kernel_sysctl_kernel_panic_on_oops/rule.yml
@@ -97,7 +97,6 @@ identifiers:
    cce@ocp4: CCE-86114-6
 
 references:
-  cis@ocp4: 4.2.6
   nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
   nist: CM-6,CM-6(1)
   srg: SRG-APP-000516-CTR-001325

--- a/applications/openshift/kubelet/kubelet_enable_protect_kernel_sysctl_vm_overcommit_memory/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_protect_kernel_sysctl_vm_overcommit_memory/rule.yml
@@ -97,7 +97,6 @@ identifiers:
    cce@ocp4: CCE-86085-8
 
 references:
-  cis@ocp4: 4.2.6
   nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
   nist: CM-6,CM-6(1)
   srg: SRG-APP-000516-CTR-001325

--- a/applications/openshift/kubelet/kubelet_enable_protect_kernel_sysctl_vm_panic_on_oom/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_protect_kernel_sysctl_vm_panic_on_oom/rule.yml
@@ -97,7 +97,6 @@ identifiers:
    cce@ocp4: CCE-86086-6
 
 references:
-  cis@ocp4: 4.2.6
   nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
   nist: CM-6,CM-6(1)
   srg: SRG-APP-000516-CTR-001325


### PR DESCRIPTION
Upstream guidance in the Kubernetes benchmarks for protecting kernel
defaults and sysctl rules was removed. This removal affected the CIS
benchmark since it is rebased to pickup general guidance from the
Kubernetes CIS community.

This commit updates those rules and removes the CIS references from them
so that they're consistent with CIS OpenShift 1.4.0. The following is
the relevant upstream CIS discussion about the removal.

  https://workbench.cisecurity.org/benchmarks/11107/tickets/17377
