### PR TITLE
Fix path for aide to /etc/aide/aide.conf for UBTU-20-010205

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,multi_platform_ol,multi_platform_rhel
+# platform = multi_platform_sle,multi_platform_ol,multi_platform_rhel,multi_platform_ubuntu
 # reboot = false
 # strategy = restrict
 # complexity = low
@@ -30,13 +30,13 @@
 
 - name: Ensure existing AIDE configuration for audit tools are correct
   lineinfile:
-    path: /etc/aide.conf
+    path: {{{ aide_conf_path }}}
     regexp: ^{{ item }}\s
     line: "{{ item }} {{{ aide_string() }}}"
   with_items: "{{ audit_tools }}"
 
 - name: Configure AIDE to properly protect audit tools
   lineinfile:
-    path: /etc/aide.conf
+    path: {{{ aide_conf_path }}}
     line: "{{ item }} {{{ aide_string() }}}"
   with_items: "{{ audit_tools }}"


### PR DESCRIPTION
#### Description:

- Fix UBTU-20-010205
- Use `aide_conf_path` for Ansible remediation instead of hardcoding aide config path

#### Rationale:

- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
To test these changes with Ansible:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010205"
```
To test changes with bash, run the remediation section: `xccdf_org.ssgproject.content_rule_aide_check_audit_tools`

Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout dexterle:add-manual-stig-ubtu-20-v1r9
```

This STIG can not be tested with the latest Ubuntu 2004 Benchmark SCAP. Please perform manual check with the given check text. For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/
