### PR TITLE
OCPBUGS-16628: Fix namespace when checking the hosted clusters

### DIFF
--- a/applications/openshift/api-server/api_server_encryption_provider_cipher/rule.yml
+++ b/applications/openshift/api-server/api_server_encryption_provider_cipher/rule.yml
@@ -6,7 +6,7 @@ title: 'Configure the Encryption Provider Cipher'
 
 {{% set default_jqfilter = '[.spec.encryption.type]' %}}
 {{% set default_api_path = '/apis/config.openshift.io/v1/apiservers/cluster' %}}
-{{% set hypershift_path = '/apis/hypershift.openshift.io/v1beta1/namespaces/clusters/hostedclusters/{{.hypershift_cluster}}' %}}
+{{% set hypershift_path = '/apis/hypershift.openshift.io/v1beta1/namespaces/{{.hypershift_namespace_prefix}}/hostedclusters/{{.hypershift_cluster}}' %}}
 {{% set hypershift_jqfilter = '[.spec.secretEncryption.type]' %}}
 {{% set custom_api_path = '{{if ne .hypershift_cluster "None"}}' ~ hypershift_path ~ '{{else}}' ~  default_api_path ~ '{{end}}' %}}
 {{% set custom_jqfilter = '{{if ne .hypershift_cluster "None"}}' ~ hypershift_jqfilter ~ '{{else}}' ~  default_jqfilter ~ '{{end}}' %}}

--- a/applications/openshift/api-server/audit_log_forwarding_webhook/rule.yml
+++ b/applications/openshift/api-server/audit_log_forwarding_webhook/rule.yml
@@ -4,7 +4,7 @@ title: Ensure that Audit Log Webhook Is Configured
 
 {{% set default_jqfilter = '.spec' %}}
 {{% set default_api_path = '/apis/logging.openshift.io/v1/namespaces/openshift-logging/clusterlogforwarders/instance' %}}
-{{% set hypershift_path = '/apis/hypershift.openshift.io/v1beta1/namespaces/clusters/hostedclusters/{{.hypershift_cluster}}' %}}
+{{% set hypershift_path = '/apis/hypershift.openshift.io/v1beta1/namespaces/{{.hypershift_namespace_prefix}}/hostedclusters/{{.hypershift_cluster}}' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ default_jqfilter %}}
 
 description: |-

--- a/applications/openshift/authentication/idp_is_configured/rule.yml
+++ b/applications/openshift/authentication/idp_is_configured/rule.yml
@@ -2,7 +2,7 @@ prodtype: ocp4
 
 {{% set default_jqfilter = '.spec' %}}
 {{% set default_api_path = '/apis/config.openshift.io/v1/oauths/cluster' %}}
-{{% set hypershift_path = '/apis/hypershift.openshift.io/v1beta1/namespaces/clusters/hostedclusters/{{.hypershift_cluster}}' %}}
+{{% set hypershift_path = '/apis/hypershift.openshift.io/v1beta1/namespaces/{{.hypershift_namespace_prefix}}/hostedclusters/{{.hypershift_cluster}}' %}}
 {{% set hypershift_jqfilter = '.spec.configuration.oauth' %}}
 {{% set custom_api_path = '{{if ne .hypershift_cluster "None"}}' ~ hypershift_path ~ '{{else}}' ~  default_api_path ~ '{{end}}' %}}
 {{% set custom_jqfilter = '{{if ne .hypershift_cluster "None"}}' ~ hypershift_jqfilter ~ '{{else}}' ~  default_jqfilter ~ '{{end}}' %}}

--- a/applications/openshift/authentication/oauth_inactivity_timeout/rule.yml
+++ b/applications/openshift/authentication/oauth_inactivity_timeout/rule.yml
@@ -4,7 +4,7 @@ title: "Configure OAuth server so that tokens expire after a set period of inact
 
 {{% set default_jqfilter = '.spec' %}}
 {{% set default_api_path = '/apis/config.openshift.io/v1/oauths/cluster' %}}
-{{% set hypershift_path = '/apis/hypershift.openshift.io/v1beta1/namespaces/clusters/hostedclusters/{{.hypershift_cluster}}' %}}
+{{% set hypershift_path = '/apis/hypershift.openshift.io/v1beta1/namespaces/{{.hypershift_namespace_prefix}}/hostedclusters/{{.hypershift_cluster}}' %}}
 {{% set hypershift_jqfilter = '.spec.configuration.oauth' %}}
 {{% set custom_api_path = '{{if ne .hypershift_cluster "None"}}' ~ hypershift_path ~ '{{else}}' ~  default_api_path ~ '{{end}}' %}}
 {{% set custom_jqfilter = '{{if ne .hypershift_cluster "None"}}' ~ hypershift_jqfilter ~ '{{else}}' ~  default_jqfilter ~ '{{end}}' %}}

--- a/applications/openshift/authentication/oauth_token_maxage/rule.yml
+++ b/applications/openshift/authentication/oauth_token_maxage/rule.yml
@@ -4,7 +4,7 @@ title: "Configure OAuth server so that tokens have a maximum age set"
 
 {{% set default_jqfilter = '.spec' %}}
 {{% set default_api_path = '/apis/config.openshift.io/v1/oauths/cluster' %}}
-{{% set hypershift_path = '/apis/hypershift.openshift.io/v1beta1/namespaces/clusters/hostedclusters/{{.hypershift_cluster}}' %}}
+{{% set hypershift_path = '/apis/hypershift.openshift.io/v1beta1/namespaces/{{.hypershift_namespace_prefix}}/hostedclusters/{{.hypershift_cluster}}' %}}
 {{% set hypershift_jqfilter = '.spec.configuration.oauth' %}}
 {{% set custom_api_path = '{{if ne .hypershift_cluster "None"}}' ~ hypershift_path ~ '{{else}}' ~  default_api_path ~ '{{end}}' %}}
 {{% set custom_jqfilter = '{{if ne .hypershift_cluster "None"}}' ~ hypershift_jqfilter ~ '{{else}}' ~  default_jqfilter ~ '{{end}}' %}}

--- a/applications/openshift/authentication/ocp_idp_no_htpasswd/rule.yml
+++ b/applications/openshift/authentication/ocp_idp_no_htpasswd/rule.yml
@@ -4,7 +4,7 @@ title: "Do Not Use htpasswd-based IdP"
 
 {{% set default_jqfilter = '.spec' %}}
 {{% set default_api_path = '/apis/config.openshift.io/v1/oauths/cluster' %}}
-{{% set hypershift_path = '/apis/hypershift.openshift.io/v1beta1/namespaces/clusters/hostedclusters/{{.hypershift_cluster}}' %}}
+{{% set hypershift_path = '/apis/hypershift.openshift.io/v1beta1/namespaces/{{.hypershift_namespace_prefix}}/hostedclusters/{{.hypershift_cluster}}' %}}
 {{% set hypershift_jqfilter = '.spec.configuration.oauth' %}}
 {{% set custom_api_path = '{{if ne .hypershift_cluster "None"}}' ~ hypershift_path ~ '{{else}}' ~  default_api_path ~ '{{end}}' %}}
 {{% set custom_jqfilter = '{{if ne .hypershift_cluster "None"}}' ~ hypershift_jqfilter ~ '{{else}}' ~  default_jqfilter ~ '{{end}}' %}}

--- a/applications/openshift/authentication/ocp_no_ldap_insecure/rule.yml
+++ b/applications/openshift/authentication/ocp_no_ldap_insecure/rule.yml
@@ -4,7 +4,7 @@ title: "Only Use LDAP-based IdPs with TLS"
 
 {{% set default_jqfilter = '.spec' %}}
 {{% set default_api_path = '/apis/config.openshift.io/v1/oauths/cluster' %}}
-{{% set hypershift_path = '/apis/hypershift.openshift.io/v1beta1/namespaces/clusters/hostedclusters/{{.hypershift_cluster}}' %}}
+{{% set hypershift_path = '/apis/hypershift.openshift.io/v1beta1/namespaces/{{.hypershift_namespace_prefix}}/hostedclusters/{{.hypershift_cluster}}' %}}
 {{% set hypershift_jqfilter = '.spec.configuration.oauth' %}}
 {{% set custom_api_path = '{{if ne .hypershift_cluster "None"}}' ~ hypershift_path ~ '{{else}}' ~  default_api_path ~ '{{end}}' %}}
 {{% set custom_jqfilter = '{{if ne .hypershift_cluster "None"}}' ~ hypershift_jqfilter ~ '{{else}}' ~  default_jqfilter ~ '{{end}}' %}}

--- a/applications/openshift/general/oauth_login_template_set/rule.yml
+++ b/applications/openshift/general/oauth_login_template_set/rule.yml
@@ -4,7 +4,7 @@ title: Ensure that the OpenShift OAuth login template is set
 
 {{% set default_jqfilter = '.spec' %}}
 {{% set default_api_path = '/apis/config.openshift.io/v1/oauths/cluster' %}}
-{{% set hypershift_path = '/apis/hypershift.openshift.io/v1beta1/namespaces/clusters/hostedclusters/{{.hypershift_cluster}}' %}}
+{{% set hypershift_path = '/apis/hypershift.openshift.io/v1beta1/namespaces/{{.hypershift_namespace_prefix}}/hostedclusters/{{.hypershift_cluster}}' %}}
 {{% set hypershift_jqfilter = '.spec.configuration.oauth' %}}
 {{% set custom_api_path = '{{if ne .hypershift_cluster "None"}}' ~ hypershift_path ~ '{{else}}' ~  default_api_path ~ '{{end}}' %}}
 {{% set custom_jqfilter = '{{if ne .hypershift_cluster "None"}}' ~ hypershift_jqfilter ~ '{{else}}' ~  default_jqfilter ~ '{{end}}' %}}

--- a/applications/openshift/general/oauth_provider_selection_set/rule.yml
+++ b/applications/openshift/general/oauth_provider_selection_set/rule.yml
@@ -4,7 +4,7 @@ title: Ensure that the OpenShift OAuth provider selection is set
 
 {{% set default_jqfilter = '.spec' %}}
 {{% set default_api_path = '/apis/config.openshift.io/v1/oauths/cluster' %}}
-{{% set hypershift_path = '/apis/hypershift.openshift.io/v1beta1/namespaces/clusters/hostedclusters/{{.hypershift_cluster}}' %}}
+{{% set hypershift_path = '/apis/hypershift.openshift.io/v1beta1/namespaces/{{.hypershift_namespace_prefix}}/hostedclusters/{{.hypershift_cluster}}' %}}
 {{% set hypershift_jqfilter = '.spec.configuration.oauth' %}}
 {{% set custom_api_path = '{{if ne .hypershift_cluster "None"}}' ~ hypershift_path ~ '{{else}}' ~  default_api_path ~ '{{end}}' %}}
 {{% set custom_jqfilter = '{{if ne .hypershift_cluster "None"}}' ~ hypershift_jqfilter ~ '{{else}}' ~  default_jqfilter ~ '{{end}}' %}}

--- a/applications/openshift/general/version_detect_in_hypershift/rule.yml
+++ b/applications/openshift/general/version_detect_in_hypershift/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'This is a helper rule to fetch the required api resource for detecting HyperShift OCP version'
 
 {{% set custom_jqfilter = '[.status.version.history[].version]' %}}
-{{% set custom_api_path = '/apis/hypershift.openshift.io/v1beta1/namespaces/clusters/hostedclusters/{{.hypershift_cluster}}' %}}
+{{% set custom_api_path = '/apis/hypershift.openshift.io/v1beta1/namespaces/{{.hypershift_namespace_prefix}}/hostedclusters/{{.hypershift_cluster}}' %}}
 {{% set default_api_path = '/hypershift/version' %}}
 {{% set dump_path = default_api_path ~ ',' ~ custom_jqfilter %}}
 


### PR DESCRIPTION


#### Description:

- Fix the resource path when checking hosted clusters.

#### Rationale:

- Not all clusters use 'clusters' as the prefix for hosted clusters. These rules should use the the variable `hypershift_namespace_prefix`.


