### PR TITLE
Remove rules that cannot be applied during image build

### DIFF
--- a/products/sle15/profiles/pcs-hardening-sap.profile
+++ b/products/sle15/profiles/pcs-hardening-sap.profile
@@ -29,6 +29,5 @@ selections:
     # remove some rules in pcs-hardening
     - '!accounts_umask_etc_login_defs'
     - '!accounts_umask_etc_profile'
-    - '!service_firewalld_enabled'
     - '!sshd_disable_root_login'
     - '!sshd_set_max_auth_tries'

--- a/products/sle15/profiles/pcs-hardening.profile
+++ b/products/sle15/profiles/pcs-hardening.profile
@@ -82,7 +82,7 @@ selections:
     - disable_users_coredumps
     - display_login_attempts
     - ensure_gpgcheck_globally_activated
-    - ensure_logrotate_activated
+    #- ensure_logrotate_activated
     - file_etc_security_opasswd
     - file_groupowner_etc_issue
     - file_groupownership_system_commands_dirs
@@ -104,8 +104,7 @@ selections:
     - kernel_module_udf_disabled
     - kernel_module_usb-storage_disabled
     - no_direct_root_logins
-    - pam_disable_automatic_configuration
-    - service_firewalld_enabled
+    #- pam_disable_automatic_configuration
     - set_password_hashing_algorithm_commonauth
     - set_password_hashing_algorithm_systemauth
     - smartcard_configure_ca


### PR DESCRIPTION
Public Cloud images are built in a context that is different from a running system. For example systemd is not running. As such systemctl start and systemctl status will fail, see issue #10945 for details.

Remove firewalld rule outright; in the cloud other mechanisms exist for handling connections to a running system and is generally the recommendation not to run a firewall in the instance

Comment out the logrotate rule, we'd like to re-enable this after #10945 is addressed

Comment out pam due to the way bash behaves. Requires a separate PR to address the bash issue. No issue filed yet.

#### Description:

- _Description here. Replace this text. Don't use the italics format!_

#### Rationale:

- _Rationale here. Replace this text. Don't use the italics format!_

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._

#### Review Hints:

- _Review hints here. Replace this text. Don't use the italics format!_

- _Use this optional section to give any relevant information which could help the reviewer to more quickly and assertively understand and test the changes._

- _Good examples are useful commands, if it is better to review all commits together or in a suggested sequence, any relevant discussion in other PRs or issues, etc._