### PR TITLE
SLE15 prefer systemd unit handling of AIDE checks and notifications

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -1467,6 +1467,7 @@ controls:
     - package_aide_installed
     - aide_build_database
     - aide_periodic_cron_checking
+    - aide_periodic_checking_systemd_timer
     - aide_scan_notification
     - aide_verify_acls
     - aide_verify_ext_attributes

--- a/controls/pcidss_3.yml
+++ b/controls/pcidss_3.yml
@@ -2339,6 +2339,7 @@ controls:
   - disable_prelink
   - package_aide_installed
   - aide_periodic_cron_checking
+  - aide_periodic_checking_systemd_timer
   - rpm_verify_ownership
   - rpm_verify_hashes
   - aide_build_database

--- a/controls/pcidss_4.yml
+++ b/controls/pcidss_4.yml
@@ -2592,6 +2592,7 @@ controls:
     - disable_prelink
     - package_aide_installed
     - aide_periodic_cron_checking
+    - aide_periodic_checking_systemd_timer
     - rpm_verify_ownership
     - rpm_verify_hashes
     - aide_build_database

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/rule.yml
@@ -4,7 +4,7 @@
 
 documentation_complete: true
 
-prodtype: alinux2,alinux3,anolis23,anolis8,fedora,ol7,ol8,ol9,openembedded,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,ubuntu2204
+prodtype: alinux2,alinux3,anolis23,anolis8,fedora,ol7,ol8,ol9,openembedded,rhel7,rhel8,rhel9,rhv4,sle12,ubuntu2004,ubuntu2204
 
 title: 'Configure Periodic Execution of AIDE'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/ansible/shared.yml
@@ -12,6 +12,41 @@
   with_items:
     - aide
 
+{{% if product in ["sle15"] %}}
+- name: "{{{ rule_title }}} check service"
+  ansible.builtin.blockinfile:
+      create: yes
+      dest: /etc/systemd/system/aidecheck.service
+      owner: root
+      group: root
+      mode: '0644'
+      block: |
+        [Unit]
+        Description=Aide Check
+        Before=aidecheck-notify.service
+        Wants=aidecheck-notify.service
+        [Service]
+        Type=forking
+        ExecStart={{{ aide_bin_path }}} --check -r file:/tmp/aide-report.log
+        [Install]
+        WantedBy=multi-user.target
+
+- name: "{{{ rule_title }}} notify service"
+  ansible.builtin.blockinfile:
+      create: yes
+      dest: /etc/systemd/system/aidecheck-notify.service
+      owner: root
+      group: root
+      mode: '0644'
+      block: |
+        [Unit]        
+        Description=Status email for AIDE check result
+        After=aidecheck.service
+        [Service]
+        Type=forking
+        ExecStart=/bin/sh -c 'cat /tmp/aide-report.log | /bin/mail -s "$(hostname) - AIDE Integrity Check"  {{ var_aide_scan_notification_email }}'
+        
+{{% else %}}
 - name: "{{{ rule_title }}}"
   cron:
     name: "run AIDE check"
@@ -20,3 +55,4 @@
     weekday: 0
     user: root
     job: '{{{ aide_bin_path }}}  --check | /bin/mail -s "$(hostname) - AIDE Integrity Check" {{ var_aide_scan_notification_email }}'
+{{% endif %}}

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/ansible/shared.yml
@@ -39,13 +39,13 @@
       group: root
       mode: '0644'
       block: |
-        [Unit]        
+        [Unit]
         Description=Status email for AIDE check result
         After=aidecheck.service
         [Service]
         Type=forking
         ExecStart=/bin/sh -c 'cat /tmp/aide-report.log | /bin/mail -s "$(hostname) - AIDE Integrity Check"  {{ var_aide_scan_notification_email }}'
-        
+
 {{% else %}}
 - name: "{{{ rule_title }}}"
   cron:

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/bash/shared.sh
@@ -25,6 +25,9 @@ cat > /etc/systemd/system/aidecheck-notify.service <<NOTIFYEOF
         ExecStart=/bin/sh -c 'cat /tmp/aide-report.log | /bin/mail -s "$(hostname) - AIDE Integrity Check"  $var_aide_scan_notification_email'
 NOTIFYEOF
 {{% else %}}
+CRONTAB=/etc/crontab
+CRONDIRS='/etc/cron.d /etc/cron.daily /etc/cron.weekly /etc/cron.monthly'
+
 # NOTE: on some platforms, /etc/crontab may not exist
 if [ -f /etc/crontab ]; then
 	CRONTAB_EXIST=/etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/bash/shared.sh
@@ -3,9 +3,28 @@
 {{{ bash_package_install("aide") }}}
 {{{ bash_instantiate_variables("var_aide_scan_notification_email") }}}
 
-CRONTAB=/etc/crontab
-CRONDIRS='/etc/cron.d /etc/cron.daily /etc/cron.weekly /etc/cron.monthly'
-
+{{% if product in ["sle15"] %}}
+# create unit file for periodic aide database check
+cat > /etc/systemd/system/aidecheck.service <<CHECKEOF
+[Unit]
+        Description=Aide Check
+        Before=aidecheck-notify.service
+        Wants=aidecheck-notify.service
+        [Service]
+        Type=forking
+        ExecStart={{{ aide_bin_path }}} --check -r file:/tmp/aide-report.log
+        [Install]
+        WantedBy=multi-user.target
+CHECKEOF
+cat > /etc/systemd/system/aidecheck-notify.service <<NOTIFYEOF
+[Unit]        
+        Description=Status email for AIDE check result
+        After=aidecheck.service
+        [Service]
+        Type=forking
+        ExecStart=/bin/sh -c 'cat /tmp/aide-report.log | /bin/mail -s "$(hostname) - AIDE Integrity Check"  {{ var_aide_scan_notification_email }}'
+NOTIFYEOF
+{{% else %}}
 # NOTE: on some platforms, /etc/crontab may not exist
 if [ -f /etc/crontab ]; then
 	CRONTAB_EXIST=/etc/crontab
@@ -18,4 +37,4 @@ fi
 if ! grep -qR '^.*{{{ aide_bin_path }}}\s*\-\-check.*|.*\/bin\/mail\s*-s\s*".*"\s*.*@.*$' $CRONTAB_EXIST $VARSPOOL $CRONDIRS; then
 	echo "0 5 * * * root {{{ aide_bin_path }}}  --check | /bin/mail -s \"\$(hostname) - AIDE Integrity Check\" $var_aide_scan_notification_email" >> $CRONTAB
 fi
-
+{{% endif %}}

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/bash/shared.sh
@@ -12,7 +12,7 @@ cat > /etc/systemd/system/aidecheck.service <<CHECKEOF
         Wants=aidecheck-notify.service
         [Service]
         Type=forking
-        ExecStart={{{ aide_bin_path }}} --check -r file:/tmp/aide-report.log
+        ExecStart=/usr/bin/aide --check -r file:/tmp/aide-report.log
         [Install]
         WantedBy=multi-user.target
 CHECKEOF
@@ -22,7 +22,7 @@ cat > /etc/systemd/system/aidecheck-notify.service <<NOTIFYEOF
         After=aidecheck.service
         [Service]
         Type=forking
-        ExecStart=/bin/sh -c 'cat /tmp/aide-report.log | /bin/mail -s "$(hostname) - AIDE Integrity Check"  {{ var_aide_scan_notification_email }}'
+        ExecStart=/bin/sh -c 'cat /tmp/aide-report.log | /bin/mail -s "$(hostname) - AIDE Integrity Check"  $var_aide_scan_notification_email'
 NOTIFYEOF
 {{% else %}}
 # NOTE: on some platforms, /etc/crontab may not exist

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/bash/shared.sh
@@ -17,7 +17,7 @@ cat > /etc/systemd/system/aidecheck.service <<CHECKEOF
         WantedBy=multi-user.target
 CHECKEOF
 cat > /etc/systemd/system/aidecheck-notify.service <<NOTIFYEOF
-[Unit]        
+[Unit]
         Description=Status email for AIDE check result
         After=aidecheck.service
         [Service]

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/oval/shared.xml
@@ -11,6 +11,7 @@
           test_ref="test_aide_var_cron_notification" />
         <criterion comment="notify personnel when aide completes in cron.(d|daily|weekly|monthly)"
           test_ref="test_aide_crontabs_notification" />
+{{% if product in ["sle15"] %}}
         <criteria operator="AND">
           <criterion comment="notification started after check"
             test_ref="test_aidecheck_systemd_scan_before_notification"/>
@@ -19,6 +20,7 @@
           <criterion comment="systemd aidecheck scan notification test"
             test_ref="test_aidecheck_systemd_scan_report"/>
         </criteria>
+{{% endif %}}
       </criteria>
     </criteria>
   </definition>
@@ -50,6 +52,7 @@
     <ind:pattern operation="pattern match">^.*{{{ aide_bin_path }}}[\s]*\-\-check.*\|.*/bin/mail[\s]*-s[\s]*".*"[\s]*.+@.+$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
+{{% if product in ["sle15"] %}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
     id="test_aidecheck_systemd_scan_report" version="1"
     comment="report results of aide check, when started by systemd">
@@ -83,4 +86,5 @@
     <ind:pattern operation="pattern match">^Wants\=.*aidecheck-notify.service.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
+{{% endif %}}
 </def-group>

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/oval/shared.xml
@@ -5,9 +5,20 @@
     <criteria operator="AND">
       <extend_definition comment="Aide is installed" definition_ref="package_aide_installed" />
       <criteria operator="OR">
-        <criterion comment="notify personnel when aide completes" test_ref="test_aide_scan_notification" />
-        <criterion comment="notify personnel when aide completes" test_ref="test_aide_var_cron_notification" />
-        <criterion comment="notify personnel when aide completes in cron.(d|daily|weekly|monthly)" test_ref="test_aide_crontabs_notification" />
+        <criterion comment="notify personnel when aide completes"
+          test_ref="test_aide_scan_notification" />
+        <criterion comment="notify personnel when aide completes"
+          test_ref="test_aide_var_cron_notification" />
+        <criterion comment="notify personnel when aide completes in cron.(d|daily|weekly|monthly)"
+          test_ref="test_aide_crontabs_notification" />
+        <criteria operator="AND">
+          <criterion comment="notification started after check"
+            test_ref="test_aidecheck_systemd_scan_before_notification"/>
+          <criterion comment="systemd aidecheck wants notification"
+            test_ref="test_aidecheck_systemd_scan_wants_notification"/>
+          <criterion comment="systemd aidecheck scan notification test"
+            test_ref="test_aidecheck_systemd_scan_report"/>
+        </criteria>
       </criteria>
     </criteria>
   </definition>
@@ -39,5 +50,37 @@
     <ind:pattern operation="pattern match">^.*{{{ aide_bin_path }}}[\s]*\-\-check.*\|.*/bin/mail[\s]*-s[\s]*".*"[\s]*.+@.+$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
-   
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+    id="test_aidecheck_systemd_scan_report" version="1"
+    comment="report results of aide check, when started by systemd">
+    <ind:object object_ref="obj_aidecheck_systemd_report" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_aidecheck_systemd_report" version="1"
+    comment="run aide check with output to a report file">
+    <ind:filepath>/etc/systemd/system/aidecheck.service</ind:filepath>
+    <ind:pattern operation="pattern match">^ExecStart\=.*/usr/bin/aide[\s]*\-\-check.*\-r\s*file:\/w*.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+    id="test_aidecheck_systemd_scan_before_notification" version="1"
+    comment="aide check is run before notification service">
+    <ind:object object_ref="obj_aidecheck_systemd_before_notification" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_aidecheck_systemd_before_notification" version="1"
+    comment="run aide check before notification">
+    <ind:filepath>/etc/systemd/system/aidecheck.service</ind:filepath>
+    <ind:pattern operation="pattern match">^Before\=.*aidecheck-notify.service$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_test check="all" check_existence="any_exist"
+    comment="aide check systemd unit wants notification service"
+    id="test_aidecheck_systemd_scan_wants_notification" version="1">
+    <ind:object object_ref="object_aidecheck_for_notification_enabled"/>
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_aidecheck_for_notification_enabled" version="1"
+    comment="list of dependencies should include aidecheck.service">
+    <ind:filepath>/etc/systemd/system/aidecheck.service</ind:filepath>
+    <ind:pattern operation="pattern match">^Wants\=.*aidecheck-notify.service.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/rule.yml
@@ -57,23 +57,41 @@ ocil_clause: 'AIDE has not been configured or has not been configured to notify 
 
 ocil: |-
     To determine that periodic AIDE execution has been scheduled, run the following command:
+{{% if product in ["sle15"] %}}
+    <pre>$ sudo systemctl status  aidecheck-notify|grep loaded</pre>
+    The output should return that the service is loaded.
+    Also we should make sure that notification service is started by the check:
+    <pre>$ sudo systemctl list-dependencies --reverse aidecheck-notify</pre>,
+    which should display the aidecheck.service in the dependency tree
+{{% else %}}
     <pre>$ grep aide /etc/crontab</pre>
     The output should return something similar to the following:
     <pre>05 4 * * * root /usr/sbin/aide --check | /bin/mail -s "$(hostname) - AIDE Integrity Check" root@localhost</pre>
     The email address that the notifications are sent to can be changed by overriding
     <pre><sub idref="var_aide_scan_notification_email" /></pre>.
+{{% endif %}}
 
 fixtext: |-
     Configure the file integrity tool to run automatically on the system at least weekly and to notify designated personnel if baseline configurations are changed in an unauthorized manner.
     The AIDE tool can be configured to email designated personnel with the use of the cron system.
 
     The following example output is generic. It will set cron to run AIDE daily and to send email at the completion of the analysis.
-
+{{% if product in ["sle15"] %}}
+    $ cat > /etc/systemd/system/aidecheck-notify.service <<NOTIFYEOF
+    [Unit]
+        Description=Status email for AIDE check result
+        After=aidecheck.service
+        [Service]
+        Type=forking
+        ExecStart=/bin/sh -c 'cat /tmp/aide-report.log | /bin/mail -s "$(hostname) - AIDE Integrity Check"  $var_aide_scan_notification_email'
+    NOTIFYEOF
+{{% else %}}
     $ sudo more /etc/cron.daily/aide
 
     #!/bin/bash
 
     /usr/sbin/aide --check | /bin/mail -s "$HOSTNAME - Daily aide integrity check run" root@sysname.mil
+{{% endif %}}
 
 srg_requirement: |-
     The {{{ full_name }}} file integrity tool must notify the system administrator when changes to the baseline configuration or anomalies in the operation of any security functions are discovered within an organizationally defined frequency.


### PR DESCRIPTION
#### Description:

- Make sure that for SLE15 platform the AIDE periodic check is done via systemd unit and also improve the notification rule so it can be done via systemd unit also

#### Rationale:

- Make sure to use aide_periodic_checking_systemd_timer for sle15 platform
- Add OVAL checks that allow notification to be implemented via systemd unit
- Add SLE15 specific BASH and Ansible remediation for aide check notification
