### PR TITLE
OCP4: Fix e2e result on OCP 4.14 changes

### DIFF
--- a/applications/openshift/master/file_permissions_controller_manager_kubeconfig/tests/ocp4/4.10.yml
+++ b/applications/openshift/master/file_permissions_controller_manager_kubeconfig/tests/ocp4/4.10.yml
@@ -1,0 +1,4 @@
+---
+default_result:
+  master: FAIL
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_controller_manager_kubeconfig/tests/ocp4/4.11.yml
+++ b/applications/openshift/master/file_permissions_controller_manager_kubeconfig/tests/ocp4/4.11.yml
@@ -1,0 +1,4 @@
+---
+default_result:
+  master: FAIL
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_controller_manager_kubeconfig/tests/ocp4/4.12.yml
+++ b/applications/openshift/master/file_permissions_controller_manager_kubeconfig/tests/ocp4/4.12.yml
@@ -1,0 +1,4 @@
+---
+default_result:
+  master: FAIL
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_controller_manager_kubeconfig/tests/ocp4/4.13.yml
+++ b/applications/openshift/master/file_permissions_controller_manager_kubeconfig/tests/ocp4/4.13.yml
@@ -1,0 +1,4 @@
+---
+default_result:
+  master: PASS
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_controller_manager_kubeconfig/tests/ocp4/4.14.yml
+++ b/applications/openshift/master/file_permissions_controller_manager_kubeconfig/tests/ocp4/4.14.yml
@@ -1,0 +1,4 @@
+---
+default_result:
+  master: PASS
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_controller_manager_kubeconfig/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_controller_manager_kubeconfig/tests/ocp4/e2e.yml
@@ -1,5 +1,0 @@
----
-# This will fail until OpenShift 4.14 is released and used by CI.
-default_result:
-  master: FAIL
-  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_etcd_member/tests/ocp4/4.10.yml
+++ b/applications/openshift/master/file_permissions_etcd_member/tests/ocp4/4.10.yml
@@ -1,0 +1,4 @@
+---
+default_result:
+  master: FAIL
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_etcd_member/tests/ocp4/4.11.yml
+++ b/applications/openshift/master/file_permissions_etcd_member/tests/ocp4/4.11.yml
@@ -1,0 +1,4 @@
+---
+default_result:
+  master: FAIL
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_etcd_member/tests/ocp4/4.12.yml
+++ b/applications/openshift/master/file_permissions_etcd_member/tests/ocp4/4.12.yml
@@ -1,0 +1,4 @@
+---
+default_result:
+  master: FAIL
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_etcd_member/tests/ocp4/4.13.yml
+++ b/applications/openshift/master/file_permissions_etcd_member/tests/ocp4/4.13.yml
@@ -1,0 +1,4 @@
+---
+default_result:
+  master: PASS
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_etcd_member/tests/ocp4/4.14.yml
+++ b/applications/openshift/master/file_permissions_etcd_member/tests/ocp4/4.14.yml
@@ -1,0 +1,4 @@
+---
+default_result:
+  master: PASS
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_etcd_member/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_etcd_member/tests/ocp4/e2e.yml
@@ -1,5 +1,0 @@
----
-# This will fail until OpenShift 4.14 is released and used by CI.
-default_result:
-  master: FAIL
-  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_kube_apiserver/tests/ocp4/4.10.yml
+++ b/applications/openshift/master/file_permissions_kube_apiserver/tests/ocp4/4.10.yml
@@ -1,0 +1,4 @@
+---
+default_result:
+  master: FAIL
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_kube_apiserver/tests/ocp4/4.11.yml
+++ b/applications/openshift/master/file_permissions_kube_apiserver/tests/ocp4/4.11.yml
@@ -1,0 +1,4 @@
+---
+default_result:
+  master: FAIL
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_kube_apiserver/tests/ocp4/4.12.yml
+++ b/applications/openshift/master/file_permissions_kube_apiserver/tests/ocp4/4.12.yml
@@ -1,0 +1,4 @@
+---
+default_result:
+  master: FAIL
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_kube_apiserver/tests/ocp4/4.13.yml
+++ b/applications/openshift/master/file_permissions_kube_apiserver/tests/ocp4/4.13.yml
@@ -1,0 +1,4 @@
+---
+default_result:
+  master: PASS
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_kube_apiserver/tests/ocp4/4.14.yml
+++ b/applications/openshift/master/file_permissions_kube_apiserver/tests/ocp4/4.14.yml
@@ -1,0 +1,4 @@
+---
+default_result:
+  master: PASS
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_kube_apiserver/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_kube_apiserver/tests/ocp4/e2e.yml
@@ -1,5 +1,0 @@
----
-# This will fail until OpenShift 4.14 is released and used by CI.
-default_result:
-  master: FAIL
-  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_kube_controller_manager/tests/ocp4/4.10.yml
+++ b/applications/openshift/master/file_permissions_kube_controller_manager/tests/ocp4/4.10.yml
@@ -1,0 +1,4 @@
+---
+default_result:
+  master: FAIL
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_kube_controller_manager/tests/ocp4/4.11.yml
+++ b/applications/openshift/master/file_permissions_kube_controller_manager/tests/ocp4/4.11.yml
@@ -1,0 +1,4 @@
+---
+default_result:
+  master: FAIL
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_kube_controller_manager/tests/ocp4/4.12.yml
+++ b/applications/openshift/master/file_permissions_kube_controller_manager/tests/ocp4/4.12.yml
@@ -1,0 +1,4 @@
+---
+default_result:
+  master: FAIL
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_kube_controller_manager/tests/ocp4/4.13.yml
+++ b/applications/openshift/master/file_permissions_kube_controller_manager/tests/ocp4/4.13.yml
@@ -1,0 +1,4 @@
+---
+default_result:
+  master: PASS
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_kube_controller_manager/tests/ocp4/4.14.yml
+++ b/applications/openshift/master/file_permissions_kube_controller_manager/tests/ocp4/4.14.yml
@@ -1,0 +1,4 @@
+---
+default_result:
+  master: PASS
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_kube_controller_manager/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_kube_controller_manager/tests/ocp4/e2e.yml
@@ -1,5 +1,0 @@
----
-# This will fail until OpenShift 4.14 is released and used by CI.
-default_result:
-  master: FAIL
-  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_scheduler_kubeconfig/tests/ocp4/4.10.yml
+++ b/applications/openshift/master/file_permissions_scheduler_kubeconfig/tests/ocp4/4.10.yml
@@ -1,0 +1,4 @@
+---
+default_result:
+  master: FAIL
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_scheduler_kubeconfig/tests/ocp4/4.11.yml
+++ b/applications/openshift/master/file_permissions_scheduler_kubeconfig/tests/ocp4/4.11.yml
@@ -1,0 +1,4 @@
+---
+default_result:
+  master: FAIL
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_scheduler_kubeconfig/tests/ocp4/4.12.yml
+++ b/applications/openshift/master/file_permissions_scheduler_kubeconfig/tests/ocp4/4.12.yml
@@ -1,0 +1,4 @@
+---
+default_result:
+  master: FAIL
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_scheduler_kubeconfig/tests/ocp4/4.13.yml
+++ b/applications/openshift/master/file_permissions_scheduler_kubeconfig/tests/ocp4/4.13.yml
@@ -1,0 +1,4 @@
+---
+default_result:
+  master: PASS
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_scheduler_kubeconfig/tests/ocp4/4.14.yml
+++ b/applications/openshift/master/file_permissions_scheduler_kubeconfig/tests/ocp4/4.14.yml
@@ -1,0 +1,4 @@
+---
+default_result:
+  master: PASS
+  worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_scheduler_kubeconfig/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_scheduler_kubeconfig/tests/ocp4/e2e.yml
@@ -1,5 +1,0 @@
----
-# This will fail until OpenShift 4.14 is released and used by CI.
-default_result:
-  master: FAIL
-  worker: NOT-APPLICABLE


### PR DESCRIPTION
Some of the file permission issues has been addressed on OpenShift 4.14 from 644 to 600 , let's change the expected e2e result to match that
