### PR TITLE
Add a test for pcre2 compatibility

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -140,7 +140,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install deps python
-        run: pip install -r requirements.txt -r test-requirements.txt
+        run: pip install pcre2 -r requirements.txt -r test-requirements.txt
       - name: Build
         run: |-
           ./build_product \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,7 @@ find_python_module(json2html)
 find_python_module(mypy)
 find_python_module(openpyxl)
 find_python_module(pandas)
+find_python_module(pcre2)
 find_python_module(cmakelint)
 
 # sphinx documentation requirements
@@ -243,6 +244,7 @@ message(STATUS "python sphinx_rtd_theme module (optional): ${PY_SPHINX_RTD_THEME
 message(STATUS "python myst-parser module (optional): ${PY_MYST_PARSER}")
 message(STATUS "python openpyxl module (optional): ${PY_OPENPYXL}")
 message(STATUS "python pandas module (optional): ${PY_PANDAS}")
+message(STATUS "python pcre2 module (optional): ${PY_PCRE2}")
 message(STATUS " ")
 
 message(STATUS "Build options:")

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -586,6 +586,13 @@ macro(ssg_build_sds PRODUCT)
             COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tests/test_ds_sce.py" "${CMAKE_BINARY_DIR}" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
         )
     endif()
+    if(PYTHON_VERSION_MAJOR GREATER 2 AND PY_PCRE2)
+        add_test(
+            NAME "check-pcre2-compatibility-ssg-${PRODUCT}-ds.xml"
+            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tests/check_pcre2_compatibility.py" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
+        )
+        set_tests_properties("check-pcre2-compatibility-ssg-${PRODUCT}-ds.xml" PROPERTIES LABELS quick)
+    endif()
 endmacro()
 
 # Build per-product HTML guides to see the status of various profiles and

--- a/tests/check_pcre2_compatibility.py
+++ b/tests/check_pcre2_compatibility.py
@@ -1,0 +1,64 @@
+#!/usr/bin/python3
+
+import argparse
+import pcre2
+import xml.etree.ElementTree as ET
+from typing import Generator, List
+
+from ssg.constants import PREFIX_TO_NS
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("data_stream")
+    return parser.parse_args()
+
+
+def find_all_patern_match(root: ET.Element, section_xpath: str) -> Generator:
+    section = root.find(section_xpath, PREFIX_TO_NS)
+    if section is None:
+        return
+    for child in section:
+        for el in child.findall(".//*[@operation='pattern match']"):
+            if el.text is not None:
+                yield el.text
+
+
+def extract_all_regexes_from_oval(root: ET.Element) -> list:
+    regexes: List[str] = []
+    sections_xpaths = ["./oval-def:objects", "./oval-def:states"]
+    for section_xpath in sections_xpaths:
+        regexes += find_all_patern_match(root, section_xpath)
+    return regexes
+
+
+def extract_all_regexes_from_data_stream(ds_file_path: str) -> set:
+    regexes = []
+    tree = ET.parse(ds_file_path)
+    root = tree.getroot()
+    xpath = "./ds:component/oval-def:oval_definitions"
+    for oval_definitions in root.findall(xpath, PREFIX_TO_NS):
+        regexes += extract_all_regexes_from_oval(oval_definitions)
+    return set(regexes)
+
+
+def check_pcre2_compatibility(regexes: set) -> bool:
+    result = True
+    for regex in regexes:
+        try:
+            pcre2.compile(regex)
+        except pcre2.exceptions.CompileError as ecp:
+            result = False
+            print(f"Regular expression {regex} is invalid: {str(ecp)}")
+    return result
+
+
+def main():
+    args = parse_args()
+    regexes = extract_all_regexes_from_data_stream(args.data_stream)
+    if not check_pcre2_compatibility(regexes):
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This test will ensure that the regular expressions used in OVAL checks are compatible with the pcre2 library. This will be important when OpenSCAP will move to use pcre2 internally.

The test collects regular expressions used in SCAP source data streams and tries to compile these regular expressions using the code from pcre2 library.

Unfortunately, a large amount of regular expressions used in our OVAL checks are composed dynamically using data collected during the scan from the evaluated system. These regular expressions won't be tested by this test that performs a static analysis. I think that possible problems with these expressions could be caught by Automatus test scenarios eventually.

Related to: https://bugzilla.redhat.com/show_bug.cgi?id=2128342



#### Review Hints:

1. sudo pip3 install pcre2
2. break some regular expression in an OVAL check in your favorite rule to make the regular expression invalid
3. build the content
4. cd build && ctest --verbose -R check-pcre2-compatibility-ssg-rhel9-ds.xml