### PR TITLE
OCPBUGS-16877: Update etcd member rules texts' to align with the checks

### DIFF
--- a/applications/openshift/master/file_groupowner_etcd_member/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_member/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify Group Who Owns The etcd Member Pod Specification File'
 
-description: '{{{ describe_file_group_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", group="root") }}}'
+description: '{{{ describe_file_group_owner(file="/etc/kubernetes/manifests/etcd-pod.yaml", group="root") }}}'
 
 rationale: |-
     The etcd pod specification file controls various parameters that
@@ -25,10 +25,10 @@ references:
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/manifests/etcd-pod.yaml", group="root") }}}'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", group="root") }}}
+    {{{ ocil_file_group_owner(file="/etc/kubernetes/manifests/etcd-pod.yaml", group="root") }}}
 
 platforms:
     - ocp4-master-node

--- a/applications/openshift/master/file_owner_etcd_member/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_member/rule.yml
@@ -4,7 +4,7 @@ prodtype: ocp4
 
 title: 'Verify User Who Owns The Etcd Member Pod Specification File'
 
-description: '{{{ describe_file_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", owner="root") }}}'
+description: '{{{ describe_file_owner(file="/etc/kubernetes/manifests/etcd-pod.yaml", owner="root") }}}'
 
 rationale: |-
     The etcd pod specification file controls various parameters that
@@ -25,10 +25,10 @@ references:
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/manifests/etcd-pod.yaml", owner="root") }}}'
 
 ocil: |-
-    {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", owner="root") }}}
+    {{{ ocil_file_owner(file="/etc/kubernetes/manifests/etcd-pod.yaml", owner="root") }}}
 
 platforms:
     - ocp4-master-node

--- a/applications/openshift/master/file_permissions_etcd_member/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_member/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Permissions on the Etcd Member Pod Specification File'
 
 description: |-
-    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", perms="0600") }}}
+    {{{ describe_file_permissions(file="/etc/kubernetes/manifests/etcd-pod.yaml", perms="0600") }}}
 
 rationale: |-
     The etcd pod specification file controls various parameters that
@@ -26,10 +26,10 @@ references:
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", perms="-rw-------") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/manifests/etcd-pod.yaml", perms="-rw-------") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", perms="-rw-------") }}}
+    {{{ ocil_file_permissions(file="/etc/kubernetes/manifests/etcd-pod.yaml", perms="-rw-------") }}}
 
 platforms:
     - ocp4-master-node


### PR DESCRIPTION


#### Description:

- Update description mention the actual checked paths.
  These rules now check /etc/kubernetes/manifests/etcd-pod.yaml.

#### Rationale:

- Follow up from #10964
