### PR TITLE
Improve rendering controls to HTML

### DIFF
--- a/ssg/entities/profile.py
+++ b/ssg/entities/profile.py
@@ -98,6 +98,7 @@ class ProfileWithInlinePolicies(ResolvableProfile):
         return controls
 
     def resolve_controls(self, controls_manager):
+        self.policies = list(self.controls_by_policy.keys())
         for policy_id, controls_ids in self.controls_by_policy.items():
             controls = self._process_controls_ids_into_controls(
                 controls_manager, policy_id, controls_ids)

--- a/ssg/entities/profile_base.py
+++ b/ssg/entities/profile_base.py
@@ -45,6 +45,7 @@ class Profile(XCCDFEntity, SelectionHandler):
         cpe_names=lambda: set(),
         platform=lambda: None,
         filter_rules=lambda: "",
+        policies=lambda: list(),
         ** XCCDFEntity.KEYS
     )
 

--- a/utils/gen_rendered_policies_index.py
+++ b/utils/gen_rendered_policies_index.py
@@ -10,14 +10,21 @@ from utils.template_renderer import render_template
 
 # Helper script used to generate an HTML page to display rendered policies.
 
-Product = namedtuple("Product", ["id", "name"])
-Policy = namedtuple("Policy", ["id", "name"])
+Product = namedtuple("Product", ["id", "name", "policy_ids"])
 
 TEMPLATE = os.path.join(os.path.dirname(__file__), "html_rendered_policies_index_template.html")
 
 
-def get_control_files(ssg_root):
-    control_files = []
+def get_rendered_policies_ids(rendered_policies_dir):
+    policy_ids = []
+    for html_filename in rendered_policies_dir.glob("*.html"):
+        policy_id = html_filename.stem
+        policy_ids.append(policy_id)
+    return policy_ids
+
+
+def get_policy_names(ssg_root):
+    policy_names = dict()
     p = pathlib.Path(ssg_root)
     for control_file in p.glob("controls/*.yml"):
         # only process files, ignore controls directories
@@ -27,27 +34,36 @@ def get_control_files(ssg_root):
         with open(control_file, "r") as f:
             policy_yaml = yaml.full_load(f)
         policy_name = policy_yaml["policy"]
-        policy = Policy(id=policy_id, name=policy_name)
-        control_files.append(policy)
-    return control_files
+        policy_names[policy_id] = policy_name
+    return policy_names
 
 
-def get_data(ssg_root):
+def get_products(ssg_root):
     products = []
     p = pathlib.Path(ssg_root)
     for product_file in p.glob("products/**/product.yml"):
         product_dir = product_file.parent
         product_id = product_dir.name
-
+        rendered_policies_dir = p / "build" / product_id / "rendered-policies"
         # skip if there are not built rendered-polices
-        if not os.path.isdir(os.path.join(ssg_root, "build", product_id, "rendered-policies")):
+        if not rendered_policies_dir.is_dir():
             continue
         with open(product_file, "r") as f:
             product_yaml = yaml.full_load(f)
         product_name = product_yaml["full_name"]
-        product = Product(id=product_id, name=product_name)
+        policy_ids = get_rendered_policies_ids(rendered_policies_dir)
+        product = Product(
+            id=product_id,
+            name=product_name,
+            policy_ids=policy_ids)
         products.append(product)
-    data = {"products": products}
+    return products
+
+
+def get_data(ssg_root):
+    products = get_products(ssg_root)
+    policy_names = get_policy_names(ssg_root)
+    data = {"products": products, "policy_names": policy_names}
     return data
 
 
@@ -61,5 +77,4 @@ if __name__ == "__main__":
         help="Path where the output HTML file should be generated")
     args = parser.parse_args()
     data = get_data(args.ssg_root)
-    data.update({"control_files": get_control_files(args.ssg_root)})
     render_template(data, TEMPLATE, args.output)

--- a/utils/html_rendered_policies_index_template.html
+++ b/utils/html_rendered_policies_index_template.html
@@ -13,9 +13,9 @@
 {{% for product in products|sort(attribute="name") %}}
 <h4>{{{ product.name }}}</h4>
   <ul>
-    {{% for control_file in control_files|sort(attribute="id") %}}
+    {{% for policy_id in product.policy_ids %}}
     <li>
-      <a href="{{{ product.id }}}/{{{ control_file.id }}}.html">{{{ control_file.id }}}: {{{ control_file.name }}}</a>
+      <a href="{{{ product.id }}}/{{{ policy_id }}}.html">{{{ policy_id }}}: {{{ policy_names[policy_id] }}}</a>
     </li>
     {{% endfor %}}
   </ul>

--- a/utils/render_all_policies.py
+++ b/utils/render_all_policies.py
@@ -1,0 +1,91 @@
+#!/usr/bin/python3
+
+import argparse
+import os
+import pathlib
+
+import ssg.build_yaml
+import ssg.controls
+import ssg.entities.profile_base
+import utils.template_renderer
+
+
+TEMPLATES_DIR = os.path.join(os.path.dirname(__file__), "rendering")
+CONTROLS_TEMPLATE = os.path.join(TEMPLATES_DIR, "controls-template.html")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build HTML pages for all policies that are used in the "
+        "given product")
+    parser.add_argument("--product", required=True, help="Product ID")
+    parser.add_argument(
+        "--ssg-root", default=".",
+        help="Path to the project's build directory")
+    parser.add_argument(
+        "--output-dir", required=True,
+        help="Path to the output directory where the HTML pages will "
+        "be stored")
+    return parser.parse_args()
+
+
+def get_used_policies(built_product_dir: str) -> set:
+    policies = set()
+    profiles_dir = os.path.join(built_product_dir, "profiles")
+    for profile_file_name in os.listdir(profiles_dir):
+        profile_file_path = os.path.join(profiles_dir, profile_file_name)
+        profile = ssg.entities.profile_base.Profile.from_yaml(profile_file_path)
+        for policy_id in profile.policies:
+            policies.add(policy_id)
+    return policies
+
+
+def get_rules(root_abspath: str, built_product_dir: str) -> dict:
+    resolved_rules_dir = os.path.join(built_product_dir, "rules")
+    rules = dict()
+    for r_file in os.listdir(resolved_rules_dir):
+        r_file_path = os.path.join(resolved_rules_dir, r_file)
+        rule = ssg.build_yaml.Rule.from_yaml(r_file_path)
+        rule.relative_definition_location = rule.definition_location.replace(
+            root_abspath, "")
+        rules[rule.id_] = rule
+    return rules
+
+
+def load_policy(controls_dir: str, policy_id: str) -> ssg.controls.Policy:
+    policy_file = os.path.join(controls_dir, policy_id + ".yml")
+    policy = ssg.controls.Policy(policy_file)
+    policy.load()
+    return policy
+
+
+def render_policy(
+        policy: ssg.controls.Policy, product_id: str, rules: list,
+        output_dir: str) -> None:
+    output_path = os.path.join(output_dir, policy.id + ".html")
+    data = {
+        "policy": policy,
+        "title": f"Definition of {policy.title} for {product_id}",
+        "rules": rules
+    }
+    utils.template_renderer.render_template(
+        data, CONTROLS_TEMPLATE, output_path)
+
+
+def main():
+    args = parse_args()
+    root_path = os.path.abspath(args.ssg_root)
+    build_dir = os.path.join(root_path, "build")
+    built_product_dir = os.path.join(build_dir, args.product)
+    policies_used_in_product = get_used_policies(built_product_dir)
+    controls_dir = os.path.join(built_product_dir, "controls")
+    rules = get_rules(root_path, built_product_dir)
+    if not os.path.exists(args.output_dir):
+        os.mkdir(args.output_dir)
+    for policy_id in policies_used_in_product:
+        policy = load_policy(controls_dir, policy_id)
+        render_policy(policy, args.product, rules, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/render_all_policies.py
+++ b/utils/render_all_policies.py
@@ -2,7 +2,6 @@
 
 import argparse
 import os
-import pathlib
 
 import ssg.build_yaml
 import ssg.controls


### PR DESCRIPTION
We will generate HTML pages only for controls that are actually used in the product. That means we will stop generating bizzare pages like "CIS benchmark for SUSE Linux Enterprise 15 for RHEL 7". A side effect is that the build will be faster.

Fixes: #10791


#### Review Hints:
 python3 utils/render_all_policies.py --output-dir /tmp/out --ssg-root $(pwd) --product rhel9
