### PR TITLE
Add UBTU-20-010401 to restrict kernel message buffer

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15
+prodtype: fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Restrict Access to Kernel Message Buffer'
 
@@ -33,6 +33,7 @@ references:
     stigid@rhel8: RHEL-08-010375
     stigid@sle12: SLES-12-010375
     stigid@sle15: SLES-15-010375
+    stigid@ubuntu2004: UBTU-20-010401
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="kernel.dmesg_restrict", value="1") }}}
 

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -427,6 +427,9 @@ selections:
     - var_accounts_max_concurrent_login_sessions=10
     - accounts_max_concurrent_login_sessions
 
+    #UBTU-20-010401 The Ubuntu operating system must restrict access to the kernel message buffer.
+    - sysctl_kernel_dmesg_restrict
+
     # UBTU-20-010403 The Ubuntu operating system must monitor remote access methods.
     - rsyslog_remote_access_monitoring
 


### PR DESCRIPTION
#### Description:

- Add UBTU-20-010401

#### Rationale:

- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
To test these changes with Ansible:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010401"
```
To test changes with bash, run the remediation section: `xccdf_org.ssgproject.content_rule_sysctl_kernel_dmesg_restrict`

Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout dexterle:add-manual-stig-ubtu-20-v1r9
```

This STIG can not be tested with the latest Ubuntu 2004 Benchmark SCAP. Please perform a manual test by following the check text on the Manual STIG. For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/
