### PR TITLE
Fix variable selection when selecting the default value

### DIFF
--- a/linux_os/guide/system/software/sudo/var_sudo_dedicated_group.var
+++ b/linux_os/guide/system/software/sudo/var_sudo_dedicated_group.var
@@ -13,4 +13,5 @@ operator: equals
 
 options:
     default: root
+    root: root
     sudogrp: sudogrp

--- a/products/ol7/profiles/e8.profile
+++ b/products/ol7/profiles/e8.profile
@@ -130,7 +130,6 @@ selections:
   - sshd_disable_empty_passwords
   - sshd_disable_user_known_hosts
   - sshd_enable_strictmodes
-  - sshd_strong_macs=default
   - sshd_use_strong_macs
 
   ### Backup

--- a/products/rhel7/profiles/e8.profile
+++ b/products/rhel7/profiles/e8.profile
@@ -136,7 +136,6 @@ selections:
   - sshd_disable_empty_passwords
   - sshd_disable_user_known_hosts
   - sshd_enable_strictmodes
-  - sshd_strong_macs=default
   - sshd_use_strong_macs
 
   ### Backup

--- a/products/sle12/profiles/anssi_bp28_enhanced.profile
+++ b/products/sle12/profiles/anssi_bp28_enhanced.profile
@@ -25,7 +25,7 @@ selections:
     - anssi:all:enhanced
     - var_multiple_time_servers=suse
     - var_multiple_time_pools=suse
-    - var_sudo_dedicated_group=default
+    - var_sudo_dedicated_group=root
     - '!accounts_password_pam_unix_rounds_system_auth'
     - '!accounts_password_pam_unix_rounds_password_auth'
     -  set_password_hashing_min_rounds_logindefs

--- a/products/sle12/profiles/anssi_bp28_high.profile
+++ b/products/sle12/profiles/anssi_bp28_high.profile
@@ -25,7 +25,7 @@ selections:
     - anssi:all:high
     - var_multiple_time_servers=suse
     - var_multiple_time_pools=suse
-    - var_sudo_dedicated_group=default
+    - var_sudo_dedicated_group=root
     - '!accounts_password_pam_unix_rounds_system_auth'
     - '!accounts_password_pam_unix_rounds_password_auth'
     -  set_password_hashing_min_rounds_logindefs

--- a/products/sle12/profiles/anssi_bp28_intermediary.profile
+++ b/products/sle12/profiles/anssi_bp28_intermediary.profile
@@ -25,7 +25,7 @@ selections:
   - anssi:all:intermediary
   - var_multiple_time_servers=suse
   - var_multiple_time_pools=suse
-  - var_sudo_dedicated_group=default
+  - var_sudo_dedicated_group=root
   - '!accounts_password_pam_unix_rounds_system_auth'
   - '!accounts_password_pam_unix_rounds_password_auth'
   -  set_password_hashing_min_rounds_logindefs

--- a/products/sle12/profiles/anssi_bp28_minimal.profile
+++ b/products/sle12/profiles/anssi_bp28_minimal.profile
@@ -25,7 +25,7 @@ selections:
   - anssi:all:minimal
   - var_multiple_time_servers=suse
   - var_multiple_time_pools=suse
-  - var_sudo_dedicated_group=default
+  - var_sudo_dedicated_group=root
   - '!accounts_password_pam_unix_rounds_system_auth'
   - '!accounts_password_pam_unix_rounds_password_auth'
   -  set_password_hashing_min_rounds_logindefs

--- a/products/sle15/profiles/anssi_bp28_enhanced.profile
+++ b/products/sle15/profiles/anssi_bp28_enhanced.profile
@@ -25,7 +25,7 @@ selections:
     - anssi:all:enhanced
     - var_multiple_time_servers=suse
     - var_multiple_time_pools=suse
-    - var_sudo_dedicated_group=default
+    - var_sudo_dedicated_group=root
     - '!accounts_password_pam_unix_rounds_system_auth'
     - '!accounts_password_pam_unix_rounds_password_auth'
     -  set_password_hashing_min_rounds_logindefs

--- a/products/sle15/profiles/anssi_bp28_high.profile
+++ b/products/sle15/profiles/anssi_bp28_high.profile
@@ -25,7 +25,7 @@ selections:
     - anssi:all:high
     - var_multiple_time_servers=suse
     - var_multiple_time_pools=suse
-    - var_sudo_dedicated_group=default
+    - var_sudo_dedicated_group=root
     - '!accounts_password_pam_unix_rounds_system_auth'
     - '!accounts_password_pam_unix_rounds_password_auth'
     -  set_password_hashing_min_rounds_logindefs

--- a/products/sle15/profiles/anssi_bp28_intermediary.profile
+++ b/products/sle15/profiles/anssi_bp28_intermediary.profile
@@ -25,7 +25,7 @@ selections:
   - anssi:all:intermediary
   - var_multiple_time_servers=suse
   - var_multiple_time_pools=suse
-  - var_sudo_dedicated_group=default
+  - var_sudo_dedicated_group=root
   - '!accounts_password_pam_unix_rounds_system_auth'
   - '!accounts_password_pam_unix_rounds_password_auth'
   -  set_password_hashing_min_rounds_logindefs

--- a/products/sle15/profiles/anssi_bp28_minimal.profile
+++ b/products/sle15/profiles/anssi_bp28_minimal.profile
@@ -25,7 +25,7 @@ selections:
   - anssi:all:minimal
   - var_multiple_time_servers=suse
   - var_multiple_time_pools=suse
-  - var_sudo_dedicated_group=default
+  - var_sudo_dedicated_group=root
   - '!accounts_password_pam_unix_rounds_system_auth'
   - '!accounts_password_pam_unix_rounds_password_auth'
   -  set_password_hashing_min_rounds_logindefs

--- a/tests/data/profile_stability/rhel7/e8.profile
+++ b/tests/data/profile_stability/rhel7/e8.profile
@@ -109,5 +109,4 @@ selections:
 - var_selinux_state=enforcing
 - var_selinux_policy_name=targeted
 - var_auditd_flush=incremental_async
-- sshd_strong_macs=default
 title: Australian Cyber Security Centre (ACSC) Essential Eight


### PR DESCRIPTION
#### Description:

- Fix variable selection when selecting the default value

#### Rationale:

- It's not possible to directly select the default value, so instead we either remove or create a new value to represent the default value.

- Fixes: https://github.com/ComplianceAsCode/content/issues/11018
```
OpenSCAP Error: Attempt to get non-existent selector "default" from variable "xccdf_org.ssgproject.content_value_sshd_strong_macs" [xccdf_policy.c:462]
Invalid selector 'default' for xccdf:value/@id='xccdf_org.ssgproject.content_value_sshd_strong_macs'. Using null value instead. [xccdf_policy.c:2137]
```