### PR TITLE
Fix OrderedDict definition

### DIFF
--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -362,8 +362,10 @@ class AnsibleRemediation(Remediation):
                     has_ansible_facts_packages_clause = True
 
         if has_ansible_facts_packages_clause and not has_package_facts_task:
-            facts_task = OrderedDict({'name': 'Gather the package facts',
-                                      'package_facts': {'manager': 'auto'}})
+            facts_task = OrderedDict([
+                ('name', 'Gather the package facts'),
+                ('package_facts', {'manager': 'auto'})
+            ])
             parsed_snippet.insert(0, facts_task)
 
     def update_when_from_rule(self, to_update, cpe_platforms):


### PR DESCRIPTION
We shouldn't pass a dict to the OrderedDict because in Python older than 3.6 dicts aren't ordered, it goes against the intention of using the OrderedDict here.