### PR TITLE
OCPBUGS-10508: Add quotes around SCC audit procedure

### DIFF
--- a/applications/openshift/scc/scc_limit_container_allowed_capabilities/rule.yml
+++ b/applications/openshift/scc/scc_limit_container_allowed_capabilities/rule.yml
@@ -66,7 +66,7 @@ ocil: |-
     check the variable value, e.g:
     <pre>$ oc get variable ocp4-var-sccs-with-allowed-capabilities-regex  -ojsonpath='{.value}' </pre>
     Then use following command to list the SCCs that would fail the test:
-    <pre>$ oc get scc -o json | jq {{{ jqfilter }}}</pre>
+    <pre>$ oc get scc -o json | jq '{{{ jqfilter }}}'</pre>
     Please replace the regular expression in the test command with the value read from the variable
     <pre>ocp4-var-sccs-with-allowed-capabilities-regex</pre>. You can read the variable
     value with:


### PR DESCRIPTION
The json query we're using to help users detect SCCs they need to
monitor is rather complicated and should be quoted. Otherwise, it will
fail to run, which is frustrating for users if they're copy/pasting the
command out of the CRD (which is common).
