### PR TITLE
Update sshd_approved_ciphers value for RHEL in STIG profile

### DIFF
--- a/controls/srg_gpos.yml
+++ b/controls/srg_gpos.yml
@@ -20,7 +20,7 @@ controls:
             - var_password_hashing_algorithm=SHA512
             - var_password_pam_dictcheck=1
             - sshd_approved_macs=stig_extended
-            - sshd_approved_ciphers=stig
+            - sshd_approved_ciphers=stig_extended
             - sshd_idle_timeout_value=10_minutes
             - var_accounts_authorized_local_users_regex=rhel8
             - var_account_disable_post_pw_expiration=35

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -51,7 +51,7 @@ selections:
     - var_password_pam_minlen=15
     - var_sshd_set_keepalive=1
     - sshd_approved_macs=stig_extended
-    - sshd_approved_ciphers=stig
+    - sshd_approved_ciphers=stig_extended
     - sshd_idle_timeout_value=10_minutes
     - var_accounts_authorized_local_users_regex=rhel8
     - var_accounts_passwords_pam_faillock_deny=3


### PR DESCRIPTION
#### Description:

Update sshd_approved_ciphers value for RHEL8 STIG
Update sshd_approved_ciphers value for RHEL9 STIG Draft

#### Rationale:

Better alignment of crypto related settings for SSH.

It is somehow related to the following issues:
- https://github.com/ComplianceAsCode/content/issues/8580
- https://github.com/ComplianceAsCode/content/issues/9540
- https://github.com/ComplianceAsCode/content/issues/10164