### PR TITLE
Drop irrelevant return statement in bash remediation

### DIFF
--- a/shared/templates/mount_option_removable_partitions/bash.template
+++ b/shared/templates/mount_option_removable_partitions/bash.template
@@ -11,5 +11,4 @@ if grep -q $device_regex /etc/fstab ; then
     sed -i "s|\($device_regex.*$previous_opts\)|\1,$mount_option|" /etc/fstab
 else
     echo "Not remediating, because there is no record of $var_removable_partition in /etc/fstab" >&2
-    return 1
 fi


### PR DESCRIPTION

#### Description:

- Remove irrelevant return in bash remediation template

#### Rationale:

- Return statement is irrelevant in case the remediation cannot be performed. Even a `false` result will not be helpful, since the else case means ignoring rather than failure to remediatie

- Fixes #7459

