### PR TITLE
Modify adie db exist path for UBTU-20-010450

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/ansible/shared.yml
@@ -3,38 +3,37 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: "Ensure AIDE is installed"
-  package:
+{{% if 'sle' in product %}}
+{{%- set aide_init_command = "/usr/bin/aide --init" -%}}
+{{%- set aide_stage_src = "/var/lib/aide/aide.db.new" -%}}
+{{%- set aide_stage_dest = "/var/lib/aide/aide.db" -%}}
+{{% else %}}
+{{%- set aide_init_command = "/usr/sbin/aide --init" -%}}
+{{%- set aide_stage_src = "/var/lib/aide/aide.db.new.gz" -%}}
+{{%- set aide_stage_dest = "/var/lib/aide/aide.db.gz" -%}}
+{{% endif %}}
+
+- name: "{{{ rule_title }}} - Ensure AIDE Is Installed"
+  ansible.builtin.package:
     name: "{{ item }}"
     state: present
   with_items:
     - aide
 
-- name: "Build and Test AIDE Database"
-{{% if 'sle' in product %}}
-  command: /usr/bin/aide --init
-{{% elif 'ubuntu' in product %}}
-  command: /usr/sbin/aideinit -y -f
-{{% else %}}
-  command: /usr/sbin/aide --init
-{{% endif %}}
+- name: "{{{ rule_title }}} - Build and Test AIDE Database"
+  ansible.builtin.command: {{{ aide_init_command }}}
   changed_when: True
 
 # mainly to allow ansible's check mode to work
-- name: "Check whether the stock AIDE Database exists"
-  stat:
+- name: "{{{ rule_title }}} - Check Whether the Stock AIDE Database Exists"
+  ansible.builtin.stat:
     path: /var/lib/aide/aide.db.new.gz
   register: aide_database_stat
 
-- name: "Stage AIDE Database"
-  copy:
-{{% if 'ubuntu' in product or 'sle' in product %}}
-    src: /var/lib/aide/aide.db.new
-    dest: /var/lib/aide/aide.db
-{{% else %}}
-    src: /var/lib/aide/aide.db.new.gz
-    dest: /var/lib/aide/aide.db.gz
-{{% endif %}}
+- name: "{{{ rule_title }}} - Stage AIDE Database"
+  ansible.builtin.copy:
+    src: {{{ aide_stage_src }}}
+    dest: {{{ aide_stage_dest }}}
     backup: yes
     remote_src: yes
   when: (aide_database_stat.stat.exists is defined and aide_database_stat.stat.exists)

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/ansible/ubuntu.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/ansible/ubuntu.yml
@@ -1,0 +1,61 @@
+# platform = multi_platform_ubuntu
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: "{{{ rule_title }}} - Ensure AIDE Is Installed"
+  ansible.builtin.apt:
+    name: aide
+    state: present
+
+- name: "{{{ rule_title }}} - Check if DB Path in /etc/aide/aide.conf Is Already Set"
+  ansible.builtin.lineinfile:
+    path: /etc/aide/aide.conf
+    regexp: ^#?(\s*)(database=)(.*)$
+    state: absent
+  check_mode: true
+  changed_when: false
+  register: database_replace
+
+- name: "{{{ rule_title }}} - Check if DB Out Path in /etc/aide/aide.conf Is Already Set"
+  ansible.builtin.lineinfile:
+    path: /etc/aide/aide.conf
+    regexp: ^#?(\s*)(database_out=)(.*)$
+    state: absent
+  check_mode: true
+  changed_when: false
+  register: database_out_replace
+
+- name: "{{{ rule_title }}} - Fix DB Path in Config File if Necessary"
+  ansible.builtin.lineinfile:
+    path: /etc/aide/aide.conf
+    regexp: ^#?(\s*)(database)(\s*)=(\s*)(.*)$
+    line: \2\3=\4file:/var/lib/aide/aide.db
+    backrefs: true
+  when: database_replace.found > 0
+
+- name: "{{{ rule_title }}} - Fix DB Out Path in Config File if Necessary"
+  ansible.builtin.lineinfile:
+    path: /etc/aide/aide.conf
+    regexp: ^#?(\s*)(database_out)(\s*)=(\s*)(.*)$
+    line: \2\3=\4file:/var/lib/aide/aide.db.new
+    backrefs: true
+  when: database_out_replace.found > 0
+
+- name: "{{{ rule_title }}} - Ensure the Default DB Path is Added"
+  ansible.builtin.lineinfile:
+    path: /etc/aide/aide.conf
+    line: database=file:/var/lib/aide/aide.db
+    create: true
+  when: database_replace.found == 0
+
+- name: "{{{ rule_title }}} - Ensure the Default Out Path is Added"
+  ansible.builtin.lineinfile:
+    path: /etc/aide/aide.conf
+    line: database_out=file:/var/lib/aide/aide.db.new
+    create: true
+  when: database_out_replace.found == 0
+
+- name: "{{{ rule_title }}} - Build and Test AIDE Database"
+  ansible.builtin.command: /usr/sbin/aideinit -y -f


### PR DESCRIPTION
#### Description:

- Fix `aide_build_database` ansible remediation to ensure proper aide path

#### Rationale:

- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
To test these changes with Ansible:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010450"
```
To test changes with bash, run the remediation section: `xccdf_org.ssgproject.content_rule_aide_build_database`

Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout dexterle:add-manual-stig-ubtu-20-v1r9
```

This STIG can be tested with the latest Ubuntu 2004 Benchmark SCAP. For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/
