### PR TITLE
Add SRG ID to logind_session_timeout - stabilization 

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/logind_session_timeout/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/logind_session_timeout/rule.yml
@@ -39,6 +39,7 @@ references:
     nist-csf: DE.CM-1,DE.CM-3,PR.AC-1,PR.AC-4,PR.AC-6,PR.AC-7,PR.IP-2
     ospp: FMT_SMF_EXT.1.1
     pcidss: Req-8.1.8
+    srg: SRG-OS-000163-GPOS-00072
     stigid@rhel8: RHEL-08-020035
 
 ocil_clause: "the option is not configured"


### PR DESCRIPTION
#### Description:

Add's an SRG ID to logind_session_timeout

#### Rationale:

It's needed

See: https://stigaview.com/products/rhel8/v1r11/RHEL-08-020035/