### PR TITLE
Fix for broken bash remediation for 'set_nftables_loopback_traffic'

### DIFF
--- a/linux_os/guide/system/network/network-nftables/set_nftables_loopback_traffic/ansible/shared.yml
+++ b/linux_os/guide/system/network/network-nftables/set_nftables_loopback_traffic/ansible/shared.yml
@@ -4,7 +4,7 @@
   ansible.builtin.command: nft add rule inet filter input iif lo accept
 
 - name: Create Rule to Drop Input IP Address from Loopback
-  ansible.builtin.command: nft insert rule inet filter input ip saddr 127.0.0.0/8 counter drop
+  ansible.builtin.command: nft add rule inet filter input ip saddr 127.0.0.0/8 counter drop
 
 - name: Check if IPv6 is Disabled in grub Configuration
   ansible.builtin.shell: |

--- a/linux_os/guide/system/network/network-nftables/set_nftables_loopback_traffic/bash/shared.sh
+++ b/linux_os/guide/system/network/network-nftables/set_nftables_loopback_traffic/bash/shared.sh
@@ -8,7 +8,7 @@ grubfile="{{{ grub2_boot_path }}}/grub.cfg"
 
 # Implement the loopback rules:
 nft add rule inet filter input iif lo accept
-nft insert rule inet filter input ip saddr 127.0.0.0/8 counter drop
+nft add rule inet filter input ip saddr 127.0.0.0/8 counter drop
 
 # Check IPv6 is disabled, if false implement IPv6 loopback rules
 disabled="false"


### PR DESCRIPTION
#### Description:

Fixed broken bash remediation for 'set_nftables_loopback_traffic'

Regression introduced in #10366 .

The commit corrected the broken remediation for rule 3.5.2.6 as defined in the Ubuntu 22.04 LTS CIS benchmark 1.0.0 (`nft create` is not used for adding rules). By making use of `nft insert`, the second rule (ip saddr ...) was added before the first (iif "lo" accept") thus dropping all packets originating from loopback.

One known issue resulting from this is loss of DNS resolution via `resolved`:
```
dig archive.ubuntu.com
;; communications error to 127.0.0.53#53: timed out
;; communications error to 127.0.0.53#53: timed out
;; communications error to 127.0.0.53#53: timed out

; <<>> DiG 9.18.12-0ubuntu0.22.04.3-Ubuntu <<>> archive.ubuntu.com
;; global options: +cmd
;; no servers could be reached
```

nftables ruleset after applying remediation
```
$ nft list ruleset

table inet filter {
 chain input {
  type filter hook input priority filter; policy accept;
  ip saddr 127.0.0.0/8 counter packets 8 bytes 640 drop
  iif "lo" accept
  ip6 saddr ::1 counter packets 0 bytes 0 drop
 }

 chain forward {
  type filter hook forward priority filter; policy accept;
 }

 chain output {
  type filter hook output priority filter; policy accept;
 }
}
```

**Solution**
Fix is simply to replace `nft insert` with `nft add`, which appends the rules one after the other.


#### Rationale:

- Fixes broken bash remediation

#### Review Hints:
