### PR TITLE
Remove duplicate builds for GitHub Actions

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -125,10 +125,6 @@ jobs:
               rhel7 \
               rhel8 \
               rhel9 \
-              sle12 \
-              sle15 \
-              ubuntu2004 \
-              ubuntu2204 \
               uos20 \
               ocp4 \
               eks
@@ -177,10 +173,6 @@ jobs:
                 rhel7 \
                 rhel8 \
                 rhel9 \
-                sle12 \
-                sle15 \
-                ubuntu2004 \
-                ubuntu2204 \
                 uos20 \
                 ocp4
           env:


### PR DESCRIPTION
In Fedora jobs we will not build and test products that are built and tested in other jobs. This will speed up CI.