### PR TITLE
Fix rule ubtu 20 010033

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/ansible/shared.yml
@@ -1,32 +1,45 @@
-# platform = multi_platform_sle
+# platform = multi_platform_sle,multi_platform_ubuntu
 # reboot = false
 # strategy = restrict
 # complexity = low
 # disruption = low
 
-- name: "Gather list of packages"
-  package_facts:
+{{%- if 'sle' in product %}}
+  {{%- set pam_package = "pam_pkcs11" %}}
+{{%- else %}}
+  {{%- set pam_package = "libpam-pkcs11" %}}
+{{% endif %}}
+
+{{%- if 'sle' in product %}}
+  {{%- set pam_pkcs11_control_flag = "sufficient" %}}
+{{%- else %}}
+  {{%- set pam_pkcs11_control_flag = "\u005Bsuccess=2 default=ignore\u005D" %}}
+{{% endif %}}
+
+- name: "{{{ rule_title }}} - Gather List of Packages"
+  ansible.builtin.package_facts:
     manager: auto
 
-- name: Check to see if 'pam_pkcs11' module is configured in '/etc/pam.d/common-auth'
-  shell: grep -E '^\s*auth\s+\S+\s+pam_pkcs11\.so' /etc/pam.d/common-auth || true
+- name: "{{{ rule_title }}} - Check to See if 'pam_pkcs11' Module Is Configured in '/etc/pam.d/common-auth'"
+  ansible.builtin.shell: grep -E '^\s*auth\s+\S+\s+pam_pkcs11\.so' /etc/pam.d/common-auth || true
   register: check_pam_pkcs11_module_result
-  when: '"pam_pkcs11" in ansible_facts.packages'
+  changed_when: false
+  when: '"{{{ pam_package }}}" in ansible_facts.packages'
 
-- name: Configure 'pam_pkcs11' module in '/etc/pam.d/common-auth'
-  lineinfile:
+- name: "{{{ rule_title }}} - Configure 'pam_pkcs11' Module in '/etc/pam.d/common-auth'"
+  ansible.builtin.lineinfile:
     path: /etc/pam.d/common-auth
-    line: 'auth sufficient pam_pkcs11.so'
+    line: 'auth {{{ pam_pkcs11_control_flag }}} pam_pkcs11.so'
     insertafter: '^\s*#'
     state: present
-  when:
-    - '"pam_pkcs11" in ansible_facts.packages'
+  when: 
+    - '"{{{ pam_package }}}" in ansible_facts.packages'
     - '"pam_pkcs11.so" not in check_pam_pkcs11_module_result.stdout'
 
-- name: Ensure 'pam_pkcs11' module has 'sufficient' control flag
-  lineinfile:
+- name: "{{{ rule_title }}} - Ensure 'pam_pkcs11' Module Has {{{ pam_pkcs11_control_flag }}} Control Flag"
+  ansible.builtin.lineinfile:
     path: /etc/pam.d/common-auth
     regexp: '^(\s*auth\s+)\S+(\s+pam_pkcs11\.so.*)'
-    line: '\g<1>sufficient\g<2>'
+    line: '\g<1>{{{ pam_pkcs11_control_flag }}}\g<2>'
     backrefs: yes
-  when: '"pam_pkcs11" in ansible_facts.packages'
+  when: '"{{{ pam_package }}}" in ansible_facts.packages'

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/rule.yml
@@ -15,7 +15,11 @@ description: |-
 
     <pre># grep pam_pkcs11.so /etc/pam.d/common-auth
 
+    {{% if 'ubuntu' in product %}}
+    auth [success=2 default=ignore] pam_pkcs11.so</pre>
+    {{% else %}}
     auth sufficient pam_pkcs11.so</pre>
+    {{% endif %}}
 
     For general information about enabling smart card authentication, consult
     the documentation at:
@@ -77,7 +81,11 @@ ocil: |-
 
     <pre># grep pam_pkcs11.so /etc/pam.d/common-auth
 
+    {{% if 'ubuntu' in product %}}
+    auth [success=2 default=ignore] pam_pkcs11.so</pre>
+    {{% else %}}
     auth sufficient pam_pkcs11.so</pre>
+    {{% endif %}}
 
     If <tt>pam_pkcs11.so</tt> is not set in <tt>etc/pam.d/common-auth</tt> this
     is a finding.


### PR DESCRIPTION
#### Description:

- Fix UBTU-20-010033
- Deprecate `ubuntu.xml` OVAL definition and to use modified `shared.xml`
- Refactor ansible remediation to simplify PAM specific packages and config lines

#### Rationale:

- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
To test these changes with Ansible:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010033"
```
To test changes with bash, run the remediation section: `xccdf_org.ssgproject.content_rule_smartcard_pam_enabled`

Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout dexterle:add-manual-stig-ubtu-20-v1r9
```

This STIG can be tested with the latest Ubuntu 2004 Benchmark SCAP. For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/
