### PR TITLE
test_machine_only_rules: allow multiple blank characters

### DIFF
--- a/tests/test_machine_only_rules.py
+++ b/tests/test_machine_only_rules.py
@@ -13,7 +13,8 @@ import re
 BASH_MACHINE_CONDITIONAL = re.compile(
     r'^.*\[ ! -f /.dockerenv \] && \[ ! -f /run/.containerenv \].*$', re.M)
 ANSIBLE_MACHINE_CONDITIONAL = re.compile(
-    r'ansible_virtualization_type not in \["docker", "lxc", "openvz", "podman", "container"\]',
+    r'ansible_virtualization_type not in \["docker",\s+"lxc",\s+"openvz",\s+"podman",\s+' +
+    '"container"\]',
     re.M)
 MACHINE_PLATFORM_ONE_LINE = re.compile(
     r'^\s*platform:\s+machine\s*$', re.M)


### PR DESCRIPTION
#### Description:

- modify regex which checks for presence of machine platform conditional in Ansible remediations - allow multiple blank chars between items of a list

#### Rationale:



- Fixes #10943 
- fixes: #10976 

#### Review Hints:

1. ./build_product ol8
2. cd build
3. ctest -R machine-only-rules --output-on-failure

