### PR TITLE
Fix UBTU-20-010179 to use proper parameters and key

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/ansible/shared.yml
@@ -1,10 +1,10 @@
-# platform = multi_platform_rhel,multi_platform_ol,multi_platform_rhv,multi_platform_sle
+# platform = multi_platform_rhel,multi_platform_ol,multi_platform_rhv,multi_platform_sle,multi_platform_ubuntu
 # reboot = false
 # complexity = low
 # disruption = low
 # strategy = configure
 
-{{% if "ol" in product or 'rhel' in product %}}
+{{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
 {{% set auid_filters = "-F auid>=" ~ auid ~ " -F auid!=unset" %}}
 {{% else %}}
 {{% set auid_filters = "" %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/bash/shared.sh
@@ -12,7 +12,7 @@ for ARCH in "${RULE_ARCHS[@]}"
 do
 	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
 	OTHER_FILTERS=""
-	{{% if "ol" in product or 'rhel' in product %}}
+	{{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
 	AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
 	{{% else %}}
 	AUID_FILTERS=""

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/oval/shared.xml
@@ -36,7 +36,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_ardm_finit_module_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    {{% if "ol" in product or 'rhel' in product %}}
+    {{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+finit_module[\s]+|([\s]+|[,])finit_module([\s]+|[,]))).*(?:-F\s+auid>={{{ uid_min }}}[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+finit_module[\s]+|([\s]+|[,])finit_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
@@ -49,7 +49,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_ardm_finit_module_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    {{% if "ol" in product or 'rhel' in product %}}
+    {{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+finit_module[\s]+|([\s]+|[,])finit_module([\s]+|[,]))).*(?:-F\s+auid>={{{ uid_min }}}[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+finit_module[\s]+|([\s]+|[,])finit_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
@@ -62,7 +62,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_ardm_finit_module_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    {{% if "ol" in product or 'rhel' in product %}}
+    {{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+finit_module[\s]+|([\s]+|[,])finit_module([\s]+|[,]))).*(?:-F\s+auid>={{{ uid_min }}}[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+finit_module[\s]+|([\s]+|[,])finit_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
@@ -75,7 +75,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_ardm_finit_module_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    {{% if "ol" in product or 'rhel' in product %}}
+    {{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+finit_module[\s]+|([\s]+|[,])finit_module([\s]+|[,]))).*(?:-F\s+auid>={{{ uid_min }}}[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+finit_module[\s]+|([\s]+|[,])finit_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/rule.yml
@@ -9,7 +9,7 @@ description: |-
     to read audit rules during daemon startup (the default), add the following lines to a file
     with suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt> to capture kernel module
     loading and unloading events, setting ARCH to either b32 or b64 as appropriate for your system:
-    {{% if "ol" in product or 'rhel' in product %}}
+    {{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=<i>ARCH</i> -S finit_module -F auid>={{{ uid_min }}} -F auid!=unset -F key=modules</pre>
     {{% else %}}
     <pre>-a always,exit -F arch=<i>ARCH</i> -S finit_module -F key=modules</pre>
@@ -17,7 +17,7 @@ description: |-
     rules during daemon startup, add the following lines to <tt>/etc/audit/audit.rules</tt> file
     in order to capture kernel module loading and unloading events, setting ARCH to either b32 or
     b64 as appropriate for your system:
-    {{% if "ol" in product or 'rhel' in product %}}
+    {{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=<i>ARCH</i> -S finit_module -F auid>={{{ uid_min }}} -F auid!=unset -F key=modules</pre>
     {{% else %}}
     <pre>-a always,exit -F arch=<i>ARCH</i> -S finit_module -F key=modules</pre>
@@ -65,7 +65,7 @@ references:
     stigid@rhel8: RHEL-08-030360
     stigid@sle12: SLES-12-020740
     stigid@sle15: SLES-15-030530
-    stigid@ubuntu2004: UBTU-20-010180
+    stigid@ubuntu2004: UBTU-20-010179
 
 {{{ complete_ocil_entry_audit_syscall(syscall="finit_module") }}}
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/ansible/shared.yml
@@ -1,10 +1,10 @@
-# platform = multi_platform_rhel,multi_platform_rhv,multi_platform_sle,multi_platform_ol
+# platform = multi_platform_rhel,multi_platform_rhv,multi_platform_sle,multi_platform_ol,multi_platform_ubuntu
 # reboot = false
 # complexity = low
 # disruption = low
 # strategy = configure
 
-{{% if "ol" in product or 'rhel' in product %}}
+{{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
 {{% set auid_filters = "-F auid>=" ~ auid ~ " -F auid!=unset" %}}
 {{% else %}}
 {{% set auid_filters = "" %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/bash/shared.sh
@@ -12,7 +12,7 @@ for ARCH in "${RULE_ARCHS[@]}"
 do
 	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
 	OTHER_FILTERS=""
-	{{% if "ol" in product or 'rhel' in product %}}
+	{{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
 	AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
 	{{% else %}}
 	AUID_FILTERS=""

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/oval/shared.xml
@@ -36,7 +36,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_ardm_init_module_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    {{% if "ol" in product or 'rhel' in product %}}
+    {{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+init_module[\s]+|([\s]+|[,])init_module([\s]+|[,]))).*(?:-F\s+auid>={{{ uid_min }}}[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+init_module[\s]+|([\s]+|[,])init_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
@@ -49,7 +49,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_ardm_init_module_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    {{% if "ol" in product or 'rhel' in product %}}
+    {{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+init_module[\s]+|([\s]+|[,])init_module([\s]+|[,]))).*(?:-F\s+auid>={{{ uid_min }}}[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+init_module[\s]+|([\s]+|[,])init_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
@@ -62,7 +62,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_ardm_init_module_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    {{% if "ol" in product or 'rhel' in product %}}
+    {{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+init_module[\s]+|([\s]+|[,])init_module([\s]+|[,]))).*(?:-F\s+auid>={{{ uid_min }}}[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+init_module[\s]+|([\s]+|[,])init_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
@@ -75,7 +75,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_ardm_init_module_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    {{% if "ol" in product or 'rhel' in product %}}
+    {{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+init_module[\s]+|([\s]+|[,])init_module([\s]+|[,]))).*(?:-F\s+auid>={{{ uid_min }}}[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+init_module[\s]+|([\s]+|[,])init_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/rule.yml
@@ -7,7 +7,7 @@ title: 'Ensure auditd Collects Information on Kernel Module Loading - init_modul
 description: |-
     To capture kernel module loading events, use following line, setting ARCH to
     either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:
-    {{% if "ol" in product or 'rhel' in product %}}
+    {{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=<i>ARCH</i> -S init_module -F auid>={{{ uid_min }}} -F auid!=unset -F key=modules</pre>
     {{% else %}}
     <pre>-a always,exit -F arch=<i>ARCH</i> -S init_module -F key=modules</pre>


### PR DESCRIPTION
#### Description:

- Fix UBTU-20-010179
- Fix OVAL definition (`kernel_module_loading_finit` & `kernel_module_loading_init`)
- Fix Ansible Remediation (`kernel_module_loading_finit` & `kernel_module_loading_init`)
- Fix Bash Remediation (`kernel_module_loading_finit` & `kernel_module_loading_init`)

#### Rationale:

- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
To test these changes with Ansible:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010179"
```
To test changes with bash, run the remediation section: `xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_finit` and `xccdf_org.ssgproject.content_rule_audit_rules_kernel_module_loading_init`

Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout dexterle:add-manual-stig-ubtu-20-v1r9
```

This STIG can be tested with the latest Ubuntu 2004 Benchmark SCAP. For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/
