### PR TITLE
Add rsyslog ansible remediation for UBTU-20-010403

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/ansible/ubuntu.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/ansible/ubuntu.yml
@@ -1,0 +1,43 @@
+# platform = multi_platform_ubuntu
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = medium
+
+- name: "{{{ rule_title }}} - Set Facts"
+  ansible.builtin.set_fact:
+      conf_files: [ '/etc/rsyslog.d/50-default.conf' ]
+      remote_methods:
+        - selector: 'auth.*'
+          regexp: ^.*auth\.\*.*$
+          log_path_name: secure
+        - selector: 'authpriv.*'
+          regexp: ^.*authpriv\.\*.*$
+          log_path_name: secure
+        - selector: 'daemon.*'
+          regexp: ^.*daemon\.\*.*$
+          log_path_name: messages
+
+- name: "{{{ rule_title }}} - Ensure /etc/rsyslog.d/50-default.conf Exists"
+  ansible.builtin.file:
+      path: "{{ conf_files.0 }}"
+      state: touch
+
+- name: "{{{ rule_title }}} - Check for Existing Values in Conf Files"
+  ansible.builtin.lineinfile:
+      path: "{{ item.1 }}"
+      regexp: "{{ item.0.regexp }}"
+      state: absent
+  check_mode: true
+  changed_when: false
+  register: remote_method_values
+  loop: "{{ remote_methods|product(conf_files)|list }}"
+
+- name: "{{{ rule_title }}} - Configure /etc/rsyslog.d/50-default.conf With Proper Log Paths"
+  ansible.builtin.lineinfile:
+      path: /etc/rsyslog.d/50-default.conf
+      line: "{{ item.item.0.selector }} /var/log/{{ item.item.0.log_path_name }}"
+      insertafter: ^.*\/var\/log\/secure.*$
+      create: yes
+  loop: '{{ remote_method_values.results }}'
+  when: item.found == 0


### PR DESCRIPTION
#### Description:

- Fix UBTU-20-010403
- Add Ansible remediation for Ubuntu

#### Rationale:

- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
To test these changes with Ansible:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010403"
```
To test changes with bash, run the remediation sections: `xccdf_org.ssgproject.content_rule_rsyslog_remote_access_monitoring`

Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout dexterle:add-manual-stig-ubtu-20-v1r9
```

This STIG can not be tested with the latest Ubuntu 2004 Benchmark SCAP. Please perform a manual check given the check text. For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/
