### PR TITLE
Add product as parameter when building profile reports

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -649,13 +649,13 @@ endmacro()
 macro(ssg_make_stats_for_product PRODUCT)
     add_custom_target(${PRODUCT}-stats
         COMMAND ${CMAKE_COMMAND} -E echo "Benchmark statistics for '${PRODUCT}':"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/profile_tool.py" stats --benchmark "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" --profile all
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/profile_tool.py" stats --product "${PRODUCT}" --benchmark "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" --profile all
         DEPENDS generate-ssg-${PRODUCT}-ds.xml "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
         COMMENT "[${PRODUCT}-stats] generating benchmark statistics"
     )
     add_custom_target(${PRODUCT}-profile-stats
         COMMAND ${CMAKE_COMMAND} -E echo "Per profile statistics for '${PRODUCT}':"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/profile_tool.py" stats --benchmark "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/profile_tool.py" stats --product "${PRODUCT}" --benchmark "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
         DEPENDS generate-ssg-${PRODUCT}-ds.xml "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
         COMMENT "[${PRODUCT}-profile-stats] generating per profile statistics"
     )
@@ -664,12 +664,12 @@ endmacro()
 # As above
 macro(ssg_make_html_stats_for_product PRODUCT)
     add_custom_target(${PRODUCT}-html-stats
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/profile_tool.py" stats --format html --benchmark "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" --profile all --output "${CMAKE_BINARY_DIR}/${PRODUCT}/product-statistics/"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/profile_tool.py" stats  --product "${PRODUCT}" --format html --benchmark "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" --profile all --output "${CMAKE_BINARY_DIR}/${PRODUCT}/product-statistics/"
         DEPENDS generate-ssg-${PRODUCT}-ds.xml "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
         COMMENT "[${PRODUCT}-html-stats] generating benchmark html statistics"
     )
     add_custom_target(${PRODUCT}-html-profile-stats
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/profile_tool.py" stats --format html --benchmark "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" --output "${CMAKE_BINARY_DIR}/${PRODUCT}/profile-statistics/"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/profile_tool.py" stats  --product "${PRODUCT}" --format html --benchmark "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" --output "${CMAKE_BINARY_DIR}/${PRODUCT}/profile-statistics/"
         DEPENDS generate-ssg-${PRODUCT}-ds.xml "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
         COMMENT "[${PRODUCT}-html-profile-stats] generating per profile html statistics"
     )

--- a/ssg/build_profile.py
+++ b/ssg/build_profile.py
@@ -130,7 +130,7 @@ class XCCDFBenchmark(object):
         self.cis_ns = cis_ns
         self.stig_ns = stig_ns
         if product:
-            constants_path = os.path.join(product, "transforms/constants.xslt")
+            constants_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "products", product, "transforms/constants.xslt")
             if os.path.exists(constants_path):
                 root = ElementTree.parse(constants_path)
                 cis_var = root.find('./{%s}variable[@name="cisuri"]' % (xslt_ns))


### PR DESCRIPTION
#### Description:

- Make sure that the product paramter is passed when building profile stats

#### Rationale:
- Until now only the STIG references worked for SLE products
Now when one runs:
```
# python3 build-scripts/profile_tool.py stats --benchmark build/ssg-sle15-xccdf.xml --profile xccdf_org.ssgproject.content_profile_cis --missing-cis-refs --product sle15
```
The result is much more close to reality:
```
Profile cis:
* rules:              375
* checks (OVAL):      359	[95% complete]
* checks (SCE):       0	[0% complete]
* checks (any):       359	[95% complete]
* fixes (bash):       337	[89% complete]
* fixes (ansible):    328	[87% complete]
* fixes (ignition):   0	[0% complete]
* fixes (kubernetes): 0	[0% complete]
* fixes (puppet):     64	[17% complete]
* fixes (anaconda):   1	[0% complete]
* fixes (any):        338	[90% complete]
* CCEs:               374	[99% complete]
*** rules of 'xccdf_org.ssgproject.content_profile_cis' profile missing CIS Refs: 373 of 375 have them [0% missing]
   xccdf_org.ssgproject.content_rule_dconf_db_up_to_date
   xccdf_org.ssgproject.content_rule_set_iptables_default_rule_forward

```
