### PR TITLE
ANSSI: add rules to enable auditing service

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -817,6 +817,8 @@ controls:
     - sshd_disable_root_login
     - package_sudo_installed
     - audit_rules_privileged_commands_sudo
+    - service_auditd_enabled
+    - package_audit_installed
 
   - id: R34
     title: Deactivation of service accounts
@@ -1427,6 +1429,8 @@ controls:
     - audit_rules_privileged_commands_kmod
 
     - audit_rules_immutable
+    - service_auditd_enabled
+    - package_audit_installed
 
   - id: R74
     title: Configuring the local messaging service

--- a/linux_os/guide/system/auditing/package_audit_installed/rule.yml
+++ b/linux_os/guide/system/auditing/package_audit_installed/rule.yml
@@ -17,7 +17,7 @@ identifiers:
     cce@sle15: CCE-85612-0
 
 references:
-    anssi: BP28(R50)
+    anssi: BP28(R33),BP28(R73)
     cis@alinux3: 4.1.1.1
     cis@rhel7: 4.1.1.1
     cis@rhel8: 4.1.1.1

--- a/linux_os/guide/system/auditing/service_auditd_enabled/rule.yml
+++ b/linux_os/guide/system/auditing/service_auditd_enabled/rule.yml
@@ -32,6 +32,7 @@ identifiers:
     cce@sle15: CCE-85581-7
 
 references:
+    anssi: BP28(R33),BP28(R73)
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
     cis@alinux2: 4.1.2
     cis@alinux3: 4.1.1.2


### PR DESCRIPTION
#### Description:

- add rules package_audit_installed and service_auditd_enabled to ANSSI controls which utilize Audit rules

#### Rationale:

- without thosse rules, it could happen that Audit is configured correctly, but it is not running.


#### Review Hints:

compare compiled ANSSI profiles produced by master branch and by this PR