### PR TITLE
Fix UBTU-20-010013 OVAL and simplify ansible remediation

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
@@ -11,21 +11,37 @@
   {{% set system_configuration_using_etc_bashrc_expected = true %}}
 {{% endif %}}
 
+- name: "{{{ rule_title }}} - Set TMOUT Line Fact"
+  ansible.builtin.set_fact:
+    {{% if product in ['ubuntu2004'] %}}
+    tmout_line: "TMOUT={{ var_accounts_tmout }}"
+    {{% else %}}
+    tmout_line: "declare -xr TMOUT={{ var_accounts_tmout }}"
+    {{% endif %}}
+
+{{% if 'ubuntu2004' in product %}}
+- name: "{{{ rule_title }}} - Correct Any Occurence of TMOUT in /etc/bash.bashrc"
+  ansible.builtin.replace:
+    path: /etc/bash.bashrc
+    regexp: '^[^#].*TMOUT=.*'
+    replace: "{{ tmout_line }}"
+{{% endif %}}
+
 {{% if system_configuration_using_etc_bashrc_expected %}}
-- name: Correct any occurrence of TMOUT in /etc/bashrc
-  replace:
+- name: "{{{ rule_title }}} - Correct Any Occurrence of TMOUT in /etc/bashrc"
+  ansible.builtin.replace:
     path: /etc/bashrc
     regexp: '^[^#].*TMOUT=.*'
-    replace: declare -xr TMOUT={{ var_accounts_tmout }}
+    replace: "{{ tmout_line }}"
   register: bashrc_replaced
 {{% endif %}}
 
-- name: Correct any occurrence of TMOUT in /etc/profile
-  replace:
+- name: "{{{ rule_title }}} - Correct Any Occurrence of TMOUT in /etc/profile"
+  ansible.builtin.replace:
     path: /etc/profile
     regexp: '^[^#].*TMOUT=.*'
-    replace: declare -xr TMOUT={{ var_accounts_tmout }}
+    replace: "{{ tmout_line }}"
   register: profile_replaced
 
-{{{ ansible_lineinfile("", "/etc/profile.d/tmout.sh", regex='TMOUT=', new_line='declare -xr TMOUT={{ var_accounts_tmout }}',
+{{{ ansible_lineinfile("", "/etc/profile.d/tmout.sh", regex='TMOUT=', new_line='{{ tmout_line }}',
     create='yes', state='present', when="profile_replaced is defined and not profile_replaced.changed" + " and bashrc_replaced is defined and not bashrc_replaced.changed" if product in ["ol7", "rhel7"]) }}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
@@ -37,8 +37,10 @@
     {{% if filepath %}}
     <ind:filepath>{{{ filepath }}}</ind:filepath>
     {{% endif %}}
-    {{% if product in ['sle12', 'sle15'] or "ubuntu" in product %}}
+    {{% if product in ['sle12', 'sle15'] or product in ['ubuntu1804', 'ubuntu2204'] %}}
     <ind:pattern operation="pattern match">^[\s]*TMOUT=([\w$]+)[\s]*readonly TMOUT[\s]*export TMOUT$</ind:pattern>
+    {{% elif 'ubuntu2004' in product %}}
+    <ind:pattern operation="pattern match">^[\s]*TMOUT=([\w$]+).*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*declare[\s]+-xr[\s]+TMOUT=([\w$]+).*$</ind:pattern>
     {{% endif %}}


### PR DESCRIPTION
#### Description:

- Fix UBTU-20-010013
- Fix remediations and OVAL definitions for Ubuntu

#### Rationale:

- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
To test these changes with Ansible:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010013"
```
To test changes with bash, run the remediation sections: `xccdf_org.ssgproject.content_rule_accounts_tmout`

Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout dexterle:add-manual-stig-ubtu-20-v1r9
```

This STIG can not be tested with the latest Ubuntu 2004 Benchmark SCAP. Please perform a manual check given the check text. For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/
