### PR TITLE
Enable logrotate.timer check on RHCOS4

### DIFF
--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/oval/shared.xml
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/oval/shared.xml
@@ -11,7 +11,7 @@
       test_ref="test_logrotate_conf_no_other_keyword" />
       <criteria comment="Check if either logrotate timer or cron job is enabled" operator="OR">
         <criterion comment="Check if /etc/cron.daily/logrotate file exists (and calls logrotate)" test_ref="test_cron_daily_logrotate_existence" />
-{{% if product in ["rhel9", "sle12", "sle15"] %}}
+{{% if product in ["rhcos4", "rhel9", "sle12", "sle15"] %}}
         <extend_definition comment="Check if logrotate timer is being enabled" definition_ref="timer_logrotate_enabled" />
 {{% endif %}}
       </criteria>

--- a/linux_os/guide/system/logging/log_rotation/timer_logrotate_enabled/rule.yml
+++ b/linux_os/guide/system/logging/log_rotation/timer_logrotate_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol9,rhel9,sle12,sle15
+prodtype: ol9,rhcos4,rhel9,sle12,sle15
 
 title: 'Enable logrotate Timer'
 


### PR DESCRIPTION


#### Description:

- Enable check for `logrotate.timer` on `rhcos4`.
  From 4.13 RHCOS4 is based on RHEL9, so this check can be enabled.

#### Rationale:
 - On 4.13, the timer for logrotate is enabled by default.
 - And on 4.12 and older, the daily cron job for logrotate is enabled by default.

#### Fixes:
- `ensure_logrotate_activated` result after remediation with compliance-operator
- CI run on rhcos4-moderate and high.

#### Related:
- https://github.com/ComplianceAsCode/content/pull/10796