### PR TITLE
Fix umask bash

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/bash/shared.sh
@@ -9,7 +9,7 @@
 readarray -t profile_files < <(find /etc/profile.d/ -type f -name '*.sh' -or -name 'sh.local')
 
 for file in "${profile_files[@]}" /etc/profile; do
-  grep -qE '^[^#]*umask' "$file" && sed -i "s/umask.*/umask $var_accounts_user_umask/g" "$file"
+  grep -qE '^[^#]*umask' "$file" && sed -i -E "s/^(\s*umask\s*)[0-7]+/\1$var_accounts_user_umask/g" "$file"
 done
 
 if ! grep -qrE '^[^#]*umask' /etc/profile*; then

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/ansible/shared.yml
@@ -10,7 +10,7 @@
       for dir in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) print $6}' /etc/passwd); do
         for file in $(find $dir -maxdepth 1 -type f -name ".*"); do
           if [ "$(basename $file)" != ".bash_history" ]; then
-            sed -i 's/^\([\s]*umask\s*\)/#\1/g' $file
+            sed -i 's/^\(\s*umask\s*\)/#\1/g' $file
           fi
         done
       done

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/bash/shared.sh
@@ -7,7 +7,7 @@
 {{% call iterate_over_command_output("dir", "awk -F':' '{ if ($3 >= " ~ uid_min ~ " && $3 != " ~ nobody_uid ~ ") print $6}' /etc/passwd") -%}}
 {{% call iterate_over_find_output("file", '$dir -maxdepth 1 -type f -name ".*"') -%}}
 if [ "$(basename $file)" != ".bash_history" ]; then
-    sed -i 's/^\([\s]*umask\s*\)/#\1/g' "$file"
+    sed -i 's/^\(\s*umask\s*\)/#\1/g' "$file"
 fi
 {{%- endcall %}}
 {{%- endcall %}}

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/tests/umask_defined_whith_spaces.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/tests/umask_defined_whith_spaces.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m $USER
+echo "  umask 022" >> /home/$USER/.bashrc


### PR DESCRIPTION
#### Description:

- Updated sed regexes in rules `accounts_umask_etc_profile` & `accounts_umask_interactive_users`

#### Rationale:

- In `accounts_umask_etc_profile` the sed command would modify also commented lines
- In `accounts_umask_interactive_users` the `umask` ocurrences that have leading spaces were being ignored

#### Review Hints:

- For `accounts_umask_interactive_users` I added a automatus test
- For  `accounts_umask_etc_profile` I tested in this way:
Whith existing regex:
```
$ cat file.txt 
# umask 777 This shouldn't be touched
# umask 000
umask 022
   umask 026 # This shouldn't be touched either
$ file=file.txt;var_accounts_user_umask=077; grep -qE '^[^#]*umask' "$file" && sed -i "s/umask.*/umask $var_accounts_user_umask/g" "$file"
$ cat file.txt 
# umask 077
# umask 077
umask 077
   umask 077
```
Whith new regex:
```
cat file.txt 
# umask 777 This shouldn't be touched
# umask 000
umask 022
   umask 026 # This shouldn't be touched either
$ file=file.txt;var_accounts_user_umask=077; grep -qE '^[^#]*umask' "$file" && sed -i -E "s/^(\s*umask\s*)[0-7]+/\1$var_accounts_user_umask/g" "$file"
$ # umask 777 This shouldn't be touched
# umask 000
umask 077
   umask 077 # This shouldn't be touched either
```