### PR TITLE
Remove "not available" message

### DIFF
--- a/utils/render-policy.py
+++ b/utils/render-policy.py
@@ -44,6 +44,17 @@ class HtmlOutput(template_renderer.Renderer):
             .format(policy_title=policy.title, product=self.product)
         )
 
+    def set_all_values_with_metadata(self):
+        resolved_values_dir = os.path.join(self.built_content_path, "values")
+        values = dict()
+        for v_file in os.listdir(resolved_values_dir):
+            v_file_path = os.path.join(resolved_values_dir, v_file)
+            val = ssg.build_yaml.Value.from_yaml(v_file_path)
+            val.relative_definition_location = val.definition_location.replace(
+                self.project_directory, "")
+            values[val.id_] = val
+        self.template_data["values"] = values
+
 
 def parse_args():
     parser = HtmlOutput.create_parser(
@@ -59,5 +70,6 @@ if __name__ == "__main__":
     args = parse_args()
     renderer = HtmlOutput(args.product, args.build_dir)
     renderer.set_all_rules_with_metadata()
+    renderer.set_all_values_with_metadata()
     renderer.set_policy(args.policy)
     renderer.output_results(args)

--- a/utils/rendering/controls-template.html
+++ b/utils/rendering/controls-template.html
@@ -24,7 +24,10 @@ based on <a href="{{{ policy.source }}}">{{{ policy.source }}}</a>
   <ul>
     {{%- for selection in control.selections|sort -%}}
     {{%- if '=' in selection %}}
-    <li>{{{ selection }}}</li>
+    {{% set value_id, value = selection.split('=') %}}
+    {{%- if value_id in values %}}
+    <li><a href="https://github.com/ComplianceAsCode/content/tree/master/{{{ values[value_id].relative_definition_location }}}">{{{ value_id }}}</a> = {{{ value }}}</li>
+    {{%- endif -%}}
     {{%- else %}}
     {{%- if selection in rules %}}
     <li><a href="https://github.com/ComplianceAsCode/content/tree/master/{{{ rules[selection].relative_definition_location }}}">{{{ selection }}}</a>: {{{ rules[selection].title }}}</li>

--- a/utils/rendering/controls-template.html
+++ b/utils/rendering/controls-template.html
@@ -22,12 +22,15 @@ based on <a href="{{{ policy.source }}}">{{{ policy.source }}}</a>
   {{% if control.selections -%}}
   Selections:
   <ul>
-    {{%- for ruleobj in control.selections -%}}
-    {{%- set rule_id = ruleobj|string %}}
-    {{%- if rule_id in rules %}}
-    <li><a href="https://github.com/ComplianceAsCode/content/tree/master/{{{ rules[rule_id].relative_definition_location }}}">{{{ rule_id }}}</a>: {{{ rules[rule_id].title }}}</li>
+    {{%- for selection in control.selections|sort -%}}
+    {{%- if '=' in selection %}}
+    <li>{{{ selection }}}</li>
     {{%- else %}}
-    <li>{{{ rule_id }}} - not available for this product</li>
+    {{%- if selection in rules %}}
+    <li><a href="https://github.com/ComplianceAsCode/content/tree/master/{{{ rules[selection].relative_definition_location }}}">{{{ selection }}}</a>: {{{ rules[selection].title }}}</li>
+    {{%- else %}}
+    <li>{{{ selection }}} - not available for this product</li>
+    {{%- endif -%}}
     {{%- endif -%}}
     {{%- endfor %}}
   </ul>


### PR DESCRIPTION
In the HTML controls pages, the variables are shown with a "not available in this product" message, which is incorrect. This message makes sense only with rules selections but not with variables selections.


#### Review Hints:
python3 utils/render_all_policies.py --output-dir /tmp/out --ssg-root $(pwd) --product rhel9
firefox /tmp/out/anssi.html