### PR TITLE
Add version for OCP STIG

### DIFF
--- a/products/ocp4/profiles/stig-node.profile
+++ b/products/ocp4/profiles/stig-node.profile
@@ -3,6 +3,7 @@ documentation_complete: true
 platform: ocp4-node
 
 metadata:
+    version: V1R1
     SMEs:
         - jhrozek
         - Vincent056

--- a/products/ocp4/profiles/stig.profile
+++ b/products/ocp4/profiles/stig.profile
@@ -3,6 +3,7 @@ documentation_complete: true
 platform: ocp4
 
 metadata:
+    version: V1R1
     SMEs:
         - jhrozek
         - Vincent056

--- a/products/rhcos4/profiles/stig.profile
+++ b/products/rhcos4/profiles/stig.profile
@@ -1,7 +1,7 @@
 documentation_complete: true
 
 metadata:
-    version: TBD
+    version: V1R1
     SMEs:
         - jhrozek
         - Vincent056


### PR DESCRIPTION
Now that the STIG is published, we can associated a version to the
metadata.
