### PR TITLE
Add Ansible remediation for directory_group_ownership_var_log_audit

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_group_ownership_var_log_audit/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_group_ownership_var_log_audit/ansible/shared.yml
@@ -1,0 +1,15 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+
+- name: '{{{ rule_title }}} - Register Audit Configuration Text'
+  ansible.builtin.slurp:
+    src: /etc/audit/auditd.conf
+  register: auditd_config_slurp
+
+- name: '{{{ rule_title }}} - Set Permissions Custom Location'
+  ansible.builtin.file:
+    group: "{{ auditd_config_slurp['content'] | b64decode | regex_findall('\nlog_group\\s*=\\s*(.+)') | default(['root',], boolean=True) | first }}"
+    path: "{{ auditd_config_slurp['content'] | b64decode | regex_findall('\nlog_file\\s*=\\s*(.+)') | default(['/var/log/audit/audit.log',], boolean=True) | first | dirname }}"


### PR DESCRIPTION
#### Description:

* Add Ansible remediation for directory_group_ownership_var_log_audit

#### Rationale:
* Ansible parity

