### PR TITLE
Add RHEL as platform in su pam wheel group remidiation

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
 
 {{{ bash_instantiate_variables("var_pam_wheel_group_for_su") }}}
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_group_for_su/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_group_for_su/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_group_for_su/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_group_for_su/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
 {{{ bash_instantiate_variables("var_pam_wheel_group_for_su") }}}
 
 PAM_CONF=/etc/pam.d/su


### PR DESCRIPTION
#### Description:

-This is to complete a previously merged PR which added use_pam_wheel_group_for_su and ensure_pam_wheel_group_empty to the CIS profile for RHEL 8 and RHEL 9, but didn't add RHEL to platform in the remidiations

#### Review Hints:
- This is to complete #10762