### PR TITLE
fix unix_update path for UBTU-20-010173

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_update/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_update/rule.yml
@@ -1,3 +1,9 @@
+{{%- if product in ["ubuntu2004"] %}}
+    {{%- set unix_update_path="/sbin/unix_update" %}}
+{{%- else %}}
+    {{%- set unix_update_path="/usr/sbin/unix_update" %}}
+{{%- endif %}}
+
 documentation_complete: true
 
 prodtype: ol8,ol9,rhel8,rhel9,ubuntu2004,ubuntu2204
@@ -10,11 +16,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/unix_update -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    <pre>-a always,exit -F path={{{ unix_update_path }}} -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/unix_update -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    <pre>-a always,exit -F path={{{ unix_update_path }}} -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
@@ -47,3 +53,4 @@ template:
     name: audit_rules_privileged_commands
     vars:
         path: /usr/sbin/unix_update
+        path@ubuntu2004: /sbin/unix_update


### PR DESCRIPTION
This commit will fix the unix_update path for UBTU-20-010173 which is specified on DISA STIG to be /sbin/unix_update

#### Description:

- _Description here. Replace this text. Don't use the italics format!_

#### Rationale:

- _Rationale here. Replace this text. Don't use the italics format!_

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._

#### Review Hints:

- _Review hints here. Replace this text. Don't use the italics format!_

- _Use this optional section to give any relevant information which could help the reviewer to more quickly and assertively understand and test the changes._

- _Good examples are useful commands, if it is better to review all commits together or in a suggested sequence, any relevant discussion in other PRs or issues, etc._