### PR TITLE
Fix path and add ansible remediation UBTU-20-010298

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/ansible/shared.yml
@@ -1,0 +1,8 @@
+# platform = multi_platform_ubuntu
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+{{{ ansible_audit_augenrules_add_watch_rule(path='/sbin/fdisk', permissions='x', key='modules') }}}
+{{{ ansible_audit_auditctl_add_watch_rule(path='/sbin/fdisk', permissions='x', key='modules') }}}


### PR DESCRIPTION
#### Description:

- Fix UBTU-20-010298
- Add Ansible remediation for Ubuntu 

#### Rationale:

- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
To test these changes with Ansible:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010298"
```

Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout dexterle:add-manual-stig-ubtu-20-v1r9
```

This STIG can not be tested with the latest Ubuntu 2004 Benchmark SCAP. Please perform a manual check given the check text. For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/
