### PR TITLE
OCPBUGS-16877: Check for etcd pod specification in /etc/kubernetes/manifests

### DIFF
--- a/applications/openshift/master/file_groupowner_etcd_member/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_member/rule.yml
@@ -42,6 +42,6 @@ warnings:
 template:
     name: file_groupowner
     vars:
-        filepath: ^/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml$
+        filepath: ^/etc/kubernetes/manifests/etcd-pod.yaml$
         gid_or_name: '0'
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_owner_etcd_member/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_member/rule.yml
@@ -42,6 +42,6 @@ warnings:
 template:
     name: file_owner
     vars:
-        filepath: ^/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml$
+        filepath: ^/etc/kubernetes/manifests/etcd-pod.yaml$
         fileuid: '0'
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_etcd_member/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_member/rule.yml
@@ -43,6 +43,6 @@ warnings:
 template:
     name: file_permissions
     vars:
-        filepath: ^/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml$
+        filepath: ^/etc/kubernetes/manifests/etcd-pod.yaml$
         filemode: '0600'
         filepath_is_regex: "true"


### PR DESCRIPTION


#### Description:

- Change the path where the etcd pod specification file is checked to `/etc/kubernetes/manifests/etcd-pod.yaml`

#### Rationale:

- This aligns the rules with items 1.1.7 and 1.1.8 in CIS 1.4.0.

- Fixes OCPBUGS-16877
