### PR TITLE
Improve sshd_use_approved_kex_ordered_stig

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/oval/shared.xml
@@ -13,7 +13,8 @@
              "diffie-hellman-group-exchange-sha256"]  %}}
 {{% endif %}}
 
-{{% set kex_algos_regex=prefix_conf %}}
+{{% set kex_algos_regex=prefix_conf ~ "(?=[\w-])" "(\\b" ~ kex_algos|join("\\b,?)?(\\b") ~ ")?" ~
+                        sufix_conf ~ "[\\s]*(?:#.*)?$" %}}
 
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
@@ -26,10 +27,10 @@
           <extend_definition comment="sshd is not required or requirement is unset"
             definition_ref="sshd_not_required_or_unset" />
           {{% if product in ['sle12', 'sle15'] %}}
-          <extend_definition comment="rpm package openssh removed"
+          <extend_definition comment="package openssh removed"
             definition_ref="package_openssh_removed" />
           {{% else %}}
-          <extend_definition comment="rpm package openssh-server removed"
+          <extend_definition comment="package openssh-server removed"
             definition_ref="package_openssh-server_removed" />
           {{% endif %}}
         </criteria>
@@ -37,10 +38,10 @@
           <extend_definition comment="sshd is required or requirement is unset"
             definition_ref="sshd_required_or_unset" />
           {{% if product in ['sle12', 'sle15'] %}}
-          <extend_definition comment="rpm package openssh installed"
+          <extend_definition comment="package openssh installed"
             definition_ref="package_openssh_installed" />
           {{% else %}}
-          <extend_definition comment="rpm package openssh-server installed"
+          <extend_definition comment="package openssh-server installed"
             definition_ref="package_openssh-server_installed" />
           {{% endif %}}
           <criterion comment="Check Kex in {{{ path }}}"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/comment.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/comment.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
 
 source common.sh
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/common.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/common.sh
@@ -5,7 +5,7 @@ CONF_PREFIX="CRYPTO_POLICY='-oKexAlgorithms="
 KEX_ALGOS="ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512"
 CONF_SUFIX="'"
 CONF_PREFIX_REGEX="^\s*CRYPTO_POLICY"
-{{% elif product in ['ol7','rhel7','sle12','sle15'] %}}
+{{% elif product in ['ol7','rhel7','sle12','sle15','ubuntu2004'] %}}
 FILE_PATH='/etc/ssh/sshd_config'
 CONF_PREFIX="KexAlgorithms "
 KEX_ALGOS="ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/correct_reduced_list.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/correct_reduced_list.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
 
 source common.sh
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/correct_scrambled.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/correct_scrambled.fail.sh
@@ -7,7 +7,7 @@ readarray -t KEX_ALGOS_ARR < <(echo $KEX_ALGOS | tr "," "\n")
 
 #swap first and second algorithms
 
-KEX_ALGOS_SCRAMBLED=$(echo ${KEY_ALGOS_ARR[0]},${KEY_ALGOS_ARR[1]},$(echo ${KEY_ALGOS_ARR[@]:2} | tr " " ","))
+KEX_ALGOS_SCRAMBLED=$(echo ${KEX_ALGOS_ARR[0]},${KEX_ALGOS_ARR[1]},$(echo ${KEX_ALGOS_ARR[@]:2} | tr " " ","))
 
 CONF="${CONF_PREFIX}${KEX_ALGOS_SCRAMBLED}${CONF_SUFIX}"
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/correct_scrambled.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/correct_scrambled.fail.sh
@@ -7,7 +7,7 @@ readarray -t KEX_ALGOS_ARR < <(echo $KEX_ALGOS | tr "," "\n")
 
 #swap first and second algorithms
 
-KEX_ALGOS_SCRAMBLED=$(echo ${KEX_ALGOS_ARR[0]},${KEX_ALGOS_ARR[1]},$(echo ${KEX_ALGOS_ARR[@]:2} | tr " " ","))
+KEX_ALGOS_SCRAMBLED=$(echo ${KEX_ALGOS_ARR[1]},${KEX_ALGOS_ARR[0]},$(echo ${KEX_ALGOS_ARR[@]:2} | tr " " ","))
 
 CONF="${CONF_PREFIX}${KEX_ALGOS_SCRAMBLED}${CONF_SUFIX}"
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/correct_scrambled.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/correct_scrambled.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
 
 source common.sh
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/correct_value.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
 
 source common.sh
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/line_not_there.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/line_not_there.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
 
 source common.sh

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/no_parameters.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/no_parameters.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
 
 source common.sh
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/wrong_value.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
 
 source common.sh
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/oval/shared.xml
@@ -51,7 +51,7 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <local_variable id="var_sshd_config_kex" datatype="string" version="1" comment="MACs values splitted on comma">
+  <local_variable id="var_sshd_config_kex" datatype="string" version="1" comment="KEXs values splitted on comma">
     <split delimiter=",">
       <object_component item_field="subexpression" object_ref="obj_sshd_config_kex" />
     </split>


### PR DESCRIPTION
#### Description:

- While reviewing PR #10738 , I came across an issue in `sshd_use_approved_kex_ordered_stig`. Its OVAL wasn't checking the value against anything and tests were passing for cases that should be failing.
- As @Xeicker suggested, I've reverted the OVAL changes as this issue was introduced in #10639 and fixed issues in the `correct_scrambled.fail.sh` test.
- Added `multi_platform_ubuntu` to tests
- Small fix on `sshd_use_strong_kex` variable state comment

#### Rationale:

- This rule is needed for DISA STIG in different vendors.