### PR TITLE
Add refchecker tests to RHEL 9

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -287,13 +287,19 @@ macro(ssg_refcheck_test PRODUCT PROFILE KEY)
     set_tests_properties("refchecker-${PRODUCT}-${PROFILE}" PROPERTIES LABELS quick)
 endmacro()
 
+if(PYTHON_VERSION_MAJOR GREATER 2 AND SSG_PRODUCT_RHEL9)
+    ssg_refcheck_test("rhel9" "cis_workstation_l1" "cis")
+    ssg_refcheck_test("rhel9" "cis_workstation_l2" "cis")
+    ssg_refcheck_test("rhel9" "cis_server_l1" "cis")
+    ssg_refcheck_test("rhel9" "cis" "cis")
+endif()
+
 if(PYTHON_VERSION_MAJOR GREATER 2 AND SSG_PRODUCT_RHEL8)
     ssg_refcheck_test("rhel8" "cis_workstation_l1" "cis")
     ssg_refcheck_test("rhel8" "cis_workstation_l2" "cis")
     ssg_refcheck_test("rhel8" "cis_server_l1" "cis")
     ssg_refcheck_test("rhel8" "cis" "cis")
 endif()
-
 
 if(PYTHON_VERSION_MAJOR GREATER 2 AND SSG_PRODUCT_RHEL7)
     ssg_refcheck_test("rhel7" "cis_workstation_l1" "cis")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -292,6 +292,8 @@ if(PYTHON_VERSION_MAJOR GREATER 2 AND SSG_PRODUCT_RHEL9)
     ssg_refcheck_test("rhel9" "cis_workstation_l2" "cis")
     ssg_refcheck_test("rhel9" "cis_server_l1" "cis")
     ssg_refcheck_test("rhel9" "cis" "cis")
+    ssg_refcheck_test("rhel9" "ccn_basic" "ccn")
+    ssg_refcheck_test("rhel9" "ccn_advanced" "ccn")
 endif()
 
 if(PYTHON_VERSION_MAJOR GREATER 2 AND SSG_PRODUCT_RHEL8)


### PR DESCRIPTION
#### Description:

- _Description here. Replace this text. Don't use the italics format!_

#### Rationale:
* Add tests to match RHEL 7 and 8
* Add CCN tests as its new profile only in RHEL 9

