### PR TITLE
Add UBTU-20-010461 to ensure kernel module usb-storage is blacklisted…

### DIFF
--- a/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/rule.yml
@@ -53,6 +53,7 @@ references:
     stigid@rhel8: RHEL-08-040080
     stigid@sle12: SLES-12-010580
     stigid@sle15: SLES-15-010480
+    stigid@ubuntu2004: UBTU-20-010461
 
 {{{ complete_ocil_entry_module_disable(module="usb-storage") }}}
 

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -593,3 +593,6 @@ selections:
 
     # UBTU-20-010462 The Ubuntu operating system must not have accounts configured with blank or null passwords.
     - no_empty_passwords_etc_shadow
+
+    # UBTU-20-010461 The Ubuntu operating system must disable automatic mounting of Universal Serial Bus (USB) mass storage driver.
+    - kernel_module_usb-storage_disabled

--- a/shared/templates/kernel_module_disabled/ansible.template
+++ b/shared/templates/kernel_module_disabled/ansible.template
@@ -9,7 +9,7 @@
     dest: "/etc/modprobe.d/{{{ KERNMODULE }}}.conf"
     regexp: 'install\s+{{{ KERNMODULE }}}'
     line: "install {{{ KERNMODULE }}} /bin/true"
-{{% if product in ["sle12", "sle15"] or 'ol' in product or 'rhel' in product %}}
+{{% if product in ["sle12", "sle15"] or 'ol' in product or 'rhel' in product or 'ubuntu' in product %}}
 - name: Ensure kernel module '{{{ KERNMODULE }}}' is blacklisted
   lineinfile:
     create: yes

--- a/shared/templates/kernel_module_disabled/bash.template
+++ b/shared/templates/kernel_module_disabled/bash.template
@@ -12,7 +12,7 @@ else
 	echo -e "\n# Disable per security requirements" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
 	echo "install {{{ KERNMODULE }}} /bin/true" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
 fi
-{{% if product in ["sle12", "sle15"] or 'ol' in product or 'rhel' in product %}}
+{{% if product in ["sle12", "sle15"] or 'ol' in product or 'rhel' in product or 'ubuntu' in product %}}
 if ! LC_ALL=C grep -q -m 1 "^blacklist {{{ KERNMODULE }}}$" /etc/modprobe.d/{{{ KERNMODULE }}}.conf ; then
 	echo "blacklist {{{ KERNMODULE }}}" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
 fi


### PR DESCRIPTION
#### Description:

- Add UBTU-20-010461
- Modify ansible template for `kernel_module_disable` to add ubuntu2004 support

#### Rationale:

- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
To test these changes with Ansible:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010461"
```
To test changes with bash, run the remediation section: `xccdf_org.ssgproject.content_rule_kernel_module_usb-storage_disabled`

Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout dexterle:add-manual-stig-ubtu-20-v1r9
```

This STIG can be tested with the latest Ubuntu 2004 Benchmark SCAP. For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/
