### PR TITLE
Use up to date `build_ds_container` script in `add_platform_rule.py`

### DIFF
--- a/utils/add_platform_rule.py
+++ b/utils/add_platform_rule.py
@@ -277,7 +277,7 @@ def clusterTestFunc(args):
         print('* Pushing image build to cluster')
         # execute the build_ds_container script
         buildp = subprocess.run(
-            ['utils/build_ds_container.sh', '-P', 'ocp4', '-P', 'rhcos4'])
+            ['utils/build_ds_container.py', '-P', 'ocp4', 'rhcos4'])
         if buildp.returncode != 0:
             try:
                 os.remove(PROFILE_PATH)


### PR DESCRIPTION
#### Description:

- Switch to the python script.
- And fix the arguments to build ocp4 and rhcos4.
  Having the '-P'  twice caused the script to build only one of the products, the one defined later.


#### Rationale:

- `utils/build_ds_container.sh` is deprecated.