### PR TITLE
OCPBUGS-7455: Hide API warning messages

### DIFF
--- a/applications/openshift/api-server/api_server_api_priority_flowschema_catch_all/rule.yml
+++ b/applications/openshift/api-server/api_server_api_priority_flowschema_catch_all/rule.yml
@@ -46,4 +46,4 @@ ocil: |-
 
 warnings:
     - general: |-
-        {{{ openshift_cluster_setting(["/apis/flowcontrol.apiserver.k8s.io/v1alpha1/flowschemas/catch-all", "/apis/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas/catch-all", "/apis/flowcontrol.apiserver.k8s.io/v1beta2/flowschemas/catch-all"]) | indent(8) }}}
+        {{{ openshift_cluster_setting(["/apis/flowcontrol.apiserver.k8s.io/v1alpha1/flowschemas/catch-all", "/apis/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas/catch-all", "/apis/flowcontrol.apiserver.k8s.io/v1beta2/flowschemas/catch-all"], true) | indent(8) }}}

--- a/applications/openshift/api-server/api_server_api_priority_v1alpha1_flowschema_catch_all/rule.yml
+++ b/applications/openshift/api-server/api_server_api_priority_v1alpha1_flowschema_catch_all/rule.yml
@@ -50,7 +50,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/apis/flowcontrol.apiserver.k8s.io/v1alpha1/flowschemas/catch-all") | indent(4) }}}
+    {{{ openshift_cluster_setting("/apis/flowcontrol.apiserver.k8s.io/v1alpha1/flowschemas/catch-all", true) | indent(4) }}}
 - dependency: |-
     Note that this rule is only applicable in OpenShift Container Platform
     versions 4.7 and below.

--- a/applications/openshift/api-server/api_server_api_priority_v1beta1_flowschema_catch_all/rule.yml
+++ b/applications/openshift/api-server/api_server_api_priority_v1beta1_flowschema_catch_all/rule.yml
@@ -49,7 +49,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/apis/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas/catch-all") | indent(4) }}}
+    {{{ openshift_cluster_setting("/apis/flowcontrol.apiserver.k8s.io/v1beta1/flowschemas/catch-all", true) | indent(4) }}}
 - dependency: |-
     Note that this is only applicable in OpenShift Container Platform version 4.8
     and higher

--- a/applications/openshift/api-server/api_server_api_priority_v1beta2_flowschema_catch_all/rule.yml
+++ b/applications/openshift/api-server/api_server_api_priority_v1beta2_flowschema_catch_all/rule.yml
@@ -49,7 +49,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/apis/flowcontrol.apiserver.k8s.io/v1beta2/flowschemas/catch-all") | indent(4) }}}
+    {{{ openshift_cluster_setting("/apis/flowcontrol.apiserver.k8s.io/v1beta2/flowschemas/catch-all", true) | indent(4) }}}
 - dependency: |-
     Note that this is only applicable in OpenShift Container Platform version 4.11
     and higher

--- a/applications/openshift/api-server/audit_log_forwarding_enabled/rule.yml
+++ b/applications/openshift/api-server/audit_log_forwarding_enabled/rule.yml
@@ -39,7 +39,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/apis/logging.openshift.io/v1/namespaces/openshift-logging/clusterlogforwarders/instance") | indent(4) }}}
+    {{{ openshift_cluster_setting("/apis/logging.openshift.io/v1/namespaces/openshift-logging/clusterlogforwarders/instance", true) | indent(4) }}}
 
 template:
   name: yamlfile_value

--- a/applications/openshift/api-server/audit_log_forwarding_webhook/rule.yml
+++ b/applications/openshift/api-server/audit_log_forwarding_webhook/rule.yml
@@ -39,7 +39,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_filtered_cluster_setting({hypershift_path: dump_path}) | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting_suppressed({hypershift_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value

--- a/applications/openshift/logging/audit_log_forwarding_uses_tls/rule.yml
+++ b/applications/openshift/logging/audit_log_forwarding_uses_tls/rule.yml
@@ -39,7 +39,7 @@ ocil: |-
 warnings:
 - general: |-
     {{{ openshift_cluster_setting() | indent(4) }}}
-    {{{ openshift_filtered_cluster_setting({
+    {{{ openshift_filtered_cluster_setting_suppressed({
             "/apis/logging.openshift.io/v1/namespaces/openshift-logging/clusterlogforwarders/instance": 'try [.spec.outputs[].url] catch []',
         }) | indent(4) }}}
 

--- a/shared/macros/01-general.jinja
+++ b/shared/macros/01-general.jinja
@@ -16,7 +16,7 @@ Therefore, you need to use a tool that can query the OCP API, retrieve the {{% i
 
 {{% macro openshift_cluster_setting_kubeletconfig() -%}}
 This rule's check operates on the cluster configuration dump. This will be a Platform rule, var_role_worker and var_role_master needed to be set if scan is not expected to run on master, and worker nodes.
-Therefore, you need to use a tool that can query the OCP API, retrieve KubeletConfig through <code class="ocp-api-endpoint-kubeletconfig">"/api/v1/nodes/NODE_NAME/proxy/configz"</code> API endpoint to the local <code class="ocp-dump-location-kubeletconfig">{{{ xccdf_value("ocp_data_root") }}}"/kubeletconfig/role/role"</code> file.
+Therefore, you need to use a tool that can query the OCP API, retrieve KubeletConfig through <code class="ocp-api-endpoint-kubeletconfig">"/api/v1/nodes/NODE_NAME/proxy/configz"</code> {{{suppressed_warning()}}} API endpoint to the local <code class="ocp-dump-location-kubeletconfig">{{{ xccdf_value("ocp_data_root") }}}"/kubeletconfig/role/role"</code> file.
 {{%- endmacro %}}
 
 


### PR DESCRIPTION
Hide KubeletConfig related /api/v1/nodes/proxy/configz warning message, and FlowSchema api warning messages

[OCPBUGS-7455](https://issues.redhat.com/browse/OCPBUGS-7455)