### PR TITLE
Minor fix for pam_faillock regex on Ubuntu (5.4.2)

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/oval/ubuntu.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/oval/ubuntu.xml
@@ -40,7 +40,7 @@
   <constant_variable id="var_accounts_passwords_pam_faillock_deny_pam_faillock_account_regex"
                 datatype="string" version="1"
                 comment="regex to identify pam_faillock.so entry in account section of pam files">
-    <value>^\s*account\s+required\s+pam_faillock\.so$</value>
+    <value>^\s*account\s+required\s+pam_faillock\.so\s*(#.*)?$</value>
   </constant_variable>
 
   <constant_variable

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/oval/ubuntu.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/oval/ubuntu.xml
@@ -40,7 +40,7 @@
   <constant_variable id="var_accounts_passwords_pam_faillock_interval_pam_faillock_account_regex"
                 datatype="string" version="1"
                 comment="regex to identify pam_faillock.so entry in account section of pam files">
-    <value>^\s*account\s+required\s+pam_faillock\.so$</value>
+    <value>^\s*account\s+required\s+pam_faillock\.so\s*(#.*)?$</value>
   </constant_variable>
 
   <constant_variable

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/ubuntu.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/ubuntu.xml
@@ -40,7 +40,7 @@
   <constant_variable id="var_accounts_passwords_pam_faillock_unlock_time_pam_faillock_account_regex"
                 datatype="string" version="1"
                 comment="regex to identify pam_faillock.so entry in account section of pam files">
-    <value>^\s*account\s+required\s+pam_faillock\.so$</value>
+    <value>^\s*account\s+required\s+pam_faillock\.so\s*(#.*)?$</value>
   </constant_variable>
 
   <constant_variable


### PR DESCRIPTION
#### Description:

Fixed regex to allow trailing whitespaces and comments

#### Rationale:

- Fixes #11200

#### Review Hints:
