### PR TITLE
Fix kernel config name typo in rule kernel_config_slab_freelist_random

### DIFF
--- a/linux_os/guide/system/kernel_build_config/kernel_config_slab_freelist_random/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_slab_freelist_random/rule.yml
@@ -8,7 +8,7 @@ description: |-
     Randomizes the freelist order used on creating new pages.
     This configuration is available from kernel 5.9, but may be available if backported by distros.
 
-    {{{ describe_kernel_build_config("CONFIG_SLAB_FRELIST_RANDOM", "y") | indent(4) }}}
+    {{{ describe_kernel_build_config("CONFIG_SLAB_FREELIST_RANDOM", "y") | indent(4) }}}
 
 rationale: |-
     This security feature reduces the predictability of the kernel slab allocator against heap overflows.
@@ -28,11 +28,11 @@ references:
 ocil_clause: 'the kernel was not built with the required value'
 
 ocil: |-
-    {{{ ocil_kernel_build_config("CONFIG_SLAB_FRELIST_RANDOM", "y") | indent(4) }}}
+    {{{ ocil_kernel_build_config("CONFIG_SLAB_FREELIST_RANDOM", "y") | indent(4) }}}
 
 template:
     name: kernel_build_config
     vars:
-        config: CONFIG_SLAB_FRELIST_RANDOM
+        config: CONFIG_SLAB_FREELIST_RANDOM
         value: 'y'
 

--- a/shared/templates/kernel_build_config/tests/common.sh
+++ b/shared/templates/kernel_build_config/tests/common.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [ ! -e /boot/config-$(uname -r) ]; then
+    mkdir -p /boot
+    touch /boot/config-$(uname -r)
+fi

--- a/shared/templates/kernel_build_config/tests/extra_quotes.fail.sh
+++ b/shared/templates/kernel_build_config/tests/extra_quotes.fail.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # remediation = none
 
+source common.sh
+
 # The sets up a config file with extra double quotes
 
 {{%- if VARIABLE %}}

--- a/shared/templates/kernel_build_config/tests/fail1.fail.sh
+++ b/shared/templates/kernel_build_config/tests/fail1.fail.sh
@@ -5,6 +5,8 @@
 {{%- set VALUE="correct_value" %}}
 {{%- endif %}}
 
+source common.sh
+
 # fail1 is the plain expected fail scenario, the config with a wrong value
 
 for file in /boot/config-* ; do

--- a/shared/templates/kernel_build_config/tests/fail1_multiple_files.fail.sh
+++ b/shared/templates/kernel_build_config/tests/fail1_multiple_files.fail.sh
@@ -5,6 +5,8 @@
 {{%- set VALUE="correct_value" %}}
 {{%- endif %}}
 
+source common.sh
+
 # fail1 is the plain expected fail scenario, the config with a wrong value
 for file in /boot/config-* ; do
     if grep -q ^{{{ CONFIG }}} "$file" ; then
@@ -15,6 +17,5 @@ for file in /boot/config-* ; do
 done
 
 # Ensure one config file is compliant
-cp /boot/config-$(uname -r ) /boot/config-test
+touch /boot/config-test
 sed -i "s/{{{ CONFIG }}}.*/{{{ CONFIG }}}={{{ VALUE }}}/" /boot/config-test
-

--- a/shared/templates/kernel_build_config/tests/fail2.fail.sh
+++ b/shared/templates/kernel_build_config/tests/fail2.fail.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # remediation = none
 
+source common.sh
+
 # fail2 is the second fail scenario
 
 {{%- if VALUE == "n" %}}

--- a/shared/templates/kernel_build_config/tests/pass1.pass.sh
+++ b/shared/templates/kernel_build_config/tests/pass1.pass.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source common.sh
+
 # pass1 is the plain expected pass scenario
 
 {{%- if VALUE == "n" %}}

--- a/shared/templates/kernel_build_config/tests/pass2.pass.sh
+++ b/shared/templates/kernel_build_config/tests/pass2.pass.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source common.sh
+
 # pass 2 is the second pass scenario
 
 {{%- if VALUE == "n" %}}

--- a/shared/templates/kernel_build_config/tests/substrings.fail.sh
+++ b/shared/templates/kernel_build_config/tests/substrings.fail.sh
@@ -10,6 +10,8 @@
 {{%- set SUPER_VALUE='XYZ' ~ VALUE %}}
 {{%- endif %}}
 
+source common.sh
+
 for file in /boot/config-* ; do
     if grep -q ^{{{ CONFIG }}} "$file" ; then
         sed -i "s/{{{ CONFIG }}}.*/{{{ CONFIG }}}={{{ SUPER_VALUE }}}/" "$file"


### PR DESCRIPTION
#### Description:

- Fixed typo in kernel config name for rule `kernel_config_slab_freelist_random`

