### PR TITLE
Remove sebool_secure_mode_insmod from anssi

### DIFF
--- a/products/rhel8/profiles/anssi_bp28_high.profile
+++ b/products/rhel8/profiles/anssi_bp28_high.profile
@@ -17,3 +17,5 @@ description: |-
 
 selections:
     - anssi:all:high
+    # the following rule renders UEFI systems unbootable
+    - '!sebool_secure_mode_insmod'

--- a/products/rhel9/profiles/anssi_bp28_high.profile
+++ b/products/rhel9/profiles/anssi_bp28_high.profile
@@ -17,3 +17,5 @@ description: |-
 
 selections:
     - anssi:all:high
+    # the following rule renders UEFI systems unbootable
+    - '!sebool_secure_mode_insmod'


### PR DESCRIPTION
#### Description:

- remove sebool_secure_mode_insmod from ANSSI high on RHEL 8 and RHEL 9

#### Rationale:

- the rule prevents UEFI systems from booting properly


#### Review Hints:

perform diff of compiled ANSSI high profiles