### PR TITLE
Add libvirt-dev to read the docs apt packages

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,8 @@ version: 2
 
 build:
   os: ubuntu-22.04
+  apt_packages:
+      - libvirt-dev
   tools:
     python: "3.11"
 


### PR DESCRIPTION
#### Description:
Add libvirt-dev to read the docs apt packages

#### Rationale:

Fix the docs build