### PR TITLE
Fix remediation ubtu 20 010065

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/ansible/shared.yml
@@ -7,16 +7,52 @@
 - name: Package facts
   package_facts:
 
+- name: Check if cert_policy entry exists in /etc/pam_pkcs11/pam_pkcs11.conf
+  shell: grep "cert_policy" /etc/pam_pkcs11/pam_pkcs11.conf | wc -l
+  register: cert_policy_count
+  changed_when: false
+  when:
+    {{% if 'sle' in product %}}
+    - "'pam_pkcs11' in ansible_facts.packages"
+    {{% else %}}
+    - "'libpam-pkcs11' in ansible_facts.packages"
+    {{% endif %}}
+
+- name: Add cert_policy entry if none exist in /etc/pam_pkcs11/pam_pkcs11.conf
+  lineinfile:
+    path: /etc/pam_pkcs11/pam_pkcs11.conf
+    line: 'cert_policy = ca,signature,ocsp_on;'
+    create: true
+  when:
+    - (cert_policy_count.stdout | int) == 0
+    {{% if 'sle' in product %}}
+    - "'pam_pkcs11' in ansible_facts.packages"
+    {{% else %}}
+    - "'libpam-pkcs11' in ansible_facts.packages"
+    {{% endif %}}
+
 - name: Replace 'none' from cert_policy
   replace:
     path: /etc/pam_pkcs11/pam_pkcs11.conf
     regexp: (^\s*cert_policy\s*=\s*)none\s*;(\s*$)
     replace: \g<1>ocsp_on,ca,signature;\g<2>
-  when: "'pam_pkcs11' in ansible_facts.packages"
+  when:
+    {{% if 'sle' in product %}}
+    - "'pam_pkcs11' in ansible_facts.packages"
+    {{% else %}}
+    - "'libpam-pkcs11' in ansible_facts.packages"
+    {{% endif %}}
+
 
 - name: Add 'ocsp_on' parameter for cert_policy in /etc/pam_pkcs11/pam_pkcs11.conf
   replace:
     path: /etc/pam_pkcs11/pam_pkcs11.conf
     regexp: (^\s*cert_policy\s*=\s*)(?!.*ocsp_on)(.*)
     replace: \g<1>ocsp_on,\g<2>
-  when: "'pam_pkcs11' in ansible_facts.packages"
+  when:
+    {{% if 'sle' in product %}}
+    - "'pam_pkcs11' in ansible_facts.packages"
+    {{% else %}}
+    - "'libpam-pkcs11' in ansible_facts.packages"
+    {{% endif %}}
+

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/ansible/shared.yml
@@ -1,58 +1,52 @@
-# platform = multi_platform_sle,multi_platform_rhel
+# platform = multi_platform_sle,multi_platform_rhel,multi_platform_ubuntu
 # reboot = false
 # strategy = restrict
 # complexity = low
 # disruption = low
 
-- name: Package facts
-  package_facts:
+{{%- if 'sle' in product %}}
+  {{%- set pam_package = "pam_pkcs11" %}}
+{{%- else %}}
+  {{%- set pam_package = "libpam-pkcs11" %}}
+{{% endif %}}
 
-- name: Check if cert_policy entry exists in /etc/pam_pkcs11/pam_pkcs11.conf
-  shell: grep "cert_policy" /etc/pam_pkcs11/pam_pkcs11.conf | wc -l
-  register: cert_policy_count
-  changed_when: false
-  when:
-    {{% if 'sle' in product %}}
-    - "'pam_pkcs11' in ansible_facts.packages"
-    {{% else %}}
-    - "'libpam-pkcs11' in ansible_facts.packages"
-    {{% endif %}}
+- name: "{{{ rule_title }}} - Gather Package Facts"
+  ansible.builtin.package_facts:
 
-- name: Add cert_policy entry if none exist in /etc/pam_pkcs11/pam_pkcs11.conf
-  lineinfile:
+- name: "{{{ rule_title }}} - Check if cert_policy in /etc/pam_pkcs11/pam_pkcs11.conf Is Already Set"
+  ansible.builtin.lineinfile:
     path: /etc/pam_pkcs11/pam_pkcs11.conf
-    line: 'cert_policy = ca,signature,ocsp_on;'
-    create: true
-  when:
-    - (cert_policy_count.stdout | int) == 0
-    {{% if 'sle' in product %}}
-    - "'pam_pkcs11' in ansible_facts.packages"
-    {{% else %}}
-    - "'libpam-pkcs11' in ansible_facts.packages"
-    {{% endif %}}
+    regexp: ^(\s*)cert_policy\s+.*
+    state: absent
+  check_mode: true
+  changed_when: false
+  register: cert_policy_replace
+  when: '"{{{ pam_package }}}" in ansible_facts.packages'
 
-- name: Replace 'none' from cert_policy
-  replace:
+- name: "{{{ rule_title }}} - Ensure 'none' Parameter for cert_policy in /etc/pam_pkcs11/pam_pkcs11.conf Is Removed"
+  ansible.builtin.replace:
     path: /etc/pam_pkcs11/pam_pkcs11.conf
     regexp: (^\s*cert_policy\s*=\s*)none\s*;(\s*$)
     replace: \g<1>ocsp_on,ca,signature;\g<2>
   when:
-    {{% if 'sle' in product %}}
-    - "'pam_pkcs11' in ansible_facts.packages"
-    {{% else %}}
-    - "'libpam-pkcs11' in ansible_facts.packages"
-    {{% endif %}}
-
-
-- name: Add 'ocsp_on' parameter for cert_policy in /etc/pam_pkcs11/pam_pkcs11.conf
-  replace:
+  - cert_policy_replace.found > 0 
+  - '"{{{ pam_package }}}" in ansible_facts.packages'
+  
+- name: "{{{ rule_title }}} - Add 'ocsp_on' Parameter for cert_policy in /etc/pam_pkcs11/pam_pkcs11.conf"
+  ansible.builtin.replace:
     path: /etc/pam_pkcs11/pam_pkcs11.conf
     regexp: (^\s*cert_policy\s*=\s*)(?!.*ocsp_on)(.*)
     replace: \g<1>ocsp_on,\g<2>
   when:
-    {{% if 'sle' in product %}}
-    - "'pam_pkcs11' in ansible_facts.packages"
-    {{% else %}}
-    - "'libpam-pkcs11' in ansible_facts.packages"
-    {{% endif %}}
+  - cert_policy_replace.found > 0 
+  - '"{{{ pam_package }}}" in ansible_facts.packages'
 
+- name: "{{{ rule_title }}} - Add cert_policy if It Does Not Exist"
+  ansible.builtin.lineinfile:
+    path: /etc/pam_pkcs11/pam_pkcs11.conf
+    line: cert_policy = ocsp_on,ca,signature;
+    state: present
+    create: true
+  when: 
+  - cert_policy_replace.found == 0
+  - '"{{{ pam_package }}}" in ansible_facts.packages'

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/bash/shared.sh
@@ -1,6 +1,10 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_ol,multi_platform_sle
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_ol,multi_platform_sle,multi_platform_ubuntu
 
+{{% if 'ubuntu' in product %}}
+{{{ bash_package_install("libpam-pkcs11") }}}
+{{% else %}}
 {{{ bash_package_install("pam_pkcs11") }}}
+{{% endif %}}
 
 if grep "^\s*cert_policy" /etc/pam_pkcs11/pam_pkcs11.conf | grep -qv "ocsp_on"; then
 	sed -i "/^\s*#/! s/cert_policy.*/cert_policy = ca, ocsp_on, signature;/g" /etc/pam_pkcs11/pam_pkcs11.conf

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/bash/ubuntu.sh
@@ -1,9 +1,0 @@
-# platform = multi_platform_ubuntu
-
-if [ ! -f /etc/pam_pkcs11/pam_pkcs11.conf ]; then
-    cp /usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example /etc/pam_pkcs11/pam_pkcs11.conf
-fi
-
-if grep -v "^\s*\#+cert_policy" /etc/pam_pkcs11/pam_pkcs11.conf | grep -qv "oscp_on"; then
-    sed -i "s/\(^[[:blank:]]*\)\(\(\#*[[:blank:]]*cert_policy[[:blank:]]*=[[:blank:]]*.*;\)[^ $]*\)/\1cert_policy = ca,signature,ocsp_on;/" /etc/pam_pkcs11/pam_pkcs11.conf
-fi


### PR DESCRIPTION
#### Description:

- Fix UBTU-20-010065
- Fix Ansible remediation `smartcard_configure_cert_checking` and use proper styling

#### Rationale:

- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
To test these changes with Ansible:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010065"
```

Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout dexterle:add-manual-stig-ubtu-20-v1r9
```

This STIG can be tested with the latest Ubuntu 2004 Benchmark SCAP. For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/
