### PR TITLE
Fix UBTU-20-010449 ansible remediation to proper path and substitution

### DIFF
--- a/linux_os/guide/system/software/updating/clean_components_post_updating/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/clean_components_post_updating/ansible/shared.yml
@@ -3,20 +3,31 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+
 {{% if 'sle' in product %}}
-- name: Ensure Zypper Removes Previous Package Versions
-  ini_file:
+- name: "{{{ rule_title }}} - Ensure Zypper Removes Previous Package Versions"
+  ansible.builtin.ini_file:
     dest: /etc/zypp/zypp.conf
     section: main
     option: solver.upgradeRemoveDroppedPackages
     value: true
     create: False
+{{% elif 'ubuntu' in product %}}
+- name: "{{{ rule_title }}} - Ensure Apt Removes Previous Package Versions"
+  ansible.builtin.lineinfile:
+    dest: /etc/apt/apt.conf.d/50unattended-upgrades
+    regexp: ^(\/\/)?\\s*{{ item }}.*$
+    line: '{{ item }} "true";'
+    create: true
+  with_items:
+  - Unattended-Upgrade::Remove-Unused-Dependencies
+  - Unattended-Upgrade::Remove-Unused-Kernel-Packages
 {{% else %}}
-- name: "Ensure {{{ pkg_manager | upper }}} Removes Previous Package Versions"
-  lineinfile:
-      dest: {{{ pkg_manager_config_file }}}
-      regexp: ^#?clean_requirements_on_remove
-      line: clean_requirements_on_remove=1
-      insertafter: '\[main\]'
-      create: yes
+- name: "{{{ rule_title }}} - Ensure {{{ pkg_manager | upper }}} Removes Previous Package Versions"
+  ansible.builtin.lineinfile:
+    dest: {{{ pkg_manager_config_file }}}
+    regexp: ^#?clean_requirements_on_remove
+    line: clean_requirements_on_remove=1
+    insertafter: '\[main\]'
+    create: yes
 {{% endif %}}


### PR DESCRIPTION
#### Description:

- Fix UBTU-20-010449
- Modify Ansible remediation to follow style guide, and Ubuntu proper remediation

#### Rationale:

- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
To test these changes with Ansible:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010449"
```
To test changes with bash, run the remediation section: `xccdf_org.ssgproject.content_rule_clean_components_post_updating`

Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout dexterle:add-manual-stig-ubtu-20-v1r9
```

This STIG can be tested with the latest Ubuntu 2004 Benchmark SCAP. For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/
