### PR TITLE
Move master to use merge groups

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -1,7 +1,9 @@
 name: Gate
 on:
+  merge_group:
+    branches: [ 'master' ]
   push:
-    branches: [ 'master', '*', '!stabilization*', '!stable*' ]
+    branches: ['*', '!stabilization*', '!stable*', '!master' ]
   pull_request:
     branches: [ 'master', 'stabilization*' ]
 jobs:


### PR DESCRIPTION
#### Description:
This is the first step in turning on [merge queues](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) in the project.

If there no objections and this PR merged I will turn on merge queues for the project.

#### Rationale:

Merge queue's should help us catch issues better before they land on master.

 See #11116 for the discussion.

