### PR TITLE
Use var_accounts_passwords_pam_faillock_dir in audit_rules_login_events

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/bash/shared.sh
@@ -2,11 +2,13 @@
 
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 
+{{{ bash_instantiate_variables("var_accounts_passwords_pam_faillock_dir") }}}
+
 {{{ bash_fix_audit_watch_rule("auditctl", "/var/log/tallylog", "wa", "logins") }}}
 {{{ bash_fix_audit_watch_rule("augenrules", "/var/log/tallylog", "wa", "logins") }}}
 
-{{{ bash_fix_audit_watch_rule("auditctl", faillock_path, "wa", "logins") }}}
-{{{ bash_fix_audit_watch_rule("augenrules", faillock_path, "wa", "logins") }}}
+{{{ bash_fix_audit_watch_rule("auditctl", "${var_accounts_passwords_pam_faillock_dir}", "wa", "logins") }}}
+{{{ bash_fix_audit_watch_rule("augenrules", "${var_accounts_passwords_pam_faillock_dir}", "wa", "logins") }}}
 
 {{{ bash_fix_audit_watch_rule("auditctl", "/var/log/lastlog", "wa", "logins") }}}
 {{{ bash_fix_audit_watch_rule("augenrules", "/var/log/lastlog", "wa", "logins") }}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/rule.yml
@@ -12,14 +12,14 @@ description: |-
     directory <tt>/etc/audit/rules.d</tt> in order to watch for attempted manual
     edits of files involved in storing logon events:
     <pre>-w /var/log/tallylog -p wa -k logins
-    -w {{{ faillock_path }}} -p wa -k logins
+    -w {{{ xccdf_value("var_accounts_passwords_pam_faillock_dir") }}} -p wa -k logins
     -w /var/log/lastlog -p wa -k logins</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file in order to watch for unattempted manual
     edits of files involved in storing logon events:
     <pre>-w /var/log/tallylog -p wa -k logins
-    -w {{{ faillock_path }}} -p wa -k logins
+    -w {{{ xccdf_value("var_accounts_passwords_pam_faillock_dir") }}} -p wa -k logins
     -w /var/log/lastlog -p wa -k logins</pre>
 
 rationale: |-

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/tests/default.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/tests/default.pass.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # packages = audit
 # remediation = bash
+# variables = var_accounts_passwords_pam_faillock_dir=/var/log/faillock
 
-echo "-w {{{ faillock_path }}} -p wa -k logins" >> /etc/audit/rules.d/logins.rules
+echo "-w /var/log/faillock -p wa -k logins" >> /etc/audit/rules.d/logins.rules
 echo "-w /var/log/lastlog -p wa -k logins" >> /etc/audit/rules.d/logins.rules
 echo "-w /var/log/tallylog -p wa -k logins" >> /etc/audit/rules.d/logins.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/tests/rules_without_keys.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/tests/rules_without_keys.pass.sh
@@ -1,14 +1,8 @@
 #!/bin/bash
 # packages = audit
 # remediation = bash
+# variables = var_accounts_passwords_pam_faillock_dir=/var/log/faillock
 
-{{% if product in ["ol8", "ol9", "rhel8", "rhel9"] %}}
-{{% set faillock_path="/var/log/faillock" %}}
-{{% else %}}
-{{% set faillock_path="/var/run/faillock" %}}
-{{% endif %}}
-
-
-echo "-w {{{ faillock_path }}} -p wa" >> /etc/audit/rules.d/logins.rules
+echo "-w /var/log/faillock -p wa" >> /etc/audit/rules.d/logins.rules
 echo "-w /var/log/lastlog -p wa" >> /etc/audit/rules.d/logins.rules
 echo "-w /var/log/tallylog -p wa" >> /etc/audit/rules.d/logins.rules

--- a/products/rhel7/profiles/C2S.profile
+++ b/products/rhel7/profiles/C2S.profile
@@ -153,6 +153,7 @@ selections:
     - audit_rules_networkconfig_modification
     - audit_rules_mac_modification
     - audit_rules_login_events
+    - var_accounts_passwords_pam_faillock_dir=run
     - audit_rules_session_events
     - audit_rules_dac_modification_chmod
     - audit_rules_dac_modification_chown

--- a/products/rhel7/profiles/cjis.profile
+++ b/products/rhel7/profiles/cjis.profile
@@ -50,6 +50,7 @@ selections:
     - audit_rules_dac_modification_removexattr
     - audit_rules_dac_modification_setxattr
     - audit_rules_login_events
+    - var_accounts_passwords_pam_faillock_dir=run
     - audit_rules_session_events
     - audit_rules_unsuccessful_file_modification
     - audit_rules_privileged_commands

--- a/products/rhel7/profiles/e8.profile
+++ b/products/rhel7/profiles/e8.profile
@@ -105,6 +105,7 @@ selections:
   - audit_rules_login_events_faillock
   - audit_rules_login_events_lastlog
   - audit_rules_login_events
+  - var_accounts_passwords_pam_faillock_dir=run
   - audit_rules_time_adjtimex
   - audit_rules_time_clock_settime
   - audit_rules_time_watch_localtime

--- a/products/rhel7/profiles/pci-dss.profile
+++ b/products/rhel7/profiles/pci-dss.profile
@@ -48,6 +48,7 @@ selections:
     - audit_rules_dac_modification_removexattr
     - audit_rules_dac_modification_setxattr
     - audit_rules_login_events
+    - var_accounts_passwords_pam_faillock_dir=run
     - audit_rules_session_events
     - audit_rules_unsuccessful_file_modification
     - audit_rules_privileged_commands

--- a/tests/data/profile_stability/rhel7/e8.profile
+++ b/tests/data/profile_stability/rhel7/e8.profile
@@ -109,4 +109,5 @@ selections:
 - var_selinux_state=enforcing
 - var_selinux_policy_name=targeted
 - var_auditd_flush=incremental_async
+- var_accounts_passwords_pam_faillock_dir=run
 title: Australian Cyber Security Centre (ACSC) Essential Eight


### PR DESCRIPTION
The rule `audit_rules_login_events` depends on rule `audit_rules_login_events_faillock`, the OVAL check from `audit_rules_login_events_faillock` is reused as `extend_definition` in `audit_rules_login_events`. But, the rule
`audit_rules_login_events_faillock` recently changed in 5304dcb37582c0038df1352c6e8d945468377867 to use the XCCDF value `var_accounts_passwords_pam_faillock_dir` in the rule which also changed the OVAL check in this rule which affects `audit_rules_login_events` as well. But, `audit_rules_login_events` wasn't updated. In this patch, we will update `audit_rules_login_events` to use
`var_accounts_passwords_pam_faillock_dir` in `audit_rules_login_events` in a similar way to `audit_rules_login_events_faillock`. As a consequence, we also need to explicitly set the value of the variable in RHEL 7 profiles where the default variable can't be used to make sure the correct path is used.

Fixes: #11102
