### PR TITLE
Fix verify-ssg-ds.xml-override-true-all-profile-* Tests in Rawhide

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -544,24 +544,10 @@ macro(ssg_build_sds PRODUCT)
         endif()
     endif()
     add_test(
-        NAME "verify-ssg-${PRODUCT}-ds.xml-override-true-all-profile-titles"
-        COMMAND "${XMLLINT_EXECUTABLE}" --xpath "//*[local-name()=\"Profile\"]/*[local-name()=\"title\"][not(@override=\"true\")]" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
+        NAME "verify-ssg-${PRODUCT}-ds.xml-override-true-all-profile"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tests/verify_override_true_profile.py" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
     )
-    set_tests_properties("verify-ssg-${PRODUCT}-ds.xml-override-true-all-profile-titles" PROPERTIES LABELS quick)
-    add_test(
-        NAME "verify-ssg-${PRODUCT}-ds.xml-override-true-all-profile-descriptions"
-        COMMAND "${XMLLINT_EXECUTABLE}" --xpath "//*[local-name()=\"Profile\"]/*[local-name()=\"description\"][not(@override=\"true\")]" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
-    )
-    set_tests_properties("verify-ssg-${PRODUCT}-ds.xml-override-true-all-profile-descriptions" PROPERTIES LABELS quick)
-    # Sets WILL_FAIL property for all '*-override-true-all-profile-*' tests to
-    # true as it is expected that XPath of a passing test will be empty (and
-    # non-zero exit code is returned in such case).
-    set_tests_properties(
-        "verify-ssg-${PRODUCT}-ds.xml-override-true-all-profile-titles"
-        "verify-ssg-${PRODUCT}-ds.xml-override-true-all-profile-descriptions"
-        PROPERTIES
-        WILL_FAIL true
-    )
+    set_tests_properties("verify-ssg-${PRODUCT}-ds.xml-override-true-all-profile" PROPERTIES LABELS quick)
     add_test(
         NAME "verify-references-ssg-${PRODUCT}-ds.xml"
         COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/verify_references.py" --rules-with-invalid-checks --base-dir "${CMAKE_BINARY_DIR}" --ovaldefs-unused "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -300,3 +300,18 @@ add_test(
     COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/test_components.py" --build-dir "${CMAKE_BINARY_DIR}" --source-dir "${CMAKE_SOURCE_DIR}" --product "rhel9"
 )
 endif()
+
+add_test(
+    NAME "verify-override-valid"
+    COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/verify_override_true_profile.py" "${CMAKE_CURRENT_SOURCE_DIR}/data/verify_override/valid.xml"
+)
+
+add_test(
+    NAME "verify-override-invalid"
+    COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/verify_override_true_profile.py" "${CMAKE_CURRENT_SOURCE_DIR}/data/verify_override/fail.xml"
+)
+set_tests_properties(
+    "verify-override-invalid"
+    PROPERTIES
+    WILL_FAIL true
+)

--- a/tests/data/verify_override/fail.xml
+++ b/tests/data/verify_override/fail.xml
@@ -1,0 +1,13 @@
+<ds:data-stream-collection xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog" xmlns:cpe-dict="http://cpe.mitre.org/dictionary/2.0" xmlns:cpe-lang="http://cpe.mitre.org/language/2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ds="http://scap.nist.gov/schema/scap/source/1.2" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:ind="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:linux="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" xmlns:ocil="http://scap.nist.gov/schema/ocil/2.0" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" xmlns:xccdf-1.2="http://checklists.nist.gov/xccdf/1.2" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="scap_org.open-scap_collection_from_xccdf_ssg-rhel9-xccdf.xml" schematron-version="1.3">
+
+<xccdf-1.2:Profile id="xccdf_org.ssgproject.content_profile_anssi_bp28_enhanced">
+    <xccdf-1.2:title>ANSSI-BP-028 (enhanced)</xccdf-1.2:title>
+    <xccdf-1.2:description override="true">This profile contains configurations that align to ANSSI-BP-028 v2.0 at the enhanced hardening level.
+
+ANSSI is the French National Information Security Agency, and stands for Agence nationale de la s&#xE9;curit&#xE9; des syst&#xE8;mes d'information.
+ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
+
+A copy of the ANSSI-BP-028 can be found at the ANSSI website:
+https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/</xccdf-1.2:description>
+</xccdf-1.2:Profile>
+</ds:data-stream-collection>

--- a/tests/data/verify_override/valid.xml
+++ b/tests/data/verify_override/valid.xml
@@ -1,0 +1,13 @@
+<ds:data-stream-collection xmlns:cat="urn:oasis:names:tc:entity:xmlns:xml:catalog" xmlns:cpe-dict="http://cpe.mitre.org/dictionary/2.0" xmlns:cpe-lang="http://cpe.mitre.org/language/2.0" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ds="http://scap.nist.gov/schema/scap/source/1.2" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:ind="http://oval.mitre.org/XMLSchema/oval-definitions-5#independent" xmlns:linux="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" xmlns:ocil="http://scap.nist.gov/schema/ocil/2.0" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix" xmlns:xccdf-1.2="http://checklists.nist.gov/xccdf/1.2" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="scap_org.open-scap_collection_from_xccdf_ssg-rhel9-xccdf.xml" schematron-version="1.3">
+
+<xccdf-1.2:Profile id="xccdf_org.ssgproject.content_profile_anssi_bp28_enhanced">
+    <xccdf-1.2:title override="true">ANSSI-BP-028 (enhanced)</xccdf-1.2:title>
+    <xccdf-1.2:description override="true">This profile contains configurations that align to ANSSI-BP-028 v2.0 at the enhanced hardening level.
+
+ANSSI is the French National Information Security Agency, and stands for Agence nationale de la s&#xE9;curit&#xE9; des syst&#xE8;mes d'information.
+ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
+
+A copy of the ANSSI-BP-028 can be found at the ANSSI website:
+https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/</xccdf-1.2:description>
+</xccdf-1.2:Profile>
+</ds:data-stream-collection>

--- a/tests/verify_override_true_profile.py
+++ b/tests/verify_override_true_profile.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python
+
+import argparse
+import lxml.etree as ET
+from sys import stderr
+
+
+TITLES_PATH = "//*[local-name()=\"Profile\"]/*[local-name()=\"title\"][not(@override=\"true\")]"
+DESCRIPTION_PATH = "//*[local-name()=\"Profile\"]/*[local-name()=\"description\"][not(@override=\"true\")]"
+
+def _parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("datastream", help="Path to the datastream to test")
+    return parser.parse_args()
+
+def _get_matching_elements_count(root, xpath_query):
+    elements = root.xpath(xpath_query)
+    return len(elements)
+
+def main():
+    args = _parse_args()
+    datastream = args.datastream
+    status = 0
+    with open(datastream, 'r') as ds_fp:
+        root = ET.parse(ds_fp)
+        if _get_matching_elements_count(root, TITLES_PATH) != 0:
+            print("Datastream %s found profile title without an override." % datastream, file=stderr)
+            status = 1
+        if _get_matching_elements_count(root, DESCRIPTION_PATH) != 0:
+            print("Datastream %s found profile title without an override." % datastream, file=stderr)
+            status += 1
+    exit(status)
+
+
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
#### Description:
Replace the verify-ssg-${PRODUCT}-ds.xml-override-true-all-profile-* tests with a Python based test

#### Rationale:

Fixes #11051

Using a Python script as the behavior of xmllint as been changed.

#### Review Hints:

1.Build your favorite profile product
2. Replace remove `override="true"` from the title and/or description element of your favorite profile in the datastream
3. Run the tests using `ctest -j 9 --output-on-failure -R override-true-all-profile`
4. Observe the failure(s)
 