### PR TITLE
Fix rule ubtu 20 010066

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/oval/shared.xml
@@ -4,6 +4,8 @@
 {{% set smartcard_packages = ['pam_pkcs11', 'mozilla-nss', 'mozilla-nss-tools', 'pcsc-ccid', 'pcsc-lite', 'pcsc-tools', 'opensc'] %}}
 {{% elif product in ["rhel7", "ol7"] %}}
 {{% set smartcard_packages = ['pam_pkcs11'] %}}
+{{% elif product in ["ubuntu2004"] %}}
+{{% set smartcard_packages = ['libpam-pkcs11'] %}}
 {{% else %}}
 {{% set smartcard_packages = ['openssl-pkcs11'] %}}
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_crl/ansible/ubuntu.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_crl/ansible/ubuntu.yml
@@ -1,0 +1,46 @@
+# platform = multi_platform_ubuntu
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: "{{{ rule_title }}} - Gather Package Facts"
+  ansible.builtin.package_facts:
+
+- name: "{{{ rule_title }}} - Check if cert_policy in /etc/pam_pkcs11/pam_pkcs11.conf Is Already Set"
+  ansible.builtin.lineinfile:
+      path: /etc/pam_pkcs11/pam_pkcs11.conf
+      regexp: ^(\s*)cert_policy\s+.*
+      state: absent
+  check_mode: true
+  changed_when: false
+  register: cert_policy_replace
+  when: '"{{{ pam_package }}}" in ansible_facts.packages'
+
+- name: "{{{ rule_title }}} - Ensure 'none' Parameter for cert_policy in /etc/pam_pkcs11/pam_pkcs11.conf Is Removed"
+  ansible.builtin.replace:
+      path: /etc/pam_pkcs11/pam_pkcs11.conf
+      regexp: (^\s*cert_policy\s*=\s*)none\s*;(\s*$)
+      replace: \g<1>ca,signature,ocsp_on,crl_auto;\g<2>
+  when:
+  - cert_policy_replace.found > 0 
+  - '"{{{ pam_package }}}" in ansible_facts.packages'
+
+- name: "{{{ rule_title }}} - Add 'crl_auto' Parameter for cert_policy in /etc/pam_pkcs11/pam_pkcs11.conf"
+  ansible.builtin.replace:
+      path: /etc/pam_pkcs11/pam_pkcs11.conf
+      regexp: (^\s*cert_policy\s*=\s*)(?!.*crl_auto)(.*)
+      replace: \g<1>crl_auto,\g<2>
+  when:
+  - cert_policy_replace.found > 0 
+  - '"{{{ pam_package }}}" in ansible_facts.packages'
+
+- name: "{{{ rule_title }}} - Add cert_policy if It Does Not Exist"
+  ansible.builtin.lineinfile:
+      path: /etc/pam_pkcs11/pam_pkcs11.conf
+      line: cert_policy = ca,signature,ocsp_on,crl_auto;
+      state: present
+      create: true
+  when: 
+  - cert_policy_replace.found == 0
+  - '"{{{ pam_package }}}" in ansible_facts.packages'

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_crl/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_crl/oval/shared.xml
@@ -21,7 +21,7 @@
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_pam_pkcs11_cert_policy_crl" version="1">
-    <ind:subexpression operation="pattern match">(^|,\s*)(crl_auto|crl_offline)(\s*,|$)</ind:subexpression>
+    <ind:subexpression operation="pattern match">(^|,\s*)(crl_auto|crl_offline)(\s*,|$|;)</ind:subexpression>
   </ind:textfilecontent54_state>
 
 </def-group>


### PR DESCRIPTION
#### Description:

- Fix UBTU-20-010066
- Add Ansible remediation for ubuntu
- Fix OVAL Definition to include PAM specific package (Install package PAM)
- Fix OVAL Definition to regex check for a semicolon `;` (smartcard_configure_crl)

#### Rationale:

- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
To test these changes with Ansible:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010066
```
To test changes with bash, run the remediation section: `xccdf_org.ssgproject.content_rule_install_smartcard_packages` and `xccdf_org.ssgproject.content_rule_smartcard_configure_crl`

Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout dexterle:add-manual-stig-ubtu-20-v1r9
```

This STIG can be tested with the latest Ubuntu 2004 Benchmark SCAP. For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/
