### PR TITLE
Add warning to network_configure_name_resolution

### DIFF
--- a/linux_os/guide/system/network/network_configure_name_resolution/rule.yml
+++ b/linux_os/guide/system/network/network_configure_name_resolution/rule.yml
@@ -72,3 +72,6 @@ fixtext: |-
     $ sudo echo -n > /etc/resolv.conf
 
 srg_requirement: 'For {{{ full_name }}} systems using Domain Name Servers (DNS) resolution, at least two name servers must be configured.'
+
+warnings:
+  - general: This rule doesn't come with a remediation, the IP addresses of local authoritative name servers need to be added by the administrator.


### PR DESCRIPTION
This rule doesn't have any remediation. The warning will help investigating why remediation has failed.
