### PR TITLE
Add ansible remediation for UBTU-20-010075

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faildelay_delay/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faildelay_delay/ansible/shared.yml
@@ -1,0 +1,12 @@
+# platform = multi_platform_ubuntu
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: "{{{ rule_title }}} - Ensure pam_faildelay.so Is Properly Configured in /etc/pam.d/common-auth"
+  ansible.builtin.lineinfile:
+      dest: /etc/pam.d/common-auth
+      regexp: ^(#)?.*pam_faildelay.so.*$
+      line: auth required pam_faildelay.so delay=4000000
+      create: true

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faildelay_delay/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faildelay_delay/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_ubuntu
+# platform = multi_platform_sle,multi_platform_ubuntu
 
 {{{ bash_instantiate_variables("var_password_pam_delay") }}}
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faildelay_delay/bash/sle12.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faildelay_delay/bash/sle12.sh
@@ -1,5 +1,0 @@
-# platform = multi_platform_sle
-
-{{{ bash_instantiate_variables("var_password_pam_delay") }}}
-
-{{{ bash_ensure_pam_module_options('/etc/pam.d/common-auth', 'auth', 'required', 'pam_faildelay.so', 'delay', "$var_password_pam_delay", "$var_password_pam_delay") }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faildelay_delay/bash/sle15.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faildelay_delay/bash/sle15.sh
@@ -1,5 +1,0 @@
-# platform = multi_platform_sle
-
-{{{ bash_instantiate_variables("var_password_pam_delay") }}}
-
-{{{ bash_ensure_pam_module_options('/etc/pam.d/common-auth', 'auth', 'required', 'pam_faildelay.so', 'delay', "$var_password_pam_delay", "$var_password_pam_delay") }}}


### PR DESCRIPTION
#### Description:

- Fix UBTU-20-010075
- Add Ansible remediation for `accounts_passwords_pam_faildelay_delay`

#### Rationale:

- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
To test these changes with Ansible:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010075"
```

Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout dexterle:add-manual-stig-ubtu-20-v1r9
```

This STIG can be tested with the latest Ubuntu 2004 Benchmark SCAP. For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/
