### PR TITLE
Copy files before remediating if they are symlinks

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/ansible/shared.yml
@@ -12,8 +12,13 @@
 - name: "{{{ rule_title }}}: stat"
   stat:
     path: "{{ path }}"
-    follow: yes
   register: gnutls_file
+
+- name: "{{{ rule_title }}}: Copy file if symlink"
+  ansible.builtin.copy:
+    src: "{{ gnutls_file.stat.lnk_source }}"
+    dest: "{{ path }}"
+  when: gnutls_file.stat.islnk is defined and gnutls_file.stat.islnk
 
 - name: "{{{ rule_title }}}: Add"
   lineinfile:

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/ansible/shared.yml
@@ -5,6 +5,17 @@
 # disruption = low
 {{{ ansible_instantiate_variables("sshd_approved_ciphers") }}}
 
+- name: "{{{ rule_title }}}: Stat"
+  stat:
+    path: "{{ path }}"
+  register: openssh_file
+
+- name: "{{{ rule_title }}}: Copy file if symlink"
+  ansible.builtin.copy:
+    src: "{{ openssh_file.stat.lnk_source }}"
+    dest: "/etc/crypto-policies/back-ends/openssh.config"
+  when: openssh_file.stat.islnk is defined and openssh_file.stat.islnk
+
 {{{ ansible_set_config_file(
         msg='Configure SSH Daemon to Use FIPS 140-2 Validated Ciphers: openssh.config',
         file='/etc/crypto-policies/back-ends/openssh.config',

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/ansible/shared.yml
@@ -13,8 +13,13 @@
 - name: "{{{ rule_title }}}: Stat"
   stat:
     path: "{{ path }}"
-    follow: yes
   register: opensshserver_file
+
+- name: "{{{ rule_title }}}: Copy file if symlink"
+  ansible.builtin.copy:
+    src: "{{ opensshserver_file.stat.lnk_source }}"
+    dest: "{{ path }}"
+  when: opensshserver_file.stat.islnk is defined and opensshserver_file.stat.islnk
 
 - name: "{{{ rule_title }}}: Create"
   lineinfile:

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/ansible/shared.yml
@@ -5,6 +5,17 @@
 # disruption = low
 {{{ ansible_instantiate_variables("sshd_approved_macs") }}}
 
+- name: "{{{ rule_title }}}: Stat"
+  stat:
+    path: "{{ path }}"
+  register: openssh_file
+
+- name: "{{{ rule_title }}}: Copy file if symlink"
+  ansible.builtin.copy:
+    src: "{{ openssh_file.stat.lnk_source }}"
+    dest: "/etc/crypto-policies/back-ends/openssh.config"
+  when: openssh_file.stat.islnk is defined and openssh_file.stat.islnk
+
 {{{ ansible_set_config_file(
         msg='Configure SSH Daemon to Use FIPS 140-2 Validated MACs: openssh.config',
         file='/etc/crypto-policies/back-ends/openssh.config',

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/ansible/shared.yml
@@ -13,8 +13,13 @@
 - name: "{{{ rule_title }}}: Stat"
   stat:
     path: "{{ path }}"
-    follow: yes
   register: opensshserver_file
+
+- name: "{{{ rule_title }}}: Copy file if symlink"
+  ansible.builtin.copy:
+    src: "{{ opensshserver_file.stat.lnk_source }}"
+    dest: "{{ path }}"
+  when: opensshserver_file.stat.islnk is defined and opensshserver_file.stat.islnk
 
 - name: "{{{ rule_title }}}: Create"
   lineinfile:


### PR DESCRIPTION


#### Description:
- Copy files before remediating if they are symlinks
  - Crypto policies sometimes use symlinks and when we edit them, they might get reverted if they are not copied first because they belong to crypto-policies package and the source is not considered configuration files.

#### Rationale:

- This workaround does not discard the fact that the optimal solution is to create a subpolicy in crypto-policies, for example `FIPS:STIG` to accommodate exactly the ciphers required by STIG.
- Fixes #10978

#### Review Hints:

- Test `testing-farm:centos-stream-8-x86_64` should pass.