### PR TITLE
Add UBTU-20-010045 for enforcing proper kex exchange algorithms

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/comment.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/comment.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
 
 source common.sh
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/common.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/common.sh
@@ -5,7 +5,7 @@ CONF_PREFIX="CRYPTO_POLICY='-oKexAlgorithms="
 KEX_ALGOS="ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512"
 CONF_SUFIX="'"
 CONF_PREFIX_REGEX="^\s*CRYPTO_POLICY"
-{{% elif product in ['ol7','rhel7','sle12','sle15'] %}}
+{{% elif product in ['ol7','rhel7','sle12','sle15','ubuntu2004'] %}}
 FILE_PATH='/etc/ssh/sshd_config'
 CONF_PREFIX="KexAlgorithms "
 KEX_ALGOS="ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/correct_reduced_list.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/correct_reduced_list.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
 
 source common.sh
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/correct_scrambled.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/correct_scrambled.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
 
 source common.sh
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/correct_value.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
 
 source common.sh
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/line_not_there.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/line_not_there.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
 
 source common.sh

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/no_parameters.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/no_parameters.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
 
 source common.sh
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/wrong_value.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
 
 source common.sh
 


### PR DESCRIPTION
This commit will add UBTU-20-010045 for sshd_use_approved_kex_ordered_stig rule. Additionally, ubuntu2004 has been included in the tests

#### Description:

- _Description here. Replace this text. Don't use the italics format!_

#### Rationale:

- _Rationale here. Replace this text. Don't use the italics format!_

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._

#### Review Hints:

- _Review hints here. Replace this text. Don't use the italics format!_

- _Use this optional section to give any relevant information which could help the reviewer to more quickly and assertively understand and test the changes._

- _Good examples are useful commands, if it is better to review all commits together or in a suggested sequence, any relevant discussion in other PRs or issues, etc._