### PR TITLE
Add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+        interval: "daily"


### PR DESCRIPTION
#### Description:
This will  add Dependabot to the project. Dependabot will open nicely formated ([example](https://github.com/Mab879/content/pull/23)) PRs when there are new version of our actions.

Blocked by #11112

#### Rationale:

So that we don't have to manually update things.

#### Review Hints:
* [GitHub Docs on Configuring Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)
* [Example PR](https://github.com/Mab879/content/pull/23)