### PR TITLE
build perf: avoid thousands of needless file opens and yaml parses

### DIFF
--- a/ssg/components.py
+++ b/ssg/components.py
@@ -1,11 +1,13 @@
 from __future__ import print_function
 
 from collections import defaultdict
+from functools import cache
 import os
 
 import ssg.yaml
 
 
+@cache # A speed up cache. We have been opening these same 150 files 300 times per a product build.
 def load(components_dir):
     components = {}
     for component_filename in os.listdir(components_dir):


### PR DESCRIPTION
Avoid hundred thousands of useless yaml parses on make all products

This Speeds up rhel8 build for me by 5 seconds.

## Explainer

The `load()` function is parsing ./components/*.yml every time it is called. Unfortunately, it is being called at least once per Xccdf:Rule or Xccdf:Group in the benchmark. So for instance, with rhel9 the `load()` function is called 187 times. Each time it is called, it needs to parse those 150 yaml files in ./components/ directory thus it leads to 27900 useless yaml parses just per rhel9.

## Before ( ~ 29s)
    # time make rhel8-compile-all
    [rhel8-content] generating sce/metadata.json
    Built target generate-internal-rhel8-sce-metadata.json
    [rhel8-content] compiling product yaml
    [rhel8-content] compiling everything
    Built target rhel8-compile-all

    real    0m29.446s
    user    0m27.508s
    sys     0m1.720s

## After ( ~24s)

    time make rhel8-compile-all
    [rhel8-content] generating sce/metadata.json
    Built target generate-internal-rhel8-sce-metadata.json
    [rhel8-content] compiling product yaml
    [rhel8-content] compiling everything
    Built target rhel8-compile-all

    real    0m24.772s
    user    0m23.141s
    sys     0m1.485s