### PR TITLE
Add ansible for gnome messsage banner UBTU-20-010003

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/ansible/ubuntu.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/ansible/ubuntu.yml
@@ -1,0 +1,25 @@
+# platform = multi_platform_ubuntu
+# reboot = false
+# strategy = unknown
+# complexity = low
+# disruption = medium
+{{{ ansible_instantiate_variables("login_banner_text") }}}
+
+- name: "{{{ rule_title }}}"
+  lineinfile:
+    path: /etc/gdm3/greeter.dconf-defaults
+    regexp: ^(#.*)(banner-message-text=)
+    line: \2
+    backrefs: true
+
+- name: "{{{ rule_title }}}"
+  ini_file:
+    dest: /etc/gdm3/greeter.dconf-defaults
+    section: org/gnome/login-screen
+    option: banner-message-text
+    value: '{{{ ansible_deregexify_banner_dconf_gnome("login_banner_text") }}}'
+    create: yes
+    no_extra_spaces: yes
+
+- name: Dconf Update
+  command: dconf update


### PR DESCRIPTION
#### Description:

- Fix UBTU-20-010003
- Add Ansible remediation for Ubuntu

#### Rationale:

- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
To test these changes with Ansible:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010003"
```

Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout dexterle:add-manual-stig-ubtu-20-v1r9
```

This STIG can not be tested with the latest Ubuntu 2004 Benchmark SCAP. Please perform a manual check given the check text. For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/
