### PR TITLE
Skip fontconfig verification due to temporary issue with SLES platforms

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/oval/shared.xml
@@ -13,7 +13,11 @@
   </linux:rpmverifyfile_test>
   <linux:rpmverifyfile_object id="object_files_fail_mode" version="1" comment="rpm verify of all files">
     <linux:behaviors nomd5="true" noghostfiles="true"/>
-    <linux:name operation="pattern match">.*</linux:name>
+    {{% if product in ["sle12", "sle15"] %}}
+      <linux:name operation="not equal">fontconfig</linux:name>
+    {{% else %}}
+      <linux:name operation="pattern match">.*</linux:name>
+    {{% endif %}}
     <linux:epoch operation="pattern match">.*</linux:epoch>
     <linux:version operation="pattern match">.*</linux:version>
     <linux:release operation="pattern match">.*</linux:release>


### PR DESCRIPTION

#### Description:

- Ignore fontconfig packet on rpm_verify_permissions check

#### Rationale:

- Currently the fonts-config packet modifies a file owned by the fontconfig, which causes false positive failure of the rpm_verify_permissions test



