### PR TITLE
Add ansible remediation for log perm for UBTU-20-010122

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/ansible/shared.yml
@@ -1,62 +1,80 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle,multi_platform_ubuntu
 # reboot = false
 # strategy = restrict
 # complexity = low
 # disruption = low
 
-- name: Get audit log files
-  command: grep -iw ^log_file /etc/audit/auditd.conf
+- name: "{{{ rule_title }}} - Get Audit Log Files"
+  ansible.builtin.command: grep -iw ^log_file /etc/audit/auditd.conf
   failed_when: false
   register: log_file_exists
 
-- name: Parse log file line
-  command: awk -F '=' '/^log_file/ {print $2}' /etc/audit/auditd.conf
+- name: "{{{ rule_title }}} - Parse Log File Line"
+  ansible.builtin.command: awk -F '=' '/^log_file/ {print $2}' /etc/audit/auditd.conf
   register: log_file_line
   when: (log_file_exists.stdout | length > 0)
 
-- name: Set default log_file if not set
-  set_fact:
+- name: "{{{ rule_title }}} - Set Default log_file if Not Set"
+  ansible.builtin.set_fact:
     log_file: "/var/log/audit/audit.log"
   when: (log_file_exists is undefined) or (log_file_exists.stdout | length == 0)
 
-- name: Set log_file from log_file_line if not set already
-  set_fact:
+- name: "{{{ rule_title }}} - Set log_file From log_file_line if Not Set Already"
+  ansible.builtin.set_fact:
     log_file: "{{ log_file_line.stdout | trim }}"
   when: (log_file_line.stdout is defined) and (log_file_line.stdout | length > 0)
 
-{{% if 'ol' not in product and "rhel" not in product %}}
-- name: Get log files group
-  command: grep -m 1 ^log_group /etc/audit/auditd.conf
+{{% if 'ol' not in product and "rhel" not in product and "ubuntu" not in product %}}
+- name: "{{{ rule_title }}} - Get Log Files Group"
+  ansible.builtin.command: grep -m 1 ^log_group /etc/audit/auditd.conf
   failed_when: false
   register: log_group_line
 
-- name: Parse log group line
-  command: awk -F '=' '/log_group/ {print $2}' /etc/audit/auditd.conf
+- name: "{{{ rule_title }}} - Parse Log Group Line"
+  ansible.builtin.command: awk -F '=' '/log_group/ {print $2}' /etc/audit/auditd.conf
   register: log_group
   when: (log_group_line.stdout | length > 0)
 
-- name: Apply mode to log file when group root
-  file:
+- name: "{{{ rule_title }}} - Apply Mode to Log File When Group Root"
+  ansible.builtin.file:
     path: "{{ log_file }}"
     mode: (( log_group is defined ) and ( ( log_group.stdout | trim ) == 'root' )) | ternary( '0600', '0640')
   failed_when: false
 
-- name: List all log file backups
-  find:
+- name: "{{{ rule_title }}} - List All Log File Backups"
+  ansible.builtin.find:
     path: "{{ log_file | dirname }}"
     patterns: "{{ log_file | basename }}.*"
   register: backup_files
 
-- name: Apply mode to log file when group not root
-  file:
+- name: "{{{ rule_title }}} - Apply Mode to Log File When Group Not Root"
+  ansible.builtin.file:
     path: "{{ item }}"
     mode: (( log_group is defined ) and ( ( log_group.stdout | trim ) == 'root' ))  | ternary( '0400', '0440')
   loop: "{{ backup_files.files| map(attribute='path') | list }}"
   failed_when: false
+{{% elif "ubuntu" in product %}}
+- name: "{{{ rule_title }}} - List All Log File Backups"
+  ansible.builtin.find:
+    path: "{{ log_file | dirname }}"
+    patterns: "{{ log_file | basename }}.*"
+  register: backup_files
 
+- name: "{{{ rule_title }}} - Apply Mode to All Backup Log Files"
+  ansible.builtin.file:
+    path: "{{ item }}"
+    mode: 0600
+  failed_when: false
+  loop: "{{ backup_files.files| map(attribute='path') | list }}"
+
+- name: "{{{ rule_title }}} - Apply Mode to Log File"
+  ansible.builtin.file:
+    path: "{{ log_file }}"
+    mode: 0600
+  failed_when: false
 {{% else %}}
-- name: Apply mode to log file
-  file:
+- name: "{{{ rule_title }}} - Apply Mode to Log File"
+  ansible.builtin.file:
     path: "{{ log_file }}"
     mode: 0600
   failed_when: false


### PR DESCRIPTION
#### Description:

- Fix UBTU-20-010122
- Add ansible remediation for ubuntu, and fix styling

#### Rationale:

- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
To test these changes with Ansible:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010122"
```
To test changes with bash, run the remediation sections: `xccdf_org.ssgproject.content_rule_file_permissions_var_log_audit`

Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout dexterle:add-manual-stig-ubtu-20-v1r9
```

This STIG can not be tested with the latest Ubuntu 2004 Benchmark SCAP. Please perform a manual check given the check text. For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/
