### PR TITLE
Reduce the number of times we build all of the products in CI

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -17,20 +17,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Build
         run: |-
-          ./build_product \
-              alinux2 \
-              alinux3 \
-              anolis23 \
-              anolis8 \
-              chromium \
-              fedora \
-              firefox \
-              rhcos4 \
-              rhel7 \
-              rhel8 \
-              rhel9 \
-              uos20 \
-              --derivatives
+          ./build_product rhel7 rhel8 rhel9 --derivatives
         env:
           ADDITIONAL_CMAKE_OPTIONS: "-DSSG_OVAL_SCHEMATRON_VALIDATION_ENABLED=OFF"
       - name: Test
@@ -48,7 +35,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build
-        run: ./build_product alinux2 alinux3 anolis23 anolis8 chromium fedora firefox rhcos4 rhel7 rhel8 rhel9 sle12 sle15 ubuntu2004 ubuntu2204 uos20
+        run: ./build_product sle12 sle15
         env:
           ADDITIONAL_CMAKE_OPTIONS: "-DSSG_OVAL_SCHEMATRON_VALIDATION_ENABLED=OFF"
       - name: Test
@@ -90,23 +77,7 @@ jobs:
         env:
           ADDITIONAL_CMAKE_OPTIONS: "-DSSG_SCE_ENABLED:BOOL=ON -DSSG_OVAL_SCHEMATRON_VALIDATION_ENABLED=OFF"
         run: |-
-          ./build_product \
-              alinux2 \
-              alinux3 \
-              anolis23 \
-              anolis8 \
-              chromium \
-              fedora \
-              firefox \
-              rhcos4 \
-              rhel7 \
-              rhel8 \
-              rhel9 \
-              sle12 \
-              sle15 \
-              ubuntu2004 \
-              ubuntu2204 \
-              uos20
+          ./build_product ubuntu2004 ubuntu2204
       - name: Test
         run: ctest -j2 --output-on-failure -E unique-stigids
         working-directory: ./build
@@ -123,9 +94,7 @@ jobs:
         env:
           ADDITIONAL_CMAKE_OPTIONS: "-DSSG_SCE_ENABLED:BOOL=ON -DSSG_OVAL_SCHEMATRON_VALIDATION_ENABLED=OFF"
         run: |-
-          ./build_product \
-              ubuntu2004 \
-              ubuntu2204
+          ./build_product ubuntu2004 ubuntu2204
       - name: Test
         run: ctest -j2 --output-on-failure -E unique-stigids
         working-directory: ./build


### PR DESCRIPTION
#### Description:

Remove building all products from OpenSUSE and Ubuntu.

#### Rationale:

Speed up CI
