### PR TITLE
Fix multiple STIG id table generation

### DIFF
--- a/linux_os/guide/services/rng/service_rngd_enabled/rule.yml
+++ b/linux_os/guide/services/rng/service_rngd_enabled/rule.yml
@@ -24,6 +24,7 @@ references:
     ospp: FCS_RBG_EXT.1
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-010471
+    stigid@rhel8: RHEL-08-010471
 
 {{% if product == "ol8" %}}
 platform: os_linux[ol]<8.4 or not runtime_kernel_fips_enabled

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/rule.yml
@@ -23,7 +23,7 @@ references:
     nist: AC-7 (a)
     srg: SRG-OS-000021-GPOS-00005
     stigid@ol8: OL08-00-020027
-    stigid@rhel8: RHEL-08-020027
+    stigid@rhel8: RHEL-08-020027,RHEL-08-020028
 
 platform: machine
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/rule.yml
@@ -21,6 +21,10 @@ references:
     stigid@ol8: OL08-00-020021
     stigid@rhel8: RHEL-08-020021
 
+{{% if product == "rhel8" %}}
+platform: os_linux[rhel]>=8.2
+{{% endif %}}
+
 ocil_clause: 'the "audit" option is not set, is missing or commented out'
 
 ocil: |-

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/rule.yml
@@ -45,6 +45,10 @@ references:
     stigid@rhel7: RHEL-07-010330
     stigid@rhel8: RHEL-08-020023
 
+{{% if product == "rhel8" %}}
+platform: os_linux[rhel]>=8.2
+{{% endif %}}
+
 ocil_clause: 'the "even_deny_root" option is not set, is missing or commented out'
 
 ocil: |-

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/rule.yml
@@ -33,8 +33,8 @@ references:
     disa: CCI-000044,CCI-002238
     nist: AC-7(b),AC-7(a),AC-7.1(ii)
     srg: SRG-OS-000021-GPOS-00005,SRG-OS-000329-GPOS-00128
-    stigid@ol8: OL08-00-020016
-    stigid@rhel8: RHEL-08-020017
+    stigid@ol8: OL08-00-020016,OL08-00-020017
+    stigid@rhel8: RHEL-08-020016,RHEL-08-020017
 
 ocil_clause: 'the "dir" option is not set to a non-default documented tally log directory, is missing or commented out'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/rule.yml
@@ -30,7 +30,7 @@ references:
     disa: CCI-002238,CCI-000044
     srg: SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005
     stigid@ol8: OL08-00-020019
-    stigid@rhel8: RHEL-08-020019
+    stigid@rhel8: RHEL-08-020018,RHEL-08-020019
 
 ocil_clause: 'the system shows messages when three unsuccessful logon attempts occur'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
@@ -66,7 +66,7 @@ references:
     stigid@ol7: OL07-00-010320
     stigid@ol8: OL08-00-020014
     stigid@rhel7: RHEL-07-010320
-    stigid@rhel8: RHEL-08-020015
+    stigid@rhel8: RHEL-08-020014,RHEL-08-020015
 
 platform: package[pam]
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/rule.yml
@@ -54,7 +54,7 @@ references:
     stigid@ol7: OL07-00-010290
     stigid@ol8: OL08-00-020331
     stigid@rhel7: RHEL-07-010290
-    stigid@rhel8: RHEL-08-020331
+    stigid@rhel8: RHEL-08-020331,RHEL-08-020332
     stigid@sle12: SLES-12-010231
     stigid@sle15: SLES-15-020300
 

--- a/utils/create-stig-overlay.py
+++ b/utils/create-stig-overlay.py
@@ -52,7 +52,7 @@ def ssg_xccdf_stigid_mapping(ssgtree):
 
     for rule in ssgtree.findall(".//{%s}Rule" % xccdf_ns):
         srgs = []
-        rhid = ""
+        rhid = []
 
         xccdfid = rule.get("id")
         if xccdf_ns == XCCDF12_NS:
@@ -62,10 +62,11 @@ def ssg_xccdf_stigid_mapping(ssgtree):
                 stig = [ids for ids in rule.findall(".//{%s}reference[@href='%s']" % (xccdf_ns, references))]
                 for ref in reversed(stig):
                     if not ref.text.startswith("SRG-"):
-                        rhid = ref.text
+                        rhid.append(ref.text)
                     else:
                         srgs.append(ref.text)
-            xccdftostig_idmapping.update({rhid: {xccdfid: srgs}})
+            for id in rhid:
+                xccdftostig_idmapping.update({id: {xccdfid: srgs}})
 
     return xccdftostig_idmapping
 


### PR DESCRIPTION
#### Description:

- Fix multiple STIG id table generation

#### Rationale:

- Rules that have multiple STIG ids assigned were not being processed correctly in this table for example:
- https://complianceascode.github.io/content-pages/tables/table-rhel8-stig.html
- Related to: https://github.com/ComplianceAsCode/content/pull/10846

#### Review Hints:

- build RHEL8 content and inspect the table build/tables/table-rhel8-stig.html
- rules that have multiple STIG ids assigned should appear more than once in the table