### PR TITLE
Fix privileged commands not concating gathered lists

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
@@ -18,7 +18,7 @@
 
 - name: {{{ rule_title }}} - Set List of Privileged Commands Found in Eligible Mount Points
   ansible.builtin.set_fact:
-    privileged_commands: "{{( result_privileged_commands_search.results | map(attribute='stdout_lines') | select() | list )[-1] }}"
+    privileged_commands: "{{( result_privileged_commands_search.results | map(attribute='stdout_lines') | select() | list ) | sum(start=[]) }}"
 
 - name: {{{ rule_title }}} - Privileged Commands are Present in the System
   block:


### PR DESCRIPTION
#### Description:

If multiple mount points had commands when gathering privileged commands
only the ones on the last mount point found would be added to audit rules
This concatinates the lists gathered to include all commands found