### PR TITLE
Skip OVAL schematron validation in CI

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -31,6 +31,8 @@ jobs:
               rhel9 \
               uos20 \
               --derivatives
+        env:
+          ADDITIONAL_CMAKE_OPTIONS: "-DSSG_OVAL_SCHEMATRON_VALIDATION_ENABLED=OFF"
       - name: Test
         run: ctest -j2 --output-on-failure -E unique-stigids
         working-directory: ./build
@@ -47,6 +49,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Build
         run: ./build_product alinux2 alinux3 anolis23 anolis8 chromium fedora firefox rhcos4 rhel7 rhel8 rhel9 sle12 sle15 ubuntu2004 ubuntu2204 uos20
+        env:
+          ADDITIONAL_CMAKE_OPTIONS: "-DSSG_OVAL_SCHEMATRON_VALIDATION_ENABLED=OFF"
       - name: Test
         run: ctest -j2 --output-on-failure -E unique-stigids
         working-directory: ./build
@@ -67,7 +71,7 @@ jobs:
         run: pip3 install -r requirements.txt -r test-requirements.txt
       - name: Build
         env:
-          ADDITIONAL_CMAKE_OPTIONS: "-DSSG_ANSIBLE_PLAYBOOKS_PER_RULE_ENABLED=ON"
+          ADDITIONAL_CMAKE_OPTIONS: "-DSSG_ANSIBLE_PLAYBOOKS_PER_RULE_ENABLED=ON -DSSG_OVAL_SCHEMATRON_VALIDATION_ENABLED=OFF"
         run: |-
           ./build_product debian10 debian11
       - name: Test
@@ -84,7 +88,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Build
         env:
-          ADDITIONAL_CMAKE_OPTIONS: "-DSSG_SCE_ENABLED:BOOL=ON"
+          ADDITIONAL_CMAKE_OPTIONS: "-DSSG_SCE_ENABLED:BOOL=ON -DSSG_OVAL_SCHEMATRON_VALIDATION_ENABLED=OFF"
         run: |-
           ./build_product \
               alinux2 \
@@ -117,7 +121,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Build
         env:
-          ADDITIONAL_CMAKE_OPTIONS: "-DSSG_SCE_ENABLED:BOOL=ON"
+          ADDITIONAL_CMAKE_OPTIONS: "-DSSG_SCE_ENABLED:BOOL=ON -DSSG_OVAL_SCHEMATRON_VALIDATION_ENABLED=OFF"
         run: |-
           ./build_product \
               ubuntu2004 \
@@ -160,7 +164,7 @@ jobs:
               ocp4 \
               eks
         env:
-          ADDITIONAL_CMAKE_OPTIONS: "-DSSG_ANSIBLE_PLAYBOOKS_PER_RULE_ENABLED=ON"
+          ADDITIONAL_CMAKE_OPTIONS: "-DSSG_ANSIBLE_PLAYBOOKS_PER_RULE_ENABLED=ON -DSSG_OVAL_SCHEMATRON_VALIDATION_ENABLED=OFF"
       - name: Test
         run: ctest -j2 --output-on-failure -E unique-stigids
         working-directory: ./build
@@ -210,6 +214,8 @@ jobs:
                 ubuntu2204 \
                 uos20 \
                 ocp4
+          env:
+            ADDITIONAL_CMAKE_OPTIONS: "-DSSG_OVAL_SCHEMATRON_VALIDATION_ENABLED=OFF"
       -   name: Test
           run: ctest -j2 --output-on-failure -E unique-stigids
           working-directory: ./build

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -59,9 +59,20 @@
 
 
 if(SSG_OVAL_SCHEMATRON_VALIDATION_ENABLED)
-    set(OSCAP_OVAL_SCHEMATRON_OPTION "--schematron")
+# Starting OpenSCAP 1.3.5, the schematron validation is the default behaviour
+# due to certification requirements, the --schematron has been deprecated
+# and --skip-schematron has been introduced.
+    if("${OSCAP_VERSION}" VERSION_LESS "1.3.5")
+        set(OSCAP_OVAL_SCHEMATRON_OPTION "--schematron")
+    else()
+        set(OSCAP_OVAL_SCHEMATRON_OPTION "")
+    endif()
 else()
-    set(OSCAP_OVAL_SCHEMATRON_OPTION "")
+    if("${OSCAP_VERSION}" VERSION_LESS "1.3.5")
+        set(OSCAP_OVAL_SCHEMATRON_OPTION "")
+    else()
+        set(OSCAP_OVAL_SCHEMATRON_OPTION "--skip-schematron")
+    endif()
 endif()
 
 set(SSG_HTML_GUIDE_FILE_LIST "")


### PR DESCRIPTION
Stop performing OVAL schematron validation in our GitHub Actions CI. The additional validation takes a lot of time and slows down tests significantly. OTOH the value that it adds is low. Most of the problems will be discovered by XML schema validation which we keep in the tests. Advanced problems are discovered in SCAPVal runs that are also a part of our daylife.

