### PR TITLE
Make package installation for iptables and nftables mutually exclusive

### DIFF
--- a/linux_os/guide/system/network/network-iptables/package_iptables_installed/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/package_iptables_installed/rule.yml
@@ -1,7 +1,7 @@
 documentation_complete: true
 
 
-platform: machine and not rhcos4-rhel9 and not package[nftables] and not package[ufw]
+platform: machine and not rhcos4-rhel9 and service_disabled[nftables] and service_disabled[ufw]
 
 title: 'Install iptables Package'
 

--- a/linux_os/guide/system/network/network-iptables/package_iptables_installed/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/package_iptables_installed/rule.yml
@@ -1,7 +1,7 @@
 documentation_complete: true
 
 
-platform: machine and not rhcos4-rhel9
+platform: machine and not rhcos4-rhel9 and not package[nftables] and not package[ufw]
 
 title: 'Install iptables Package'
 

--- a/linux_os/guide/system/network/network-nftables/package_nftables_installed/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/package_nftables_installed/rule.yml
@@ -32,7 +32,7 @@ ocil_clause: 'the package is not installed'
 
 ocil: '{{{ ocil_package(package="nftables") }}}'
 
-platform: machine and not package[iptables] and not package[ufw]
+platform: machine and service_disabled[iptables] and service_disabled[ufw]
 
 template:
     name: package_installed

--- a/linux_os/guide/system/network/network-nftables/package_nftables_installed/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/package_nftables_installed/rule.yml
@@ -32,7 +32,7 @@ ocil_clause: 'the package is not installed'
 
 ocil: '{{{ ocil_package(package="nftables") }}}'
 
-platform: machine
+platform: machine and not package[iptables] and not package[ufw]
 
 template:
     name: package_installed

--- a/shared/applicability/service_disabled.yml
+++ b/shared/applicability/service_disabled.yml
@@ -7,3 +7,12 @@ args:
   firewalld:
       servicename: firewalld
       packagename: firewalld
+  iptables:
+      servicename: iptables
+      packagename: iptables
+  nftables:
+      servicename: nftables
+      packagename: nftables
+  ufw:
+      servicename: ufw
+      packagename: ufw


### PR DESCRIPTION
#### Description:

- Make package installation rules for iptables and nftables mutually exclusive

#### Rationale:

- nftables related rule rely on nftables package being installed, same is valid for iptables related rules, but the package_installed rules do not reflect the conflict between the two approaches so remediation of one package_installed_ rule breaks the other dependant rules and vice versa

#### Review Hints:

- _Review hints here. Replace this text. Don't use the italics format!_

- _Use this optional section to give any relevant information which could help the reviewer to more quickly and assertively understand and test the changes._

- _Good examples are useful commands, if it is better to review all commits together or in a suggested sequence, any relevant discussion in other PRs or issues, etc._