### PR TITLE
Fix remediation of sssd_enable_smartcards

### DIFF
--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/bash/shared.sh
@@ -15,9 +15,7 @@ umask $OLD_UMASK
 
 {{% if product in ["fedora", "ol8", "ol9", "rhel8", "rhel9"] %}}
 if [ -f /usr/bin/authselect ]; then
-    if authselect check; then
-        {{{ bash_enable_authselect_feature('with-smartcard') | indent(8) }}}
-    fi
+    {{{ bash_enable_authselect_feature('with-smartcard') | indent(4) }}}
 else
     {{{ bash_ensure_pam_module_option('/etc/pam.d/smartcard-auth', 'auth', 'sufficient', 'pam_sss.so', 'allow_missing_name', '', '') | indent(4) }}}
     {{{ bash_ensure_pam_module_option('/etc/pam.d/system-auth', 'auth', '\[success=done authinfo_unavail=ignore ignore=ignore default=die\]', 'pam_sss.so', 'try_cert_auth', '', '') | indent(4) }}}


### PR DESCRIPTION
#### Description:

- remove unnecessary if statement

#### Rationale:

- Fix implementation in which there were unreachable code due to wrong macro usage

#### Review Hints:

Previously generated bash code:

```
if [ -f /usr/bin/authselect ]; then
    if authselect check; then
        if ! authselect check; then
        echo "
        authselect integrity check failed. Remediation aborted!
        This remediation could not be applied because an authselect profile was not selected or the selected profile is not intact.
        It is not recommended to manually edit the PAM files when authselect tool is available.
        In cases where the default authselect profile does not cover a specific demand, a custom authselect profile is recommended."
        exit 1
        fi
        authselect enable-feature with-smartcard

        authselect apply-changes -b
    fi
else
[...]
```
Now it looks like this:

```
if [ -f /usr/bin/authselect ]; then
    if ! authselect check; then
    echo "
    authselect integrity check failed. Remediation aborted!
    This remediation could not be applied because an authselect profile was not selected or the selected profile is not intact.
    It is not recommended to manually edit the PAM files when authselect tool is available.
    In cases where the default authselect profile does not cover a specific demand, a custom authselect profile is recommended."
    exit 1
    fi
    authselect enable-feature with-smartcard

    authselect apply-changes -b
else
[...]
```