### PR TITLE
Add rules ubtu 20 010437

### DIFF
--- a/components/aide.yml
+++ b/components/aide.yml
@@ -6,6 +6,7 @@ packages:
 rules:
 - aide_build_database
 - aide_check_audit_tools
+- aide_disable_silentreports
 - aide_periodic_cron_checking
 - aide_periodic_checking_systemd_timer
 - aide_scan_notification

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_disable_silentreports/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_disable_silentreports/rule.yml
@@ -1,0 +1,49 @@
+documentation_complete: true
+
+prodtype: ubuntu1804,ubuntu2004
+
+title: 'Configure AIDE To Notify Personnel if Baseline Configurations Are Altered'
+
+description: |-
+    The operating system file integrity tool must be configured to notify designated personnel of any changes to configurations.
+
+rationale: |-
+    Detecting changes in the system can help avoid unintended, and negative consequences 
+    that could affect the security state of the operating system
+
+severity: medium
+
+references:
+    disa: "CCI-001744,CCI-002702"
+    srg: "SRG-OS-000447-GPOS-00201,SRG-OS-000363-GPOS-00150"
+    stigid@ubuntu2004: UBTU-20-010437
+
+ocil_clause: 'silentreports is enabled in aide default configuration, or is missing'
+
+ocil: |- 
+    Verify that Advanced Intrusion Detection Environment (AIDE) notifies the System Administrator
+    when anomalies in the operation of any security functions are discovered with the following command: 
+    <pre># grep SILENTREPORTS {{{ aide_default_path }}} </pre>
+
+    SILENTREPORTS=no 
+
+    If SILENTREPORTS is commented out, this is a finding. 
+ 
+    If SILENTREPORTS is set to "yes", this is a finding. 
+ 
+    If SILENTREPORTS is not set to "no", this is a finding.
+
+fixtext: |-
+    Configure the {{{ full_name }}} operating system to notify designated personnel if baseline configurations are changed in an unauthorized manner. 
+ 
+    Modify the "SILENTREPORTS" parameter in the "{{{ aide_default_path }}}" file with a value of "no" if it does not already exist.
+
+srg_requirement:
+    {{{ full_name }}} must notify designated personnel if baseline configurations are changed in an unauthorized manner.
+
+template: 
+    name: lineinfile
+    vars:
+      text: 'SILENTREPORTS=no'
+      path: '{{{ aide_default_path }}}'
+

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_disable_silentreports/tests/correct.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_disable_silentreports/tests/correct.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = aide
+
+echo "SILENTREPORTS=no" >> /etc/default/aide

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_disable_silentreports/tests/not_config.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_disable_silentreports/tests/not_config.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = aide
+
+echo sed -i "^SILENTREPORTS\s*=\s*no$" /etc/default/aide

--- a/products/ubuntu2004/product.yml
+++ b/products/ubuntu2004/product.yml
@@ -22,6 +22,7 @@ oval_feed_url: "https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.fo
 
 aide_bin_path: "/usr/bin/aide.wrapper"
 aide_conf_path: "/etc/aide/aide.conf"
+aide_default_path: "/etc/default/aide"
 chrony_conf_path: "/etc/chrony/chrony.conf"
 
 cpes_root: "../../shared/applicability"

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -526,6 +526,7 @@ selections:
     - chronyd_sync_clock
 
     # UBTU-20-010437 The Ubuntu operating system must notify designated personnel if baseline configurations are changed in an unauthorized manner. The file integrity tool must notify the System Administrator when changes to the baseline configuration or anomalies in the oper
+    - aide_disable_silentreports
 
     # UBTU-20-010438 The Ubuntu operating system's Advance Package Tool (APT) must be configured to prevent the installation of patches, service packs, device drivers, or Ubuntu operating system components without verification they have been digitally signed using a certificate that is recognized and approved by the organization.
     - apt_conf_disallow_unauthenticated

--- a/tests/data/product_stability/ubuntu2004.yml
+++ b/tests/data/product_stability/ubuntu2004.yml
@@ -2,6 +2,7 @@ aide_also_checks_audispd: 'yes'
 aide_also_checks_rsyslog: 'no'
 aide_bin_path: /usr/bin/aide.wrapper
 aide_conf_path: /etc/aide/aide.conf
+aide_default_path: /etc/default/aide
 audisp_conf_path: /etc/audit
 auid: 1000
 basic_properties_derived: true


### PR DESCRIPTION
#### Description:

- Adds new rule: `aide_disable_silentreports`
- Adds UBTU-20-010437
- Defines `aide_default_path`
- Ensures aide database is built after initializing 

#### Rationale:

- Adds in new STIG: UBTU-20-010437, and ensures that AIDE is built properly
- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
To test these changes with Ansible:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010437"
```
To test changes with bash, run the remediation section: `xccdf_org.ssgproject.content_rule_aide_disable_silentreports`.

Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout dexterle:add-manual-stig-ubtu-20-v1r9
```

This STIG can not be tested with the latest Ubuntu 2004 Benchmark SCAP please test this manually. For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/
