### PR TITLE
Remove `controller_rotate_kubelet_server_certs`  from OCP CIS v.1.4.0

### DIFF
--- a/applications/openshift/controller/controller_rotate_kubelet_server_certs/rule.yml
+++ b/applications/openshift/controller/controller_rotate_kubelet_server_certs/rule.yml
@@ -63,7 +63,6 @@ warnings:
     of rotation yourself
 
 references:
-    cis@ocp4: 4.2.11
     nerc-cip: CIP-003-8 R4.2,CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R5.1,CIP-007-3 R6.1
     nist: CM-6,CM-6(1),SC-8,SC-8(1)
     pcidss: Req-2.2

--- a/controls/cis_ocp_1_4_0/section-4.yml
+++ b/controls/cis_ocp_1_4_0/section-4.yml
@@ -151,7 +151,6 @@ controls:
       status: automated
       rules:
         - kubelet_enable_server_cert_rotation
-        - controller_rotate_kubelet_server_certs
       levels: level_1
     - id: 4.2.12
       title: Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers


### PR DESCRIPTION


#### Description:

- Remove `controller_rotate_kubelet_server_certs`  from OCP CIS v.1.4.0

#### Rationale:

- The rule was supporting CIS v1.3.0 `1.3.6` but it was removed in v1.4.0 update. 
  The rule was transferred to CIS v1.4.0 `4.2.11` but it is not relevant to this item.

#### Review Hints:

- Check CIS v1.4.0, and compare with v1.3.0.
