### PR TITLE
Replace shell command with find for chrony.conf files on UBTU-20-010435

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/ansible/shared.yml
@@ -6,20 +6,20 @@
 
 {{{ ansible_instantiate_variables('var_time_service_set_maxpoll') }}}
 
-- name: Check that /etc/ntp.conf exist
-  stat:
+- name: "{{{ rule_title }}} - Check That /etc/ntp.conf Exist"
+  ansible.builtin.stat:
     path: /etc/ntp.conf
   register: ntp_conf_exist_result
 
-- name: Update the maxpoll values in /etc/ntp.conf
-  replace:
+- name: "{{{ rule_title }}} - Update the Maxpoll Values in /etc/ntp.conf"
+  ansible.builtin.replace:
     path: /etc/ntp.conf
     regexp: '^(server.*maxpoll)[ ]+[0-9]+(.*)$'
     replace: '\1 {{ var_time_service_set_maxpoll }}\2'
   when: ntp_conf_exist_result.stat.exists
 
-- name: Set the maxpoll values in /etc/ntp.conf
-  replace:
+- name: "{{{ rule_title }}} - Set the Maxpoll Values in /etc/ntp.conf"
+  ansible.builtin.replace:
     path: /etc/ntp.conf
     regexp: '(^server\s+((?!maxpoll).)*)$'
     replace: '\1 maxpoll {{ var_time_service_set_maxpoll }}\n'
@@ -29,33 +29,34 @@
 # since chrony_conf_path is the full path to chrony.conf
 # and includes chrony.conf, that must be handled as well
 
-- name: Check that {{{ chrony_conf_path }}} exist
-  stat:
+- name: "{{{ rule_title }}} - Check That {{{ chrony_conf_path }}} Exist"
+  ansible.builtin.stat:
     path: {{{ chrony_conf_path }}}
   register: chrony_conf_exist_result
 
-- name: Get get conf files from {{{ chrony_conf_path }}}
-  shell: |
-    set -o pipefail
-    CHRONY_NAME={{{ chrony_conf_path }}}
-    CHRONY_PATH=${CHRONY_NAME%%.*}
-    find ${CHRONY_PATH}.* -type f -name '*.conf'
-  register: update_chrony_files
-  when: chrony_conf_exist_result.stat.exists
-  changed_when: False
+- name: "{{{ rule_title }}} - Set Chrony Path Facts"
+  ansible.builtin.set_fact:
+    chrony_path: {{{ chrony_conf_path }}}
 
-- name: Update the maxpoll values in {{{ chrony_conf_path }}}
-  replace:
-    path: "{{ item }}"
+- name: "{{{ rule_title }}} - Get Conf Files from {{ chrony_path | dirname }}"
+  ansible.builtin.find:
+    path: "{{ chrony_path | dirname }}"
+    patterns: '*.conf'
+    file_type: file
+  register: chrony_conf_files
+
+- name: "{{{ rule_title }}} - Update the Maxpoll Values in {{{ chrony_conf_path }}}"
+  ansible.builtin.replace:
+    path: "{{ item.path }}"
     regexp: '^((?:server|pool|peer).*maxpoll)[ ]+[0-9]+(.*)$'
     replace: '\1 {{ var_time_service_set_maxpoll }}\2'
-  loop: "{{ update_chrony_files.stdout_lines|list|flatten|unique }}"
-  when: chrony_conf_exist_result.stat.exists
+  loop: '{{ chrony_conf_files.files }}'
+  when: chrony_conf_files.matched
 
-- name: Set the maxpoll values in {{{ chrony_conf_path }}}
-  replace:
-    path: "{{ item }}"
+- name: "{{{ rule_title }}} - Set the Maxpoll Values in {{{ chrony_conf_path }}}"
+  ansible.builtin.replace:
+    path: "{{ item.path }}"
     regexp: '(^(?:server|pool|peer)\s+((?!maxpoll).)*)$'
     replace: '\1 maxpoll {{ var_time_service_set_maxpoll }}\n'
-  loop: "{{ update_chrony_files.stdout_lines|list|flatten|unique }}"
-  when: chrony_conf_exist_result.stat.exists
+  loop: '{{ chrony_conf_files.files }}'
+  when: chrony_conf_files.matched


### PR DESCRIPTION
#### Description:

- Fix UBTU-20-010435
- Enhance Ansible remediation to remove `shell` module calls

#### Rationale:

- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
To test these changes with Ansible:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010435"
```
Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout dexterle:add-manual-stig-ubtu-20-v1r9
```

This STIG can not be tested with the latest Ubuntu 2004 Benchmark SCAP. Please perform a manual check given the check text. For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/
