### PR TITLE
Add version metadata to the OCP PCI-DSS profile

### DIFF
--- a/products/ocp4/profiles/pci-dss-node.profile
+++ b/products/ocp4/profiles/pci-dss-node.profile
@@ -3,6 +3,7 @@ documentation_complete: true
 platform: ocp4-node
 
 metadata:
+    version: 3.2.1
     SMEs:
         - JAORMX
         - jhrozek

--- a/products/ocp4/profiles/pci-dss.profile
+++ b/products/ocp4/profiles/pci-dss.profile
@@ -3,6 +3,7 @@ documentation_complete: true
 platform: ocp4
 
 metadata:
+    version: 3.2.1
     SMEs:
         - JAORMX
         - jhrozek


### PR DESCRIPTION
The initial implementation of the PCI-DSS profiles for OpenShift were
based on 3.2.1. Let's advertise that so users know what version they're
using.
