### PR TITLE
Fix Rawhide Build

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -189,7 +189,7 @@ jobs:
       -   name: Checkout
           uses: actions/checkout@v3
       -   name: Install deps python
-          run: pip install -r requirements.txt -r test-requirements.txt
+          run: pip install -r requirements-base.txt -r test-requirements.txt
       -   name: Build
           run: |-
             ./build_product \

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,0 +1,4 @@
+pyyaml
+Jinja2
+setuptools
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,10 @@
+-r requirements-base.txt
 cmakelint
 types-openpyxl
 types-PyYAML
 openpyxl-stubs
 openpyxl
 json2html
-pyyaml
-Jinja2
-setuptools
 ruamel.yaml
 pandas
 mypy


### PR DESCRIPTION
#### Description:

* Fix Rawhide build
* Splits base build requirements into a new file
* Is backwards compatible since requirements.txt includes requirements-base.txt.   

#### Rationale:
Make it easier during reviews.

The commit changing the workflow should be reverted once 3.12 is more stable.
