### PR TITLE
Build OCP STIG profiles by default

### DIFF
--- a/products/ocp4/profiles/stig-node.profile
+++ b/products/ocp4/profiles/stig-node.profile
@@ -1,4 +1,4 @@
-documentation_complete: false
+documentation_complete: true
 
 platform: ocp4-node
 

--- a/products/ocp4/profiles/stig.profile
+++ b/products/ocp4/profiles/stig.profile
@@ -1,4 +1,4 @@
-documentation_complete: false
+documentation_complete: true
 
 platform: ocp4
 


### PR DESCRIPTION


#### Description:

- Build OCP STIG profiles by default

#### Rationale:

- With the STIG for OCP4 being released, we can enable build of this profile by default.