### PR TITLE
fix ssh-keysign path for UBTU-20-010141

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/rule.yml
@@ -4,6 +4,8 @@
 
 {{%- if product in ["sle12", "sle15"] %}}
   {{%- set ssh_keysign_path="/usr/lib/ssh/ssh-keysign" %}}
+{{%- elif 'ubuntu' in product %}}
+  {{%- set ssh_keysign_path="/usr/lib/openssh/ssh-keysign" %}}
 {{%- else %}}
   {{%- set ssh_keysign_path="/usr/libexec/openssh/ssh-keysign" %}}
 {{%- endif %}}
@@ -79,3 +81,4 @@ template:
         path: /usr/libexec/openssh/ssh-keysign
         path@sle12: /usr/lib/ssh/ssh-keysign
         path@sle15: /usr/lib/ssh/ssh-keysign
+        path@ubuntu2004: /usr/lib/openssh/ssh-keysign


### PR DESCRIPTION
#### Description:

- Fix UBTU-20-010141
- Add proper template path 

#### Rationale:

- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
To test these changes with Ansible:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010141"
```
To test changes with bash, run the remediation section: `xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_ssh_keysign`

Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout dexterle:add-manual-stig-ubtu-20-v1r9
```

This STIG can be tested with the latest Ubuntu 2004 Benchmark SCAP. For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/
