### PR TITLE
Corrections in bash/ansible remedition of the rule audit_rules_privil…

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_ubuntu
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_ubuntu
 
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 {{{ bash_fix_audit_watch_rule("auditctl", "/usr/bin/kmod", "x", "modules") }}}


### PR DESCRIPTION
…eged_commands_kmod

#### Description:

- _Fix is necessary because the rule does not work as expected on SLE 12/15_

#### Rationale:

- _Because the rule uses template - ansbibe/bash remediation do not require sle_
