### PR TITLE
Remove DRAFT wording for OpenShift STIG

### DIFF
--- a/products/ocp4/profiles/stig-node.profile
+++ b/products/ocp4/profiles/stig-node.profile
@@ -10,14 +10,12 @@ metadata:
         - rhmdnd
         - david-rh
 
-reference: https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_Container_Platform_V1R3_SRG.zip
+reference: https://public.cyber.mil/stigs/downloads/
 
-title: 'DRAFT - DISA STIG for Red Hat OpenShift Container Platform 4 - Node level'
+title: 'DISA STIG for Red Hat OpenShift Container Platform 4 - Node level'
 
 description: |-
-    This is a draft profile for experimental purposes. It is not based on the
-    DISA STIG for OCP4, because one was not available at the time yet. This
-    profile contains configuration checks that align to the DISA STIG for
+    This profile contains configuration checks that align to the DISA STIG for
     Red Hat OpenShift Container Platform 4.
 
 filter_rules: '"ocp4-node" in platforms or "ocp4-master-node" in platforms or "ocp4-node-on-sdn" in platforms or "ocp4-node-on-ovn" in platforms'

--- a/products/ocp4/profiles/stig.profile
+++ b/products/ocp4/profiles/stig.profile
@@ -10,14 +10,12 @@ metadata:
         - rhmdnd
         - david-rh
 
-reference: https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_Container_Platform_V1R3_SRG.zip
+reference: https://public.cyber.mil/stigs/downloads/
 
-title: 'DRAFT - DISA STIG for Red Hat OpenShift Container Platform 4 - Platform level'
+title: 'DISA STIG for Red Hat OpenShift Container Platform 4 - Platform level'
 
 description: |-
-    This is a draft profile for experimental purposes. It is not based on the
-    DISA STIG for OCP4, because one was not available at the time yet. This
-    profile contains configuration checks that align to the DISA STIG for
+    This profile contains configuration checks that align to the DISA STIG for
     Red Hat OpenShift Container Platform 4.
 
 filter_rules: '"ocp4-node" not in platforms and "ocp4-master-node" not in platforms and "ocp4-node-on-sdn" not in platforms and "ocp4-node-on-ovn" not in platforms'

--- a/products/rhcos4/profiles/stig.profile
+++ b/products/rhcos4/profiles/stig.profile
@@ -10,12 +10,11 @@ metadata:
 
 reference: https://dl.dod.cyber.mil/wp-content/uploads/stigs/zip/U_Container_Platform_V1R3_SRG.zip
 
-title: 'DRAFT - DISA STIG for Red Hat Enterprise Linux CoreOS'
+title: 'DISA STIG for Red Hat Enterprise Linux CoreOS'
 
 description: |-
-    This is a draft profile for experimental purposes
-    It is not based on the DISA STIG for RHCOS4, because this one was not available at time of
-    the release
+    This profile contains configuration checks that align to the DISA STIG for
+    Red Hat Enterprise Linux CoreOS 4.
 
 selections:
   - srg_ctr:all


### PR DESCRIPTION
The OpenShift STIG was published by DISA:

  https://public.cyber.mil/stigs/downloads/

This commit removes the draft wording from the STIG profile for
OpenShift, since it's publicly available.
