### PR TITLE
exclude some audit rules from aarch64 platform

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_chmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_chmod/rule.yml
@@ -26,6 +26,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhcos4: CCE-82556-2
     cce@rhel7: CCE-27339-1

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_chown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_chown/rule.yml
@@ -24,6 +24,9 @@ rationale: |-
     can facilitate the identification of patterns of abuse among both authorized and
     unauthorized users.
 
+platforms:
+    - not aarch64_arch
+
 severity: medium
 
 identifiers:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lchown/rule.yml
@@ -26,6 +26,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhcos4: CCE-82564-6
     cce@rhel7: CCE-27083-5

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount/rule.yml
@@ -22,6 +22,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhel9: CCE-89272-9
     cce@sle12: CCE-83218-8

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rename/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rename/rule.yml
@@ -23,6 +23,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhcos4: CCE-82575-2
     cce@rhel7: CCE-80995-4

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rmdir/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rmdir/rule.yml
@@ -23,6 +23,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhcos4: CCE-82577-8
     cce@rhel7: CCE-80412-0

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlink/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlink/rule.yml
@@ -23,6 +23,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhcos4: CCE-82578-6
     cce@rhel7: CCE-80996-2

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_chmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_chmod/rule.yml
@@ -30,6 +30,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhel7: CCE-82097-7
     cce@rhel8: CCE-82098-5

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_chown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_chown/rule.yml
@@ -30,6 +30,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhel7: CCE-82130-6
     cce@rhel8: CCE-82131-4

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_creat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_creat/rule.yml
@@ -30,6 +30,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhel7: CCE-81149-7
     cce@rhel8: CCE-81150-5

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_lchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_lchown/rule.yml
@@ -30,6 +30,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhel7: CCE-82124-9
     cce@rhel8: CCE-82125-6

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_open/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_open/rule.yml
@@ -30,6 +30,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhel7: CCE-81146-3
     cce@rhel8: CCE-81147-1

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_rename/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_rename/rule.yml
@@ -30,6 +30,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhel7: CCE-82091-0
     cce@rhel8: CCE-82092-8

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_unlink/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_successful_file_modification_unlink/rule.yml
@@ -30,6 +30,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhel7: CCE-82085-2
     cce@rhel8: CCE-82086-0

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/rule.yml
@@ -32,6 +32,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhel7: CCE-27347-4
     cce@rhel8: CCE-80750-3

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_chmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_chmod/rule.yml
@@ -27,6 +27,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhcos4: CCE-82619-8
     cce@rhel7: CCE-81086-1

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_chown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_chown/rule.yml
@@ -27,6 +27,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhcos4: CCE-82620-6
     cce@rhel7: CCE-81082-0

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/rule.yml
@@ -32,6 +32,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhcos4: CCE-82621-4
     cce@rhel7: CCE-80385-8

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_lchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_lchown/rule.yml
@@ -31,6 +31,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhcos4: CCE-82630-5
     cce@rhel7: CCE-81078-8

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/rule.yml
@@ -35,6 +35,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhcos4: CCE-82633-9
     cce@rhel7: CCE-80386-6

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/rule.yml
@@ -38,6 +38,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhcos4: CCE-82644-6
     cce@rhel7: CCE-81119-0

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/rule.yml
@@ -33,6 +33,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhcos4: CCE-82645-3
     cce@rhel7: CCE-81121-6

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/rule.yml
@@ -45,6 +45,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhcos4: CCE-82646-1
     cce@rhel8: CCE-80970-7

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_rename/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_rename/rule.yml
@@ -26,6 +26,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhcos4: CCE-82648-7
     cce@rhel7: CCE-81108-3

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/rule.yml
@@ -40,6 +40,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhcos4: CCE-82652-9
     cce@rhel7: CCE-81106-7

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_create/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_create/rule.yml
@@ -23,6 +23,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhel7: CCE-86115-3
     cce@rhel8: CCE-88435-3

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_query/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_query/rule.yml
@@ -23,6 +23,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhel8: CCE-88748-9
     cce@rhel9: CCE-88749-7

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_group_open/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_group_open/rule.yml
@@ -24,6 +24,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhcos4: CCE-82700-6
     cce@rhel8: CCE-80927-7

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_gshadow_open/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_gshadow_open/rule.yml
@@ -24,6 +24,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhcos4: CCE-82703-0
     cce@rhel8: CCE-80959-0

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/rule.yml
@@ -24,6 +24,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhcos4: CCE-82706-3
     cce@rhel8: CCE-80930-1

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_shadow_open/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_shadow_open/rule.yml
@@ -24,6 +24,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch
+
 identifiers:
     cce@rhcos4: CCE-82709-7
     cce@rhel8: CCE-80956-6

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/rule.yml
@@ -34,6 +34,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not aarch64_arch and not s390x_arch
+
 identifiers:
     cce@rhcos4: CCE-82617-2
     cce@rhel7: CCE-27299-7


### PR DESCRIPTION
#### Description:

- add platform not aarch64_arch to appropriate rules
- also one not s390x_arch platform has been added

#### Rationale:

- if there is an Audit config line containing nonexisting syscall, the audit service fails to start. This fixes the problem on aarch64 platform.
- analysis done based on https://marcin.juszkiewicz.com.pl/download/tables/syscalls.html

#### Review Hints:

1. get access to a aarch64 machine
2. check list of changed rules. Use the master branch to remediate all of them.
3. run augenrules --load - it will complain about a wrong syscall
4. restore to the previous state and now remediate rules with the new datastream built from this branch; all should be not applicable.