### PR TITLE
Add Ansible Remediation for directory_ownership_var_log_audit

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_ownership_var_log_audit/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_ownership_var_log_audit/ansible/shared.yml
@@ -1,0 +1,15 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+
+- name: '{{{ rule_title }}} - Register Audit Configuration Text'
+  ansible.builtin.slurp:
+    src: /etc/audit/auditd.conf
+  register: auditd_config_slurp
+
+- name: '{{{ rule_title }}} - Set Permissions Custom Location'
+  ansible.builtin.file:
+    owner: root
+    path: "{{ auditd_config_slurp['content'] | b64decode | regex_findall('\nlog_file\\s*=\\s*(.+)') | default(['/var/log/audit/audit.log',], boolean=True) | first | dirname }}"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_ownership_var_log_audit/tests/correct_value_custom.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_ownership_var_log_audit/tests/correct_value_custom.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+sed -i "/\s*log_file.*/d" /etc/audit/auditd.conf
+echo "log_file = /var/log/audit2/audit.log" >> /etc/audit/auditd.conf
+
+mkdir /var/log/audit2
+touch /var/log/audit2/audit.log
+chown root /var/log/audit2

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_ownership_var_log_audit/tests/no_configured_value.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_ownership_var_log_audit/tests/no_configured_value.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+sed -i "/\s*log_file.*/d" /etc/audit/auditd.conf
+
+useradd testuser_123
+chown testuser_123 /var/log/audit

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_ownership_var_log_audit/tests/wrong_value_custom.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_ownership_var_log_audit/tests/wrong_value_custom.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+sed -i "/\s*log_file.*/d" /etc/audit/auditd.conf
+echo "log_file = /var/log/audit2/audit.log" >> /etc/audit/auditd.conf
+
+mkdir /var/log/audit2
+touch /var/log/audit2/audit.log
+useradd testuser_123
+chown testuser_123 /var/log/audit2


### PR DESCRIPTION
#### Description:

Add Ansible Remediation for directory_ownership_var_log_audit

#### Rationale:
* Ansible parity 

