### PR TITLE
Fix ansible remediation of configure_ssh_crypto_policy

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/ansible/shared.yml
@@ -8,4 +8,4 @@
   lineinfile:
     dest: /etc/sysconfig/sshd
     state: absent
-    regexp: ^\s*(?i)CRYPTO_POLICY.*$
+    regexp: ^(?i)\s*CRYPTO_POLICY.*$


### PR DESCRIPTION
#### Description:
- Fix ansible remediation of configure_ssh_crypto_policy.
  - The (?i) needs to appear first in the regex otherwise it throws an error.
  - https://stackoverflow.com/questions/75895460/the-error-was-re-error-global-flags-not-at-the-start-of-the-expression-at-posi

#### Rationale:

- Fixes: #10954