### PR TITLE
Add UBTU-20-010462 to lock accounts without passwords

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/rule.yml
@@ -45,6 +45,7 @@ references:
     stigid@rhel8: RHEL-08-010121
     stigid@sle12: SLES-12-010221
     stigid@sle15: SLES-15-020181
+    stigid@ubuntu2004: UBTU-20-010462
 
 ocil_clause: 'Blank or NULL passwords can be used'
 

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -595,3 +595,6 @@ selections:
     # UBTU-20-010460 The Ubuntu operating system must disable the x86 Ctrl-Alt-Delete key sequence.
     - disable_ctrlaltdel_reboot
     - disable_ctrlaltdel_burstaction
+
+    # UBTU-20-010462 The Ubuntu operating system must not have accounts configured with blank or null passwords.
+    - no_empty_passwords_etc_shadow


### PR DESCRIPTION
This commit will add in STIG UBTU-20-010462 and associate the STIG with the rule no_empty_passwords_etc_shadow.

#### Description:

- Adds UBTU-20-010462

#### Rationale:

- Adds in new STIG: UBTU-20-010462 
- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
To test these changes with Ansible:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010462"
```
To test changes with bash, run the remediation section: `xccdf_org.ssgproject.content_rule_no_empty_passwords_etc_shadow`.

Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout dexterle:add-manual-stig-ubtu-20-v1r9
```

This STIG can be tested with the latest Ubuntu 2004 Benchmark SCAP. For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/
