### PR TITLE
Remove CIS reference from image policy webhook rule

### DIFF
--- a/applications/openshift/general/general_configure_imagepolicywebhook/rule.yml
+++ b/applications/openshift/general/general_configure_imagepolicywebhook/rule.yml
@@ -30,7 +30,6 @@ ocil: |-
 #    cce@ocp4:
 
 references:
-    cis@ocp4: 5.5.1
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     pcidss: Req-2.2


### PR DESCRIPTION
While updating the CIS profile to support 1.4.0, we implemented more
rules to ensure image configuration is setup properly, which superseded
the general advice we had for configuring image provenance.

This commit removes the CIS reference from the
general_configure_imagepolicywebhook rule since that rule is no longer
included in the CIS profile in favor of:

  ocp-allowed-registries
  ocp-allowed-registries-for-import
  ocp-insecure-registries
  ocp-insecure-allowed-registries-for-import
