### PR TITLE
Add SELinux as platform

### DIFF
--- a/linux_os/guide/system/selinux/selinux-booleans/group.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/group.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 title: 'SELinux - Booleans'
 
-platform: not osbuild
+platform: not osbuild and selinux
 
 description: |-
     Enable or Disable runtime customization of SELinux system policies

--- a/shared/applicability/oval/selinux_is_enabled.xml
+++ b/shared/applicability/oval/selinux_is_enabled.xml
@@ -1,0 +1,32 @@
+<def-group>
+  <definition class="inventory" id="selinux_is_enabled" version="1">
+    <metadata>
+      <title>SELinux status check</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Check if System has SELinux enabled.</description>
+      <reference ref_id="cpe:/a:selinux" source="CPE" />
+    </metadata>
+    <criteria operator="AND">
+      <criterion comment="enforce is disabled" test_ref="test_etc_selinux_configured" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="/selinux/enforce is 1" id="test_etc_selinux_configured" version="1">
+    <ind:object object_ref="object_etc_selinux_configured" />
+    <ind:state state_ref="state_etc_selinux_configured" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_etc_selinux_configured" version="1">
+    <ind:filepath>/etc/selinux/config</ind:filepath>
+    <ind:pattern operation="pattern match">^SELINUX=(.*)$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_etc_selinux_configured" version="1">
+    <ind:subexpression datatype="string"
+      operation="pattern match">^(enforcing|permissive)$</ind:subexpression>
+  </ind:textfilecontent54_state>
+</def-group>

--- a/shared/applicability/selinux.yml
+++ b/shared/applicability/selinux.yml
@@ -1,0 +1,3 @@
+name: cpe:/a:selinux
+title: SELinux enabled on system
+check_id: selinux_is_enabled


### PR DESCRIPTION


#### Description:

- Make sure SELinux variables are not checked when no selinux is enabled 

#### Rationale:

- The effect of the above missing is that rules checks remediation will attempt changes to the system, but those were not applicable. Also the change communicates with a side effect we observed in https://github.com/OpenSCAP/openscap/issues/1959

