### PR TITLE
Prepare OVAL object model for integration

### DIFF
--- a/ssg/build_ovals.py
+++ b/ssg/build_ovals.py
@@ -19,6 +19,7 @@ from .rules import get_rule_dir_ovals, find_rule_dirs_in_paths
 from . import utils, products
 from .utils import mkdir_p
 from .xml import ElementTree, oval_generated_header
+from .oval_object_model import get_product_name
 
 
 def _create_subtree(shorthand_tree, category):
@@ -74,14 +75,7 @@ def _check_is_applicable_for_product(oval_check_def, product):
 
     for afftype in affected_type_elements:
         # Get official name for product (prefixed with content of afftype)
-        product_name = afftype + utils.map_name(product)
-        # Append the product version to the official name
-        if product_version is not None:
-            # Some product versions have a dot in between the numbers
-            # While the prodtype doesn't have the dot, the full product name does
-            if product == "ubuntu" or product == "macos":
-                product_version = product_version[:2] + "." + product_version[2:]
-            product_name += ' ' + product_version
+        product_name = afftype + get_product_name(product, product_version)
 
         # Test if this OVAL check is for the concrete product version
         if product_name in oval_check_def:

--- a/ssg/oval_object_model/__init__.py
+++ b/ssg/oval_object_model/__init__.py
@@ -5,15 +5,11 @@ from .general import (
     OVALComponent,
     OVALEntity,
     OVALEntityProperty,
-    load_oval_entity_property,
     load_notes,
     get_product_name,
+    load_oval_entity_property,
 )
-from .oval_document import (
-    ExceptionDuplicateOVALEntity,
-    OVALDocument,
-    load_oval_document,
-)
+from .oval_document import OVALDocument, load_oval_document
 from .oval_entities import (
     ExceptionDuplicateObjectReferenceInTest,
     ExceptionMissingObjectReferenceInTest,

--- a/ssg/oval_object_model/__init__.py
+++ b/ssg/oval_object_model/__init__.py
@@ -7,6 +7,7 @@ from .general import (
     OVALEntityProperty,
     load_oval_entity_property,
     load_notes,
+    get_product_name,
 )
 from .oval_document import (
     ExceptionDuplicateOVALEntity,

--- a/ssg/oval_object_model/__init__.py
+++ b/ssg/oval_object_model/__init__.py
@@ -9,6 +9,7 @@ from .general import (
     get_product_name,
     load_oval_entity_property,
 )
+from .oval_container import ExceptionDuplicateOVALEntity
 from .oval_document import OVALDocument, load_oval_document
 from .oval_entities import (
     ExceptionDuplicateObjectReferenceInTest,

--- a/ssg/oval_object_model/__init__.py
+++ b/ssg/oval_object_model/__init__.py
@@ -10,7 +10,7 @@ from .general import (
     load_oval_entity_property,
 )
 from .oval_container import ExceptionDuplicateOVALEntity
-from .oval_document import OVALDocument, load_oval_document
+from .oval_document import MissingOVALComponent, OVALDocument, load_oval_document
 from .oval_entities import (
     ExceptionDuplicateObjectReferenceInTest,
     ExceptionMissingObjectReferenceInTest,

--- a/ssg/oval_object_model/general.py
+++ b/ssg/oval_object_model/general.py
@@ -102,6 +102,12 @@ class OVALEntity(OVALComponent):
         super(OVALEntity, self).__init__(tag, id_)
         self.properties = properties
 
+    def _get_references(self, key):
+        out = []
+        for property_ in self.properties:
+            out.extend(property_.get_values_by_key(key))
+        return out
+
     def get_xml_element(self, **attributes):
         el = super(OVALEntity, self).get_xml_element()
 
@@ -202,3 +208,13 @@ class OVALEntityProperty(OVALBaseObject):
             property_el.append(child.get_xml_element())
 
         return property_el
+
+    def get_values_by_key(self, key):
+        out = []
+        if self.attributes and key in self.attributes:
+            out.append(self.attributes.get(key))
+        if key in self.tag:
+            out.append(self.text)
+        for property_ in self.properties:
+            out.extend(property_.get_values_by_key(key))
+        return out

--- a/ssg/oval_object_model/general.py
+++ b/ssg/oval_object_model/general.py
@@ -1,8 +1,8 @@
 import re
+
 from ..constants import BOOL_TO_STR, xsi_namespace
 from ..xml import ElementTree
 from .. import utils
-
 
 # ----- General functions
 

--- a/ssg/oval_object_model/general.py
+++ b/ssg/oval_object_model/general.py
@@ -1,6 +1,7 @@
 import re
 from ..constants import BOOL_TO_STR, xsi_namespace
 from ..xml import ElementTree
+from .. import utils
 
 
 # ----- General functions
@@ -12,6 +13,28 @@ def required_attribute(_xml_el, _key):
     raise ValueError(
         "%s is required but was not found in:\n%s" % (_key, repr(_xml_el.attrib))
     )
+
+
+def get_product_name(product, product_version=None):
+    # Current SSG checks aren't unified which element of '<platform>'
+    # and '<product>' to use as OVAL AffectedType metadata element,
+    # e.g. Chromium content uses both of them across the various checks
+    # Thus for now check both of them when checking concrete platform / product
+
+    # Get official name for product (prefixed with content of afftype)
+    product_name = utils.map_name(product)
+
+    # Append the product version to the official name
+    if product_version is not None:
+        product_name += " " + utils.get_fixed_product_version(product, product_version)
+    return product_name
+
+
+def is_product_name_in(list_, product_name):
+    for item in list_ if list_ is not None else []:
+        if product_name in item:
+            return True
+    return False
 
 
 # ----- General Objects

--- a/ssg/oval_object_model/oval_container.py
+++ b/ssg/oval_object_model/oval_container.py
@@ -1,0 +1,224 @@
+import logging
+
+from .general import OVALBaseObject
+from .oval_definition_references import OVALDefinitionReference
+from .oval_entities import (
+    load_definition,
+    load_object,
+    load_state,
+    load_test,
+    load_variable,
+)
+
+
+class ExceptionDuplicateOVALEntity(Exception):
+    pass
+
+
+def _is_external_variable(component):
+    return "external_variable" in component.tag
+
+
+def _handle_existing_id(component, component_dict):
+    # ID is identical, but OVAL entities are semantically different =>
+    # report and error and exit with failure
+    # Fixes: https://github.com/ComplianceAsCode/content/issues/1275
+    if (
+        component != component_dict[component.id_]
+        and not _is_external_variable(component)
+        and not _is_external_variable(component_dict[component.id_])
+    ):
+        # This is an error scenario - since by skipping second
+        # implementation and using the first one for both references,
+        # we might evaluate wrong requirement for the second entity
+        # => report an error and exit with failure in that case
+        # See
+        #   https://github.com/ComplianceAsCode/content/issues/1275
+        # for a reproducer and what could happen in this case
+        raise ExceptionDuplicateOVALEntity(
+            (
+                "ERROR: it's not possible to use the same ID: {} for two semantically"
+                " different OVAL entities:\nFirst entity:\n{}\nSecond entity:\n{}\n"
+                "Use different ID for the second entity!!!\n"
+            ).format(
+                component.id_,
+                str(component),
+                str(component_dict[component.id_]),
+            )
+        )
+    elif not _is_external_variable(component):
+        # If OVAL entity is identical, but not external_variable, the
+        # implementation should be rewritten each entity to be present
+        # just once
+        logging.info(
+            (
+                "OVAL ID {} is used multiple times and should represent "
+                "the same elements.\nRewrite the OVAL checks. Place the identical IDs"
+                " into their own definition and extend this definition by it.\n"
+            ).format(component.id_)
+        )
+
+
+def add_oval_component(component, component_dict):
+    if component.id_ not in component_dict:
+        component_dict[component.id_] = component
+    else:
+        _handle_existing_id(component, component_dict)
+
+
+def _copy_component(destination, source_of_components):
+    for component in source_of_components.values():
+        add_oval_component(component, destination)
+
+
+def _remove_keys_from_dict(to_remove, dict_):
+    for k in to_remove:
+        del dict_[k]
+
+
+def _keep_keys_in_dict(dict_, to_keep):
+    to_remove = [key for key in dict_ if key not in to_keep]
+    _remove_keys_from_dict(to_remove, dict_)
+
+
+def _save_referenced_vars(ref, entity):
+    ref.save_variables(entity.get_variable_references())
+
+
+def _save_definitions_references(ref, definition):
+    if definition.criteria:
+        ref.save_tests(definition.criteria.get_test_references())
+        ref.save_definitions(definition.criteria.get_extend_definition_references())
+
+
+def _save_test_references(ref, test):
+    ref.save_object(test.object_ref)
+    ref.save_states(test.state_refs)
+
+
+def _save_object_references(ref, object_):
+    _save_referenced_vars(ref, object_)
+    ref.save_states(object_.get_state_references())
+    ref.save_objects(object_.get_object_references())
+
+
+def _save_variable_references(ref, variable):
+    _save_referenced_vars(ref, variable)
+    ref.save_objects(variable.get_object_references())
+
+
+class OVALContainer(OVALBaseObject):
+    def __init__(self):
+        self.definitions = {}
+        self.tests = {}
+        self.objects = {}
+        self.states = {}
+        self.variables = {}
+
+    def _call_function_for_every_component(self, _function, object_):
+        _function(self.definitions, object_.definitions)
+        _function(self.tests, object_.tests)
+        _function(self.objects, object_.objects)
+        _function(self.states, object_.states)
+        _function(self.variables, object_.variables)
+
+    def load_definition(self, oval_definition_xml_el):
+        definition = load_definition(oval_definition_xml_el)
+        add_oval_component(definition, self.definitions)
+
+    def load_test(self, oval_test_xml_el):
+        test = load_test(oval_test_xml_el)
+        add_oval_component(test, self.tests)
+
+    def load_object(self, oval_object_xml_el):
+        object_ = load_object(oval_object_xml_el)
+        add_oval_component(object_, self.objects)
+
+    def load_state(self, oval_state_xml_element):
+        state = load_state(oval_state_xml_element)
+        add_oval_component(state, self.states)
+
+    def load_variable(self, oval_variable_xml_element):
+        variable = load_variable(oval_variable_xml_element)
+        add_oval_component(variable, self.variables)
+
+    def add_content_of_container(self, container):
+        self._call_function_for_every_component(_copy_component, container)
+
+    @staticmethod
+    def _skip_if_is_none(value, component_id):
+        raise NotImplementedError()
+
+    def _process_component(self, ref, type_, function_save_refs):
+        MAP_COMPONENT_DICT = {
+            "definitions": self.definitions,
+            "tests": self.tests,
+            "objects": self.objects,
+            "states": self.states,
+            "variables": self.variables,
+        }
+        source = MAP_COMPONENT_DICT.get(type_)
+        to_process, id_getter = ref.get_to_process_dict_and_id_getter(type_)
+        while to_process:
+            id_ = id_getter()
+            entity = source.get(id_)
+            if self._skip_if_is_none(entity, id_):
+                continue
+            function_save_refs(ref, entity)
+
+    def _process_definition_references(self, ref):
+        self._process_component(
+            ref,
+            "definitions",
+            _save_definitions_references,
+        )
+
+    def _process_test_references(self, ref):
+        self._process_component(
+            ref,
+            "tests",
+            _save_test_references,
+        )
+
+    def _process_object_references(self, ref):
+        self._process_component(
+            ref,
+            "objects",
+            _save_object_references,
+        )
+
+    def _process_state_references(self, ref):
+        self._process_component(
+            ref,
+            "states",
+            _save_referenced_vars,
+        )
+
+    def _process_variable_references(self, ref):
+        self._process_component(
+            ref,
+            "variables",
+            _save_variable_references,
+        )
+
+    def _process_objects_states_variables_references(self, ref):
+        while (
+            ref.to_process_objects or ref.to_process_states or ref.to_process_variables
+        ):
+            self._process_object_references(ref)
+            self._process_state_references(ref)
+            self._process_variable_references(ref)
+
+    def get_all_references_of_definition(self, definition_id):
+        if definition_id not in self.definitions:
+            raise ValueError(
+                "ERROR: OVAL definition '{}' doesn't exist.".format(definition_id)
+            )
+        ref = OVALDefinitionReference(definition_id)
+        self._process_definition_references(ref)
+        self._process_test_references(ref)
+        self._process_objects_states_variables_references(ref)
+        return ref
+
+    def keep_referenced_components(self, ref):
+        self._call_function_for_every_component(_keep_keys_in_dict, ref)

--- a/ssg/oval_object_model/oval_definition_references.py
+++ b/ssg/oval_object_model/oval_definition_references.py
@@ -1,0 +1,117 @@
+def _process(list_, to_process_list):
+    id_ = to_process_list.pop()
+    if id_ not in list_:
+        list_.append(id_)
+    return id_
+
+
+def _save(id_, list_, to_process_list):
+    if id_ not in list_:
+        list_.append(id_)
+        to_process_list.append(id_)
+
+
+def _save_multiple(list_of_ids, list_, to_process_list):
+    for id_ in list_of_ids:
+        _save(id_, list_, to_process_list)
+
+
+class OVALDefinitionReference:
+    def __init__(self, definition_id=None):
+        self.definitions = []
+        self.to_process_definitions = []
+        if definition_id is not None:
+            self.definitions.append(definition_id)
+            self.to_process_definitions.append(definition_id)
+
+        self.tests = []
+        self.objects = []
+        self.states = []
+        self.variables = []
+
+        self.to_process_tests = []
+        self.to_process_objects = []
+        self.to_process_states = []
+        self.to_process_variables = []
+
+    def is_done(self):
+        return (
+            len(self.to_process_definitions) == 0
+            and len(self.to_process_tests) == 0
+            and len(self.to_process_objects) == 0
+            and len(self.to_process_states) == 0
+            and len(self.to_process_variables) == 0
+        )
+
+    def __iadd__(self, other):
+        self.definitions.extend(other.definitions)
+        self.tests.extend(other.tests)
+        self.objects.extend(other.objects)
+        self.states.extend(other.states)
+        self.variables.extend(other.variables)
+        return self
+
+    def __repr__(self):
+        return str(self.__dict__)
+
+    def get_to_process_dict_and_id_getter(self, key):
+        MAP_ID_GETTERS = {
+            "definitions": self.process_definition,
+            "tests": self.process_test,
+            "objects": self.process_object,
+            "states": self.process_state,
+            "variables": self.process_variable,
+        }
+        MAP_TO_PROCESS = {
+            "definitions": self.to_process_definitions,
+            "tests": self.to_process_tests,
+            "objects": self.to_process_objects,
+            "states": self.to_process_states,
+            "variables": self.to_process_variables,
+        }
+        return (MAP_TO_PROCESS.get(key), MAP_ID_GETTERS.get(key))
+
+    def process_definition(self):
+        return _process(self.definitions, self.to_process_definitions)
+
+    def save_definition(self, id_):
+        _save(id_, self.definitions, self.to_process_definitions)
+
+    def save_definitions(self, definition_ids):
+        _save_multiple(definition_ids, self.definitions, self.to_process_definitions)
+
+    def process_test(self):
+        return _process(self.tests, self.to_process_tests)
+
+    def save_test(self, id_):
+        _save(id_, self.tests, self.to_process_tests)
+
+    def save_tests(self, test_ids):
+        _save_multiple(test_ids, self.tests, self.to_process_tests)
+
+    def process_object(self):
+        return _process(self.objects, self.to_process_objects)
+
+    def save_object(self, id_):
+        _save(id_, self.objects, self.to_process_objects)
+
+    def save_objects(self, object_ids):
+        _save_multiple(object_ids, self.objects, self.to_process_objects)
+
+    def process_state(self):
+        return _process(self.states, self.to_process_states)
+
+    def save_state(self, id_):
+        _save(id_, self.states, self.to_process_states)
+
+    def save_states(self, state_ids):
+        _save_multiple(state_ids, self.states, self.to_process_states)
+
+    def process_variable(self):
+        return _process(self.variables, self.to_process_variables)
+
+    def save_variable(self, id_):
+        _save(id_, self.variables, self.to_process_variables)
+
+    def save_variables(self, variable_ids):
+        _save_multiple(variable_ids, self.variables, self.to_process_variables)

--- a/ssg/oval_object_model/oval_document.py
+++ b/ssg/oval_object_model/oval_document.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import sys
 import platform
 
 from ..constants import oval_footer, oval_header, timestamp

--- a/ssg/oval_object_model/oval_entities/__init__.py
+++ b/ssg/oval_object_model/oval_entities/__init__.py
@@ -9,7 +9,6 @@ from .definition import (
     Reference,
     load_definition,
 )
-
 from .object import ObjectOVAL, load_object
 from .state import State, load_state
 from .test import (

--- a/ssg/oval_object_model/oval_entities/definition.py
+++ b/ssg/oval_object_model/oval_entities/definition.py
@@ -1,6 +1,7 @@
-import sys
+import logging
 
-from ...constants import BOOL_TO_STR, OVAL_NAMESPACES, STR_TO_BOOL, MULTI_PLATFORM_LIST
+from ... import utils
+from ...constants import BOOL_TO_STR, MULTI_PLATFORM_LIST, OVAL_NAMESPACES, STR_TO_BOOL
 from ...xml import ElementTree
 from ..general import (
     OVALBaseObject,
@@ -10,7 +11,6 @@ from ..general import (
     is_product_name_in,
     get_product_name,
 )
-from ... import utils
 
 
 class GeneralCriteriaNode(OVALBaseObject):
@@ -96,9 +96,7 @@ def load_criteria(oval_criteria_xml_el):
                 load_terminate_criteria(child_node_el, ExtendDefinition, "definition")
             )
         else:
-            sys.stderr.write(
-                "Warning: Unknown element '{}'\n".format(child_node_el.tag)
-            )
+            logging.warning("Unknown element '{}'\n".format(child_node_el.tag))
     return criteria
 
 

--- a/ssg/oval_object_model/oval_entities/definition.py
+++ b/ssg/oval_object_model/oval_entities/definition.py
@@ -390,6 +390,17 @@ class Definition(OVALComponent):
         self.class_ = class_
         self.metadata = metadata
 
+    def check_affected(self):
+        if (
+            self.metadata.array_of_affected is None
+            or not self.metadata.array_of_affected
+        ):
+            raise ValueError(
+                "Definition '{}' doesn't contain OVAL 'affected' element".format(
+                    self.id_
+                )
+            )
+
     def is_applicable_for_product(self, product):
         return self.metadata.is_applicable_for_product(product)
 

--- a/ssg/oval_object_model/oval_entities/definition.py
+++ b/ssg/oval_object_model/oval_entities/definition.py
@@ -125,6 +125,21 @@ class Criteria(GeneralCriteriaNode):
 
         return criteria_el
 
+    def _get_reference(self, ref_type):
+        out = []
+        for child_criteria_node in self.child_criteria_nodes:
+            if isinstance(child_criteria_node, ref_type):
+                out.append(child_criteria_node.ref)
+            elif isinstance(child_criteria_node, Criteria):
+                out.extend(child_criteria_node._get_reference(ref_type))
+        return out
+
+    def get_test_references(self):
+        return self._get_reference(Criterion)
+
+    def get_extend_definition_references(self):
+        return self._get_reference(ExtendDefinition)
+
 
 # -----
 

--- a/ssg/oval_object_model/oval_entities/definition.py
+++ b/ssg/oval_object_model/oval_entities/definition.py
@@ -229,11 +229,10 @@ class Affected(OVALBaseObject):
         from given OVAL tree. It then adds one platform of the product we are
         building.
         """
-        if type_ == "platform":
-            self.platforms = [full_name]
-
-        if type_ == "product":
-            self.products = [full_name]
+        setattr(self, "{}s".format(type_), [full_name])
+        setattr(
+            self, "{}_tag".format(type_), "{%s}%s" % (OVAL_NAMESPACES.definition, type_)
+        )
 
     def _is_in_platforms(self, multi_prod, product):
         for platform in self.platforms if self.platforms is not None else []:
@@ -273,9 +272,9 @@ class Affected(OVALBaseObject):
         # for this product => return False to indicate that
         return False
 
-    def _add_to_affected_element(self, affected_el, elements):
+    def _add_to_affected_element(self, affected_el, elements, tag):
         for platform in elements if elements is not None else []:
-            platform_el = ElementTree.Element(self.platform_tag)
+            platform_el = ElementTree.Element(tag)
             platform_el.text = platform
             affected_el.append(platform_el)
 
@@ -283,9 +282,8 @@ class Affected(OVALBaseObject):
         affected_el = ElementTree.Element("{}{}".format(self.namespace, self.tag))
         affected_el.set("family", self.family)
 
-        self._add_to_affected_element(affected_el, self.platforms)
-        self._add_to_affected_element(affected_el, self.products)
-
+        self._add_to_affected_element(affected_el, self.platforms, self.platform_tag)
+        self._add_to_affected_element(affected_el, self.products, self.product_tag)
         return affected_el
 
 

--- a/ssg/oval_object_model/oval_entities/object.py
+++ b/ssg/oval_object_model/oval_entities/object.py
@@ -29,3 +29,12 @@ class ObjectOVAL(OVALEntity):
 
     def get_xml_element(self):
         return super(ObjectOVAL, self).get_xml_element()
+
+    def get_variable_references(self):
+        return self._get_references("var_ref")
+
+    def get_state_references(self):
+        return self._get_references("filter")
+
+    def get_object_references(self):
+        return self._get_references("object_reference")

--- a/ssg/oval_object_model/oval_entities/state.py
+++ b/ssg/oval_object_model/oval_entities/state.py
@@ -30,3 +30,6 @@ class State(OVALEntity):
 
     def get_xml_element(self):
         return super(State, self).get_xml_element(operator=self.operator)
+
+    def get_variable_references(self):
+        return self._get_references("var_ref")

--- a/ssg/oval_object_model/oval_entities/test.py
+++ b/ssg/oval_object_model/oval_entities/test.py
@@ -1,7 +1,7 @@
-import sys
+import logging
 
-from ...xml import ElementTree
 from ...constants import OVAL_NAMESPACES, STR_TO_BOOL
+from ...xml import ElementTree
 from ..general import OVALComponent, load_notes, required_attribute
 
 
@@ -29,9 +29,7 @@ def load_test(oval_test_xml_el):
             test.add_state_ref(child_node_el.get("state_ref"))
             test.state_ref_tag = child_node_el.tag
         else:
-            sys.stderr.write(
-                "Warning: Unknown element '{}'\n".format(child_node_el.tag)
-            )
+            logging.warning("Unknown element '{}'\n".format(child_node_el.tag))
     return test
 
 

--- a/ssg/oval_object_model/oval_entities/variable.py
+++ b/ssg/oval_object_model/oval_entities/variable.py
@@ -33,3 +33,9 @@ class Variable(OVALEntity):
 
     def get_xml_element(self):
         return super(Variable, self).get_xml_element(datatype=self.data_type)
+
+    def get_variable_references(self):
+        return self._get_references("var_ref")
+
+    def get_object_references(self):
+        return self._get_references("object_ref")

--- a/ssg/oval_object_model/oval_shorthand.py
+++ b/ssg/oval_object_model/oval_shorthand.py
@@ -1,0 +1,76 @@
+import logging
+
+from ..constants import OVAL_NAMESPACES, oval_footer, oval_header
+from ..xml import ElementTree
+from .oval_container import OVALContainer
+
+
+def _get_xml_element_from_string_shorthand(shorthand):
+    valid_oval_xml_string = "{}{}{}".format(oval_header, shorthand, oval_footer).encode(
+        "utf-8"
+    )
+    xml_element = ElementTree.fromstring(valid_oval_xml_string)
+    return xml_element.findall("./{%s}def-group/*" % OVAL_NAMESPACES.definition)
+
+
+def _is_definition_applicable_for_product(definition, product):
+    if product is None or definition.is_applicable_for_product(product):
+        return True
+
+    logging.info(
+        "Definition '{}' is not applicable for product '{}'.".format(
+            definition.id_, product
+        )
+    )
+    return False
+
+
+def _is_definitions_applicable_for_product(definitions_dict, product):
+    is_present_applicable_definition = []
+    for definition in definitions_dict.values():
+        definition.check_affected()
+
+        is_present_applicable_definition.append(
+            _is_definition_applicable_for_product(definition, product)
+        )
+    return any(is_present_applicable_definition)
+
+
+class OVALShorthand(OVALContainer):
+    def __init__(self):
+        super(OVALShorthand, self).__init__()
+
+    def _load_element(self, xml_el):
+        if xml_el.tag.endswith("definition"):
+            self.load_definition(xml_el)
+        elif xml_el.tag.endswith("_test"):
+            self.load_test(xml_el)
+        elif xml_el.tag.endswith("_object"):
+            self.load_object(xml_el)
+        elif xml_el.tag.endswith("_state"):
+            self.load_state(xml_el)
+        elif xml_el.tag.endswith("_variable"):
+            self.load_variable(xml_el)
+        elif xml_el.tag is not ElementTree.Comment:
+            logging.warning("Unknown element '{}'\n".format(xml_el.tag))
+
+    @staticmethod
+    def _skip_if_is_none(value, component_id):
+        return value is None
+
+    def validate(self, product, rule_id):
+        if not _is_definitions_applicable_for_product(self.definitions, product):
+            return False
+
+        if rule_id is not None and rule_id not in self.definitions:
+            raise ValueError(
+                (
+                    "ERROR: OVAL definition that match the rule ID '{}'"
+                    " do not appear in the shorthand."
+                ).format(rule_id)
+            )
+        return True
+
+    def load_shorthand(self, xml_string):
+        for xml_el in _get_xml_element_from_string_shorthand(xml_string):
+            self._load_element(xml_el)

--- a/ssg/utils.py
+++ b/ssg/utils.py
@@ -179,6 +179,14 @@ def parse_name(product):
     return prod_tuple(_product, _product_version)
 
 
+def get_fixed_product_version(product, product_version):
+    # Some product versions have a dot in between the numbers
+    # While the prodtype doesn't have the dot, the full product name does
+    if product == "ubuntu" or product == "macos":
+        product_version = product_version[:2] + "." + product_version[2:]
+    return product_version
+
+
 def is_applicable_for_product(platform, product):
     """Based on the platform dict specifier of the remediation script to
     determine if this remediation script is applicable for this product.
@@ -203,9 +211,9 @@ def is_applicable_for_product(platform, product):
     product_name = ""
     # Get official name for product
     if product_version is not None:
-        if product == "ubuntu" or product == "macos":
-            product_version = product_version[:2] + "." + product_version[2:]
-        product_name = map_name(product) + ' ' + product_version
+        product_name = map_name(product) + ' ' + get_fixed_product_version(
+            product, product_version
+        )
     else:
         product_name = map_name(product)
 

--- a/tests/unit/ssg-module/data/minimal_oval_of_oval_ssg-sshd_rekey_limit_def.xml
+++ b/tests/unit/ssg-module/data/minimal_oval_of_oval_ssg-sshd_rekey_limit_def.xml
@@ -16,6 +16,9 @@
     <oval-def:reference ref_id="sshd_rekey_limit" source="ssg" />
     <oval-def:description>Ensure RekeyLimit is configured with the appropriate value in /etc/ssh/sshd_config or in /etc/ssh/sshd_config.d</oval-def:description>
    </oval-def:metadata>
+   <oval-def:notes>
+     <oval-def:note>This is note.</oval-def:note>
+   </oval-def:notes>
    <oval-def:criteria comment="sshd is configured correctly or is not installed" operator="OR">
     <oval-def:criteria comment="sshd is not installed" operator="AND">
      <oval-def:extend_definition comment="sshd is not required or requirement is unset" definition_ref="oval:ssg-sshd_not_required_or_unset:def:1" />

--- a/tests/unit/ssg-module/data/shorthand_installed_OS_is_rhel8.xml
+++ b/tests/unit/ssg-module/data/shorthand_installed_OS_is_rhel8.xml
@@ -1,0 +1,358 @@
+<def-group>
+  <definition class="inventory"
+  id="installed_OS_is_rhel8" version="1">
+    <metadata>
+      <title>Red Hat Enterprise Linux 8</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <reference ref_id="cpe:/o:redhat:enterprise_linux:8"
+      source="CPE" />
+      <description>The operating system installed on the system is
+      Red Hat Enterprise Linux 8</description>
+    </metadata>
+    <criteria>
+      <criterion comment="Installed operating system is part of the unix family"
+      test_ref="test_rhel8_unix_family" />
+      <criteria operator="OR">
+        <criterion comment="RHEL 8 is installed" test_ref="test_rhel8" />
+        <criteria operator="AND" comment="Red Hat Enterprise Virtualization Host is installed">
+          <criterion comment="Red Hat Virtualization Host (RHVH)" test_ref="test_rhvh4_version" />
+          <criterion comment="Red Hat Enterprise Virtualization Host is based on RHEL 8" test_ref="test_rhevh_rhel8_version" />
+        </criteria>
+      </criteria>
+    </criteria>
+  </definition>
+
+  <ind:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="test_rhel8_unix_family" version="1">
+    <ind:object object_ref="obj_rhel8_unix_family" />
+    <ind:state state_ref="state_rhel8_unix_family" />
+  </ind:family_test>
+  <ind:family_state id="state_rhel8_unix_family" version="1">
+    <ind:family>unix</ind:family>
+  </ind:family_state>
+  <ind:family_object id="obj_rhel8_unix_family" version="1" />
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release is version 8" id="test_rhel8" version="1">
+    <linux:object object_ref="obj_rhel8" />
+    <linux:state state_ref="state_rhel8" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_rhel8" version="1">
+    <linux:version operation="pattern match">^8.*$</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_rhel8" version="1">
+    <linux:name>redhat-release</linux:name>
+  </linux:rpminfo_object>
+
+
+  <definition class="inventory" id="installed_OS_is_rhel8_0" version="1">
+    <metadata>
+      <title>Red Hat Enterprise Linux 8.0</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 8.0</platform>
+      </affected>
+      <reference ref_id="cpe:/o:redhat:enterprise_linux:8.0" source="CPE" />
+      <description>The operating system installed on the system is Red Hat Enterprise Linux 8.0</description>
+    </metadata>
+    <criteria>
+      <criterion comment="RHEL 8.0 is installed" test_ref="test_rhel8_0" />
+    </criteria>
+  </definition>
+
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release is version 8.0"
+   id="test_rhel8_0" version="1">
+    <linux:object object_ref="obj_rhel8_0" />
+    <linux:state state_ref="state_rhel8_0" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_rhel8_0" version="1">
+    <linux:version operation="pattern match">^8.0*$</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_rhel8_0" version="1">
+    <linux:name>redhat-release</linux:name>
+  </linux:rpminfo_object>
+
+  <definition class="inventory" id="installed_OS_is_rhel8_1" version="1">
+    <metadata>
+      <title>Red Hat Enterprise Linux 8.1</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 8.1</platform>
+      </affected>
+      <reference ref_id="cpe:/o:redhat:enterprise_linux:8.1" source="CPE" />
+      <description>The operating system installed on the system is Red Hat Enterprise Linux 8.1</description>
+    </metadata>
+    <criteria>
+      <criterion comment="RHEL 8.1 is installed" test_ref="test_rhel8_1" />
+    </criteria>
+  </definition>
+
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release is version 8.1"
+   id="test_rhel8_1" version="1">
+    <linux:object object_ref="obj_rhel8_1" />
+    <linux:state state_ref="state_rhel8_1" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_rhel8_1" version="1">
+    <linux:version operation="pattern match">^8.1*$</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_rhel8_1" version="1">
+    <linux:name>redhat-release</linux:name>
+  </linux:rpminfo_object>
+
+  <definition class="inventory" id="installed_OS_is_rhel8_2" version="1">
+    <metadata>
+      <title>Red Hat Enterprise Linux 8.2</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 8.2</platform>
+      </affected>
+      <reference ref_id="cpe:/o:redhat:enterprise_linux:8.2" source="CPE" />
+      <description>The operating system installed on the system is Red Hat Enterprise Linux 8.2</description>
+    </metadata>
+    <criteria>
+      <criterion comment="RHEL 8.2 is installed" test_ref="test_rhel8_2" />
+    </criteria>
+  </definition>
+
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release is version 8.2"
+   id="test_rhel8_2" version="1">
+    <linux:object object_ref="obj_rhel8_2" />
+    <linux:state state_ref="state_rhel8_2" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_rhel8_2" version="1">
+    <linux:version operation="pattern match">^8.2*$</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_rhel8_2" version="1">
+    <linux:name>redhat-release</linux:name>
+  </linux:rpminfo_object>
+
+  <definition class="inventory" id="installed_OS_is_rhel8_3" version="1">
+    <metadata>
+      <title>Red Hat Enterprise Linux 8.3</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 8.3</platform>
+      </affected>
+      <reference ref_id="cpe:/o:redhat:enterprise_linux:8.3" source="CPE" />
+      <description>The operating system installed on the system is Red Hat Enterprise Linux 8.3</description>
+    </metadata>
+    <criteria>
+      <criterion comment="RHEL 8.3 is installed" test_ref="test_rhel8_3" />
+    </criteria>
+  </definition>
+
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release is version 8.3"
+   id="test_rhel8_3" version="1">
+    <linux:object object_ref="obj_rhel8_3" />
+    <linux:state state_ref="state_rhel8_3" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_rhel8_3" version="1">
+    <linux:version operation="pattern match">^8.3*$</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_rhel8_3" version="1">
+    <linux:name>redhat-release</linux:name>
+  </linux:rpminfo_object>
+
+  <definition class="inventory" id="installed_OS_is_rhel8_4" version="1">
+    <metadata>
+      <title>Red Hat Enterprise Linux 8.4</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 8.4</platform>
+      </affected>
+      <reference ref_id="cpe:/o:redhat:enterprise_linux:8.4" source="CPE" />
+      <description>The operating system installed on the system is Red Hat Enterprise Linux 8.4</description>
+    </metadata>
+    <criteria>
+      <criterion comment="RHEL 8.4 is installed" test_ref="test_rhel8_4" />
+    </criteria>
+  </definition>
+
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release is version 8.4"
+   id="test_rhel8_4" version="1">
+    <linux:object object_ref="obj_rhel8_4" />
+    <linux:state state_ref="state_rhel8_4" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_rhel8_4" version="1">
+    <linux:version operation="pattern match">^8.4*$</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_rhel8_4" version="1">
+    <linux:name>redhat-release</linux:name>
+  </linux:rpminfo_object>
+
+  <definition class="inventory" id="installed_OS_is_rhel8_5" version="1">
+    <metadata>
+      <title>Red Hat Enterprise Linux 8.5</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 8.5</platform>
+      </affected>
+      <reference ref_id="cpe:/o:redhat:enterprise_linux:8.5" source="CPE" />
+      <description>The operating system installed on the system is Red Hat Enterprise Linux 8.5</description>
+    </metadata>
+    <criteria>
+      <criterion comment="RHEL 8.5 is installed" test_ref="test_rhel8_5" />
+    </criteria>
+  </definition>
+
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release is version 8.5"
+   id="test_rhel8_5" version="1">
+    <linux:object object_ref="obj_rhel8_5" />
+    <linux:state state_ref="state_rhel8_5" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_rhel8_5" version="1">
+    <linux:version operation="pattern match">^8.5*$</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_rhel8_5" version="1">
+    <linux:name>redhat-release</linux:name>
+  </linux:rpminfo_object>
+
+  <definition class="inventory" id="installed_OS_is_rhel8_6" version="1">
+    <metadata>
+      <title>Red Hat Enterprise Linux 8.6</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 8.6</platform>
+      </affected>
+      <reference ref_id="cpe:/o:redhat:enterprise_linux:8.6" source="CPE" />
+      <description>The operating system installed on the system is Red Hat Enterprise Linux 8.6</description>
+    </metadata>
+    <criteria>
+      <criterion comment="RHEL 8.6 is installed" test_ref="test_rhel8_6" />
+    </criteria>
+  </definition>
+
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release is version 8.6"
+   id="test_rhel8_6" version="1">
+    <linux:object object_ref="obj_rhel8_6" />
+    <linux:state state_ref="state_rhel8_6" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_rhel8_6" version="1">
+    <linux:version operation="pattern match">^8.6*$</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_rhel8_6" version="1">
+    <linux:name>redhat-release</linux:name>
+  </linux:rpminfo_object>
+
+  <definition class="inventory" id="installed_OS_is_rhel8_7" version="1">
+    <metadata>
+      <title>Red Hat Enterprise Linux 8.7</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 8.7</platform>
+      </affected>
+      <reference ref_id="cpe:/o:redhat:enterprise_linux:8.7" source="CPE" />
+      <description>The operating system installed on the system is Red Hat Enterprise Linux 8.7</description>
+    </metadata>
+    <criteria>
+      <criterion comment="RHEL 8.7 is installed" test_ref="test_rhel8_7" />
+    </criteria>
+  </definition>
+
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release is version 8.7"
+   id="test_rhel8_7" version="1">
+    <linux:object object_ref="obj_rhel8_7" />
+    <linux:state state_ref="state_rhel8_7" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_rhel8_7" version="1">
+    <linux:version operation="pattern match">^8.7*$</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_rhel8_7" version="1">
+    <linux:name>redhat-release</linux:name>
+  </linux:rpminfo_object>
+
+  <definition class="inventory" id="installed_OS_is_rhel8_8" version="1">
+    <metadata>
+      <title>Red Hat Enterprise Linux 8.8</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 8.8</platform>
+      </affected>
+      <reference ref_id="cpe:/o:redhat:enterprise_linux:8.8" source="CPE" />
+      <description>The operating system installed on the system is Red Hat Enterprise Linux 8.8</description>
+    </metadata>
+    <criteria>
+      <criterion comment="RHEL 8.8 is installed" test_ref="test_rhel8_8" />
+    </criteria>
+  </definition>
+
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release is version 8.8"
+   id="test_rhel8_8" version="1">
+    <linux:object object_ref="obj_rhel8_8" />
+    <linux:state state_ref="state_rhel8_8" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_rhel8_8" version="1">
+    <linux:version operation="pattern match">^8.8*$</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_rhel8_8" version="1">
+    <linux:name>redhat-release</linux:name>
+  </linux:rpminfo_object>
+
+  <definition class="inventory" id="installed_OS_is_rhel8_9" version="1">
+    <metadata>
+      <title>Red Hat Enterprise Linux 8.9</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 8.9</platform>
+      </affected>
+      <reference ref_id="cpe:/o:redhat:enterprise_linux:8.9" source="CPE" />
+      <description>The operating system installed on the system is Red Hat Enterprise Linux 8.9</description>
+    </metadata>
+    <criteria>
+      <criterion comment="RHEL 8.9 is installed" test_ref="test_rhel8_9" />
+    </criteria>
+  </definition>
+
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release is version 8.9"
+   id="test_rhel8_9" version="1">
+    <linux:object object_ref="obj_rhel8_9" />
+    <linux:state state_ref="state_rhel8_9" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_rhel8_9" version="1">
+    <linux:version operation="pattern match">^8.9*$</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_rhel8_9" version="1">
+    <linux:name>redhat-release</linux:name>
+  </linux:rpminfo_object>
+
+  <definition class="inventory" id="installed_OS_is_rhel8_10" version="1">
+    <metadata>
+      <title>Red Hat Enterprise Linux 8.10</title>
+      <affected family="unix">
+        <platform>Red Hat Enterprise Linux 8.10</platform>
+      </affected>
+      <reference ref_id="cpe:/o:redhat:enterprise_linux:8.10" source="CPE" />
+      <description>The operating system installed on the system is Red Hat Enterprise Linux 8.10</description>
+    </metadata>
+    <criteria>
+      <criterion comment="RHEL 8.10 is installed" test_ref="test_rhel8_10" />
+    </criteria>
+  </definition>
+
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release is version 8.10"
+   id="test_rhel8_10" version="1">
+    <linux:object object_ref="obj_rhel8_10" />
+    <linux:state state_ref="state_rhel8_10" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_rhel8_10" version="1">
+    <linux:version operation="pattern match">^8.10*$</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_rhel8_10" version="1">
+    <linux:name>redhat-release</linux:name>
+  </linux:rpminfo_object>
+
+
+  <ind:textfilecontent54_test check="all" comment="RHEVH base RHEL is version 8" id="test_rhevh_rhel8_version" version="1">
+    <ind:object object_ref="obj_rhevh_rhel8_version" />
+    <ind:state state_ref="state_rhevh_rhel8_version" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_rhevh_rhel8_version" version="1">
+    <ind:filepath>/etc/redhat-release</ind:filepath>
+    <ind:pattern operation="pattern match">^Red Hat Enterprise Linux release (\d)\.\d+$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_rhevh_rhel8_version" version="1">
+    <ind:subexpression operation="pattern match">8</ind:subexpression>
+  </ind:textfilecontent54_state>
+</def-group>

--- a/tests/unit/ssg-module/test_oval_object_model/test_load_and_store.py
+++ b/tests/unit/ssg-module/test_oval_object_model/test_load_and_store.py
@@ -395,3 +395,12 @@ def test_content_variable_state(variable_state):
     property_value.text = "1"
 
     assert variable_state.properties[0] == property_value
+
+
+def test_load_shorthand_with_several_oval_definitions():
+    oval_doc = OVALDocument()
+    path_ = os.path.join(DATA_DIR, "shorthand_installed_OS_is_rhel8.xml")
+    shorthand_string = _read_shorthand(path_)
+    oval_doc.load_shorthand(shorthand_string, "fedora")
+    assert len(oval_doc.definitions.keys()) == 12
+    assert "installed_OS_is_rhel8" in oval_doc.definitions

--- a/tests/unit/ssg-module/test_oval_object_model/test_load_and_store.py
+++ b/tests/unit/ssg-module/test_oval_object_model/test_load_and_store.py
@@ -53,10 +53,10 @@ def oval_document():
 
 @pytest.fixture
 def oval_document_from_shorthand():
-    oval_doc = OVALDocument("Test", "1.2", "1")
+    oval_doc = OVALDocument()
 
     for shorthand in _list_of_shorthands():
-        oval_doc.load_shorthand(shorthand)
+        oval_doc.load_shorthand(shorthand, "rhel")
 
     return oval_doc
 

--- a/tests/unit/ssg-module/test_oval_object_model/test_oval_document.py
+++ b/tests/unit/ssg-module/test_oval_object_model/test_oval_document.py
@@ -1,0 +1,58 @@
+import pytest
+import os
+
+from test_load_and_store import _load_oval_document
+
+
+DATA_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "data"))
+OVAL_DOCUMENT_PATH = os.path.join(
+    DATA_DIR, "minimal_oval_of_oval_ssg-sshd_rekey_limit_def.xml"
+)
+
+
+@pytest.fixture
+def oval_document():
+    return _load_oval_document(OVAL_DOCUMENT_PATH)
+
+
+def test_all_references_of_definition(oval_document):
+    ref = oval_document.get_all_references_of_definition(
+        "oval:ssg-sshd_not_required_or_unset:def:1"
+    )
+    assert ref.is_done()
+    assert ref.definitions == [
+        "oval:ssg-sshd_not_required_or_unset:def:1",
+        "oval:ssg-sshd_requirement_unset:def:1",
+    ]
+    assert ref.tests == [
+        "oval:ssg-test_sshd_not_required:tst:1",
+        "oval:ssg-test_sshd_requirement_unset:tst:1",
+    ]
+    assert ref.objects == [
+        "oval:ssg-object_sshd_requirement_unknown:obj:1",
+        "oval:ssg-object_sshd_not_required:obj:1",
+    ]
+    assert ref.states == [
+        "oval:ssg-state_sshd_requirement_unset:ste:1",
+        "oval:ssg-state_sshd_not_required:ste:1",
+    ]
+    assert ref.variables == [
+        "oval:ssg-sshd_required:var:1",
+    ]
+
+
+def test_keep_referenced_components(oval_document):
+    def_id = "oval:ssg-sshd_not_required_or_unset:def:1"
+    ref = oval_document.get_all_references_of_definition(def_id)
+    oval_document.keep_referenced_components(ref)
+
+    assert def_id in oval_document.definitions
+    assert "oval:ssg-sshd_rekey_limit:def:1" not in oval_document.definitions
+    assert "oval:ssg-test_sshd_not_required:tst:1" in oval_document.tests
+    assert "oval:ssg-test_sshd_rekey_limit:tst:1" not in oval_document.tests
+    assert "oval:ssg-object_sshd_requirement_unknown:obj:1" in oval_document.objects
+    assert "oval:ssg-obj_sshd_rekey_limit:obj:1" not in oval_document.objects
+    assert "oval:ssg-state_sshd_requirement_unset:ste:1" in oval_document.states
+    assert "oval:ssg-state_sshd_rekey_limit:ste:1" not in oval_document.states
+    assert "oval:ssg-sshd_required:var:1" in oval_document.variables
+    assert "oval:ssg-var_rekey_limit_size:var:1" not in oval_document.variables


### PR DESCRIPTION
This PR adds and enhances the OVAL object model capabilities for integration into `combine_ovals.py`.

New capabilities:
- Finding references to OVAL components
- Remove OVAL definitions with all referenced OVAL components (preserves components used in other OVAL components).
- Check if the OVAL definition is applicable to the product.
- Check that the Affected attribute in the metadata is not empty.
- Add error logging or other warnings

Enhanced capabilities:
- Load from shorthands has been redesigned.
- Fixed fields in the element generator in the generated OVAL document.

#### Review Hints:
#### Test script
[test.py](https://pastebin.com/zjUmV7ST)

Execution of test script:
```
python3 test.py
```
This test script generates one document for each OVAL definition with all referenced OVAL components and then performs validation using `oscap oval validate FILE_PATH`, but ignores validation for the `ocp` and `eks` products. 

**Note: the test script processes all OVAL documents in the build directory**.


#### Unit tests

Run unit tests:

```
tox
```