### PR TITLE
Fix rule ubtu 20 010072

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle,multi_platform_ubuntu
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/oval/shared.xml
@@ -12,24 +12,35 @@
         comment="Check expected value for pam_faillock.so audit parameter">
             <criteria operator="AND"
             comment="Check expected pam_faillock.so audit parameter in pam files">
+                {{% if 'ubuntu' not in product %}}
                 <criterion
                 test_ref="test_pam_faillock_audit_parameter_system_auth"
                 comment="Check the audit parameter in auth section of system-auth file"/>
                 <criterion
                 test_ref="test_pam_faillock_audit_parameter_password_auth"
                 comment="Check the audit parameter in auth section of password-auth file"/>
+                {{% else %}}
+                <criterion
+                test_ref="test_pam_faillock_audit_parameter_common_auth"
+                comment="Check the audit parmaeter in auth section of common-auth file"/>
+                {{% endif %}}
+                {{% if 'ubuntu' not in product %}}
                 <criterion
                 test_ref="test_pam_faillock_audit_parameter_no_faillock_conf"
                 comment="Ensure /etc/security/faillock.conf is not used together with pam files"/>
+                {{% endif %}}
             </criteria>
             <criteria operator="AND"
             comment="Check expected pam_faillock.so audit parameter in faillock.conf">
+                {{% if 'ubuntu' not in product %}}
                 <criterion
                 test_ref="test_pam_faillock_audit_parameter_no_pamd_system"
                 comment="Check the audit parameter is not present system-auth file"/>
                 <criterion
                 test_ref="test_pam_faillock_audit_parameter_no_pamd_password"
                 comment="Check the audit parameter is not present password-auth file"/>
+                {{% else %}}
+                {{% endif %}}
                 <criterion
                 test_ref="test_pam_faillock_audit_parameter_faillock_conf"
                 comment="Ensure the audit parameter is present in /etc/security/faillock.conf"/>
@@ -42,6 +53,10 @@
         <value>^[\s]*auth[\s]+(?:required|requisite)[\s]+pam_faillock.so[^\n#]preauth[^\n#]*audit</value>
     </constant_variable>
 
+    <constant_variable id="var_pam_faillock_audit_parameter_authsucc_regex" version="1" datatype="string" comment="regex to identify the authsucc audit parameter in pam files">
+        <value>[\s]*auth[\s]+(?:sufficient)[\s]+pam_faillock.so[^\n#]authsucc</value>
+    </constant_variable>
+
     <ind:textfilecontent54_object id="obj_all_pam_faillock_audit_parameter_system_auth"
     comment="Get the pam_faillock.so preauth audit parameter from system-auth file" version="1">
         <ind:filepath >/etc/pam.d/system-auth</ind:filepath>
@@ -51,10 +66,17 @@
     </ind:textfilecontent54_object>
 
     <ind:textfilecontent54_object id="obj_all_pam_faillock_audit_parameter_password_auth"
-    comment="Get the pam_faillock.so preauth audit parameter from system-auth file" version="1">
+    comment="Get the pam_faillock.so preauth audit parameter from password-auth file" version="1">
         <ind:filepath >/etc/pam.d/password-auth</ind:filepath>
         <ind:pattern operation="pattern match"
         var_ref="var_pam_faillock_audit_parameter_regex" />
+        <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    </ind:textfilecontent54_object>
+
+    <ind:textfilecontent54_object id="obj_all_pam_faillock_audit_parameter_common_auth" comment="Get the pam_faillock.so authsucc audit parameter from common-auth file" version="1">
+        <ind:filepath >/etc/pam.d/common-auth</ind:filepath>
+        <ind:pattern operation="pattern match"
+        var_ref="var_pam_faillock_audit_parameter_authsucc_regex" />
         <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
     </ind:textfilecontent54_object>
 
@@ -71,6 +93,19 @@
     comment="Check the absence of audit parameter in system-auth">
         <ind:object
         object_ref="obj_all_pam_faillock_audit_parameter_system_auth"/>
+    </ind:textfilecontent54_test>
+
+    <!-- Check the pam_faillock.so audit parameter in common-auth -->
+    <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists" version="1"
+    id="test_pam_faillock_audit_parameter_common_auth"
+    comment="Check the presence of audit parameter in common-auth">
+        <ind:object
+        object_ref="obj_all_pam_faillock_audit_parameter_common_auth"/>
+    </ind:textfilecontent54_test>
+
+    <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1" id="test_pam_faillock_audit_parameter_no_pamd_common" comment="Check the absence of audit parameter in common-auth">
+        <ind:object
+        object_ref="obj_all_pam_faillock_audit_parameter_common_auth"/> 
     </ind:textfilecontent54_test>
 
     <!-- Check the pam_faillock.so audit parameter in password-auth -->

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/rule.yml
@@ -20,6 +20,7 @@ references:
     srg: SRG-OS-000021-GPOS-00005
     stigid@ol8: OL08-00-020021
     stigid@rhel8: RHEL-08-020021
+    stigid@ubuntu2004: UBTU-20-010072
 
 {{% if product == "rhel8" %}}
 platform: os_linux[rhel]>=8.2

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_ubuntu
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/oval/ubuntu.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/oval/ubuntu.xml
@@ -10,13 +10,17 @@
             comment="pam_unix.so appears only once in auth section of common-auth"/>
         <criterion test_ref="test_accounts_passwords_pam_faillock_deny_common_pam_faillock_auth"
             comment="pam_faillock.so is properly defined in auth section of common-auth"/>
+        {{% if 'ubuntu2004' not in product %}}
         <criterion test_ref="test_accounts_passwords_pam_faillock_deny_common_pam_faillock_account"
             comment="pam_faillock.so is properly defined in common-account"/>
+        {{% endif %}}
       </criteria>
       <criteria operator="AND"
           comment="Check expected pam_faillock.so deny parameter in faillock.conf">
+        {{% if 'ubuntu2004' not in product %}}
         <criterion test_ref="test_accounts_passwords_pam_faillock_deny_parameter_no_pamd_common"
             comment="Check the deny parameter is not present in common-auth file"/>
+        {{% endif %}}
         <criterion  test_ref="test_accounts_passwords_pam_faillock_deny_parameter_faillock_conf"
             comment="Ensure the deny parameter is present in /etc/security/faillock.conf"/>
         </criteria>
@@ -31,10 +35,32 @@
     <value>^\s*auth.*pam_unix\.so</value>
   </constant_variable>
 
-  <constant_variable id="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_regex"
+  <constant_variable
+  id="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_preauth_regex"
                 datatype="string" version="1"
                 comment="regex to identify pam_faillock.so entries in auth section of pam files">
-    <value>^\s*auth\s+required\s+pam_faillock\.so.*preauth.*[\s\S]*^\s*auth.*pam_unix\.so[\s\S]*^\s*auth\s+\[default=die\]\s+pam_faillock\.so\s+authfail[\s\S]*^\s*auth\s+sufficient\s+pam_faillock\.so\s+authsucc</value>
+    <value>^\s*auth\s+required\s+pam_faillock\.so.*preauth.*$</value>
+  </constant_variable>
+
+  <constant_variable
+  id="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_unix_regex"
+                datatype="string" version="1"
+                comment="regex to identify pam_faillock.so entries in auth section of pam files">
+    <value>^\s*auth.*pam_unix\.so.*$</value>
+  </constant_variable>
+
+  <constant_variable
+  id="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_authfail_regex"
+                datatype="string" version="1"
+                comment="regex to identify pam_faillock.so entries in auth section of pam files">
+    <value>^\s*auth\s+\[default=die\]\s+pam_faillock\.so\s+authfail.*$</value>
+  </constant_variable>
+
+  <constant_variable
+  id="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_authsucc_regex"
+                datatype="string" version="1"
+                comment="regex to identify pam_faillock.so entries in auth section of pam files">
+    <value>^\s*auth\s+sufficient\s+pam_faillock\.so\s+authsucc.*$</value>
   </constant_variable>
 
   <constant_variable id="var_accounts_passwords_pam_faillock_deny_pam_faillock_account_regex"
@@ -86,7 +112,13 @@
         comment="Check common definition of pam_faillock.so in auth section of common-auth">
     <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
     <ind:pattern operation="pattern match"
-                 var_ref="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_regex"/>
+                 var_ref="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_preauth_regex"/>
+    <ind:pattern operation="pattern match"
+                 var_ref="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_unix_regex"/>
+    <ind:pattern operation="pattern match"
+                 var_ref="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_authfail_regex"/>
+    <ind:pattern operation="pattern match"
+                 var_ref="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_authsucc_regex"/>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,ubuntu2204
+prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,ubuntu2004,ubuntu2204
 
 title: 'Lock Accounts After Failed Password Attempts'
 
@@ -65,6 +65,7 @@ references:
     stigid@ol8: OL08-00-020010
     stigid@rhel7: RHEL-07-010320
     stigid@rhel8: RHEL-08-020011
+    stigid@ubuntu2004: UBTU-20-010072
 
 platform: package[pam]
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle,multi_platform_ubuntu
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/oval/ubuntu.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/oval/ubuntu.xml
@@ -10,8 +10,10 @@
             comment="pam_unix.so appears only once in auth section of common-auth"/>
         <criterion test_ref="test_accounts_passwords_pam_faillock_interval_common_pam_faillock_auth"
              comment="pam_faillock.so is properly defined in auth section of common-auth"/>
+        {{% if 'ubuntu2004' not in product %}}
         <criterion test_ref="test_accounts_passwords_pam_faillock_interval_common_pam_faillock_account"
              comment="pam_faillock.so is properly defined in common-account"/>
+        {{% endif %}}
       </criteria>
       <criteria operator="AND"
                 comment="Check expected value for pam_faillock.so fail_interval parameter">
@@ -31,10 +33,32 @@
     <value>^\s*auth.*pam_unix\.so</value>
   </constant_variable>
 
-  <constant_variable id="var_accounts_passwords_pam_faillock_interval_pam_faillock_auth_regex"
+  <constant_variable
+  id="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_preauth_regex"
                 datatype="string" version="1"
                 comment="regex to identify pam_faillock.so entries in auth section of pam files">
-    <value>^\s*auth\s+required\s+pam_faillock\.so.*preauth.*[\s\S]*^\s*auth.*pam_unix\.so[\s\S]*^\s*auth\s+\[default=die\]\s+pam_faillock\.so\s+authfail[\s\S]*^\s*auth\s+sufficient\s+pam_faillock\.so\s+authsucc</value>
+    <value>^\s*auth\s+required\s+pam_faillock\.so.*preauth.*$</value>
+  </constant_variable>
+
+  <constant_variable
+  id="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_unix_regex"
+                datatype="string" version="1"
+                comment="regex to identify pam_faillock.so entries in auth section of pam files">
+    <value>^\s*auth.*pam_unix\.so.*$</value>
+  </constant_variable>
+
+  <constant_variable
+  id="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_authfail_regex"
+                datatype="string" version="1"
+                comment="regex to identify pam_faillock.so entries in auth section of pam files">
+    <value>^\s*auth\s+\[default=die\]\s+pam_faillock\.so\s+authfail.*$</value>
+  </constant_variable>
+
+  <constant_variable
+  id="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_authsucc_regex"
+                datatype="string" version="1"
+                comment="regex to identify pam_faillock.so entries in auth section of pam files">
+    <value>^\s*auth\s+sufficient\s+pam_faillock\.so\s+authsucc.*$</value>
   </constant_variable>
 
   <constant_variable id="var_accounts_passwords_pam_faillock_interval_pam_faillock_account_regex"
@@ -86,7 +110,13 @@
         comment="Check common definition of pam_faillock.so in auth section of common-auth">
     <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
     <ind:pattern operation="pattern match"
-                 var_ref="var_accounts_passwords_pam_faillock_interval_pam_faillock_auth_regex"/>
+                 var_ref="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_preauth_regex"/>
+    <ind:pattern operation="pattern match"
+                 var_ref="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_unix_regex"/>
+    <ind:pattern operation="pattern match"
+                 var_ref="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_authfail_regex"/>
+    <ind:pattern operation="pattern match"
+                 var_ref="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_authsucc_regex"/>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle15,ubuntu2204
+prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle15,ubuntu2004,ubuntu2204
 
 title: 'Set Interval For Counting Failed Password Attempts'
 
@@ -55,6 +55,7 @@ references:
     stigid@ol8: OL08-00-020012
     stigid@rhel7: RHEL-07-010320
     stigid@rhel8: RHEL-08-020012,RHEL-08-020013
+    stigid@ubuntu2004: UBTU-20-010072
 
 platform: package[pam]
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/ansible/shared.yml
@@ -5,6 +5,12 @@
 # disruption = low
 {{{ ansible_pam_faillock_enable() }}}
 
+{{% if 'ubuntu' in product %}}
+  {{%- set pam_path = ['/etc/pam.d/common-auth'] %}}
+{{% else %}}
+  {{%- set pam_path = ['/etc/pam.d/system-auth', '/etc/pam.d/password-auth'] %}}
+{{% endif %}}
+
 - name: {{{ rule_title }}} - Check the presence of /etc/security/faillock.conf file
   ansible.builtin.stat:
     path: /etc/security/faillock.conf
@@ -29,12 +35,6 @@
         regexp: (^\s*auth\s+)([\w\[].*\b)(\s+pam_faillock.so preauth(:?(?!silent).)*)
         line: \1required\3 silent
         state: present
-      loop:
-        {{% if 'ubuntu' in product %}}
-        - /etc/pam.d/common-auth
-        {{% else %}}
-        - /etc/pam.d/system-auth
-        - /etc/pam.d/password-auth
-        {{% endif %}}
+      loop: {{{ pam_path }}}
   when:
     - not result_faillock_conf_check.stat.exists

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/ansible/shared.yml
@@ -30,7 +30,11 @@
         line: \1required\3 silent
         state: present
       loop:
+        {{% if 'ubuntu' in product %}}
+        - /etc/pam.d/common-auth
+        {{% else %}}
         - /etc/pam.d/system-auth
         - /etc/pam.d/password-auth
+        {{% endif %}}
   when:
     - not result_faillock_conf_check.stat.exists

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/oval/shared.xml
@@ -10,6 +10,7 @@
             that if faillock.conf is available, authselect tool only manage parameters on it -->
         <criteria operator="OR"
         comment="Check expected value for pam_faillock.so silent parameter">
+            {{% if 'ubuntu' not in product %}}
             <criteria operator="AND"
             comment="Check expected pam_faillock.so silent parameter in pam files">
                 <criterion
@@ -19,14 +20,17 @@
                 test_ref="test_pam_faillock_silent_parameter_password_auth"
                 comment="Check the silent parameter in auth section of password-auth file"/>
             </criteria>
+            {{% endif %}}
             <criteria operator="AND"
             comment="Check expected pam_faillock.so silent parameter in faillock.conf">
+                {{% if 'ubuntu' not in product %}}
                 <criterion
                 test_ref="test_pam_faillock_silent_parameter_no_pamd_system"
                 comment="Check the silent parameter is not present system-auth file"/>
                 <criterion
                 test_ref="test_pam_faillock_silent_parameter_no_pamd_password"
                 comment="Check the silent parameter is not present password-auth file"/>
+                {{% endif %}}
                 <criterion
                 test_ref="test_pam_faillock_silent_parameter_faillock_conf"
                 comment="Ensure the silent parameter is present in /etc/security/faillock.conf"/>
@@ -48,7 +52,7 @@
     </ind:textfilecontent54_object>
 
     <ind:textfilecontent54_object id="obj_all_pam_faillock_silent_parameter_password_auth"
-    comment="Get the pam_faillock.so preauth silent parameter from system-auth file" version="1">
+    comment="Get the pam_faillock.so preauth silent parameter from password-auth file" version="1">
         <ind:filepath >/etc/pam.d/password-auth</ind:filepath>
         <ind:pattern operation="pattern match"
         var_ref="var_pam_faillock_silent_parameter_regex" />

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol8,rhel8,rhel9
+prodtype: ol8,rhel8,rhel9,ubuntu2004
 
 title: 'Do Not Show System Messages When Unsuccessful Logon Attempts Occur'
 
@@ -31,6 +31,7 @@ references:
     srg: SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005
     stigid@ol8: OL08-00-020019
     stigid@rhel8: RHEL-08-020018,RHEL-08-020019
+    stigid@ubuntu2004: UBTU-20-010072
 
 ocil_clause: 'the system shows messages when three unsuccessful logon attempts occur'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_ubuntu
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,ubuntu2204
+prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,ubuntu2004,ubuntu2204
 
 title: 'Set Lockout Time for Failed Password Attempts'
 
@@ -67,6 +67,7 @@ references:
     stigid@ol8: OL08-00-020014
     stigid@rhel7: RHEL-07-010320
     stigid@rhel8: RHEL-08-020014,RHEL-08-020015
+    stigid@ubuntu2004: UBTU-20-010072
 
 platform: package[pam]
 

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -153,7 +153,11 @@ selections:
     - accounts_password_pam_unix_remember
 
     # UBTU-20-010072 The Ubuntu operating system must automatically lock an account until the locked account is released by an administrator when three unsuccessful logon attempts have been made.
-    - accounts_passwords_pam_tally2
+    - accounts_passwords_pam_faillock_audit
+    - accounts_passwords_pam_faillock_silent
+    - accounts_passwords_pam_faillock_deny
+    - accounts_passwords_pam_faillock_interval
+    - accounts_passwords_pam_faillock_unlock_time
 
     # UBTU-20-010074 The Ubuntu operating system must be configured so that the script which runs each 30 days or less to check file integrity is the default one.
     - aide_periodic_cron_checking

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1081,19 +1081,26 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
       changed_when: false
       register: result_pam_faillock_is_enabled
 
-    {{% if 'ubuntu' not in product %}}
     - name: {{{ rule_title }}} - Enable pam_faillock.so preauth editing PAM files
       ansible.builtin.lineinfile:
         path: '{{ item }}'
         line: auth        required      pam_faillock.so preauth
+        {{% if 'ubuntu' in product %}}
+        insertbefore: ^auth.*.*pam_unix\.so.*
+        {{% else %}}
         insertbefore: ^auth.*sufficient.*pam_unix\.so.*
+        {{% endif %}}
         state: present
       loop:
+        {{% if 'ubuntu' in product %}}
+        - /etc/pam.d/common-auth
+        {{% else %}}
         - /etc/pam.d/system-auth
         - /etc/pam.d/password-auth
+        {{% endif %}}
       when:
         - result_pam_faillock_is_enabled.found == 0
-    {{% else %}}
+    {{% if 'ubuntu' not in product %}}
     - name: {{{ rule_title }}} - Enable pam_faillock.so authsucc editing PAM files
       ansible.builtin.lineinfile:
         path: /etc/pam.d/common-auth

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1070,13 +1070,18 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
   block:
     - name: {{{ rule_title }}} - Check if pam_faillock.so is already enabled
       ansible.builtin.lineinfile:
+        {{% if 'ubuntu' in product %}}
+        path: /etc/pam.d/common-auth
+        {{% else %}}
         path: /etc/pam.d/system-auth
+        {{% endif %}}
         regexp: .*auth.*pam_faillock\.so (preauth|authfail)
         state: absent
       check_mode: yes
       changed_when: false
       register: result_pam_faillock_is_enabled
 
+    {{% if 'ubuntu' not in product %}}
     - name: {{{ rule_title }}} - Enable pam_faillock.so preauth editing PAM files
       ansible.builtin.lineinfile:
         path: '{{ item }}'
@@ -1088,19 +1093,38 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
         - /etc/pam.d/password-auth
       when:
         - result_pam_faillock_is_enabled.found == 0
+    {{% else %}}
+    - name: {{{ rule_title }}} - Enable pam_faillock.so authsucc editing PAM files
+      ansible.builtin.lineinfile:
+        path: /etc/pam.d/common-auth
+        line: auth        sufficient      pam_faillock.so authsucc
+        insertbefore: ^auth.*sufficient.*pam_unix\.so.*
+        state: present
+      when:
+        - not result_authselect_present.stat.exists
+    {{% endif %}}
 
     - name: {{{ rule_title }}} - Enable pam_faillock.so authfail editing PAM files
       ansible.builtin.lineinfile:
         path: '{{ item }}'
+        {{% if 'ubuntu' in product %}}
+        line: auth     [default=die]  pam_faillock.so authfail
+        {{% else %}}
         line: auth        required      pam_faillock.so authfail
+        {{% endif %}}
         insertbefore: ^auth.*required.*pam_deny\.so.*
         state: present
       loop:
+        {{% if 'ubuntu' in product %}}
+        - /etc/pam.d/common-auth
+        {{% else %}}
         - /etc/pam.d/system-auth
         - /etc/pam.d/password-auth
+        {{% endif %}}
       when:
         - result_pam_faillock_is_enabled.found == 0
 
+    {{% if 'ubuntu' not in product %}}
     - name: {{{ rule_title }}} - Enable pam_faillock.so account section editing PAM files
       ansible.builtin.lineinfile:
         path: '{{ item }}'
@@ -1112,6 +1136,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
         - /etc/pam.d/password-auth
       when:
         - result_pam_faillock_is_enabled.found == 0
+    {{% endif %}}
   when:
     - not result_authselect_present.stat.exists
 {{%- endmacro -%}}
@@ -1157,8 +1182,12 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
 
 - name: {{{ rule_title }}} - Ensure the pam_faillock.so {{{ parameter }}} parameter not in PAM files
   block:
+    {{% if 'ubuntu' in product %}}
+    {{{ ansible_remove_pam_module_option_configuration('/etc/pam.d/common-auth','auth','','pam_faillock.so',parameter) | indent(4) }}}
+    {{% else %}}
     {{{ ansible_remove_pam_module_option_configuration('/etc/pam.d/system-auth','auth','','pam_faillock.so',parameter) | indent(4) }}}
     {{{ ansible_remove_pam_module_option_configuration('/etc/pam.d/password-auth','auth','','pam_faillock.so',parameter) | indent(4) }}}
+    {{% endif %}}
   when:
     - result_faillock_conf_check.stat.exists
 
@@ -1167,7 +1196,11 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
   block:
     - name: {{{ rule_title }}} - Check if pam_faillock.so {{{ parameter }}} parameter is already enabled in pam files
       ansible.builtin.lineinfile:
+        {{% if 'ubuntu' in product %}}
+        path: /etc/pam.d/common-auth
+        {{% else %}}
         path: /etc/pam.d/system-auth
+        {{% endif %}}
         regexp: .*auth.*pam_faillock\.so (preauth|authfail).*{{{ parameter }}}
         state: absent
       check_mode: yes
@@ -1186,8 +1219,12 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
         {{%- endif %}}
         state: present
       loop:
+        {{% if 'ubuntu' in product %}}
+        - /etc/pam.d/common-auth
+        {{% else %}}
         - /etc/pam.d/system-auth
         - /etc/pam.d/password-auth
+        {{% endif %}}
       when:
         - result_pam_faillock_{{{ parameter }}}_parameter_is_present.found == 0
 
@@ -1204,8 +1241,12 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
         {{%- endif %}}
         state: present
       loop:
+        {{% if 'ubuntu' in product %}}
+        - /etc/pam.d/common-auth
+        {{% else %}}
         - /etc/pam.d/system-auth
         - /etc/pam.d/password-auth
+        {{% endif %}}
       when:
         - result_pam_faillock_{{{ parameter }}}_parameter_is_present.found == 0
     {{%- endif %}}
@@ -1219,8 +1260,12 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
         line: \1required\3\4={{ {{{ faillock_var_name }}} }}\5
         state: present
       loop:
+        {{% if 'ubuntu' in product %}}
+        - /etc/pam.d/common-auth
+        {{% else %}}
         - /etc/pam.d/system-auth
         - /etc/pam.d/password-auth
+        {{% endif %}}
       when:
         - result_pam_faillock_{{{ parameter }}}_parameter_is_present.found > 0
 
@@ -1233,8 +1278,12 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
         line: \1required\3\4={{ {{{ faillock_var_name }}} }}\5
         state: present
       loop:
+        {{% if 'ubuntu' in product %}}
+        - /etc/pam.d/common-auth
+        {{% else %}}
         - /etc/pam.d/system-auth
         - /etc/pam.d/password-auth
+        {{% endif %}}
       when:
         - result_pam_faillock_{{{ parameter }}}_parameter_is_present.found > 0
     {{%- endif %}}


### PR DESCRIPTION
#### Description:

- Fix UBTU-20-010072
- Fix ansible remediation
- Fix OVAL definition

#### Rationale:

- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
To test these changes with Ansible:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010072"
```
To test changes with bash, run the remediation section: `xccdf_org.ssgproject.content_rule_accounts_passwords_pam_faillock_audit`

Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout dexterle:add-manual-stig-ubtu-20-v1r9
```

This STIG can be tested with the latest Ubuntu 2004 Benchmark SCAP. For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/
