### PR TITLE
Add UBTU-20-010181 for generating audit record for unsuccessful attem…

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/ansible/shared.yml
@@ -1,10 +1,10 @@
-# platform = multi_platform_rhel,multi_platform_rhv,multi_platform_sle,multi_platform_ol
+# platform = multi_platform_rhel,multi_platform_rhv,multi_platform_sle,multi_platform_ol,multi_platform_ubuntu
 # reboot = false
 # complexity = low
 # disruption = low
 # strategy = configure
 
-{{% if "ol" in product or 'rhel' in product %}}
+{{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
 {{% set auid_filters = "-F auid>=" ~ auid ~ " -F auid!=unset" %}}
 {{% else %}}
 {{% set auid_filters = "" %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/bash/shared.sh
@@ -12,7 +12,7 @@ for ARCH in "${RULE_ARCHS[@]}"
 do
 	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
 	OTHER_FILTERS=""
-	{{% if "ol" in product or 'rhel' in product %}}
+	{{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
 	AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
 	{{% else %}}
 	AUID_FILTERS=""

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/oval/shared.xml
@@ -36,7 +36,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_ardm_delete_module_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    {{% if "ol" in product or 'rhel' in product %}}
+    {{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+delete_module[\s]+|([\s]+|[,])delete_module([\s]+|[,]))).*(?:-F\s+auid>={{{ uid_min }}}[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+delete_module[\s]+|([\s]+|[,])delete_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
@@ -49,7 +49,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_ardm_delete_module_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    {{% if "ol" in product or 'rhel' in product %}}
+    {{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+delete_module[\s]+|([\s]+|[,])delete_module([\s]+|[,]))).*(?:-F\s+auid>={{{ uid_min }}}[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+delete_module[\s]+|([\s]+|[,])delete_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
@@ -62,7 +62,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_ardm_delete_module_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    {{% if "ol" in product or 'rhel' in product %}}
+    {{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+delete_module[\s]+|([\s]+|[,])delete_module([\s]+|[,]))).*(?:-F\s+auid>={{{ uid_min }}}[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+delete_module[\s]+|([\s]+|[,])delete_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
@@ -75,7 +75,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_ardm_delete_module_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    {{% if "ol" in product or 'rhel' in product %}}
+    {{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+delete_module[\s]+|([\s]+|[,])delete_module([\s]+|[,]))).*(?:-F\s+auid>={{{ uid_min }}}[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+delete_module[\s]+|([\s]+|[,])delete_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/rule.yml
@@ -67,7 +67,7 @@ references:
     stigid@rhel8: RHEL-08-030390
     stigid@sle12: SLES-12-020730
     stigid@sle15: SLES-15-030520
-    stigid@ubuntu2004: UBTU-20-010302
+    stigid@ubuntu2004: UBTU-20-010181
 
 {{{ complete_ocil_entry_audit_syscall(syscall="delete_module") }}}
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/rule.yml
@@ -7,7 +7,7 @@ title: 'Ensure auditd Collects Information on Kernel Module Unloading - delete_m
 description: |-
     To capture kernel module unloading events, use following line, setting ARCH to
     either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:
-    {{% if "ol" in product or 'rhel' in product %}}
+    {{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=<i>ARCH</i> -S delete_module -F auid>={{{ uid_min }}} -F auid!=unset -F key=modules</pre>
     {{% else %}}
     <pre>-a always,exit -F arch=<i>ARCH</i> -S delete_module -F key=modules</pre>

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -343,6 +343,7 @@ selections:
     - audit_rules_kernel_module_loading_finit
 
     # UBTU-20-010181 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the delete_module syscall
+    - audit_rules_kernel_module_loading_delete
 
     # UBTU-20-010182 The Ubuntu operating system must produce audit records and reports containing information to establish when, where, what type, the source, and the outcome for all DoD-defined auditable events and actions in near real time.
     - package_audit_installed
@@ -419,9 +420,6 @@ selections:
 
     # UBTU-20-010300 The Ubuntu operating system must have a crontab script running weekly to offload audit events of standalone systems.
     - auditd_offload_logs
-
-    # UBTU-20-010302 The Ubuntu operating system must generate records for successful/unsuccessful uses of delete_module syscall.
-    - audit_rules_kernel_module_loading_delete
 
     # UBTU-20-010400 The Ubuntu operating system must limit the number of concurrent sessions to ten for all accounts and/or account types.
     - var_accounts_max_concurrent_login_sessions=10


### PR DESCRIPTION

#### Description:

- Add UBTU-20-010181
- Removes UBTU-20-010302
- Fix remediations and OVAL definitions for Ubuntu

#### Rationale:

- Removes UBTU-20-010302 which no longer exists, and replaces with UBTU-20-010181
- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
To test these changes with Ansible:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010181"
```
To test changes with bash, run the remediation section: `xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_delete`

Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout dexterle:add-manual-stig-ubtu-20-v1r9
```

This STIG can be tested with the latest Ubuntu 2004 Benchmark SCAP. For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/
