### PR TITLE
Add ansible remediation for root group owner of audit for UBTU-20-010124

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/ansible/shared.yml
@@ -1,0 +1,43 @@
+# platform = multi_platform_ubuntu
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: "{{{ rule_title }}} - Get Audit Log Files"
+  ansible.builtin.command: grep -iw ^log_file /etc/audit/auditd.conf
+  failed_when: false
+  register: log_file_exists
+
+- name: "{{{ rule_title }}} - Set Log File Facts"
+  ansible.builtin.set_fact:
+      log_file_line: "{{ log_file_exists.stdout | split(' ') | last }}"
+
+- name: "{{{ rule_title }}} - Set Default log_file if Not Set"
+  ansible.builtin.set_fact:
+      log_file: "/var/log/audit/audit.log"
+  when: (log_file_exists is undefined) or (log_file_exists.stdout | length == 0)
+
+- name: "{{{ rule_title }}} - Set log_file From log_file_line if Not Set Already"
+  ansible.builtin.set_fact:
+      log_file: "{{ log_file_line }}"
+  when: (log_file_line is defined) and (log_file_line | length > 0)
+
+- name: "{{{ rule_title }}} - List All Log File Backups"
+  ansible.builtin.find:
+      path: "{{ log_file | dirname }}"
+      patterns: "{{ log_file | basename }}.*"
+  register: backup_files
+
+- name: "{{{ rule_title }}} - Apply Mode to All Backup Log Files"
+  ansible.builtin.file:
+      path: "{{ item }}"
+      group: root
+  failed_when: false
+  loop: "{{ backup_files.files| map(attribute='path') | list }}"
+
+- name: "{{{ rule_title }}} - Apply Mode to Log File"
+  ansible.builtin.file:
+      path: "{{ log_file }}"
+      group: root
+  failed_when: false


### PR DESCRIPTION
#### Description:

- Fix UBTU-20-010124
- Add Ansible remediation for ubuntu

#### Rationale:

- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
To test these changes with Ansible:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010124"
```
To test changes with bash, run the remediation sections: `xccdf_org.ssgproject.content_rule_file_group_ownership_var_log_audit`

Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout dexterle:add-manual-stig-ubtu-20-v1r9
```

This STIG can not be tested with the latest Ubuntu 2004 Benchmark SCAP. Please perform a manual check given the check text. For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/
