### PR TITLE
Update kubelet event creation limit to 50

### DIFF
--- a/applications/openshift/kubelet/var_event_record_qps.var
+++ b/applications/openshift/kubelet/var_event_record_qps.var
@@ -11,4 +11,6 @@ operator: equals
 interactive: false
 
 options:
-    default: 5
+    default: 50
+    5: 5
+    50: 50

--- a/products/ocp4/profiles/cis.profile
+++ b/products/ocp4/profiles/cis.profile
@@ -30,6 +30,7 @@ selections:
     - cis_ocp_1_4_0:all
     ### Variables
     - var_openshift_audit_profile=WriteRequestBodies
+    - var_event_record_qps=50
     ### Helper Rules
     ### This is a helper rule to fetch the required api resource for detecting OCP version
     - version_detect_in_ocp


### PR DESCRIPTION
#### Description:

- Update default event creation limit to `50`.
- The value of `5` is still selectable via tailored profile.

#### Rationale:

- The kubelet event creation limit bumped from 5 to 50 in OCP CIS 1.4.0. 
- The default value in OCP 4.14 is also bumped from 5 to 50.

This keeps the rule aligned with CIS and OCP.

- Fixes OCPBUGS-16727