### PR TITLE
Optimize tests that run fix_rules.py

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -83,68 +83,12 @@ add_test(
 set_tests_properties("macros-oval" PROPERTIES LABELS quick)
 
 add_test(
-    NAME "fix_rules-empty_identifiers"
-    COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/fix_rules.py" "--dry-run" "--root" "${CMAKE_SOURCE_DIR}" "--json" "${CMAKE_SOURCE_DIR}/build/rule_dirs.json" "empty_identifiers"
+    NAME "fix_rules"
+    COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/fix_rules.py" "--dry-run" "--root" "${CMAKE_SOURCE_DIR}" "--json" "${CMAKE_SOURCE_DIR}/build/rule_dirs.json" "test_all"
 )
-set_tests_properties("fix_rules-empty_identifiers" PROPERTIES LABELS quick)
-set_tests_properties("fix_rules-empty_identifiers" PROPERTIES DEPENDS "test-rule-dir-json")
-set_tests_properties("fix_rules-empty_identifiers" PROPERTIES FIXTURES_REQUIRED "rule-dir-json")
-
-add_test(
-    NAME "fix_rules-invalid_identifiers"
-    COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/fix_rules.py" "--dry-run" "--root" "${CMAKE_SOURCE_DIR}" "--json" "${CMAKE_SOURCE_DIR}/build/rule_dirs.json" "invalid_identifiers"
-)
-set_tests_properties("fix_rules-invalid_identifiers" PROPERTIES LABELS quick)
-set_tests_properties("fix_rules-invalid_identifiers" PROPERTIES DEPENDS "test-rule-dir-json")
-set_tests_properties("fix_rules-invalid_identifiers" PROPERTIES FIXTURES_REQUIRED "rule-dir-json")
-
-add_test(
-    NAME "fix_rules-int_identifiers"
-    COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/fix_rules.py" "--dry-run" "--root" "${CMAKE_SOURCE_DIR}" "--json" "${CMAKE_SOURCE_DIR}/build/rule_dirs.json" "int_identifiers"
-)
-set_tests_properties("fix_rules-int_identifiers" PROPERTIES LABELS quick)
-set_tests_properties("fix_rules-int_identifiers" PROPERTIES DEPENDS "test-rule-dir-json")
-set_tests_properties("fix_rules-int_identifiers" PROPERTIES FIXTURES_REQUIRED "rule-dir-json")
-
-add_test(
-    NAME "fix_rules-empty_references"
-    COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/fix_rules.py" "--dry-run" "--root" "${CMAKE_SOURCE_DIR}" "--json" "${CMAKE_SOURCE_DIR}/build/rule_dirs.json" "empty_references"
-)
-set_tests_properties("fix_rules-empty_references" PROPERTIES LABELS quick)
-set_tests_properties("fix_rules-empty_references" PROPERTIES DEPENDS "test-rule-dir-json")
-set_tests_properties("fix_rules-empty_references" PROPERTIES FIXTURES_REQUIRED "rule-dir-json")
-
-add_test(
-    NAME "fix_rules-int_references"
-    COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/fix_rules.py" "--dry-run" "--root" "${CMAKE_SOURCE_DIR}" "--json" "${CMAKE_SOURCE_DIR}/build/rule_dirs.json" "int_references"
-)
-set_tests_properties("fix_rules-int_references" PROPERTIES LABELS quick)
-set_tests_properties("fix_rules-int_references" PROPERTIES DEPENDS "test-rule-dir-json")
-set_tests_properties("fix_rules-int_references" PROPERTIES FIXTURES_REQUIRED "rule-dir-json")
-
-add_test(
-    NAME "fix_rules-duplicate_subkeys"
-    COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/fix_rules.py" "--dry-run" "--root" "${CMAKE_SOURCE_DIR}" "--json" "${CMAKE_SOURCE_DIR}/build/rule_dirs.json" "duplicate_subkeys"
-)
-set_tests_properties("fix_rules-duplicate_subkeys" PROPERTIES LABELS quick)
-set_tests_properties("fix_rules-duplicate_subkeys" PROPERTIES DEPENDS "test-rule-dir-json")
-set_tests_properties("fix_rules-duplicate_subkeys" PROPERTIES FIXTURES_REQUIRED "rule-dir-json")
-
-add_test(
-    NAME "fix_rules-sort_subkeys"
-    COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/fix_rules.py" "--dry-run" "--root" "${CMAKE_SOURCE_DIR}" "--json" "${CMAKE_SOURCE_DIR}/build/rule_dirs.json" "sort_subkeys"
-)
-set_tests_properties("fix_rules-sort_subkeys" PROPERTIES LABELS quick)
-set_tests_properties("fix_rules-sort_subkeys" PROPERTIES DEPENDS "test-rule-dir-json")
-set_tests_properties("fix_rules-sort_subkeys" PROPERTIES FIXTURES_REQUIRED "rule-dir-json")
-
-add_test(
-    NAME "fix_rules-sort_prodtypes"
-    COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/fix_rules.py" "--dry-run" "--root" "${CMAKE_SOURCE_DIR}" "--json" "${CMAKE_SOURCE_DIR}/build/rule_dirs.json" "sort_prodtypes"
-)
-set_tests_properties("fix_rules-sort_prodtypes" PROPERTIES LABELS quick)
-set_tests_properties("fix_rules-sort_prodtypes" PROPERTIES DEPENDS "test-rule-dir-json")
-set_tests_properties("fix_rules-sort_prodtypes" PROPERTIES FIXTURES_REQUIRED "rule-dir-json")
+set_tests_properties("fix_rules" PROPERTIES LABELS quick)
+set_tests_properties("fix_rules" PROPERTIES DEPENDS "test-rule-dir-json")
+set_tests_properties("fix_rules" PROPERTIES FIXTURES_REQUIRED "rule-dir-json")
 
 if(PY_YAMLPATH)
     if(PY_PYTEST)
@@ -157,7 +101,6 @@ if(PY_YAMLPATH)
         NAME "ansible-file-removed-and-added"
         COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/test_ansible_file_removed_and_added.py" --ansible_dir "${CMAKE_BINARY_DIR}/ansible"
     )
-    set_tests_properties("fix_rules-sort_subkeys" PROPERTIES LABELS quick)
 endif()
 
 macro(mypy_test SCRIPT)

--- a/utils/fix_rules.py
+++ b/utils/fix_rules.py
@@ -750,6 +750,28 @@ def sort_prodtypes(args, product_yaml):
     exit(int(len(results) > 0))
 
 
+@command("test_all", "Perform all checks on all rules")
+def test_all(args, product_yaml):
+    result = 0
+    checks = [
+        (has_empty_identifier, "empty identifiers"),
+        (has_invalid_cce, "invalid CCEs"),
+        (has_int_identifier, "integer references"),
+        (has_empty_references, "empty references"),
+        (has_int_reference, "unsorted references"),
+        (has_duplicated_subkeys, "duplicated subkeys"),
+        (has_unordered_sections, "unsorted references"),
+        (has_unsorted_prodtype, "unsorted prodtype")
+    ]
+    for item in rule_data_generator(args):
+        rule_path, rule, rule_lines, _, _ = item
+        for func, msg in checks:
+            if func(rule_path, rule, rule_lines):
+                print("Rule '%s' has %s" % (rule_path, msg))
+                result = 1
+    exit(result)
+
+
 def create_parser_from_functions(subparsers):
     for name, function in _COMMANDS.items():
         subparser = subparsers.add_parser(name, description=function.description)


### PR DESCRIPTION
#### Description:

We currently have multiple CTest tests that run `fix_rules.py`, eg. `fix_rules-empty_identifiers`, `fix_rules-invalid_identifiers`, `fix_rules-duplicate_subkeys`. There is 8 of them and each runs for ~ 10 seconds.

Each of the tests runs a different subcommand of `fix_rules.py`. These tests test various aspects of rule.yml files. Each test
tests all rule.yml files in a product. That means that each test loads all rule.yml files to perform the check. This isn't
efficient and takes a lot of time.

We will introduce a new subcommand `test_all` to `fix_rules.py` . This subcommand can run all checks at once. It iterates over rules and on each rule it runs multiple checks. Each rule.yml is loaded and parsed just once.

Therefore, we will merge all the CTest tests that run `fix_rules.py` to a single test. This way, we will parse each rule.yml file single time instead of 8 times during the test run, and that will save us a lot of time during testing.

#### Rationale:

GitHub Actions CI speed up.

#### Review Hints:

Modify some rules so that the test is trigerred, for example, break ordering of items in prodtype key or break soorting of references in rule.yml. Then run `ctest --verbose -R fix_rules` in `build` directory.