### PR TITLE
Fix Automatus traceback

### DIFF
--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -602,11 +602,7 @@ def install_packages(test_env, packages):
             "Couldn't install required packages: {packages}".format(packages=",".join(packages)))
 
 
-def cpe_to_platform(cpe):
-    trivials = ["fedora", "sles", "ubuntu"]
-    for platform in trivials:
-        if platform in cpe:
-            return platform
+def _match_rhel_version(cpe):
     rhel_cpe = {
         "redhat:enterprise_linux": r":enterprise_linux:([^:]+):",
         "centos:centos": r"centos:centos:([0-9]+)"}
@@ -616,6 +612,16 @@ def cpe_to_platform(cpe):
             if match:
                 major_version = match.groups()[0].split(".")[0]
                 return "rhel" + major_version
+
+
+def cpe_to_platform(cpe):
+    trivials = ["fedora", "sles", "ubuntu"]
+    for platform in trivials:
+        if platform in cpe:
+            return platform
+    rhel_version = _match_rhel_version(cpe)
+    if rhel_version is not None:
+        return rhel_version
     if "oracle:linux" in cpe:
         match = re.search(r":linux:([^:]+):", cpe)
         if match:

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -580,6 +580,7 @@ INSTALL_COMMANDS = dict(
     rhel7=("yum", "install", "-y"),
     rhel8=("yum", "install", "-y"),
     rhel9=("yum", "install", "-y"),
+    sles=("zypper", "install", "-y"),
     ubuntu=("DEBIAN_FRONTEND=noninteractive", "apt", "install", "-y"),
 )
 
@@ -606,6 +607,8 @@ def cpes_to_platform(cpes):
     for cpe in cpes:
         if "fedora" in cpe:
             return "fedora"
+        if "sles" in cpe:
+            return "sles"
         for cpe_item in rhel_cpe.keys():
             if cpe_item in cpe:
                 match = re.search(rhel_cpe.get(cpe_item), cpe)

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -602,26 +602,32 @@ def install_packages(test_env, packages):
             "Couldn't install required packages: {packages}".format(packages=",".join(packages)))
 
 
-def cpes_to_platform(cpes):
-    rhel_cpe = {"redhat:enterprise_linux": r":enterprise_linux:([^:]+):", "centos:centos": r"centos:centos:([0-9]+)"}
-    for cpe in cpes:
-        if "fedora" in cpe:
-            return "fedora"
-        if "sles" in cpe:
-            return "sles"
-        for cpe_item in rhel_cpe.keys():
-            if cpe_item in cpe:
-                match = re.search(rhel_cpe.get(cpe_item), cpe)
-                if match:
-                    major_version = match.groups()[0].split(".")[0]
-                    return "rhel" + major_version
-        if "ubuntu" in cpe:
-            return "ubuntu"
-        if "oracle:linux" in cpe:
-            match = re.search(r":linux:([^:]+):", cpe)
+def cpe_to_platform(cpe):
+    trivials = ["fedora", "sles", "ubuntu"]
+    for platform in trivials:
+        if platform in cpe:
+            return platform
+    rhel_cpe = {
+        "redhat:enterprise_linux": r":enterprise_linux:([^:]+):",
+        "centos:centos": r"centos:centos:([0-9]+)"}
+    for cpe_item in rhel_cpe.keys():
+        if cpe_item in cpe:
+            match = re.search(rhel_cpe.get(cpe_item), cpe)
             if match:
-                major_version = match.groups()[0]
-                return "ol" + major_version
+                major_version = match.groups()[0].split(".")[0]
+                return "rhel" + major_version
+    if "oracle:linux" in cpe:
+        match = re.search(r":linux:([^:]+):", cpe)
+        if match:
+            major_version = match.groups()[0]
+            return "ol" + major_version
+
+
+def cpes_to_platform(cpes):
+    for cpe in cpes:
+        platform = cpe_to_platform(cpe)
+        if platform is not None:
+            return platform
     msg = "Unable to deduce a platform from these CPEs: {cpes}".format(cpes=cpes)
     raise ValueError(msg)
 


### PR DESCRIPTION
This commit tries to fix a traceback that happens when evaluating a SLE15 data stream on a container back end when the test scenarios require to install a package into the back end.

Resolves:

```
[jcerny@fedora scap-security-guide{master}]$ tests/test_rule_in_container.sh --no-remove-machine-only --dontclean --logdir logs_bash --remediate-using bash --name ssg_test_suite --datastream build/ssg-sle15-ds.xml audit_rules_login_events
Setting console output to log level INFO
INFO - The base image option has been specified, choosing Podman-based test environment.
INFO - Logging into logs_bash-4/test_suite.log
WARNING - Nothing has been tested!
Traceback (most recent call last):
  File "/home/jcerny/work/git/scap-security-guide/tests/automatus.py", line 511, in <module>
    main()
  File "/home/jcerny/work/git/scap-security-guide/tests/automatus.py", line 507, in main
    options.func(options)
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/rule.py", line 689, in perform_rule_check
    checker.test_target()
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/oscap.py", line 683, in test_target
    self._test_target()
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/rule.py", line 458, in _test_target
    self._prepare_environment(test_content_by_rule_id)
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/rule.py", line 275, in _prepare_environment
    self._ensure_package_present_for_all_scenarios(test_content_by_rule_id)
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/rule.py", line 265, in _ensure_package_present_for_all_scenarios
    common.install_packages(self.test_env, packages_to_install)
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/common.py", line 592, in install_packages
    platform = cpes_to_platform([platform_cpe])
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/common.py", line 623, in cpes_to_platform
    raise ValueError(msg)
ValueError: Unable to deduce a platform from these CPEs: ['cpe:/o:suse:sles:15:sp5']
```
