### PR TITLE
Add UBTU-20-010044 to existing ansible remediation

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Oracle Linux 7,multi_platform_sle
+# platform = Red Hat Enterprise Linux 7,Oracle Linux 7,multi_platform_sle,multi_platform_ubuntu
 # reboot = false
 # strategy = restrict
 # complexity = low


### PR DESCRIPTION
#### Description:

- Fix UBTU-20-010044
- Add `multi_platform_ubuntu` to Ansible remediation

#### Rationale:

- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
To test these changes with Ansible:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010044"
```

Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout dexterle:add-manual-stig-ubtu-20-v1r9
```

This STIG can be tested with the latest Ubuntu 2004 Benchmark SCAP. For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/
