### PR TITLE
Fix UBTU-20-010267 and deprecate STIGs

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rename/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rename/rule.yml
@@ -60,7 +60,7 @@ references:
     stigid@ol8: OL08-00-030361
     stigid@rhel7: RHEL-07-030910
     stigid@rhel8: RHEL-08-030361
-    stigid@ubuntu2004: UBTU-20-010269
+    stigid@ubuntu2004: UBTU-20-010267
 
 {{{ complete_ocil_entry_audit_syscall(syscall="rename") }}}
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_renameat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_renameat/rule.yml
@@ -59,7 +59,7 @@ references:
     stigid@ol8: OL08-00-030361
     stigid@rhel7: RHEL-07-030910
     stigid@rhel8: RHEL-08-030361
-    stigid@ubuntu2004: UBTU-20-010270
+    stigid@ubuntu2004: UBTU-20-010267
 
 {{{ complete_ocil_entry_audit_syscall(syscall="renameat") }}}
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rmdir/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rmdir/rule.yml
@@ -53,6 +53,7 @@ references:
     stigid@ol8: OL08-00-030361
     stigid@rhel7: RHEL-07-030910
     stigid@rhel8: RHEL-08-030361
+    stigid@ubuntu2004: UBTU-20-010267
 
 {{{ complete_ocil_entry_audit_syscall(syscall="rmdir") }}}
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlinkat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlinkat/rule.yml
@@ -59,7 +59,7 @@ references:
     stigid@ol8: OL08-00-030361
     stigid@rhel7: RHEL-07-030910
     stigid@rhel8: RHEL-08-030361
-    stigid@ubuntu2004: UBTU-20-010268
+    stigid@ubuntu2004: UBTU-20-010267
 
 {{{ complete_ocil_entry_audit_syscall(syscall="unlinkat") }}}
 

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -387,15 +387,10 @@ selections:
 
     # UBTU-20-010267 The Ubuntu operating system must generate audit records for any successful/unsuccessful use of unlink system call.
     - audit_rules_file_deletion_events_unlink
-
-    # UBTU-20-010268 The Ubuntu operating system must generate audit records for any successful/unsuccessful use of unlinkat system call.
-    - audit_rules_file_deletion_events_unlinkat
-
-    # UBTU-20-010269 The Ubuntu operating system must generate audit records for any successful/unsuccessful use of rename system call.
-    - audit_rules_file_deletion_events_rename
-
-    # UBTU-20-010270 The Ubuntu operating system must generate audit records for any successful/unsuccessful use of renameat system call.
+    - audit_rules_file_deletion_events_rmdir
     - audit_rules_file_deletion_events_renameat
+    - audit_rules_file_deletion_events_rename
+    - audit_rules_file_deletion_events_unlinkat
 
     # UBTU-20-010276 The Ubuntu operating system must generate audit records when loading dynamic kernel modules.
 


### PR DESCRIPTION
#### Description:

- Fix UBTU-20-010267
- Removes UBTU-20-010268, UBTU-20-010269, and UBTU-20-010270
- Fix remediations and OVAL definitions for Ubuntu

#### Rationale:

- Removes UBTU-20-010268, UBTU-20-010269, and UBTU-20-010270 which no longer exists, and replaces with UBTU-20-010267
- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
To test these changes with Ansible:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010267"
```
To test changes with bash, run the remediation sections:
```
xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_unlinkat
xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_rmdir
xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_renameat
xccdf_org.ssgproject.content_rule_audit_rules_file_deletion_events_rename
```

Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout dexterle:add-manual-stig-ubtu-20-v1r9
```

This STIG can be tested with the latest Ubuntu 2004 Benchmark SCAP. For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/
