### PR TITLE
Remove dnf5 from Rawhide job

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -187,9 +187,6 @@ jobs:
     steps:
       -   name: Run Updates
           run: dnf update -y
-      -   name: Ensure dnf Command
-          run: dnf5 install -y dnf
-          # https://discussion.fedoraproject.org/t/rawhide-psa-what-to-do-if-dnf-goes-missing/87133
       -   name: Install Deps
           run: dnf install -y cmake make openscap-utils bats ansible python3-pip ShellCheck git
       -   name: Checkout


### PR DESCRIPTION
Today, the workaround in the GitHub Actions Workflow definition for Rawhide started to cause a trouble. For example, in PR https://github.com/ComplianceAsCode/content/pull/11121 the build on Rawhide failed with this message:

```

Run dnf5 install -y dnf
/__w/_temp/93cd66dc-fcda-4ce6-95b8-25f457532355.sh: line 1: dnf5: command not found
Error: Process completed with exit code 127.
```