### PR TITLE
remove rules not relevant to RHEL 9 from STIG profile

### DIFF
--- a/controls/srg_gpos/SRG-OS-000125-GPOS-00065.yml
+++ b/controls/srg_gpos/SRG-OS-000125-GPOS-00065.yml
@@ -7,6 +7,4 @@ controls:
         rules:
             - sshd_enable_pam
             - sysctl_crypto_fips_enabled
-            - harden_sshd_ciphers_openssh_conf_crypto_policy
-            - harden_sshd_macs_openssh_conf_crypto_policy
         status: automated


### PR DESCRIPTION
#### Description:

- remove two rules from RHEL 9 STIG
    -  harden_sshd_macs_openssh_conf_crypto_policy
    - harden_sshd_ciphers_openssh_conf_crypto_policy

#### Rationale:

- rules do not have remediations for RHEL 9 

#### Review Hints:

- build master and copy the compiled profile somewhere
- compare with this branch
- rules mentioned in the description should not be present