### PR TITLE
Change rule to use variable when auditing faillock

### DIFF
--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -1622,6 +1622,7 @@ controls:
     rules:
       - audit_rules_login_events_faillock
       - audit_rules_login_events_lastlog
+      - var_accounts_passwords_pam_faillock_dir=run
 
   - id: 4.1.3.13
     title: Ensure file deletion events by users are collected (Automated)

--- a/controls/cis_rhel9.yml
+++ b/controls/cis_rhel9.yml
@@ -1375,6 +1375,7 @@ controls:
     rules:
       - audit_rules_login_events_faillock
       - audit_rules_login_events_lastlog
+      - var_accounts_passwords_pam_faillock_dir=run
 
   - id: 4.1.3.13
     title: Ensure file deletion events by users are collected (Automated)

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/var_accounts_passwords_pam_faillock_dir.var
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/var_accounts_passwords_pam_faillock_dir.var
@@ -13,3 +13,4 @@ interactive: false
 options:
     ol8: "/var/log/faillock"
     default: "/var/log/faillock"
+    run: "/var/run/faillock"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/rule.yml
@@ -11,12 +11,12 @@ description: |-
     default), add the following lines to a file with suffix <tt>.rules</tt> in the
     directory <tt>/etc/audit/rules.d</tt> in order to watch for attempted manual
     edits of files involved in storing logon events:
-    <pre>-w {{{ faillock_path }}} -p wa -k logins</pre>
+    <pre>-w {{{ xccdf_value("var_accounts_passwords_pam_faillock_dir") }}} -p wa -k logins</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file in order to watch for unattempted manual
     edits of files involved in storing logon events:
-    <pre>-w {{{ faillock_path }}} -p wa -k logins</pre>
+    <pre>-w {{{ xccdf_value("var_accounts_passwords_pam_faillock_dir") }}} -p wa -k logins</pre>
 
 rationale: |-
     Manual editing of these files may indicate nefarious activity, such
@@ -66,16 +66,18 @@ ocil_clause: 'the command does not return a line, or the line is commented out'
 ocil: |-
     Verify {{{ full_name }}} generates audit records for all account creations, modifications, disabling, and termination events that affect "/etc/security/opasswd" with the following command:
 
-    $ sudo auditctl -l | grep {{{ faillock_path }}}
+    $ sudo auditctl -l | grep {{{ xccdf_value("var_accounts_passwords_pam_faillock_dir") }}}
 
-    -w {{{ faillock_path }}} -p wa -k logins
+    -w {{{ xccdf_value("var_accounts_passwords_pam_faillock_dir") }}} -p wa -k logins
 
 template:
     name: audit_rules_login_events
     vars:
-        path: {{{ faillock_path }}}
+        path: var_accounts_passwords_pam_faillock_dir
+        path_is_variable: "true"
+
 
 fixtext: |-
-    {{{ fixtext_audit_file_watch_rule(faillock_path, "logins", "/etc/audit/rules.d/audit.rules") | indent(4) }}}
+    {{{ fixtext_audit_file_watch_rule(xccdf_value("var_accounts_passwords_pam_faillock_dir"), "logins", "/etc/audit/rules.d/audit.rules") | indent(4) }}}
 
-srg_requirement: '{{{ srg_requirement_audit_file_watch_rule(faillock_path) }}}'
+srg_requirement: '{{{ srg_requirement_audit_file_watch_rule(xccdf_value("var_accounts_passwords_pam_faillock_dir")) }}}'

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct.pass.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
-# profiles = xccdf_org.ssgproject.content_profile_cis
+# platform = multi_platform_all
 
-echo "-w /var/run/faillock -p wa -k logins" >> /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+path="/var/log/faillock"
+. $SHARED/audit_rules_login_events/auditctl_correct.pass.sh

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
+# profiles = xccdf_org.ssgproject.content_profile_cis
+
+echo "-w /var/run/faillock -p wa -k logins" >> /etc/audit/audit.rules
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct_cis.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct_cis.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
+# profiles = xccdf_org.ssgproject.content_profile_cis
+
+path="/var/run/faillock"
+. $SHARED/audit_rules_login_events/auditctl_correct.pass.sh

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct_extra_permission.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct_extra_permission.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
+# profiles = xccdf_org.ssgproject.content_profile_cis
+
+echo "-w /var/run/faillock -p wra -k logins" >> /etc/audit/audit.rules
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct_extra_permission.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct_extra_permission.pass.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
-# profiles = xccdf_org.ssgproject.content_profile_cis
+# platform = multi_platform_all
 
-echo "-w /var/run/faillock -p wra -k logins" >> /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+path="/var/log/faillock"
+. $SHARED/audit_rules_login_events/auditctl_correct_extra_permission.pass.sh

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct_extra_permission_cis.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct_extra_permission_cis.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
+# profiles = xccdf_org.ssgproject.content_profile_cis
+
+path="/var/run/faillock"
+. $SHARED/audit_rules_login_events/auditctl_correct_extra_permission.pass.sh

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct_without_key.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct_without_key.pass.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
-# profiles = xccdf_org.ssgproject.content_profile_cis
+# platform = multi_platform_all
 
-echo "-w /var/run/faillock  -p wa" >> /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+path="/var/log/faillock"
+. $SHARED/audit_rules_login_events/auditctl_correct_without_key.pass.sh

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct_without_key.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct_without_key.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
+# profiles = xccdf_org.ssgproject.content_profile_cis
+
+echo "-w /var/run/faillock  -p wa" >> /etc/audit/audit.rules
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct_without_key_cis.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct_without_key_cis.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
+# profiles = xccdf_org.ssgproject.content_profile_cis
+
+path="/var/run/faillock"
+. $SHARED/audit_rules_login_events/auditctl_correct_without_key.pass.sh

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_remove_all_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_remove_all_rules.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # packages = audit
+# platform = multi_platform_all
 
-path={{{ PATH }}}
 . $SHARED/audit_rules_login_events/auditctl_remove_all_rules.fail.sh

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_remove_all_rules_cis.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_remove_all_rules_cis.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
+# profiles = xccdf_org.ssgproject.content_profile_cis
+
+path="/var/run/faillock"
+. $SHARED/audit_rules_login_events/auditctl_remove_all_rules.fail.sh

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_wrong_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_wrong_rule.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
+# profiles = xccdf_org.ssgproject.content_profile_cis
+
+echo "-w /var/run/faillock  -p w -k logins" >> /etc/audit/audit.rules
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_wrong_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_wrong_rule.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
-# profiles = xccdf_org.ssgproject.content_profile_cis
+# platform = multi_platform_all
 
-echo "-w /var/run/faillock  -p w -k logins" >> /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+path="/var/log/faillock"
+. $SHARED/audit_rules_login_events/auditctl_wrong_rule.fail.sh

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_wrong_rule_cis.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_wrong_rule_cis.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
+# profiles = xccdf_org.ssgproject.content_profile_cis
+
+path="/var/run/faillock"
+. $SHARED/audit_rules_login_events/auditctl_wrong_rule.fail.sh

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_wrong_rule_without_key.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_wrong_rule_without_key.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
+# profiles = xccdf_org.ssgproject.content_profile_cis
+
+echo "-w /var/run/faillock  -p w" >> /etc/audit/audit.rules
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_wrong_rule_without_key.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_wrong_rule_without_key.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
-# profiles = xccdf_org.ssgproject.content_profile_cis
+# platform = multi_platform_all
 
-echo "-w /var/run/faillock  -p w" >> /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+path="/var/log/faillock"
+. $SHARED/audit_rules_login_events/auditctl_wrong_rule_without_key.fail.sh

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_wrong_rule_without_key_cis.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_wrong_rule_without_key_cis.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
+# profiles = xccdf_org.ssgproject.content_profile_cis
+
+path="/var/run/faillock"
+. $SHARED/audit_rules_login_events/auditctl_wrong_rule_without_key.fail.sh

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_correct.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_correct.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
+# profiles = xccdf_org.ssgproject.content_profile_cis
+
+
+echo "-w /var/run/faillock -p wa -k logins" >> /etc/audit/rules.d/login.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_correct.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_correct.pass.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
-# profiles = xccdf_org.ssgproject.content_profile_cis
+# platform = multi_platform_all
 
-
-echo "-w /var/run/faillock -p wa -k logins" >> /etc/audit/rules.d/login.rules
+path="/var/log/faillock"
+. $SHARED/audit_rules_login_events/augenrules_correct.pass.sh

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_correct_cis.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_correct_cis.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
+# profiles = xccdf_org.ssgproject.content_profile_cis
+
+path="/var/run/faillock"
+. $SHARED/audit_rules_login_events/augenrules_correct.pass.sh

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_correct_extra_permission.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_correct_extra_permission.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
+# profiles = xccdf_org.ssgproject.content_profile_cis
+
+
+echo "-w /var/run/faillock  -p wra -k login" >> /etc/audit/rules.d/login.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_correct_extra_permission.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_correct_extra_permission.pass.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
-# profiles = xccdf_org.ssgproject.content_profile_cis
+# platform = multi_platform_all
 
-
-echo "-w /var/run/faillock  -p wra -k login" >> /etc/audit/rules.d/login.rules
+path="/var/log/faillock"
+. $SHARED/audit_rules_login_events/augenrules_correct_extra_permission.pass.sh

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_correct_extra_permission_cis.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_correct_extra_permission_cis.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
+# profiles = xccdf_org.ssgproject.content_profile_cis
+
+path="/var/run/faillock"
+. $SHARED/audit_rules_login_events/augenrules_correct_extra_permission.pass.sh

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_correct_without_key.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_correct_without_key.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
+# profiles = xccdf_org.ssgproject.content_profile_cis
+
+
+echo "-w /var/run/faillock  -p wa" >> /etc/audit/rules.d/login.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_correct_without_key.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_correct_without_key.pass.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
-# profiles = xccdf_org.ssgproject.content_profile_cis
+# platform = multi_platform_all
 
-
-echo "-w /var/run/faillock  -p wa" >> /etc/audit/rules.d/login.rules
+path="/var/log/faillock"
+. $SHARED/audit_rules_login_events/augenrules_correct_without_key.pass.sh

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_correct_without_key_cis.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_correct_without_key_cis.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
+# profiles = xccdf_org.ssgproject.content_profile_cis
+
+path="/var/run/faillock"
+. $SHARED/audit_rules_login_events/augenrules_correct_without_key.pass.sh

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_remove_all_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_remove_all_rules.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # packages = audit
+# platform = multi_platform_all
 
-path={{{ PATH }}}
 . $SHARED/audit_rules_login_events/augenrules_remove_all_rules.fail.sh

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_remove_all_rules_cis.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_remove_all_rules_cis.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
+# profiles = xccdf_org.ssgproject.content_profile_cis
+
+path="/var/run/faillock"
+. $SHARED/audit_rules_login_events/augenrules_remove_all_rules.fail.sh

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_wrong_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_wrong_rule.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
+# profiles = xccdf_org.ssgproject.content_profile_cis
+
+
+echo "-w /var/run/faillock  -p w -k login" >> /etc/audit/rules.d/login.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_wrong_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_wrong_rule.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
-# profiles = xccdf_org.ssgproject.content_profile_cis
+# platform = multi_platform_all
 
-
-echo "-w /var/run/faillock  -p w -k login" >> /etc/audit/rules.d/login.rules
+path="/var/log/faillock"
+. $SHARED/audit_rules_login_events/augenrules_wrong_rule.fail.sh

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_wrong_rule_cis.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_wrong_rule_cis.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
+# profiles = xccdf_org.ssgproject.content_profile_cis
+
+path="/var/run/faillock"
+. $SHARED/audit_rules_login_events/augenrules_wrong_rule.fail.sh

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_wrong_rule_without_key.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_wrong_rule_without_key.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
+# profiles = xccdf_org.ssgproject.content_profile_cis
+
+
+echo "-w /var/run/faillock  -p w" >> /etc/audit/rules.d/login.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_wrong_rule_without_key.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_wrong_rule_without_key.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
-# profiles = xccdf_org.ssgproject.content_profile_cis
+# platform = multi_platform_all
 
-
-echo "-w /var/run/faillock  -p w" >> /etc/audit/rules.d/login.rules
+path="/var/log/faillock"
+. $SHARED/audit_rules_login_events/augenrules_wrong_rule_without_key.fail.sh

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_wrong_rule_without_key_cis.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/augenrules_wrong_rule_without_key_cis.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
+# profiles = xccdf_org.ssgproject.content_profile_cis
+
+path="/var/run/faillock"
+. $SHARED/audit_rules_login_events/augenrules_wrong_rule_without_key.fail.sh

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/test_config.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/test_config.yml
@@ -1,0 +1,13 @@
+deny_templated_scenarios:
+- auditctl_correct_extra_permission.pass.sh
+- auditctl_correct.pass.sh
+- auditctl_correct_without_key.pass.sh
+- auditctl_remove_all_rules.fail.sh
+- auditctl_wrong_rule.fail.sh
+- auditctl_wrong_rule_without_key.fail.sh
+- augenrules_correct_extra_permission.pass.sh
+- augenrules_correct.pass.sh
+- augenrules_correct_without_key.pass.sh
+- augenrules_remove_all_rules.fail.sh
+- augenrules_wrong_rule.fail.sh
+- augenrules_wrong_rule_without_key.fail.sh

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/group.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/group.yml
@@ -10,12 +10,12 @@ description: |-
     directory <tt>/etc/audit/rules.d</tt> in order to watch for attempted manual
     edits of files involved in storing logon events:
     <pre>-w /var/log/tallylog -p wa -k logins
-    -w {{{ faillock_path }}} -p wa -k logins
+    -w {{{ xccdf_value("var_accounts_passwords_pam_faillock_dir") }}} -p wa -k logins
     -w /var/log/lastlog -p wa -k logins</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file in order to watch for unattempted manual
     edits of files involved in storing logon events:
     <pre>-w /var/log/tallylog -p wa -k logins
-    -w {{{ faillock_path }}} -p wa -k logins
+    -w {{{ xccdf_value("var_accounts_passwords_pam_faillock_dir") }}} -p wa -k logins
     -w /var/log/lastlog -p wa -k logins</pre>

--- a/shared/templates/audit_rules_login_events/ansible.template
+++ b/shared/templates/audit_rules_login_events/ansible.template
@@ -4,5 +4,11 @@
 # complexity = low
 # disruption = low
 
+{{% if PATH_IS_VARIABLE %}}
+{{{ ansible_instantiate_variables("var_accounts_passwords_pam_faillock_dir") }}}
+{{{ ansible_audit_augenrules_add_watch_rule(path="{{ var_accounts_passwords_pam_faillock_dir }}", permissions='wa', key='logins') }}}
+{{{ ansible_audit_auditctl_add_watch_rule(path="{{ var_accounts_passwords_pam_faillock_dir }}", permissions='wa', key='logins') }}}
+{{% else %}}
 {{{ ansible_audit_augenrules_add_watch_rule(path=PATH, permissions='wa', key='logins') }}}
 {{{ ansible_audit_auditctl_add_watch_rule(path=PATH, permissions='wa', key='logins') }}}
+{{% endif %}}

--- a/shared/templates/audit_rules_login_events/bash.template
+++ b/shared/templates/audit_rules_login_events/bash.template
@@ -2,5 +2,11 @@
 
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 
+{{% if PATH_IS_VARIABLE %}}
+{{{ bash_instantiate_variables("var_accounts_passwords_pam_faillock_dir") }}}
+{{{ bash_fix_audit_watch_rule("auditctl", "${var_accounts_passwords_pam_faillock_dir}", "wa", "logins") }}}
+{{{ bash_fix_audit_watch_rule("augenrules", "${var_accounts_passwords_pam_faillock_dir}", "wa", "logins") }}}
+{{% else %}}
 {{{ bash_fix_audit_watch_rule("auditctl", PATH, "wa", "logins") }}}
 {{{ bash_fix_audit_watch_rule("augenrules", PATH, "wa", "logins") }}}
+{{% endif %}}

--- a/shared/templates/audit_rules_login_events/oval.template
+++ b/shared/templates/audit_rules_login_events/oval.template
@@ -24,7 +24,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_arle_{{{ NAME }}}_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w[\s]+{{{ PATH }}}[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
+    <ind:pattern operation="pattern match" var_ref="{{{ NAME }}}_path_pattern"/>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -33,8 +33,21 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_arle_{{{ NAME }}}_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w[\s]+{{{ PATH }}}[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
+    <ind:pattern operation="pattern match" var_ref="{{{ NAME }}}_path_pattern" />
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-
+  <local_variable id="{{{ NAME }}}_path_pattern" comment="The composite pattern used to detect if audit as been configured" datatype="string" version="1">
+    <concat>
+      <literal_component>^\-w[\s]+</literal_component>
+  {{% if PATH_IS_VARIABLE %}}
+      <variable_component var_ref="var_accounts_passwords_pam_faillock_dir"/>
+  {{% else %}}
+      <literal_component>{{{ PATH }}}</literal_component>
+  {{% endif %}}
+      <literal_component>[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</literal_component>
+    </concat>
+  </local_variable>
+  {{% if PATH_IS_VARIABLE %}}
+  <external_variable id="var_accounts_passwords_pam_faillock_dir" comment="Faillock directory" datatype="string" version="1"/>
+  {{% endif %}}
 </def-group>

--- a/shared/templates/audit_rules_login_events/tests/auditctl_correct.pass.sh
+++ b/shared/templates/audit_rules_login_events/tests/auditctl_correct.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # packages = audit
 
-echo "-w {{{ PATH }}} -p wa -k logins" >> /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+path={{{ PATH }}}
+. $SHARED/audit_rules_login_events/auditctl_correct.pass.sh

--- a/shared/templates/audit_rules_login_events/tests/auditctl_correct_extra_permission.pass.sh
+++ b/shared/templates/audit_rules_login_events/tests/auditctl_correct_extra_permission.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # packages = audit
 
-echo "-w {{{ PATH }}} -p wra -k logins" >> /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+path={{{ PATH }}}
+. $SHARED/audit_rules_login_events/auditctl_correct_extra_permission.pass.sh

--- a/shared/templates/audit_rules_login_events/tests/auditctl_correct_without_key.pass.sh
+++ b/shared/templates/audit_rules_login_events/tests/auditctl_correct_without_key.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # packages = audit
 
-echo "-w {{{ PATH }}} -p wa" >> /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+path={{{ PATH }}}
+. $SHARED/audit_rules_login_events/auditctl_correct_without_key.pass.sh

--- a/shared/templates/audit_rules_login_events/tests/auditctl_wrong_rule.fail.sh
+++ b/shared/templates/audit_rules_login_events/tests/auditctl_wrong_rule.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # packages = audit
 
-echo "-w {{{ PATH }}} -p w -k logins" >> /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+path={{{ PATH }}}
+. $SHARED/audit_rules_login_events/auditctl_wrong_rule.fail.sh

--- a/shared/templates/audit_rules_login_events/tests/auditctl_wrong_rule_without_key.fail.sh
+++ b/shared/templates/audit_rules_login_events/tests/auditctl_wrong_rule_without_key.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # packages = audit
 
-echo "-w {{{ PATH }}} -p w" >> /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+path={{{ PATH }}}
+. $SHARED/audit_rules_login_events/auditctl_wrong_rule_without_key.fail.sh

--- a/shared/templates/audit_rules_login_events/tests/augenrules_correct.pass.sh
+++ b/shared/templates/audit_rules_login_events/tests/augenrules_correct.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # packages = audit
 
-
-echo "-w {{{ PATH }}} -p wa -k login" >> /etc/audit/rules.d/login.rules
+path={{{ PATH }}}
+. $SHARED/audit_rules_login_events/augenrules_correct.pass.sh

--- a/shared/templates/audit_rules_login_events/tests/augenrules_correct_extra_permission.pass.sh
+++ b/shared/templates/audit_rules_login_events/tests/augenrules_correct_extra_permission.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # packages = audit
 
-
-echo "-w {{{ PATH }}} -p wra -k login" >> /etc/audit/rules.d/login.rules
+path={{{ PATH }}}
+. $SHARED/audit_rules_login_events/augenrules_correct_extra_permission.pass.sh

--- a/shared/templates/audit_rules_login_events/tests/augenrules_correct_without_key.pass.sh
+++ b/shared/templates/audit_rules_login_events/tests/augenrules_correct_without_key.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # packages = audit
 
-
-echo "-w {{{ PATH }}} -p wa" >> /etc/audit/rules.d/login.rules
+path={{{ PATH }}}
+. $SHARED/audit_rules_login_events/augenrules_correct_without_key.pass.sh

--- a/shared/templates/audit_rules_login_events/tests/augenrules_wrong_rule.fail.sh
+++ b/shared/templates/audit_rules_login_events/tests/augenrules_wrong_rule.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # packages = audit
 
-
-echo "-w {{{ PATH }}} -p w -k login" >> /etc/audit/rules.d/login.rules
+path={{{ PATH }}}
+. $SHARED/audit_rules_login_events/augenrules_wrong_rule.fail.sh

--- a/shared/templates/audit_rules_login_events/tests/augenrules_wrong_rule_without_key.fail.sh
+++ b/shared/templates/audit_rules_login_events/tests/augenrules_wrong_rule_without_key.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # packages = audit
 
-
-echo "-w {{{ PATH }}} -p w" >> /etc/audit/rules.d/login.rules
+path={{{ PATH }}}
+. $SHARED/audit_rules_login_events/augenrules_wrong_rule_without_key.fail.sh

--- a/tests/shared/audit_rules_login_events/auditctl_correct.pass.sh
+++ b/tests/shared/audit_rules_login_events/auditctl_correct.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = audit
+
+echo "-w $path -p wa -k logins" >> /etc/audit/audit.rules
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/tests/shared/audit_rules_login_events/auditctl_correct_extra_permission.pass.sh
+++ b/tests/shared/audit_rules_login_events/auditctl_correct_extra_permission.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = audit
+
+echo "-w $path -p wra -k logins" >> /etc/audit/audit.rules
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/tests/shared/audit_rules_login_events/auditctl_correct_without_key.pass.sh
+++ b/tests/shared/audit_rules_login_events/auditctl_correct_without_key.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = audit
+
+echo "-w $path -p wa" >> /etc/audit/audit.rules
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/tests/shared/audit_rules_login_events/auditctl_remove_all_rules.fail.sh
+++ b/tests/shared/audit_rules_login_events/auditctl_remove_all_rules.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = audit
+
+rm -f /etc/audit/audit.rules
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/tests/shared/audit_rules_login_events/auditctl_wrong_rule.fail.sh
+++ b/tests/shared/audit_rules_login_events/auditctl_wrong_rule.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = audit
+
+echo "-w $path -p w -k logins" >> /etc/audit/audit.rules
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/tests/shared/audit_rules_login_events/auditctl_wrong_rule_without_key.fail.sh
+++ b/tests/shared/audit_rules_login_events/auditctl_wrong_rule_without_key.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = audit
+
+echo "-w $path -p w" >> /etc/audit/audit.rules
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/tests/shared/audit_rules_login_events/augenrules_correct.pass.sh
+++ b/tests/shared/audit_rules_login_events/augenrules_correct.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = audit
+
+
+echo "-w $path -p wa -k login" >> /etc/audit/rules.d/login.rules

--- a/tests/shared/audit_rules_login_events/augenrules_correct_extra_permission.pass.sh
+++ b/tests/shared/audit_rules_login_events/augenrules_correct_extra_permission.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = audit
+
+
+echo "-w $path -p wra -k login" >> /etc/audit/rules.d/login.rules

--- a/tests/shared/audit_rules_login_events/augenrules_correct_without_key.pass.sh
+++ b/tests/shared/audit_rules_login_events/augenrules_correct_without_key.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = audit
+
+
+echo "-w $path -p wa" >> /etc/audit/rules.d/login.rules

--- a/tests/shared/audit_rules_login_events/augenrules_remove_all_rules.fail.sh
+++ b/tests/shared/audit_rules_login_events/augenrules_remove_all_rules.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# packages = audit
+
+
+rm -f /etc/audit/rules.d/*
+> /etc/audit/audit.rules

--- a/tests/shared/audit_rules_login_events/augenrules_wrong_rule.fail.sh
+++ b/tests/shared/audit_rules_login_events/augenrules_wrong_rule.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = audit
+
+
+echo "-w $path -p w -k login" >> /etc/audit/rules.d/login.rules

--- a/tests/shared/audit_rules_login_events/augenrules_wrong_rule_without_key.fail.sh
+++ b/tests/shared/audit_rules_login_events/augenrules_wrong_rule_without_key.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = audit
+
+
+echo "-w $path -p w" >> /etc/audit/rules.d/login.rules


### PR DESCRIPTION
#### Description:

- Some benchmarks specify different paths when monitoring the faillock file, depending on if a permanent faillock path has been configured. This updates the audit_rules_login_event_faillock to use the variable var_accounts_passwords_pam_faillock_dir instead of the profile faillock_path