### PR TITLE
fix naming for UBTU-20-010430

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/rule.yml
@@ -46,7 +46,7 @@ references:
     stigid@rhel8: RHEL-08-010350
     stigid@sle12: SLES-12-010875
     stigid@sle15: SLES-15-010355
-    stigid@ubuntu2004: UBTU-20-01430
+    stigid@ubuntu2004: UBTU-20-010430
 
 ocil_clause: any system wide shared library file is returned and is not group-owned by a required system account
 


### PR DESCRIPTION
The original STIG ID which was UBTU-20-01430 is a nonexistent STIG. This is actually 010430, which is also noted in the STIG profile

#### Description:

- The original STIG ID, UBTU-20-01430 does not exist

#### Rationale:

- Updates the STIG to the correct identifier, UBTU-20-010430
- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:
Build the product:
```
./build_product ubuntu2004
```
To test these changes with `Ansible`:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010430"
```

To test changes with `bash`, run the remediation section: `xccdf_org.ssgproject.content_rule_root_permissions_syslibrary_files`

Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout dexterle:add-manual-stig-ubtu-20-v1r9
```

This STIG cannot be tested with the latest Ubuntu 2004 Benchmark SCAP, and must be done manually. For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/
