### PR TITLE
Fix UBTU-20-10450 STIG

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/rule.yml
@@ -70,6 +70,7 @@ references:
     stigid@rhel8: RHEL-08-010359
     stigid@sle12: SLES-12-010499
     stigid@sle15: SLES-15-010419
+    stigid@ubuntu2004: UBTU-20-010450
 
 ocil_clause: 'there is no database file'
 

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -564,6 +564,7 @@ selections:
 
     # UBTU-20-010450 The Ubuntu operating system must use a file integrity tool to verify correct operation of all security functions.
     - package_aide_installed
+    - aide_build_database
 
     # UBTU-20-010451 The Ubuntu operating system must notify designated personnel if baseline configurations are changed in an unauthorized manner. The file integrity tool must notify the System Administrator when changes to the baseline configuration or anomalies in the operation of any security functions are discovered.
 


### PR DESCRIPTION
#### Description:

- Fix UBTU-20-010450
- Add rule target in stig profile

#### Rationale:

- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
To test these changes with Ansible:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010450"
```
To test changes with bash, run the remediation section: `xccdf_org.ssgproject.content_rule_aide_build_database` and `xccdf_org.ssgproject.content_rule_package_aide_installed`

Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout dexterle:add-manual-stig-ubtu-20-v1r9
```

This STIG can be tested with the latest Ubuntu 2004 Benchmark SCAP. For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/
