### PR TITLE
Update metadata of OSPP profile in RHEL8/9

### DIFF
--- a/products/rhel8/profiles/ospp.profile
+++ b/products/rhel8/profiles/ospp.profile
@@ -3,10 +3,10 @@ documentation_complete: true
 metadata:
     version: 4.2.1
     SMEs:
-        - comps
-        - stevegrubb
+        - ggbecker
+        - matusmarhefka
 
-reference: https://www.niap-ccevs.org/Profile/PP.cfm
+reference: https://www.niap-ccevs.org/Profile/Info.cfm?PPID=442&id=442
 
 title: 'Protection Profile for General Purpose Operating Systems'
 

--- a/products/rhel9/profiles/ospp.profile
+++ b/products/rhel9/profiles/ospp.profile
@@ -1,19 +1,19 @@
 documentation_complete: true
 
 metadata:
-    version: 4.2.1
+    version: 4.3
     SMEs:
-        - comps
-        - stevegrubb
+        - ggbecker
+        - matusmarhefka
 
-reference: https://www.niap-ccevs.org/Profile/Info.cfm?PPID=442&id=442
+reference: https://www.niap-ccevs.org/Profile/Info.cfm?PPID=469&id=469
 
 title: 'Protection Profile for General Purpose Operating Systems'
 
 description: |-
     This profile is part of Red Hat Enterprise Linux 9 Common Criteria Guidance
     documentation for Target of Evaluation based on Protection Profile for
-    General Purpose Operating Systems (OSPP) version 4.2.1 and Functional
+    General Purpose Operating Systems (OSPP) version 4.3 and Functional
     Package for SSH version 1.0.
 
     Where appropriate, CNSSI 1253 or DoD-specific values are used for

--- a/tests/data/profile_stability/rhel8/ospp.profile
+++ b/tests/data/profile_stability/rhel8/ospp.profile
@@ -1,4 +1,3 @@
-title: Protection Profile for General Purpose Operating Systems
 description: 'This profile reflects mandatory configuration controls identified in
     the
 
@@ -18,9 +17,9 @@ extends: null
 metadata:
     version: 4.2.1
     SMEs:
-    - comps
-    - stevegrubb
-reference: https://www.niap-ccevs.org/Profile/PP.cfm
+    - ggbecker
+    - matusmarhefka
+reference: https://www.niap-ccevs.org/Profile/Info.cfm?PPID=442&id=442
 selections:
 - accounts_max_concurrent_login_sessions
 - accounts_password_pam_dcredit
@@ -262,8 +261,10 @@ selections:
 - grub2_vsyscall_argument.severity=info
 - sysctl_user_max_user_namespaces.role=unscored
 - sysctl_user_max_user_namespaces.severity=info
+unselected_groups: []
 platforms: !!set {}
 cpe_names: !!set {}
 platform: null
 filter_rules: ''
+title: Protection Profile for General Purpose Operating Systems
 documentation_complete: true


### PR DESCRIPTION
#### Description:

- Update metadata of OSPP profile in RHEL8/9.
  - RHEL9 targets the common criteria using the OSPP profile version 4.3.