### PR TITLE
Remove groupmems command from ensure_pam_wheel_group_empty rule

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/bash/shared.sh
@@ -7,4 +7,4 @@ if ! grep -q "^${var_pam_wheel_group_for_su}:[^:]*:[^:]*:[^:]*" /etc/group; then
 fi
 
 # group must be empty
-groupmems -g ${var_pam_wheel_group_for_su} -p
+sed -i -E "s/^(${var_pam_wheel_group_for_su}:[^:]*:[^:]*:)[^:]*/\1/g" /etc/group

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/bash/shared.sh
@@ -7,4 +7,4 @@ if ! grep -q "^${var_pam_wheel_group_for_su}:[^:]*:[^:]*:[^:]*" /etc/group; then
 fi
 
 # group must be empty
-sed -i -E "s/^(${var_pam_wheel_group_for_su}:[^:]*:[^:]*:)[^:]*/\1/g" /etc/group
+gpasswd -M '' ${var_pam_wheel_group_for_su}

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/tests/group_without_members.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/tests/group_without_members.pass.sh
@@ -3,4 +3,4 @@
 
 GRP_NAME=sugroup
 groupadd ${GRP_NAME}
-groupmems -g ${GRP_NAME} -p
+sed -i -E "s/^(${GRP_NAME}:[^:]*:[^:]*:)[^:]*/\1/" /etc/group

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/tests/group_without_members.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/tests/group_without_members.pass.sh
@@ -3,4 +3,4 @@
 
 GRP_NAME=sugroup
 groupadd ${GRP_NAME}
-sed -i -E "s/^(${GRP_NAME}:[^:]*:[^:]*:)[^:]*/\1/" /etc/group
+gpasswd -M '' ${GRP_NAME}


### PR DESCRIPTION
#### Description:

It was noticed that `groupmems` command, which initially seemed like a handy command, does not work on all distros or behaves differently among distros.
It is better to avoid it and use a more generic approach that works for all distros.

The issue was discovered after https://github.com/ComplianceAsCode/content/pull/11192

#### Rationale:

- More compatibility among products
- Fixes #11203
- Fixes #11208

#### Review Hints:

automatus tests should be enough to test the change.