### PR TITLE
Change `[DRAFT]` to `DRAFT` in draft profiles

### DIFF
--- a/products/ocp4/profiles/stig-node.profile
+++ b/products/ocp4/profiles/stig-node.profile
@@ -12,12 +12,12 @@ metadata:
 
 reference: https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_Container_Platform_V1R3_SRG.zip
 
-title: '[DRAFT] DISA STIG for Red Hat OpenShift Container Platform 4 - Node level'
+title: 'DRAFT - DISA STIG for Red Hat OpenShift Container Platform 4 - Node level'
 
 description: |-
-    This is a draft profile for experimental purposes. It is not based on the 
-    DISA STIG for OCP4, because one was not available at the time yet. This 
-    profile contains configuration checks that align to the DISA STIG for 
+    This is a draft profile for experimental purposes. It is not based on the
+    DISA STIG for OCP4, because one was not available at the time yet. This
+    profile contains configuration checks that align to the DISA STIG for
     Red Hat OpenShift Container Platform 4.
 
 filter_rules: '"ocp4-node" in platforms or "ocp4-master-node" in platforms or "ocp4-node-on-sdn" in platforms or "ocp4-node-on-ovn" in platforms'

--- a/products/ocp4/profiles/stig.profile
+++ b/products/ocp4/profiles/stig.profile
@@ -12,12 +12,12 @@ metadata:
 
 reference: https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_Container_Platform_V1R3_SRG.zip
 
-title: '[DRAFT] DISA STIG for Red Hat OpenShift Container Platform 4 - Platform level'
+title: 'DRAFT - DISA STIG for Red Hat OpenShift Container Platform 4 - Platform level'
 
 description: |-
-    This is a draft profile for experimental purposes. It is not based on the 
-    DISA STIG for OCP4, because one was not available at the time yet. This 
-    profile contains configuration checks that align to the DISA STIG for 
+    This is a draft profile for experimental purposes. It is not based on the
+    DISA STIG for OCP4, because one was not available at the time yet. This
+    profile contains configuration checks that align to the DISA STIG for
     Red Hat OpenShift Container Platform 4.
 
 filter_rules: '"ocp4-node" not in platforms and "ocp4-master-node" not in platforms and "ocp4-node-on-sdn" not in platforms and "ocp4-node-on-ovn" not in platforms'

--- a/products/ol7/profiles/e8.profile
+++ b/products/ol7/profiles/e8.profile
@@ -2,7 +2,7 @@ documentation_complete: true
 
 reference: https://www.cyber.gov.au/acsc/view-all-content/publications/hardening-linux-workstations-and-servers
 
-title: '[DRAFT] Australian Cyber Security Centre (ACSC) Essential Eight'
+title: 'DRAFT - Australian Cyber Security Centre (ACSC) Essential Eight'
 
 description: |-
   This profile contains configuration checks for {{{ full_name }}}

--- a/products/ol7/profiles/ospp.profile
+++ b/products/ol7/profiles/ospp.profile
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: '[DRAFT] Protection Profile for General Purpose Operating Systems'
+title: 'DRAFT - Protection Profile for General Purpose Operating Systems'
 
 description: |-
     This profile reflects mandatory configuration controls identified in the

--- a/products/ol8/profiles/e8.profile
+++ b/products/ol8/profiles/e8.profile
@@ -1,8 +1,8 @@
 documentation_complete: true
 
-reference: https://www.cyber.gov.au/acsc/view-all-content/publications/hardening-linux-workstations-and-servers 
+reference: https://www.cyber.gov.au/acsc/view-all-content/publications/hardening-linux-workstations-and-servers
 
-title: '[DRAFT] Australian Cyber Security Centre (ACSC) Essential Eight'
+title: 'DRAFT - Australian Cyber Security Centre (ACSC) Essential Eight'
 
 description: |-
   This profile contains configuration checks for {{{ full_name }}}

--- a/products/ol8/profiles/ospp.profile
+++ b/products/ol8/profiles/ospp.profile
@@ -5,7 +5,7 @@ metadata:
 
 reference: https://www.niap-ccevs.org/Profile/PP.cfm
 
-title: '[DRAFT] Protection Profile for General Purpose Operating Systems'
+title: 'DRAFT - Protection Profile for General Purpose Operating Systems'
 
 description: |-
     This profile reflects mandatory configuration controls identified in the

--- a/products/ol9/profiles/cui.profile
+++ b/products/ol9/profiles/cui.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 metadata:
     version: TBD
 
-title: '[DRAFT] Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)'
+title: 'DRAFT - Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)'
 
 description: |-
     From NIST 800-171, Section 2.2:

--- a/products/ol9/profiles/ospp.profile
+++ b/products/ol9/profiles/ospp.profile
@@ -5,7 +5,7 @@ metadata:
 
 reference: https://www.niap-ccevs.org/Profile/PP.cfm
 
-title: '[DRAFT] Protection Profile for General Purpose Operating Systems'
+title: 'DRAFT - Protection Profile for General Purpose Operating Systems'
 
 description: |-
     This profile is part of Oracle Linux 9 Common Criteria Guidance

--- a/products/ol9/profiles/stig.profile
+++ b/products/ol9/profiles/stig.profile
@@ -5,7 +5,7 @@ metadata:
 
 reference: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
 
-title: '[DRAFT] DISA STIG for Oracle Linux 9'
+title: 'DRAFT - DISA STIG for Oracle Linux 9'
 
 description: |-
     This is a draft profile based on its OL8 version for experimental purposes.

--- a/products/ol9/profiles/stig_gui.profile
+++ b/products/ol9/profiles/stig_gui.profile
@@ -5,7 +5,7 @@ metadata:
 
 reference: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
 
-title: '[DRAFT] DISA STIG with GUI for Oracle Linux 9'
+title: 'DRAFT - DISA STIG with GUI for Oracle Linux 9'
 
 description: |-
     This is a draft profile based on its OL8 version for experimental purposes.

--- a/products/rhcos4/profiles/stig.profile
+++ b/products/rhcos4/profiles/stig.profile
@@ -10,7 +10,7 @@ metadata:
 
 reference: https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_Container_Platform_V1R3_SRG.zip
 
-title: '[DRAFT] DISA STIG for Red Hat Enterprise Linux CoreOS'
+title: 'DRAFT - DISA STIG for Red Hat Enterprise Linux CoreOS'
 
 description: |-
     This is a draft profile for experimental purposes

--- a/products/rhel9/profiles/cui.profile
+++ b/products/rhel9/profiles/cui.profile
@@ -5,7 +5,7 @@ metadata:
     SMEs:
         - ggbecker
 
-title: '[DRAFT] Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)'
+title: 'DRAFT - Unclassified Information in Non-federal Information Systems and Organizations (NIST 800-171)'
 
 description: |-
     From NIST 800-171, Section 2.2:

--- a/products/rhel9/profiles/stig.profile
+++ b/products/rhel9/profiles/stig.profile
@@ -8,7 +8,7 @@ metadata:
 
 reference: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
 
-title: '[DRAFT] DISA STIG for Red Hat Enterprise Linux 9'
+title: 'DRAFT - DISA STIG for Red Hat Enterprise Linux 9'
 
 description: |-
     This is a draft profile based on its RHEL8 version for experimental purposes.

--- a/products/rhel9/profiles/stig_gui.profile
+++ b/products/rhel9/profiles/stig_gui.profile
@@ -8,7 +8,7 @@ metadata:
 
 reference: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
 
-title: '[DRAFT] DISA STIG with GUI for Red Hat Enterprise Linux 9'
+title: 'DRAFT - DISA STIG with GUI for Red Hat Enterprise Linux 9'
 
 description: |-
     This is a draft profile based on its RHEL8 version for experimental purposes.

--- a/products/rhv4/profiles/rhvh-stig.profile
+++ b/products/rhv4/profiles/rhvh-stig.profile
@@ -8,12 +8,12 @@ metadata:
 
 reference: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
 
-title: '[DRAFT] DISA STIG for Red Hat Virtualization Host (RHVH)'
+title: 'DRAFT - DISA STIG for Red Hat Virtualization Host (RHVH)'
 
 description: |-
     This *draft* profile contains configuration checks that align to the
     DISA STIG for Red Hat Virtualization Host (RHVH).
-    
+
 selections:
     - installed_OS_is_FIPS_certified
     - login_banner_text=dod_banners


### PR DESCRIPTION
#### Description:

* `[DRAFT]` to `DRAFT`
* Trailing white-space clean up

#### Rationale:

Fixes #10186
Fixes #10962