### PR TITLE
Update sshd lineinfile

### DIFF
--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -203,7 +203,7 @@ value: :code:`Setting={{ varname1 }}`
 {{% if product in ["ol8", "ol9"] %}}
 - name: "Find sshd_config included files"
   shell: |-
-    included_files=$(grep -oP "^\s*(?i)include.*" /etc/ssh/sshd_config | sed -e 's/Include\s*//i' | sed -e 's|^[^/]|/etc/ssh/&|')
+    included_files=$(grep -oP "^\s*(?i)include.*" /etc/ssh/sshd_config | sed -e 's/\s*Include\s*//i' | sed -e 's|^[^/]|/etc/ssh/&|')
     [[ -n $included_files ]] && ls $included_files || true
   register: sshd_config_included_files
 

--- a/shared/templates/sshd_lineinfile/tests/correct_value_multiple_includes.pass.sh
+++ b/shared/templates/sshd_lineinfile/tests/correct_value_multiple_includes.pass.sh
@@ -4,8 +4,8 @@
 
 source common.sh
 
-{{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "sshd_config.d/*.conf", "%s %s") }}}
-echo "Include /etc/dummy" >> "/etc/ssh/sshd_config"
+{{{ bash_replace_or_append("/etc/ssh/sshd_config", "   InCLude", "sshd_config.d/*.conf", "%s %s") }}}
+echo "   INclUde /etc/dummy" >> "/etc/ssh/sshd_config"
 
 echo "{{{ PARAMETER }}} {{{ VALUE }}}" >> /etc/dummy
 echo "{{{ PARAMETER }}} {{{ VALUE }}}" >> /etc/ssh/sshd_config.d/other.conf


### PR DESCRIPTION
#### Description:

- Update regex in ansible to align it with bash so it allows blank spaces leading the Include keyword
- Update test `correct_value_multiple_includes.pass` so it validate OVAL is case insensitive and also allows leading spaces

#### Rationale:

- Existing ansible code was failing test to remediate from `wrong_value_different_includings.fail` test

#### Review Hints:

- Automatus results should be sufficient
- This only actually affects OL8 & OL9