### PR TITLE
Introduce controleval_metrics.py tool to generate metrics in Prometheus format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,8 @@ find_python_module(sphinxcontrib.autojinja)
 find_python_module(sphinx_rtd_theme)
 find_python_module(myst_parser)
 
+# prometheus_metrics requirements
+find_python_module(prometheus_client)
 
 include(CMakeDependentOption)
 cmake_dependent_option(ENABLE_PYTHON_COVERAGE "Enable Python tests with coverage support" ON "PY_PYTEST_COV" OFF)
@@ -247,7 +249,7 @@ message(STATUS "python openpyxl module (optional): ${PY_OPENPYXL}")
 message(STATUS "python pandas module (optional): ${PY_PANDAS}")
 message(STATUS "python pcre2 module (optional): ${PY_PCRE2}")
 message(STATUS "python lxml module (optional): ${PY_LXML}")
-
+message(STATUS "python prometheus-client module (optional): ${PY_PROMETHEUS_CLIENT}")
 message(STATUS " ")
 
 message(STATUS "Build options:")

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ pandas
 mypy
 lxml
 pycompliance
-# used in utils/controleval.py
+# used in utils/controleval_metrics.py
 prometheus_client

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ pandas
 mypy
 lxml
 pycompliance
+# used in utils/controleval.py
+prometheus_client

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -181,7 +181,7 @@ set_tests_properties("test-create_scap_delta_tailoring_resolved" PROPERTIES DEPE
 endif()
 
 
-if(PYTHON_VERSION_MAJOR GREATER 2  AND PYTHON_VERSION_MINOR GREATER 6)
+if(PYTHON_VERSION_MAJOR GREATER 2 AND PYTHON_VERSION_MINOR GREATER 6)
     add_test(
         NAME "test-controleval-directory"
         COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/controleval.py" "--controls-dir" "${CMAKE_SOURCE_DIR}/tests/unit/ssg-module/data/controls_dir" "stats" "--level" "high" "--product" "rhel9" "--id" "qrst-levels"
@@ -199,6 +199,14 @@ if(PYTHON_VERSION_MAJOR GREATER 2  AND PYTHON_VERSION_MINOR GREATER 6)
         COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/controleval.py" "--controls-dir" "${CMAKE_SOURCE_DIR}/tests/unit/ssg-module/data/controls_dir" "stats" "--level" "medium" "--product" "rhel8" "--id" "qrst-levels" "--output-format" "json"
     )
     set_tests_properties("test-controleval-json" PROPERTIES LABELS quick)
+
+    if(PY_PROMETHEUS_CLIENT)
+        add_test(
+            NAME "test-controleval-prometheus-metrics"
+            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/controleval_metrics.py" "--controls-dir" "${CMAKE_SOURCE_DIR}/tests/unit/ssg-module/data/controls_dir" "prometheus" "--products" "fedora" "ol9" "rhel7" "rhel8" "rhel9" "sle15"
+        )
+        set_tests_properties("test-controleval-prometheus-metrics" PROPERTIES LABELS quick)
+    endif()
 endif()
 
 macro(ssg_refcheck_test PRODUCT PROFILE KEY)

--- a/utils/controleval.py
+++ b/utils/controleval.py
@@ -242,8 +242,14 @@ def stats(args):
         print_stats(status_count, control_list, args)
 
 
+def prometheus(args):
+    for product in args.products:
+        print(product)
+
+
 subcmds = dict(
-    stats=stats
+    stats=stats,
+    prometheus=prometheus
 )
 
 
@@ -278,6 +284,12 @@ def parse_arguments():
     stats_parser.add_argument(
         '-s', '--status', default='all',
         help="status used to filter the controls list output")
+    prometheus_parser = subparsers.add_parser(
+        'prometheus',
+        help="calculate and return benchmarks metrics in Prometheus format")
+    prometheus_parser.add_argument(
+        '-p', '--products', nargs='+', required=True,
+        help="list of products to process the respective controls files")
     return parser.parse_args()
 
 

--- a/utils/controleval.py
+++ b/utils/controleval.py
@@ -218,7 +218,7 @@ def stats(controls_manager, args):
     total = len(ctrls)
 
     if total == 0:
-        print("No controls founds with the given inputs. Maybe try another level.")
+        print("No controls found with the given inputs. Maybe try another level.")
         exit(1)
 
     status_count, control_list = count_controls_by_status(ctrls)

--- a/utils/controleval.py
+++ b/utils/controleval.py
@@ -4,7 +4,8 @@ import collections
 import json
 import os
 import yaml
-from prometheus_client import CollectorRegistry, Gauge, write_to_textfile
+
+from prometheus_client import CollectorRegistry, Gauge, generate_latest, write_to_textfile
 
 # NOTE: This is not to be confused with the https://pypi.org/project/ssg/
 # package. The ssg package we're referencing here is actually a relative import
@@ -313,7 +314,11 @@ def prometheus(args):
     ctrls_mgr = load_controls_manager(args.controls_dir, args.products[0])
     used_controls = get_controls_used_by_products(ctrls_mgr, args.products)
     registry = get_prometheus_metrics_registry(used_controls, ctrls_mgr)
-    write_to_textfile(args.output_file, registry)
+    if args.output_file:
+        write_to_textfile(args.output_file, registry)
+    else:
+        metrics = generate_latest(registry)
+        print(metrics.decode('utf-8'))
 
 
 subcmds = dict(
@@ -360,8 +365,8 @@ def parse_arguments():
         '-p', '--products', nargs='+', required=True,
         help="list of products to process the respective controls files")
     prometheus_parser.add_argument(
-        '-f', '--output-file', default='policies_metrics',
-        help="resulting file with policy metrics in Prometheus format")
+        '-f', '--output-file',
+        help="save policy metrics in a file instead of showing in stdout")
     return parser.parse_args()
 
 

--- a/utils/controleval.py
+++ b/utils/controleval.py
@@ -93,6 +93,18 @@ def get_product_yaml(product):
     exit(1)
 
 
+def load_product_yaml(product):
+    product_yaml = get_product_yaml(product)
+    return ssg.products.load_product_yaml(product_yaml)
+
+
+def load_controls_manager(controls_dir, product):
+    product_yaml = load_product_yaml(product)
+    controls_manager = controls.ControlsManager(controls_dir, product_yaml)
+    controls_manager.load()
+    return controls_manager
+
+
 def get_formatted_name(text_name):
     for special_char in '-. ':
         text_name = text_name.replace(special_char, '_')
@@ -212,7 +224,8 @@ def print_stats_json(product, id, level, control_list):
     print(json.dumps(data))
 
 
-def stats(controls_manager, args):
+def stats(args):
+    controls_manager = load_controls_manager(args.controls_dir, args.product)
     validate_args(controls_manager, args)
     ctrls = set(controls_manager.get_all_controls_of_level(args.id, args.level))
     total = len(ctrls)
@@ -270,12 +283,7 @@ def parse_arguments():
 
 def main():
     args = parse_arguments()
-    product_yaml = get_product_yaml(args.product)
-    env_yaml = ssg.products.load_product_yaml(product_yaml)
-    controls_manager = controls.ControlsManager(
-        args.controls_dir, env_yaml=env_yaml)
-    controls_manager.load()
-    subcmds[args.subcmd](controls_manager, args)
+    subcmds[args.subcmd](args)
 
 
 if __name__ == "__main__":

--- a/utils/controleval_metrics.py
+++ b/utils/controleval_metrics.py
@@ -1,0 +1,100 @@
+#!/usr/bin/python3
+import argparse
+
+from prometheus_client import CollectorRegistry, Gauge, generate_latest, write_to_textfile
+from utils.controleval import (
+    count_controls_by_status,
+    get_controls_used_by_products,
+    get_policy_levels,
+    load_controls_manager
+)
+
+try:
+    from ssg import controls
+except ModuleNotFoundError as e:
+    if e.name == 'ssg':
+        msg = """Unable to import local 'ssg' module.
+
+The 'ssg' package from within this repository must be discoverable before
+invoking this script. Make sure the top-level directory of the
+ComplianceAsCode/content repository is available in the PYTHONPATH environment
+variable (example: $ export PYTHONPATH=($pwd)).
+HINT: $ source .pyenv.sh
+"""
+        raise RuntimeError(msg) from e
+    raise
+
+
+def create_prometheus_policy_metric(
+        unit: str, description: str, registry: CollectorRegistry) -> Gauge:
+    metric = Gauge(unit, description, ['level', 'status'], registry=registry)
+    return metric
+
+
+def append_prometheus_policy_metric(
+        metric: object, level: str, status: str, value: float) -> Gauge:
+    metric.labels(level=level, status=status).set(value)
+    return metric
+
+
+def get_prometheus_metrics_registry(
+        used_controls: list, ctrls_mgr: controls.ControlsManager) -> CollectorRegistry:
+    registry = CollectorRegistry()
+    for policy_id in sorted(used_controls):
+        metric_id = f'policy_requirements_status_{policy_id}'
+        metric_description = f'{policy_id} Requirements Status'
+        metric = create_prometheus_policy_metric(metric_id, metric_description, registry=registry)
+        for level in get_policy_levels(ctrls_mgr, policy_id):
+            ctrls = set(ctrls_mgr.get_all_controls_of_level(policy_id, level))
+            status_count, _ = count_controls_by_status(ctrls)
+            for status in status_count.keys():
+                metric = append_prometheus_policy_metric(
+                    metric, level, status, status_count[status])
+    return registry
+
+
+def prometheus(args):
+    ctrls_mgr = load_controls_manager(args.controls_dir, args.products[0])
+    used_controls = get_controls_used_by_products(ctrls_mgr, args.products)
+    registry = get_prometheus_metrics_registry(used_controls, ctrls_mgr)
+    if args.output_file:
+        write_to_textfile(args.output_file, registry)
+    else:
+        metrics = generate_latest(registry)
+        print(metrics.decode('utf-8'))
+
+
+subcmds = dict(
+    prometheus=prometheus
+)
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description="Tool used to evaluate control files",
+        epilog="Usage example: utils/controleval.py prometheus -p rhel9")
+    parser.add_argument(
+        '--controls-dir', default='./controls/', help=(
+            "Directory that contains control files with policy controls. "
+            "e.g.: ~/scap-security-guide/controls"))
+    subparsers = parser.add_subparsers(dest='subcmd', required=True)
+
+    prometheus_parser = subparsers.add_parser(
+        'prometheus',
+        help="calculate and return benchmarks metrics in Prometheus format")
+    prometheus_parser.add_argument(
+        '-p', '--products', nargs='+', required=True,
+        help="list of products to process the respective controls files")
+    prometheus_parser.add_argument(
+        '-f', '--output-file',
+        help="save policy metrics in a file instead of showing in stdout")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_arguments()
+    subcmds[args.subcmd](args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
#### Description:

In the previous state of `controleval.py` we can easily collect stats about control files.
This is pretty useful to check the current state.
However, it would be also very useful to have metrics showing the history of policies so we can easily see how it is progressing, maintained, etc. To achieve this, the information should be periodically collected and ideally stored in a time series database.

[Prometheus](https://prometheus.io/) is a pretty popular and straightforward tool to collect metrics in a time series database which can be easily integrated with [Grafana](https://grafana.com/) to show nice dashboards, like it is done in the [CommunityMon](https://github.com/marcusburghardt/CommunityMon) project.

This PR extends the `controleval.py` tool to use the already collected metrics and export them in the Prometheus format.

#### Rationale:

- Better resources to monitor control files requirements
- Enable easy integration of control files metrics in [CommunityMon](https://github.com/marcusburghardt/CommunityMon) project or any other instance of Prometheus

#### Review Hints:

Please, check the commits and their respective commit messages as they are ordered.
To see how the metrics are exported, here is an example for policies used by rhel9 and rhel8:
```
$ utils/controleval.py prometheus -p rhel9 rhel8 -f /tmp/policies_metrics
$ cat /tmp/policies_metrics
```