### PR TITLE
Update Ubuntu 20.04 DISA Manual STIG to v1r9

### DIFF
--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Canonical Ubuntu 20.04 LTS Security Technical Implementation Guide (STIG) V1R1'
+title: 'Canonical Ubuntu 20.04 LTS Security Technical Implementation Guide (STIG) V1R9'
 
 description: |-
     This Security Technical Implementation Guide is published as a tool to

--- a/shared/references/disa-stig-ubuntu2004-v1r9-xccdf-manual.xml
+++ b/shared/references/disa-stig-ubuntu2004-v1r9-xccdf-manual.xml
@@ -1,0 +1,3453 @@
+<?xml version="1.0" encoding="utf-8"?><?xml-stylesheet type='text/xsl' href='STIG_unclass.xsl'?><Benchmark xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cpe="http://cpe.mitre.org/language/2.0" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.1 http://nvd.nist.gov/schema/xccdf-1.1.4.xsd http://cpe.mitre.org/dictionary/2.0 http://cpe.mitre.org/files/cpe-dictionary_2.1.xsd" id="Canonical_Ubuntu_20-04_LTS_STIG" xml:lang="en" xmlns="http://checklists.nist.gov/xccdf/1.1"><status date="2023-06-02">accepted</status><title>Canonical Ubuntu 20.04 LTS Security Technical Implementation Guide</title><description>This Security Technical Implementation Guide is published as a tool to improve the security of Department of Defense (DOD) information systems. The requirements are derived from the National Institute of Standards and Technology (NIST) 800-53 and related documents. Comments or proposed revisions to this document should be sent via email to the following address: disa.stig_spt@mail.mil.</description><notice id="terms-of-use" xml:lang="en"></notice><front-matter xml:lang="en"></front-matter><rear-matter xml:lang="en"></rear-matter><reference href="https://cyber.mil"><dc:publisher>DISA</dc:publisher><dc:source>STIG.DOD.MIL</dc:source></reference><plain-text id="release-info">Release: 9 Benchmark Date: 26 Jul 2023</plain-text><plain-text id="generator">3.4.0.34222</plain-text><plain-text id="conventionsVersion">1.10.0</plain-text><version>1</version><Profile id="MAC-1_Classified"><title>I - Mission Critical Classified</title><description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</description><select idref="V-238196" selected="true" /><select idref="V-238197" selected="true" /><select idref="V-238198" selected="true" /><select idref="V-238199" selected="true" /><select idref="V-238200" selected="true" /><select idref="V-238201" selected="true" /><select idref="V-238202" selected="true" /><select idref="V-238203" selected="true" /><select idref="V-238204" selected="true" /><select idref="V-238205" selected="true" /><select idref="V-238206" selected="true" /><select idref="V-238207" selected="true" /><select idref="V-238208" selected="true" /><select idref="V-238209" selected="true" /><select idref="V-238210" selected="true" /><select idref="V-238211" selected="true" /><select idref="V-238212" selected="true" /><select idref="V-238213" selected="true" /><select idref="V-238214" selected="true" /><select idref="V-238215" selected="true" /><select idref="V-238216" selected="true" /><select idref="V-238217" selected="true" /><select idref="V-238218" selected="true" /><select idref="V-238219" selected="true" /><select idref="V-238220" selected="true" /><select idref="V-238221" selected="true" /><select idref="V-238222" selected="true" /><select idref="V-238223" selected="true" /><select idref="V-238224" selected="true" /><select idref="V-238225" selected="true" /><select idref="V-238226" selected="true" /><select idref="V-238227" selected="true" /><select idref="V-238228" selected="true" /><select idref="V-238229" selected="true" /><select idref="V-238230" selected="true" /><select idref="V-238231" selected="true" /><select idref="V-238232" selected="true" /><select idref="V-238233" selected="true" /><select idref="V-238234" selected="true" /><select idref="V-238235" selected="true" /><select idref="V-238236" selected="true" /><select idref="V-238237" selected="true" /><select idref="V-238238" selected="true" /><select idref="V-238239" selected="true" /><select idref="V-238240" selected="true" /><select idref="V-238241" selected="true" /><select idref="V-238242" selected="true" /><select idref="V-238243" selected="true" /><select idref="V-238244" selected="true" /><select idref="V-238245" selected="true" /><select idref="V-238246" selected="true" /><select idref="V-238247" selected="true" /><select idref="V-238248" selected="true" /><select idref="V-238249" selected="true" /><select idref="V-238250" selected="true" /><select idref="V-238251" selected="true" /><select idref="V-238252" selected="true" /><select idref="V-238253" selected="true" /><select idref="V-238254" selected="true" /><select idref="V-238255" selected="true" /><select idref="V-238256" selected="true" /><select idref="V-238257" selected="true" /><select idref="V-238258" selected="true" /><select idref="V-238264" selected="true" /><select idref="V-238268" selected="true" /><select idref="V-238271" selected="true" /><select idref="V-238277" selected="true" /><select idref="V-238278" selected="true" /><select idref="V-238279" selected="true" /><select idref="V-238280" selected="true" /><select idref="V-238281" selected="true" /><select idref="V-238282" selected="true" /><select idref="V-238283" selected="true" /><select idref="V-238284" selected="true" /><select idref="V-238285" selected="true" /><select idref="V-238286" selected="true" /><select idref="V-238287" selected="true" /><select idref="V-238288" selected="true" /><select idref="V-238289" selected="true" /><select idref="V-238290" selected="true" /><select idref="V-238291" selected="true" /><select idref="V-238292" selected="true" /><select idref="V-238293" selected="true" /><select idref="V-238294" selected="true" /><select idref="V-238295" selected="true" /><select idref="V-238297" selected="true" /><select idref="V-238298" selected="true" /><select idref="V-238299" selected="true" /><select idref="V-238300" selected="true" /><select idref="V-238301" selected="true" /><select idref="V-238302" selected="true" /><select idref="V-238303" selected="true" /><select idref="V-238304" selected="true" /><select idref="V-238305" selected="true" /><select idref="V-238306" selected="true" /><select idref="V-238307" selected="true" /><select idref="V-238308" selected="true" /><select idref="V-238309" selected="true" /><select idref="V-238310" selected="true" /><select idref="V-238315" selected="true" /><select idref="V-238316" selected="true" /><select idref="V-238317" selected="true" /><select idref="V-238318" selected="true" /><select idref="V-238319" selected="true" /><select idref="V-238320" selected="true" /><select idref="V-238321" selected="true" /><select idref="V-238323" selected="true" /><select idref="V-238324" selected="true" /><select idref="V-238325" selected="true" /><select idref="V-238326" selected="true" /><select idref="V-238327" selected="true" /><select idref="V-238328" selected="true" /><select idref="V-238329" selected="true" /><select idref="V-238330" selected="true" /><select idref="V-238331" selected="true" /><select idref="V-238332" selected="true" /><select idref="V-238333" selected="true" /><select idref="V-238334" selected="true" /><select idref="V-238335" selected="true" /><select idref="V-238336" selected="true" /><select idref="V-238337" selected="true" /><select idref="V-238338" selected="true" /><select idref="V-238339" selected="true" /><select idref="V-238340" selected="true" /><select idref="V-238341" selected="true" /><select idref="V-238342" selected="true" /><select idref="V-238343" selected="true" /><select idref="V-238344" selected="true" /><select idref="V-238345" selected="true" /><select idref="V-238346" selected="true" /><select idref="V-238347" selected="true" /><select idref="V-238348" selected="true" /><select idref="V-238349" selected="true" /><select idref="V-238350" selected="true" /><select idref="V-238351" selected="true" /><select idref="V-238352" selected="true" /><select idref="V-238353" selected="true" /><select idref="V-238354" selected="true" /><select idref="V-238355" selected="true" /><select idref="V-238356" selected="true" /><select idref="V-238357" selected="true" /><select idref="V-238358" selected="true" /><select idref="V-238359" selected="true" /><select idref="V-238360" selected="true" /><select idref="V-238361" selected="true" /><select idref="V-238362" selected="true" /><select idref="V-238363" selected="true" /><select idref="V-238364" selected="true" /><select idref="V-238365" selected="true" /><select idref="V-238366" selected="true" /><select idref="V-238367" selected="true" /><select idref="V-238368" selected="true" /><select idref="V-238369" selected="true" /><select idref="V-238370" selected="true" /><select idref="V-238371" selected="true" /><select idref="V-238372" selected="true" /><select idref="V-238373" selected="true" /><select idref="V-238374" selected="true" /><select idref="V-238376" selected="true" /><select idref="V-238377" selected="true" /><select idref="V-238378" selected="true" /><select idref="V-238379" selected="true" /><select idref="V-238380" selected="true" /><select idref="V-251503" selected="true" /><select idref="V-251504" selected="true" /><select idref="V-251505" selected="true" /><select idref="V-252704" selected="true" /><select idref="V-255912" selected="true" /><select idref="V-255913" selected="true" /></Profile><Profile id="MAC-1_Public"><title>I - Mission Critical Public</title><description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</description><select idref="V-238196" selected="true" /><select idref="V-238197" selected="true" /><select idref="V-238198" selected="true" /><select idref="V-238199" selected="true" /><select idref="V-238200" selected="true" /><select idref="V-238201" selected="true" /><select idref="V-238202" selected="true" /><select idref="V-238203" selected="true" /><select idref="V-238204" selected="true" /><select idref="V-238205" selected="true" /><select idref="V-238206" selected="true" /><select idref="V-238207" selected="true" /><select idref="V-238208" selected="true" /><select idref="V-238209" selected="true" /><select idref="V-238210" selected="true" /><select idref="V-238211" selected="true" /><select idref="V-238212" selected="true" /><select idref="V-238213" selected="true" /><select idref="V-238214" selected="true" /><select idref="V-238215" selected="true" /><select idref="V-238216" selected="true" /><select idref="V-238217" selected="true" /><select idref="V-238218" selected="true" /><select idref="V-238219" selected="true" /><select idref="V-238220" selected="true" /><select idref="V-238221" selected="true" /><select idref="V-238222" selected="true" /><select idref="V-238223" selected="true" /><select idref="V-238224" selected="true" /><select idref="V-238225" selected="true" /><select idref="V-238226" selected="true" /><select idref="V-238227" selected="true" /><select idref="V-238228" selected="true" /><select idref="V-238229" selected="true" /><select idref="V-238230" selected="true" /><select idref="V-238231" selected="true" /><select idref="V-238232" selected="true" /><select idref="V-238233" selected="true" /><select idref="V-238234" selected="true" /><select idref="V-238235" selected="true" /><select idref="V-238236" selected="true" /><select idref="V-238237" selected="true" /><select idref="V-238238" selected="true" /><select idref="V-238239" selected="true" /><select idref="V-238240" selected="true" /><select idref="V-238241" selected="true" /><select idref="V-238242" selected="true" /><select idref="V-238243" selected="true" /><select idref="V-238244" selected="true" /><select idref="V-238245" selected="true" /><select idref="V-238246" selected="true" /><select idref="V-238247" selected="true" /><select idref="V-238248" selected="true" /><select idref="V-238249" selected="true" /><select idref="V-238250" selected="true" /><select idref="V-238251" selected="true" /><select idref="V-238252" selected="true" /><select idref="V-238253" selected="true" /><select idref="V-238254" selected="true" /><select idref="V-238255" selected="true" /><select idref="V-238256" selected="true" /><select idref="V-238257" selected="true" /><select idref="V-238258" selected="true" /><select idref="V-238264" selected="true" /><select idref="V-238268" selected="true" /><select idref="V-238271" selected="true" /><select idref="V-238277" selected="true" /><select idref="V-238278" selected="true" /><select idref="V-238279" selected="true" /><select idref="V-238280" selected="true" /><select idref="V-238281" selected="true" /><select idref="V-238282" selected="true" /><select idref="V-238283" selected="true" /><select idref="V-238284" selected="true" /><select idref="V-238285" selected="true" /><select idref="V-238286" selected="true" /><select idref="V-238287" selected="true" /><select idref="V-238288" selected="true" /><select idref="V-238289" selected="true" /><select idref="V-238290" selected="true" /><select idref="V-238291" selected="true" /><select idref="V-238292" selected="true" /><select idref="V-238293" selected="true" /><select idref="V-238294" selected="true" /><select idref="V-238295" selected="true" /><select idref="V-238297" selected="true" /><select idref="V-238298" selected="true" /><select idref="V-238299" selected="true" /><select idref="V-238300" selected="true" /><select idref="V-238301" selected="true" /><select idref="V-238302" selected="true" /><select idref="V-238303" selected="true" /><select idref="V-238304" selected="true" /><select idref="V-238305" selected="true" /><select idref="V-238306" selected="true" /><select idref="V-238307" selected="true" /><select idref="V-238308" selected="true" /><select idref="V-238309" selected="true" /><select idref="V-238310" selected="true" /><select idref="V-238315" selected="true" /><select idref="V-238316" selected="true" /><select idref="V-238317" selected="true" /><select idref="V-238318" selected="true" /><select idref="V-238319" selected="true" /><select idref="V-238320" selected="true" /><select idref="V-238321" selected="true" /><select idref="V-238323" selected="true" /><select idref="V-238324" selected="true" /><select idref="V-238325" selected="true" /><select idref="V-238326" selected="true" /><select idref="V-238327" selected="true" /><select idref="V-238328" selected="true" /><select idref="V-238329" selected="true" /><select idref="V-238330" selected="true" /><select idref="V-238331" selected="true" /><select idref="V-238332" selected="true" /><select idref="V-238333" selected="true" /><select idref="V-238334" selected="true" /><select idref="V-238335" selected="true" /><select idref="V-238336" selected="true" /><select idref="V-238337" selected="true" /><select idref="V-238338" selected="true" /><select idref="V-238339" selected="true" /><select idref="V-238340" selected="true" /><select idref="V-238341" selected="true" /><select idref="V-238342" selected="true" /><select idref="V-238343" selected="true" /><select idref="V-238344" selected="true" /><select idref="V-238345" selected="true" /><select idref="V-238346" selected="true" /><select idref="V-238347" selected="true" /><select idref="V-238348" selected="true" /><select idref="V-238349" selected="true" /><select idref="V-238350" selected="true" /><select idref="V-238351" selected="true" /><select idref="V-238352" selected="true" /><select idref="V-238353" selected="true" /><select idref="V-238354" selected="true" /><select idref="V-238355" selected="true" /><select idref="V-238356" selected="true" /><select idref="V-238357" selected="true" /><select idref="V-238358" selected="true" /><select idref="V-238359" selected="true" /><select idref="V-238360" selected="true" /><select idref="V-238361" selected="true" /><select idref="V-238362" selected="true" /><select idref="V-238363" selected="true" /><select idref="V-238364" selected="true" /><select idref="V-238365" selected="true" /><select idref="V-238366" selected="true" /><select idref="V-238367" selected="true" /><select idref="V-238368" selected="true" /><select idref="V-238369" selected="true" /><select idref="V-238370" selected="true" /><select idref="V-238371" selected="true" /><select idref="V-238372" selected="true" /><select idref="V-238373" selected="true" /><select idref="V-238374" selected="true" /><select idref="V-238376" selected="true" /><select idref="V-238377" selected="true" /><select idref="V-238378" selected="true" /><select idref="V-238379" selected="true" /><select idref="V-238380" selected="true" /><select idref="V-251503" selected="true" /><select idref="V-251504" selected="true" /><select idref="V-251505" selected="true" /><select idref="V-252704" selected="true" /><select idref="V-255912" selected="true" /><select idref="V-255913" selected="true" /></Profile><Profile id="MAC-1_Sensitive"><title>I - Mission Critical Sensitive</title><description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</description><select idref="V-238196" selected="true" /><select idref="V-238197" selected="true" /><select idref="V-238198" selected="true" /><select idref="V-238199" selected="true" /><select idref="V-238200" selected="true" /><select idref="V-238201" selected="true" /><select idref="V-238202" selected="true" /><select idref="V-238203" selected="true" /><select idref="V-238204" selected="true" /><select idref="V-238205" selected="true" /><select idref="V-238206" selected="true" /><select idref="V-238207" selected="true" /><select idref="V-238208" selected="true" /><select idref="V-238209" selected="true" /><select idref="V-238210" selected="true" /><select idref="V-238211" selected="true" /><select idref="V-238212" selected="true" /><select idref="V-238213" selected="true" /><select idref="V-238214" selected="true" /><select idref="V-238215" selected="true" /><select idref="V-238216" selected="true" /><select idref="V-238217" selected="true" /><select idref="V-238218" selected="true" /><select idref="V-238219" selected="true" /><select idref="V-238220" selected="true" /><select idref="V-238221" selected="true" /><select idref="V-238222" selected="true" /><select idref="V-238223" selected="true" /><select idref="V-238224" selected="true" /><select idref="V-238225" selected="true" /><select idref="V-238226" selected="true" /><select idref="V-238227" selected="true" /><select idref="V-238228" selected="true" /><select idref="V-238229" selected="true" /><select idref="V-238230" selected="true" /><select idref="V-238231" selected="true" /><select idref="V-238232" selected="true" /><select idref="V-238233" selected="true" /><select idref="V-238234" selected="true" /><select idref="V-238235" selected="true" /><select idref="V-238236" selected="true" /><select idref="V-238237" selected="true" /><select idref="V-238238" selected="true" /><select idref="V-238239" selected="true" /><select idref="V-238240" selected="true" /><select idref="V-238241" selected="true" /><select idref="V-238242" selected="true" /><select idref="V-238243" selected="true" /><select idref="V-238244" selected="true" /><select idref="V-238245" selected="true" /><select idref="V-238246" selected="true" /><select idref="V-238247" selected="true" /><select idref="V-238248" selected="true" /><select idref="V-238249" selected="true" /><select idref="V-238250" selected="true" /><select idref="V-238251" selected="true" /><select idref="V-238252" selected="true" /><select idref="V-238253" selected="true" /><select idref="V-238254" selected="true" /><select idref="V-238255" selected="true" /><select idref="V-238256" selected="true" /><select idref="V-238257" selected="true" /><select idref="V-238258" selected="true" /><select idref="V-238264" selected="true" /><select idref="V-238268" selected="true" /><select idref="V-238271" selected="true" /><select idref="V-238277" selected="true" /><select idref="V-238278" selected="true" /><select idref="V-238279" selected="true" /><select idref="V-238280" selected="true" /><select idref="V-238281" selected="true" /><select idref="V-238282" selected="true" /><select idref="V-238283" selected="true" /><select idref="V-238284" selected="true" /><select idref="V-238285" selected="true" /><select idref="V-238286" selected="true" /><select idref="V-238287" selected="true" /><select idref="V-238288" selected="true" /><select idref="V-238289" selected="true" /><select idref="V-238290" selected="true" /><select idref="V-238291" selected="true" /><select idref="V-238292" selected="true" /><select idref="V-238293" selected="true" /><select idref="V-238294" selected="true" /><select idref="V-238295" selected="true" /><select idref="V-238297" selected="true" /><select idref="V-238298" selected="true" /><select idref="V-238299" selected="true" /><select idref="V-238300" selected="true" /><select idref="V-238301" selected="true" /><select idref="V-238302" selected="true" /><select idref="V-238303" selected="true" /><select idref="V-238304" selected="true" /><select idref="V-238305" selected="true" /><select idref="V-238306" selected="true" /><select idref="V-238307" selected="true" /><select idref="V-238308" selected="true" /><select idref="V-238309" selected="true" /><select idref="V-238310" selected="true" /><select idref="V-238315" selected="true" /><select idref="V-238316" selected="true" /><select idref="V-238317" selected="true" /><select idref="V-238318" selected="true" /><select idref="V-238319" selected="true" /><select idref="V-238320" selected="true" /><select idref="V-238321" selected="true" /><select idref="V-238323" selected="true" /><select idref="V-238324" selected="true" /><select idref="V-238325" selected="true" /><select idref="V-238326" selected="true" /><select idref="V-238327" selected="true" /><select idref="V-238328" selected="true" /><select idref="V-238329" selected="true" /><select idref="V-238330" selected="true" /><select idref="V-238331" selected="true" /><select idref="V-238332" selected="true" /><select idref="V-238333" selected="true" /><select idref="V-238334" selected="true" /><select idref="V-238335" selected="true" /><select idref="V-238336" selected="true" /><select idref="V-238337" selected="true" /><select idref="V-238338" selected="true" /><select idref="V-238339" selected="true" /><select idref="V-238340" selected="true" /><select idref="V-238341" selected="true" /><select idref="V-238342" selected="true" /><select idref="V-238343" selected="true" /><select idref="V-238344" selected="true" /><select idref="V-238345" selected="true" /><select idref="V-238346" selected="true" /><select idref="V-238347" selected="true" /><select idref="V-238348" selected="true" /><select idref="V-238349" selected="true" /><select idref="V-238350" selected="true" /><select idref="V-238351" selected="true" /><select idref="V-238352" selected="true" /><select idref="V-238353" selected="true" /><select idref="V-238354" selected="true" /><select idref="V-238355" selected="true" /><select idref="V-238356" selected="true" /><select idref="V-238357" selected="true" /><select idref="V-238358" selected="true" /><select idref="V-238359" selected="true" /><select idref="V-238360" selected="true" /><select idref="V-238361" selected="true" /><select idref="V-238362" selected="true" /><select idref="V-238363" selected="true" /><select idref="V-238364" selected="true" /><select idref="V-238365" selected="true" /><select idref="V-238366" selected="true" /><select idref="V-238367" selected="true" /><select idref="V-238368" selected="true" /><select idref="V-238369" selected="true" /><select idref="V-238370" selected="true" /><select idref="V-238371" selected="true" /><select idref="V-238372" selected="true" /><select idref="V-238373" selected="true" /><select idref="V-238374" selected="true" /><select idref="V-238376" selected="true" /><select idref="V-238377" selected="true" /><select idref="V-238378" selected="true" /><select idref="V-238379" selected="true" /><select idref="V-238380" selected="true" /><select idref="V-251503" selected="true" /><select idref="V-251504" selected="true" /><select idref="V-251505" selected="true" /><select idref="V-252704" selected="true" /><select idref="V-255912" selected="true" /><select idref="V-255913" selected="true" /></Profile><Profile id="MAC-2_Classified"><title>II - Mission Support Classified</title><description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</description><select idref="V-238196" selected="true" /><select idref="V-238197" selected="true" /><select idref="V-238198" selected="true" /><select idref="V-238199" selected="true" /><select idref="V-238200" selected="true" /><select idref="V-238201" selected="true" /><select idref="V-238202" selected="true" /><select idref="V-238203" selected="true" /><select idref="V-238204" selected="true" /><select idref="V-238205" selected="true" /><select idref="V-238206" selected="true" /><select idref="V-238207" selected="true" /><select idref="V-238208" selected="true" /><select idref="V-238209" selected="true" /><select idref="V-238210" selected="true" /><select idref="V-238211" selected="true" /><select idref="V-238212" selected="true" /><select idref="V-238213" selected="true" /><select idref="V-238214" selected="true" /><select idref="V-238215" selected="true" /><select idref="V-238216" selected="true" /><select idref="V-238217" selected="true" /><select idref="V-238218" selected="true" /><select idref="V-238219" selected="true" /><select idref="V-238220" selected="true" /><select idref="V-238221" selected="true" /><select idref="V-238222" selected="true" /><select idref="V-238223" selected="true" /><select idref="V-238224" selected="true" /><select idref="V-238225" selected="true" /><select idref="V-238226" selected="true" /><select idref="V-238227" selected="true" /><select idref="V-238228" selected="true" /><select idref="V-238229" selected="true" /><select idref="V-238230" selected="true" /><select idref="V-238231" selected="true" /><select idref="V-238232" selected="true" /><select idref="V-238233" selected="true" /><select idref="V-238234" selected="true" /><select idref="V-238235" selected="true" /><select idref="V-238236" selected="true" /><select idref="V-238237" selected="true" /><select idref="V-238238" selected="true" /><select idref="V-238239" selected="true" /><select idref="V-238240" selected="true" /><select idref="V-238241" selected="true" /><select idref="V-238242" selected="true" /><select idref="V-238243" selected="true" /><select idref="V-238244" selected="true" /><select idref="V-238245" selected="true" /><select idref="V-238246" selected="true" /><select idref="V-238247" selected="true" /><select idref="V-238248" selected="true" /><select idref="V-238249" selected="true" /><select idref="V-238250" selected="true" /><select idref="V-238251" selected="true" /><select idref="V-238252" selected="true" /><select idref="V-238253" selected="true" /><select idref="V-238254" selected="true" /><select idref="V-238255" selected="true" /><select idref="V-238256" selected="true" /><select idref="V-238257" selected="true" /><select idref="V-238258" selected="true" /><select idref="V-238264" selected="true" /><select idref="V-238268" selected="true" /><select idref="V-238271" selected="true" /><select idref="V-238277" selected="true" /><select idref="V-238278" selected="true" /><select idref="V-238279" selected="true" /><select idref="V-238280" selected="true" /><select idref="V-238281" selected="true" /><select idref="V-238282" selected="true" /><select idref="V-238283" selected="true" /><select idref="V-238284" selected="true" /><select idref="V-238285" selected="true" /><select idref="V-238286" selected="true" /><select idref="V-238287" selected="true" /><select idref="V-238288" selected="true" /><select idref="V-238289" selected="true" /><select idref="V-238290" selected="true" /><select idref="V-238291" selected="true" /><select idref="V-238292" selected="true" /><select idref="V-238293" selected="true" /><select idref="V-238294" selected="true" /><select idref="V-238295" selected="true" /><select idref="V-238297" selected="true" /><select idref="V-238298" selected="true" /><select idref="V-238299" selected="true" /><select idref="V-238300" selected="true" /><select idref="V-238301" selected="true" /><select idref="V-238302" selected="true" /><select idref="V-238303" selected="true" /><select idref="V-238304" selected="true" /><select idref="V-238305" selected="true" /><select idref="V-238306" selected="true" /><select idref="V-238307" selected="true" /><select idref="V-238308" selected="true" /><select idref="V-238309" selected="true" /><select idref="V-238310" selected="true" /><select idref="V-238315" selected="true" /><select idref="V-238316" selected="true" /><select idref="V-238317" selected="true" /><select idref="V-238318" selected="true" /><select idref="V-238319" selected="true" /><select idref="V-238320" selected="true" /><select idref="V-238321" selected="true" /><select idref="V-238323" selected="true" /><select idref="V-238324" selected="true" /><select idref="V-238325" selected="true" /><select idref="V-238326" selected="true" /><select idref="V-238327" selected="true" /><select idref="V-238328" selected="true" /><select idref="V-238329" selected="true" /><select idref="V-238330" selected="true" /><select idref="V-238331" selected="true" /><select idref="V-238332" selected="true" /><select idref="V-238333" selected="true" /><select idref="V-238334" selected="true" /><select idref="V-238335" selected="true" /><select idref="V-238336" selected="true" /><select idref="V-238337" selected="true" /><select idref="V-238338" selected="true" /><select idref="V-238339" selected="true" /><select idref="V-238340" selected="true" /><select idref="V-238341" selected="true" /><select idref="V-238342" selected="true" /><select idref="V-238343" selected="true" /><select idref="V-238344" selected="true" /><select idref="V-238345" selected="true" /><select idref="V-238346" selected="true" /><select idref="V-238347" selected="true" /><select idref="V-238348" selected="true" /><select idref="V-238349" selected="true" /><select idref="V-238350" selected="true" /><select idref="V-238351" selected="true" /><select idref="V-238352" selected="true" /><select idref="V-238353" selected="true" /><select idref="V-238354" selected="true" /><select idref="V-238355" selected="true" /><select idref="V-238356" selected="true" /><select idref="V-238357" selected="true" /><select idref="V-238358" selected="true" /><select idref="V-238359" selected="true" /><select idref="V-238360" selected="true" /><select idref="V-238361" selected="true" /><select idref="V-238362" selected="true" /><select idref="V-238363" selected="true" /><select idref="V-238364" selected="true" /><select idref="V-238365" selected="true" /><select idref="V-238366" selected="true" /><select idref="V-238367" selected="true" /><select idref="V-238368" selected="true" /><select idref="V-238369" selected="true" /><select idref="V-238370" selected="true" /><select idref="V-238371" selected="true" /><select idref="V-238372" selected="true" /><select idref="V-238373" selected="true" /><select idref="V-238374" selected="true" /><select idref="V-238376" selected="true" /><select idref="V-238377" selected="true" /><select idref="V-238378" selected="true" /><select idref="V-238379" selected="true" /><select idref="V-238380" selected="true" /><select idref="V-251503" selected="true" /><select idref="V-251504" selected="true" /><select idref="V-251505" selected="true" /><select idref="V-252704" selected="true" /><select idref="V-255912" selected="true" /><select idref="V-255913" selected="true" /></Profile><Profile id="MAC-2_Public"><title>II - Mission Support Public</title><description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</description><select idref="V-238196" selected="true" /><select idref="V-238197" selected="true" /><select idref="V-238198" selected="true" /><select idref="V-238199" selected="true" /><select idref="V-238200" selected="true" /><select idref="V-238201" selected="true" /><select idref="V-238202" selected="true" /><select idref="V-238203" selected="true" /><select idref="V-238204" selected="true" /><select idref="V-238205" selected="true" /><select idref="V-238206" selected="true" /><select idref="V-238207" selected="true" /><select idref="V-238208" selected="true" /><select idref="V-238209" selected="true" /><select idref="V-238210" selected="true" /><select idref="V-238211" selected="true" /><select idref="V-238212" selected="true" /><select idref="V-238213" selected="true" /><select idref="V-238214" selected="true" /><select idref="V-238215" selected="true" /><select idref="V-238216" selected="true" /><select idref="V-238217" selected="true" /><select idref="V-238218" selected="true" /><select idref="V-238219" selected="true" /><select idref="V-238220" selected="true" /><select idref="V-238221" selected="true" /><select idref="V-238222" selected="true" /><select idref="V-238223" selected="true" /><select idref="V-238224" selected="true" /><select idref="V-238225" selected="true" /><select idref="V-238226" selected="true" /><select idref="V-238227" selected="true" /><select idref="V-238228" selected="true" /><select idref="V-238229" selected="true" /><select idref="V-238230" selected="true" /><select idref="V-238231" selected="true" /><select idref="V-238232" selected="true" /><select idref="V-238233" selected="true" /><select idref="V-238234" selected="true" /><select idref="V-238235" selected="true" /><select idref="V-238236" selected="true" /><select idref="V-238237" selected="true" /><select idref="V-238238" selected="true" /><select idref="V-238239" selected="true" /><select idref="V-238240" selected="true" /><select idref="V-238241" selected="true" /><select idref="V-238242" selected="true" /><select idref="V-238243" selected="true" /><select idref="V-238244" selected="true" /><select idref="V-238245" selected="true" /><select idref="V-238246" selected="true" /><select idref="V-238247" selected="true" /><select idref="V-238248" selected="true" /><select idref="V-238249" selected="true" /><select idref="V-238250" selected="true" /><select idref="V-238251" selected="true" /><select idref="V-238252" selected="true" /><select idref="V-238253" selected="true" /><select idref="V-238254" selected="true" /><select idref="V-238255" selected="true" /><select idref="V-238256" selected="true" /><select idref="V-238257" selected="true" /><select idref="V-238258" selected="true" /><select idref="V-238264" selected="true" /><select idref="V-238268" selected="true" /><select idref="V-238271" selected="true" /><select idref="V-238277" selected="true" /><select idref="V-238278" selected="true" /><select idref="V-238279" selected="true" /><select idref="V-238280" selected="true" /><select idref="V-238281" selected="true" /><select idref="V-238282" selected="true" /><select idref="V-238283" selected="true" /><select idref="V-238284" selected="true" /><select idref="V-238285" selected="true" /><select idref="V-238286" selected="true" /><select idref="V-238287" selected="true" /><select idref="V-238288" selected="true" /><select idref="V-238289" selected="true" /><select idref="V-238290" selected="true" /><select idref="V-238291" selected="true" /><select idref="V-238292" selected="true" /><select idref="V-238293" selected="true" /><select idref="V-238294" selected="true" /><select idref="V-238295" selected="true" /><select idref="V-238297" selected="true" /><select idref="V-238298" selected="true" /><select idref="V-238299" selected="true" /><select idref="V-238300" selected="true" /><select idref="V-238301" selected="true" /><select idref="V-238302" selected="true" /><select idref="V-238303" selected="true" /><select idref="V-238304" selected="true" /><select idref="V-238305" selected="true" /><select idref="V-238306" selected="true" /><select idref="V-238307" selected="true" /><select idref="V-238308" selected="true" /><select idref="V-238309" selected="true" /><select idref="V-238310" selected="true" /><select idref="V-238315" selected="true" /><select idref="V-238316" selected="true" /><select idref="V-238317" selected="true" /><select idref="V-238318" selected="true" /><select idref="V-238319" selected="true" /><select idref="V-238320" selected="true" /><select idref="V-238321" selected="true" /><select idref="V-238323" selected="true" /><select idref="V-238324" selected="true" /><select idref="V-238325" selected="true" /><select idref="V-238326" selected="true" /><select idref="V-238327" selected="true" /><select idref="V-238328" selected="true" /><select idref="V-238329" selected="true" /><select idref="V-238330" selected="true" /><select idref="V-238331" selected="true" /><select idref="V-238332" selected="true" /><select idref="V-238333" selected="true" /><select idref="V-238334" selected="true" /><select idref="V-238335" selected="true" /><select idref="V-238336" selected="true" /><select idref="V-238337" selected="true" /><select idref="V-238338" selected="true" /><select idref="V-238339" selected="true" /><select idref="V-238340" selected="true" /><select idref="V-238341" selected="true" /><select idref="V-238342" selected="true" /><select idref="V-238343" selected="true" /><select idref="V-238344" selected="true" /><select idref="V-238345" selected="true" /><select idref="V-238346" selected="true" /><select idref="V-238347" selected="true" /><select idref="V-238348" selected="true" /><select idref="V-238349" selected="true" /><select idref="V-238350" selected="true" /><select idref="V-238351" selected="true" /><select idref="V-238352" selected="true" /><select idref="V-238353" selected="true" /><select idref="V-238354" selected="true" /><select idref="V-238355" selected="true" /><select idref="V-238356" selected="true" /><select idref="V-238357" selected="true" /><select idref="V-238358" selected="true" /><select idref="V-238359" selected="true" /><select idref="V-238360" selected="true" /><select idref="V-238361" selected="true" /><select idref="V-238362" selected="true" /><select idref="V-238363" selected="true" /><select idref="V-238364" selected="true" /><select idref="V-238365" selected="true" /><select idref="V-238366" selected="true" /><select idref="V-238367" selected="true" /><select idref="V-238368" selected="true" /><select idref="V-238369" selected="true" /><select idref="V-238370" selected="true" /><select idref="V-238371" selected="true" /><select idref="V-238372" selected="true" /><select idref="V-238373" selected="true" /><select idref="V-238374" selected="true" /><select idref="V-238376" selected="true" /><select idref="V-238377" selected="true" /><select idref="V-238378" selected="true" /><select idref="V-238379" selected="true" /><select idref="V-238380" selected="true" /><select idref="V-251503" selected="true" /><select idref="V-251504" selected="true" /><select idref="V-251505" selected="true" /><select idref="V-252704" selected="true" /><select idref="V-255912" selected="true" /><select idref="V-255913" selected="true" /></Profile><Profile id="MAC-2_Sensitive"><title>II - Mission Support Sensitive</title><description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</description><select idref="V-238196" selected="true" /><select idref="V-238197" selected="true" /><select idref="V-238198" selected="true" /><select idref="V-238199" selected="true" /><select idref="V-238200" selected="true" /><select idref="V-238201" selected="true" /><select idref="V-238202" selected="true" /><select idref="V-238203" selected="true" /><select idref="V-238204" selected="true" /><select idref="V-238205" selected="true" /><select idref="V-238206" selected="true" /><select idref="V-238207" selected="true" /><select idref="V-238208" selected="true" /><select idref="V-238209" selected="true" /><select idref="V-238210" selected="true" /><select idref="V-238211" selected="true" /><select idref="V-238212" selected="true" /><select idref="V-238213" selected="true" /><select idref="V-238214" selected="true" /><select idref="V-238215" selected="true" /><select idref="V-238216" selected="true" /><select idref="V-238217" selected="true" /><select idref="V-238218" selected="true" /><select idref="V-238219" selected="true" /><select idref="V-238220" selected="true" /><select idref="V-238221" selected="true" /><select idref="V-238222" selected="true" /><select idref="V-238223" selected="true" /><select idref="V-238224" selected="true" /><select idref="V-238225" selected="true" /><select idref="V-238226" selected="true" /><select idref="V-238227" selected="true" /><select idref="V-238228" selected="true" /><select idref="V-238229" selected="true" /><select idref="V-238230" selected="true" /><select idref="V-238231" selected="true" /><select idref="V-238232" selected="true" /><select idref="V-238233" selected="true" /><select idref="V-238234" selected="true" /><select idref="V-238235" selected="true" /><select idref="V-238236" selected="true" /><select idref="V-238237" selected="true" /><select idref="V-238238" selected="true" /><select idref="V-238239" selected="true" /><select idref="V-238240" selected="true" /><select idref="V-238241" selected="true" /><select idref="V-238242" selected="true" /><select idref="V-238243" selected="true" /><select idref="V-238244" selected="true" /><select idref="V-238245" selected="true" /><select idref="V-238246" selected="true" /><select idref="V-238247" selected="true" /><select idref="V-238248" selected="true" /><select idref="V-238249" selected="true" /><select idref="V-238250" selected="true" /><select idref="V-238251" selected="true" /><select idref="V-238252" selected="true" /><select idref="V-238253" selected="true" /><select idref="V-238254" selected="true" /><select idref="V-238255" selected="true" /><select idref="V-238256" selected="true" /><select idref="V-238257" selected="true" /><select idref="V-238258" selected="true" /><select idref="V-238264" selected="true" /><select idref="V-238268" selected="true" /><select idref="V-238271" selected="true" /><select idref="V-238277" selected="true" /><select idref="V-238278" selected="true" /><select idref="V-238279" selected="true" /><select idref="V-238280" selected="true" /><select idref="V-238281" selected="true" /><select idref="V-238282" selected="true" /><select idref="V-238283" selected="true" /><select idref="V-238284" selected="true" /><select idref="V-238285" selected="true" /><select idref="V-238286" selected="true" /><select idref="V-238287" selected="true" /><select idref="V-238288" selected="true" /><select idref="V-238289" selected="true" /><select idref="V-238290" selected="true" /><select idref="V-238291" selected="true" /><select idref="V-238292" selected="true" /><select idref="V-238293" selected="true" /><select idref="V-238294" selected="true" /><select idref="V-238295" selected="true" /><select idref="V-238297" selected="true" /><select idref="V-238298" selected="true" /><select idref="V-238299" selected="true" /><select idref="V-238300" selected="true" /><select idref="V-238301" selected="true" /><select idref="V-238302" selected="true" /><select idref="V-238303" selected="true" /><select idref="V-238304" selected="true" /><select idref="V-238305" selected="true" /><select idref="V-238306" selected="true" /><select idref="V-238307" selected="true" /><select idref="V-238308" selected="true" /><select idref="V-238309" selected="true" /><select idref="V-238310" selected="true" /><select idref="V-238315" selected="true" /><select idref="V-238316" selected="true" /><select idref="V-238317" selected="true" /><select idref="V-238318" selected="true" /><select idref="V-238319" selected="true" /><select idref="V-238320" selected="true" /><select idref="V-238321" selected="true" /><select idref="V-238323" selected="true" /><select idref="V-238324" selected="true" /><select idref="V-238325" selected="true" /><select idref="V-238326" selected="true" /><select idref="V-238327" selected="true" /><select idref="V-238328" selected="true" /><select idref="V-238329" selected="true" /><select idref="V-238330" selected="true" /><select idref="V-238331" selected="true" /><select idref="V-238332" selected="true" /><select idref="V-238333" selected="true" /><select idref="V-238334" selected="true" /><select idref="V-238335" selected="true" /><select idref="V-238336" selected="true" /><select idref="V-238337" selected="true" /><select idref="V-238338" selected="true" /><select idref="V-238339" selected="true" /><select idref="V-238340" selected="true" /><select idref="V-238341" selected="true" /><select idref="V-238342" selected="true" /><select idref="V-238343" selected="true" /><select idref="V-238344" selected="true" /><select idref="V-238345" selected="true" /><select idref="V-238346" selected="true" /><select idref="V-238347" selected="true" /><select idref="V-238348" selected="true" /><select idref="V-238349" selected="true" /><select idref="V-238350" selected="true" /><select idref="V-238351" selected="true" /><select idref="V-238352" selected="true" /><select idref="V-238353" selected="true" /><select idref="V-238354" selected="true" /><select idref="V-238355" selected="true" /><select idref="V-238356" selected="true" /><select idref="V-238357" selected="true" /><select idref="V-238358" selected="true" /><select idref="V-238359" selected="true" /><select idref="V-238360" selected="true" /><select idref="V-238361" selected="true" /><select idref="V-238362" selected="true" /><select idref="V-238363" selected="true" /><select idref="V-238364" selected="true" /><select idref="V-238365" selected="true" /><select idref="V-238366" selected="true" /><select idref="V-238367" selected="true" /><select idref="V-238368" selected="true" /><select idref="V-238369" selected="true" /><select idref="V-238370" selected="true" /><select idref="V-238371" selected="true" /><select idref="V-238372" selected="true" /><select idref="V-238373" selected="true" /><select idref="V-238374" selected="true" /><select idref="V-238376" selected="true" /><select idref="V-238377" selected="true" /><select idref="V-238378" selected="true" /><select idref="V-238379" selected="true" /><select idref="V-238380" selected="true" /><select idref="V-251503" selected="true" /><select idref="V-251504" selected="true" /><select idref="V-251505" selected="true" /><select idref="V-252704" selected="true" /><select idref="V-255912" selected="true" /><select idref="V-255913" selected="true" /></Profile><Profile id="MAC-3_Classified"><title>III - Administrative Classified</title><description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</description><select idref="V-238196" selected="true" /><select idref="V-238197" selected="true" /><select idref="V-238198" selected="true" /><select idref="V-238199" selected="true" /><select idref="V-238200" selected="true" /><select idref="V-238201" selected="true" /><select idref="V-238202" selected="true" /><select idref="V-238203" selected="true" /><select idref="V-238204" selected="true" /><select idref="V-238205" selected="true" /><select idref="V-238206" selected="true" /><select idref="V-238207" selected="true" /><select idref="V-238208" selected="true" /><select idref="V-238209" selected="true" /><select idref="V-238210" selected="true" /><select idref="V-238211" selected="true" /><select idref="V-238212" selected="true" /><select idref="V-238213" selected="true" /><select idref="V-238214" selected="true" /><select idref="V-238215" selected="true" /><select idref="V-238216" selected="true" /><select idref="V-238217" selected="true" /><select idref="V-238218" selected="true" /><select idref="V-238219" selected="true" /><select idref="V-238220" selected="true" /><select idref="V-238221" selected="true" /><select idref="V-238222" selected="true" /><select idref="V-238223" selected="true" /><select idref="V-238224" selected="true" /><select idref="V-238225" selected="true" /><select idref="V-238226" selected="true" /><select idref="V-238227" selected="true" /><select idref="V-238228" selected="true" /><select idref="V-238229" selected="true" /><select idref="V-238230" selected="true" /><select idref="V-238231" selected="true" /><select idref="V-238232" selected="true" /><select idref="V-238233" selected="true" /><select idref="V-238234" selected="true" /><select idref="V-238235" selected="true" /><select idref="V-238236" selected="true" /><select idref="V-238237" selected="true" /><select idref="V-238238" selected="true" /><select idref="V-238239" selected="true" /><select idref="V-238240" selected="true" /><select idref="V-238241" selected="true" /><select idref="V-238242" selected="true" /><select idref="V-238243" selected="true" /><select idref="V-238244" selected="true" /><select idref="V-238245" selected="true" /><select idref="V-238246" selected="true" /><select idref="V-238247" selected="true" /><select idref="V-238248" selected="true" /><select idref="V-238249" selected="true" /><select idref="V-238250" selected="true" /><select idref="V-238251" selected="true" /><select idref="V-238252" selected="true" /><select idref="V-238253" selected="true" /><select idref="V-238254" selected="true" /><select idref="V-238255" selected="true" /><select idref="V-238256" selected="true" /><select idref="V-238257" selected="true" /><select idref="V-238258" selected="true" /><select idref="V-238264" selected="true" /><select idref="V-238268" selected="true" /><select idref="V-238271" selected="true" /><select idref="V-238277" selected="true" /><select idref="V-238278" selected="true" /><select idref="V-238279" selected="true" /><select idref="V-238280" selected="true" /><select idref="V-238281" selected="true" /><select idref="V-238282" selected="true" /><select idref="V-238283" selected="true" /><select idref="V-238284" selected="true" /><select idref="V-238285" selected="true" /><select idref="V-238286" selected="true" /><select idref="V-238287" selected="true" /><select idref="V-238288" selected="true" /><select idref="V-238289" selected="true" /><select idref="V-238290" selected="true" /><select idref="V-238291" selected="true" /><select idref="V-238292" selected="true" /><select idref="V-238293" selected="true" /><select idref="V-238294" selected="true" /><select idref="V-238295" selected="true" /><select idref="V-238297" selected="true" /><select idref="V-238298" selected="true" /><select idref="V-238299" selected="true" /><select idref="V-238300" selected="true" /><select idref="V-238301" selected="true" /><select idref="V-238302" selected="true" /><select idref="V-238303" selected="true" /><select idref="V-238304" selected="true" /><select idref="V-238305" selected="true" /><select idref="V-238306" selected="true" /><select idref="V-238307" selected="true" /><select idref="V-238308" selected="true" /><select idref="V-238309" selected="true" /><select idref="V-238310" selected="true" /><select idref="V-238315" selected="true" /><select idref="V-238316" selected="true" /><select idref="V-238317" selected="true" /><select idref="V-238318" selected="true" /><select idref="V-238319" selected="true" /><select idref="V-238320" selected="true" /><select idref="V-238321" selected="true" /><select idref="V-238323" selected="true" /><select idref="V-238324" selected="true" /><select idref="V-238325" selected="true" /><select idref="V-238326" selected="true" /><select idref="V-238327" selected="true" /><select idref="V-238328" selected="true" /><select idref="V-238329" selected="true" /><select idref="V-238330" selected="true" /><select idref="V-238331" selected="true" /><select idref="V-238332" selected="true" /><select idref="V-238333" selected="true" /><select idref="V-238334" selected="true" /><select idref="V-238335" selected="true" /><select idref="V-238336" selected="true" /><select idref="V-238337" selected="true" /><select idref="V-238338" selected="true" /><select idref="V-238339" selected="true" /><select idref="V-238340" selected="true" /><select idref="V-238341" selected="true" /><select idref="V-238342" selected="true" /><select idref="V-238343" selected="true" /><select idref="V-238344" selected="true" /><select idref="V-238345" selected="true" /><select idref="V-238346" selected="true" /><select idref="V-238347" selected="true" /><select idref="V-238348" selected="true" /><select idref="V-238349" selected="true" /><select idref="V-238350" selected="true" /><select idref="V-238351" selected="true" /><select idref="V-238352" selected="true" /><select idref="V-238353" selected="true" /><select idref="V-238354" selected="true" /><select idref="V-238355" selected="true" /><select idref="V-238356" selected="true" /><select idref="V-238357" selected="true" /><select idref="V-238358" selected="true" /><select idref="V-238359" selected="true" /><select idref="V-238360" selected="true" /><select idref="V-238361" selected="true" /><select idref="V-238362" selected="true" /><select idref="V-238363" selected="true" /><select idref="V-238364" selected="true" /><select idref="V-238365" selected="true" /><select idref="V-238366" selected="true" /><select idref="V-238367" selected="true" /><select idref="V-238368" selected="true" /><select idref="V-238369" selected="true" /><select idref="V-238370" selected="true" /><select idref="V-238371" selected="true" /><select idref="V-238372" selected="true" /><select idref="V-238373" selected="true" /><select idref="V-238374" selected="true" /><select idref="V-238376" selected="true" /><select idref="V-238377" selected="true" /><select idref="V-238378" selected="true" /><select idref="V-238379" selected="true" /><select idref="V-238380" selected="true" /><select idref="V-251503" selected="true" /><select idref="V-251504" selected="true" /><select idref="V-251505" selected="true" /><select idref="V-252704" selected="true" /><select idref="V-255912" selected="true" /><select idref="V-255913" selected="true" /></Profile><Profile id="MAC-3_Public"><title>III - Administrative Public</title><description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</description><select idref="V-238196" selected="true" /><select idref="V-238197" selected="true" /><select idref="V-238198" selected="true" /><select idref="V-238199" selected="true" /><select idref="V-238200" selected="true" /><select idref="V-238201" selected="true" /><select idref="V-238202" selected="true" /><select idref="V-238203" selected="true" /><select idref="V-238204" selected="true" /><select idref="V-238205" selected="true" /><select idref="V-238206" selected="true" /><select idref="V-238207" selected="true" /><select idref="V-238208" selected="true" /><select idref="V-238209" selected="true" /><select idref="V-238210" selected="true" /><select idref="V-238211" selected="true" /><select idref="V-238212" selected="true" /><select idref="V-238213" selected="true" /><select idref="V-238214" selected="true" /><select idref="V-238215" selected="true" /><select idref="V-238216" selected="true" /><select idref="V-238217" selected="true" /><select idref="V-238218" selected="true" /><select idref="V-238219" selected="true" /><select idref="V-238220" selected="true" /><select idref="V-238221" selected="true" /><select idref="V-238222" selected="true" /><select idref="V-238223" selected="true" /><select idref="V-238224" selected="true" /><select idref="V-238225" selected="true" /><select idref="V-238226" selected="true" /><select idref="V-238227" selected="true" /><select idref="V-238228" selected="true" /><select idref="V-238229" selected="true" /><select idref="V-238230" selected="true" /><select idref="V-238231" selected="true" /><select idref="V-238232" selected="true" /><select idref="V-238233" selected="true" /><select idref="V-238234" selected="true" /><select idref="V-238235" selected="true" /><select idref="V-238236" selected="true" /><select idref="V-238237" selected="true" /><select idref="V-238238" selected="true" /><select idref="V-238239" selected="true" /><select idref="V-238240" selected="true" /><select idref="V-238241" selected="true" /><select idref="V-238242" selected="true" /><select idref="V-238243" selected="true" /><select idref="V-238244" selected="true" /><select idref="V-238245" selected="true" /><select idref="V-238246" selected="true" /><select idref="V-238247" selected="true" /><select idref="V-238248" selected="true" /><select idref="V-238249" selected="true" /><select idref="V-238250" selected="true" /><select idref="V-238251" selected="true" /><select idref="V-238252" selected="true" /><select idref="V-238253" selected="true" /><select idref="V-238254" selected="true" /><select idref="V-238255" selected="true" /><select idref="V-238256" selected="true" /><select idref="V-238257" selected="true" /><select idref="V-238258" selected="true" /><select idref="V-238264" selected="true" /><select idref="V-238268" selected="true" /><select idref="V-238271" selected="true" /><select idref="V-238277" selected="true" /><select idref="V-238278" selected="true" /><select idref="V-238279" selected="true" /><select idref="V-238280" selected="true" /><select idref="V-238281" selected="true" /><select idref="V-238282" selected="true" /><select idref="V-238283" selected="true" /><select idref="V-238284" selected="true" /><select idref="V-238285" selected="true" /><select idref="V-238286" selected="true" /><select idref="V-238287" selected="true" /><select idref="V-238288" selected="true" /><select idref="V-238289" selected="true" /><select idref="V-238290" selected="true" /><select idref="V-238291" selected="true" /><select idref="V-238292" selected="true" /><select idref="V-238293" selected="true" /><select idref="V-238294" selected="true" /><select idref="V-238295" selected="true" /><select idref="V-238297" selected="true" /><select idref="V-238298" selected="true" /><select idref="V-238299" selected="true" /><select idref="V-238300" selected="true" /><select idref="V-238301" selected="true" /><select idref="V-238302" selected="true" /><select idref="V-238303" selected="true" /><select idref="V-238304" selected="true" /><select idref="V-238305" selected="true" /><select idref="V-238306" selected="true" /><select idref="V-238307" selected="true" /><select idref="V-238308" selected="true" /><select idref="V-238309" selected="true" /><select idref="V-238310" selected="true" /><select idref="V-238315" selected="true" /><select idref="V-238316" selected="true" /><select idref="V-238317" selected="true" /><select idref="V-238318" selected="true" /><select idref="V-238319" selected="true" /><select idref="V-238320" selected="true" /><select idref="V-238321" selected="true" /><select idref="V-238323" selected="true" /><select idref="V-238324" selected="true" /><select idref="V-238325" selected="true" /><select idref="V-238326" selected="true" /><select idref="V-238327" selected="true" /><select idref="V-238328" selected="true" /><select idref="V-238329" selected="true" /><select idref="V-238330" selected="true" /><select idref="V-238331" selected="true" /><select idref="V-238332" selected="true" /><select idref="V-238333" selected="true" /><select idref="V-238334" selected="true" /><select idref="V-238335" selected="true" /><select idref="V-238336" selected="true" /><select idref="V-238337" selected="true" /><select idref="V-238338" selected="true" /><select idref="V-238339" selected="true" /><select idref="V-238340" selected="true" /><select idref="V-238341" selected="true" /><select idref="V-238342" selected="true" /><select idref="V-238343" selected="true" /><select idref="V-238344" selected="true" /><select idref="V-238345" selected="true" /><select idref="V-238346" selected="true" /><select idref="V-238347" selected="true" /><select idref="V-238348" selected="true" /><select idref="V-238349" selected="true" /><select idref="V-238350" selected="true" /><select idref="V-238351" selected="true" /><select idref="V-238352" selected="true" /><select idref="V-238353" selected="true" /><select idref="V-238354" selected="true" /><select idref="V-238355" selected="true" /><select idref="V-238356" selected="true" /><select idref="V-238357" selected="true" /><select idref="V-238358" selected="true" /><select idref="V-238359" selected="true" /><select idref="V-238360" selected="true" /><select idref="V-238361" selected="true" /><select idref="V-238362" selected="true" /><select idref="V-238363" selected="true" /><select idref="V-238364" selected="true" /><select idref="V-238365" selected="true" /><select idref="V-238366" selected="true" /><select idref="V-238367" selected="true" /><select idref="V-238368" selected="true" /><select idref="V-238369" selected="true" /><select idref="V-238370" selected="true" /><select idref="V-238371" selected="true" /><select idref="V-238372" selected="true" /><select idref="V-238373" selected="true" /><select idref="V-238374" selected="true" /><select idref="V-238376" selected="true" /><select idref="V-238377" selected="true" /><select idref="V-238378" selected="true" /><select idref="V-238379" selected="true" /><select idref="V-238380" selected="true" /><select idref="V-251503" selected="true" /><select idref="V-251504" selected="true" /><select idref="V-251505" selected="true" /><select idref="V-252704" selected="true" /><select idref="V-255912" selected="true" /><select idref="V-255913" selected="true" /></Profile><Profile id="MAC-3_Sensitive"><title>III - Administrative Sensitive</title><description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</description><select idref="V-238196" selected="true" /><select idref="V-238197" selected="true" /><select idref="V-238198" selected="true" /><select idref="V-238199" selected="true" /><select idref="V-238200" selected="true" /><select idref="V-238201" selected="true" /><select idref="V-238202" selected="true" /><select idref="V-238203" selected="true" /><select idref="V-238204" selected="true" /><select idref="V-238205" selected="true" /><select idref="V-238206" selected="true" /><select idref="V-238207" selected="true" /><select idref="V-238208" selected="true" /><select idref="V-238209" selected="true" /><select idref="V-238210" selected="true" /><select idref="V-238211" selected="true" /><select idref="V-238212" selected="true" /><select idref="V-238213" selected="true" /><select idref="V-238214" selected="true" /><select idref="V-238215" selected="true" /><select idref="V-238216" selected="true" /><select idref="V-238217" selected="true" /><select idref="V-238218" selected="true" /><select idref="V-238219" selected="true" /><select idref="V-238220" selected="true" /><select idref="V-238221" selected="true" /><select idref="V-238222" selected="true" /><select idref="V-238223" selected="true" /><select idref="V-238224" selected="true" /><select idref="V-238225" selected="true" /><select idref="V-238226" selected="true" /><select idref="V-238227" selected="true" /><select idref="V-238228" selected="true" /><select idref="V-238229" selected="true" /><select idref="V-238230" selected="true" /><select idref="V-238231" selected="true" /><select idref="V-238232" selected="true" /><select idref="V-238233" selected="true" /><select idref="V-238234" selected="true" /><select idref="V-238235" selected="true" /><select idref="V-238236" selected="true" /><select idref="V-238237" selected="true" /><select idref="V-238238" selected="true" /><select idref="V-238239" selected="true" /><select idref="V-238240" selected="true" /><select idref="V-238241" selected="true" /><select idref="V-238242" selected="true" /><select idref="V-238243" selected="true" /><select idref="V-238244" selected="true" /><select idref="V-238245" selected="true" /><select idref="V-238246" selected="true" /><select idref="V-238247" selected="true" /><select idref="V-238248" selected="true" /><select idref="V-238249" selected="true" /><select idref="V-238250" selected="true" /><select idref="V-238251" selected="true" /><select idref="V-238252" selected="true" /><select idref="V-238253" selected="true" /><select idref="V-238254" selected="true" /><select idref="V-238255" selected="true" /><select idref="V-238256" selected="true" /><select idref="V-238257" selected="true" /><select idref="V-238258" selected="true" /><select idref="V-238264" selected="true" /><select idref="V-238268" selected="true" /><select idref="V-238271" selected="true" /><select idref="V-238277" selected="true" /><select idref="V-238278" selected="true" /><select idref="V-238279" selected="true" /><select idref="V-238280" selected="true" /><select idref="V-238281" selected="true" /><select idref="V-238282" selected="true" /><select idref="V-238283" selected="true" /><select idref="V-238284" selected="true" /><select idref="V-238285" selected="true" /><select idref="V-238286" selected="true" /><select idref="V-238287" selected="true" /><select idref="V-238288" selected="true" /><select idref="V-238289" selected="true" /><select idref="V-238290" selected="true" /><select idref="V-238291" selected="true" /><select idref="V-238292" selected="true" /><select idref="V-238293" selected="true" /><select idref="V-238294" selected="true" /><select idref="V-238295" selected="true" /><select idref="V-238297" selected="true" /><select idref="V-238298" selected="true" /><select idref="V-238299" selected="true" /><select idref="V-238300" selected="true" /><select idref="V-238301" selected="true" /><select idref="V-238302" selected="true" /><select idref="V-238303" selected="true" /><select idref="V-238304" selected="true" /><select idref="V-238305" selected="true" /><select idref="V-238306" selected="true" /><select idref="V-238307" selected="true" /><select idref="V-238308" selected="true" /><select idref="V-238309" selected="true" /><select idref="V-238310" selected="true" /><select idref="V-238315" selected="true" /><select idref="V-238316" selected="true" /><select idref="V-238317" selected="true" /><select idref="V-238318" selected="true" /><select idref="V-238319" selected="true" /><select idref="V-238320" selected="true" /><select idref="V-238321" selected="true" /><select idref="V-238323" selected="true" /><select idref="V-238324" selected="true" /><select idref="V-238325" selected="true" /><select idref="V-238326" selected="true" /><select idref="V-238327" selected="true" /><select idref="V-238328" selected="true" /><select idref="V-238329" selected="true" /><select idref="V-238330" selected="true" /><select idref="V-238331" selected="true" /><select idref="V-238332" selected="true" /><select idref="V-238333" selected="true" /><select idref="V-238334" selected="true" /><select idref="V-238335" selected="true" /><select idref="V-238336" selected="true" /><select idref="V-238337" selected="true" /><select idref="V-238338" selected="true" /><select idref="V-238339" selected="true" /><select idref="V-238340" selected="true" /><select idref="V-238341" selected="true" /><select idref="V-238342" selected="true" /><select idref="V-238343" selected="true" /><select idref="V-238344" selected="true" /><select idref="V-238345" selected="true" /><select idref="V-238346" selected="true" /><select idref="V-238347" selected="true" /><select idref="V-238348" selected="true" /><select idref="V-238349" selected="true" /><select idref="V-238350" selected="true" /><select idref="V-238351" selected="true" /><select idref="V-238352" selected="true" /><select idref="V-238353" selected="true" /><select idref="V-238354" selected="true" /><select idref="V-238355" selected="true" /><select idref="V-238356" selected="true" /><select idref="V-238357" selected="true" /><select idref="V-238358" selected="true" /><select idref="V-238359" selected="true" /><select idref="V-238360" selected="true" /><select idref="V-238361" selected="true" /><select idref="V-238362" selected="true" /><select idref="V-238363" selected="true" /><select idref="V-238364" selected="true" /><select idref="V-238365" selected="true" /><select idref="V-238366" selected="true" /><select idref="V-238367" selected="true" /><select idref="V-238368" selected="true" /><select idref="V-238369" selected="true" /><select idref="V-238370" selected="true" /><select idref="V-238371" selected="true" /><select idref="V-238372" selected="true" /><select idref="V-238373" selected="true" /><select idref="V-238374" selected="true" /><select idref="V-238376" selected="true" /><select idref="V-238377" selected="true" /><select idref="V-238378" selected="true" /><select idref="V-238379" selected="true" /><select idref="V-238380" selected="true" /><select idref="V-251503" selected="true" /><select idref="V-251504" selected="true" /><select idref="V-251505" selected="true" /><select idref="V-252704" selected="true" /><select idref="V-255912" selected="true" /><select idref="V-255913" selected="true" /></Profile><Group id="V-238196"><title>SRG-OS-000002-GPOS-00002</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238196r653763_rule" weight="10.0" severity="medium"><version>UBTU-20-010000</version><title>The Ubuntu operating system must provision temporary user accounts with an expiration time of 72 hours or less.</title><description>&lt;VulnDiscussion&gt;If temporary user accounts remain active when no longer needed or for an excessive period, these accounts may be used to gain unauthorized access. To mitigate this risk, automated termination of all temporary accounts must be set upon account creation. 
+ 
+Temporary accounts are established as part of normal account activation procedures when there is a need for short-term accounts without the demand for immediacy in account activation. 
+ 
+If temporary accounts are used, the operating system must be configured to automatically terminate these types of accounts after a DoD-defined time period of 72 hours. 
+ 
+To address access requirements, many operating systems may be integrated with enterprise-level authentication/access mechanisms that meet or exceed access control policy requirements.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000016</ident><fixtext fixref="F-41365r653762_fix">If a temporary account must be created, configure the system to terminate the account after a 72-hour time period with the following command to set an expiration date on it.  
+ 
+Substitute "system_account_name" with the account to be created. 
+ 
+$ sudo chage -E $(date -d "+3 days" +%F) system_account_name</fixtext><fix id="F-41365r653762_fix" /><check system="C-41406r653761_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that the Ubuntu operating system expires temporary user accounts within 72 hours or less. 
+ 
+For every existing temporary account, run the following command to obtain its account expiration information: 
+ 
+$ sudo chage -l system_account_name | grep expires 
+ 
+Password expires : Aug 07, 2019 
+Account expires : Aug 07, 2019 
+ 
+Verify that each of these accounts has an expiration date set within 72 hours of account creation. 
+ 
+If any temporary account does not expire within 72 hours of that account's creation, this is a finding.</check-content></check></Rule></Group><Group id="V-238197"><title>SRG-OS-000023-GPOS-00006</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238197r653766_rule" weight="10.0" severity="medium"><version>UBTU-20-010002</version><title>The Ubuntu operating system must enable the graphical user logon banner to display the Standard Mandatory DoD Notice and Consent Banner before granting local access to the system via a graphical user logon.</title><description>&lt;VulnDiscussion&gt;Display of a standardized and approved use notification before granting access to the Ubuntu operating system ensures privacy and security notification verbiage used is consistent with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance. 
+ 
+System use notifications are required only for access via logon interfaces with human users and are not required when such human interfaces do not exist. 
+ 
+The banner must be formatted in accordance with applicable DoD policy. Use the following verbiage for operating systems that can accommodate banners of 1300 characters: 
+ 
+"You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only. 
+ 
+By using this IS (which includes any device attached to this IS), you consent to the following conditions: 
+ 
+-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations. 
+ 
+-At any time, the USG may inspect and seize data stored on this IS. 
+ 
+-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose. 
+ 
+-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy. 
+ 
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details." 
+ 
+Use the following verbiage for operating systems that have severe limitations on the number of characters that can be displayed in the banner: 
+ 
+"I've read &amp; consent to terms in IS user agreem't."&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000048</ident><fixtext fixref="F-41366r653765_fix">Edit the "/etc/gdm3/greeter.dconf-defaults" file. 
+ 
+Look for the "banner-message-enable" parameter under the "[org/gnome/login-screen]" section and uncomment it (remove the leading "#" characters): 
+ 
+Note: The lines are all near the bottom of the file but not adjacent to each other. 
+ 
+[org/gnome/login-screen] 
+ 
+banner-message-enable=true 
+ 
+Update the GDM with the new configuration: 
+ 
+$ sudo dconf update 
+$ sudo systemctl restart gdm3</fixtext><fix id="F-41366r653765_fix" /><check system="C-41407r653764_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system is configured to display the Standard Mandatory DoD Notice and Consent Banner before granting access to the operating system via a graphical user logon. 
+ 
+Note: If the system does not have a graphical user interface installed, this requirement is Not Applicable. 
+ 
+Check that the operating banner message for the graphical user logon is enabled with the following command: 
+ 
+$ grep ^banner-message-enable /etc/gdm3/greeter.dconf-defaults 
+ 
+banner-message-enable=true 
+ 
+If the line is commented out or set to "false", this is a finding.</check-content></check></Rule></Group><Group id="V-238198"><title>SRG-OS-000023-GPOS-00006</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238198r653769_rule" weight="10.0" severity="medium"><version>UBTU-20-010003</version><title>The Ubuntu operating system must display the Standard Mandatory DoD Notice and Consent Banner before granting local access to the system via a graphical user logon.</title><description>&lt;VulnDiscussion&gt;Display of a standardized and approved use notification before granting access to the Ubuntu operating system ensures privacy and security notification verbiage used is consistent with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance. 
+ 
+System use notifications are required only for access via logon interfaces with human users and are not required when such human interfaces do not exist. 
+ 
+The banner must be formatted in accordance with applicable DoD policy. Use the following verbiage for operating systems that can accommodate banners of 1300 characters: 
+ 
+"You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only. 
+ 
+By using this IS (which includes any device attached to this IS), you consent to the following conditions: 
+ 
+-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations. 
+ 
+-At any time, the USG may inspect and seize data stored on this IS. 
+ 
+-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose. 
+ 
+-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy. 
+ 
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details." 
+ 
+Use the following verbiage for operating systems that have severe limitations on the number of characters that can be displayed in the banner: 
+ 
+"I've read &amp; consent to terms in IS user agreem't."&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000048</ident><fixtext fixref="F-41367r653768_fix">Edit the "/etc/gdm3/greeter.dconf-defaults" file. 
+ 
+Set the "banner-message-text" line to contain the appropriate banner message text as shown below: 
+ 
+banner-message-text='You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only.\n\nBy using this IS (which includes any device attached to this IS), you consent to the following conditions:\n\n-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.\n\n-At any time, the USG may inspect and seize data stored on this IS.\n\n-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.\n\n-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy.\n\n-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details.' 
+ 
+Update the GDM with the new configuration: 
+ 
+$ sudo dconf update 
+$ sudo systemctl restart gdm3</fixtext><fix id="F-41367r653768_fix" /><check system="C-41408r653767_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system displays the Standard Mandatory DoD Notice and Consent Banner before granting access to the operating system via a graphical user logon. 
+ 
+Note: If the system does not have a graphical user interface installed, this requirement is Not Applicable. 
+ 
+Verify the operating system displays the exact approved Standard Mandatory DoD Notice and Consent Banner text with the command: 
+ 
+$ grep ^banner-message-text /etc/gdm3/greeter.dconf-defaults 
+ 
+banner-message-text="You are accessing a U.S. Government \(USG\) Information System \(IS\) that is provided for USG-authorized use only.\s+By using this IS \(which includes any device attached to this IS\), you consent to the following conditions:\s+-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct \(PM\), law enforcement \(LE\), and counterintelligence \(CI\) investigations.\s+-At any time, the USG may inspect and seize data stored on this IS.\s+-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.\s+-This IS includes security measures \(e.g., authentication and access controls\) to protect USG interests--not for your personal benefit or privacy.\s+-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details." 
+ 
+If the banner-message-text is missing, commented out, or does not match the Standard Mandatory DoD Notice and Consent Banner exactly, this is a finding.</check-content></check></Rule></Group><Group id="V-238199"><title>SRG-OS-000028-GPOS-00009</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238199r653772_rule" weight="10.0" severity="medium"><version>UBTU-20-010004</version><title>The Ubuntu operating system must retain a user's session lock until that user reestablishes access using established identification and authentication procedures.</title><description>&lt;VulnDiscussion&gt;A session lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity of the information system but does not want to log out because of the temporary nature of the absence. 
+ 
+The session lock is implemented at the point where session activity can be determined. 
+ 
+Regardless of where the session lock is determined and implemented, once invoked, a session lock of the Ubuntu operating system must remain in place until the user reauthenticates. No other activity aside from reauthentication must unlock the system.
+
+Satisfies: SRG-OS-000028-GPOS-00009, SRG-OS-000029-GPOS-00010&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000056</ident><ident system="http://cyber.mil/cci">CCI-000057</ident><fixtext fixref="F-41368r653771_fix">Configure the Ubuntu operating system to allow a user to lock the current graphical user interface session.  
+ 
+Note: If the Ubuntu operating system does not have a graphical user interface installed, this requirement is Not Applicable.  
+ 
+Set the "lock-enabled" setting to allow graphical user interface session locks with the following command:  
+ 
+$ sudo gsettings set org.gnome.desktop.screensaver lock-enabled true</fixtext><fix id="F-41368r653771_fix" /><check system="C-41409r653770_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operation system has a graphical user interface session lock enabled.  
+ 
+Note: If the Ubuntu operating system does not have a graphical user interface installed, this requirement is Not Applicable. 
+ 
+Get the "lock-enabled" setting to verify the graphical user interface session has the lock enabled with the following command: 
+  
+$ sudo gsettings get org.gnome.desktop.screensaver lock-enabled 
+ 
+ true  
+ 
+If "lock-enabled" is not set to "true", this is a finding.</check-content></check></Rule></Group><Group id="V-238200"><title>SRG-OS-000030-GPOS-00011</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238200r653775_rule" weight="10.0" severity="medium"><version>UBTU-20-010005</version><title>The Ubuntu operating system must allow users to directly initiate a session lock for all connection types.</title><description>&lt;VulnDiscussion&gt;A session lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity of the information system but does not want to log out because of the temporary nature of the absence. 
+ 
+The session lock is implemented at the point where session activity can be determined. Rather than be forced to wait for a period of time to expire before the user session can be locked, the Ubuntu operating systems need to provide users with the ability to manually invoke a session lock so users may secure their session if they need to temporarily vacate the immediate physical vicinity.
+
+Satisfies: SRG-OS-000030-GPOS-00011, SRG-OS-000031-GPOS-00012&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000058</ident><ident system="http://cyber.mil/cci">CCI-000060</ident><fixtext fixref="F-41369r653774_fix">Install the "vlock" package (if it is not already installed) by running the following command: 
+ 
+$ sudo apt-get install vlock</fixtext><fix id="F-41369r653774_fix" /><check system="C-41410r653773_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system has the "vlock" package installed by running the following command: 
+ 
+$ dpkg -l | grep vlock 
+ 
+If "vlock" is not installed, this is a finding.</check-content></check></Rule></Group><Group id="V-238201"><title>SRG-OS-000068-GPOS-00036</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238201r832933_rule" weight="10.0" severity="high"><version>UBTU-20-010006</version><title>The Ubuntu operating system must map the authenticated identity to the user or group account for PKI-based authentication.</title><description>&lt;VulnDiscussion&gt;Without mapping the certificate used to authenticate to the user account, the ability to determine the identity of the individual user or group will not be available for forensic analysis.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000187</ident><fixtext fixref="F-41370r653777_fix">Set "use_mappers=pwent" in "/etc/pam_pkcs11/pam_pkcs11.conf" or, if there is already a comma-separated list of mappers, add it to the list, separated by comma, and before the null mapper. 
+ 
+If the system is missing an "/etc/pam_pkcs11/" directory and an "/etc/pam_pkcs11/pam_pkcs11.conf", find an example to copy into place and modify accordingly at "/usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example.gz".</fixtext><fix id="F-41370r653777_fix" /><check system="C-41411r832932_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that "use_mappers" is set to "pwent" in "/etc/pam_pkcs11/pam_pkcs11.conf" file: 
+ 
+$ grep use_mappers /etc/pam_pkcs11/pam_pkcs11.conf 
+use_mappers = pwent 
+ 
+If "use_mappers" is not found or the list does not contain "pwent" this is a finding.</check-content></check></Rule></Group><Group id="V-238202"><title>SRG-OS-000075-GPOS-00043</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238202r653781_rule" weight="10.0" severity="low"><version>UBTU-20-010007</version><title>The Ubuntu operating system must enforce 24 hours/1 day as the minimum password lifetime. Passwords for new users must have a 24 hours/1 day minimum password lifetime restriction.</title><description>&lt;VulnDiscussion&gt;Enforcing a minimum password lifetime helps to prevent repeated password changes to defeat the password reuse or history enforcement requirement. If users are allowed to immediately and continually change their password, then the password could be repeatedly changed in a short period of time to defeat the organization's policy regarding password reuse.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000198</ident><fixtext fixref="F-41371r653780_fix">Configure the Ubuntu operating system to enforce a 24 hours/1 day minimum password lifetime. 
+ 
+Add or modify the following line in the "/etc/login.defs" file: 
+ 
+PASS_MIN_DAYS    1</fixtext><fix id="F-41371r653780_fix" /><check system="C-41412r653779_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system enforces a 24 hours/1 day minimum password lifetime for new user accounts by running the following command: 
+ 
+$ grep -i ^pass_min_days /etc/login.defs 
+ 
+PASS_MIN_DAYS    1 
+ 
+If the "PASS_MIN_DAYS" parameter value is less than "1" or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-238203"><title>SRG-OS-000076-GPOS-00044</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238203r653784_rule" weight="10.0" severity="low"><version>UBTU-20-010008</version><title>The Ubuntu operating system must enforce a 60-day maximum password lifetime restriction. Passwords for new users must have a 60-day maximum password lifetime restriction.</title><description>&lt;VulnDiscussion&gt;Any password, no matter how complex, can eventually be cracked. Therefore, passwords need to be changed periodically. If the operating system does not limit the lifetime of passwords and force users to change their passwords, there is the risk that the operating system passwords could be compromised.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000199</ident><fixtext fixref="F-41372r653783_fix">Configure the Ubuntu operating system to enforce a 60-day maximum password lifetime. 
+ 
+Add or modify the following line in the "/etc/login.defs" file: 
+ 
+PASS_MAX_DAYS    60</fixtext><fix id="F-41372r653783_fix" /><check system="C-41413r653782_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system enforces a 60-day maximum password lifetime for new user accounts by running the following command: 
+ 
+$ grep -i ^pass_max_days /etc/login.defs 
+PASS_MAX_DAYS    60 
+ 
+If the "PASS_MAX_DAYS" parameter value is less than "60" or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-238204"><title>SRG-OS-000080-GPOS-00048</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238204r832936_rule" weight="10.0" severity="high"><version>UBTU-20-010009</version><title>Ubuntu operating systems when booted must require authentication upon booting into single-user and maintenance modes.</title><description>&lt;VulnDiscussion&gt;To mitigate the risk of unauthorized access to sensitive information by entities that have been issued certificates by DoD-approved PKIs, all DoD systems (e.g., web servers and web portals) must be properly configured to incorporate access control methods that do not rely solely on the possession of a certificate for access.  
+ 
+Successful authentication must not automatically give an entity access to an asset or security boundary. Authorization procedures and controls must be implemented to ensure each authenticated entity also has a validated and current authorization. Authorization is the process of determining whether an entity, once authenticated, is permitted to access a specific asset. Information systems use access control policies and enforcement mechanisms to implement this requirement. 
+ 
+Access control policies include identity-based policies, role-based policies, and attribute-based policies. Access enforcement mechanisms include access control lists, access control matrices, and cryptography. These policies and mechanisms must be employed by the application to control access between users (or processes acting on behalf of users) and objects (e.g., devices, files, records, processes, programs, and domains) in the information system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000213</ident><fixtext fixref="F-41373r832935_fix">Configure the system to require a password for authentication upon booting into single-user and maintenance modes. 
+ 
+Generate an encrypted (grub) password for root with the following command: 
+ 
+$ grub-mkpasswd-pbkdf2 
+Enter Password: 
+Reenter Password: 
+PBKDF2 hash of your password is grub.pbkdf2.sha512.10000.MFU48934NJD84NF8NSD39993JDHF84NG 
+ 
+Using the hash from the output, modify the "/etc/grub.d/40_custom" file with the following command to add a boot password: 
+ 
+$ sudo sed -i '$i set superusers=\"root\"\npassword_pbkdf2 root &lt;hash&gt;' /etc/grub.d/40_custom 
+ 
+where &lt;hash&gt; is the hash generated by grub-mkpasswd-pbkdf2 command. 
+ 
+Generate an updated "grub.conf" file with the new password by using the following command: 
+ 
+$ sudo update-grub</fixtext><fix id="F-41373r832935_fix" /><check system="C-41414r832934_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Run the following command to verify the encrypted password is set: 
+ 
+$ sudo grep -i password /boot/grub/grub.cfg 
+ 
+password_pbkdf2 root grub.pbkdf2.sha512.10000.MFU48934NJA87HF8NSD34493GDHF84NG 
+ 
+If the root password entry does not begin with "password_pbkdf2", this is a finding.</check-content></check></Rule></Group><Group id="V-238205"><title>SRG-OS-000104-GPOS-00051</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238205r653790_rule" weight="10.0" severity="medium"><version>UBTU-20-010010</version><title>The Ubuntu operating system must uniquely identify interactive users.</title><description>&lt;VulnDiscussion&gt;To assure accountability and prevent unauthenticated access, organizational users must be identified and authenticated to prevent potential misuse and compromise of the system. 
+ 
+Organizational users include organizational employees or individuals the organization deems to have equivalent status of employees (e.g., contractors). Organizational users (and processes acting on behalf of users) must be uniquely identified and authenticated to all accesses, except for the following:  
+ 
+1) Accesses explicitly identified and documented by the organization. Organizations document specific user actions that can be performed on the information system without identification or authentication; and 
+ 
+2) Accesses that occur through authorized use of group authenticators without individual authentication. Organizations may require unique identification of individuals in group accounts (e.g., shared privilege accounts) or for detailed accountability of individual activity.
+
+Satisfies: SRG-OS-000104-GPOS-00051, SRG-OS-000121-GPOS-00062&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000764</ident><ident system="http://cyber.mil/cci">CCI-000804</ident><fixtext fixref="F-41374r653789_fix">Edit the file "/etc/passwd" and provide each interactive user account that has a duplicate UID with a unique UID.</fixtext><fix id="F-41374r653789_fix" /><check system="C-41415r653788_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system contains no duplicate User IDs (UIDs) for interactive users with the following command: 
+ 
+$ awk -F ":" 'list[$3]++{print $1, $3}' /etc/passwd 
+ 
+If output is produced and the accounts listed are interactive user accounts, this is a finding.</check-content></check></Rule></Group><Group id="V-238206"><title>SRG-OS-000134-GPOS-00068</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238206r653793_rule" weight="10.0" severity="high"><version>UBTU-20-010012</version><title>The Ubuntu operating system must ensure only users who need access to security functions are part of sudo group.</title><description>&lt;VulnDiscussion&gt;An isolation boundary provides access control and protects the integrity of the hardware, software, and firmware that perform security functions. 
+ 
+Security functions are the hardware, software, and/or firmware of the information system responsible for enforcing the system security policy and supporting the isolation of code and data on which the protection is based. Operating systems implement code separation (i.e., separation of security functions from nonsecurity functions) in a number of ways, including through the provision of security kernels via processor rings or processor modes. For non-kernel code, security function isolation is often achieved through file system protections that serve to protect the code on disk and address space protections that protect executing code. 
+ 
+Developers and implementers can increase the assurance in security functions by employing well-defined security policy models; structured, disciplined, and rigorous hardware and software development techniques; and sound system/security engineering principles. Implementation may include isolation of memory space and libraries.  
+ 
+The Ubuntu operating system restricts access to security functions through the use of access control mechanisms and by implementing least privilege capabilities.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001084</ident><fixtext fixref="F-41375r653792_fix">Configure the sudo group with only members requiring access to security functions. 
+ 
+To remove a user from the sudo group, run: 
+ 
+$ sudo gpasswd -d &lt;username&gt; sudo</fixtext><fix id="F-41375r653792_fix" /><check system="C-41416r653791_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the sudo group has only members who should have access to security functions.  
+ 
+$ grep sudo /etc/group 
+ 
+sudo:x:27:foo 
+ 
+If the sudo group contains users not needing access to security functions, this is a finding.</check-content></check></Rule></Group><Group id="V-238207"><title>SRG-OS-000279-GPOS-00109</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238207r853404_rule" weight="10.0" severity="medium"><version>UBTU-20-010013</version><title>The Ubuntu operating system must automatically terminate a user session after inactivity timeouts have expired.</title><description>&lt;VulnDiscussion&gt;Automatic session termination addresses the termination of user-initiated logical sessions in contrast to the termination of network connections that are associated with communications sessions (i.e., network disconnect). A logical session (for local, network, and remote access) is initiated whenever a user (or process acting on behalf of a user) accesses an organizational information system. Such user sessions can be terminated (and thus terminate user access) without terminating network sessions. 
+ 
+Session termination terminates all processes associated with a user's logical session except those processes that are specifically created by the user (i.e., session owner) to continue after the session is terminated. 
+ 
+Conditions or trigger events requiring automatic session termination can include, for example, organization-defined periods of user inactivity, targeted responses to certain types of incidents, and time-of-day restrictions on information system use. 
+ 
+This capability is typically reserved for specific operating system functionality where the system owner, data owner, or organization requires additional assurance.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-002361</ident><fixtext fixref="F-41376r653795_fix">Configure the operating system to automatically terminate a user session after inactivity timeouts have expired or at shutdown. 
+ 
+Create the file "/etc/profile.d/99-terminal_tmout.sh" file if it does not exist. 
+ 
+Modify or append the following line in the "/etc/profile.d/99-terminal_tmout.sh " file: 
+ 
+TMOUT=600 
+ 
+This will set a timeout value of 10 minutes for all future sessions. 
+ 
+To set the timeout for the current sessions, execute the following command over the terminal session: 
+ 
+$ export TMOUT=600</fixtext><fix id="F-41376r653795_fix" /><check system="C-41417r653794_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the operating system automatically terminates a user session after inactivity timeouts have expired. 
+ 
+Check that "TMOUT" environment variable is set in the "/etc/bash.bashrc" file or in any file inside the "/etc/profile.d/" directory by performing the following command: 
+ 
+$ grep -E "\bTMOUT=[0-9]+" /etc/bash.bashrc /etc/profile.d/* 
+ 
+TMOUT=600 
+ 
+If "TMOUT" is not set, or if the value is "0" or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-238208"><title>SRG-OS-000373-GPOS-00156</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238208r853405_rule" weight="10.0" severity="medium"><version>UBTU-20-010014</version><title>The Ubuntu operating system must require users to reauthenticate for privilege escalation or when changing roles.</title><description>&lt;VulnDiscussion&gt;Without reauthentication, users may access resources or perform tasks for which they do not have authorization.  
+ 
+When operating systems provide the capability to escalate a functional capability, it is critical the user reauthenticate.
+
+Satisfies: SRG-OS-000373-GPOS-00156, SRG-OS-000373-GPOS-00157&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-002038</ident><fixtext fixref="F-41377r653798_fix">Remove any occurrence of "NOPASSWD" or "!authenticate" found in "/etc/sudoers" file or files in the "/etc/sudoers.d" directory.</fixtext><fix id="F-41377r653798_fix" /><check system="C-41418r653797_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the "/etc/sudoers" file has no occurrences of "NOPASSWD" or "!authenticate" by running the following command: 
+ 
+$ sudo egrep -i '(nopasswd|!authenticate)' /etc/sudoers /etc/sudoers.d/* 
+ 
+If any occurrences of "NOPASSWD" or "!authenticate" return from the command, this is a finding.</check-content></check></Rule></Group><Group id="V-238209"><title>SRG-OS-000480-GPOS-00228</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238209r653802_rule" weight="10.0" severity="medium"><version>UBTU-20-010016</version><title>The Ubuntu operating system default filesystem permissions must be defined in such a way that all authenticated users can read and modify only their own files.</title><description>&lt;VulnDiscussion&gt;Setting the most restrictive default permissions ensures that when new accounts are created they do not have unnecessary access.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000366</ident><fixtext fixref="F-41378r653801_fix">Configure the system to define the default permissions for all authenticated users in such a way that the user can read and modify only their own files. 
+ 
+Edit the "UMASK" parameter in the "/etc/login.defs" file to match the example below: 
+ 
+UMASK 077</fixtext><fix id="F-41378r653801_fix" /><check system="C-41419r653800_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system defines default permissions for all authenticated users in such a way that the user can read and modify only their own files. 
+ 
+Verify the Ubuntu operating system defines default permissions for all authenticated users with the following command:  
+ 
+$ grep -i "umask" /etc/login.defs 
+ 
+UMASK 077 
+ 
+If the "UMASK" variable is set to "000", this is a finding with the severity raised to a CAT I. 
+ 
+If the value of "UMASK" is not set to "077", is commented out, or is missing completely, this is a finding.</check-content></check></Rule></Group><Group id="V-238210"><title>SRG-OS-000105-GPOS-00052</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238210r917810_rule" weight="10.0" severity="medium"><version>UBTU-20-010033</version><title>The Ubuntu operating system must implement smart card logins for multifactor authentication for local and network access to privileged and non-privileged accounts.</title><description>&lt;VulnDiscussion&gt;Without the use of multifactor authentication, the ease of access to privileged functions is greatly increased. 
+ 
+Multifactor authentication requires using two or more factors to achieve authentication. 
+ 
+Factors include:  
+1) something a user knows (e.g., password/PIN); 
+2) something a user has (e.g., cryptographic identification device, token); and 
+3) something a user is (e.g., biometric). 
+ 
+A privileged account is defined as an information system account with authorizations of a privileged user. 
+ 
+Network access is defined as access to an information system by a user (or a process acting on behalf of a user) communicating through a network (e.g., local area network, wide area network, or the internet). 
+ 
+The DoD CAC with DoD-approved PKI is an example of multifactor authentication.
+
+Satisfies: SRG-OS-000105-GPOS-00052, SRG-OS-000106-GPOS-00053, SRG-OS-000107-GPOS-00054, SRG-OS-000108-GPOS-00055&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000765</ident><ident system="http://cyber.mil/cci">CCI-000766</ident><ident system="http://cyber.mil/cci">CCI-000767</ident><ident system="http://cyber.mil/cci">CCI-000768</ident><fixtext fixref="F-41379r653804_fix">Configure the Ubuntu operating system to use multifactor authentication for network access to accounts. 
+ 
+Add or update "pam_pkcs11.so" in "/etc/pam.d/common-auth" to match the following line: 
+ 
+auth    [success=2 default=ignore] pam_pkcs11.so 
+ 
+Set the sshd option "PubkeyAuthentication yes" in the "/etc/ssh/sshd_config" file.</fixtext><fix id="F-41379r653804_fix" /><check system="C-41420r917809_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system has the packages required for multifactor authentication installed with the following commands:
+
+$ dpkg -l | grep libpam-pkcs11
+
+ii  libpam-pkcs11    0.6.8-4    amd64    Fully featured PAM module for using PKCS#11 smart cards
+
+If the "libpam-pkcs11" package is not installed, this is a finding.
+
+Verify the sshd daemon allows public key authentication with the following command:
+ 
+$ grep -ir pubkeyauthentication /etc/ssh/sshd_config*
+
+PubkeyAuthentication yes
+
+If this option is set to "no" or is missing, this is a finding.
+
+If conflicting results are returned, this is a finding.</check-content></check></Rule></Group><Group id="V-238211"><title>SRG-OS-000125-GPOS-00065</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238211r877395_rule" weight="10.0" severity="medium"><version>UBTU-20-010035</version><title>The Ubuntu operating system must use strong authenticators in establishing nonlocal maintenance and diagnostic sessions.</title><description>&lt;VulnDiscussion&gt;Nonlocal maintenance and diagnostic activities are those activities conducted by individuals communicating through a network, either an external network (e.g., the internet) or an internal network. Local maintenance and diagnostic activities are those activities carried out by individuals physically present at the information system or information system component and not communicating across a network connection. Typically, strong authentication requires authenticators that are resistant to replay attacks and employ multifactor authentication. Strong authenticators include, for example, PKI where certificates are stored on a token protected by a password, passphrase, or biometric.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000877</ident><fixtext fixref="F-41380r653807_fix">Configure the Ubuntu operating system to use strong authentication when establishing nonlocal maintenance and diagnostic sessions.  
+ 
+Add or modify the following line to /etc/ssh/sshd_config: 
+ 
+UsePAM yes</fixtext><fix id="F-41380r653807_fix" /><check system="C-41421r858518_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system is configured to use strong authenticators in the establishment of nonlocal maintenance and diagnostic maintenance.
+
+Verify that "UsePAM" is set to "yes" in "/etc/ssh/sshd_config:
+
+$ grep -r ^UsePAM /etc/ssh/sshd_config*
+
+UsePAM yes
+
+If "UsePAM" is not set to "yes", this is a finding.
+If conflicting results are returned, this is a finding.</check-content></check></Rule></Group><Group id="V-238212"><title>SRG-OS-000126-GPOS-00066</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238212r858521_rule" weight="10.0" severity="medium"><version>UBTU-20-010036</version><title>The Ubuntu operating system must immediately terminate all network connections associated with SSH traffic after a period of inactivity.</title><description>&lt;VulnDiscussion&gt;Automatic session termination addresses the termination of user-initiated logical sessions in contrast to the termination of network connections that are associated with communications sessions (i.e., network disconnect). A logical session (for local, network, and remote access) is initiated whenever a user (or process acting on behalf of a user) accesses an organizational information system. Such user sessions can be terminated (and thus terminate user access) without terminating network sessions. 
+ 
+Session termination terminates all processes associated with a user's logical session except those processes that are specifically created by the user (i.e., session owner) to continue after the session is terminated. 
+ 
+Conditions or trigger events requiring automatic session termination can include, for example, organization-defined periods of user inactivity, targeted responses to certain types of incidents, and time-of-day restrictions on information system use. 
+ 
+This capability is typically reserved for specific Ubuntu operating system functionality where the system owner, data owner, or organization requires additional assurance.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000879</ident><fixtext fixref="F-41381r653810_fix">Configure the Ubuntu operating system to automatically terminate inactive SSH sessions after a period of inactivity. 
+ 
+Modify or append the following line in the "/etc/ssh/sshd_config" file, replacing "[Count]" with a value of 1: 
+ 
+ClientAliveCountMax 1 
+ 
+Restart the SSH daemon for the changes to take effect: 
+ 
+$ sudo systemctl restart sshd.service</fixtext><fix id="F-41381r653810_fix" /><check system="C-41422r858520_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that all network connections associated with SSH traffic automatically terminate after a period of inactivity. 
+
+Verify the "ClientAliveCountMax" variable is set in the "/etc/ssh/sshd_config" file by performing the following command:
+
+$ sudo grep -ir clientalivecountmax /etc/ssh/sshd_config*
+
+ClientAliveCountMax  1
+
+If "ClientAliveCountMax" is not set, is not set to "1", or is commented out, this is a finding.
+If conflicting results are returned, this is a finding.</check-content></check></Rule></Group><Group id="V-238213"><title>SRG-OS-000163-GPOS-00072</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238213r858523_rule" weight="10.0" severity="medium"><version>UBTU-20-010037</version><title>The Ubuntu operating system must immediately terminate all network connections associated with SSH traffic at the end of the session or after 10 minutes of inactivity.</title><description>&lt;VulnDiscussion&gt;Terminating an idle session within a short time period reduces the window of opportunity for unauthorized personnel to take control of a management session enabled on the console or console port that has been left unattended. In addition, quickly terminating an idle session will also free up resources committed by the managed network element.  
+ 
+Terminating network connections associated with communications sessions includes, for example, de-allocating associated TCP/IP address/port pairs at the operating system level, and de-allocating networking assignments at the application level if multiple application sessions are using a single operating system-level network connection. This does not mean that the operating system terminates all sessions or network access; it only ends the inactive session and releases the resources associated with that session.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001133</ident><fixtext fixref="F-41382r653813_fix">Configure the Ubuntu operating system to automatically terminate all network connections associated with SSH traffic at the end of a session or after a 10-minute period of inactivity. 
+ 
+Modify or append the following line in the "/etc/ssh/sshd_config" file replacing "[Interval]" with a value of "600" or less: 
+ 
+ClientAliveInterval 600 
+ 
+Restart the SSH daemon for the changes to take effect: 
+ 
+$ sudo systemctl restart sshd.service</fixtext><fix id="F-41382r653813_fix" /><check system="C-41423r858522_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that all network connections associated with SSH traffic are automatically terminated at the end of the session or after 10 minutes of inactivity.
+
+Verify the "ClientAliveInterval" variable is set to a value of "600" or less by performing the following command:
+
+$ sudo grep -ir clientalive /etc/ssh/sshd_config*
+
+ClientAliveInterval 600
+
+If "ClientAliveInterval" does not exist, is not set to a value of "600" or less in "/etc/ssh/sshd_config", or is commented out, this is a finding.
+If conflicting results are returned, this is a finding.</check-content></check></Rule></Group><Group id="V-238214"><title>SRG-OS-000228-GPOS-00088</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238214r858525_rule" weight="10.0" severity="medium"><version>UBTU-20-010038</version><title>The Ubuntu operating system must display the Standard Mandatory DoD Notice and Consent Banner before granting any local or remote connection to the system.</title><description>&lt;VulnDiscussion&gt;Display of a standardized and approved use notification before granting access to the publicly accessible operating system ensures privacy and security notification verbiage used is consistent with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance. 
+ 
+System use notifications are required only for access via logon interfaces with human users and are not required when such human interfaces do not exist. 
+ 
+The banner must be formatted in accordance with applicable DoD policy. Use the following verbiage for operating systems that can accommodate banners of 1300 characters: 
+ 
+"You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only. 
+ 
+By using this IS (which includes any device attached to this IS), you consent to the following conditions: 
+ 
+-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations. 
+ 
+-At any time, the USG may inspect and seize data stored on this IS. 
+ 
+-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose. 
+ 
+-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy. 
+ 
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details." 
+ 
+Use the following verbiage for operating systems that have severe limitations on the number of characters that can be displayed in the banner: 
+ 
+"I've read &amp; consent to terms in IS user agreem't."
+
+Satisfies: SRG-OS-000228-GPOS-00088, SRG-OS-000023-GPOS-00006&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000048</ident><ident system="http://cyber.mil/cci">CCI-001384</ident><ident system="http://cyber.mil/cci">CCI-001385</ident><ident system="http://cyber.mil/cci">CCI-001386</ident><ident system="http://cyber.mil/cci">CCI-001387</ident><ident system="http://cyber.mil/cci">CCI-001388</ident><fixtext fixref="F-41383r653816_fix">Set the parameter Banner in "/etc/ssh/sshd_config" to point to the "/etc/issue.net" file: 
+ 
+$ sudo sed -i '/^Banner/d' /etc/ssh/sshd_config 
+$ sudo sed -i '$aBanner /etc/issue.net' /etc/ssh/sshd_config 
+ 
+Either create the file containing the banner or replace the text in the file with the Standard Mandatory DoD Notice and Consent Banner. The DoD required text is: 
+ 
+"You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only. 
+ 
+By using this IS (which includes any device attached to this IS), you consent to the following conditions: 
+ 
+-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations. 
+ 
+-At any time, the USG may inspect and seize data stored on this IS. 
+ 
+-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose. 
+ 
+-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy. 
+ 
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details." 
+ 
+Restart the SSH daemon for the changes to take effect and then signal the SSH server to reload the configuration file: 
+ 
+$ sudo systemctl -s SIGHUP kill sshd</fixtext><fix id="F-41383r653816_fix" /><check system="C-41424r858524_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system displays the Standard Mandatory DoD Notice and Consent Banner before granting access to the Ubuntu operating system via an SSH logon with the following command: 
+ 
+$ grep -ir banner /etc/ssh/sshd_config* 
+ 
+/etc/ssh/sshd_config:Banner /etc/issue.net
+ 
+The command will return the banner option along with the name of the file that contains the SSH banner. If the line is commented out, this is a finding.
+
+If conflicting results are returned, this is a finding.
+ 
+Verify the specified banner file matches the Standard Mandatory DoD Notice and Consent Banner exactly: 
+ 
+$ cat /etc/issue.net 
+ 
+"You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only. 
+ 
+By using this IS (which includes any device attached to this IS), you consent to the following conditions: 
+ 
+-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations. 
+ 
+-At any time, the USG may inspect and seize data stored on this IS. 
+ 
+-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose. 
+ 
+-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy. 
+ 
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details." 
+ 
+If the banner text does not match the Standard Mandatory DoD Notice and Consent Banner exactly, this is a finding.</check-content></check></Rule></Group><Group id="V-238215"><title>SRG-OS-000423-GPOS-00187</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238215r916422_rule" weight="10.0" severity="high"><version>UBTU-20-010042</version><title>The Ubuntu operating system must use SSH to protect the confidentiality and integrity of transmitted information.</title><description>&lt;VulnDiscussion&gt;Without protection of the transmitted information, confidentiality and integrity may be compromised because unprotected communications can be intercepted and either read or altered.  
+ 
+This requirement applies to both internal and external networks and all types of information system components from which information can be transmitted (e.g., servers, mobile devices, notebook computers, printers, copiers, scanners, and facsimile machines). Communication paths outside the physical protection of a controlled boundary are exposed to the possibility of interception and modification.  
+ 
+Protecting the confidentiality and integrity of organizational information can be accomplished by physical means (e.g., employing physical distribution systems) or by logical means (e.g., employing cryptographic techniques). If physical means of protection are employed, then logical means (cryptography) do not have to be employed, and vice versa.
+
+Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000425-GPOS-00189, SRG-OS-000426-GPOS-00190&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-002418</ident><ident system="http://cyber.mil/cci">CCI-002420</ident><ident system="http://cyber.mil/cci">CCI-002422</ident><fixtext fixref="F-41384r653819_fix">Install the "ssh" meta-package on the system with the following command: 
+ 
+$ sudo apt install ssh 
+ 
+Enable the "ssh" service to start automatically on reboot with the following command: 
+ 
+$ sudo systemctl enable sshd.service 
+ 
+ensure the "ssh" service is running 
+ 
+$ sudo systemctl start sshd.service</fixtext><fix id="F-41384r653819_fix" /><check system="C-41425r653818_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the SSH package is installed with the following command: 
+ 
+$ sudo dpkg -l | grep openssh 
+ii  openssh-client                        1:7.6p1-4ubuntu0.1                 amd64        secure shell (SSH) client, for secure access to remote machines 
+ii  openssh-server                        1:7.6p1-4ubuntu0.1                 amd64        secure shell (SSH) server, for secure access from remote machines 
+ii  openssh-sftp-server                   1:7.6p1-4ubuntu0.1                 amd64        secure shell (SSH) sftp server module, for SFTP access from remote machines 
+ 
+If the "openssh" server package is not installed, this is a finding. 
+ 
+Verify the "sshd.service" is loaded and active with the following command: 
+ 
+$ sudo systemctl status sshd.service | egrep -i "(active|loaded)" 
+   Loaded: loaded (/lib/systemd/system/ssh.service; enabled; vendor preset: enabled) 
+   Active: active (running) since Thu 2019-01-24 22:52:58 UTC; 1 weeks 3 days ago 
+ 
+If "sshd.service" is not active or loaded, this is a finding.</check-content></check></Rule></Group><Group id="V-238216"><title>SRG-OS-000424-GPOS-00188</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238216r877465_rule" weight="10.0" severity="medium"><version>UBTU-20-010043</version><title>The Ubuntu operating system must configure the SSH daemon to use Message Authentication Codes (MACs) employing FIPS 140-2 approved cryptographic hashes to prevent the unauthorized disclosure of information and/or detect changes to information during transmission.</title><description>&lt;VulnDiscussion&gt;Without cryptographic integrity protections, information can be altered by unauthorized users without detection.  
+ 
+Remote access (e.g., RDP) is access to DoD nonpublic information systems by an authorized user (or an information system) communicating through an external, non-organization-controlled network. Remote access methods include, for example, dial-up, broadband, and wireless. Nonlocal maintenance and diagnostic activities are those activities conducted by individuals communicating through a network, either an external network (e.g., the internet) or an internal network.  
+ 
+Local maintenance and diagnostic activities are those activities carried out by individuals physically present at the information system or information system component and not communicating across a network connection.  
+ 
+Encrypting information for transmission protects information from unauthorized disclosure and modification. Cryptographic mechanisms implemented to protect information integrity include, for example, cryptographic hash functions which have common application in digital signatures, checksums, and message authentication codes.
+
+Satisfies: SRG-OS-000424-GPOS-00188, SRG-OS-000250-GPOS-00093, SRG-OS-000393-GPOS-00173&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001453</ident><ident system="http://cyber.mil/cci">CCI-002421</ident><ident system="http://cyber.mil/cci">CCI-002890</ident><fixtext fixref="F-41385r653822_fix">Configure the Ubuntu operating system to allow the SSH daemon to only use MACs that employ FIPS 140-2 approved ciphers. 
+ 
+Add the following line (or modify the line to have the required value) to the "/etc/ssh/sshd_config" file (this file may be named differently or be in a different location if using a version of SSH that is provided by a third-party vendor): 
+ 
+MACs hmac-sha2-512,hmac-sha2-256 
+ 
+Restart the SSH daemon for the changes to take effect: 
+ 
+$ sudo systemctl reload sshd.service</fixtext><fix id="F-41385r653822_fix" /><check system="C-41426r858526_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the SSH daemon is configured to only use MACs that employ FIPS 140-2 approved ciphers with the following command:
+
+$ grep -ir macs /etc/ssh/sshd_config*
+ 
+MACs hmac-sha2-512,hmac-sha2-256
+
+If any ciphers other than "hmac-sha2-512" or "hmac-sha2-256" are listed, the order differs from the example above, or the returned line is commented out, this is a finding.
+If conflicting results are returned, this is a finding.</check-content></check></Rule></Group><Group id="V-238217"><title>SRG-OS-000424-GPOS-00188</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238217r877465_rule" weight="10.0" severity="medium"><version>UBTU-20-010044</version><title>The Ubuntu operating system must configure the SSH daemon to use FIPS 140-2 approved ciphers to prevent the unauthorized disclosure of information and/or detect changes to information during transmission.</title><description>&lt;VulnDiscussion&gt;Without cryptographic integrity protections, information can be altered by unauthorized users without detection.  
+ 
+Remote access (e.g., RDP) is access to DoD nonpublic information systems by an authorized user (or an information system) communicating through an external, non-organization-controlled network. Remote access methods include, for example, dial-up, broadband, and wireless.  
+ 
+Nonlocal maintenance and diagnostic activities are those activities conducted by individuals communicating through a network, either an external network (e.g., the internet) or an internal network.  
+ 
+Local maintenance and diagnostic activities are those activities carried out by individuals physically present at the information system or information system component and not communicating across a network connection.  
+ 
+Encrypting information for transmission protects information from unauthorized disclosure and modification. Cryptographic mechanisms implemented to protect information integrity include, for example, cryptographic hash functions which have common application in digital signatures, checksums, and message authentication codes. 
+ 
+By specifying a cipher list with the order of ciphers being in a "strongest to weakest" orientation, the system will automatically attempt to use the strongest cipher for securing SSH connections.
+
+Satisfies: SRG-OS-000424-GPOS-00188, SRG-OS-000033-GPOS-00014, SRG-OS-000394-GPOS-00174&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000068</ident><ident system="http://cyber.mil/cci">CCI-002421</ident><ident system="http://cyber.mil/cci">CCI-003123</ident><fixtext fixref="F-41386r653825_fix">Configure the Ubuntu operating system to allow the SSH daemon to only implement FIPS-approved algorithms. 
+ 
+Add the following line (or modify the line to have the required value) to the "/etc/ssh/sshd_config" file (this file may be named differently or be in a different location if using a version of SSH that is provided by a third-party vendor): 
+ 
+Ciphers aes256-ctr,aes192-ctr,aes128-ctr 
+ 
+Restart the SSH daemon for the changes to take effect: 
+ 
+$ sudo systemctl restart sshd.service</fixtext><fix id="F-41386r653825_fix" /><check system="C-41427r858528_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the SSH daemon is configured to only implement FIPS-approved algorithms by running the following command:
+
+$ grep -r 'Ciphers' /etc/ssh/sshd_config*
+ 
+Ciphers aes256-ctr,aes192-ctr,aes128-ctr 
+ 
+If any ciphers other than "aes256-ctr", "aes192-ctr", or "aes128-ctr" are listed, the order differs from the example above, the "Ciphers" keyword is missing, or the returned line is commented out, this is a finding.
+If conflicting results are returned, this is a finding.</check-content></check></Rule></Group><Group id="V-238218"><title>SRG-OS-000480-GPOS-00229</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238218r877377_rule" weight="10.0" severity="high"><version>UBTU-20-010047</version><title>The Ubuntu operating system must not allow unattended or automatic login via SSH.</title><description>&lt;VulnDiscussion&gt;Failure to restrict system access to authenticated users negatively impacts Ubuntu operating system security.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000366</ident><fixtext fixref="F-41387r653828_fix">Configure the Ubuntu operating system to allow the SSH daemon to not allow unattended or automatic login to the system. 
+ 
+Add or edit the following lines in the "/etc/ssh/sshd_config" file: 
+ 
+PermitEmptyPasswords no 
+PermitUserEnvironment no 
+ 
+Restart the SSH daemon for the changes to take effect: 
+ 
+$ sudo systemctl restart sshd.service</fixtext><fix id="F-41387r653828_fix" /><check system="C-41428r858530_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that unattended or automatic login via SSH is disabled with the following command:
+
+$ egrep -r '(Permit(.*?)(Passwords|Environment))' /etc/ssh/sshd_config
+
+PermitEmptyPasswords no
+PermitUserEnvironment no
+
+If "PermitEmptyPasswords" or "PermitUserEnvironment" keywords are not set to "no", are missing completely, or are commented out, this is a finding.
+If conflicting results are returned, this is a finding.</check-content></check></Rule></Group><Group id="V-238219"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238219r858533_rule" weight="10.0" severity="high"><version>UBTU-20-010048</version><title>The Ubuntu operating system must be configured so that remote X connections are disabled, unless to fulfill documented and validated mission requirements.</title><description>&lt;VulnDiscussion&gt;The security risk of using X11 forwarding is that the client's X11 display server may be exposed to attack when the SSH client requests forwarding.  A System Administrator may have a stance in which they want to protect clients that may expose themselves to attack by unwittingly requesting X11 forwarding, which can warrant a ''no'' setting. 
+ 
+X11 forwarding should be enabled with caution. Users with the ability to bypass file permissions on the remote host (for the user's X11 authorization database) can access the local X11 display through the forwarded connection. An attacker may then be able to perform activities such as keystroke monitoring if the ForwardX11Trusted option is also enabled. 
+ 
+If X11 services are not required for the system's intended function, they should be disabled or restricted as appropriate to the system’s needs.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000366</ident><fixtext fixref="F-41388r653831_fix">Edit the "/etc/ssh/sshd_config" file to uncomment or add the line for the "X11Forwarding" keyword and set its value to "no" (this file may be named differently or be in a different location if using a version of SSH that is provided by a third-party vendor): 
+ 
+X11Forwarding no 
+ 
+Restart the SSH daemon for the changes to take effect: 
+ 
+$ sudo systemctl restart sshd.service</fixtext><fix id="F-41388r653831_fix" /><check system="C-41429r858532_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that X11Forwarding is disabled with the following command: 
+ 
+$ grep -ir x11forwarding /etc/ssh/sshd_config* | grep -v "^#" 
+ 
+X11Forwarding no 
+ 
+If the "X11Forwarding" keyword is set to "yes" and is not documented with the Information System Security Officer (ISSO) as an operational requirement or is missing, this is a finding.
+If conflicting results are returned, this is a finding.</check-content></check></Rule></Group><Group id="V-238220"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238220r858535_rule" weight="10.0" severity="medium"><version>UBTU-20-010049</version><title>The Ubuntu operating system SSH daemon must prevent remote hosts from connecting to the proxy display.</title><description>&lt;VulnDiscussion&gt;When X11 forwarding is enabled, there may be additional exposure to the server and client displays if the sshd proxy display is configured to listen on the wildcard address.  By default, sshd binds the forwarding server to the loopback address and sets the hostname part of the DISPLAY environment variable to localhost. This prevents remote hosts from connecting to the proxy display.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000366</ident><fixtext fixref="F-41389r653834_fix">Configure the SSH daemon to prevent remote hosts from connecting to the proxy display. 
+ 
+Edit the "/etc/ssh/sshd_config" file to uncomment or add the line for the "X11UseLocalhost" keyword and set its value to "yes" (this file may be named differently or be in a different location if using a version of SSH that is provided by a third-party vendor): 
+ 
+X11UseLocalhost yes 
+ 
+Restart the SSH daemon for the changes to take effect: 
+ 
+$ sudo systemctl restart sshd.service</fixtext><fix id="F-41389r653834_fix" /><check system="C-41430r858534_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the SSH daemon prevents remote hosts from connecting to the proxy display.
+
+Check the SSH X11UseLocalhost setting with the following command:
+
+$ sudo grep -ir x11uselocalhost /etc/ssh/sshd_config*
+X11UseLocalhost yes
+
+If the "X11UseLocalhost" keyword is set to "no", is missing, or is commented out, this is a finding.
+If conflicting results are returned, this is a finding.</check-content></check></Rule></Group><Group id="V-238221"><title>SRG-OS-000069-GPOS-00037</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238221r653838_rule" weight="10.0" severity="low"><version>UBTU-20-010050</version><title>The Ubuntu operating system must enforce password complexity by requiring that at least one upper-case character be used.</title><description>&lt;VulnDiscussion&gt;Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. 
+ 
+Password complexity is one factor of several that determines how long it takes to crack a password. The more complex the password, the greater the number of possible combinations that need to be tested before the password is compromised.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000192</ident><fixtext fixref="F-41390r653837_fix">Add or update the "/etc/security/pwquality.conf" file to contain the "ucredit" parameter: 
+ 
+ucredit=-1</fixtext><fix id="F-41390r653837_fix" /><check system="C-41431r653836_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system enforces password complexity by requiring that at least one upper-case character be used. 
+ 
+Determine if the field "ucredit" is set in the "/etc/security/pwquality.conf" file with the following command: 
+ 
+$ grep -i "ucredit" /etc/security/pwquality.conf  
+ucredit=-1 
+ 
+If the "ucredit" parameter is greater than "-1" or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-238222"><title>SRG-OS-000070-GPOS-00038</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238222r653841_rule" weight="10.0" severity="low"><version>UBTU-20-010051</version><title>The Ubuntu operating system must enforce password complexity by requiring that at least one lower-case character be used.</title><description>&lt;VulnDiscussion&gt;Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. 
+ 
+Password complexity is one factor of several that determines how long it takes to crack a password. The more complex the password, the greater the number of possible combinations that need to be tested before the password is compromised.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000193</ident><fixtext fixref="F-41391r653840_fix">Add or update the "/etc/security/pwquality.conf" file to contain the "lcredit" parameter: 
+ 
+lcredit=-1</fixtext><fix id="F-41391r653840_fix" /><check system="C-41432r653839_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system enforces password complexity by requiring that at least one lower-case character be used. 
+ 
+Determine if the field "lcredit" is set in the "/etc/security/pwquality.conf" file with the following command: 
+ 
+$ grep -i "lcredit" /etc/security/pwquality.conf  
+lcredit=-1 
+ 
+If the "lcredit" parameter is greater than "-1" or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-238223"><title>SRG-OS-000071-GPOS-00039</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238223r653844_rule" weight="10.0" severity="low"><version>UBTU-20-010052</version><title>The Ubuntu operating system must enforce password complexity by requiring that at least one numeric character be used.</title><description>&lt;VulnDiscussion&gt;Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. 
+ 
+Password complexity is one factor of several that determines how long it takes to crack a password. The more complex the password, the greater the number of possible combinations that need to be tested before the password is compromised.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000194</ident><fixtext fixref="F-41392r653843_fix">Configure the Ubuntu operating system to enforce password complexity by requiring that at least one numeric character be used. 
+ 
+Add or update the "/etc/security/pwquality.conf" file to contain the "dcredit" parameter: 
+ 
+dcredit=-1</fixtext><fix id="F-41392r653843_fix" /><check system="C-41433r653842_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system enforces password complexity by requiring that at least one numeric character be used. 
+ 
+Determine if the field "dcredit" is set in the "/etc/security/pwquality.conf" file with the following command: 
+ 
+$ grep -i "dcredit" /etc/security/pwquality.conf  
+dcredit=-1 
+ 
+If the "dcredit" parameter is greater than "-1" or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-238224"><title>SRG-OS-000072-GPOS-00040</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238224r653847_rule" weight="10.0" severity="low"><version>UBTU-20-010053</version><title>The Ubuntu operating system must require the change of at least 8 characters when passwords are changed.</title><description>&lt;VulnDiscussion&gt; If the operating system allows the user to consecutively reuse extensive portions of passwords, this increases the chances of password compromise by increasing the window of opportunity for attempts at guessing and brute-force attacks. 
+ 
+The number of changed characters refers to the number of changes required with respect to the total number of positions in the current password. In other words, characters may be the same within the two passwords; however, the positions of the like characters must be different. 
+ 
+If the password length is an odd number then number of changed characters must be rounded up.  For example, a password length of 15 characters must require the change of at least 8 characters.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000195</ident><fixtext fixref="F-41393r653846_fix">Configure the Ubuntu operating system to require the change of at least eight characters when passwords are changed. 
+ 
+Add or update the "/etc/security/pwquality.conf" file to include the "difok=8" parameter: 
+ 
+difok=8</fixtext><fix id="F-41393r653846_fix" /><check system="C-41434r653845_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system requires the change of at least eight characters when passwords are changed. 
+ 
+Determine if the field "difok" is set in the "/etc/security/pwquality.conf" file with the following command: 
+ 
+$ grep -i "difok" /etc/security/pwquality.conf 
+difok=8 
+ 
+If the "difok" parameter is less than "8" or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-238225"><title>SRG-OS-000078-GPOS-00046</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238225r832942_rule" weight="10.0" severity="medium"><version>UBTU-20-010054</version><title>The Ubuntu operating system must enforce a minimum 15-character password length.</title><description>&lt;VulnDiscussion&gt;The shorter the password, the lower the number of possible combinations that need to be tested before the password is compromised. 
+ 
+Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. Password length is one factor of several that helps to determine strength and how long it takes to crack a password. Use of more characters in a password helps to exponentially increase the time and/or resources required to compromise the password.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000205</ident><fixtext fixref="F-41394r653849_fix">Configure the Ubuntu operating system to enforce a minimum 15-character password length. 
+ 
+Add or modify the "minlen" parameter value to the "/etc/security/pwquality.conf" file: 
+ 
+minlen=15</fixtext><fix id="F-41394r653849_fix" /><check system="C-41435r832941_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the pwquality configuration file enforces a minimum 15-character password length by running the following command:
+
+$ grep -i minlen /etc/security/pwquality.conf
+minlen=15
+
+If "minlen" parameter value is not "15" or higher or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-238226"><title>SRG-OS-000266-GPOS-00101</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238226r653853_rule" weight="10.0" severity="low"><version>UBTU-20-010055</version><title>The Ubuntu operating system must enforce password complexity by requiring that at least one special character be used.</title><description>&lt;VulnDiscussion&gt;Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity or strength is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. 
+ 
+Password complexity is one factor in determining how long it takes to crack a password. The more complex the password, the greater the number of possible combinations that need to be tested before the password is compromised. 
+ 
+Special characters are those characters that are not alphanumeric. Examples include: ~ ! @ # $ % ^ *.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001619</ident><fixtext fixref="F-41395r653852_fix">Configure the Ubuntu operating system to enforce password complexity by requiring that at least one special character be used.  
+ 
+Add or update the following line in the "/etc/security/pwquality.conf" file to include the "ocredit=-1" parameter: 
+ 
+ocredit=-1</fixtext><fix id="F-41395r653852_fix" /><check system="C-41436r653851_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Determine if the field "ocredit" is set in the "/etc/security/pwquality.conf" file with the following command: 
+ 
+$ grep -i "ocredit" /etc/security/pwquality.conf  
+ocredit=-1 
+ 
+If the "ocredit" parameter is greater than "-1" or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-238227"><title>SRG-OS-000480-GPOS-00225</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238227r653856_rule" weight="10.0" severity="medium"><version>UBTU-20-010056</version><title>The Ubuntu operating system must prevent the use of dictionary words for passwords.</title><description>&lt;VulnDiscussion&gt;If the Ubuntu operating system allows the user to select passwords based on dictionary words, then this increases the chances of password compromise by increasing the opportunity for successful guesses and brute-force attacks.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000366</ident><fixtext fixref="F-41396r653855_fix">Configure the Ubuntu operating system to prevent the use of dictionary words for passwords. 
+ 
+Add or update the following line in the "/etc/security/pwquality.conf" file to include the "dictcheck=1" parameter: 
+ 
+dictcheck=1</fixtext><fix id="F-41396r653855_fix" /><check system="C-41437r653854_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system uses the "cracklib" library to prevent the use of dictionary words with the following command: 
+ 
+$ grep dictcheck /etc/security/pwquality.conf 
+ 
+dictcheck=1 
+ 
+If the "dictcheck" parameter is not set to "1" or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-238228"><title>SRG-OS-000480-GPOS-00225</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238228r653859_rule" weight="10.0" severity="medium"><version>UBTU-20-010057</version><title>The Ubuntu operating system must be configured so that when passwords are changed or new passwords are established, pwquality must be used.</title><description>&lt;VulnDiscussion&gt;Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. "pwquality" enforces complex password construction configuration and has the ability to limit brute-force attacks on the system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000366</ident><fixtext fixref="F-41397r653858_fix">Configure the operating system to use "pwquality" to enforce password complexity rules. 
+ 
+Install the "pam_pwquality" package by using the following command: 
+ 
+$ sudo apt-get install libpam-pwquality -y 
+ 
+Add the following line to "/etc/security/pwquality.conf" (or modify the line to have the required value): 
+ 
+enforcing = 1 
+ 
+Add the following line to "/etc/pam.d/common-password" (or modify the line to have the required value): 
+ 
+password requisite pam_pwquality.so retry=3 
+ 
+Note: The value of "retry" should be between "1" and "3".</fixtext><fix id="F-41397r653858_fix" /><check system="C-41438r653857_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system has the "libpam-pwquality" package installed by running the following command: 
+ 
+$ dpkg -l libpam-pwquality 
+ 
+ii  libpam-pwquality:amd64            1.4.0-2               amd64             PAM module to check password strength 
+ 
+If "libpam-pwquality" is not installed, this is a finding. 
+ 
+Verify that the operating system uses "pwquality" to enforce the password complexity rules.  
+ 
+Verify the pwquality module is being enforced by the Ubuntu operating system by running the following command: 
+ 
+$ grep -i enforcing /etc/security/pwquality.conf 
+ 
+enforcing = 1 
+ 
+If the value of "enforcing" is not "1" or the line is commented out, this is a finding. 
+ 
+Check for the use of "pwquality" with the following command: 
+ 
+$ cat /etc/pam.d/common-password | grep requisite | grep pam_pwquality 
+ 
+password requisite pam_pwquality.so retry=3 
+ 
+If no output is returned or the line is commented out, this is a finding. 
+ 
+If the value of "retry" is set to "0" or greater than "3", this is a finding.</check-content></check></Rule></Group><Group id="V-238229"><title>SRG-OS-000066-GPOS-00034</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238229r653862_rule" weight="10.0" severity="medium"><version>UBTU-20-010060</version><title>The Ubuntu operating system, for PKI-based authentication, must validate certificates by constructing a certification path (which includes status information) to an accepted trust anchor.</title><description>&lt;VulnDiscussion&gt;Without path validation, an informed trust decision by the relying party cannot be made when presented with any certificate not already explicitly trusted. 
+ 
+A trust anchor is an authoritative entity represented via a public key and associated data. It is used in the context of public key infrastructures, X.509 digital certificates, and DNSSEC. 
+ 
+When there is a chain of trust, usually the top entity to be trusted becomes the trust anchor; it can be, for example, a Certification Authority (CA). A certification path starts with the subject certificate and proceeds through a number of intermediate certificates up to a trusted root certificate, typically issued by a trusted CA. 
+ 
+This requirement verifies that a certification path to an accepted trust anchor is used for certificate validation and that the path includes status information. Path validation is necessary for a relying party to make an informed trust decision when presented with any certificate not already explicitly trusted. Status information for certification paths includes certificate revocation lists or online certificate status protocol responses. Validation of the certificate status information is out of scope for this requirement.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000185</ident><fixtext fixref="F-41398r653861_fix">Configure the Ubuntu operating system, for PKI-based authentication, to validate certificates by constructing a certification path to an accepted trust anchor. 
+ 
+Determine which pkcs11 module is being used via the "use_pkcs11_module" in "/etc/pam_pkcs11/pam_pkcs11.conf" and ensure "ca" is enabled in "cert_policy". 
+ 
+Add or update the "cert_policy" to ensure "ca" is enabled: 
+ 
+cert_policy = ca,signature,ocsp_on; 
+ 
+If the system is missing an "/etc/pam_pkcs11/" directory and an "/etc/pam_pkcs11/pam_pkcs11.conf", find an example to copy into place and modify accordingly at "/usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example.gz".</fixtext><fix id="F-41398r653861_fix" /><check system="C-41439r653860_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system, for PKI-based authentication, has valid certificates by constructing a certification path to an accepted trust anchor. 
+ 
+Determine which pkcs11 module is being used via the "use_pkcs11_module" in "/etc/pam_pkcs11/pam_pkcs11.conf" and then ensure "ca" is enabled in "cert_policy" with the following command: 
+  
+$ sudo grep use_pkcs11_module /etc/pam_pkcs11/pam_pkcs11.conf | awk '/pkcs11_module opensc {/,/}/' /etc/pam_pkcs11/pam_pkcs11.conf | grep cert_policy | grep ca  
+ 
+cert_policy = ca,signature,ocsp_on; 
+ 
+If "cert_policy" is not set to "ca" or the line is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-238230"><title>SRG-OS-000375-GPOS-00160</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238230r853410_rule" weight="10.0" severity="medium"><version>UBTU-20-010063</version><title>The Ubuntu operating system must implement multifactor authentication for remote access to privileged accounts in such a way that one of the factors is provided by a device separate from the system gaining access.</title><description>&lt;VulnDiscussion&gt;Using an authentication device, such as a CAC or token that is separate from the information system, ensures that even if the information system is compromised, that compromise will not affect credentials stored on the authentication device. 
+ 
+Multifactor solutions that require devices separate from information systems gaining access include, for example, hardware tokens providing time-based or challenge-response authenticators and smart cards such as the U.S. Government Personal Identity Verification card and the DoD Common Access Card. 
+ 
+A privileged account is defined as an information system account with authorizations of a privileged user. 
+ 
+Remote access is access to DoD nonpublic information systems by an authorized user (or an information system) communicating through an external, non-organization-controlled network. Remote access methods include, for example, dial-up, broadband, and wireless. 
+ 
+This requirement only applies to components where this is specific to the function of the device or has the concept of an organizational user (e.g., VPN, proxy capability). This does not apply to authentication for the purpose of configuring the device itself (management).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001948</ident><fixtext fixref="F-41399r653864_fix">Configure the Ubuntu operating system to implement multifactor authentication by installing the required packages. 
+ 
+Install the "libpam-pkcs11" package on the system with the following command: 
+ 
+$ sudo apt install libpam-pkcs11</fixtext><fix id="F-41399r653864_fix" /><check system="C-41440r653863_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system has the packages required for multifactor authentication installed with the following commands: 
+ 
+$ dpkg -l | grep libpam-pkcs11 
+ 
+ii  libpam-pkcs11    0.6.8-4    amd64    Fully featured PAM module for using PKCS#11 smart cards 
+ 
+If the "libpam-pkcs11" package is not installed, this is a finding.</check-content></check></Rule></Group><Group id="V-238231"><title>SRG-OS-000376-GPOS-00161</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238231r853411_rule" weight="10.0" severity="medium"><version>UBTU-20-010064</version><title>The Ubuntu operating system must accept Personal Identity Verification (PIV) credentials.</title><description>&lt;VulnDiscussion&gt;The use of PIV credentials facilitates standardization and reduces the risk of unauthorized access. 
+ 
+DoD has mandated the use of the CAC to support identity management and personal authentication for systems covered under Homeland Security Presidential Directive (HSPD) 12, as well as making the CAC a primary component of layered protection for national security systems.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001953</ident><fixtext fixref="F-41400r653867_fix">Configure the Ubuntu operating system to accept PIV credentials. 
+ 
+Install the "opensc-pkcs11" package using the following command: 
+ 
+$ sudo apt-get install opensc-pkcs11</fixtext><fix id="F-41400r653867_fix" /><check system="C-41441r653866_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system accepts PIV credentials. 
+ 
+Verify the "opensc-pcks11" package is installed on the system with the following command: 
+ 
+$ dpkg -l | grep opensc-pkcs11 
+ 
+ii  opensc-pkcs11:amd64        0.15.0-1Ubuntu1    amd64        Smart card utilities with support for PKCS#15 compatible cards 
+ 
+If the "opensc-pcks11" package is not installed, this is a finding.</check-content></check></Rule></Group><Group id="V-238232"><title>SRG-OS-000377-GPOS-00162</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238232r853412_rule" weight="10.0" severity="medium"><version>UBTU-20-010065</version><title>The Ubuntu operating system must electronically verify Personal Identity Verification (PIV) credentials.</title><description>&lt;VulnDiscussion&gt;The use of PIV credentials facilitates standardization and reduces the risk of unauthorized access. 
+ 
+DoD has mandated the use of the CAC to support identity management and personal authentication for systems covered under Homeland Security Presidential Directive (HSPD) 12, as well as making the CAC a primary component of layered protection for national security systems.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001954</ident><fixtext fixref="F-41401r653870_fix">Configure the Ubuntu operating system to do certificate status checking for multifactor authentication. 
+ 
+Modify all of the "cert_policy" lines in "/etc/pam_pkcs11/pam_pkcs11.conf" to include "ocsp_on".</fixtext><fix id="F-41401r653870_fix" /><check system="C-41442r653869_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system electronically verifies PIV credentials. 
+ 
+Verify that certificate status checking for multifactor authentication is implemented with the following command: 
+ 
+$ sudo grep use_pkcs11_module /etc/pam_pkcs11/pam_pkcs11.conf | awk '/pkcs11_module opensc {/,/}/' /etc/pam_pkcs11/pam_pkcs11.conf | grep cert_policy | grep ocsp_on 
+ 
+cert_policy = ca,signature,ocsp_on; 
+ 
+If "cert_policy" is not set to "ocsp_on", or the line is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-238233"><title>SRG-OS-000384-GPOS-00167</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238233r880870_rule" weight="10.0" severity="medium"><version>UBTU-20-010066</version><title>The Ubuntu operating system for PKI-based authentication, must implement a local cache of revocation data in case of the inability to access revocation information via the network.</title><description>&lt;VulnDiscussion&gt;Without configuring a local cache of revocation data, there is the potential to allow access to users who are no longer authorized (users with revoked certificates).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001991</ident><fixtext fixref="F-41402r880869_fix">Configure the Ubuntu operating system, for PKI-based authentication, to use local revocation data when unable to access the network to obtain it remotely. 
+ 
+Add or update the "cert_policy" option in "/etc/pam_pkcs11/pam_pkcs11.conf" to include "crl_auto" or "crl_offline". 
+ 
+cert_policy = ca,signature,ocsp_on, crl_auto; 
+ 
+If the system is missing an "/etc/pam_pkcs11/" directory and an "/etc/pam_pkcs11/pam_pkcs11.conf", find an example to copy into place and modify accordingly at "/usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example.gz".</fixtext><fix id="F-41402r880869_fix" /><check system="C-41443r653872_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system, for PKI-based authentication, uses local revocation data when unable to access it from the network.  
+ 
+Verify that "crl_offline" or "crl_auto" is part of the "cert_policy" definition in "/etc/pam_pkcs11/pam_pkcs11.conf" using the following command: 
+ 
+# sudo grep cert_policy /etc/pam_pkcs11/pam_pkcs11.conf | grep  -E -- 'crl_auto|crl_offline' 
+ 
+cert_policy = ca,signature,ocsp_on,crl_auto; 
+ 
+If "cert_policy" is not set to include "crl_auto" or "crl_offline", this is a finding.</check-content></check></Rule></Group><Group id="V-238234"><title>SRG-OS-000077-GPOS-00045</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238234r832945_rule" weight="10.0" severity="low"><version>UBTU-20-010070</version><title>The Ubuntu operating system must prohibit password reuse for a minimum of five generations.</title><description>&lt;VulnDiscussion&gt;Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. If the information system or application allows the user to consecutively reuse their password when that password has exceeded its defined lifetime, the end result is a password that is not changed as per policy requirements.
+
+Satisfies: SRG-OS-000077-GPOS-00045, SRG-OS-000073-GPOS-00041&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000196</ident><ident system="http://cyber.mil/cci">CCI-000200</ident><fixtext fixref="F-41403r832944_fix">Configure the Ubuntu operating system to prevent passwords from being reused for a minimum of five generations.
+
+Add or modify the "remember" parameter value to the following line in "/etc/pam.d/common-password" file:
+
+password [success=1 default=ignore] pam_unix.so obscure sha512 shadow remember=5 rounds=5000</fixtext><fix id="F-41403r832944_fix" /><check system="C-41444r832943_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system prevents passwords from being reused for a minimum of five generations by running the following command:
+
+$ grep -i remember /etc/pam.d/common-password
+
+password [success=1 default=ignore] pam_unix.so obscure sha512 shadow remember=5 rounds=5000
+
+If the "remember" parameter value is not greater than or equal to "5", is commented out, or is not set at all, this is a finding.</check-content></check></Rule></Group><Group id="V-238235"><title>SRG-OS-000329-GPOS-00128</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238235r853414_rule" weight="10.0" severity="low"><version>UBTU-20-010072</version><title>The Ubuntu operating system must automatically lock an account until the locked account is released by an administrator when three unsuccessful logon attempts have been made.</title><description>&lt;VulnDiscussion&gt;By limiting the number of failed logon attempts, the risk of unauthorized system access via user password guessing, otherwise known as brute-forcing, is reduced. Limits are imposed by locking the account.
+
+Satisfies: SRG-OS-000329-GPOS-00128, SRG-OS-000021-GPOS-00005&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000044</ident><ident system="http://cyber.mil/cci">CCI-002238</ident><fixtext fixref="F-41404r802382_fix">Configure the Ubuntu operating system to utilize the "pam_faillock" module. 
+
+Edit the /etc/pam.d/common-auth file. 
+
+Add the following lines below the "auth" definition for pam_unix.so:
+auth     [default=die]  pam_faillock.so authfail
+auth     sufficient     pam_faillock.so authsucc
+
+Configure the "pam_faillock" module to use the following options:
+
+Edit the /etc/security/faillock.conf file and add/update the following keywords and values:
+audit
+silent
+deny = 3
+fail_interval = 900
+unlock_time = 0</fixtext><fix id="F-41404r802382_fix" /><check system="C-41445r802381_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that the Ubuntu operating system utilizes the "pam_faillock" module with the following command:
+$ grep faillock /etc/pam.d/common-auth 
+
+auth     [default=die]  pam_faillock.so authfail
+auth     sufficient     pam_faillock.so authsucc
+
+If the pam_faillock.so module is not present in the "/etc/pam.d/common-auth" file, this is a finding.
+
+Verify the pam_faillock module is configured to use the following options:
+$ sudo egrep 'silent|audit|deny|fail_interval| unlock_time' /etc/security/faillock.conf
+
+audit
+silent
+deny = 3
+fail_interval = 900
+unlock_time = 0
+
+If the "silent" keyword is missing or commented out, this is a finding.
+If the "audit" keyword is missing or commented out, this is a finding.
+If the "deny" keyword is missing, commented out, or set to a value greater than 3, this is a finding.
+If the "fail_interval" keyword is missing, commented out, or set to a value greater than 900, this is a finding.
+If the "unlock_time" keyword is missing, commented out, or not set to 0, this is a finding.</check-content></check></Rule></Group><Group id="V-238236"><title>SRG-OS-000446-GPOS-00200</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238236r853415_rule" weight="10.0" severity="medium"><version>UBTU-20-010074</version><title>The Ubuntu operating system must be configured so that the script which runs each 30 days or less to check file integrity is the default one.</title><description>&lt;VulnDiscussion&gt;Without verification of the security functions, security functions may not operate correctly and the failure may go unnoticed. Security function is defined as the hardware, software, and/or firmware of the information system responsible for enforcing the system security policy and supporting the isolation of code and data on which the protection is based. Security functionality includes, but is not limited to, establishing system accounts, configuring access authorizations (i.e., permissions, privileges), setting events to be audited, and setting intrusion detection parameters. 
+ 
+Notifications provided by information systems include, for example, electronic alerts to System Administrators, messages to local computer consoles, and/or hardware indications, such as lights. 
+ 
+This requirement applies to the Ubuntu operating system performing security function verification/testing and/or systems and environments that require this functionality.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-002699</ident><fixtext fixref="F-41405r653882_fix">The cron file for AIDE is fairly complex as it creates the report. This file is installed with the "aide-common" package, and the default can be restored by copying it from the package: 
+ 
+Download the original package to the /tmp dir: 
+ 
+$ cd /tmp; apt download aide-common 
+ 
+Extract the aide script to its original place: 
+ 
+$ dpkg-deb --fsys-tarfile /tmp/aide-common_*.deb | sudo tar -x ./usr/share/aide/config/cron.daily/aide -C / 
+ 
+Copy it to the cron.daily directory: 
+ 
+$  sudo cp -f /usr/share/aide/config/cron.daily/aide /etc/cron.daily/aide</fixtext><fix id="F-41405r653882_fix" /><check system="C-41446r653881_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that the Advanced Intrusion Detection Environment (AIDE) default script used to check file integrity each 30 days or less is unchanged. 
+ 
+Download the original aide-common package in the /tmp directory: 
+ 
+$ cd /tmp; apt download aide-common 
+ 
+Fetch the SHA1 of the original script file: 
+ 
+$ dpkg-deb --fsys-tarfile /tmp/aide-common_*.deb | tar -xO ./usr/share/aide/config/cron.daily/aide | sha1sum 
+32958374f18871e3f7dda27a58d721f471843e26  - 
+ 
+Compare with the SHA1 of the file in the daily or monthly cron directory: 
+ 
+$ sha1sum /etc/cron.{daily,monthly}/aide 2&gt;/dev/null 
+32958374f18871e3f7dda27a58d721f471843e26  /etc/cron.daily/aide 
+ 
+If there is no AIDE script file in the cron directories, or the SHA1 value of at least one file in the daily or monthly cron directory does not match the SHA1 of the original, this is a finding.</check-content></check></Rule></Group><Group id="V-238237"><title>SRG-OS-000480-GPOS-00226</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238237r653886_rule" weight="10.0" severity="low"><version>UBTU-20-010075</version><title>The Ubuntu operating system must enforce a delay of at least 4 seconds between logon prompts following a failed logon attempt.</title><description>&lt;VulnDiscussion&gt;Limiting the number of logon attempts over a certain time interval reduces the chances that an unauthorized user may gain access to an account.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000366</ident><fixtext fixref="F-41406r653885_fix">Configure the Ubuntu operating system to enforce a delay of at least 4 seconds between logon prompts following a failed logon attempt. 
+ 
+Edit the file "/etc/pam.d/common-auth" and set the parameter "pam_faildelay" to a value of  4000000 or greater: 
+ 
+auth    required    pam_faildelay.so    delay=4000000</fixtext><fix id="F-41406r653885_fix" /><check system="C-41447r653884_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system enforces a delay of at least 4 seconds between logon prompts following a failed logon attempt with the following command: 
+ 
+$ grep pam_faildelay /etc/pam.d/common-auth 
+ 
+auth    required    pam_faildelay.so    delay=4000000 
+ 
+If the line is not present or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-238238"><title>SRG-OS-000004-GPOS-00004</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238238r853416_rule" weight="10.0" severity="medium"><version>UBTU-20-010100</version><title>The Ubuntu operating system must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/passwd.</title><description>&lt;VulnDiscussion&gt;Once an attacker establishes access to a system, the attacker often attempts to create a persistent method of reestablishing access. One way to accomplish this is for the attacker to create an account. Auditing account creation actions provides logging that can be used for forensic purposes. 
+ 
+To address access requirements, many operating systems may be integrated with enterprise level authentication/access/auditing mechanisms that meet or exceed access control policy requirements.
+
+Satisfies: SRG-OS-000004-GPOS-00004, SRG-OS-000239-GPOS-00089, SRG-OS-000240-GPOS-00090, SRG-OS-000241-GPOS-00091, SRG-OS-000303-GPOS-00120, SRG-OS-000458-GPOS-00203, SRG-OS-000463-GPOS-00207, SRG-OS-000476-GPOS-00221&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000018</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><ident system="http://cyber.mil/cci">CCI-001403</ident><ident system="http://cyber.mil/cci">CCI-001404</ident><ident system="http://cyber.mil/cci">CCI-001405</ident><ident system="http://cyber.mil/cci">CCI-002130</ident><fixtext fixref="F-41407r653888_fix">Configure the Ubuntu operating system to generate audit records for all account creations, modifications, disabling, and termination events that affect "/etc/passwd". 
+ 
+Add or update the following rule to "/etc/audit/rules.d/stig.rules": 
+ 
+-w /etc/passwd -p wa -k usergroup_modification 
+  
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41407r653888_fix" /><check system="C-41448r653887_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records for all account creations, modifications, disabling, and termination events that affect "/etc/passwd". 
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep passwd 
+ 
+-w /etc/passwd -p wa -k usergroup_modification 
+ 
+If the command does not return a line that matches the example or the line is commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238239"><title>SRG-OS-000004-GPOS-00004</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238239r853417_rule" weight="10.0" severity="medium"><version>UBTU-20-010101</version><title>The Ubuntu operating system must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/group.</title><description>&lt;VulnDiscussion&gt;Once an attacker establishes access to a system, the attacker often attempts to create a persistent method of reestablishing access. One way to accomplish this is for the attacker to create an account. Auditing account creation actions provides logging that can be used for forensic purposes. 
+ 
+To address access requirements, many operating systems may be integrated with enterprise level authentication/access/auditing mechanisms that meet or exceed access control policy requirements.
+
+Satisfies: SRG-OS-000004-GPOS-00004, SRG-OS-000239-GPOS-00089, SRG-OS-000240-GPOS-00090, SRG-OS-000241-GPOS-00091, SRG-OS-000303-GPOS-00120, SRG-OS-000458-GPOS-00203, SRG-OS-000476-GPOS-00221&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000018</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><ident system="http://cyber.mil/cci">CCI-001403</ident><ident system="http://cyber.mil/cci">CCI-001404</ident><ident system="http://cyber.mil/cci">CCI-001405</ident><ident system="http://cyber.mil/cci">CCI-002130</ident><fixtext fixref="F-41408r653891_fix">Configure the Ubuntu operating system to generate audit records for all account creations, modifications, disabling, and termination events that affect "/etc/group". 
+ 
+Add or update the following rule to "/etc/audit/rules.d/stig.rules": 
+ 
+-w /etc/group -p wa -k usergroup_modification 
+  
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41408r653891_fix" /><check system="C-41449r653890_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records for all account creations, modifications, disabling, and termination events that affect "/etc/group". 
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep group 
+ 
+-w /etc/group -p wa -k usergroup_modification 
+ 
+If the command does not return a line that matches the example or the line is commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238240"><title>SRG-OS-000004-GPOS-00004</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238240r853418_rule" weight="10.0" severity="medium"><version>UBTU-20-010102</version><title>The Ubuntu operating system must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/shadow.</title><description>&lt;VulnDiscussion&gt;Once an attacker establishes access to a system, the attacker often attempts to create a persistent method of reestablishing access. One way to accomplish this is for the attacker to create an account. Auditing account creation actions provides logging that can be used for forensic purposes. 
+ 
+To address access requirements, many operating systems may be integrated with enterprise level authentication/access/auditing mechanisms that meet or exceed access control policy requirements.
+
+Satisfies: SRG-OS-000004-GPOS-00004, SRG-OS-000239-GPOS-00089, SRG-OS-000240-GPOS-00090, SRG-OS-000241-GPOS-00091, SRG-OS-000303-GPOS-00120, SRG-OS-000458-GPOS-00203, SRG-OS-000476-GPOS-00221&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000018</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><ident system="http://cyber.mil/cci">CCI-001403</ident><ident system="http://cyber.mil/cci">CCI-001404</ident><ident system="http://cyber.mil/cci">CCI-001405</ident><ident system="http://cyber.mil/cci">CCI-002130</ident><fixtext fixref="F-41409r653894_fix">Configure the Ubuntu operating system to generate audit records for all account creations, modifications, disabling, and termination events that affect "/etc/shadow". 
+ 
+Add or update the following rule to "/etc/audit/rules.d/stig.rules": 
+ 
+-w /etc/shadow -p wa -k usergroup_modification 
+  
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41409r653894_fix" /><check system="C-41450r653893_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records for all account creations, modifications, disabling, and termination events that affect "/etc/shadow". 
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep shadow 
+ 
+-w /etc/shadow -p wa -k usergroup_modification 
+ 
+If the command does not return a line that matches the example or the line is commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238241"><title>SRG-OS-000004-GPOS-00004</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238241r853419_rule" weight="10.0" severity="medium"><version>UBTU-20-010103</version><title>The Ubuntu operating system must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/gshadow.</title><description>&lt;VulnDiscussion&gt;Once an attacker establishes access to a system, the attacker often attempts to create a persistent method of reestablishing access. One way to accomplish this is for the attacker to create an account. Auditing account creation actions provides logging that can be used for forensic purposes. 
+ 
+To address access requirements, many operating systems may be integrated with enterprise level authentication/access/auditing mechanisms that meet or exceed access control policy requirements.
+
+Satisfies: SRG-OS-000004-GPOS-00004, SRG-OS-000239-GPOS-00089, SRG-OS-000240-GPOS-00090, SRG-OS-000241-GPOS-00091, SRG-OS-000303-GPOS-00120, SRG-OS-000458-GPOS-00203, SRG-OS-000476-GPOS-00221&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><ident system="http://cyber.mil/cci">CCI-001403</ident><ident system="http://cyber.mil/cci">CCI-001404</ident><ident system="http://cyber.mil/cci">CCI-001405</ident><ident system="http://cyber.mil/cci">CCI-002130</ident><fixtext fixref="F-41410r653897_fix">Configure the Ubuntu operating system to generate audit records for all account creations, modifications, disabling, and termination events that affect "/etc/gshadow". 
+ 
+Add or update the following rule to "/etc/audit/rules.d/stig.rules": 
+ 
+-w /etc/gshadow -p wa -k usergroup_modification 
+  
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41410r653897_fix" /><check system="C-41451r653896_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records for all account creations, modifications, disabling, and termination events that affect "/etc/gshadow". 
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep gshadow 
+ 
+-w /etc/gshadow -p wa -k usergroup_modification 
+ 
+If the command does not return a line that matches the example or the line is commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238242"><title>SRG-OS-000004-GPOS-00004</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238242r853420_rule" weight="10.0" severity="medium"><version>UBTU-20-010104</version><title>The Ubuntu operating system must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/opasswd.</title><description>&lt;VulnDiscussion&gt;Once an attacker establishes access to a system, the attacker often attempts to create a persistent method of reestablishing access. One way to accomplish this is for the attacker to create an account. Auditing account creation actions provides logging that can be used for forensic purposes. 
+ 
+To address access requirements, many operating systems may be integrated with enterprise level authentication/access/auditing mechanisms that meet or exceed access control policy requirements. 
+
+Satisfies: SRG-OS-000004-GPOS-00004, SRG-OS-000239-GPOS-00089, SRG-OS-000240-GPOS-00090, SRG-OS-000241-GPOS-00091, SRG-OS-000303-GPOS-00120, SRG-OS-000458-GPOS-00203, SRG-OS-000476-GPOS-00221&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000018</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><ident system="http://cyber.mil/cci">CCI-001403</ident><ident system="http://cyber.mil/cci">CCI-001404</ident><ident system="http://cyber.mil/cci">CCI-001405</ident><ident system="http://cyber.mil/cci">CCI-002130</ident><fixtext fixref="F-41411r653900_fix">Configure the Ubuntu operating system to generate audit records for all account creations, modifications, disabling, and termination events that affect "/etc/security/opasswd". 
+ 
+Add or update the following rule to "/etc/audit/rules.d/stig.rules": 
+ 
+-w /etc/security/opasswd -p wa -k usergroup_modification 
+  
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41411r653900_fix" /><check system="C-41452r653899_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records for all account creations, modifications, disabling, and termination events that affect "/etc/security/opasswd". 
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep opasswd 
+ 
+-w /etc/security/opasswd -p wa -k usergroup_modification 
+ 
+If the command does not return a line that matches the example or the line is commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238243"><title>SRG-OS-000046-GPOS-00022</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238243r653904_rule" weight="10.0" severity="medium"><version>UBTU-20-010117</version><title>The Ubuntu operating system must alert the ISSO and SA (at a minimum) in the event of an audit processing failure.</title><description>&lt;VulnDiscussion&gt;It is critical for the appropriate personnel to be aware if a system is at risk of failing to process audit logs as required. Without this notification, the security personnel may be unaware of an impending failure of the audit capability, and system operation may be adversely affected. 
+ 
+Audit processing failures include software/hardware errors, failures in the audit capturing mechanisms, and audit storage capacity being reached or exceeded. 
+ 
+This requirement applies to each audit data storage repository (i.e., distinct information system component where audit records are stored), the centralized audit storage capacity of organizations (i.e., all audit data storage repositories combined), or both.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000139</ident><fixtext fixref="F-41412r653903_fix">Configure "auditd" service to notify the SA and ISSO in the event of an audit processing failure.  
+ 
+Edit the following line in "/etc/audit/auditd.conf" to ensure administrators are notified via email for those situations: 
+ 
+action_mail_acct = &lt;administrator_account&gt; 
+ 
+Note: Change "administrator_account" to an account for security personnel. 
+ 
+Restart the "auditd" service so the changes take effect: 
+ 
+$ sudo systemctl restart auditd.service</fixtext><fix id="F-41412r653903_fix" /><check system="C-41453r653902_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that the SA and ISSO (at a minimum) are notified in the event of an audit processing failure with the following command: 
+ 
+$ sudo grep '^action_mail_acct = root' /etc/audit/auditd.conf 
+ 
+action_mail_acct = &lt;administrator_account&gt; 
+ 
+If the value of the "action_mail_acct" keyword is not set to an accounts for security personnel, the "action_mail_acct" keyword is missing, or the returned line is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-238244"><title>SRG-OS-000047-GPOS-00023</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238244r653907_rule" weight="10.0" severity="medium"><version>UBTU-20-010118</version><title>The Ubuntu operating system must shut down by default upon audit failure (unless availability is an overriding concern).</title><description>&lt;VulnDiscussion&gt;It is critical that when the operating system is at risk of failing to process audit logs as required, it takes action to mitigate the failure. Audit processing failures include: software/hardware errors; failures in the audit capturing mechanisms; and audit storage capacity being reached or exceeded. Responses to audit failure depend upon the nature of the failure mode. 
+ 
+When availability is an overriding concern, other approved actions in response to an audit failure are as follows:  
+ 
+1) If the failure was caused by the lack of audit record storage capacity, the operating system must continue generating audit records if possible (automatically restarting the audit service if necessary), overwriting the oldest audit records in a first-in-first-out manner. 
+ 
+2) If audit records are sent to a centralized collection server and communication with this server is lost or the server fails, the operating system must queue audit records locally until communication is restored or until the audit records are retrieved manually. Upon restoration of the connection to the centralized collection server, action should be taken to synchronize the local audit data with the collection server.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000140</ident><fixtext fixref="F-41413r653906_fix">Configure the Ubuntu operating system to shut down by default upon audit failure (unless availability is an overriding concern). 
+ 
+Add or update the following line (depending on configuration, "disk_full_action" can be set to "SYSLOG", "HALT" or "SINGLE") in "/etc/audit/auditd.conf" file: 
+ 
+disk_full_action = HALT 
+ 
+Restart the "auditd" service so the changes take effect: 
+ 
+$ sudo systemctl restart auditd.service</fixtext><fix id="F-41413r653906_fix" /><check system="C-41454r653905_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system takes the appropriate action when the audit storage volume is full with the following command: 
+ 
+$ sudo grep '^disk_full_action' /etc/audit/auditd.conf 
+ 
+disk_full_action = HALT 
+ 
+If the value of the "disk_full_action" option is not "SYSLOG", "SINGLE", or "HALT", or the line is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-238245"><title>SRG-OS-000057-GPOS-00027</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238245r653910_rule" weight="10.0" severity="medium"><version>UBTU-20-010122</version><title>The Ubuntu operating system must be configured so that audit log files are not read or write-accessible by unauthorized users.</title><description>&lt;VulnDiscussion&gt;Unauthorized disclosure of audit records can reveal system and configuration data to attackers, thus compromising its confidentiality. 
+ 
+Audit information includes all information (e.g., audit records, audit settings, audit reports) needed to successfully audit operating system activity.
+
+Satisfies: SRG-OS-000057-GPOS-00027, SRG-OS-000058-GPOS-00028&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000162</ident><ident system="http://cyber.mil/cci">CCI-000163</ident><fixtext fixref="F-41414r653909_fix">Configure the audit log files to have a mode of "0600" or less permissive. 
+ 
+Determine where the audit logs are stored with the following command: 
+ 
+$ sudo grep -iw log_file /etc/audit/auditd.conf 
+log_file = /var/log/audit/audit.log 
+ 
+Using the path of the directory containing the audit logs, configure the audit log files to have a mode of "0600" or less permissive by using the following command: 
+ 
+$ sudo chmod 0600 /var/log/audit/*</fixtext><fix id="F-41414r653909_fix" /><check system="C-41455r653908_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that the audit log files have a mode of "0600" or less permissive. 
+ 
+Determine where the audit logs are stored with the following command: 
+ 
+$ sudo grep -iw log_file /etc/audit/auditd.conf 
+log_file = /var/log/audit/audit.log 
+ 
+Using the path of the directory containing the audit logs, determine if the audit log files have a mode of "0600" or less by using the following command: 
+ 
+$ sudo stat -c "%n %a" /var/log/audit/* 
+/var/log/audit/audit.log 600 
+ 
+If the audit log files have a mode more permissive than "0600", this is a finding.</check-content></check></Rule></Group><Group id="V-238246"><title>SRG-OS-000057-GPOS-00027</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238246r653913_rule" weight="10.0" severity="medium"><version>UBTU-20-010123</version><title>The Ubuntu operating system must be configured to permit only authorized users ownership of the audit log files.</title><description>&lt;VulnDiscussion&gt;Unauthorized disclosure of audit records can reveal system and configuration data to attackers, thus compromising its confidentiality. 
+ 
+Audit information includes all information (e.g., audit records, audit settings, audit reports) needed to successfully audit operating system activity.
+
+Satisfies: SRG-OS-000057-GPOS-00027, SRG-OS-000058-GPOS-00028, SRG-OS-000059-GPOS-00029&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000162</ident><fixtext fixref="F-41415r653912_fix">Configure the audit log directory and its underlying files to be owned by "root" user. 
+ 
+Determine where the audit logs are stored with the following command: 
+ 
+$ sudo grep -iw log_file /etc/audit/auditd.conf 
+log_file = /var/log/audit/audit.log 
+ 
+Using the path of the directory containing the audit logs, configure the audit log files to be owned by "root" user by using the following command: 
+ 
+$ sudo chown root /var/log/audit/*</fixtext><fix id="F-41415r653912_fix" /><check system="C-41456r653911_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the audit log files are owned by "root" account. 
+ 
+Determine where the audit logs are stored with the following command: 
+ 
+$ sudo grep -iw log_file /etc/audit/auditd.conf 
+log_file = /var/log/audit/audit.log 
+ 
+Using the path of the directory containing the audit logs, determine if the audit log files are owned by the "root" user by using the following command: 
+ 
+$ sudo stat -c "%n %U" /var/log/audit/* 
+/var/log/audit/audit.log root 
+ 
+If the audit log files are owned by an user other than "root", this is a finding.</check-content></check></Rule></Group><Group id="V-238247"><title>SRG-OS-000057-GPOS-00027</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238247r832947_rule" weight="10.0" severity="medium"><version>UBTU-20-010124</version><title>The Ubuntu operating system must permit only authorized groups ownership of the audit log files.</title><description>&lt;VulnDiscussion&gt;Unauthorized disclosure of audit records can reveal system and configuration data to attackers, thus compromising its confidentiality. 
+ 
+Audit information includes all information (e.g., audit records, audit settings, audit reports) needed to successfully audit operating system activity.
+
+Satisfies: SRG-OS-000057-GPOS-00027, SRG-OS-000058-GPOS-00028, SRG-OS-000059-GPOS-00029&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000162</ident><fixtext fixref="F-41416r832946_fix">Configure the audit log directory and its underlying files to be owned by "root" group.
+
+Set the "log_group" parameter of the audit configuration file to the "root" value so when a new log file is created, its group owner is properly set:
+$ sudo sed -i '/^log_group/D' /etc/audit/auditd.conf
+$ sudo sed -i /^log_file/a'log_group = root' /etc/audit/auditd.conf
+
+Last, signal the audit daemon to reload the configuration file to update the group owners of existing files:
+$ sudo systemctl kill auditd -s SIGHUP</fixtext><fix id="F-41416r832946_fix" /><check system="C-41457r802384_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the group owner is set to own newly created audit logs in the audit configuration file with the following command: 
+$ sudo grep -iw log_group /etc/audit/auditd.conf 
+log_group = root 
+
+If the value of the "log_group" parameter is other than "root", this is a finding.
+
+Determine where the audit logs are stored with the following command: 
+$ sudo grep -iw log_file /etc/audit/auditd.conf 
+log_file = /var/log/audit/audit.log 
+
+Using the path of the directory containing the audit logs, determine if the audit log files are owned by the "root" group by using the following command: 
+$ sudo stat -c "%n %G" /var/log/audit/* 
+/var/log/audit/audit.log root 
+
+If the audit log files are owned by a group other than "root", this is a finding.</check-content></check></Rule></Group><Group id="V-238248"><title>SRG-OS-000059-GPOS-00029</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238248r653919_rule" weight="10.0" severity="medium"><version>UBTU-20-010128</version><title>The Ubuntu operating system must be configured so that the audit log directory is not write-accessible by unauthorized users.</title><description>&lt;VulnDiscussion&gt;If audit information were to become compromised, then forensic analysis and discovery of the true source of potentially malicious system activity is impossible to achieve. 
+ 
+To ensure the veracity of audit information, the operating system must protect audit information from unauthorized deletion. This requirement can be achieved through multiple methods, which will depend upon system architecture and design. 
+ 
+Audit information includes all information (e.g., audit records, audit settings, audit reports) needed to successfully audit information system activity.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000164</ident><fixtext fixref="F-41417r653918_fix">Configure the audit log directory to have a mode of "0750" or less permissive. 
+ 
+Determine where the audit logs are stored with the following command: 
+ 
+$ sudo grep -iw ^log_file /etc/audit/auditd.conf 
+log_file = /var/log/audit/audit.log 
+ 
+Using the path of the directory containing the audit logs, configure the audit log directory to have a mode of "0750" or less permissive by 
+ using the following command: 
+ 
+$ sudo chmod -R  g-w,o-rwx /var/log/audit</fixtext><fix id="F-41417r653918_fix" /><check system="C-41458r653917_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that the audit log directory has a mode of "0750" or less permissive. 
+ 
+Determine where the audit logs are stored with the following command: 
+ 
+$ sudo grep -iw ^log_file /etc/audit/auditd.conf 
+log_file = /var/log/audit/audit.log 
+ 
+Using the path of the directory containing the audit logs, determine if the directory has a mode of "0750" or less by using the following command: 
+ 
+$ sudo stat -c "%n %a" /var/log/audit /var/log/audit/* 
+/var/log/audit 750 
+/var/log/audit/audit.log 600 
+ 
+If the audit log directory has a mode more permissive than "0750", this is a finding.</check-content></check></Rule></Group><Group id="V-238249"><title>SRG-OS-000063-GPOS-00032</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238249r653922_rule" weight="10.0" severity="medium"><version>UBTU-20-010133</version><title>The Ubuntu operating system must be configured so that audit configuration files are not write-accessible by unauthorized users.</title><description>&lt;VulnDiscussion&gt;Without the capability to restrict which roles and individuals can select which events are audited, unauthorized personnel may be able to prevent the auditing of critical events. 
+ 
+Misconfigured audits may degrade the system's performance by overwhelming the audit log. Misconfigured audits may also make it more difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000171</ident><fixtext fixref="F-41418r653921_fix">Configure "/etc/audit/audit.rules", "/etc/audit/rules.d/*", and "/etc/audit/auditd.conf" files to have a mode of "0640" by using the following command: 
+ 
+$ sudo chmod -R 0640 /etc/audit/audit*.{rules,conf} /etc/audit/rules.d/*</fixtext><fix id="F-41418r653921_fix" /><check system="C-41459r653920_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that "/etc/audit/audit.rules", "/etc/audit/rules.d/*", and "/etc/audit/auditd.conf" files have a mode of "0640" or less permissive by using the following command: 
+ 
+$ sudo ls -al /etc/audit/ /etc/audit/rules.d/ 
+ 
+/etc/audit/: 
+ 
+-rw-r-----   1 root root   804 Nov 25 11:01 auditd.conf 
+ 
+-rw-r-----   1 root root  9128 Dec 27 09:56 audit.rules 
+ 
+-rw-r-----   1 root root  9373 Dec 27 09:56 audit.rules.prev 
+ 
+-rw-r-----   1 root root   127 Feb  7  2018 audit-stop.rules 
+ 
+drwxr-x---   2 root root  4096 Dec 27 09:56 rules.d 
+ 
+/etc/audit/rules.d/: 
+ 
+-rw-r----- 1 root root 10357 Dec 27 09:56 stig.rules 
+ 
+If "/etc/audit/audit.rule","/etc/audit/rules.d/*", or "/etc/audit/auditd.conf" file have a mode more permissive than "0640", this is a finding.</check-content></check></Rule></Group><Group id="V-238250"><title>SRG-OS-000063-GPOS-00032</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238250r653925_rule" weight="10.0" severity="medium"><version>UBTU-20-010134</version><title>The Ubuntu operating system must permit only authorized accounts to own the audit configuration files.</title><description>&lt;VulnDiscussion&gt;Without the capability to restrict which roles and individuals can select which events are audited, unauthorized personnel may be able to prevent the auditing of critical events.  
+ 
+Misconfigured audits may degrade the system's performance by overwhelming the audit log. Misconfigured audits may also make it more difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000171</ident><fixtext fixref="F-41419r653924_fix">Configure "/etc/audit/audit.rules", "/etc/audit/rules.d/*" and "/etc/audit/auditd.conf" files to be owned by root user by using the following command: 
+ 
+$ sudo chown root /etc/audit/audit*.{rules,conf} /etc/audit/rules.d/*</fixtext><fix id="F-41419r653924_fix" /><check system="C-41460r653923_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that "/etc/audit/audit.rules", "/etc/audit/rules.d/*" and "/etc/audit/auditd.conf" files are owned by root account by using the following command: 
+ 
+$ sudo ls -al /etc/audit/ /etc/audit/rules.d/ 
+ 
+/etc/audit/: 
+ 
+drwxr-x---   3 root root  4096 Nov 25 11:02 . 
+ 
+drwxr-xr-x 130 root root 12288 Dec 19 13:42 .. 
+ 
+-rw-r-----   1 root root   804 Nov 25 11:01 auditd.conf 
+ 
+-rw-r-----   1 root root  9128 Dec 27 09:56 audit.rules 
+ 
+-rw-r-----   1 root root  9373 Dec 27 09:56 audit.rules.prev 
+ 
+-rw-r-----   1 root root   127 Feb  7  2018 audit-stop.rules 
+ 
+drwxr-x---   2 root root  4096 Dec 27 09:56 rules.d 
+ 
+/etc/audit/rules.d/: 
+ 
+drwxr-x--- 2 root root  4096 Dec 27 09:56 . 
+ 
+drwxr-x--- 3 root root  4096 Nov 25 11:02 .. 
+ 
+-rw-r----- 1 root root 10357 Dec 27 09:56 stig.rules 
+ 
+If the "/etc/audit/audit.rules", "/etc/audit/rules.d/*", or "/etc/audit/auditd.conf" file is owned by a user other than "root", this is a finding.</check-content></check></Rule></Group><Group id="V-238251"><title>SRG-OS-000063-GPOS-00032</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238251r653928_rule" weight="10.0" severity="medium"><version>UBTU-20-010135</version><title>The Ubuntu operating system must permit only authorized groups to own the audit configuration files.</title><description>&lt;VulnDiscussion&gt;Without the capability to restrict which roles and individuals can select which events are audited, unauthorized personnel may be able to prevent the auditing of critical events.  
+ 
+Misconfigured audits may degrade the system's performance by overwhelming the audit log. Misconfigured audits may also make it more difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000171</ident><fixtext fixref="F-41420r653927_fix">Configure "/etc/audit/audit.rules", "/etc/audit/rules.d/*", and "/etc/audit/auditd.conf" files to be owned by root group by using the following command: 
+ 
+$ sudo chown :root /etc/audit/audit*.{rules,conf} /etc/audit/rules.d/*</fixtext><fix id="F-41420r653927_fix" /><check system="C-41461r653926_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that "/etc/audit/audit.rules", "/etc/audit/rules.d/*", and "/etc/audit/auditd.conf" files are owned by root group by using the following command: 
+ 
+$ sudo ls -al /etc/audit/ /etc/audit/rules.d/ 
+ 
+/etc/audit/: 
+ 
+-rw-r-----   1 root root   804 Nov 25 11:01 auditd.conf 
+ 
+-rw-r-----   1 root root  9128 Dec 27 09:56 audit.rules 
+ 
+-rw-r-----   1 root root  9373 Dec 27 09:56 audit.rules.prev 
+ 
+-rw-r-----   1 root root   127 Feb  7  2018 audit-stop.rules 
+ 
+drwxr-x---   2 root root  4096 Dec 27 09:56 rules.d 
+ 
+/etc/audit/rules.d/: 
+ 
+-rw-r----- 1 root root 10357 Dec 27 09:56 stig.rules 
+ 
+If the "/etc/audit/audit.rules", "/etc/audit/rules.d/*", or "/etc/audit/auditd.conf" file is owned by a group other than "root", this is a finding.</check-content></check></Rule></Group><Group id="V-238252"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238252r653931_rule" weight="10.0" severity="medium"><version>UBTU-20-010136</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the su command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41421r653930_fix">Configure the Ubuntu operating system to generate audit records when successful/unsuccessful attempts to use the "su" command occur. 
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-a always,exit -F path=/bin/su -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged-priv_change  
+ 
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41421r653930_fix" /><check system="C-41462r653929_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records upon successful/unsuccessful attempts to use the "su" command. 
+ 
+Check the configured audit rules with the following commands: 
+ 
+$ sudo auditctl -l | grep '/bin/su' 
+ 
+-a always,exit -F path=/bin/su -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged-priv_change 
+ 
+If the command does not return lines that match the example or the lines are commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238253"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238253r653934_rule" weight="10.0" severity="medium"><version>UBTU-20-010137</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the chfn command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41422r653933_fix">Configure the audit system to generate an audit event for any successful/unsuccessful uses of the "chfn" command. 
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-a always,exit -F path=/usr/bin/chfn -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged-chfn 
+ 
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41422r653933_fix" /><check system="C-41463r653932_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records upon successful/unsuccessful attempts to use the "chfn" command.  
+ 
+Check the configured audit rules with the following commands: 
+ 
+$ sudo auditctl -l | grep '/usr/bin/chfn' 
+ 
+-a always,exit -F path=/usr/bin/chfn -F perm=x -F auid&gt;=1000 -F auid!=-1 -k privileged-chfn 
+ 
+If the command does not return lines that match the example or the lines are commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238254"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238254r653937_rule" weight="10.0" severity="medium"><version>UBTU-20-010138</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the mount command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41423r653936_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "mount" command.  
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-a always,exit -F path=/usr/bin/mount -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged-mount 
+ 
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41423r653936_fix" /><check system="C-41464r653935_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records upon successful/unsuccessful attempts to use the "mount" command. 
+ 
+Check the configured audit rules with the following commands: 
+ 
+$ sudo auditctl -l | grep '/usr/bin/mount' 
+ 
+-a always,exit -F path=/usr/bin/mount -F perm=x -F auid&gt;=1000 -F auid!=-1 -k privileged-mount 
+ 
+If the command does not return lines that match the example or the lines are commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238255"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238255r653940_rule" weight="10.0" severity="medium"><version>UBTU-20-010139</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the umount command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41424r653939_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "umount" command.  
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-a always,exit -F path=/usr/bin/umount -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged-umount 
+ 
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41424r653939_fix" /><check system="C-41465r653938_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify if the Ubuntu operating system generates audit records upon successful/unsuccessful attempts to use the "umount" command. 
+ 
+Check the configured audit rules with the following commands: 
+ 
+$ sudo auditctl -l | grep '/usr/bin/umount' 
+ 
+-a always,exit -F path=/usr/bin/umount -F perm=x -F auid&gt;=1000 -F auid!=-1 -k privileged-umount 
+ 
+If the command does not return lines that match the example or the lines are commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238256"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238256r653943_rule" weight="10.0" severity="medium"><version>UBTU-20-010140</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the ssh-agent command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41425r653942_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "ssh-agent" command.  
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged-ssh 
+ 
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41425r653942_fix" /><check system="C-41466r653941_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record upon successful/unsuccessful attempts to use the "ssh-agent" command. 
+ 
+Check the configured audit rules with the following commands: 
+ 
+$ sudo auditctl -l | grep '/usr/bin/ssh-agent' 
+ 
+-a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid&gt;=1000 -F auid!=-1 -k privileged-ssh 
+ 
+If the command does not return lines that match the example or the lines are commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238257"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238257r653946_rule" weight="10.0" severity="medium"><version>UBTU-20-010141</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the ssh-keysign command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41426r653945_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "ssh-keysign" command.  
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-a always,exit -F path=/usr/lib/openssh/ssh-keysign -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged-ssh 
+ 
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41426r653945_fix" /><check system="C-41467r653944_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record upon successful/unsuccessful attempts to use the "ssh-keysign" command. 
+ 
+Check the configured audit rules with the following commands: 
+ 
+$ sudo auditctl -l | grep ssh-keysign 
+ 
+-a always,exit -F path=/usr/lib/openssh/ssh-keysign -F perm=x -F auid&gt;=1000 -F auid!=-1 -k privileged-ssh 
+ 
+If the command does not return lines that match the example or the lines are commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238258"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238258r808474_rule" weight="10.0" severity="medium"><version>UBTU-20-010142</version><title>The Ubuntu operating system must generate audit records for any use of the setxattr, fsetxattr, lsetxattr, removexattr, fremovexattr, and lremovexattr system calls.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+The system call rules are loaded into a matching engine that intercepts each syscall that all programs on the system makes. Therefore, it is very important to only use syscall rules when absolutely necessary since these affect performance. The more rules, the bigger the performance hit. The performance is helped, though, by combining syscalls into one rule whenever possible.
+
+Satisfies: SRG-OS-000064-GPOS-00033, SRG-OS-000462-GPOS-00206&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41427r808473_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "setxattr", "fsetxattr", "lsetxattr", "removexattr", "fremovexattr", and "lremovexattr" system calls. 
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-a always,exit -F arch=b32 -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod 
+-a always,exit -F arch=b32 -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid=0 -k perm_mod  
+-a always,exit -F arch=b64 -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod 
+-a always,exit -F arch=b64 -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid=0 -k perm_mod  
+ 
+Note: For 32-bit architectures, only the 32-bit specific entries are required.
+ 
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41427r808473_fix" /><check system="C-41468r808472_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record upon successful/unsuccessful attempts to use the "setxattr", "fsetxattr", "lsetxattr", "removexattr", "fremovexattr", and "lremovexattr" system calls. 
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep xattr  
+ 
+-a always,exit -F arch=b32 -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid&gt;=1000 -F auid!=-1 -k perm_mod 
+-a always,exit -F arch=b32 -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid=0 -k perm_mod  
+-a always,exit -F arch=b64 -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid&gt;=1000 -F auid!=-1 -k perm_mod 
+-a always,exit -F arch=b64 -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid=0 -k perm_mod  
+ 
+If the command does not return audit rules for the "setxattr", "fsetxattr", "lsetxattr", "removexattr", "fremovexattr" and "lremovexattr" syscalls or the lines are commented out, this is a finding. 
+ 
+Notes: 
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required. 
+The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238264"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238264r808477_rule" weight="10.0" severity="medium"><version>UBTU-20-010148</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the chown, fchown, fchownat, and lchown system calls.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+The system call rules are loaded into a matching engine that intercepts each syscall that all programs on the system makes. Therefore, it is very important to only use syscall rules when absolutely necessary since these affect performance. The more rules, the bigger the performance hit. The performance is helped, though, by combining syscalls into one rule whenever possible.
+
+Satisfies: SRG-OS-000064-GPOS-00033, SRG-OS-000462-GPOS-00206&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41433r808476_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "chown", "fchown", "fchownat", and "lchown" system calls. 
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules": 
+ 
+-a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng 
+-a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng 
+ 
+Note: For 32-bit architectures, only the 32-bit specific entries are required.  
+ 
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41433r808476_fix" /><check system="C-41474r808475_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record upon successful/unsuccessful attempts to use the "chown", "fchown", "fchownat", and "lchown" system calls. 
+ 
+Check the configured audit rules with the following commands: 
+ 
+$ sudo auditctl -l | grep chown 
+ 
+-a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -F auid&gt;=1000 -F auid!=-1 -k perm_chng 
+-a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -F auid&gt;=1000 -F auid!=-1 -k perm_chng 
+ 
+If the command does not return audit rules for the "chown", "fchown", "fchownat", and "lchown" syscalls or the lines are commented out, this is a finding. 
+ 
+Notes: 
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required. 
+The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238268"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238268r808480_rule" weight="10.0" severity="medium"><version>UBTU-20-010152</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the chmod, fchmod, and fchmodat system calls.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+The system call rules are loaded into a matching engine that intercepts each syscall that all programs on the system makes. Therefore, it is very important to only use syscall rules when absolutely necessary since these affect performance. The more rules, the bigger the performance hit. The performance is helped, though, by combining syscalls into one rule whenever possible.
+
+Satisfies: SRG-OS-000064-GPOS-00033, SRG-OS-000462-GPOS-00206&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41437r808479_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "chmod", "fchmod", and "fchmodat" system calls. 
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules": 
+ 
+-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng 
+-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng 
+ 
+Notes: For 32-bit architectures, only the 32-bit specific entries are required.  
+ 
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41437r808479_fix" /><check system="C-41478r808478_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record upon successful/unsuccessful attempts to use the "chmod", "fchmod", and "fchmodat" system calls. 
+ 
+Check the configured audit rules with the following commands: 
+ 
+$ sudo auditctl -l | grep chmod 
+ 
+-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -F auid&gt;=1000 -F auid!=-1 -k perm_chng 
+-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat -F auid&gt;=1000 -F auid!=-1 -k perm_chng 
+ 
+If the command does not return audit rules for the "chmod", "fchmod" and "fchmodat" syscalls or the lines are commented out, this is a finding. 
+ 
+Notes: 
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required. 
+The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238271"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238271r808483_rule" weight="10.0" severity="medium"><version>UBTU-20-010155</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the creat, open, openat, open_by_handle_at, truncate, and ftruncate system calls.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+The system call rules are loaded into a matching engine that intercepts each syscall that all programs on the system makes. Therefore, it is very important to only use syscall rules when absolutely necessary since these affect performance. The more rules, the bigger the performance hit. The performance is helped, though, by combining syscalls into one rule whenever possible.
+
+Satisfies: SRG-OS-000064-GPOS-00033, SRG-OS-000474-GPOS-00219&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41440r808482_fix">Configure the audit system to generate an audit event for any unsuccessful use of the"creat", "open", "openat", "open_by_handle_at", "truncate", and "ftruncate" system calls.  
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-a always,exit -F arch=b32 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access 
+-a always,exit -F arch=b32 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access 
+-a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access 
+-a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access 
+ 
+Notes: For 32-bit architectures, only the 32-bit specific entries are required.  
+ 
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41440r808482_fix" /><check system="C-41481r808481_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record upon unsuccessful attempts to use the "creat", "open", "openat", "open_by_handle_at", "truncate", and "ftruncate" system calls. 
+ 
+Check the configured audit rules with the following commands: 
+ 
+$ sudo auditctl -l | grep 'open\|truncate\|creat' 
+ 
+-a always,exit -F arch=b32 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid&gt;=1000 -F auid!=-1 -k perm_access 
+-a always,exit -F arch=b32 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid&gt;=1000 -F auid!=-1 -k perm_access 
+-a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid&gt;=1000 -F auid!=-1 -k perm_access 
+-a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid&gt;=1000 -F auid!=-1 -k perm_access  
+ 
+If the command does not return audit rules for the "creat", "open", "openat", "open_by_handle_at", "truncate", and "ftruncate" syscalls or the lines are commented out, this is a finding. 
+ 
+Notes: 
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required. 
+The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238277"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238277r654006_rule" weight="10.0" severity="medium"><version>UBTU-20-010161</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the sudo command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41446r654005_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "sudo" command.  
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k priv_cmd 
+   
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41446r654005_fix" /><check system="C-41487r654004_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that an audit event is generated for any successful/unsuccessful use of the "sudo" command.  
+ 
+Check the configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep /usr/bin/sudo 
+ 
+-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid&gt;=1000 -F auid!=-1 -k priv_cmd 
+ 
+If the command does not return a line that matches the example or the line is commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238278"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238278r654009_rule" weight="10.0" severity="medium"><version>UBTU-20-010162</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the sudoedit command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41447r654008_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "sudoedit" command.  
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules": 
+ 
+-a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k priv_cmd 
+   
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41447r654008_fix" /><check system="C-41488r654007_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record upon successful/unsuccessful attempts to use the "sudoedit" command. 
+ 
+Check the configured audit rules with the following commands: 
+ 
+$ sudo auditctl -l | grep /usr/bin/sudoedit 
+ 
+-a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid&gt;=1000 -F auid!=-1 -k priv_cmd 
+ 
+If the command does not return a line that matches the example or the line is commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238279"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238279r654012_rule" weight="10.0" severity="medium"><version>UBTU-20-010163</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the chsh command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41448r654011_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "chsh" command.  
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-a always,exit -F path=/usr/bin/chsh -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k priv_cmd 
+   
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41448r654011_fix" /><check system="C-41489r654010_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record upon successful/unsuccessful attempts to use the "chsh" command. 
+ 
+Check the configured audit rules with the following commands: 
+ 
+$ sudo auditctl -l | grep chsh 
+ 
+-a always,exit -F path=/usr/bin/chsh -F perm=x -F auid&gt;=1000 -F auid!=-1 -k priv_cmd 
+ 
+If the command does not return a line that matches the example or the line is commented out, this is a finding. 
+ 
+Notes: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238280"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238280r654015_rule" weight="10.0" severity="medium"><version>UBTU-20-010164</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the newgrp command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41449r654014_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "newgrp" command.  
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k priv_cmd 
+   
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41449r654014_fix" /><check system="C-41490r654013_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record upon successful/unsuccessful attempts to use the "newgrp" command. 
+ 
+Check the configured audit rules with the following commands: 
+ 
+$ sudo auditctl -l | grep newgrp 
+ 
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid&gt;=1000 -F auid!=-1 -k priv_cmd 
+ 
+If the command does not return a line that matches the example or the line is commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238281"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238281r654018_rule" weight="10.0" severity="medium"><version>UBTU-20-010165</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the chcon command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41450r654017_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "chcon" command.  
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng 
+   
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41450r654017_fix" /><check system="C-41491r654016_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record upon successful/unsuccessful attempts to use the "chcon" command. 
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep chcon 
+ 
+-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid&gt;=1000 -F auid!=-1 -k perm_chng 
+ 
+If the command does not return a line that matches the example or the line is commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238282"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238282r654021_rule" weight="10.0" severity="medium"><version>UBTU-20-010166</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the apparmor_parser command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41451r654020_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "apparmor_parser" command.  
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-a always,exit -F path=/sbin/apparmor_parser -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng 
+   
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41451r654020_fix" /><check system="C-41492r654019_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record upon successful/unsuccessful attempts to use the "apparmor_parser" command. 
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep apparmor_parser 
+ 
+-a always,exit -F path=/sbin/apparmor_parser -F perm=x -F auid&gt;=1000 -F auid!=-1 -k perm_chng 
+ 
+If the command does not return a line that matches the example or the line is commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238283"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238283r654024_rule" weight="10.0" severity="medium"><version>UBTU-20-010167</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the setfacl command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41452r654023_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "setfacl" command.  
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-a always,exit -F path=/usr/bin/setfacl -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng 
+   
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41452r654023_fix" /><check system="C-41493r654022_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record upon successful/unsuccessful attempts to use the "setfacl" command. 
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep setfacl 
+ 
+-a always,exit -F path=/usr/bin/setfacl -F perm=x -F auid&gt;=1000 -F auid!=-1 -k perm_chng 
+ 
+If the command does not return a line that matches the example or the line is commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238284"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238284r654027_rule" weight="10.0" severity="medium"><version>UBTU-20-010168</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the chacl command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41453r654026_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "chacl" command.  
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-a always,exit -F path=/usr/bin/chacl -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng 
+    
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41453r654026_fix" /><check system="C-41494r654025_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record upon successful/unsuccessful attempts to use the "chacl" command. 
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo audtctl -l | grep chacl 
+ 
+-a always,exit -F path=/usr/bin/chacl -F perm=x -F auid&gt;=1000 -F auid!=-1 -k perm_chng 
+ 
+If the command does not return a line that matches the example or the line is commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238285"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238285r654030_rule" weight="10.0" severity="medium"><version>UBTU-20-010169</version><title>The Ubuntu operating system must generate audit records for the use and modification of the tallylog file.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000064-GPOS-00033, SRG-OS-000470-GPOS-00214, SRG-OS-000473-GPOS-00218&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41454r654029_fix">Configure the audit system to generate an audit event for any successful/unsuccessful modifications to the "tallylog" file.  
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-w /var/log/tallylog -p wa -k logins 
+   
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41454r654029_fix" /><check system="C-41495r654028_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record upon successful/unsuccessful modifications to the "tallylog" file. 
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep tallylog 
+ 
+-w /var/log/tallylog -p wa -k logins 
+ 
+If the command does not return a line that matches the example or the line is commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238286"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238286r654033_rule" weight="10.0" severity="medium"><version>UBTU-20-010170</version><title>The Ubuntu operating system must generate audit records for the use and modification of faillog file.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000064-GPOS-00033, SRG-OS-000470-GPOS-00214, SRG-OS-000473-GPOS-00218&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41455r654032_fix">Configure the audit system to generate an audit event for any successful/unsuccessful modifications to the "faillog" file.  
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-w /var/log/faillog -p wa -k logins 
+   
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41455r654032_fix" /><check system="C-41496r654031_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record upon successful/unsuccessful modifications to the "faillog" file. 
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep faillog 
+ 
+-w /var/log/faillog -p wa -k logins 
+ 
+If the command does not return a line that matches the example or the line is commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238287"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238287r654036_rule" weight="10.0" severity="medium"><version>UBTU-20-010171</version><title>The Ubuntu operating system must generate audit records for the use and modification of the lastlog file.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000064-GPOS-00033, SRG-OS-000470-GPOS-00214, SRG-OS-000473-GPOS-00218&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41456r654035_fix">Configure the audit system to generate an audit event for any successful/unsuccessful modifications to the "lastlog" file.  
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-w /var/log/lastlog -p wa -k logins 
+  
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41456r654035_fix" /><check system="C-41497r654034_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when successful/unsuccessful modifications to the "lastlog" file occur. 
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep lastlog 
+ 
+-w /var/log/lastlog -p wa -k logins 
+ 
+If the command does not return a line that matches the example or the line is commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238288"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238288r833012_rule" weight="10.0" severity="medium"><version>UBTU-20-010172</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the passwd command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41457r832949_fix">Configure the audit system to generate an audit event for any successful/unsuccessful uses of the "passwd" command.  
+ 
+Add or update the following rule in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged-passwd 
+   
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41457r832949_fix" /><check system="C-41498r833011_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that an audit event is generated for any successful/unsuccessful use of the "passwd" command.  
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep -w passwd 
+ 
+-a always,exit -S all -F path=/usr/bin/passwd -F perm=x -F auid&gt;=1000 -F auid!=-1 -F key=privileged-passwd 
+ 
+If the command does not return a line that matches the example or the line is commented out, this is a finding. 
+ 
+Note: The "key" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238289"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238289r654042_rule" weight="10.0" severity="medium"><version>UBTU-20-010173</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the unix_update command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41458r654041_fix">Configure the audit system to generate an audit event for any successful/unsuccessful uses of the "unix_update" command.  
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-a always,exit -F path=/sbin/unix_update -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged-unix-update 
+  
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41458r654041_fix" /><check system="C-41499r654040_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that an audit event is generated for any successful/unsuccessful use of the "unix_update" command. 
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep -w unix_update 
+ 
+-a always,exit -F path=/sbin/unix_update -F perm=x -F auid&gt;=1000 -F auid!=-1 -k privileged-unix-update 
+ 
+If the command does not return a line that matches the example or the line is commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238290"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238290r654045_rule" weight="10.0" severity="medium"><version>UBTU-20-010174</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the gpasswd command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41459r654044_fix">Configure the audit system to generate an audit event for any successful/unsuccessful uses of the "gpasswd" command.  
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged-gpasswd 
+   
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41459r654044_fix" /><check system="C-41500r654043_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that an audit event is generated for any successful/unsuccessful use of the "gpasswd" command.  
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep -w gpasswd 
+ 
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid&gt;=1000 -F auid!=-1 -k privileged-gpasswd 
+ 
+If the command does not return a line that matches the example or the line is commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238291"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238291r654048_rule" weight="10.0" severity="medium"><version>UBTU-20-010175</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the chage command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41460r654047_fix">Configure the audit system to generate an audit event for any successful/unsuccessful uses of the "chage" command.  
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-a always,exit -F path=/usr/bin/chage -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged-chage 
+   
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41460r654047_fix" /><check system="C-41501r654046_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that an audit event is generated for any successful/unsuccessful use of the "chage" command. 
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep -w chage 
+ 
+-a always,exit -F path=/usr/bin/chage -F perm=x -F auid&gt;=1000 -F auid!=-1 -k privileged-chage 
+ 
+If the command does not return a line that matches the example or the line is commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238292"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238292r654051_rule" weight="10.0" severity="medium"><version>UBTU-20-010176</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the usermod command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41461r654050_fix">Configure the audit system to generate an audit event for any successful/unsuccessful uses of the "usermod" command.  
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-a always,exit -F path=/usr/sbin/usermod -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged-usermod 
+   
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41461r654050_fix" /><check system="C-41502r654049_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that an audit event is generated for any successful/unsuccessful use of the "usermod" command. 
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep -w usermod 
+ 
+-a always,exit -F path=/usr/sbin/usermod -F perm=x -F auid&gt;=1000 -F auid!=-1 -k privileged-usermod 
+ 
+If the command does not return a line that matches the example or the line is commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238293"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238293r654054_rule" weight="10.0" severity="medium"><version>UBTU-20-010177</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the crontab command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41462r654053_fix">Configure the audit system to generate an audit event for any successful/unsuccessful uses of the "crontab" command.  
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged-crontab 
+   
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41462r654053_fix" /><check system="C-41503r654052_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that an audit event is generated for any successful/unsuccessful use of the "crontab" command. 
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep -w crontab 
+ 
+-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid&gt;=1000 -F auid!=-1 -k privileged-crontab 
+ 
+If the command does not return a line that matches the example or the line is commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238294"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238294r654057_rule" weight="10.0" severity="medium"><version>UBTU-20-010178</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the pam_timestamp_check command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41463r654056_fix">Configure the audit system to generate an audit event for any successful/unsuccessful uses of the "pam_timestamp_check" command.  
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged-pam_timestamp_check 
+   
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41463r654056_fix" /><check system="C-41504r654055_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that an audit event is generated for any successful/unsuccessful use of the "pam_timestamp_check" command. 
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep -w pam_timestamp_check 
+ 
+-a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid&gt;=1000 -F auid!=-1 -k privileged-pam_timestamp_check 
+ 
+If the command does not return a line that matches the example or the line is commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238295"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238295r808486_rule" weight="10.0" severity="medium"><version>UBTU-20-010179</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the init_module and finit_module syscalls.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+The system call rules are loaded into a matching engine that intercepts each syscall that all programs on the system makes. Therefore, it is very important to only use syscall rules when absolutely necessary since these affect performance. The more rules, the bigger the performance hit. The performance is helped, though, by combining syscalls into one rule whenever possible.
+
+Satisfies: SRG-OS-000064-GPOS-00033, SRG-OS-000471-GPOS-00216&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41464r808485_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "init_module" and "finit_module" syscalls.  
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-a always,exit -F arch=b32 -S init_module,finit_module -F auid&gt;=1000 -F auid!=4294967295 -k module_chng 
+-a always,exit -F arch=b64 -S init_module,finit_module -F auid&gt;=1000 -F auid!=4294967295 -k module_chng 
+  
+Notes: For 32-bit architectures, only the 32-bit specific entries are required.  
+  
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41464r808485_fix" /><check system="C-41505r808484_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record for any successful/unsuccessful attempts to use the "init_module" and "finit_module" syscalls. 
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep init_module 
+ 
+-a always,exit -F arch=b32 -S init_module,finit_module -F auid&gt;=1000 -F auid!=-1 -k module_chng 
+-a always,exit -F arch=b64 -S init_module,finit_module -F auid&gt;=1000 -F auid!=-1 -k module_chng  
+ 
+If the command does not return audit rules for the "init_module" and "finit_module" syscalls or the lines are commented out, this is a finding.
+ 
+Notes: 
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required. 
+The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238297"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238297r802387_rule" weight="10.0" severity="medium"><version>UBTU-20-010181</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the delete_module syscall.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000477-GPOS-00222&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41466r654065_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "delete_module" syscall.  
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-a always,exit -F arch=b32 -S delete_module -F auid&gt;=1000 -F auid!=4294967295 -k module_chng 
+-a always,exit -F arch=b64 -S delete_module -F auid&gt;=1000 -F auid!=4294967295 -k module_chng 
+  
+Notes: For 32-bit architectures, only the 32-bit specific entries are required.  
+  
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41466r654065_fix" /><check system="C-41507r654064_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record for any successful/unsuccessful attempts to use the "delete_module" syscall. 
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep -w delete_module 
+ 
+-a always,exit -F arch=b32 -S delete_module -F auid&gt;=1000 -F auid!=-1 -k module_chng 
+-a always,exit -F arch=b64 -S delete_module -F auid&gt;=1000 -F auid!=-1 -k module_chng 
+ 
+If the command does not return a line that matches the example or the line is commented out, this is a finding. 
+ 
+Notes: 
+- For 32-bit architectures, only the 32-bit specific output lines from the commands are required. 
+- The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238298"><title>SRG-OS-000122-GPOS-00063</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238298r853421_rule" weight="10.0" severity="medium"><version>UBTU-20-010182</version><title>The Ubuntu operating system must produce audit records and reports containing information to establish when, where, what type, the source, and the outcome for all DoD-defined auditable events and actions in near real time.</title><description>&lt;VulnDiscussion&gt;Without establishing the when, where, type, source, and outcome of events that occurred, it would be difficult to establish, correlate, and investigate the events leading up to an outage or attack. 
+ 
+Without the capability to generate audit records, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit record content that may be necessary to satisfy this requirement includes, for example, time stamps, source and destination addresses, user/process identifiers, event descriptions, success/fail indications, filenames involved, and access control or flow control rules invoked. 
+ 
+Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information. 
+ 
+Successful incident response and auditing relies on timely, accurate system information and analysis in order to allow the organization to identify and respond to potential incidents in a proficient manner. If the operating system does not provide the ability to centrally review the operating system logs, forensic analysis is negatively impacted. 
+ 
+Associating event types with detected events in the Ubuntu operating system audit logs provides a means of investigating an attack; recognizing resource utilization or capacity thresholds; or identifying an improperly configured operating system.
+
+Satisfies: SRG-OS-000122-GPOS-00063, SRG-OS-000037-GPOS-00015, SRG-OS-000038-GPOS-00016, SRG-OS-000039-GPOS-00017, SRG-OS-000040-GPOS-00018, SRG-OS-000041-GPOS-00019, SRG-OS-000042-GPOS-00020, SRG-OS-000042-GPOS-00021, SRG-OS-000051-GPOS-00024, SRG-OS-000054-GPOS-00025, SRG-OS-000062-GPOS-00031, SRG-OS-000337-GPOS-00129, SRG-OS-000348-GPOS-00136, SRG-OS-000349-GPOS-00137, SRG-OS-000350-GPOS-00138, SRG-OS-000351-GPOS-00139, SRG-OS-000352-GPOS-00140, SRG-OS-000353-GPOS-00141, SRG-OS-000354-GPOS-00142, SRG-OS-000475-GPOS-00220&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000130</ident><ident system="http://cyber.mil/cci">CCI-000131</ident><ident system="http://cyber.mil/cci">CCI-000132</ident><ident system="http://cyber.mil/cci">CCI-000133</ident><ident system="http://cyber.mil/cci">CCI-000134</ident><ident system="http://cyber.mil/cci">CCI-000135</ident><ident system="http://cyber.mil/cci">CCI-000154</ident><ident system="http://cyber.mil/cci">CCI-000158</ident><ident system="http://cyber.mil/cci">CCI-000169</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><ident system="http://cyber.mil/cci">CCI-001875</ident><ident system="http://cyber.mil/cci">CCI-001876</ident><ident system="http://cyber.mil/cci">CCI-001877</ident><ident system="http://cyber.mil/cci">CCI-001878</ident><ident system="http://cyber.mil/cci">CCI-001879</ident><ident system="http://cyber.mil/cci">CCI-001880</ident><ident system="http://cyber.mil/cci">CCI-001881</ident><ident system="http://cyber.mil/cci">CCI-001882</ident><ident system="http://cyber.mil/cci">CCI-001914</ident><fixtext fixref="F-41467r654068_fix">Configure the audit service to produce audit records containing the information needed to establish when (date and time) an event occurred. 
+ 
+Install the audit service (if the audit service is not already installed) with the following command: 
+ 
+$ sudo apt-get install auditd 
+ 
+Enable the audit service with the following command: 
+ 
+$ sudo systemctl enable auditd.service 
+ 
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41467r654068_fix" /><check system="C-41508r654067_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the audit service is configured to produce audit records with the following command: 
+ 
+$ dpkg -l | grep auditd 
+ 
+If the "auditd" package is not installed, this is a finding. 
+ 
+Verify the audit service is enabled with the following command: 
+ 
+$ systemctl is-enabled auditd.service 
+ 
+If the command above returns "disabled", this is a finding. 
+ 
+Verify the audit service is properly running and active on the system with the following command: 
+ 
+$ systemctl is-active auditd.service 
+active 
+ 
+If the command above returns "inactive", this is a finding.</check-content></check></Rule></Group><Group id="V-238299"><title>SRG-OS-000254-GPOS-00095</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238299r654072_rule" weight="10.0" severity="medium"><version>UBTU-20-010198</version><title>The Ubuntu operating system must initiate session audits at system start-up.</title><description>&lt;VulnDiscussion&gt;If auditing is enabled late in the start-up process, the actions of some start-up processes may not be audited. Some audit systems also maintain state information only available if auditing is enabled before a given process is created.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001464</ident><fixtext fixref="F-41468r654071_fix">Configure the Ubuntu operating system to produce audit records at system startup.  
+ 
+Edit the "/etc/default/grub" file and add "audit=1" to the "GRUB_CMDLINE_LINUX" option. 
+ 
+To update the grub config file, run: 
+ 
+$ sudo update-grub</fixtext><fix id="F-41468r654071_fix" /><check system="C-41509r654070_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that the Ubuntu operating system enables auditing at system startup.  
+ 
+Verify that the auditing is enabled in grub with the following command: 
+ 
+$ sudo grep "^\s*linux" /boot/grub/grub.cfg 
+ 
+linux        /boot/vmlinuz-5.4.0-31-generic root=UUID=74d13bcd-6ebd-4493-b5d2-3ebc37d01702 ro  audit=1 
+linux      /boot/vmlinuz-5.4.0-31-generic root=UUID=74d13bcd-6ebd-4493-b5d2-3ebc37d01702 ro recovery nomodeset audit=1 
+ 
+If any linux lines do not contain "audit=1", this is a finding.</check-content></check></Rule></Group><Group id="V-238300"><title>SRG-OS-000256-GPOS-00097</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238300r654075_rule" weight="10.0" severity="medium"><version>UBTU-20-010199</version><title>The Ubuntu operating system must configure audit tools with a mode of 0755 or less permissive.</title><description>&lt;VulnDiscussion&gt;Protecting audit information also includes identifying and protecting the tools used to view and manipulate log data. Therefore, protecting audit tools is necessary to prevent unauthorized operation on audit information. 
+ 
+Operating systems providing tools to interface with audit information will leverage user permissions and roles identifying the user accessing the tools and the corresponding rights the user enjoys in order to make access decisions regarding the access to audit tools. 
+ 
+Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators.
+
+Satisfies: SRG-OS-000256-GPOS-00097, SRG-OS-000257-GPOS-00098&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001493</ident><ident system="http://cyber.mil/cci">CCI-001494</ident><fixtext fixref="F-41469r654074_fix">Configure the audit tools on the Ubuntu operating system to be protected from unauthorized access by setting the correct permissive mode using the following command: 
+ 
+$ sudo chmod 0755 [audit_tool] 
+ 
+Replace "[audit_tool]" with the audit tool that does not have the correct permissions.</fixtext><fix id="F-41469r654074_fix" /><check system="C-41510r654073_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system configures the audit tools to have a file permission of 0755 or less to prevent unauthorized access by running the following command: 
+ 
+$ stat -c "%n %a" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace /sbin/auditd /sbin/audispd /sbin/augenrules 
+ 
+/sbin/auditctl 755 
+/sbin/aureport 755 
+/sbin/ausearch 755 
+/sbin/autrace 755 
+/sbin/auditd 755 
+/sbin/audispd 755 
+/sbin/augenrules 755 
+ 
+If any of the audit tools have a mode more permissive than 0755, this is a finding.</check-content></check></Rule></Group><Group id="V-238301"><title>SRG-OS-000256-GPOS-00097</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238301r654078_rule" weight="10.0" severity="medium"><version>UBTU-20-010200</version><title>The Ubuntu operating system must configure audit tools to be owned by root.</title><description>&lt;VulnDiscussion&gt;Protecting audit information also includes identifying and protecting the tools used to view and manipulate log data. Therefore, protecting audit tools is necessary to prevent unauthorized operation on audit information. 
+ 
+Operating systems providing tools to interface with audit information will leverage user permissions and roles identifying the user accessing the tools and the corresponding rights the user enjoys in order to make access decisions regarding the access to audit tools. 
+ 
+Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators.
+
+Satisfies: SRG-OS-000256-GPOS-00097, SRG-OS-000257-GPOS-00098&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001493</ident><ident system="http://cyber.mil/cci">CCI-001494</ident><fixtext fixref="F-41470r654077_fix">Configure the audit tools on the Ubuntu operating system to be protected from unauthorized access by setting the file owner as  root using the following command: 
+ 
+$ sudo chown root [audit_tool] 
+ 
+Replace "[audit_tool]" with each audit tool not owned by root.</fixtext><fix id="F-41470r654077_fix" /><check system="C-41511r654076_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system configures the audit tools to be owned by root to prevent any unauthorized access. 
+ 
+Check the ownership by running the following command: 
+ 
+$ stat -c "%n %U" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace /sbin/auditd /sbin/audispd /sbin/augenrules 
+ 
+/sbin/auditctl root 
+/sbin/aureport root 
+/sbin/ausearch root 
+/sbin/autrace root 
+/sbin/auditd root 
+/sbin/audispd root 
+/sbin/augenrules root 
+ 
+If any of the audit tools are not owned by root, this is a finding.</check-content></check></Rule></Group><Group id="V-238302"><title>SRG-OS-000256-GPOS-00097</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238302r654081_rule" weight="10.0" severity="medium"><version>UBTU-20-010201</version><title>The Ubuntu operating system must configure the audit tools to be group-owned by root.</title><description>&lt;VulnDiscussion&gt;Protecting audit information also includes identifying and protecting the tools used to view and manipulate log data. Therefore, protecting audit tools is necessary to prevent unauthorized operation on audit information. 
+ 
+Operating systems providing tools to interface with audit information will leverage user permissions and roles identifying the user accessing the tools and the corresponding rights the user enjoys in order to make access decisions regarding the access to audit tools. 
+ 
+Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators.
+
+Satisfies: SRG-OS-000256-GPOS-00097, SRG-OS-000257-GPOS-00098&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001493</ident><ident system="http://cyber.mil/cci">CCI-001494</ident><fixtext fixref="F-41471r654080_fix">Configure the audit tools on the Ubuntu operating system to be protected from unauthorized access by setting the file group as  root using the following command: 
+ 
+$ sudo chown :root [audit_tool] 
+ 
+Replace "[audit_tool]" with each audit tool not group-owned by root.</fixtext><fix id="F-41471r654080_fix" /><check system="C-41512r654079_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system configures the audit tools to be group-owned by root to prevent any unauthorized access. 
+ 
+Check the group ownership by running the following command: 
+ 
+$ stat -c "%n %G" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace /sbin/auditd /sbin/audispd /sbin/augenrules 
+ 
+/sbin/auditctl root 
+/sbin/aureport root 
+/sbin/ausearch root 
+/sbin/autrace root 
+/sbin/auditd root 
+/sbin/audispd root 
+/sbin/augenrules root 
+ 
+If any of the audit tools are not group-owned by root, this is a finding.</check-content></check></Rule></Group><Group id="V-238303"><title>SRG-OS-000278-GPOS-00108</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238303r877393_rule" weight="10.0" severity="medium"><version>UBTU-20-010205</version><title>The Ubuntu operating system must use cryptographic mechanisms to protect the integrity of audit tools.</title><description>&lt;VulnDiscussion&gt;Protecting the integrity of the tools used for auditing purposes is a critical step toward ensuring the integrity of audit information. Audit information includes all information (e.g., audit records, audit settings, and audit reports) needed to successfully audit information system activity. 
+ 
+Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators. 
+ 
+It is not uncommon for attackers to replace the audit tools or inject code into the existing tools with the purpose of providing the capability to hide or erase system activity from the audit logs. 
+ 
+To address this risk, audit tools must be cryptographically signed in order to provide the capability to identify when the audit tools have been modified, manipulated, or replaced. An example is a checksum hash of the file or files.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001496</ident><fixtext fixref="F-41472r654083_fix">Add or update the following selection lines for "/etc/aide/aide.conf" to protect the integrity of the audit tools: 
+ 
+# Audit Tools 
+/sbin/auditctl p+i+n+u+g+s+b+acl+xattrs+sha512 
+/sbin/auditd p+i+n+u+g+s+b+acl+xattrs+sha512 
+/sbin/ausearch p+i+n+u+g+s+b+acl+xattrs+sha512 
+/sbin/aureport p+i+n+u+g+s+b+acl+xattrs+sha512 
+/sbin/autrace p+i+n+u+g+s+b+acl+xattrs+sha512 
+/sbin/audispd p+i+n+u+g+s+b+acl+xattrs+sha512 
+/sbin/augenrules p+i+n+u+g+s+b+acl+xattrs+sha512</fixtext><fix id="F-41472r654083_fix" /><check system="C-41513r654082_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that Advanced Intrusion Detection Environment (AIDE) is properly configured to use cryptographic mechanisms to protect the integrity of audit tools. 
+ 
+Check the selection lines that AIDE is configured to add/check with the following command: 
+ 
+$ egrep '(\/sbin\/(audit|au))' /etc/aide/aide.conf 
+ 
+/sbin/auditctl p+i+n+u+g+s+b+acl+xattrs+sha512 
+/sbin/auditd p+i+n+u+g+s+b+acl+xattrs+sha512 
+/sbin/ausearch p+i+n+u+g+s+b+acl+xattrs+sha512 
+/sbin/aureport p+i+n+u+g+s+b+acl+xattrs+sha512 
+/sbin/autrace p+i+n+u+g+s+b+acl+xattrs+sha512 
+/sbin/audispd p+i+n+u+g+s+b+acl+xattrs+sha512 
+/sbin/augenrules p+i+n+u+g+s+b+acl+xattrs+sha512 
+ 
+If any of the seven audit tools do not have appropriate selection lines, this is a finding.</check-content></check></Rule></Group><Group id="V-238304"><title>SRG-OS-000326-GPOS-00126</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238304r853422_rule" weight="10.0" severity="medium"><version>UBTU-20-010211</version><title>The Ubuntu operating system must prevent all software from executing at higher privilege levels than users executing the software and the audit system must be configured to audit the execution of privileged functions.</title><description>&lt;VulnDiscussion&gt;In certain situations, software applications/programs need to execute with elevated privileges to perform required functions. However, if the privileges required for execution are at a higher level than the privileges assigned to organizational users invoking such applications/programs, those users are indirectly provided with greater privileges than assigned by the organizations. 
+ 
+Some programs and processes are required to operate at a higher privilege level and therefore should be excluded from the organization-defined software list after review.
+
+Satisfies: SRG-OS-000326-GPOS-00126, SRG-OS-000327-GPOS-00127&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-002233</ident><ident system="http://cyber.mil/cci">CCI-002234</ident><fixtext fixref="F-41473r654086_fix">Configure the Ubuntu operating system to audit the execution of all privileged functions. 
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -F key=execpriv  
+-a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -F key=execpriv  
+-a always,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -F key=execpriv  
+-a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -F key=execpriv 
+ 
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+ 
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41473r654086_fix" /><check system="C-41514r654085_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system audits the execution of privilege functions by auditing the "execve" system call. 
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep execve 
+ 
+-a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -F key=execpriv  
+-a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -F key=execpriv  
+-a always,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -F key=execpriv  
+-a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -F key=execpriv 
+ 
+If the command does not return lines that match the example or the lines are commented out, this is a finding. 
+ 
+Notes: 
+- For 32-bit architectures, only the 32-bit specific output lines from the commands are required. 
+- The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238305"><title>SRG-OS-000341-GPOS-00132</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238305r877391_rule" weight="10.0" severity="low"><version>UBTU-20-010215</version><title>The Ubuntu operating system must allocate audit record storage capacity to store at least one weeks' worth of audit records, when audit records are not immediately sent to a central audit record storage facility.</title><description>&lt;VulnDiscussion&gt;In order to ensure operating systems have a sufficient storage capacity in which to write the audit logs, operating systems need to be able to allocate audit record storage capacity. 
+ 
+The task of allocating audit record storage capacity is usually performed during initial installation of the operating system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001849</ident><fixtext fixref="F-41474r654089_fix">Allocate enough storage capacity for at least one week's worth of audit records when audit records are not immediately sent to a central audit record storage facility. 
+ 
+If audit records are stored on a partition made specifically for audit records, use the "parted" program to resize the partition with sufficient space to contain one week's worth of audit records. 
+ 
+If audit records are not stored on a partition made specifically for audit records, a new partition with sufficient amount of space will need be to be created. 
+ 
+Set the auditd server to point to the mount point where the audit records must be located: 
+ 
+$ sudo sed -i -E 's@^(log_file\s*=\s*).*@\1 &lt;log mountpoint&gt;/audit.log@' /etc/audit/auditd.conf 
+ 
+where &lt;log mountpoint&gt; is the aforementioned mount point.</fixtext><fix id="F-41474r654089_fix" /><check system="C-41515r654088_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system allocates audit record storage capacity to store at least one week's worth of audit records when audit records are not immediately sent to a central audit record storage facility. 
+ 
+Determine which partition the audit records are being written to with the following command: 
+ 
+$ sudo grep ^log_file /etc/audit/auditd.conf 
+log_file = /var/log/audit/audit.log 
+ 
+Check the size of the partition that audit records are written to (with the example being "/var/log/audit/") with the following command: 
+ 
+$ sudo df –h /var/log/audit/ 
+/dev/sda2 24G 10.4G 13.6G 43% /var/log/audit 
+ 
+If the audit records are not written to a partition made specifically for audit records ("/var/log/audit" is a separate partition), determine the amount of space being used by other files in the partition with the following command: 
+ 
+$ sudo du –sh [audit_partition] 
+1.8G /var/log/audit 
+ 
+Note: The partition size needed to capture a week's worth of audit records is based on the activity level of the system and the total storage capacity available. In normal circumstances, 10.0 GB of storage space for audit records will be sufficient. 
+ 
+If the audit record partition is not allocated for sufficient storage capacity, this is a finding.</check-content></check></Rule></Group><Group id="V-238306"><title>SRG-OS-000342-GPOS-00133</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238306r877390_rule" weight="10.0" severity="low"><version>UBTU-20-010216</version><title>The Ubuntu operating system audit event multiplexor must be configured to off-load audit logs onto a different system or storage media from the system being audited.</title><description>&lt;VulnDiscussion&gt;Information stored in one location is vulnerable to accidental or incidental deletion or alteration. 
+ 
+Off-loading is a common process in information systems with limited audit storage capacity.
+
+Satisfies: SRG-OS-000342-GPOS-00133, SRG-OS-000479-GPOS-00224&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001851</ident><fixtext fixref="F-41475r654092_fix">Configure the audit event multiplexor to offload audit records to a different system or storage media from the system being audited. 
+ 
+Install the audisp-remote plugin: 
+ 
+$ sudo apt-get install audispd-plugins -y 
+ 
+Set the audisp-remote plugin as active by editing the "/etc/audisp/plugins.d/au-remote.conf" file: 
+ 
+$ sudo sed -i -E 's/active\s*=\s*no/active = yes/' /etc/audisp/plugins.d/au-remote.conf 
+ 
+Set the address of the remote machine by editing the "/etc/audisp/audisp-remote.conf" file: 
+ 
+$ sudo sed -i -E 's/(remote_server\s*=).*/\1 &lt;remote addr&gt;/' /etc/audisp/audisp-remote.conf 
+ 
+where &lt;remote addr&gt; must be substituted by the address of the remote server receiving the audit log. 
+ 
+Make the audit service reload its configuration files: 
+ 
+$ sudo systemctl restart auditd.service</fixtext><fix id="F-41475r654092_fix" /><check system="C-41516r654091_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the audit event multiplexor is configured to offload audit records to a different system or storage media from the system being audited. 
+ 
+Check that audisp-remote plugin is installed: 
+ 
+$ sudo dpkg -s audispd-plugins 
+ 
+If status is "not installed", this is a finding. 
+ 
+Check that the records are being offloaded to a remote server with the following command: 
+ 
+$ sudo grep -i active /etc/audisp/plugins.d/au-remote.conf 
+ 
+active = yes 
+ 
+If "active" is not set to "yes", or the line is commented out, this is a finding. 
+ 
+Check that audisp-remote plugin is configured to send audit logs to a different system: 
+ 
+$ sudo grep -i ^remote_server /etc/audisp/audisp-remote.conf  
+ 
+remote_server = 192.168.122.126 
+ 
+If the "remote_server" parameter is not set, is set with a local address, or is set with an invalid address, this is a finding.</check-content></check></Rule></Group><Group id="V-238307"><title>SRG-OS-000343-GPOS-00134</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238307r877389_rule" weight="10.0" severity="low"><version>UBTU-20-010217</version><title>The Ubuntu operating system must immediately notify the SA and ISSO (at a minimum) when allocated audit record storage volume reaches 75% of the repository maximum audit record storage capacity.</title><description>&lt;VulnDiscussion&gt;If security personnel are not notified immediately when storage volume reaches 75% utilization, they are unable to plan for audit record storage capacity expansion.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001855</ident><fixtext fixref="F-41476r654095_fix">Edit "/etc/audit/auditd.conf" and set the "space_left_action" parameter to "exec" or "email".  
+ 
+If the "space_left_action" parameter is set to "email", set the "action_mail_acct" parameter to an email address for the SA and ISSO. 
+ 
+If the "space_left_action" parameter is set to "exec", ensure the command being executed notifies the SA and ISSO. 
+ 
+Edit "/etc/audit/auditd.conf" and set the "space_left" parameter to be at least 25% of the repository maximum audit record storage capacity.</fixtext><fix id="F-41476r654095_fix" /><check system="C-41517r654094_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system notifies the SA and ISSO (at a minimum) when allocated audit record storage volume reaches 75% of the repository maximum audit record storage capacity with the following command: 
+ 
+$ sudo grep ^space_left_action /etc/audit/auditd.conf 
+ 
+space_left_action email 
+ 
+$ sudo grep ^space_left /etc/audit/auditd.conf 
+ 
+space_left 250000 
+ 
+If the "space_left" parameter is missing, set to blanks, or set to a value less than 25% of the space free in the allocated audit record storage, this is a finding. 
+ 
+If the "space_left_action" parameter is missing or set to blanks, this is a finding. 
+ 
+If the "space_left_action" is set to "syslog", the system logs the event but does not generate a notification, and this is a finding. 
+ 
+If the "space_left_action" is set to "exec", the system executes a designated script. If this script informs the SA of the event, this is not a finding. 
+ 
+If the "space_left_action" is set to "email", check the value of the "action_mail_acct" parameter with the following command: 
+ 
+$ sudo grep ^action_mail_acct /etc/audit/auditd.conf 
+ 
+action_mail_acct root@localhost 
+ 
+The "action_mail_acct" parameter, if missing, defaults to "root". If the "action_mail_acct parameter" is not set to the email address of the SA(s) and/or ISSO, this is a finding.   
+ 
+Note: If the email address of the System Administrator
+ is on a remote system, a mail package must be available.</check-content></check></Rule></Group><Group id="V-238308"><title>SRG-OS-000359-GPOS-00146</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238308r877383_rule" weight="10.0" severity="low"><version>UBTU-20-010230</version><title>The Ubuntu operating system must record time stamps for audit records that can be mapped to Coordinated Universal Time (UTC) or Greenwich Mean Time (GMT).</title><description>&lt;VulnDiscussion&gt;If time stamps are not consistently applied and there is no common time reference, it is difficult to perform forensic analysis. 
+ 
+Time stamps generated by the operating system include date and time. Time is commonly expressed in Coordinated Universal Time (UTC), a modern continuation of Greenwich Mean Time (GMT), or local time with an offset from UTC.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001890</ident><fixtext fixref="F-41477r654098_fix">To configure the system time zone to use UTC or GMT, run the following command, replacing [ZONE] with UTC or GMT: 
+ 
+$ sudo timedatectl set-timezone [ZONE]</fixtext><fix id="F-41477r654098_fix" /><check system="C-41518r654097_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>To verify the time zone is configured to use UTC or GMT, run the following command.  
+ 
+$ timedatectl status | grep -i "time zone" 
+Timezone: UTC (UTC, +0000) 
+ 
+If "Timezone" is not set to UTC or GMT, this is a finding.</check-content></check></Rule></Group><Group id="V-238309"><title>SRG-OS-000392-GPOS-00172</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238309r853427_rule" weight="10.0" severity="medium"><version>UBTU-20-010244</version><title>The Ubuntu operating system must generate audit records for privileged activities, nonlocal maintenance, diagnostic sessions and other system-level access.</title><description>&lt;VulnDiscussion&gt;If events associated with nonlocal administrative access or diagnostic sessions are not logged, a major tool for assessing and investigating attacks would not be available. 
+ 
+This requirement addresses auditing-related issues associated with maintenance tools used specifically for diagnostic and repair actions on organizational information systems. 
+ 
+Nonlocal maintenance and diagnostic activities are those activities conducted by individuals communicating through a network, either an external network (e.g., the internet) or an internal network. Local maintenance and diagnostic activities are those activities carried out by individuals physically present at the information system or information system component and not communicating across a network connection. 
+ 
+This requirement applies to hardware/software diagnostic test equipment or tools. This requirement does not cover hardware/software components that may support information system maintenance, yet are a part of the system, for example, the software implementing "ping," "ls," "ipconfig," or the hardware and software implementing the monitoring port of an Ethernet switch.
+
+Satisfies: SRG-OS-000392-GPOS-00172, SRG-OS-000471-GPOS-00215&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><ident system="http://cyber.mil/cci">CCI-002884</ident><fixtext fixref="F-41478r654101_fix">Configure the Ubuntu operating system to audit activities performed during nonlocal maintenance and diagnostic sessions. 
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-w /var/log/sudo.log -p wa -k maintenance 
+  
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41478r654101_fix" /><check system="C-41519r654100_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system audits activities performed during nonlocal maintenance and diagnostic sessions. 
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep sudo.log 
+ 
+-w /var/log/sudo.log -p wa -k maintenance 
+ 
+If the command does not return lines that match the example or the lines are commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238310"><title>SRG-OS-000468-GPOS-00212</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238310r832953_rule" weight="10.0" severity="medium"><version>UBTU-20-010267</version><title>The Ubuntu operating system must generate audit records for any successful/unsuccessful use of unlink, unlinkat, rename, renameat, and rmdir system calls.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+The system call rules are loaded into a matching engine that intercepts each syscall that all programs on the system makes. Therefore, it is very important to only use syscall rules when absolutely necessary since these affect performance. The more rules, the bigger the performance hit. The performance is helped, though, by combining syscalls into one rule whenever possible.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41479r832952_fix">Configure the audit system to generate audit events for any successful/unsuccessful use of "unlink", "unlinkat", "rename", "renameat", and "rmdir" system calls. 
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+ 
+-a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat,rmdir -F auid&gt;=1000 -F auid!=4294967295 -k delete 
+-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat,rmdir -F auid&gt;=1000 -F auid!=4294967295 -k delete 
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+ 
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41479r832952_fix" /><check system="C-41520r832951_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records for any successful/unsuccessful use of "unlink", "unlinkat", "rename", "renameat", and "rmdir" system calls. 
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep 'unlink\|rename\|rmdir' 
+ 
+-a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat,rmdir -F auid&gt;=1000 -F auid!=-1 -F key=delete 
+-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat,rmdir -F auid&gt;=1000 -F auid!=-1 -F key=delete 
+ 
+If the command does not return audit rules for the "unlink", "unlinkat", "rename", "renameat", and "rmdir" syscalls or the lines are commented out, this is a finding. 
+ 
+Notes: 
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required. 
+The "key" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238315"><title>SRG-OS-000472-GPOS-00217</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238315r654120_rule" weight="10.0" severity="medium"><version>UBTU-20-010277</version><title>The Ubuntu operating system must generate audit records for the /var/log/wtmp file.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41484r654119_fix">Configure the audit system to generate audit events showing start and stop times for user access via the "/var/log/wtmp" file. 
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-w /var/log/wtmp -p wa -k logins 
+  
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41484r654119_fix" /><check system="C-41525r654118_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records showing start and stop times for user access to the system via the "/var/log/wtmp" file. 
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep '/var/log/wtmp' 
+ 
+-w /var/log/wtmp -p wa -k logins 
+ 
+If the command does not return a line matching the example or the line is commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238316"><title>SRG-OS-000472-GPOS-00217</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238316r880873_rule" weight="10.0" severity="medium"><version>UBTU-20-010278</version><title>The Ubuntu operating system must generate audit records for the /var/run/utmp file.</title><description>&lt;VulnDiscussion&gt;Without generating audit records specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41485r880872_fix">Configure the audit system to generate audit events showing start and stop times for user access via the "/var/run/utmp" file. 
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-w /var/run/utmp -p wa -k logins 
+  
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41485r880872_fix" /><check system="C-41526r880871_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records showing start and stop times for user access to the system via the "/var/run/utmp" file. 
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep '/var/run/utmp' 
+ 
+-w /var/run/utmp -p wa -k logins 
+ 
+If the command does not return a line matching the example or the line is commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238317"><title>SRG-OS-000472-GPOS-00217</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238317r654126_rule" weight="10.0" severity="medium"><version>UBTU-20-010279</version><title>The Ubuntu operating system must generate audit records for the /var/log/btmp file.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41486r654125_fix">Configure the audit system to generate audit events showing start and stop times for user access via the "/var/log/btmp file". 
+ 
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-w /var/log/btmp -p wa -k logins 
+  
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41486r654125_fix" /><check system="C-41527r654124_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records showing start and stop times for user access to the system via the "/var/log/btmp" file. 
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep '/var/log/btmp' 
+ 
+-w /var/log/btmp -p wa -k logins 
+ 
+If the command does not return a line matching the example or the line is commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238318"><title>SRG-OS-000477-GPOS-00222</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238318r654129_rule" weight="10.0" severity="medium"><version>UBTU-20-010296</version><title>The Ubuntu operating system must generate audit records when successful/unsuccessful attempts to use modprobe command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41487r654128_fix">Configure the Ubuntu operating system to audit the execution of the module management program "modprobe". 
+ 
+Add or update the following rule in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-w /sbin/modprobe -p x -k modules 
+  
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41487r654128_fix" /><check system="C-41528r654127_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify if the Ubuntu operating system is configured to audit the execution of the module management program "modprobe" by running the following command: 
+ 
+$ sudo auditctl -l | grep "/sbin/modprobe" 
+ 
+-w /sbin/modprobe -p x -k modules 
+ 
+If the command does not return a line, or the line is commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238319"><title>SRG-OS-000477-GPOS-00222</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238319r654132_rule" weight="10.0" severity="medium"><version>UBTU-20-010297</version><title>The Ubuntu operating system must generate audit records when successful/unsuccessful attempts to use the kmod command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41488r654131_fix">Configure the Ubuntu operating system to audit the execution of the module management program "kmod". 
+ 
+Add or update the following rule in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-w /bin/kmod -p x -k modules 
+  
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41488r654131_fix" /><check system="C-41529r654130_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system is configured to audit the execution of the module management program "kmod". 
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep kmod 
+ 
+-w /bin/kmod -p x -k module 
+ 
+If the command does not return a line, or the line is commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238320"><title>SRG-OS-000477-GPOS-00222</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238320r832956_rule" weight="10.0" severity="medium"><version>UBTU-20-010298</version><title>The Ubuntu operating system must generate audit records when successful/unsuccessful attempts to use the fdisk command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+ 
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-41489r832955_fix">Configure the Ubuntu operating system to audit the execution of the partition management program "fdisk". 
+ 
+Add or update the following rule in the "/etc/audit/rules.d/stig.rules" file: 
+ 
+-w /usr/sbin/fdisk -p x -k fdisk 
+  
+To reload the rules file, issue the following command: 
+ 
+$ sudo augenrules --load</fixtext><fix id="F-41489r832955_fix" /><check system="C-41530r832954_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system is configured to audit the execution of the partition management program "fdisk". 
+ 
+Check the currently configured audit rules with the following command: 
+ 
+$ sudo auditctl -l | grep fdisk 
+ 
+-w /usr/sbin/fdisk -p x -k fdisk 
+ 
+If the command does not return a line, or the line is commented out, this is a finding. 
+ 
+Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-238321"><title>SRG-OS-000479-GPOS-00224</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238321r853428_rule" weight="10.0" severity="low"><version>UBTU-20-010300</version><title>The Ubuntu operating system must have a crontab script running weekly to offload audit events of standalone systems.</title><description>&lt;VulnDiscussion&gt;Information stored in one location is vulnerable to accidental or incidental deletion or alteration. 
+ 
+Offloading is a common process in information systems with limited audit storage capacity.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001851</ident><fixtext fixref="F-41490r654137_fix">Create a script that offloads audit logs to external media and runs weekly. 
+ 
+The script must be located in the "/etc/cron.weekly" directory.</fixtext><fix id="F-41490r654137_fix" /><check system="C-41531r654136_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Note: If this is an interconnected system, this is Not Applicable. 
+ 
+Verify there is a script that offloads audit data and that script runs weekly. 
+ 
+Check if there is a script in the "/etc/cron.weekly" directory that offloads audit data: 
+ 
+# sudo ls /etc/cron.weekly 
+ 
+audit-offload 
+ 
+Check if the script inside the file does offloading of audit logs to external media. 
+ 
+If the script file does not exist or does not offload audit logs, this is a finding.</check-content></check></Rule></Group><Group id="V-238323"><title>SRG-OS-000027-GPOS-00008</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238323r877399_rule" weight="10.0" severity="low"><version>UBTU-20-010400</version><title>The Ubuntu operating system must limit the number of concurrent sessions to ten for all accounts and/or account types.</title><description>&lt;VulnDiscussion&gt;The Ubuntu operating system management includes the ability to control the number of users and user sessions that utilize an operating system. Limiting the number of allowed users and sessions per user is helpful in reducing the risks related to DoS attacks. 
+ 
+This requirement addresses concurrent sessions for information system accounts and does not address concurrent sessions by single users via multiple system accounts. The maximum number of concurrent sessions should be defined based upon mission needs and the operational environment for each system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000054</ident><fixtext fixref="F-41492r654143_fix">Configure the Ubuntu operating system to limit the number of concurrent sessions to 10 for all accounts and/or account types. 
+ 
+Add the following line to the top of the "/etc/security/limits.conf" file: 
+ 
+* hard maxlogins 10</fixtext><fix id="F-41492r654143_fix" /><check system="C-41533r654142_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system limits the number of concurrent sessions to 10 for all accounts and/or account types by running the following command: 
+ 
+$ grep maxlogins /etc/security/limits.conf | grep -v '^* hard maxlogins' 
+ 
+The result must contain the following line: 
+ 
+* hard maxlogins 10 
+ 
+If the "maxlogins" item is missing or the value is not set to 10 or less or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-238324"><title>SRG-OS-000032-GPOS-00013</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238324r832959_rule" weight="10.0" severity="medium"><version>UBTU-20-010403</version><title>The Ubuntu operating system must monitor remote access methods.</title><description>&lt;VulnDiscussion&gt;Remote access services, such as those providing remote access to network devices and information systems, which lack automated monitoring capabilities, increase risk and make remote user access management difficult at best. 
+ 
+Remote access is access to DoD nonpublic information systems by an authorized user (or an information system) communicating through an external, non-organization-controlled network. Remote access methods include, for example, dial-up, broadband, and wireless. 
+ 
+Automated monitoring of remote access sessions allows organizations to detect cyber attacks and also ensure ongoing compliance with remote access policies by auditing connection activities of remote access capabilities, such as Remote Desktop Protocol (RDP), on a variety of information system components (e.g., servers, workstations, notebook computers, smartphones, and tablets).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000067</ident><fixtext fixref="F-41493r832958_fix">Configure the Ubuntu operating system to monitor all remote access methods by adding the following lines to the "/etc/rsyslog.d/50-default.conf" file: 
+ 
+auth.*,authpriv.* /var/log/secure 
+daemon.* /var/log/messages 
+ 
+For the changes to take effect, restart the "rsyslog" service with the following command: 
+ 
+$ sudo systemctl restart rsyslog.service</fixtext><fix id="F-41493r832958_fix" /><check system="C-41534r832957_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that the Ubuntu operating system monitors all remote access methods. 
+ 
+Check that remote access methods are being logged by running the following command: 
+ 
+$  grep -E -r '^(auth,authpriv\.\*|daemon\.\*)' /etc/rsyslog.* 
+/etc/rsyslog.d/50-default.conf:auth,authpriv.*                        /var/log/auth.log 
+/etc/rsyslog.d/50-default.conf:daemon.*                        /var/log/messages 
+ 
+If "auth.*", "authpriv.*", or "daemon.*" are not configured to be logged in at least one of the config files, this is a finding.</check-content></check></Rule></Group><Group id="V-238325"><title>SRG-OS-000120-GPOS-00061</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238325r654150_rule" weight="10.0" severity="medium"><version>UBTU-20-010404</version><title>The Ubuntu operating system must encrypt all stored passwords with a FIPS 140-2 approved cryptographic hashing algorithm.</title><description>&lt;VulnDiscussion&gt;Passwords need to be protected at all times, and encryption is the standard method for protecting passwords. If passwords are not encrypted, they can be plainly read (i.e., clear text) and easily compromised.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000803</ident><fixtext fixref="F-41494r654149_fix">Configure the Ubuntu operating system to encrypt all stored passwords.  
+ 
+Edit/modify the following line in the "/etc/login.defs" file and set "ENCRYPT_METHOD" to SHA512: 
+ 
+ENCRYPT_METHOD SHA512</fixtext><fix id="F-41494r654149_fix" /><check system="C-41535r654148_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that the shadow password suite configuration is set to encrypt passwords with a FIPS 140-2 approved cryptographic hashing algorithm. 
+ 
+Check the hashing algorithm that is being used to hash passwords with the following command: 
+ 
+$ cat /etc/login.defs | grep -i encrypt_method 
+ 
+ENCRYPT_METHOD SHA512 
+ 
+If "ENCRYPT_METHOD" does not equal SHA512 or greater, this is a finding.</check-content></check></Rule></Group><Group id="V-238326"><title>SRG-OS-000074-GPOS-00042</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238326r877396_rule" weight="10.0" severity="high"><version>UBTU-20-010405</version><title>The Ubuntu operating system must not have the telnet package installed.</title><description>&lt;VulnDiscussion&gt;Passwords need to be protected at all times, and encryption is the standard method for protecting passwords. If passwords are not encrypted, they can be plainly read (i.e., clear text) and easily compromised.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000197</ident><fixtext fixref="F-41495r654152_fix">Remove the telnet package from the Ubuntu operating system by running the following command: 
+ 
+$ sudo apt-get remove telnetd</fixtext><fix id="F-41495r654152_fix" /><check system="C-41536r654151_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that the telnet package is not installed on the Ubuntu operating system by running the following command: 
+ 
+$ dpkg -l | grep telnetd 
+ 
+If the package is installed, this is a finding.</check-content></check></Rule></Group><Group id="V-238327"><title>SRG-OS-000095-GPOS-00049</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238327r654156_rule" weight="10.0" severity="high"><version>UBTU-20-010406</version><title>The Ubuntu operating system must not have the rsh-server package installed.</title><description>&lt;VulnDiscussion&gt;It is detrimental for operating systems to provide, or install by default, functionality exceeding requirements or mission objectives. These unnecessary capabilities or services are often overlooked and therefore may remain unsecured. They increase the risk to the platform by providing additional attack vectors. 
+ 
+Operating systems are capable of providing a wide variety of functions and services. Some of the functions and services, provided by default, may not be necessary to support essential organizational operations (e.g., key missions, functions). 
+ 
+Examples of non-essential capabilities include, but are not limited to, games, software packages, tools, and demonstration software, not related to requirements or providing a wide array of functionality not required for every mission, but which cannot be disabled.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000381</ident><fixtext fixref="F-41496r654155_fix">Configure the Ubuntu operating system to disable non-essential capabilities by removing the rsh-server package from the system with the following command: 
+ 
+$ sudo apt-get remove rsh-server</fixtext><fix id="F-41496r654155_fix" /><check system="C-41537r654154_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the rsh-server package is installed with the following command: 
+ 
+$ dpkg -l | grep rsh-server 
+ 
+If the rsh-server package is installed, this is a finding.</check-content></check></Rule></Group><Group id="V-238328"><title>SRG-OS-000096-GPOS-00050</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238328r654159_rule" weight="10.0" severity="medium"><version>UBTU-20-010407</version><title>The Ubuntu operating system must be configured to prohibit or restrict the use of functions, ports, protocols, and/or services, as defined in the PPSM CAL and vulnerability assessments.</title><description>&lt;VulnDiscussion&gt;In order to prevent unauthorized connection of devices, unauthorized transfer of information, or unauthorized tunneling (i.e., embedding of data types within data types), organizations must disable or restrict unused or unnecessary physical and logical ports/protocols on information systems. 
+ 
+Operating systems are capable of providing a wide variety of functions and services. Some of the functions and services provided by default may not be necessary to support essential organizational operations. Additionally, it is sometimes convenient to provide multiple services from a single component (e.g., VPN and IPS); however, doing so increases risk over limiting the services provided by any one component. 
+ 
+To support the requirements and principles of least functionality, the operating system must support the organizational requirements, providing only essential capabilities and limiting the use of ports, protocols, and/or services to only those required, authorized, and approved to conduct official business or to address authorized quality of life issues.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000382</ident><fixtext fixref="F-41497r654158_fix">Add all ports, protocols, or services allowed by the PPSM CLSA by using the following command: 
+ 
+$ sudo ufw allow &lt;direction&gt; &lt;port/protocol/service&gt; 
+ 
+where the direction is "in" or "out" and the port is the one corresponding to the protocol  or service allowed. 
+ 
+To deny access to ports, protocols, or services, use: 
+ 
+$ sudo ufw deny &lt;direction&gt; &lt;port/protocol/service&gt;</fixtext><fix id="F-41497r654158_fix" /><check system="C-41538r654157_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system is configured to prohibit or restrict the use of functions, ports, protocols, and/or services as defined in the Ports, Protocols, and Services Management (PPSM) Category Assignments List (CAL) and vulnerability assessments. 
+ 
+Check the firewall configuration for any unnecessary or prohibited functions, ports, protocols, and/or services by running the following command: 
+ 
+$ sudo ufw show raw 
+ 
+Chain OUTPUT (policy ACCEPT) 
+target  prot opt sources    destination 
+Chain INPUT (policy ACCEPT 1 packets, 40 bytes) 
+    pkts      bytes target     prot opt in     out     source               destination 
+ 
+Chain FORWARD (policy ACCEPT 0 packets, 0 bytes) 
+    pkts      bytes target     prot opt in     out     source               destination 
+ 
+Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes) 
+    pkts      bytes target     prot opt in     out     source               destination 
+ 
+Ask the System Administrator
+ for the site or program PPSM CLSA. Verify the services allowed by the firewall match the PPSM CLSA.  
+ 
+If there are any additional ports, protocols, or services that are not included in the PPSM CLSA, this is a finding. 
+ 
+If there are any ports, protocols, or services that are prohibited by the PPSM CAL, this is a finding.</check-content></check></Rule></Group><Group id="V-238329"><title>SRG-OS-000109-GPOS-00056</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238329r654162_rule" weight="10.0" severity="medium"><version>UBTU-20-010408</version><title>The Ubuntu operating system must prevent direct login into the root account.</title><description>&lt;VulnDiscussion&gt;To assure individual accountability and prevent unauthorized access, organizational users must be individually identified and authenticated. 
+ 
+A group authenticator is a generic account used by multiple individuals. Use of a group authenticator alone does not uniquely identify individual users. Examples of the group authenticator is the UNIX OS "root" user account, the Windows "Administrator" account, the "sa" account, or a "helpdesk" account. 
+ 
+For example, the UNIX and Windows operating systems offer a 'switch user' capability allowing users to authenticate with their individual credentials and, when needed, 'switch' to the administrator role. This method provides for unique individual authentication prior to using a group authenticator. 
+ 
+Users (and any processes acting on behalf of users) need to be uniquely identified and authenticated for all accesses other than those accesses explicitly identified and documented by the organization, which outlines specific user actions that can be performed on the operating system without identification or authentication. 
+ 
+Requiring individuals to be authenticated with an individual authenticator prior to using a group authenticator allows for traceability of actions, as well as adding an additional level of protection of the actions that can be taken with group account knowledge.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000770</ident><fixtext fixref="F-41498r654161_fix">Configure the Ubuntu operating system to prevent direct logins to the root account by performing the following operations: 
+ 
+$ sudo passwd -l root</fixtext><fix id="F-41498r654161_fix" /><check system="C-41539r654160_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system prevents direct logins to the root account with the following command: 
+ 
+$ sudo passwd -S root 
+ 
+root L 04/23/2020 0 99999 7 -1 
+ 
+If the output does not contain "L" in the second field to indicate the account is locked, this is a finding.</check-content></check></Rule></Group><Group id="V-238330"><title>SRG-OS-000118-GPOS-00060</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238330r654165_rule" weight="10.0" severity="medium"><version>UBTU-20-010409</version><title>The Ubuntu operating system must disable account identifiers (individuals, groups, roles, and devices) after 35 days of inactivity.</title><description>&lt;VulnDiscussion&gt;Inactive identifiers pose a risk to systems and applications because attackers may exploit an inactive identifier and potentially obtain undetected access to the system. Owners of inactive accounts will not notice if unauthorized access to their user account has been obtained. 
+ 
+Operating systems need to track periods of inactivity and disable application identifiers after 35 days of inactivity.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000795</ident><fixtext fixref="F-41499r654164_fix">Configure the Ubuntu operating system to disable account identifiers after 35 days of inactivity after the password expiration.  
+ 
+Run the following command to change the configuration for adduser: 
+ 
+$ sudo useradd -D -f 35 
+ 
+Note: DoD recommendation is 35 days, but a lower value is acceptable. The value "0" will disable the account immediately after the password expires.</fixtext><fix id="F-41499r654164_fix" /><check system="C-41540r654163_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the account identifiers (individuals, groups, roles, and devices) are disabled after 35 days of inactivity with the following command: 
+ 
+Check the account inactivity value by performing the following command: 
+ 
+$ sudo grep INACTIVE /etc/default/useradd 
+ 
+INACTIVE=35 
+ 
+If "INACTIVE" is not set to a value 0&lt;[VALUE]&lt;=35, or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-238331"><title>SRG-OS-000123-GPOS-00064</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238331r902885_rule" weight="10.0" severity="low"><version>UBTU-20-010410</version><title>The Ubuntu operating system must automatically expire temporary accounts within 72 hours.</title><description>&lt;VulnDiscussion&gt;Temporary accounts are privileged or nonprivileged accounts that are established during pressing circumstances, such as new software or hardware configuration or an incident response, where the need for prompt account activation requires bypassing normal account authorization procedures. If any inactive temporary accounts are left enabled on the system and are not either manually removed or automatically expired within 72 hours, the security posture of the system will be degraded and exposed to exploitation by unauthorized users or insider threat actors.
+
+Temporary accounts are different from emergency accounts. Emergency accounts, also known as "last resort" or "break glass" accounts, are local logon accounts enabled on the system for emergency use by authorized system administrators to manage a system when standard logon methods are failing or not available. Emergency accounts are not subject to manual removal or scheduled expiration requirements.
+
+The automatic expiration of temporary accounts may be extended as needed by the circumstances but it must not be extended indefinitely. A documented permanent account should be established for privileged users who need long-term maintenance accounts.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001682</ident><fixtext fixref="F-41500r902861_fix">Configure the operating system to expire temporary accounts after 72 hours with the following command:
+
+     $ sudo chage -E $(date -d +3days +%Y-%m-%d) &lt;temporary_account_name&gt;</fixtext><fix id="F-41500r902861_fix" /><check system="C-41541r902860_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify temporary accounts have been provisioned with an expiration date of 72 hours.
+
+For every existing temporary account, run the following command to obtain its account expiration information:
+
+     $ sudo chage -l &lt;temporary_account_name&gt; | grep -i "account expires"
+
+Verify each of these accounts has an expiration date set within 72 hours.
+If any temporary accounts have no expiration date set or do not expire within 72 hours, this is a finding.</check-content></check></Rule></Group><Group id="V-238332"><title>SRG-OS-000138-GPOS-00069</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238332r654171_rule" weight="10.0" severity="medium"><version>UBTU-20-010411</version><title>The Ubuntu operating system must set a sticky bit  on all public directories to prevent unauthorized and unintended information transferred via shared system resources.</title><description>&lt;VulnDiscussion&gt;Preventing unauthorized information transfers mitigates the risk of information, including encrypted representations of information, produced by the actions of prior users/roles (or the actions of processes acting on behalf of prior users/roles) from being available to any current users/roles (or current processes) that obtain access to shared system resources (e.g., registers, main memory, hard disks) after those resources have been released back to information systems. The control of information in shared resources is also commonly referred to as object reuse and residual information protection. 
+ 
+This requirement generally applies to the design of an information technology product, but it can also apply to the configuration of particular information system components that are, or use, such products. This can be verified by acceptance/validation processes in DoD or other government agencies. 
+ 
+There may be shared resources with configurable protections (e.g., files in storage) that may be assessed on specific information system components.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001090</ident><fixtext fixref="F-41501r654170_fix">Configure all public directories to have the sticky bit set to prevent unauthorized and unintended information transferred via shared system resources. 
+ 
+Set the sticky bit on all public directories using the following command, replacing "[Public Directory]" with any directory path missing the sticky bit: 
+ 
+$ sudo chmod +t  [Public Directory]</fixtext><fix id="F-41501r654170_fix" /><check system="C-41542r654169_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that all public (world-writeable) directories have the public sticky bit set. 
+ 
+Find world-writable directories that lack the sticky bit by running the following command:  
+ 
+$ sudo find / -type d -perm -002 ! -perm -1000 
+ 
+If any world-writable directories are found missing the sticky bit, this is a finding.</check-content></check></Rule></Group><Group id="V-238333"><title>SRG-OS-000142-GPOS-00071</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238333r654174_rule" weight="10.0" severity="medium"><version>UBTU-20-010412</version><title>The Ubuntu operating system must be configured to use TCP syncookies.</title><description>&lt;VulnDiscussion&gt;DoS is a condition when a resource is not available for legitimate users. When this occurs, the organization either cannot accomplish its mission or must operate at degraded capacity.  
+ 
+Managing excess capacity ensures that sufficient capacity is available to counter flooding attacks. Employing increased capacity and service redundancy may reduce the susceptibility to some DoS attacks. Managing excess capacity may include, for example, establishing selected usage priorities, quotas, or partitioning.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001095</ident><fixtext fixref="F-41502r654173_fix">Configure the Ubuntu operating system to use TCP syncookies by running the following command: 
+ 
+$ sudo sysctl -w net.ipv4.tcp_syncookies=1 
+ 
+If "1" is not the system's default value, add or update the following line in "/etc/sysctl.conf": 
+ 
+net.ipv4.tcp_syncookies = 1</fixtext><fix id="F-41502r654173_fix" /><check system="C-41543r654172_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system is configured to use TCP syncookies. 
+ 
+Check the value of TCP syncookies with the following command: 
+ 
+$ sysctl net.ipv4.tcp_syncookies 
+net.ipv4.tcp_syncookies = 1 
+ 
+If the value is not "1", this is a finding. 
+ 
+Check the saved value of TCP syncookies with the following command: 
+ 
+$ sudo grep -i net.ipv4.tcp_syncookies /etc/sysctl.conf /etc/sysctl.d/* | grep -v '#' 
+ 
+If no output is returned, this is a finding.</check-content></check></Rule></Group><Group id="V-238334"><title>SRG-OS-000184-GPOS-00078</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238334r654177_rule" weight="10.0" severity="medium"><version>UBTU-20-010413</version><title>The Ubuntu operating system must disable kernel core dumps  so that it can fail to a secure state if system initialization fails, shutdown fails or aborts fail.</title><description>&lt;VulnDiscussion&gt;Kernel core dumps may contain the full contents of system memory at the time of the crash. Kernel core dumps may consume a considerable amount of disk space and may result in denial of service by exhausting the available space on the target file system partition.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001190</ident><fixtext fixref="F-41503r654176_fix">If kernel core dumps are not required, disable the "kdump" service with the following command: 
+ 
+$ sudo systemctl disable kdump.service 
+ 
+If kernel core dumps are required, document the need with the ISSO.</fixtext><fix id="F-41503r654176_fix" /><check system="C-41544r654175_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that kernel core dumps are disabled unless needed. 
+ 
+Check if "kdump" service is active with the following command: 
+ 
+$ systemctl is-active kdump.service 
+inactive 
+ 
+If the "kdump" service is active, ask the SA if the use of the service is required and documented with the ISSO. 
+ 
+If the service is active and is not documented, this is a finding.</check-content></check></Rule></Group><Group id="V-238335"><title>SRG-OS-000185-GPOS-00079</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238335r654180_rule" weight="10.0" severity="medium"><version>UBTU-20-010414</version><title>Ubuntu operating systems handling data requiring "data at rest" protections must employ cryptographic mechanisms to prevent unauthorized disclosure and modification of the information at rest.</title><description>&lt;VulnDiscussion&gt;Information at rest refers to the state of information when it is located on a secondary storage device (e.g., disk drive and tape drive, when used for backups) within an operating system. 
+ 
+This requirement addresses protection of user-generated data, as well as operating system-specific configuration data. Organizations may choose to employ different mechanisms to achieve confidentiality and integrity protections, as appropriate, in accordance with the security category and/or classification of the information.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001199</ident><fixtext fixref="F-41504r654179_fix">To encrypt an entire partition, dedicate a partition for encryption in the partition layout. 
+ 
+Note: Encrypting a partition in an already-installed system is more difficult because it will need to be resized and existing partitions changed.</fixtext><fix id="F-41504r654179_fix" /><check system="C-41545r654178_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>If there is a documented and approved reason for not having data-at-rest encryption, this requirement is Not Applicable. 
+ 
+Verify the Ubuntu operating system prevents unauthorized disclosure or modification of all information requiring at-rest protection by using disk encryption.  
+ 
+Determine the partition layout for the system with the following command: 
+ 
+#sudo fdisk -l 
+(..) 
+Disk /dev/vda: 15 GiB, 16106127360 bytes, 31457280 sectors 
+Units: sectors of 1 * 512 = 512 bytes 
+Sector size (logical/physical): 512 bytes / 512 bytes 
+I/O size (minimum/optimal): 512 bytes / 512 bytes 
+Disklabel type: gpt 
+Disk identifier: 83298450-B4E3-4B19-A9E4-7DF147A5FEFB 
+ 
+Device       Start      End  Sectors Size Type 
+/dev/vda1     2048     4095     2048   1M BIOS boot 
+/dev/vda2     4096  2101247  2097152   1G Linux filesystem 
+/dev/vda3  2101248 31455231 29353984  14G Linux filesystem 
+(...) 
+ 
+Verify the system partitions are all encrypted with the following command: 
+ 
+# more /etc/crypttab 
+ 
+Every persistent disk partition present must have an entry in the file.  
+ 
+If any partitions other than the boot partition or pseudo file systems (such as /proc or /sys) are not listed, this is a finding.</check-content></check></Rule></Group><Group id="V-238336"><title>SRG-OS-000191-GPOS-00080</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238336r858538_rule" weight="10.0" severity="low"><version>UBTU-20-010415</version><title>The Ubuntu operating system must deploy Endpoint Security for Linux Threat Prevention (ENSLTP).</title><description>&lt;VulnDiscussion&gt;Without the use of automated mechanisms to scan for security flaws on a continuous and/or periodic basis, the operating system or other system components may remain vulnerable to the exploits presented by undetected software flaws. 
+ 
+To support this requirement, the operating system may have an integrated solution incorporating continuous scanning using HBSS and periodic scanning using other tools, as specified in the requirement.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001233</ident><fixtext fixref="F-41505r858537_fix">The Ubuntu operating system is not compliant with this requirement; however, the severity level can be mitigated to a CAT III if the ENSLTP module is installed and running.
+
+Configure the Ubuntu operating system to use ENSLTP.
+
+Install the "mcafeetp" package via the ePO server.</fixtext><fix id="F-41505r858537_fix" /><check system="C-41546r858536_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>The Ubuntu operating system is not compliant with this requirement; hence, it is a finding. However, the severity level can be mitigated to a CAT III if the ENSLTP module is installed and running. 
+ 
+Check that the "mcafeetp" package has been installed: 
+ 
+# dpkg -l | grep mcafeetp 
+ 
+If the "mcafeetp" package is not installed, this finding will remain as a CAT II. 
+ 
+Check that the daemon is running: 
+ 
+# /opt/McAfee/ens/tp/init/mfetpd-control.sh status 
+ 
+If the daemon is not running, this finding will remain as a CAT II.</check-content></check></Rule></Group><Group id="V-238337"><title>SRG-OS-000205-GPOS-00083</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238337r880876_rule" weight="10.0" severity="medium"><version>UBTU-20-010416</version><title>The Ubuntu operating system must generate error messages that provide information necessary for corrective actions without revealing information that could be exploited by adversaries.</title><description>&lt;VulnDiscussion&gt;Any operating system providing too much information in error messages risks compromising the data and security of the structure, and content of error messages needs to be carefully considered by the organization. 
+ 
+Organizations carefully consider the structure/content of error messages. The extent to which information systems are able to identify and handle error conditions is guided by organizational policy and operational requirements. Information that could be exploited by adversaries includes, for example, erroneous logon attempts with passwords entered by mistake as the username, mission/business information that can be derived from (if not stated explicitly by) information recorded, and personal information, such as account numbers, social security numbers, and credit card numbers.
+
+The /var/log/btmp, /var/log/wtmp, and /var/log/lastlog files have group write and global read permissions to allow for the lastlog function to perform. Limiting the permissions beyond this configuration will result in the failure of functions that rely on the lastlog database.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001312</ident><fixtext fixref="F-41506r880875_fix">Configure the Ubuntu operating system to set permissions of all log files under the "/var/log" directory to "640" or more restricted by using the following command:
+
+Note: The btmp, wtmp, and lastlog files are excluded. Refer to the Discussion for details.
+
+$ sudo find /var/log -perm /137 ! -name '*[bw]tmp' ! -name '*lastlog' -type f -exec chmod 640 '{}' \;</fixtext><fix id="F-41506r880875_fix" /><check system="C-41547r880874_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system has all system log files under the "/var/log" directory with a permission set to "640" or less permissive by using the following command:
+
+Note: The btmp, wtmp, and lastlog files are excluded. Refer to the Discussion for details.
+
+$ sudo find /var/log -perm /137 ! -name '*[bw]tmp' ! -name '*lastlog' -type f -exec stat -c "%n %a" {} \;
+
+If the command displays any output, this is a finding.</check-content></check></Rule></Group><Group id="V-238338"><title>SRG-OS-000206-GPOS-00084</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238338r654189_rule" weight="10.0" severity="medium"><version>UBTU-20-010417</version><title>The Ubuntu operating system must configure the /var/log directory to be group-owned by syslog.</title><description>&lt;VulnDiscussion&gt;Only authorized personnel should be aware of errors and the details of the errors. Error messages are an indicator of an organization's operational state or can identify the operating system or platform. Additionally, Personally Identifiable Information (PII) and operational information must not be revealed through error messages to unauthorized personnel or their designated representatives. 
+ 
+The structure and content of error messages must be carefully considered by the organization and development team. The extent to which the information system is able to identify and handle error conditions is guided by organizational policy and operational requirements.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001314</ident><fixtext fixref="F-41507r654188_fix">Configure the Ubuntu operating system to have syslog group-own the "/var/log" directory by running the following command: 
+ 
+$ sudo chgrp syslog /var/log</fixtext><fix id="F-41507r654188_fix" /><check system="C-41548r654187_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that the Ubuntu operating system configures the "/var/log" directory to be group-owned by syslog with the following command: 
+ 
+$ sudo stat -c "%n %G" /var/log 
+/var/log syslog 
+ 
+If the "/var/log" directory is not group-owned by syslog, this is a finding.</check-content></check></Rule></Group><Group id="V-238339"><title>SRG-OS-000206-GPOS-00084</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238339r654192_rule" weight="10.0" severity="medium"><version>UBTU-20-010418</version><title>The Ubuntu operating system must configure the /var/log directory to be owned by root.</title><description>&lt;VulnDiscussion&gt;Only authorized personnel should be aware of errors and the details of the errors. Error messages are an indicator of an organization's operational state or can identify the operating system or platform. Additionally, Personally Identifiable Information (PII) and operational information must not be revealed through error messages to unauthorized personnel or their designated representatives. 
+ 
+The structure and content of error messages must be carefully considered by the organization and development team. The extent to which the information system is able to identify and handle error conditions is guided by organizational policy and operational requirements.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001314</ident><fixtext fixref="F-41508r654191_fix">Configure the Ubuntu operating system to have root own the "/var/log" directory by running the following command: 
+ 
+$ sudo chown root /var/log</fixtext><fix id="F-41508r654191_fix" /><check system="C-41549r654190_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system configures the "/var/log" directory to be owned by root with the following command: 
+ 
+$ sudo stat -c "%n %U" /var/log 
+/var/log root 
+ 
+If the "/var/log" directory is not owned by root, this is a finding.</check-content></check></Rule></Group><Group id="V-238340"><title>SRG-OS-000206-GPOS-00084</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238340r880879_rule" weight="10.0" severity="medium"><version>UBTU-20-010419</version><title>The Ubuntu operating system must configure the /var/log directory to have mode "0755" or less permissive.</title><description>&lt;VulnDiscussion&gt;Only authorized personnel should be aware of errors and the details of the errors. Error messages are an indicator of an organization's operational state or can identify the operating system or platform. Additionally, personally identifiable information (PII) and operational information must not be revealed through error messages to unauthorized personnel or their designated representatives. 
+ 
+The structure and content of error messages must be carefully considered by the organization and development team. The extent to which the information system is able to identify and handle error conditions is guided by organizational policy and operational requirements.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001314</ident><fixtext fixref="F-41509r880878_fix">Configure the Ubuntu operating system to have permissions of "0755" for the "/var/log" directory by running the following command: 
+ 
+$ sudo chmod 0755 /var/log</fixtext><fix id="F-41509r880878_fix" /><check system="C-41550r880877_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that the Ubuntu operating system configures the "/var/log" directory with a mode of "755" or less permissive with the following command:
+
+Note: If rsyslog is active and enabled on the operating system, this requirement is not applicable.
+
+$ stat -c "%n %a" /var/log
+
+/var/log 755
+
+If a value of "755" or less permissive is not returned, this is a finding.</check-content></check></Rule></Group><Group id="V-238341"><title>SRG-OS-000206-GPOS-00084</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238341r654198_rule" weight="10.0" severity="medium"><version>UBTU-20-010420</version><title>The Ubuntu operating system must configure the /var/log/syslog file to be group-owned by adm.</title><description>&lt;VulnDiscussion&gt;Only authorized personnel should be aware of errors and the details of the errors. Error messages are an indicator of an organization's operational state or can identify the operating system or platform. Additionally, Personally Identifiable Information (PII) and operational information must not be revealed through error messages to unauthorized personnel or their designated representatives. 
+ 
+The structure and content of error messages must be carefully considered by the organization and development team. The extent to which the information system is able to identify and handle error conditions is guided by organizational policy and operational requirements.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001314</ident><fixtext fixref="F-41510r654197_fix">Configure the Ubuntu operating system to have adm group-own the "/var/log/syslog" file by running the following command: 
+ 
+$ sudo chgrp adm /var/log/syslog</fixtext><fix id="F-41510r654197_fix" /><check system="C-41551r654196_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that the Ubuntu operating system configures the "/var/log/syslog" file to be group-owned by adm with the following command: 
+ 
+$ sudo stat -c "%n %G" /var/log/syslog 
+/var/log/syslog adm 
+ 
+If the "/var/log/syslog" file is not group-owned by adm, this is a finding.</check-content></check></Rule></Group><Group id="V-238342"><title>SRG-OS-000206-GPOS-00084</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238342r654201_rule" weight="10.0" severity="medium"><version>UBTU-20-010421</version><title>The Ubuntu operating system must configure /var/log/syslog file to be owned by syslog.</title><description>&lt;VulnDiscussion&gt;Only authorized personnel should be aware of errors and the details of the errors. Error messages are an indicator of an organization's operational state or can identify the operating system or platform. Additionally, Personally Identifiable Information (PII) and operational information must not be revealed through error messages to unauthorized personnel or their designated representatives. 
+ 
+The structure and content of error messages must be carefully considered by the organization and development team. The extent to which the information system is able to identify and handle error conditions is guided by organizational policy and operational requirements.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001314</ident><fixtext fixref="F-41511r654200_fix">Configure the Ubuntu operating system to have syslog own the "/var/log/syslog" file by running the following command: 
+ 
+$ sudo chown syslog /var/log/syslog</fixtext><fix id="F-41511r654200_fix" /><check system="C-41552r654199_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that the Ubuntu operating system configures the "/var/log/syslog" file to be owned by syslog with the following command: 
+ 
+$ sudo stat -c "%n %U" /var/log/syslog 
+/var/log/syslog syslog 
+ 
+If the "/var/log/syslog" file is not owned by syslog, this is a finding.</check-content></check></Rule></Group><Group id="V-238343"><title>SRG-OS-000206-GPOS-00084</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238343r654204_rule" weight="10.0" severity="medium"><version>UBTU-20-010422</version><title>The Ubuntu operating system must configure /var/log/syslog file with mode 0640 or less permissive.</title><description>&lt;VulnDiscussion&gt;Only authorized personnel should be aware of errors and the details of the errors. Error messages are an indicator of an organization's operational state or can identify the operating system or platform. Additionally, Personally Identifiable Information (PII) and operational information must not be revealed through error messages to unauthorized personnel or their designated representatives. 
+ 
+The structure and content of error messages must be carefully considered by the organization and development team. The extent to which the information system is able to identify and handle error conditions is guided by organizational policy and operational requirements.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001314</ident><fixtext fixref="F-41512r654203_fix">Configure the Ubuntu operating system to have permissions of 0640 for the "/var/log/syslog" file by running the following command: 
+ 
+$ sudo chmod 0640 /var/log/syslog</fixtext><fix id="F-41512r654203_fix" /><check system="C-41553r654202_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that the Ubuntu operating system configures the "/var/log/syslog" file with mode 0640 or less permissive by running the following command: 
+ 
+$ sudo stat -c "%n %a" /var/log/syslog 
+ 
+/var/log/syslog 640 
+ 
+If a value of "640" or less permissive is not returned, this is a finding.</check-content></check></Rule></Group><Group id="V-238344"><title>SRG-OS-000258-GPOS-00099</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238344r654207_rule" weight="10.0" severity="medium"><version>UBTU-20-010423</version><title>The Ubuntu operating system must have directories that contain system commands set to a mode of 0755 or less permissive.</title><description>&lt;VulnDiscussion&gt;Protecting audit information also includes identifying and protecting the tools used to view and manipulate log data. Therefore, protecting audit tools is necessary to prevent unauthorized operation on audit information. 
+ 
+Operating systems providing tools to interface with audit information will leverage user permissions and roles identifying the user accessing the tools and the corresponding rights the user has in order to make access decisions regarding the deletion of audit tools. 
+ 
+Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001495</ident><fixtext fixref="F-41513r654206_fix">Configure the system commands directories to be protected from unauthorized access. Run the following command: 
+ 
+$ sudo find /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin -perm /022 -type d -exec chmod -R 755 '{}' \;</fixtext><fix id="F-41513r654206_fix" /><check system="C-41554r654205_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the system commands directories have mode 0755 or less permissive: 
+ 
+/bin 
+/sbin 
+/usr/bin 
+/usr/sbin 
+/usr/local/bin 
+/usr/local/sbin 
+ 
+Check that the system command directories have mode 0755 or less permissive with the following command: 
+ 
+$ find /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin -perm /022 -type d -exec stat -c "%n %a" '{}' \; 
+ 
+If any directories are found to be group-writable or world-writable, this is a finding.</check-content></check></Rule></Group><Group id="V-238345"><title>SRG-OS-000258-GPOS-00099</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238345r654210_rule" weight="10.0" severity="medium"><version>UBTU-20-010424</version><title>The Ubuntu operating system must have directories that contain system commands owned by root.</title><description>&lt;VulnDiscussion&gt;Protecting audit information also includes identifying and protecting the tools used to view and manipulate log data. Therefore, protecting audit tools is necessary to prevent unauthorized operation on audit information. 
+ 
+Operating systems providing tools to interface with audit information will leverage user permissions and roles identifying the user accessing the tools and the corresponding rights the user has in order to make access decisions regarding the deletion of audit tools. 
+ 
+Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001495</ident><fixtext fixref="F-41514r654209_fix">Configure the system commands directories to be protected from unauthorized access. Run the following command: 
+ 
+$ sudo find /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin ! -user root -type d -exec chown root '{}' \;</fixtext><fix id="F-41514r654209_fix" /><check system="C-41555r654208_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the system commands directories are owned by root: 
+ 
+/bin 
+/sbin 
+/usr/bin 
+/usr/sbin 
+/usr/local/bin 
+/usr/local/sbin 
+ 
+Use the following command for the check: 
+ 
+$ sudo find /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin ! -user root -type d -exec stat -c "%n %U" '{}' \; 
+ 
+If any system commands directories are returned, this is a finding.</check-content></check></Rule></Group><Group id="V-238346"><title>SRG-OS-000258-GPOS-00099</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238346r654213_rule" weight="10.0" severity="medium"><version>UBTU-20-010425</version><title>The Ubuntu operating system must have directories that contain system commands group-owned by root.</title><description>&lt;VulnDiscussion&gt;Protecting audit information also includes identifying and protecting the tools used to view and manipulate log data. Therefore, protecting audit tools is necessary to prevent unauthorized operation on audit information. 
+ 
+Operating systems providing tools to interface with audit information will leverage user permissions and roles identifying the user accessing the tools and the corresponding rights the user has in order to make access decisions regarding the deletion of audit tools. 
+ 
+Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001495</ident><fixtext fixref="F-41515r654212_fix">Configure the system commands directories to be protected from unauthorized access. Run the following command: 
+ 
+$ sudo find /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin ! -group root -type d -exec chgrp root '{}' \;</fixtext><fix id="F-41515r654212_fix" /><check system="C-41556r654211_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the system commands directories are group-owned by root: 
+ 
+/bin 
+/sbin 
+/usr/bin 
+/usr/sbin 
+/usr/local/bin 
+/usr/local/sbin 
+ 
+Run the check with the following command: 
+ 
+$ sudo find /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin ! -group root -type d -exec stat -c "%n %G" '{}' \; 
+ 
+If any system commands directories are returned that are not Set Group ID up on execution (SGID) files and owned by a privileged account, this is a finding.</check-content></check></Rule></Group><Group id="V-238347"><title>SRG-OS-000259-GPOS-00100</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238347r654216_rule" weight="10.0" severity="medium"><version>UBTU-20-010426</version><title>The Ubuntu operating system library files must have mode 0755 or less permissive.</title><description>&lt;VulnDiscussion&gt; If the operating system were to allow any user to make changes to software libraries, then those changes might be implemented without undergoing the appropriate testing and approvals that are part of a robust change management process. 
+ 
+This requirement applies to operating systems with software libraries that are accessible and configurable, as in the case of interpreted languages. Software libraries also include privileged programs which execute with escalated privileges. Only qualified and authorized individuals must be allowed to obtain access to information system components for purposes of initiating changes, including upgrades and modifications.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001499</ident><fixtext fixref="F-41516r654215_fix">Configure the library files to be protected from unauthorized access. Run the following command: 
+ 
+$ sudo find /lib /lib64 /usr/lib -perm /022 -type f -exec chmod 755 '{}' \;</fixtext><fix id="F-41516r654215_fix" /><check system="C-41557r654214_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the system-wide shared library files contained in the directories "/lib", "/lib64", and "/usr/lib" have mode 0755 or less permissive with the following command: 
+ 
+$ sudo find /lib /lib64 /usr/lib -perm /022 -type f -exec stat -c "%n %a" '{}' \; 
+/usr/lib64/pkcs11-spy.so 
+ 
+If any files are found to be group-writable or world-writable, this is a finding.</check-content></check></Rule></Group><Group id="V-238348"><title>SRG-OS-000259-GPOS-00100</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238348r654219_rule" weight="10.0" severity="medium"><version>UBTU-20-010427</version><title>The Ubuntu operating system library directories must have mode 0755 or less permissive.</title><description>&lt;VulnDiscussion&gt; If the operating system were to allow any user to make changes to software libraries, then those changes might be implemented without undergoing the appropriate testing and approvals that are part of a robust change management process. 
+ 
+This requirement applies to operating systems with software libraries that are accessible and configurable, as in the case of interpreted languages. Software libraries also include privileged programs which execute with escalated privileges. Only qualified and authorized individuals must be allowed to obtain access to information system components for purposes of initiating changes, including upgrades and modifications.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001499</ident><fixtext fixref="F-41517r654218_fix">Configure the shared library directories to be protected from unauthorized access. Run the following command: 
+ 
+$ sudo find /lib /lib64 /usr/lib -perm /022 -type d -exec chmod 755 '{}' \;</fixtext><fix id="F-41517r654218_fix" /><check system="C-41558r654217_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the system-wide shared library directories "/lib", "/lib64", and "/usr/lib have mode 0755 or less permissive with the following command: 
+ 
+$ sudo find /lib /lib64 /usr/lib -perm /022 -type d -exec stat -c "%n %a" '{}' \; 
+ 
+If any of the aforementioned directories are found to be group-writable or world-writable, this is a finding.</check-content></check></Rule></Group><Group id="V-238349"><title>SRG-OS-000259-GPOS-00100</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238349r654222_rule" weight="10.0" severity="medium"><version>UBTU-20-010428</version><title>The Ubuntu operating system library files must be owned by root.</title><description>&lt;VulnDiscussion&gt; If the operating system were to allow any user to make changes to software libraries, then those changes might be implemented without undergoing the appropriate testing and approvals that are part of a robust change management process. 
+ 
+This requirement applies to operating systems with software libraries that are accessible and configurable, as in the case of interpreted languages. Software libraries also include privileged programs which execute with escalated privileges. Only qualified and authorized individuals must be allowed to obtain access to information system components for purposes of initiating changes, including upgrades and modifications.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001499</ident><fixtext fixref="F-41518r654221_fix">Configure the system library files to be protected from unauthorized access. Run the following command: 
+ 
+$ sudo find /lib /usr/lib /lib64 ! -user root -type f -exec chown root '{}' \;</fixtext><fix id="F-41518r654221_fix" /><check system="C-41559r654220_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the system-wide shared library files contained in the directories "/lib", "/lib64", and "/usr/lib" are owned by root with the following command: 
+ 
+$ sudo find /lib /usr/lib /lib64 ! -user root -type f -exec stat -c "%n %U" '{}' \; 
+ 
+If any system-wide library file is returned, this is a finding.</check-content></check></Rule></Group><Group id="V-238350"><title>SRG-OS-000259-GPOS-00100</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238350r654225_rule" weight="10.0" severity="medium"><version>UBTU-20-010429</version><title>The Ubuntu operating system library directories must be owned by root.</title><description>&lt;VulnDiscussion&gt; If the operating system were to allow any user to make changes to software libraries, then those changes might be implemented without undergoing the appropriate testing and approvals that are part of a robust change management process. 
+ 
+This requirement applies to operating systems with software libraries that are accessible and configurable, as in the case of interpreted languages. Software libraries also include privileged programs which execute with escalated privileges. Only qualified and authorized individuals must be allowed to obtain access to information system components for purposes of initiating changes, including upgrades and modifications.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001499</ident><fixtext fixref="F-41519r654224_fix">Configure the library files and their respective parent directories to be protected from unauthorized access. Run the following command: 
+ 
+$ sudo find /lib /usr/lib /lib64 ! -user root -type d -exec chown root '{}' \;</fixtext><fix id="F-41519r654224_fix" /><check system="C-41560r654223_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the system-wide shared library directories "/lib", "/lib64", and "/usr/lib" are owned by root with the following command: 
+ 
+$ sudo find /lib /usr/lib /lib64 ! -user root -type d -exec stat -c "%n %U" '{}' \; 
+ 
+If any system-wide library directory is returned, this is a finding.</check-content></check></Rule></Group><Group id="V-238351"><title>SRG-OS-000259-GPOS-00100</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238351r832962_rule" weight="10.0" severity="medium"><version>UBTU-20-010430</version><title>The Ubuntu operating system library files must be group-owned by root or a system account.</title><description>&lt;VulnDiscussion&gt; If the operating system were to allow any user to make changes to software libraries, then those changes might be implemented without undergoing the appropriate testing and approvals that are part of a robust change management process. 
+ 
+This requirement applies to operating systems with software libraries that are accessible and configurable, as in the case of interpreted languages. Software libraries also include privileged programs which execute with escalated privileges. Only qualified and authorized individuals must be allowed to obtain access to information system components for purposes of initiating changes, including upgrades and modifications.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001499</ident><fixtext fixref="F-41520r832961_fix">Configure the system library files to be protected from unauthorized access. Run the following command, replacing "[FILE]" with any system command file not group-owned by "root" or a required system account: 
+ 
+$ sudo chgrp root [FILE]</fixtext><fix id="F-41520r832961_fix" /><check system="C-41561r832960_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the system-wide library files contained in the directories "/lib", "/lib64", and "/usr/lib" are group-owned by root, or a required system account, with the following command: 
+ 
+$ sudo find /lib /usr/lib /lib64 ! -group root -type f -exec stat -c "%n %G" '{}' \; 
+ 
+If any system-wide shared library file is returned and is not group-owned by a required system account, this is a finding.</check-content></check></Rule></Group><Group id="V-238352"><title>SRG-OS-000259-GPOS-00100</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238352r654231_rule" weight="10.0" severity="medium"><version>UBTU-20-010431</version><title>The Ubuntu operating system library directories must be group-owned by root.</title><description>&lt;VulnDiscussion&gt; If the operating system were to allow any user to make changes to software libraries, then those changes might be implemented without undergoing the appropriate testing and approvals that are part of a robust change management process. 
+ 
+This requirement applies to operating systems with software libraries that are accessible and configurable, as in the case of interpreted languages. Software libraries also include privileged programs which execute with escalated privileges. Only qualified and authorized individuals must be allowed to obtain access to information system components for purposes of initiating changes, including upgrades and modifications.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001499</ident><fixtext fixref="F-41521r654230_fix">Configure the system library directories to be protected from unauthorized access. Run the following command: 
+ 
+$ sudo find /lib /usr/lib /lib64 ! -group root -type d -exec chgrp root '{}' \;</fixtext><fix id="F-41521r654230_fix" /><check system="C-41562r654229_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the system-wide library directories "/lib", "/lib64", and "/usr/lib" are group-owned by root with the following command: 
+ 
+$ sudo find /lib /usr/lib /lib64 ! -group root -type d -exec stat -c "%n %G" '{}' \; 
+ 
+If any system-wide shared library directory is returned, this is a finding.</check-content></check></Rule></Group><Group id="V-238353"><title>SRG-OS-000269-GPOS-00103</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238353r654234_rule" weight="10.0" severity="medium"><version>UBTU-20-010432</version><title>The Ubuntu operating system must be configured to preserve log records from failure events.</title><description>&lt;VulnDiscussion&gt;Failure to a known state can address safety or security in accordance with the mission/business needs of the organization. Failure to a known secure state helps prevent a loss of confidentiality, integrity, or availability in the event of a failure of the information system or a component of the system.  
+ 
+Preserving operating system state information helps to facilitate operating system restart and return to the operational mode of the organization with least disruption to mission/business processes.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001665</ident><fixtext fixref="F-41522r654233_fix">Configure the log service to collect failure events. 
+ 
+Install the log service (if the log service is not already installed) with the following command: 
+ 
+$ sudo apt-get install rsyslog 
+ 
+Enable the log service with the following command: 
+ 
+$ sudo systemctl enable --now rsyslog</fixtext><fix id="F-41522r654233_fix" /><check system="C-41563r654232_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the log service is configured to collect system failure events. 
+ 
+Check that the log service is installed properly with the following command: 
+ 
+$ dpkg -l | grep rsyslog 
+ 
+ii  rsyslog                                    8.32.0-1ubuntu4                                 amd64        reliable system and kernel logging daemon 
+ 
+If the "rsyslog" package is not installed, this is a finding. 
+ 
+Check that the log service is enabled with the following command: 
+ 
+$ systemctl is-enabled rsyslog 
+ 
+enabled 
+ 
+If the command above returns "disabled", this is a finding. 
+ 
+Check that the log service is properly running and active on the system with the following command: 
+ 
+$ systemctl is-active rsyslog 
+ 
+active 
+ 
+If the command above returns "inactive", this is a finding.</check-content></check></Rule></Group><Group id="V-238354"><title>SRG-OS-000297-GPOS-00115</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238354r853429_rule" weight="10.0" severity="medium"><version>UBTU-20-010433</version><title>The Ubuntu operating system must have an application firewall installed in order to control remote access methods.</title><description>&lt;VulnDiscussion&gt;Remote access services, such as those providing remote access to network devices and information systems, which lack automated control capabilities, increase risk and make remote user access management difficult at best. 
+ 
+Remote access is access to DoD nonpublic information systems by an authorized user (or an information system) communicating through an external, non-organization-controlled network. Remote access methods include, for example, dial-up, broadband, and wireless. 
+ 
+Ubuntu operating system functionality (e.g., RDP) must be capable of taking enforcement action if the audit reveals unauthorized activity. Automated control of remote access sessions allows organizations to ensure ongoing compliance with remote access policies by enforcing connection rules of remote access applications on a variety of information system components (e.g., servers, workstations, notebook computers, smartphones, and tablets).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-002314</ident><fixtext fixref="F-41523r654236_fix">Install the Uncomplicated Firewall by using the following command: 
+ 
+$ sudo apt-get install ufw</fixtext><fix id="F-41523r654236_fix" /><check system="C-41564r654235_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that the Uncomplicated Firewall is installed with the following command: 
+ 
+$ dpkg -l | grep ufw 
+ 
+ii  ufw         0.36-6 
+ 
+If the "ufw" package is not installed, ask the System Administrator if another application firewall is installed.  
+ 
+If no application firewall is installed, this is a finding.</check-content></check></Rule></Group><Group id="V-238355"><title>SRG-OS-000297-GPOS-00115</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238355r853430_rule" weight="10.0" severity="medium"><version>UBTU-20-010434</version><title>The Ubuntu operating system must enable and run the uncomplicated firewall(ufw).</title><description>&lt;VulnDiscussion&gt;Remote access services, such as those providing remote access to network devices and information systems, which lack automated control capabilities, increase risk and make remote user access management difficult at best. 
+ 
+Remote access is access to DoD nonpublic information systems by an authorized user (or an information system) communicating through an external, non-organization-controlled network. Remote access methods include, for example, dial-up, broadband, and wireless. 
+ 
+Ubuntu operating system functionality (e.g., RDP) must be capable of taking enforcement action if the audit reveals unauthorized activity. Automated control of remote access sessions allows organizations to ensure ongoing compliance with remote access policies by enforcing connection rules of remote access applications on a variety of information system components (e.g., servers, workstations, notebook computers, smartphones, and tablets).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-002314</ident><fixtext fixref="F-41524r654239_fix">Enable the Uncomplicated Firewall by using the following command: 
+ 
+$ sudo systemctl enable --now ufw.service</fixtext><fix id="F-41524r654239_fix" /><check system="C-41565r654238_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Uncomplicated Firewall is enabled on the system by running the following command: 
+ 
+$ systemctl is-enabled ufw 
+ 
+If the above command returns the status as "disabled", this is a finding. 
+ 
+Verify the Uncomplicated Firewall is active on the system by running the following command: 
+ 
+$ systemctl is-active ufw 
+ 
+If the above command returns "inactive" or any kind of error, this is a finding. 
+ 
+If the Uncomplicated Firewall is not installed, ask the System Administrator if another application firewall is installed.  
+ 
+If no application firewall is installed, this is a finding.</check-content></check></Rule></Group><Group id="V-238356"><title>SRG-OS-000355-GPOS-00143</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238356r877038_rule" weight="10.0" severity="medium"><version>UBTU-20-010435</version><title>The Ubuntu operating system must, for networked systems, compare internal information system clocks at least every 24 hours with a server which is synchronized to one of the redundant United States Naval Observatory (USNO) time servers, or a time server designated for the appropriate DoD network (NIPRNet/SIPRNet), and/or the Global Positioning System (GPS).</title><description>&lt;VulnDiscussion&gt;Inaccurate time stamps make it more difficult to correlate events and can lead to an inaccurate analysis. Determining the correct time a particular event occurred on a system is critical when conducting forensic analysis and investigating system events. Sources outside the configured acceptable allowance (drift) may be inaccurate. 
+ 
+Synchronizing internal information system clocks provides uniformity of time stamps for information systems with multiple system clocks and systems connected over a network. 
+ 
+Organizations should consider endpoints that may not have regular access to the authoritative time server (e.g., mobile, teleworking, and tactical endpoints).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001891</ident><fixtext fixref="F-41525r808491_fix">If the system is not networked, this requirement is Not Applicable. 
+ 
+To configure the system clock to compare the system clock at least every 24 hours to the authoritative time source, edit the "/etc/chrony/chrony.conf" file. Add or correct the following lines, by replacing "[source]" in the following line with an authoritative DoD time source: 
+ 
+server [source] iburst maxpoll = 16 
+ 
+If the "chrony" service was running and the value of "maxpoll" or "server" was updated, the service must be restarted using the following command: 
+ 
+$ sudo systemctl restart chrony.service</fixtext><fix id="F-41525r808491_fix" /><check system="C-41566r808490_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>If the system is not networked, this requirement is Not Applicable. 
+ 
+The system clock must be configured to compare the system clock at least every 24 hours to the authoritative time source. 
+ 
+Check the value of "maxpoll" in the "/etc/chrony/chrony.conf" file with the following command: 
+ 
+$ sudo  grep  maxpoll /etc/chrony/chrony.conf 
+server tick.usno.navy.mil iburst maxpoll 16  
+ 
+If the "maxpoll" option is set to a number greater than 16 or the line is commented out, this is a finding. 
+ 
+Verify that the "chrony.conf" file is configured to an authoritative DoD time source by running the following command: 
+ 
+$ grep -i server /etc/chrony/chrony.conf 
+server tick.usno.navy.mil iburst maxpoll 16 
+server tock.usno.navy.mil iburst maxpoll 16 
+server ntp2.usno.navy.mil iburst maxpoll 16 
+ 
+If the parameter "server" is not set, is not set to an authoritative DoD time source, or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-238357"><title>SRG-OS-000356-GPOS-00144</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238357r853432_rule" weight="10.0" severity="low"><version>UBTU-20-010436</version><title>The Ubuntu operating system must synchronize internal information system clocks to the authoritative time source when the time difference is greater than one second.</title><description>&lt;VulnDiscussion&gt;Inaccurate time stamps make it more difficult to correlate events and can lead to an inaccurate analysis. Determining the correct time a particular event occurred on a system is critical when conducting forensic analysis and investigating system events. 
+ 
+Synchronizing internal information system clocks provides uniformity of time stamps for information systems with multiple system clocks and systems connected over a network. Organizations should consider setting time periods for different types of systems (e.g., financial, legal, or mission-critical systems). 
+ 
+Organizations should also consider endpoints that may not have regular access to the authoritative time server (e.g., mobile, teleworking, and tactical endpoints). This requirement is related to the comparison done every 24 hours in SRG-OS-000355 because a comparison must be done in order to determine the time difference.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-002046</ident><fixtext fixref="F-41526r654245_fix">Configure chrony to synchronize the internal system clocks to the authoritative source when the time difference is greater than one second by doing the following: 
+ 
+Edit the "/etc/chrony/chrony.conf" file and add: 
+ 
+makestep 1 -1 
+ 
+Restart the chrony service: 
+ 
+$ sudo systemctl restart chrony.service</fixtext><fix id="F-41526r654245_fix" /><check system="C-41567r654244_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the operating system synchronizes internal system clocks to the authoritative time source when the time difference is greater than one second. 
+ 
+Check the value of "makestep" by running the following command: 
+ 
+$ sudo grep makestep /etc/chrony/chrony.conf 
+ 
+makestep 1 -1 
+ 
+If the makestep option is commented out or is not set to "1 -1", this is a finding.</check-content></check></Rule></Group><Group id="V-238358"><title>SRG-OS-000363-GPOS-00150</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238358r917812_rule" weight="10.0" severity="medium"><version>UBTU-20-010437</version><title>The Ubuntu operating system must notify designated personnel if baseline configurations are changed in an unauthorized manner. The file integrity tool must notify the system administrator (SA) when changes to the baseline configuration or anomalies in the operation of any security functions are discovered.</title><description>&lt;VulnDiscussion&gt;Unauthorized changes to the baseline configuration could make the system vulnerable to various attacks or allow unauthorized access to the operating system. Changes to operating system configurations can have unintended side effects, some of which may be relevant to security. 
+ 
+Detecting such changes and providing an automated response can help avoid unintended, negative consequences that could ultimately affect the security state of the operating system. The operating system's IMO/ISSO and SAs must be notified via email and/or monitoring system trap when there is an unauthorized modification of a configuration item.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001744</ident><fixtext fixref="F-41527r654248_fix">Configure the Ubuntu operating system to notify designated personnel if baseline configurations are changed in an unauthorized manner. 
+ 
+Modify the "SILENTREPORTS" parameter in the "/etc/default/aide" file with a value of "no" if it does not already exist.</fixtext><fix id="F-41527r654248_fix" /><check system="C-41568r917811_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that Advanced Intrusion Detection Environment (AIDE) notifies the SA when anomalies in the operation of any security functions are discovered with the following command: 
+ 
+$ grep SILENTREPORTS /etc/default/aide 
+ 
+SILENTREPORTS=no 
+ 
+If SILENTREPORTS is commented out, this is a finding. 
+ 
+If SILENTREPORTS is set to "yes", this is a finding. 
+ 
+If SILENTREPORTS is not set to "no", this is a finding.</check-content></check></Rule></Group><Group id="V-238359"><title>SRG-OS-000366-GPOS-00153</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238359r877463_rule" weight="10.0" severity="medium"><version>UBTU-20-010438</version><title>The Ubuntu operating system's Advance Package Tool (APT) must be configured to prevent the installation of patches, service packs, device drivers, or Ubuntu operating system components without verification they have been digitally signed using a certificate that is recognized and approved by the organization.</title><description>&lt;VulnDiscussion&gt;Changes to any software components can have significant effects on the overall security of the operating system. This requirement ensures the software has not been tampered with and that it has been provided by a trusted vendor. 
+ 
+Accordingly, patches, service packs, device drivers, or operating system components must be signed with a certificate recognized and approved by the organization. 
+ 
+Verifying the authenticity of the software prior to installation validates the integrity of the patch or upgrade received from a vendor. This ensures the software has not been tampered with and that it has been provided by a trusted vendor. Self-signed certificates are disallowed by this requirement. The operating system should not have to verify the software again. This requirement does not mandate DoD certificates for this purpose; however, the certificate used to verify the software must be from an approved CA.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001749</ident><fixtext fixref="F-41528r654251_fix">Configure APT to prevent the installation of patches, service packs, device drivers, or Ubuntu operating system components without verification they have been digitally signed using a certificate that is recognized and approved by the organization. 
+ 
+Remove/update any APT configuration files that contain the variable "AllowUnauthenticated" to "false", or remove "AllowUnauthenticated" entirely from each file. Below is an example of setting the "AllowUnauthenticated" variable to "false": 
+ 
+APT::Get::AllowUnauthenticated "false";</fixtext><fix id="F-41528r654251_fix" /><check system="C-41569r654250_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that APT is configured to prevent the installation of patches, service packs, device drivers, or Ubuntu operating system components without verification they have been digitally signed using a certificate that is recognized and approved by the organization. 
+ 
+Check that the "AllowUnauthenticated" variable is not set at all or is set to "false" with the following command: 
+ 
+$ grep AllowUnauthenticated /etc/apt/apt.conf.d/* 
+/etc/apt/apt.conf.d/01-vendor-Ubuntu:APT::Get::AllowUnauthenticated "false"; 
+ 
+If any of the files returned from the command with "AllowUnauthenticated" are set to "true", this is a finding.</check-content></check></Rule></Group><Group id="V-238360"><title>SRG-OS-000368-GPOS-00154</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238360r853435_rule" weight="10.0" severity="medium"><version>UBTU-20-010439</version><title>The Ubuntu operating system must be configured to use AppArmor.</title><description>&lt;VulnDiscussion&gt;Control of program execution is a mechanism used to prevent execution of unauthorized programs. Some operating systems may provide a capability that runs counter to the mission or provides users with functionality that exceeds mission requirements. This includes functions and services installed at the operating system-level. 
+ 
+Some of the programs, installed by default, may be harmful or may not be necessary to support essential organizational operations (e.g., key missions, functions). Removal of executable programs is not always possible; therefore, establishing a method of preventing program execution is critical to maintaining a secure system baseline. 
+ 
+Methods for complying with this requirement include restricting execution of programs in certain environments, while preventing execution in other environments; or limiting execution of certain program functionality based on organization-defined criteria (e.g., privileges, subnets, sandboxed environments, or roles).
+
+Satisfies: SRG-OS-000368-GPOS-00154, SRG-OS-000312-GPOS-00122, SRG-OS-000312-GPOS-00123, SRG-OS-000312-GPOS-00124, SRG-OS-000324-GPOS-00125, SRG-OS-000370-GPOS-00155&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001764</ident><ident system="http://cyber.mil/cci">CCI-001774</ident><ident system="http://cyber.mil/cci">CCI-002165</ident><ident system="http://cyber.mil/cci">CCI-002235</ident><fixtext fixref="F-41529r654254_fix">Install "AppArmor" (if it is not installed) with the following command: 
+ 
+$ sudo apt-get install apparmor 
+ 
+$ sudo systemctl enable apparmor.service 
+ 
+Start "apparmor" with the following command: 
+ 
+$ sudo systemctl start apparmor.service 
+ 
+Note: AppArmor must have properly configured profiles for applications and home directories. All configurations will be based on the actual system setup and organization and normally are on a per role basis. See the AppArmor documentation for more information on configuring profiles.</fixtext><fix id="F-41529r654254_fix" /><check system="C-41570r654253_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the operating system prevents program execution in accordance with local policies. 
+ 
+Check that AppArmor is installed and active by running the following command, 
+ 
+$ dpkg -l | grep apparmor 
+ 
+If the "apparmor" package is not installed, this is a finding. 
+ 
+$ systemctl is-active apparmor.service 
+ 
+active 
+ 
+If "active" is not returned, this is a finding. 
+ 
+$ systemctl is-enabled apparmor.service 
+ 
+enabled 
+ 
+If "enabled" is not returned, this is a finding.</check-content></check></Rule></Group><Group id="V-238361"><title>SRG-OS-000380-GPOS-00165</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238361r853436_rule" weight="10.0" severity="medium"><version>UBTU-20-010440</version><title>The Ubuntu operating system must allow the use of a temporary password for system logons with an immediate change to a permanent password.</title><description>&lt;VulnDiscussion&gt;Without providing this capability, an account may be created without a password. Non-repudiation cannot be guaranteed once an account is created if a user is not forced to change the temporary password upon initial logon. 
+ 
+Temporary passwords are typically used to allow access when new accounts are created or passwords are changed. It is common practice for administrators to create temporary passwords for user accounts which allow the users to log on, yet force them to change the password once they have successfully authenticated.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-002041</ident><fixtext fixref="F-41530r654257_fix">Create a policy that ensures when a user is created, it is created using a method that forces a user to change their password upon their next login. 
+ 
+Below are two examples of how to create a user account that requires the user to change their password upon their next login. 
+ 
+$ sudo chage -d 0 [UserName] 
+ 
+or  
+ 
+$ sudo passwd -e [UserName]</fixtext><fix id="F-41530r654257_fix" /><check system="C-41571r654256_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify a policy exists that ensures when a user account is created, it is created using a method that forces a user to change their password upon their next login. 
+ 
+If a policy does not exist, this is a finding.</check-content></check></Rule></Group><Group id="V-238362"><title>SRG-OS-000383-GPOS-00166</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238362r853437_rule" weight="10.0" severity="low"><version>UBTU-20-010441</version><title>The Ubuntu operating system must be configured such that Pluggable Authentication Module (PAM) prohibits the use of cached authentications after one day.</title><description>&lt;VulnDiscussion&gt;If cached authentication information is out-of-date, the validity of the authentication information may be questionable.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-002007</ident><fixtext fixref="F-41531r654260_fix">Configure PAM to prohibit the use of cached authentications after one day. Add or change the following line in "/etc/sssd/sssd.conf" just below the line "[pam]": 
+ 
+offline_credentials_expiration = 1 
+ 
+Note: It is valid for this configuration to be in a file with a name that ends with ".conf" and does not begin with a "." in the "/etc/sssd/conf.d/" directory instead of the "/etc/sssd/sssd.conf" file.</fixtext><fix id="F-41531r654260_fix" /><check system="C-41572r654259_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>If smart card authentication is not being used on the system, this s Not Applicable. 
+ 
+Verify that PAM prohibits the use of cached authentications after one day with the following command: 
+ 
+$ sudo grep offline_credentials_expiration /etc/sssd/sssd.conf /etc/sssd/conf.d/*.conf 
+ 
+offline_credentials_expiration = 1 
+ 
+If "offline_credentials_expiration" is not set to a value of "1" in "/etc/sssd/sssd.conf" or in a file with a name ending in .conf in the "/etc/sssd/conf.d/" directory, this is a finding.</check-content></check></Rule></Group><Group id="V-238363"><title>SRG-OS-000396-GPOS-00176</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238363r880881_rule" weight="10.0" severity="high"><version>UBTU-20-010442</version><title>The Ubuntu operating system must implement NIST FIPS-validated cryptography to protect classified information and for the following: To provision digital signatures, to generate cryptographic hashes, and to protect unclassified information requiring confidentiality and cryptographic protection in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, and standards.</title><description>&lt;VulnDiscussion&gt;Use of weak or untested encryption algorithms undermines the purposes of utilizing encryption to protect data. The operating system must implement cryptographic modules adhering to the higher standards approved by the federal government since this provides assurance they have been tested and validated.
+
+Satisfies: SRG-OS-000396-GPOS-00176, SRG-OS-000478-GPOS-00223&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-002450</ident><fixtext fixref="F-41532r880880_fix">Configure the system to run in FIPS mode. Add "fips=1" to the kernel parameter during the Ubuntu operating systems install. 
+ 
+Enabling a FIPS mode on a pre-existing system involves a number of modifications to the Ubuntu operating system. Refer to the Ubuntu Server 18.04 FIPS 140-2 security policy document for instructions.  
+ 
+A subscription to the "Ubuntu Pro" plan is required to obtain the FIPS Kernel cryptographic modules and enable FIPS.</fixtext><fix id="F-41532r880880_fix" /><check system="C-41573r654262_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the system is configured to run in FIPS mode with the following command: 
+ 
+$ grep -i 1 /proc/sys/crypto/fips_enabled 
+1 
+ 
+If a value of "1" is not returned, this is a finding.</check-content></check></Rule></Group><Group id="V-238364"><title>SRG-OS-000403-GPOS-00182</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238364r880902_rule" weight="10.0" severity="medium"><version>UBTU-20-010443</version><title>The Ubuntu operating system must use DoD PKI-established certificate authorities for verification of the establishment of protected sessions.</title><description>&lt;VulnDiscussion&gt;Untrusted Certificate Authorities (CA) can issue certificates, but they may be issued by organizations or individuals that seek to compromise DoD systems or by organizations with insufficient security controls. If the CA used for verifying the certificate is not a DoD-approved CA, trust of this CA has not been established. 
+ 
+The DoD will only accept PKI-certificates obtained from a DoD-approved internal or external certificate authority. Reliance on CAs for the establishment of secure sessions includes, for example, the use of SSL/TLS certificates.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-002470</ident><fixtext fixref="F-41533r880901_fix">Configure the Ubuntu operating system to use of DoD PKI-established certificate authorities for verification of the establishment of protected sessions. 
+ 
+Edit the "/etc/ca-certificates.conf" file, adding the character "!" to the beginning of all uncommented lines that do not start with the "!" character with the following command: 
+ 
+     $ sudo sed -i -E 's/^([^!#]+)/!\1/' /etc/ca-certificates.conf 
+ 
+Add at least one DoD certificate authority to the "/usr/local/share/ca-certificates" directory in the PEM format. 
+ 
+Update the "/etc/ssl/certs" directory with the following command: 
+ 
+     $ sudo update-ca-certificates</fixtext><fix id="F-41533r880901_fix" /><check system="C-41574r880900_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the directory containing the root certificates for the Ubuntu operating system contains certificate files for DoD PKI-established certificate authorities by iterating over all files in the "/etc/ssl/certs" directory and checking if, at least one, has the subject matching "DOD ROOT CA".
+
+If none is found, this is a finding.</check-content></check></Rule></Group><Group id="V-238365"><title>SRG-OS-000404-GPOS-00183</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238365r877379_rule" weight="10.0" severity="medium"><version>UBTU-20-010444</version><title>Ubuntu operating system must implement cryptographic mechanisms to prevent unauthorized modification of all information at rest.</title><description>&lt;VulnDiscussion&gt;Operating systems handling data requiring "data at rest" protections must employ cryptographic mechanisms to prevent unauthorized disclosure and modification of the information at rest. 
+ 
+Selection of a cryptographic mechanism is based on the need to protect the integrity of organizational information. The strength of the mechanism is commensurate with the security category and/or classification of the information. Organizations have the flexibility to either encrypt all information on storage devices (i.e., full disk encryption) or encrypt specific data structures (e.g., files, records, or fields).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-002475</ident><fixtext fixref="F-41534r654269_fix">To encrypt an entire partition, dedicate a partition for encryption in the partition layout. 
+ 
+Note: Encrypting a partition in an already-installed system is more difficult because it will need to be resized and existing partitions changed.</fixtext><fix id="F-41534r654269_fix" /><check system="C-41575r654268_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>If there is a documented and approved reason for not having data-at-rest encryption, this requirement is Not Applicable. 
+ 
+Verify the Ubuntu operating system prevents unauthorized disclosure or modification of all information requiring at-rest protection by using disk encryption.  
+ 
+Determine the partition layout for the system with the following command: 
+ 
+$ sudo fdisk -l 
+(..) 
+Disk /dev/vda: 15 GiB, 16106127360 bytes, 31457280 sectors 
+Units: sectors of 1 * 512 = 512 bytes 
+Sector size (logical/physical): 512 bytes / 512 bytes 
+I/O size (minimum/optimal): 512 bytes / 512 bytes 
+Disklabel type: gpt 
+Disk identifier: 83298450-B4E3-4B19-A9E4-7DF147A5FEFB 
+ 
+Device       Start      End  Sectors Size Type 
+/dev/vda1     2048     4095     2048   1M BIOS boot 
+/dev/vda2     4096  2101247  2097152   1G Linux filesystem 
+/dev/vda3  2101248 31455231 29353984  14G Linux filesystem 
+(...) 
+ 
+Verify that the system partitions are all encrypted with the following command: 
+ 
+$ more /etc/crypttab 
+ 
+Every persistent disk partition present must have an entry in the file. 
+ 
+If any partitions other than the boot partition or pseudo file systems (such as /proc or /sys) are not listed, this is a finding.</check-content></check></Rule></Group><Group id="V-238366"><title>SRG-OS-000405-GPOS-00184</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238366r877378_rule" weight="10.0" severity="medium"><version>UBTU-20-010445</version><title>Ubuntu operating system must implement cryptographic mechanisms to prevent unauthorized disclosure of all information at rest.</title><description>&lt;VulnDiscussion&gt;Operating systems handling data requiring "data at rest" protections must employ cryptographic mechanisms to prevent unauthorized disclosure and modification of the information at rest. 
+ 
+Selection of a cryptographic mechanism is based on the need to protect the integrity of organizational information. The strength of the mechanism is commensurate with the security category and/or classification of the information. Organizations have the flexibility to either encrypt all information on storage devices (i.e., full disk encryption) or encrypt specific data structures (e.g., files, records, or fields).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-002476</ident><fixtext fixref="F-41535r654272_fix">To encrypt an entire partition, dedicate a partition for encryption in the partition layout. 
+ 
+Note: Encrypting a partition in an already-installed system is more difficult because it will need to be resized and existing partitions changed.</fixtext><fix id="F-41535r654272_fix" /><check system="C-41576r654271_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>If there is a documented and approved reason for not having data-at-rest encryption, this requirement is Not Applicable. 
+ 
+Verify the Ubuntu operating system prevents unauthorized disclosure or modification of all information requiring at-rest protection by using disk encryption.  
+ 
+Determine the partition layout for the system with the following command: 
+ 
+$sudo fdisk -l 
+(..) 
+Disk /dev/vda: 15 GiB, 16106127360 bytes, 31457280 sectors 
+Units: sectors of 1 * 512 = 512 bytes 
+Sector size (logical/physical): 512 bytes / 512 bytes 
+I/O size (minimum/optimal): 512 bytes / 512 bytes 
+Disklabel type: gpt 
+Disk identifier: 83298450-B4E3-4B19-A9E4-7DF147A5FEFB 
+ 
+Device       Start      End  Sectors Size Type 
+/dev/vda1     2048     4095     2048   1M BIOS boot 
+/dev/vda2     4096  2101247  2097152   1G Linux filesystem 
+/dev/vda3  2101248 31455231 29353984  14G Linux filesystem 
+(...) 
+ 
+Verify that the system partitions are all encrypted with the following command: 
+ 
+$ more /etc/crypttab 
+ 
+Every persistent disk partition present must have an entry in the file.  
+ 
+If any partitions other than the boot partition or pseudo file systems (such as /proc or /sys) are not listed, this is a finding.</check-content></check></Rule></Group><Group id="V-238367"><title>SRG-OS-000420-GPOS-00186</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238367r853444_rule" weight="10.0" severity="medium"><version>UBTU-20-010446</version><title>The Ubuntu operating system must configure the uncomplicated firewall to rate-limit impacted network interfaces.</title><description>&lt;VulnDiscussion&gt;Denial of service (DoS) is a condition when a resource is not available for legitimate users. When this occurs, the organization either cannot accomplish its mission or must operate at degraded capacity. 
+ 
+This requirement addresses the configuration of the operating system to mitigate the impact of DoS attacks that have occurred or are ongoing on system availability. For each system, known and potential DoS attacks must be identified and solutions for each type implemented. A variety of technologies exist to limit or, in some cases, eliminate the effects of DoS attacks (e.g., limiting processes or establishing memory partitions). Employing increased capacity and bandwidth, combined with service redundancy, may reduce the susceptibility to some DoS attacks.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-002385</ident><fixtext fixref="F-41536r654275_fix">Configure the application firewall to protect against or limit the effects of DoS attacks by ensuring the Ubuntu operating system is implementing rate-limiting measures on impacted network interfaces. 
+ 
+Check all the services listening to the ports with the following command: 
+ 
+$ sudo ss -l46ut 
+ 
+Netid               State                Recv-Q                Send-Q                               Local Address:Port                               Peer Address:Port               Process                
+tcp                 LISTEN               0                     128                                           [::]:ssh                                        [::]:* 
+ 
+For each service with a port listening to connections, run the following command, replacing "[service]" with the service that needs to be rate limited. 
+ 
+$ sudo ufw limit [service] 
+ 
+Rate-limiting can also be done on an interface. An example of adding a rate-limit on the eth0 interface follows: 
+ 
+$ sudo ufw limit in on eth0</fixtext><fix id="F-41536r654275_fix" /><check system="C-41577r654274_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify an application firewall is configured to rate limit any connection to the system. 
+ 
+Check all the services listening to the ports with the following command: 
+ 
+$ sudo ss -l46ut 
+ 
+Netid               State                Recv-Q                Send-Q                               Local Address:Port                               Peer Address:Port               Process                
+tcp                 LISTEN               0                     128                                           [::]:ssh                                        [::]:* 
+ 
+For each entry, verify that the Uncomplicated Firewall is configured to rate limit the service ports with the following command: 
+ 
+$ sudo ufw status 
+ 
+Status: active 
+ 
+To                         Action      From 
+--                         ------      ---- 
+22/tcp                     LIMIT       Anywhere                   
+22/tcp (v6)                LIMIT       Anywhere (v6) 
+ 
+If any port with a state of "LISTEN" is not marked with the "LIMIT" action, this is a finding.</check-content></check></Rule></Group><Group id="V-238368"><title>SRG-OS-000433-GPOS-00192</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238368r880910_rule" weight="10.0" severity="medium"><version>UBTU-20-010447</version><title>The Ubuntu operating system must implement nonexecutable data to protect its memory from unauthorized code execution.</title><description>&lt;VulnDiscussion&gt;Some adversaries launch attacks with the intent of executing code in nonexecutable regions of memory or in memory locations that are prohibited. Security safeguards employed to protect memory include, for example, data execution prevention and address space layout randomization. Data execution prevention safeguards can either be hardware-enforced or software-enforced with hardware providing the greater strength of mechanism. 
+ 
+Examples of attacks are buffer overflow attacks.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-002824</ident><fixtext fixref="F-41537r654278_fix">Configure the Ubuntu operating system to enable NX. 
+ 
+If "nx" is not showing up in "/proc/cpuinfo", and the system's BIOS setup configuration permits toggling the No Execution bit, set it to "enable".</fixtext><fix id="F-41537r654278_fix" /><check system="C-41578r880909_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the NX (no-execution) bit flag is set on the system with the following commands: 
+ 
+     $ sudo dmesg | grep -i "execute disable" 
+     [    0.000000] NX (Execute Disable) protection: active 
+ 
+If "dmesg" does not show "NX (Execute Disable) protection: active", check the cpuinfo settings with the following command:  
+ 
+     $ grep flags /proc/cpuinfo | grep -w nx | sort -u 
+     flags       : fpu vme de pse tsc ms nx rdtscp lm constant_tsc 
+ 
+If "flags" does not contain the "nx" flag, this is a finding.</check-content></check></Rule></Group><Group id="V-238369"><title>SRG-OS-000433-GPOS-00193</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238369r853446_rule" weight="10.0" severity="medium"><version>UBTU-20-010448</version><title>The Ubuntu operating system must implement address space layout randomization to protect its memory from unauthorized code execution.</title><description>&lt;VulnDiscussion&gt;Some adversaries launch attacks with the intent of executing code in non-executable regions of memory or in memory locations that are prohibited. Security safeguards employed to protect memory include, for example, data execution prevention and address space layout randomization. Data execution prevention safeguards can either be hardware-enforced or software-enforced with hardware providing the greater strength of mechanism. 
+ 
+Examples of attacks are buffer overflow attacks.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-002824</ident><fixtext fixref="F-41538r654281_fix">Remove the "kernel.randomize_va_space" entry found in the "/etc/sysctl.conf" file or any file located in the "/etc/sysctl.d/" directory. 
+ 
+After the line has been removed, the kernel settings from all system configuration files must be reloaded before any of the changes will take effect. Run the following command to reload all of the kernel system configuration files: 
+ 
+$ sudo sysctl --system</fixtext><fix id="F-41538r654281_fix" /><check system="C-41579r654280_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system implements address space layout randomization (ASLR) with the following command: 
+ 
+$ sudo sysctl kernel.randomize_va_space 
+ 
+kernel.randomize_va_space = 2 
+ 
+If nothing is returned, verify the kernel parameter "randomize_va_space" is set to "2" with the following command: 
+ 
+$ cat /proc/sys/kernel/randomize_va_space 
+ 
+2 
+ 
+If "kernel.randomize_va_space" is not set to "2", this is a finding. 
+ 
+Verify that a saved value of the "kernel.randomize_va_space" variable is not defined. 
+ 
+$ sudo egrep -R "^kernel.randomize_va_space=[^2]" /etc/sysctl.conf /etc/sysctl.d 
+ 
+If this returns a result, this is a finding.</check-content></check></Rule></Group><Group id="V-238370"><title>SRG-OS-000437-GPOS-00194</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238370r853447_rule" weight="10.0" severity="medium"><version>UBTU-20-010449</version><title>The Ubuntu operating system must be configured so that Advance Package Tool (APT) removes all software components after updated versions have been installed.</title><description>&lt;VulnDiscussion&gt;Previous versions of software components that are not removed from the information system after updates have been installed may be exploited by adversaries. Some information technology products may remove older versions of software automatically from the information system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-002617</ident><fixtext fixref="F-41539r654284_fix">Configure APT to remove all software components after updated versions have been installed. 
+ 
+Add or updated the following options to the "/etc/apt/apt.conf.d/50unattended-upgrades" file: 
+ 
+Unattended-Upgrade::Remove-Unused-Dependencies "true"; 
+Unattended-Upgrade::Remove-Unused-Kernel-Packages "true";</fixtext><fix id="F-41539r654284_fix" /><check system="C-41580r654283_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify is configured to remove all software components after updated versions have been installed with the following command: 
+ 
+$ grep -i remove-unused /etc/apt/apt.conf.d/50unattended-upgrades 
+Unattended-Upgrade::Remove-Unused-Dependencies "true"; 
+Unattended-Upgrade::Remove-Unused-Kernel-Packages "true"; 
+ 
+If the "::Remove-Unused-Dependencies" and "::Remove-Unused-Kernel-Packages" parameters are not set to "true" or are missing or commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-238371"><title>SRG-OS-000445-GPOS-00199</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238371r880913_rule" weight="10.0" severity="medium"><version>UBTU-20-010450</version><title>The Ubuntu operating system must use a file integrity tool to verify correct operation of all security functions.</title><description>&lt;VulnDiscussion&gt;Without verification of the security functions, security functions may not operate correctly and the failure may go unnoticed. Security function is defined as the hardware, software, and/or firmware of the information system responsible for enforcing the system security policy and supporting the isolation of code and data on which the protection is based. Security functionality includes, but is not limited to, establishing system accounts, configuring access authorizations (i.e., permissions, privileges), setting events to be audited, and setting intrusion detection parameters. 
+ 
+This requirement applies to the Ubuntu operating system performing security function verification/testing and/or systems and environments that require this functionality.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-002696</ident><fixtext fixref="F-41540r880912_fix">Install AIDE, initialize it, and perform a manual check.
+
+Install AIDE:
+     $ sudo apt install aide
+
+Initialize it (this may take a few minutes):
+     $ sudo aideinit
+     Running aide --init...
+
+Example output:
+
+     Start timestamp: 2022-11-20 11:53:17 -0700 (AIDE 0.16)
+     AIDE initialized database at /var/lib/aide/aide.db.new
+     Verbose level: 6
+
+     Number of entries:      119543
+
+     ---------------------------------------------------
+     The attributes of the (uncompressed) database(s):
+     ---------------------------------------------------
+
+     /var/lib/aide/aide.db.new
+     RMD160   : PiEP1DX91JMcHnRSPnpFqNfIFr4=
+     TIGER    : /zM5yQBnOIoEH0jplJE5v6S0rUErbTXL
+     SHA256   : BE2iHtBN9lEX53l4R/p7t1al0dIlsgPc
+                       Lg4YI08+/Jk=
+     SHA512   : JIdGeNVRgtBPPSwun9St+9cwUrgIIKUW
+                       KVTksZXJ29Tt+luC/XNDcjIub7fbPVw/
+                       EcTDsvYtt9MBmBxw1wCYng==
+     CRC32    : jB2FVw==
+     HAVAL    : Jhe+fqaDpkswpWSnOTN28TO05QFHsjdq
+                       RcFZwCVUGTQ=
+     GOST     : WFrarVyxpXbKdW9SAaOy1Te8rSodV3/q
+                     nLsXuP7YujA=
+
+
+End timestamp: 2022-11-20 11:58:19 -0700 (run time: 5m 2s)
+
+The new database will need to be renamed to be read by AIDE:
+     $ sudo cp -p /var/lib/aide/aide.db.new /var/lib/aide/aide.db
+
+Perform a manual check:
+     $ sudo aide.wrapper --check
+
+Example output:
+     Start timestamp: 2022-11-20 11:59:16 -0700 (AIDE 0.16)
+     AIDE found differences between database and filesystem!!
+     ...
+	 
+Done.</fixtext><fix id="F-41540r880912_fix" /><check system="C-41581r880911_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that Advanced Intrusion Detection Environment (AIDE) is installed and verifies the correct operation of all security functions.
+
+Check that the AIDE package is installed with the following command:
+     $ sudo dpkg -l | grep aide 
+     ii   aide   0.16.1-1build2   amd64   Advanced Intrusion Detection Environment - static binary
+
+If AIDE is not installed, ask the System Administrator how file integrity checks are performed on the system. 
+
+If there is no application installed to perform integrity checks, this is a finding.
+
+If AIDE is installed, check if it has been initialized with the following command:
+     $ sudo aide.wrapper --check
+
+If the output is "Couldn't open file /var/lib/aide/aide.db for reading", this is a finding.</check-content></check></Rule></Group><Group id="V-238372"><title>SRG-OS-000447-GPOS-00201</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238372r853449_rule" weight="10.0" severity="medium"><version>UBTU-20-010451</version><title>The Ubuntu operating system must notify designated personnel if baseline configurations are changed in an unauthorized manner. The file integrity tool must notify the System Administrator when changes to the baseline configuration or anomalies in the operation of any security functions are discovered.</title><description>&lt;VulnDiscussion&gt;Unauthorized changes to the baseline configuration could make the system vulnerable to various attacks or allow unauthorized access to the Ubuntu operating system. Changes to Ubuntu operating system configurations can have unintended side effects, some of which may be relevant to security. 
+ 
+Detecting such changes and providing an automated response can help avoid unintended, negative consequences that could ultimately affect the security state of the Ubuntu operating system. The Ubuntu operating system's IMO/ISSO and SAs must be notified via email and/or monitoring system trap when there is an unauthorized modification of a configuration item.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-002702</ident><fixtext fixref="F-41541r654290_fix">Configure the Ubuntu operating system to notify designated personnel if baseline configurations are changed in an unauthorized manner. 
+ 
+Modify the "SILENTREPORTS" parameter in the "/etc/default/aide" file with a value of "no" if it does not already exist.</fixtext><fix id="F-41541r654290_fix" /><check system="C-41582r654289_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that Advanced Intrusion Detection Environment (AIDE) notifies the System Administrator
+ when anomalies in the operation of any security functions are discovered with the following command: 
+ 
+$ sudo grep SILENTREPORTS /etc/default/aide 
+ 
+SILENTREPORTS=no 
+ 
+If SILENTREPORTS is uncommented and set to "yes", this is a finding.</check-content></check></Rule></Group><Group id="V-238373"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238373r858539_rule" weight="10.0" severity="low"><version>UBTU-20-010453</version><title>The Ubuntu operating system must display the date and time of the last successful account logon upon logon.</title><description>&lt;VulnDiscussion&gt;Configuration settings are the set of parameters that can be changed in hardware, software, or firmware components of the system that affect the security posture and/or functionality of the system. Security-related parameters are those parameters impacting the security state of the system, including the parameters required to satisfy other security control requirements. Security-related parameters include, for example: registry settings; account, file, directory permission settings; and settings for functions, ports, protocols, services, and remote connections.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000052</ident><fixtext fixref="F-41542r654293_fix">Configure the Ubuntu operating system to provide users with feedback on when account accesses last occurred by setting the required configuration options in "/etc/pam.d/login".  
+ 
+Add the following line to the top of "/etc/pam.d/login": 
+ 
+session     required      pam_lastlog.so showfailed</fixtext><fix id="F-41542r654293_fix" /><check system="C-41583r654292_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify users are provided with feedback on when account accesses last occurred. 
+ 
+Check that "pam_lastlog" is used and not silent with the following command: 
+ 
+$ grep pam_lastlog /etc/pam.d/login 
+ 
+session     required      pam_lastlog.so showfailed 
+ 
+If "pam_lastlog" is missing from "/etc/pam.d/login" file, is not "required", or the "silent" option is present, this is a finding.</check-content></check></Rule></Group><Group id="V-238374"><title>SRG-OS-000480-GPOS-00232</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238374r654297_rule" weight="10.0" severity="medium"><version>UBTU-20-010454</version><title>The Ubuntu operating system must have an application firewall enabled.</title><description>&lt;VulnDiscussion&gt;Firewalls protect computers from network attacks by blocking or limiting access to open network ports. Application firewalls limit which applications are allowed to communicate over the network.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000366</ident><fixtext fixref="F-41543r654296_fix">Enable the Uncomplicated Firewall by using the following command: 
+ 
+$ sudo systemctl enable ufw.service  
+ 
+If the Uncomplicated Firewall is not currently running on the system, start it with the following command: 
+ 
+$ sudo systemctl start ufw.service</fixtext><fix id="F-41543r654296_fix" /><check system="C-41584r654295_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Uncomplicated Firewall is enabled on the system by running the following command: 
+ 
+$ systemctl status ufw.service | grep -i "active:" 
+ 
+Active: active (exited) since Mon 2016-10-17 12:30:29 CDT; 1s ago 
+ 
+If the above command returns the status as "inactive", this is a finding. 
+ 
+If the Uncomplicated Firewall is not installed, ask the System Administrator if another application firewall is installed. If no application firewall is installed, this is a finding.</check-content></check></Rule></Group><Group id="V-238376"><title>SRG-OS-000259-GPOS-00100</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238376r654303_rule" weight="10.0" severity="medium"><version>UBTU-20-010456</version><title>The Ubuntu operating system must have system commands set to a mode of 0755 or less permissive.</title><description>&lt;VulnDiscussion&gt;If the Ubuntu operating system were to allow any user to make changes to software libraries, then those changes might be implemented without undergoing the appropriate testing and approvals that are part of a robust change management process. 
+ 
+This requirement applies to Ubuntu operating systems with software libraries that are accessible and configurable, as in the case of interpreted languages. Software libraries also include privileged programs which execute with escalated privileges. Only qualified and authorized individuals must be allowed to obtain access to information system components for purposes of initiating changes, including upgrades and modifications.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001499</ident><fixtext fixref="F-41545r654302_fix">Configure the system commands to be protected from unauthorized access. Run the following command: 
+ 
+$ sudo find /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin -perm /022 -type f -exec chmod 755 '{}' \;</fixtext><fix id="F-41545r654302_fix" /><check system="C-41586r654301_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the system commands contained in the following directories have mode 0755 or less permissive: 
+ 
+/bin 
+/sbin 
+/usr/bin 
+/usr/sbin 
+/usr/local/bin 
+/usr/local/sbin 
+ 
+Check that the system command files have mode 0755 or less permissive with the following command: 
+ 
+$ sudo find /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin -perm /022 -type f -exec stat -c "%n %a" '{}' \; 
+ 
+If any files are found to be group-writable or world-writable, this is a finding.</check-content></check></Rule></Group><Group id="V-238377"><title>SRG-OS-000259-GPOS-00100</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238377r832968_rule" weight="10.0" severity="medium"><version>UBTU-20-010457</version><title>The Ubuntu operating system must have system commands owned by root or a system account.</title><description>&lt;VulnDiscussion&gt;If the Ubuntu operating system were to allow any user to make changes to software libraries, then those changes might be implemented without undergoing the appropriate testing and approvals that are part of a robust change management process. 
+ 
+This requirement applies to Ubuntu operating systems with software libraries that are accessible and configurable, as in the case of interpreted languages. Software libraries also include privileged programs which execute with escalated privileges. Only qualified and authorized individuals must be allowed to obtain access to information system components for purposes of initiating changes, including upgrades and modifications.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001499</ident><fixtext fixref="F-41546r832967_fix">Configure the system commands and their respective parent directories to be protected from unauthorized access. Run the following command, replacing "[FILE]" with any system command file not owned by "root" or a required system account: 
+ 
+$ sudo chown root [FILE]</fixtext><fix id="F-41546r832967_fix" /><check system="C-41587r832966_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the system commands contained in the following directories are owned by root, or a required system account: 
+ 
+/bin 
+/sbin 
+/usr/bin 
+/usr/sbin 
+/usr/local/bin 
+/usr/local/sbin 
+ 
+Use the following command for the check: 
+ 
+$ sudo find /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin ! -user root -type f -exec stat -c "%n %U" '{}' \; 
+ 
+If any system commands are returned and are not owned by a required system account, this is a finding.</check-content></check></Rule></Group><Group id="V-238378"><title>SRG-OS-000259-GPOS-00100</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238378r832971_rule" weight="10.0" severity="medium"><version>UBTU-20-010458</version><title>The Ubuntu operating system must have system commands group-owned by root or a system account.</title><description>&lt;VulnDiscussion&gt;If the Ubuntu operating system were to allow any user to make changes to software libraries, then those changes might be implemented without undergoing the appropriate testing and approvals that are part of a robust change management process. 
+ 
+This requirement applies to Ubuntu operating systems with software libraries that are accessible and configurable, as in the case of interpreted languages. Software libraries also include privileged programs which execute with escalated privileges. Only qualified and authorized individuals must be allowed to obtain access to information system components for purposes of initiating changes, including upgrades and modifications.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001499</ident><fixtext fixref="F-41547r832970_fix">Configure the system commands to be protected from unauthorized access. Run the following command, replacing "[FILE]" with any system command file not group-owned by "root" or a required system account: 
+ 
+$ sudo chgrp root [FILE]</fixtext><fix id="F-41547r832970_fix" /><check system="C-41588r832969_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the system commands contained in the following directories are group-owned by root or a required system account: 
+ 
+/bin 
+/sbin 
+/usr/bin 
+/usr/sbin 
+/usr/local/bin 
+/usr/local/sbin 
+ 
+Run the check with the following command: 
+ 
+$ sudo find -L /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin ! -group root -type f ! -perm /2000 -exec stat -c "%n %G" '{}' \; 
+ 
+If any system commands are returned that are not Set Group ID upon execution (SGID) files and group-owned by a required system account, this is a finding.</check-content></check></Rule></Group><Group id="V-238379"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238379r654312_rule" weight="10.0" severity="high"><version>UBTU-20-010459</version><title>The Ubuntu operating system must disable the x86 Ctrl-Alt-Delete key sequence if a graphical user interface is installed.</title><description>&lt;VulnDiscussion&gt;A locally logged-on user who presses Ctrl-Alt-Delete, when at the console, can reboot the system. If accidentally pressed, as could happen in the case of a mixed OS environment, this can create the risk of short-term loss of availability of systems due to unintentional reboot. In the graphical environment, risk of unintentional reboot from the Ctrl-Alt-Delete sequence is reduced because the user will be prompted before any action is taken.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000366</ident><fixtext fixref="F-41548r654311_fix">Configure the system to disable the Ctrl-Alt-Delete sequence when using a graphical user interface by creating or editing the /etc/dconf/db/local.d/00-disable-CAD file.
+
+Add the setting to disable the Ctrl-Alt-Delete sequence for the graphical user interface:
+
+[org/gnome/settings-daemon/plugins/media-keys]
+logout=''
+
+Update the dconf settings:
+
+# dconf update</fixtext><fix id="F-41548r654311_fix" /><check system="C-41589r654310_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system is not configured to reboot the system when Ctrl-Alt-Delete is pressed when using a graphical user interface.
+
+Check that the "logout" target is not bound to an action with the following command:
+
+# grep logout /etc/dconf/db/local.d/*
+
+logout=''
+
+If the "logout" key is bound to an action, is commented out, or is missing, this is a finding.</check-content></check></Rule></Group><Group id="V-238380"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-238380r832974_rule" weight="10.0" severity="high"><version>UBTU-20-010460</version><title>The Ubuntu operating system must disable the x86 Ctrl-Alt-Delete key sequence.</title><description>&lt;VulnDiscussion&gt;A locally logged-on user who presses Ctrl-Alt-Delete, when at the console, can reboot the system. If accidentally pressed, as could happen in the case of a mixed OS environment, this can create the risk of short-term loss of availability of systems due to unintentional reboot.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000366</ident><fixtext fixref="F-41549r832973_fix">Configure the system to disable the Ctrl-Alt-Delete sequence for the command line with the following commands:
+
+$ sudo systemctl disable ctrl-alt-del.target
+
+$ sudo systemctl mask ctrl-alt-del.target
+
+Reload the daemon to take effect: 
+
+$ sudo systemctl daemon-reload</fixtext><fix id="F-41549r832973_fix" /><check system="C-41590r832972_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system is not configured to reboot the system when Ctrl-Alt-Delete is pressed.
+
+Check that the "ctrl-alt-del.target" (otherwise also known as reboot.target) is not active with the following command:
+
+$ sudo systemctl status ctrl-alt-del.target
+ctrl-alt-del.target
+Loaded: masked (Reason: Unit ctrl-alt-del.target is masked.)
+Active: inactive (dead)
+
+If the "ctrl-alt-del.target" is not masked, this is a finding.</check-content></check></Rule></Group><Group id="V-251503"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-251503r808506_rule" weight="10.0" severity="high"><version>UBTU-20-010462</version><title>The Ubuntu operating system must not have accounts configured with blank or null passwords.</title><description>&lt;VulnDiscussion&gt;If an account has an empty password, anyone could log on and run commands with the privileges of that account. Accounts with empty passwords should never be used in operational environments.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000366</ident><fixtext fixref="F-54892r808505_fix">Configure all accounts on the system to have a password or lock the account with the following commands:
+
+Perform a password reset:
+$ sudo passwd [username]
+Lock an account:
+$ sudo passwd -l [username]</fixtext><fix id="F-54892r808505_fix" /><check system="C-54938r808504_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Check the "/etc/shadow" file for blank passwords with the following command:
+
+$ sudo awk -F: '!$2 {print $1}' /etc/shadow
+
+If the command returns any results, this is a finding.</check-content></check></Rule></Group><Group id="V-251504"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-251504r832977_rule" weight="10.0" severity="high"><version>UBTU-20-010463</version><title>The Ubuntu operating system must not allow accounts configured with blank or null passwords.</title><description>&lt;VulnDiscussion&gt;If an account has an empty password, anyone could log on and run commands with the privileges of that account. Accounts with empty passwords should never be used in operational environments.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000366</ident><fixtext fixref="F-54893r832976_fix">If an account is configured for password authentication but does not have an assigned password, it may be possible to log on to the account without authenticating.
+
+Remove any instances of the "nullok" option in "/etc/pam.d/common-password" to prevent logons with empty passwords.</fixtext><fix id="F-54893r832976_fix" /><check system="C-54939r832975_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>To verify that null passwords cannot be used, run the following command: 
+
+$ grep nullok /etc/pam.d/common-password
+
+If this produces any output, it may be possible to log on with accounts with empty passwords.
+
+If null passwords can be used, this is a finding.</check-content></check></Rule></Group><Group id="V-251505"><title>SRG-OS-000378-GPOS-00163</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-251505r853450_rule" weight="10.0" severity="medium"><version>UBTU-20-010461</version><title>The Ubuntu operating system must disable automatic mounting of Universal Serial Bus (USB) mass storage driver.</title><description>&lt;VulnDiscussion&gt;Without authenticating devices, unidentified or unknown devices may be introduced, thereby facilitating malicious activity.
+
+Peripherals include, but are not limited to, such devices as flash drives, external storage, and printers.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001958</ident><fixtext fixref="F-54894r808511_fix">Configure the Ubuntu operating system to disable using the USB storage kernel module. 
+
+Create a file under "/etc/modprobe.d" to contain the following:
+
+# sudo su -c "echo install usb-storage /bin/true &gt;&gt; /etc/modprobe.d/DISASTIG.conf"
+
+Configure the operating system to disable the ability to use USB mass storage devices.
+
+# sudo su -c "echo blacklist usb-storage &gt;&gt; /etc/modprobe.d/DISASTIG.conf"</fixtext><fix id="F-54894r808511_fix" /><check system="C-54940r808510_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that Ubuntu operating system disables ability to load the USB storage kernel module.
+
+# grep usb-storage /etc/modprobe.d/* | grep "/bin/true" 
+
+install usb-storage /bin/true
+
+If the command does not return any output, or the line is commented out, this is a finding.
+
+Verify the operating system disables the ability to use USB mass storage device.
+
+# grep usb-storage /etc/modprobe.d/* | grep -i "blacklist"
+
+blacklist usb-storage
+
+If the command does not return any output, or the line is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-252704"><title>SRG-OS-000481-GPOS-00481</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-252704r916433_rule" weight="10.0" severity="medium"><version>UBTU-20-010455</version><title>The Ubuntu operating system must disable all wireless network adapters.</title><description>&lt;VulnDiscussion&gt;Without protection of communications with wireless peripherals, confidentiality and integrity may be compromised because unprotected communications can be intercepted and either read, altered, or used to compromise the operating system. 
+ 
+This requirement applies to wireless peripheral technologies (e.g., wireless mice, keyboards, displays, etc.) used with an operating system. Wireless peripherals (e.g., Wi-Fi/Bluetooth/IR Keyboards, Mice, and Pointing Devices and Near Field Communications [NFC]) present a unique challenge by creating an open, unsecured port on a computer. Wireless peripherals must meet DoD requirements for wireless data transmission and be approved for use by the AO. Even though some wireless peripherals, such as mice and pointing devices, do not ordinarily carry information that need to be protected, modification of communications with these wireless peripherals may be used to compromise the operating system. Communication paths outside the physical protection of a controlled boundary are exposed to the possibility of interception and modification. 
+ 
+Protecting the confidentiality and integrity of communications with wireless peripherals can be accomplished by physical means (e.g., employing physical barriers to wireless radio frequencies) or by logical means (e.g., employing cryptographic techniques). If physical means of protection are employed, then logical means (cryptography) do not have to be employed, and vice versa. If the wireless peripheral is only passing telemetry data, encryption of the data may not be required.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-002418</ident><fixtext fixref="F-56110r819056_fix">List all the wireless interfaces with the following command: 
+ 
+$ ls -L -d /sys/class/net/*/wireless | xargs dirname | xargs basename 
+ 
+For each interface, configure the system to disable wireless network interfaces with the following command: 
+ 
+$ sudo ifdown &lt;interface name&gt; 
+ 
+For each interface listed, find their respective module with the following command: 
+ 
+$ basename $(readlink -f /sys/class/net/&lt;interface name&gt;/device/driver) 
+ 
+where &lt;interface name&gt; must be substituted by the actual interface name. 
+ 
+Create a file in the "/etc/modprobe.d" directory and for each module, add the following line: 
+ 
+install &lt;module name&gt; /bin/true 
+ 
+For each module from the system, execute the  following command to remove it: 
+ 
+$ sudo modprobe -r &lt;module name&gt;</fixtext><fix id="F-56110r819056_fix" /><check system="C-56160r819055_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Note: This requirement is Not Applicable for systems that do not have physical wireless network radios. 
+ 
+Verify that there are no wireless interfaces configured on the system with the following command: 
+ 
+$ ls -L -d /sys/class/net/*/wireless | xargs dirname | xargs basename 
+ 
+If a wireless interface is configured and has not been documented and approved by the ISSO, this is a finding.</check-content></check></Rule></Group><Group id="V-255912"><title>SRG-OS-000250-GPOS-00093</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-255912r880905_rule" weight="10.0" severity="medium"><version>UBTU-20-010045</version><title>The Ubuntu operating system SSH server must be configured to use only FIPS-validated key exchange algorithms.</title><description>&lt;VulnDiscussion&gt;Without cryptographic integrity protections provided by FIPS-validated cryptographic algorithms, information can be viewed and altered by unauthorized users without detection.
+
+The system will attempt to use the first algorithm presented by the client that matches the server list. Listing the values "strongest to weakest" is a method to ensure the use of the strongest algorithm available to secure the SSH connection.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000068</ident><fixtext fixref="F-59532r880904_fix">Configure the SSH server to use only FIPS-validated key exchange algorithms by adding or modifying the following line in "/etc/ssh/sshd_config":
+
+     KexAlgorithms ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256
+
+Restart the "sshd" service for changes to take effect:
+
+     $ sudo systemctl restart sshd</fixtext><fix id="F-59532r880904_fix" /><check system="C-59589r880903_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify that the SSH server is configured to use only FIPS-validated key exchange algorithms:
+
+     $ sudo grep -i kexalgorithms /etc/ssh/sshd_config
+     KexAlgorithms ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256
+ 
+If "KexAlgorithms" is not configured, is commented out, or does not contain only the algorithms "ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256" in exact order, this is a finding.</check-content></check></Rule></Group><Group id="V-255913"><title>SRG-OS-000138-GPOS-00069</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-255913r880908_rule" weight="10.0" severity="low"><version>UBTU-20-010401</version><title>The Ubuntu operating system must restrict access to the kernel message buffer.</title><description>&lt;VulnDiscussion&gt;Restricting access to the kernel message buffer limits access only to root. This prevents attackers from gaining additional system information as a nonprivileged user.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 20.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 20.04 LTS</dc:subject><dc:identifier>5318</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-001090</ident><fixtext fixref="F-59533r880907_fix">Configure the operating system to restrict access to the kernel message buffer.
+
+Set the system to the required kernel parameter by adding or modifying the following line in /etc/sysctl.conf or a config file in the /etc/sysctl.d/ directory:
+
+     kernel.dmesg_restrict = 1
+
+Remove any configurations that conflict with the above from the following locations: 
+     /run/sysctl.d/
+     /etc/sysctl.d/
+     /usr/local/lib/sysctl.d/
+     /usr/lib/sysctl.d/
+     /lib/sysctl.d/
+     /etc/sysctl.conf
+
+Reload settings from all system configuration files with the following command:
+
+     $ sudo sysctl --system</fixtext><fix id="F-59533r880907_fix" /><check system="C-59590r880906_chk"><check-content-ref href="Canonical_Ubuntu_20.04_LTS_STIG.xml" name="M" /><check-content>Verify the operating system is configured to restrict access to the kernel message buffer with the following commands:
+
+     $ sudo sysctl kernel.dmesg_restrict
+     kernel.dmesg_restrict = 1
+
+If "kernel.dmesg_restrict" is not set to "1" or is missing, this is a finding.
+
+Check that the configuration files are present to enable this kernel parameter:
+
+     $ sudo grep -r kernel.dmesg_restrict /run/sysctl.d/* /etc/sysctl.d/* /usr/local/lib/sysctl.d/* /usr/lib/sysctl.d/* /lib/sysctl.d/* /etc/sysctl.conf 2&gt; /dev/null
+     /etc/sysctl.conf:kernel.dmesg_restrict = 1
+     /etc/sysctl.d/99-sysctl.conf:kernel.dmesg_restrict = 1
+
+If "kernel.dmesg_restrict" is not set to "1", is missing or commented out, this is a finding.
+
+If conflicting results are returned, this is a finding.</check-content></check></Rule></Group></Benchmark>


### PR DESCRIPTION
#### Description:

- Adds Ubuntu 20.04 DISA Manual STIG v1r9
- Rename STIG Profile to v1r9 instead of v1r1

#### Rationale:

- Part of Ubuntu 20.04 DISA STIG v1r9 profile upgrade
- https://github.com/ComplianceAsCode/content/pull/10738

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```
To test these changes, please ensure that the remediation headers are updated to `V1R9`.

The Manual STIG is the current latest version, and was obtained from DISA's website. For reference, please review: https://public.cyber.mil/stigs/downloads/
