### PR TITLE
api_server_encryption_provider_cipher rule.yml has bad jsonpath

### DIFF
--- a/applications/openshift/api-server/api_server_encryption_provider_cipher/rule.yml
+++ b/applications/openshift/api-server/api_server_encryption_provider_cipher/rule.yml
@@ -76,7 +76,7 @@ ocil: |-
     API server to verify that its resources were successfully encrypted:
     <pre>
     # encrypt the etcd datastore
-    $ oc get openshiftapiserver -o=jsonpath='{range.items[0].status.conditions[?(@.type=="Encrypted")]}{.reason}{"\n"}{.message}{"\n"}'
+    $ oc get openshiftapiserver -o=jsonpath='{range .items[0]}{.status.conditions[?(@.type=="Encrypted")].status}{"\n"}{end}'
     <pre>
     The output shows <tt>EncryptionCompleted</tt> upon successful encryption.
     If the output shows <tt>EncryptionInProgress</tt> this means that encryption is still in


### PR DESCRIPTION
#### Description:

- api_server_encryption_provider_cipher rule.yml has bad jsonpath

#### Rationale:

- The jsonpath returns nothing, with the update, it processes the write results.

#### Review Hints:

as-is

```
❯ oc get openshiftapiserver -o=jsonpath='{range.items[0].status.conditions[?(@.type=="Encrypted")]}{.reason}{"\n"}{.message}{"\n"}'

```

with fix: 

```
❯ oc get openshiftapiserver -o=jsonpath='{range .items[0]}{.status.conditions[?(@.type=="Encrypted")].status}{"\n"}{end}'
False
```
@rhmdnd This might be you or @Vincent056 to review.