### PR TITLE
Update ansible in sshd_use_approved_kex_ordered_stig

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/ansible/shared.yml
@@ -7,12 +7,10 @@
 {{% set prefix_conf="^\s*KexAlgorithms\s*" %}}
 {{% set kex_algos=["ecdh-sha2-nistp256","ecdh-sha2-nistp384","ecdh-sha2-nistp521",
              "diffie-hellman-group-exchange-sha256"]  %}}
-{{% set kex_algos_regex=prefix_conf ~ "(?=[\w-])" "(\\b" ~ kex_algos|join("\\b,?)?(\\b") ~ ")?" ~
-                        sufix_conf ~ "[\s]*(?:#.*)?$" %}}
 - name: "Configure sshd to use FIPS 140-2 approved key exchange algorithms"
   lineinfile:
     path: /etc/ssh/sshd_config
     line: 'KexAlgorithms {{{ kex_algos|join(",") }}}'
     state: present
-    regexp: '{{{ kex_algos_regex }}}'
+    regexp: '{{{ prefix_conf }}}'
     create: True


### PR DESCRIPTION
#### Description:

- Update regex so it can fix the existing configuration instead of just adding another one

#### Rationale:

- This avoids to add new configuration instead of fixing the existing one

#### Review Hints:

Here what I got with existing code:

```
TASK [Configure sshd to use FIPS 140-2 approved key exchange algorithms] *********************************************************************
--- before: /etc/ssh/sshd_config (content)
+++ after: /etc/ssh/sshd_config (content)
@@ -153,3 +153,4 @@
 UsePrivilegeSeparation sandbox
 X11UseLocalhost yes
 KexAlgorithms none
+KexAlgorithms ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256

changed: [root@OL7_experiment]
```

And with these changes:

```
TASK [Configure sshd to use FIPS 140-2 approved key exchange algorithms] *********************************************************************
--- before: /etc/ssh/sshd_config (content)
+++ after: /etc/ssh/sshd_config (content)
@@ -149,7 +149,7 @@
 Banner /etc/issue
 PrintLastLog yes
 Ciphers aes256-ctr,aes192-ctr,aes128-ctr
-KexAlgorithms none
+KexAlgorithms ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256
 MACs hmac-sha2-512,hmac-sha2-256
 UsePrivilegeSeparation sandbox
 X11UseLocalhost yes

changed: [root@OL7_experiment]
```