### PR TITLE
Couple of fixes in PAM related rules for SLE platforms

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_unlock_time/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_unlock_time/oval/shared.xml
@@ -18,14 +18,16 @@
   <external_variable id="var_accounts_passwords_pam_tally2_unlock_time" datatype="int"
                      comment="number of failed login attempts allowed" version="1"/>
 
-  <ind:textfilecontent54_object id="object_accounts_passwords_pam_tally2_unlock_time" comment="Check unlock_time configuration of pam_tally2" version="1">
+  <ind:textfilecontent54_object id="object_accounts_passwords_pam_tally2_unlock_time"
+    comment="Check unlock_time configuration of pam_tally2" version="1">
     <ind:filepath>/etc/pam.d/login</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*auth\s+required\s+pam_tally2\.so\s+[^\n]*unlock_time=([0-9]+)([\s+\S+])*\s*(\\)*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*auth\s+required\s+pam_tally2\.so\s+[^\n]*unlock_time=([0-9]+)[\s+\S+]*\s*\\*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_accounts_passwords_pam_tally2_unlock_time" version="1">
-    <ind:subexpression datatype="int" operation="pattern match" var_ref="var_accounts_passwords_pam_tally2_unlock_time"/>
+    <ind:subexpression datatype="int" operation="greater than or equal"
+      var_ref="var_accounts_passwords_pam_tally2_unlock_time"/>
   </ind:textfilecontent54_state>
 
   <ind:textfilecontent54_test id="test_accounts_passwords_pam_tally2_unlock_time_account"

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/rule.yml
@@ -96,19 +96,6 @@ ocil: |-
 
 platform: package[pam]
 
-{{% if product in ["sle12", "sle15"] %}}
-template:
-    name: pam_options
-    vars:
-      path: /etc/pam.d/common-password
-      type: password
-      control_flag: required
-      module: pam_unix.so
-      arguments:
-        - argument: sha512
-          new_argument: sha512
-{{% endif %}}
-
 fixtext: |-
     {{% if product in ['ol9', 'rhel9'] -%}}
     Configure {{{ full_name }}} to use a FIPS 140-3 approved cryptographic hashing algorithm for system authentication.


### PR DESCRIPTION

#### Description:

- Fix accounts_passwords_pam_tally2_unlock_time OVAL check
- Drop template section for set_password_hashing_algorithm_systemauth rule in sle context

#### Rationale:

- The accounts_passwords_pam_tally2_unlock_time check was returning error after ansible remediation due to comparing string with integer and some extra grouping in the regex pattern
- Now there are custom ansible/bash remediations  for set_password_hashing_algorithm_systemauth, that cover sle platforms so the duplication causes only troubles
