### PR TITLE
Disable sysctl_kernel_yama_ptrace_scope rule for sle15

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_yama_ptrace_scope/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_yama_ptrace_scope/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,sle12,sle15
+prodtype: fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,sle12
 
 title: 'Restrict usage of ptrace to descendant processes'
 


### PR DESCRIPTION
#### Description:

- Stop the rule for SLE15 platform

#### Rationale:

- There are some compatibility issues which require this better be disabled for now for SLE15