### PR TITLE
OCPBUGS-11696: Update encryption type to support 4.13 deployments

### DIFF
--- a/applications/openshift/api-server/api_server_encryption_provider_cipher/kubernetes/shared.yml
+++ b/applications/openshift/api-server/api_server_encryption_provider_cipher/kubernetes/shared.yml
@@ -6,4 +6,4 @@ metadata:
   name: cluster
 spec:
   encryption:
-    type: aescbc
+    type: "{{.var_apiserver_encryption_type}}"

--- a/applications/openshift/api-server/api_server_encryption_provider_cipher/rule.yml
+++ b/applications/openshift/api-server/api_server_encryption_provider_cipher/rule.yml
@@ -96,5 +96,13 @@ template:
     entity_check: "all"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: "[:]"
-    xccdf_variable: var_apiserver_encryption_type
-    regex_data: true
+    check_existence: "at_least_one_exists"
+    values:
+        # aesgcm is available for OpenShift 4.13 and newer, but we include it
+        # in our check here since it's not possible to set the encryption
+        # provider type to aesgcm on OpenShift versions older than 4.13, which
+        # simplifies the rule since we don't have to modify the check based on
+        # the OpenShift version CPE.
+        - value: "aescbc|aesgcm"
+          type: "string"
+          operation: "pattern match"

--- a/applications/openshift/api-server/var_apiserver_encryption_type.var
+++ b/applications/openshift/api-server/var_apiserver_encryption_type.var
@@ -2,7 +2,15 @@ documentation_complete: true
 
 title: 'OpenShift APIServer etcd encryption type'
 
-description: 'OpenShift APIServer etcd encryption config check encryption type'
+description: |
+    OpenShift APIServer etcd encryption provider type to use for
+    remediation. This variable is only applicable to remediations, and does not
+    affect checks. This variable is set to 'aescbc' by default, which is
+    supported across all OpenShift versions as the etcd encryption provider
+    type. OpenShift 4.13 and newer support 'aesgcm'. Attempting to use 'aesgcm'
+    on older versions of OpenShift will result in a failed remediation. Please
+    make sure the encryption provider type you set is supported on the version
+    of OpenShift you're using.
 
 type: string
 
@@ -11,4 +19,6 @@ operator: equals
 interactive: false
 
 options:
-    default: 'aescbc'
+    default: aescbc
+    aescbc: aescbc
+    aesgcm: aesgcm


### PR DESCRIPTION
The latest CIS guidance allows OpenShift users to configure the
encryption type for the API server to `aescbc` or `aescgm`. Previously,
the variable used to evaluate this check only supported `aescbc`. This
commit update the variable to accept either type, as per the CIS
guidance.
