### PR TITLE
Fix Gate Test on Fedora Rawhide

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -183,6 +183,9 @@ jobs:
     steps:
       -   name: Run Updates
           run: dnf update -y
+      -   name: Ensure dnf Command
+          run: dnf5 install -y dnf
+          # https://discussion.fedoraproject.org/t/rawhide-psa-what-to-do-if-dnf-goes-missing/87133
       -   name: Install Deps
           run: dnf install -y cmake make openscap-utils bats ansible python3-pip ShellCheck git
       -   name: Checkout


### PR DESCRIPTION
#### Description:

This is a temporary workaround to fix Gate Test on Fedora Rawhide.
The error is present after the `dnf update` command, when the `dnf` command is called again to install the dependencies. At this point, the `dnf` command is not found and the test fails:
```
Run dnf install -y cmake make openscap-utils bats ansible python3-pip ShellCheck git
  dnf install -y cmake make openscap-utils bats ansible python3-pip ShellCheck git
  shell: sh -e {0}
/__w/_temp/f9ab4f29-dc9a-48da-b736-c[1](https://github.com/ComplianceAsCode/content/actions/runs/6074847350/job/16479774206?pr=11044#step:4:1)5a33bd[2](https://github.com/ComplianceAsCode/content/actions/runs/6074847350/job/16479774206?pr=11044#step:4:2)e17.sh: line 1: dnf: command not found
Error: Process completed with exit code 127.
```
More details about this issue in https://discussion.fedoraproject.org/t/rawhide-psa-what-to-do-if-dnf-goes-missing/87133

#### Rationale:

- Reliable Gate tests

#### Review Hints:

Take a look in CI tests and `Build, Test on Fedora Rawhide (Container)` should no longer present the error from description.