### PR TITLE
Improve remediation for SSH global settings

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/bash/shared.sh
@@ -1,5 +1,4 @@
 # platform = multi_platform_rhel,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 
 {{{ bash_instantiate_variables("var_sshd_disable_compression") }}}
-
-{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^Compression', "$var_sshd_disable_compression", '%s %s') }}}
+{{{ bash_sshd_remediation("Compression", "$var_sshd_disable_compression") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/oval/shared.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="sshd_disable_compression" version="1">
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("SSH should either have compression disabled or set to delayed.") }}}
     <criteria comment="SSH is configured correctly or is not installed"
     operator="OR">
@@ -34,8 +34,9 @@
   {{{ oval_line_in_file_object(path_or_filepath='/etc/ssh/sshd_config', prefix_regex="^[ \\t]*(?i)", parameter='Compression', separator_regex='(?-i)[ \\t]+') }}}
 
   <ind:textfilecontent54_state id="state_sshd_disable_compression" version="1">
-  <ind:subexpression operation="equals" var_ref="var_sshd_disable_compression" />
+    <ind:subexpression operation="equals" var_ref="var_sshd_disable_compression"/>
   </ind:textfilecontent54_state>
 
-  <external_variable comment="external variable for the desired value of Compression" datatype="string" id="var_sshd_disable_compression" version="1" />
+  <external_variable id="var_sshd_disable_compression" datatype="string" version="1"
+    comment="external variable for the desired value of Compression"/>
 </def-group>

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -198,7 +198,7 @@ value: :code:`Setting={{ varname1 }}`
 {{%- macro ansible_sshd_set(msg='', parameter='', value='', config_is_distributed="false", config_basename="00-complianceascode-hardening.conf") %}}
 {{%- if config_is_distributed == "true" %}}
 {{% set config_dir = "/etc/ssh/sshd_config.d" %}}
-{{{ ansible_set_config_file_dir(msg, config_file="/etc/ssh/sshd_config", config_dir=config_dir, set_file=config_dir~"/"~config_basename, parameter=parameter, separator_regex="\s+", value=value, prefix_regex="(?i)^\s*", create='yes', validate='/usr/sbin/sshd -t -f %s', insert_after='', insert_before="^[#\s]*Match") }}}
+{{{ ansible_set_config_file_dir(msg, config_file="/etc/ssh/sshd_config", config_dir=config_dir, set_file=config_dir~"/"~config_basename, parameter=parameter, separator_regex="\s+", value=value, prefix_regex="(?i)^\s*", create='yes', validate='/usr/sbin/sshd -t -f %s', insert_after='', insert_before="BOF") }}}
 {{%- else %}}
 {{% if product in ["ol8", "ol9"] %}}
 - name: "Find sshd_config included files"
@@ -215,7 +215,7 @@ value: :code:`Setting={{ varname1 }}`
   loop: "{{ sshd_config_included_files.stdout_lines }}"
 
 {{% endif %}}
-{{{ ansible_set_config_file(msg, "/etc/ssh/sshd_config", parameter, value=value, create="yes", prefix_regex='(?i)^\s*', validate="/usr/sbin/sshd -t -f %s", insert_before="^[#\s]*Match") }}}
+{{{ ansible_set_config_file(msg, "/etc/ssh/sshd_config", parameter, value=value, create="yes", prefix_regex='(?i)^\s*', validate="/usr/sbin/sshd -t -f %s", insert_before="BOF") }}}
 {{%- endif %}}
 {{%- endmacro %}}
 

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -330,7 +330,7 @@ done
         value=value,
         create=true,
         insert_after="",
-        insert_before="^Match",
+        insert_before="BOF",
         insensitive=true,
         separator=" ",
         separator_regex="\s\+",
@@ -352,7 +352,7 @@ done
 :type config_basename: str
 
 #}}
-{{% macro bash_sshd_remediation(parameter, value, config_is_distributed, config_basename="00-complianceascode-hardening.conf") -%}}
+{{% macro bash_sshd_remediation(parameter, value, config_is_distributed="false", config_basename="00-complianceascode-hardening.conf") -%}}
 {{%- set sshd_config_path = "/etc/ssh/sshd_config" %}}
 {{%- set sshd_config_dir = "/etc/ssh/sshd_config.d" -%}}
 
@@ -371,7 +371,7 @@ touch {{{ sshd_config_dir }}}/{{{ hardening_config_basename }}}
         value=value,
         create=true,
         insert_after="",
-        insert_before="^Match",
+        insert_before="BOF",
         insensitive=true,
         separator=" ",
         separator_regex=separator_regex,


### PR DESCRIPTION
#### Description:

When new lines need to be inserted in `sshd_config` file to define global settings, these lines must be inserted before any `Match` conditional. However, using `Match` lines as reference during the remediation is not robust enough specially when multiple `Match` lines are present.

Since there is no ordering restrictions to Global Settings, it is safer to include new lines at the beginning of the file.

#### Rationale:

- More robust remediation for SSH
- Fixes #5118

#### Review Hints:

Automatus tests should be enough.