### PR TITLE
Add ansible remediation for audispd plugin UBTU-20-010216

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
 # reboot = false
 # strategy = configure
 # complexity = low


### PR DESCRIPTION
#### Description:

- Fix UBTU-20-010216
- Add Ansible remediation for Ubuntu

#### Rationale:

- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
To test these changes with Ansible:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010216"
```
To test changes with bash, run the remediation sections: `xccdf_org.ssgproject.content_rule_auditd_audispd_configure_remote_server`

Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout dexterle:add-manual-stig-ubtu-20-v1r9
```

This STIG can not be tested with the latest Ubuntu 2004 Benchmark SCAP. Please perform a manual check given the check text. For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/
