### PR TITLE
Add timer_logrotate_enabled back to RHEL 7 and RHEL 8

### DIFF
--- a/linux_os/guide/system/logging/log_rotation/timer_logrotate_enabled/rule.yml
+++ b/linux_os/guide/system/logging/log_rotation/timer_logrotate_enabled/rule.yml
@@ -14,7 +14,11 @@ rationale: |-
 
 severity: medium
 
+{{% if 'rhel' in product %}}
+platform: package[logrotate] and os_linux[rhel]>=9
+{{% else %}}
 platform: package[logrotate]
+{{% endif %}}
 
 identifiers:
     cce@rhel7: CCE-86156-7

--- a/linux_os/guide/system/logging/log_rotation/timer_logrotate_enabled/rule.yml
+++ b/linux_os/guide/system/logging/log_rotation/timer_logrotate_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol9,rhcos4,rhel9,sle12,sle15
+prodtype: ol9,rhcos4,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Enable logrotate Timer'
 

--- a/products/rhel7/profiles/anssi_nt28_enhanced.profile
+++ b/products/rhel7/profiles/anssi_nt28_enhanced.profile
@@ -14,3 +14,4 @@ description: |-
 selections:
     - anssi:all:enhanced
     - '!selinux_state'
+    - '!timer_logrotate_enabled'

--- a/products/rhel7/profiles/anssi_nt28_high.profile
+++ b/products/rhel7/profiles/anssi_nt28_high.profile
@@ -13,3 +13,4 @@ description: |-
 
 selections:
     - anssi:all:high
+    - '!timer_logrotate_enabled'

--- a/products/rhel8/profiles/anssi_bp28_enhanced.profile
+++ b/products/rhel8/profiles/anssi_bp28_enhanced.profile
@@ -17,3 +17,4 @@ description: |-
 
 selections:
     - anssi:all:enhanced
+    - '!timer_logrotate_enabled'

--- a/products/rhel8/profiles/anssi_bp28_high.profile
+++ b/products/rhel8/profiles/anssi_bp28_high.profile
@@ -19,3 +19,4 @@ selections:
     - anssi:all:high
     # the following rule renders UEFI systems unbootable
     - '!sebool_secure_mode_insmod'
+    - '!timer_logrotate_enabled'


### PR DESCRIPTION
#### Description:

Add rhel7 and rhel8 back to timer_logrotate_enabled.

#### Rationale:

This is needed as last release this rule did not have a prodtype since one was added we need to add back rhel7 and rhel8 ensure that we don't break tailoring for users.

