### PR TITLE
Improve template macros for grub command line

### DIFF
--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/grub2_ipv6_disable_argument/tests/cmd_line_commented_etcdefaultgrub.fail.sh
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/grub2_ipv6_disable_argument/tests/cmd_line_commented_etcdefaultgrub.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bas
+# platform = Red Hat Enterprise Linux 7,sle12,sle15
+
+# Removes kernel command line in /etc/default/grub
+sed -i '/^\s*GRUB_CMDLINE_LINUX=/s//#&/' '/etc/default/grub'

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/grub2_ipv6_disable_argument/tests/cmd_line_commented_etcdefaultgrub.fail.sh
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/grub2_ipv6_disable_argument/tests/cmd_line_commented_etcdefaultgrub.fail.sh
@@ -1,5 +1,5 @@
-#!/bin/bas
-# platform = Red Hat Enterprise Linux 7,sle12,sle15
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 7,multi_platform_sle
 
-# Removes kernel command line in /etc/default/grub
+# Comments kernel command line in /etc/default/grub
 sed -i '/^\s*GRUB_CMDLINE_LINUX=/s//#&/' '/etc/default/grub'

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/grub2_ipv6_disable_argument/tests/cmd_line_not_there_etcdefaultgrub.fail.sh
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/grub2_ipv6_disable_argument/tests/cmd_line_not_there_etcdefaultgrub.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bas
+# platform = Red Hat Enterprise Linux 7,sle12,sle15
+
+# Removes kernel command line in /etc/default/grub
+sed -i '/^\s*GRUB_CMDLINE_LINUX=/d'  '/etc/default/grub'

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/grub2_ipv6_disable_argument/tests/cmd_line_not_there_etcdefaultgrub.fail.sh
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/grub2_ipv6_disable_argument/tests/cmd_line_not_there_etcdefaultgrub.fail.sh
@@ -1,5 +1,5 @@
-#!/bin/bas
-# platform = Red Hat Enterprise Linux 7,sle12,sle15
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 7,multi_platform_sle
 
 # Removes kernel command line in /etc/default/grub
 sed -i '/^\s*GRUB_CMDLINE_LINUX=/d'  '/etc/default/grub'

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1201,7 +1201,7 @@ Part of the grub2_bootloader_argument template.
     create: yes
     mode: '0644'
   when: argcheck.rc != 0 and linecheck.rc != 0
-  
+
 - name: Replace existing {{{ arg_name }}} argument
   replace:
       path: /etc/default/grub

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1184,23 +1184,38 @@ Part of the grub2_bootloader_argument template.
 {{%- macro ansible_grub2_bootloader_argument(arg_name, arg_name_value) -%}}
 {{% if 'ubuntu' in product or product in ['rhel7', 'ol7', 'sle12', 'sle15'] %}}
 - name: Check {{{ arg_name }}} argument exists
-  command: grep 'GRUB_CMDLINE_LINUX.*{{{ arg_name }}}=' /etc/default/grub
+  command: grep '^\s*GRUB_CMDLINE_LINUX=.*{{{ arg_name }}}=' /etc/default/grub
   failed_when: False
   register: argcheck
 
+- name: Check {{{ arg_name }}} argument exists
+  command: grep '^\s*GRUB_CMDLINE_LINUX=' /etc/default/grub
+  failed_when: False
+  register: linecheck
+
+- name: Add watch rule for {{{ path }}} in /etc/audit/audit.rules
+  ansible.builtin.lineinfile:
+    line: 'GRUB_CMDLINE_LINUX="{{{ arg_name_value }}} "'
+    state: present
+    dest: /etc/default/grub
+    create: yes
+    mode: '0644'
+  when: argcheck.rc != 0 and linecheck.rc != 0
+  
 - name: Replace existing {{{ arg_name }}} argument
   replace:
       path: /etc/default/grub
       regexp: '{{{ arg_name }}}=\w+'
       replace: '{{{ arg_name_value }}}'
-  when: argcheck.rc == 0
+  when: argcheck.rc == 0 and linecheck.rc == 0
 
 - name: Add {{{ arg_name }}} argument
   replace:
       path: /etc/default/grub
-      regexp: '(GRUB_CMDLINE_LINUX=.*)"'
+      regexp: '(^\s*GRUB_CMDLINE_LINUX=.*)"'
       replace: '\1 {{{ arg_name_value }}}"'
-  when: argcheck.rc != 0
+  when: argcheck.rc != 0 and linecheck.rc == 0
+
 {{% endif -%}}
 
 {{% if product in ['sle12', 'sle15'] %}}

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -2002,7 +2002,7 @@ if grep -q '^\s*GRUB_CMDLINE_LINUX=.*{{{ arg_name }}}=.*"'  '/etc/default/grub' 
        # modify the GRUB command-line if an {{{ arg_name }}}= arg already exists
        sed -i "s/\(^\s*GRUB_CMDLINE_LINUX=\".*\){{{ arg_name }}}=[^[:space:]]\+\(.*\"\)/\1{{{ arg_name_value }}}\2/"  '/etc/default/grub'
 # Add to already existing GRUB_CMDLINE_LINUX parameters
-elif grep -q '^\s*GRUB_CMDLINE_LINUX='  '/etc/default/grub' ; then 
+elif grep -q '^\s*GRUB_CMDLINE_LINUX='  '/etc/default/grub' ; then
        # no {{{ arg_name }}}=arg is present, append it
        sed -i "s/\(^\s*GRUB_CMDLINE_LINUX=\".*\)\"/\1 {{{ arg_name_value }}}\"/"  '/etc/default/grub'
 # Add GRUB_CMDLINE_LINUX parameters line

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1998,12 +1998,16 @@ fi
 #}}
 {{%- macro update_etc_default_grub_manually(arg_name, arg_name_value) -%}}
 # Correct the form of default kernel command line in GRUB
-if grep -q '^GRUB_CMDLINE_LINUX=.*{{{ arg_name }}}=.*"'  '/etc/default/grub' ; then
+if grep -q '^\s*GRUB_CMDLINE_LINUX=.*{{{ arg_name }}}=.*"'  '/etc/default/grub' ; then
        # modify the GRUB command-line if an {{{ arg_name }}}= arg already exists
-       sed -i "s/\(^GRUB_CMDLINE_LINUX=\".*\){{{ arg_name }}}=[^[:space:]]\+\(.*\"\)/\1{{{ arg_name_value }}}\2/"  '/etc/default/grub'
-else
+       sed -i "s/\(^\s*GRUB_CMDLINE_LINUX=\".*\){{{ arg_name }}}=[^[:space:]]\+\(.*\"\)/\1{{{ arg_name_value }}}\2/"  '/etc/default/grub'
+# Add to already existing GRUB_CMDLINE_LINUX parameters
+elif grep -q '^\s*GRUB_CMDLINE_LINUX='  '/etc/default/grub' ; then 
        # no {{{ arg_name }}}=arg is present, append it
-       sed -i "s/\(^GRUB_CMDLINE_LINUX=\".*\)\"/\1 {{{ arg_name_value }}}\"/"  '/etc/default/grub'
+       sed -i "s/\(^\s*GRUB_CMDLINE_LINUX=\".*\)\"/\1 {{{ arg_name_value }}}\"/"  '/etc/default/grub'
+# Add GRUB_CMDLINE_LINUX parameters line
+else
+       echo "GRUB_CMDLINE_LINUX=\"{{{ arg_name_value }}}\"" >> '/etc/default/grub'
 fi
 {{%- endmacro %}}
 


### PR DESCRIPTION


#### Description:

- Some border cases of strange state of `/etc/default/grub` file revealed some minor issues with current remediations

#### Rationale:

-  Cover the case where default grub file has the GRUB_CMDLINE_LINUX line but it is commented or the case where no such line exists
