### PR TITLE
Add version for OCP CIS

### DIFF
--- a/products/ocp4/profiles/cis-node.profile
+++ b/products/ocp4/profiles/cis-node.profile
@@ -11,6 +11,7 @@ metadata:
         - jhrozek
         - rhmdnd
         - Vincent056
+    version: 1.4.0
 
 description: |-
     This profile defines a baseline that aligns to the Center for Internet Security®

--- a/products/ocp4/profiles/cis.profile
+++ b/products/ocp4/profiles/cis.profile
@@ -11,6 +11,7 @@ metadata:
         - jhrozek
         - rhmdnd
         - Vincent056
+    version: 1.4.0
 
 description: |-
     This profile defines a baseline that aligns to the Center for Internet Security®


### PR DESCRIPTION
We currently support version 1.4.0, so let's advertise it.
