### PR TITLE
Add mount platform to mount_option_var_nosuid

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_var_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_nosuid/rule.yml
@@ -29,9 +29,9 @@ references:
 
 {{{ complete_ocil_entry_mount_option("/var", "nosuid") }}}
 
-severity: unknown
+severity: medium
 
-platform: machine
+platform: machine and mount[var]
 
 template:
     name: mount_option


### PR DESCRIPTION
#### Description:

- This commit was missing in PR #10794 
- Also sets the severity to medium.

#### Rationale:

- Just like all the other '/var' rules, it should be applicable only if '/var' is mounted in a separate partition.