### PR TITLE
Include test scenario scripts in timer_enabled template

### DIFF
--- a/linux_os/guide/system/software/updating/timer_dnf-automatic_enabled/tests/timer_disabled.fail.sh
+++ b/linux_os/guide/system/software/updating/timer_dnf-automatic_enabled/tests/timer_disabled.fail.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-# packages = dnf-automatic
-
-
-systemctl disable --now dnf-automatic.timer

--- a/linux_os/guide/system/software/updating/timer_dnf-automatic_enabled/tests/timer_enabled.pass.sh
+++ b/linux_os/guide/system/software/updating/timer_dnf-automatic_enabled/tests/timer_enabled.pass.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-# packages = dnf-automatic
-
-
-systemctl enable --now dnf-automatic.timer

--- a/shared/templates/timer_enabled/tests/timer_disabled.fail.sh
+++ b/shared/templates/timer_enabled/tests/timer_disabled.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# packages = {{{ PACKAGENAME }}}
+
+SYSTEMCTL_EXEC='/usr/bin/systemctl'
+"$SYSTEMCTL_EXEC" stop '{{{ TIMERNAME }}}.timer'
+"$SYSTEMCTL_EXEC" disable '{{{ TIMERNAME }}}.timer'

--- a/shared/templates/timer_enabled/tests/timer_enabled.pass.sh
+++ b/shared/templates/timer_enabled/tests/timer_enabled.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = {{{ PACKAGENAME }}}
+
+SYSTEMCTL_EXEC='/usr/bin/systemctl'
+"$SYSTEMCTL_EXEC" unmask '{{{ TIMERNAME }}}.timer'
+"$SYSTEMCTL_EXEC" start '{{{ TIMERNAME }}}.timer'
+"$SYSTEMCTL_EXEC" enable '{{{ TIMERNAME }}}.timer'


### PR DESCRIPTION
#### Description:

This template is currently used by only two rules but didn't have test scenario scripts.
This PR introduces test scenarios scripts and removes similar tests from `timer_dnf-automatic_enabled` rule.

#### Rationale:

Easier to test changes in existing rules using this template.
Also easier to test eventual new rules which adopts this template.

#### Review Hints:

The CI tests for CS8 will probably fail with `timer_logrotate_enabled` rule and this is expected since `rhel8` is not defined in `prodtype`.