### PR TITLE
Select the `var_accounts_passwords_pam_faillock_dir=run` in RHEL7 profiles

### DIFF
--- a/products/rhel7/profiles/hipaa.profile
+++ b/products/rhel7/profiles/hipaa.profile
@@ -128,6 +128,7 @@ selections:
     - audit_rules_kernel_module_loading_delete
     - audit_rules_kernel_module_loading_init
     - audit_rules_login_events_faillock
+    - var_accounts_passwords_pam_faillock_dir=run
     - audit_rules_login_events_lastlog
     - audit_rules_login_events_tallylog
     - audit_rules_mac_modification

--- a/products/rhel7/profiles/rhelh-stig.profile
+++ b/products/rhel7/profiles/rhelh-stig.profile
@@ -123,6 +123,7 @@ selections:
     - audit_rules_kernel_module_loading_delete
     - audit_rules_kernel_module_loading_init
     - audit_rules_login_events_faillock
+    - var_accounts_passwords_pam_faillock_dir=run
     - audit_rules_login_events_lastlog
     - audit_rules_login_events_tallylog
     - audit_rules_mac_modification

--- a/products/rhel7/profiles/rhelh-vpp.profile
+++ b/products/rhel7/profiles/rhelh-vpp.profile
@@ -124,6 +124,7 @@ selections:
     - audit_rules_execution_setfiles
     - audit_rules_login_events_tallylog
     - audit_rules_login_events_faillock
+    - var_accounts_passwords_pam_faillock_dir=run
     - audit_rules_login_events_lastlog
     - audit_rules_privileged_commands_passwd
     - audit_rules_privileged_commands_unix_chkpwd

--- a/products/rhel7/profiles/stig.profile
+++ b/products/rhel7/profiles/stig.profile
@@ -219,6 +219,7 @@ selections:
     - audit_rules_execution_chcon
     - audit_rules_execution_setfiles
     - audit_rules_login_events_faillock
+    - var_accounts_passwords_pam_faillock_dir=run
     - audit_rules_login_events_lastlog
     - audit_rules_privileged_commands_passwd
     - audit_rules_privileged_commands_unix_chkpwd


### PR DESCRIPTION
#### Description:

- Rules as audit_rules_login_events_faillock were changed the behavior in #11007 and didn't have the content updated for RHEL7 according to the previous default value of
https://github.com/ComplianceAsCode/content/blob/d044199f1b037e632197893adbe3ab2b78ee1138/ssg/constants.py#L475.

#### Rationale:

- Fixes #11105