### PR TITLE
iptables_ruleset_modifications: depend on iptables being installed

### DIFF
--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/group.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/group.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 title: 'Strengthen the Default Ruleset'
 
+platform: package[iptables]
+
 description: |-
     The default rules can be strengthened. The system
     scripts that activate the firewall rules expect them to be defined


### PR DESCRIPTION
#### Description:
iptables_ruleset_modifications: depend on iptables being installed

#### Rationale:

iptables rules are only applicable when iptables is installed

#### Review Hints:
