### PR TITLE
Deprecate UBTU-20-010180

### DIFF
--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -336,10 +336,8 @@ selections:
     # UBTU-20-010178 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the pam_timestamp_check command.
     - audit_rules_privileged_commands_pam_timestamp_check
 
-    # UBTU-20-010179 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the init_module syscall.
+    # UBTU-20-010179 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the init_module and finit_module syscall.
     - audit_rules_kernel_module_loading_init
-
-    # UBTU-20-010180 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the finit_module syscall.
     - audit_rules_kernel_module_loading_finit
 
     # UBTU-20-010181 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the delete_module syscall


### PR DESCRIPTION
#### Description:

- Deprecate UBTU-20-010180

#### Rationale:

- STIG is replaced with `UBTU-20-010179` and respective PR can be found: https://github.com/ComplianceAsCode/content/pull/11080
- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
UBTU-20-010180 should no longer exist in both Ansible and bash remediations.

