### PR TITLE
OCPBUGS-17216: Update rotate certificates check for OCP 4.14

### DIFF
--- a/applications/openshift/kubelet/kubelet_enable_server_cert_rotation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_server_cert_rotation/rule.yml
@@ -17,10 +17,7 @@ description: |-
     file <tt>{{{ kubeletconf_path }}}</tt>
     on the kubelet node(s) and set the below parameter:
     <pre>
-    featureGates:
-    ...
-      RotateKubeletServerCertificate: true
-    ...
+    serverTLSBootstrap: true
     </pre>
 
 rationale: |-
@@ -33,7 +30,7 @@ ocil_clause: 'the kubelet cannot rotate server certificate'
 
 ocil: |-
     Run the following command on the kubelet node(s):
-    <pre>$ for NODE_NAME in $(oc get nodes -ojsonpath='{.items[*].metadata.name}'); do oc get --raw /api/v1/nodes/$NODE_NAME/proxy/configz | jq '.kubeletconfig|.kind="KubeletConfiguration"|.apiVersion="kubelet.config.k8s.io/v1beta1"' | grep RotateKubeletServerCertificate; done</pre>
+    <pre>$ for node in $(oc get nodes -ojsonpath='{.items[*].metadata.name}'); do oc get --raw /api/v1/nodes/$node/proxy/configz | jq '.kubeletconfig.serverTLSBootstrap'; done</pre>
     The output should return <tt>true</tt>.
 
 identifiers:

--- a/applications/openshift/kubelet/kubelet_enable_server_cert_rotation_master/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_server_cert_rotation_master/rule.yml
@@ -17,10 +17,7 @@ description: |-
     file <tt>{{{ kubeletconf_path }}}</tt>
     on the kubelet node(s) and set the below parameter:
     <pre>
-    featureGates:
-    ...
-      RotateKubeletServerCertificate: true
-    ...
+    serverTLSBootstrap: true
     </pre>
 
 rationale: |-
@@ -33,7 +30,7 @@ ocil_clause: 'the kubelet cannot rotate server certificate'
 
 ocil: |-
     Run the following command on the kubelet node(s):
-    <pre>$ for NODE_NAME in $(oc get nodes -ojsonpath='{.items[*].metadata.name}'); do oc get --raw /api/v1/nodes/$NODE_NAME/proxy/configz | jq '.kubeletconfig|.kind="KubeletConfiguration"|.apiVersion="kubelet.config.k8s.io/v1beta1"' | grep RotateKubeletServerCertificate; done</pre>
+    <pre>$ for node in $(oc get nodes -ojsonpath='{.items[*].metadata.name}'); do oc get --raw /api/v1/nodes/$node/proxy/configz | jq '.kubeletconfig.serverTLSBootstrap' done</pre>
     The output should return <tt>true</tt>.
 
 references:
@@ -49,7 +46,7 @@ template:
         ocp_data: "true"
         filepath: '/kubeletconfig/role'
         filepath_suffix: var_role_master
-        yamlpath: ".featureGates.RotateKubeletServerCertificate"
+        yamlpath: ".serverTLSBootstrap"
         values:
          - value: "true"
            operation: "equals"

--- a/applications/openshift/kubelet/kubelet_enable_server_cert_rotation_worker/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_server_cert_rotation_worker/rule.yml
@@ -17,10 +17,7 @@ description: |-
     file <tt>{{{ kubeletconf_path }}}</tt>
     on the kubelet node(s) and set the below parameter:
     <pre>
-    featureGates:
-    ...
-      RotateKubeletServerCertificate: true
-    ...
+    serverTLSBootstrap: true
     </pre>
 
 rationale: |-
@@ -33,7 +30,7 @@ ocil_clause: 'the kubelet cannot rotate server certificate'
 
 ocil: |-
     Run the following command on the kubelet node(s):
-    <pre>$ for NODE_NAME in $(oc get nodes -ojsonpath='{.items[*].metadata.name}'); do oc get --raw /api/v1/nodes/$NODE_NAME/proxy/configz | jq '.kubeletconfig|.kind="KubeletConfiguration"|.apiVersion="kubelet.config.k8s.io/v1beta1"' | grep RotateKubeletServerCertificate; done</pre>
+    <pre>$ for node in $(oc get nodes -ojsonpath='{.items[*].metadata.name}'); do oc get --raw /api/v1/nodes/$node/proxy/configz | jq '.kubeletconfig.serverTLSBootstrap'; done</pre>
     The output should return <tt>true</tt>.
 
 references:
@@ -49,7 +46,7 @@ template:
         ocp_data: "true"
         filepath: '/kubeletconfig/role'
         filepath_suffix: var_role_worker
-        yamlpath: ".featureGates.RotateKubeletServerCertificate"
+        yamlpath: ".serverTLSBootstrap"
         values:
          - value: "true"
            operation: "equals"


### PR DESCRIPTION
By default, the rotate certificates rules for CIS 1.4.0 (section 4.2)
fail on OpenShift 4.14.

This commit updates the rule to check for the proper configuration so
that it passes by default, since certificate rotation is enabled by
default. This patch also updates the instructions to use a valid command
for users looking to verify the configuration manually. The old command
didn't return anything because it was looking in the wrong configuration
section.

This is documented upstream in the following doc:

  https://kubernetes.io/docs/reference/access-authn-authz/kubelet-tls-bootstrapping/#certificate-rotation

