### PR TITLE
Include metrics for rules and variables selected in Controls

### DIFF
--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -88,6 +88,7 @@ class Control(ssg.entities.common.SelectionHandler, ssg.entities.common.XCCDFEnt
         tickets=list,
         original_title=str,
         related_rules=list,
+        rules=list,
         controls=list,
     )
 
@@ -114,6 +115,7 @@ class Control(ssg.entities.common.SelectionHandler, ssg.entities.common.XCCDFEnt
         self.tickets = []
         self.original_title = ""
         self.related_rules = []
+        self.rules = []
 
     def __hash__(self):
         """ Controls are meant to be unique, so using the
@@ -145,6 +147,7 @@ class Control(ssg.entities.common.SelectionHandler, ssg.entities.common.XCCDFEnt
         control.tickets = control_dict.get('tickets')
         control.original_title = control_dict.get('original_title')
         control.related_rules = control_dict.get('related_rules')
+        control.rules = control_dict.get('rules')
 
         if control.status == "automated":
             control.automated = "yes"
@@ -161,6 +164,7 @@ class Control(ssg.entities.common.SelectionHandler, ssg.entities.common.XCCDFEnt
         control.selections = selections
 
         control.related_rules = control_dict.get("related_rules", [])
+        control.rules = control_dict.get("rules", [])
         return control
 
     def represent_as_dict(self):

--- a/utils/controleval.py
+++ b/utils/controleval.py
@@ -183,15 +183,23 @@ def create_implicit_control_lists(ctrls, control_list):
 
 
 def count_rules_and_vars_in_control(ctrl):
-    rules = [item for item in ctrl.rules if "=" not in item]
-    variables = [item for item in ctrl.rules if "=" in item]
-    return len(rules), len(variables)
+    Counts = collections.namedtuple('Counts', ['rules', 'variables'])
+    rules_count = variables_count = 0
+    for item in ctrl.rules:
+        if "=" in item:
+            variables_count += 1
+        else:
+            rules_count += 1
+    return Counts(rules_count, variables_count)
 
 
 def count_rules_and_vars(ctrls):
-    rules_count = sum(count_rules_and_vars_in_control(ctrl)[0] for ctrl in ctrls)
-    vars_count = sum(count_rules_and_vars_in_control(ctrl)[1] for ctrl in ctrls)
-    return rules_count, vars_count
+    rules_total = variables_total = 0
+    for ctrl in ctrls:
+        content_counts = count_rules_and_vars_in_control(ctrl)
+        rules_total += content_counts.rules
+        variables_total += content_counts.variables
+    return rules_total, variables_total
 
 
 def count_controls_by_status(ctrls):

--- a/utils/controleval.py
+++ b/utils/controleval.py
@@ -182,6 +182,18 @@ def create_implicit_control_lists(ctrls, control_list):
     return control_list
 
 
+def count_rules_and_vars_in_control(ctrl):
+    rules = [item for item in ctrl.rules if "=" not in item]
+    variables = [item for item in ctrl.rules if "=" in item]
+    return len(rules), len(variables)
+
+
+def count_rules_and_vars(ctrls):
+    rules_count = sum(count_rules_and_vars_in_control(ctrl)[0] for ctrl in ctrls)
+    vars_count = sum(count_rules_and_vars_in_control(ctrl)[1] for ctrl in ctrls)
+    return rules_count, vars_count
+
+
 def count_controls_by_status(ctrls):
     status_count = collections.defaultdict(int)
     control_list = collections.defaultdict(set)
@@ -229,7 +241,7 @@ def print_controls(status_count, control_list, args):
         print("There is no controls with {status} status.".format(status=status))
 
 
-def print_stats(status_count, control_list, args):
+def print_stats(status_count, control_list, rules_count, vars_count, args):
     implicit_status = controls.Status.get_status_list()
     explicit_status = status_count.keys() - implicit_status
 
@@ -240,6 +252,10 @@ def print_stats(status_count, control_list, args):
     print("\nStats grouped by status:")
     for status in sorted(implicit_status):
         print_specific_stat(status, status_count[status], status_count['applicable'])
+
+    print(f"\nRules and Variables in {args.id} - {args.level}:")
+    print(f'{rules_count} rules are selected')
+    print(f'{vars_count} variables are explicitly defined')
 
     if args.show_controls:
         print_controls(status_count, control_list, args)
@@ -273,11 +289,12 @@ def stats(args):
         exit(1)
 
     status_count, control_list = count_controls_by_status(ctrls)
+    rules_count, vars_count = count_rules_and_vars(ctrls)
 
     if args.output_format == 'json':
         print_stats_json(args.product, args.id, args.level, control_list)
     else:
-        print_stats(status_count, control_list, args)
+        print_stats(status_count, control_list, rules_count, vars_count, args)
 
 
 subcmds = dict(


### PR DESCRIPTION
#### Description:

Besides the status of each Policy, now `controleval_metrics.py` is also exporting metrics about rules and variables selected in each Policy.

For this, the `ssg/controls.py` was slightly incremented and the new property was used in two new functions of `controleval.py`. These functions are finally consumed by `controleval_metrics.py`.

#### Rationale:

Better tracking of rules and variables included in control files.

#### Review Hints:

e.g.:
`utils/controleval_metrics.py prometheus -p rhel9`
Then check the new metrics in the output while the former metrics are intact.

You can also check the output of `controleval.py stats`. e.g.:
`utils/controleval.py stats -i cis_rhel9 -p rhel9 -l l1_server`

Then observe the last lines of the output. e.g.:
```
Rules and Variables in cis_rhel9 - l1_server:
279 rules are selected
53 variables are explicitly defined
```