### PR TITLE
Fix Ansible Tasks order

### DIFF
--- a/build-scripts/generate_profile_remediations.py
+++ b/build-scripts/generate_profile_remediations.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import argparse
+import collections
 import os
 import re
 import xml.etree.ElementTree as ET
@@ -192,7 +193,7 @@ class ScriptGenerator:
         self.variables = get_all_variables(benchmark)
 
     def load_all_remediations(self, benchmark):
-        self.remediations = {}
+        self.remediations = collections.OrderedDict()
         rule_xpath = ".//{%s}Rule" % (XCCDF12_NS)
         for rule_el in benchmark.findall(rule_xpath):
             rule_id = rule_el.get("id")
@@ -238,7 +239,7 @@ class ScriptGenerator:
     def collect_ansible_vars_and_tasks(self, profile_el):
         selected_rules = get_selected_rules(profile_el)
         refinements = get_value_refinenements(profile_el)
-        all_vars = {}
+        all_vars = collections.OrderedDict()
         all_tasks = []
         for rule_id, fix_el in self.remediations.items():
             if rule_id not in selected_rules:


### PR DESCRIPTION
In https://github.com/ComplianceAsCode/content/pull/11033, we have switched to a new script for generating profile oriented Ansible Playbooks. Unfortunately, when Python 2 is used the generated Ansible Playbooks don't preserve the order of Ansible Tasks in the order defined in the SCAP source data stream. The wrong order of Ansible Tasks in a Playbook might cause an unexpected conflict between them during the run, for example https://github.com/ComplianceAsCode/content/issues/11104. The root cause of the problem is that dictionaries in Python 2 don't preserve order of elements but starting from Python 3.6 the dictionaries preserve order of its elements.

Fixes: #11104

#### Review Hints:

1. Build a scratch build for RHEL 7.9 from this PR branch
2. Run ` /hardening/ansible/anssi_nt28_high` from contest against a RHEL 7.9 machine where that scratch build is installed
3. Check that the test passes.
4. Check the after guest reboot results of mount point related rules