### PR TITLE
Grant packages write permissions to k8s-content workflow

### DIFF
--- a/.github/workflows/k8s-content.yaml
+++ b/.github/workflows/k8s-content.yaml
@@ -8,7 +8,9 @@ on:
 jobs:
   container-main:
     permissions:
+      contents: read
       id-token: write
+      packages: write
     uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main
     with:
       name: k8scontent


### PR DESCRIPTION
#### Description:

- Grant `contents: read` permission to `k8s-content` action
- Grant `packages: write` permission to `k8s-content` action

#### Rationale:

- The workflow needs permission to publish packages.
- Fixes #10746
#### Review Hints:

- Check the job logs:
https://github.com/ComplianceAsCode/content/actions/workflows/k8s-content.yaml