### PR TITLE
Add UBTU-20-010463 to ensure system does not allow accounts configure…

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/ansible/shared.yml
@@ -1,8 +1,14 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_ubuntu
 # reboot = false
 # strategy = configure
 # complexity = low
 # disruption = medium
+{{% if 'ubuntu' in product %}}
+{{%- set pam_config_paths = "['/etc/pam.d/common-password']" %}}
+{{% else %}}
+{{%- set pam_config_paths = "['/etc/pam.d/system-auth', '/etc/pam.d/password-auth']" -%}}
+{{% endif %}}
+
 - name: '{{{ rule_title }}} - Check if system relies on authselect'
   ansible.builtin.stat:
     path: /usr/bin/authselect
@@ -18,8 +24,6 @@
   ansible.builtin.replace:
     dest: "{{ item }}"
     regexp: 'nullok'
-  loop:
-    - /etc/pam.d/system-auth
-    - /etc/pam.d/password-auth
+  loop: {{{ pam_config_paths }}}
   when:
     - not result_authselect_present.stat.exists

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle,multi_platform_ubuntu
 # reboot = false
 # strategy = configure
 # complexity = low
@@ -10,6 +10,11 @@ NULLOK_FILES=$(grep -rl ".*pam_unix\\.so.*nullok.*" ${PAM_PATH})
 for FILE in ${NULLOK_FILES}; do
    sed --follow-symlinks -i 's/\<nullok\>//g' ${FILE}
 done
+{{% elif 'ubuntu' in product %}}
+COMMON_PASSWORD_PATH="/etc/pam.d/common-password"
+if grep -l "nullok.*" ${COMMON_PASSWORD_PATH}; then
+    sed -i 's/nullok.*//g' ${COMMON_PASSWORD_PATH}
+fi
 {{% else %}}
 if [ -f /usr/bin/authselect ]; then
     {{{ bash_enable_authselect_feature('without-nullok') }}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/oval/shared.xml
@@ -14,6 +14,8 @@
   <ind:textfilecontent54_object id="object_no_empty_passwords" version="1">
 {{% if product in ['sle12', 'sle15'] %}}
     <ind:filepath operation="pattern match">^/etc/pam.d/.*$</ind:filepath>
+{{% elif 'ubuntu' in product %}}
+    <ind:filepath operation="pattern match">^/etc/pam.d/common-password</ind:filepath>
 {{% else %}}
     <ind:filepath operation="pattern match">^/etc/pam.d/(system|password)-auth$</ind:filepath>
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/rule.yml
@@ -9,6 +9,8 @@ description: |-
     <tt>nullok</tt> in
     {{% if product in ["sle12", "sle15"] %}}
     password authentication configurations in <tt>/etc/pam.d/</tt>
+    {{% elif 'ubuntu' in product %}}
+    <tt>/etc/pam.d/common-password</tt>
     {{% else %}}
     <tt>/etc/pam.d/system-auth</tt> and
     <tt>/etc/pam.d/password-auth</tt>
@@ -57,6 +59,7 @@ references:
     stigid@rhel8: RHEL-08-020331,RHEL-08-020332
     stigid@sle12: SLES-12-010231
     stigid@sle15: SLES-15-020300
+    stigid@ubuntu2004: UBTU-20-010463
 
 ocil_clause: 'NULL passwords can be used'
 
@@ -64,6 +67,8 @@ ocil: |-
     To verify that null passwords cannot be used, run the following command:
     {{% if product in ["sle12", "sle15"] %}}
     <pre>$ grep pam_unix.so /etc/pam.d/* | grep nullok</pre>
+    {{% elif 'ubuntu' in product %}}
+    <pre>grep nullok /etc/pam.d/common-password</pre>
     {{% else %}}
     <pre>$ grep nullok /etc/pam.d/system-auth /etc/pam.d/password-auth</pre>
     {{% endif %}}
@@ -72,17 +77,21 @@ ocil: |-
     prevent logins with empty passwords.
 
 fixtext: |-
-    Configure {{{ full_name }}} in the system-auth and password-auth files to not allow null
+    Configure {{{ full_name }}} in the {{% if 'ubuntu' in product %}}common-password file {{% else %}}system-auth and password-auth files {{% endif %}} to not allow null
     passwords.
-
+    {{% if 'ubuntu' in product %}}
+    Remove any instances of the "nullok" option in "/etc/pam.d/common-password"
+    {{% else %}}
     Remove any instances of the "nullok" option in the "/etc/pam.d/system-auth" and
-    "/etc/pam.d/password-auth" files to prevent logons with empty passwords.
+    "/etc/pam.d/password-auth" files 
+    {{% endif %}} 
+    to prevent logons with empty passwords.
 
     Note: Manual changes to the listed file may be overwritten by the "authselect" program.
 
 srg_requirement: |-
-    '{{{ full_name }}} must not allow blank or null passwords in the system-auth file nor
-    password-auth.'
+    '{{{ full_name }}} must not allow blank or null passwords in the {{% if 'ubuntu' in product %}} common-password file.{{% else %}} system-auth file nor
+    password-auth. {{% endif %}}'
 
 warnings:
     - general: |-

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -598,3 +598,6 @@ selections:
 
     # UBTU-20-010461 The Ubuntu operating system must disable automatic mounting of Universal Serial Bus (USB) mass storage driver.
     - kernel_module_usb-storage_disabled
+
+    # UBTU-20-010463 The Ubuntu operating system must not allow accounts configured with blank or null passwords.
+    - no_empty_passwords


### PR DESCRIPTION
#### Description:

- Add UBTU-20-010463
- Add ansible remediation, add support for bash remediation and OVAL definitions for Ubuntu

#### Rationale:

- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
To test these changes with Ansible:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010463"
```
To test changes with bash, run the remediation section: `xccdf_org.ssgproject.content_rule_no_empty_passwords`

Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout dexterle:add-manual-stig-ubtu-20-v1r9
```

This STIG can be tested with the latest Ubuntu 2004 Benchmark SCAP. For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/
