### PR TITLE
Expose Prometheus metrics on GitHub Pages

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -31,6 +31,10 @@ jobs:
       - name: Render Policies (Using control files)
         run: ninja render-policies -j2
         working-directory: ./build
+      - name: Generate Prometheus Metrics
+        run: utils/controleval_metrics.py prometheus -p fedora ocp4 rhcos4 rhel9 rhel8 rhel7 sle12 sle15 -f $PAGES_DIR/policies_metrics
+        env:
+          PYTHONPATH: ${{ github.workspace }}
       - name: Generate HTML pages
         run: utils/generate_html_pages.sh $PAGES_DIR
         shell: bash

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -32,7 +32,7 @@ jobs:
         run: ninja render-policies -j2
         working-directory: ./build
       - name: Generate Prometheus Metrics
-        run: utils/controleval_metrics.py prometheus -p fedora ocp4 rhcos4 rhel9 rhel8 rhel7 sle12 sle15 -f $PAGES_DIR/policies_metrics
+        run: utils/controleval_metrics.py prometheus -p fedora ocp4 rhcos4 rhel9 rhel8 rhel7 sle12 sle15 -f ./build/policies_metrics
         env:
           PYTHONPATH: ${{ github.workspace }}
       - name: Generate HTML pages

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Deps
         run: dnf install -y cmake git ninja-build openscap-utils python3-pyyaml python3-jinja2 python3-pytest ansible-lint libxslt python3-pip rsync python3-lxml
       - name: Install deps python
-        run: pip3 install json2html
+        run: pip3 install json2html prometheus_client
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build

--- a/utils/generate_html_pages.sh
+++ b/utils/generate_html_pages.sh
@@ -115,7 +115,7 @@ fi
 # Generate Prometheus Stats
 PROMETHEUS_STATS_DIR="$PAGES_DIR/prometheus_stats"
 mkdir -p "$PROMETHEUS_STATS_DIR"
-mv "$PAGES_DIR/policies_metrics" "$PROMETHEUS_STATS_DIR"
+mv build/policies_metrics "$PROMETHEUS_STATS_DIR"
 
 
 pushd $PAGES_DIR

--- a/utils/generate_html_pages.sh
+++ b/utils/generate_html_pages.sh
@@ -112,6 +112,12 @@ if [ $retVal -ne 0 ]; then
     exit 1
 fi
 
+# Generate Prometheus Stats
+PROMETHEUS_STATS_DIR="$PAGES_DIR/prometheus_stats"
+mkdir -p "$PROMETHEUS_STATS_DIR"
+mv "$PAGES_DIR/policies_metrics" "$PROMETHEUS_STATS_DIR"
+
+
 pushd $PAGES_DIR
 touch index.html
 echo "<!DOCTYPE html>" > index.html
@@ -129,6 +135,7 @@ echo "<li><a href=\"tables/index.html\">Mapping Tables</a></li>" >> index.html
 echo "<li><a href=\"srg_mapping/index.html\">SRG Mapping Tables</a></li>" >> index.html
 echo "<li><a href=\"rendered-policies/index.html\">Rendered Policies</a></li>" >> index.html
 echo "<li><a href=\"components/index.html\">Components</a></li>" >> index.html
+echo "<li><a href=\"prometheus_stats/policies_metrics\">Prometheus Policies Metrics</a></li>" >> index.html
 echo "</ul>" >> index.html
 echo "</body>" >> index.html
 echo "</html>" >> index.html


### PR DESCRIPTION
#### Description:

Complementing the https://github.com/ComplianceAsCode/content/pull/11040 , this PR will generate and expose updated Prometheus metrics after each PR be merged into master branch.

Once merged, the new metrics should be exposed here https://complianceascode.github.io/content-pages/
Once exposed, any Prometheus instance will be able to collect these metrics.

#### Rationale:

- Automation to keep metrics updated
- Enable Prometheus to collect metrics about control files