### PR TITLE
Add support of derivatives to Automatus

### DIFF
--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -498,3 +498,10 @@ class OvalNamespaces:
 
 
 OVAL_NAMESPACES = OvalNamespaces()
+
+DERIVATIVES_PRODUCT_MAPPING = {
+    "centos7": "rhel7",
+    "centos8": "rhel8",
+    "cs9": "rhel9",
+    "sl7": "rhel7"
+}

--- a/tests/automatus.py
+++ b/tests/automatus.py
@@ -24,6 +24,7 @@ import ssg_test_suite.rule
 import ssg_test_suite.combined
 import ssg_test_suite.template
 from ssg_test_suite import xml_operations
+from ssg.constants import DERIVATIVES_PRODUCT_MAPPING
 
 
 def parse_args():
@@ -390,6 +391,8 @@ def get_product_id(datastream):
         msg += "datastream {0} lacks product name".format(datastream)
         raise RuntimeError(msg)
     product = match.group(1)
+    if product in DERIVATIVES_PRODUCT_MAPPING:
+        product = DERIVATIVES_PRODUCT_MAPPING[product]
     return product
 
 

--- a/tests/automatus.py
+++ b/tests/automatus.py
@@ -382,6 +382,17 @@ def get_unique_datastream():
         "e.g. {1}".format(len(datastreams), datastreams))
 
 
+def get_product_id(datastream):
+    product_regex = re.compile(r'^.*ssg-([a-zA-Z0-9]*)-(ds|ds-1\.2)\.xml$')
+    match = product_regex.match(datastream)
+    if not match:
+        msg = "Unable to detect product without explicit --product: "
+        msg += "datastream {0} lacks product name".format(datastream)
+        raise RuntimeError(msg)
+    product = match.group(1)
+    return product
+
+
 @contextlib.contextmanager
 def datastream_in_stash(current_location):
     tfile = tempfile.NamedTemporaryFile(prefix="ssgts-ds-")
@@ -407,13 +418,7 @@ def normalize_passed_arguments(options):
         options.datastream = get_unique_datastream()
 
     if not options.product and options.datastream:
-        product_regex = re.compile(r'^.*ssg-([a-zA-Z0-9]*)-(ds|ds-1\.2)\.xml$')
-        match = product_regex.match(options.datastream)
-        if not match:
-            msg = "Unable to detect product without explicit --product: "
-            msg += "datastream {0} lacks product name".format(options.datastream)
-            raise RuntimeError(msg)
-        options.product = match.group(1)
+        options.product = get_product_id(options.datastream)
 
     if options.xccdf_id is None:
         options.xccdf_id = auto_select_xccdf_id(options.datastream,

--- a/tests/automatus.py
+++ b/tests/automatus.py
@@ -383,12 +383,12 @@ def get_unique_datastream():
         "e.g. {1}".format(len(datastreams), datastreams))
 
 
-def get_product_id(datastream):
+def get_product_id(ds_filename):
     product_regex = re.compile(r'^.*ssg-([a-zA-Z0-9]*)-(ds|ds-1\.2)\.xml$')
-    match = product_regex.match(datastream)
+    match = product_regex.match(ds_filename)
     if not match:
         msg = "Unable to detect product without explicit --product: "
-        msg += "datastream {0} lacks product name".format(datastream)
+        msg += "datastream {0} lacks product name".format(ds_filename)
         raise RuntimeError(msg)
     product = match.group(1)
     if product in DERIVATIVES_PRODUCT_MAPPING:


### PR DESCRIPTION
#### Description:

If a derivative data stream (eg. ssg-cs9-ds.xml) is tested, Automatus will now automatically infer which product this derivative is derived from.

#### Rationale:

Fixes: #10677 

#### Review Hints:

1. Build a product and its derivatives, for example:  `./build_product rhel9 --derivatives`
2. Run test scenarios while passing the derivative data stream to Automatus, for example: `
./tests/automatus.py rule --datastream build/ssg-cs9-ds.xml --remove-platforms --remove-machine-only  --libvirt qemu:///system ssgts_rhel9 selinux_state`
3. verify that the automatus.py haven't traceback