### PR TITLE
Include remediation for fapolicy_default_deny rule

### DIFF
--- a/linux_os/guide/services/fapolicyd/fapolicy_default_deny/ansible/shared.yml
+++ b/linux_os/guide/services/fapolicyd/fapolicy_default_deny/ansible/shared.yml
@@ -1,0 +1,31 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: {{{ rule_title }}} - Ensure a Final Rule Denying Everything
+  ansible.builtin.copy:
+    content: |
+      # Red Hat KCS 7003854 (https://access.redhat.com/solutions/7003854)
+      deny perm=any all : all
+    dest: /etc/fapolicyd/rules.d/99-deny-everything.rules
+    owner: root
+    group: fapolicyd
+    mode: '0644'
+  register: result_fapolicyd_final_rule
+
+- name: {{{ rule_title }}} - Ensure fapolicyd is Not Permissive
+  ansible.builtin.lineinfile:
+    path: /etc/fapolicyd/fapolicyd.conf
+    regexp: '^(permissive\s*=).*$'
+    line: '\1 0'
+    backrefs: true
+  register: result_fapolicyd_enforced
+
+- name: "{{{ rule_title }}} - Restart fapolicyd If Permissive Mode or Final Rule is Changed"
+  ansible.builtin.service:
+    name: fapolicyd
+    state: restarted
+  when:
+    - result_fapolicyd_final_rule is changed or result_fapolicyd_enforced is changed

--- a/linux_os/guide/services/fapolicyd/fapolicy_default_deny/bash/shared.sh
+++ b/linux_os/guide/services/fapolicyd/fapolicy_default_deny/bash/shared.sh
@@ -1,0 +1,24 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+cat > /etc/fapolicyd/rules.d/99-deny-everything.rules << EOF
+# Red Hat KCS 7003854 (https://access.redhat.com/solutions/7003854)
+deny perm=any all : all
+EOF
+
+chmod 644 /etc/fapolicyd/rules.d/99-deny-everything.rules
+chgrp fapolicyd /etc/fapolicyd/rules.d/99-deny-everything.rules
+
+{{{ set_config_file(path="/etc/fapolicyd/fapolicyd.conf",
+                    parameter="permissive",
+                    value="0",
+                    create=true,
+                    insensitive=true,
+                    separator=" = ",
+                    separator_regex="\s*=\s*",
+                    prefix_regex="^\s*") }}}
+
+systemctl restart fapolicyd

--- a/linux_os/guide/services/fapolicyd/fapolicy_default_deny/rule.yml
+++ b/linux_os/guide/services/fapolicyd/fapolicy_default_deny/rule.yml
@@ -74,7 +74,3 @@ fixtext: |-
     permissive = 0
 
 srg_requirement: 'The {{{ full_name }}} fapolicy module must be configured to employ a deny-all, permit-by-exception policy to allow the execution of authorized software programs.'
-
-warnings:
-  - general:
-      This rule doesn't come with a remediation. Before remediating the system administrator needs to create an allowlist of authorized software.

--- a/linux_os/guide/services/fapolicyd/fapolicy_default_deny/tests/allow_policy.fail.sh
+++ b/linux_os/guide/services/fapolicyd/fapolicy_default_deny/tests/allow_policy.fail.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 # packages = fapolicyd
-# remediation = none
-
-{{{ bash_shell_file_set("/etc/fapolicyd/fapolicyd.conf", "permissive", "1", "true") }}}
 
 if [ -f /etc/fapolicyd/compiled.rules ]; then
     active_rules_file="/etc/fapolicyd/compiled.rules"
@@ -11,8 +8,14 @@ else
 fi
 
 truncate -s 0 $active_rules_file
-
 echo "allow exe=/usr/bin/python3.7 : ftype=text/x-python" >> $active_rules_file
 echo "allow perm=any all : all" >> $active_rules_file
 
-{{{ bash_shell_file_set("/etc/fapolicyd/fapolicyd.conf", "permissive", "0", "true") }}}
+{{{ set_config_file(path="/etc/fapolicyd/fapolicyd.conf",
+                    parameter="permissive",
+                    value="0",
+                    create=true,
+                    insensitive=true,
+                    separator=" = ",
+                    separator_regex="\s*=\s*",
+                    prefix_regex="^\s*") }}}

--- a/linux_os/guide/services/fapolicyd/fapolicy_default_deny/tests/deny_policy.pass.sh
+++ b/linux_os/guide/services/fapolicyd/fapolicy_default_deny/tests/deny_policy.pass.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 # packages = fapolicyd
-# remediation = none
-
-{{{ bash_shell_file_set("/etc/fapolicyd/fapolicyd.conf", "permissive", "1", "true") }}}
 
 if [ -f /etc/fapolicyd/compiled.rules ]; then
     active_rules_file="/etc/fapolicyd/compiled.rules"
@@ -11,8 +8,14 @@ else
 fi
 
 truncate -s 0 $active_rules_file
-
 echo "allow exe=/usr/bin/python3.7 : ftype=text/x-python" >> $active_rules_file
 echo "deny perm=any all : all" >> $active_rules_file
 
-{{{ bash_shell_file_set("/etc/fapolicyd/fapolicyd.conf", "permissive", "0", "true") }}}
+{{{ set_config_file(path="/etc/fapolicyd/fapolicyd.conf",
+                    parameter="permissive",
+                    value="0",
+                    create=true,
+                    insensitive=true,
+                    separator=" = ",
+                    separator_regex="\s*=\s*",
+                    prefix_regex="^\s*") }}}

--- a/linux_os/guide/services/fapolicyd/fapolicy_default_deny/tests/deny_policy_but_permissive.fail.sh
+++ b/linux_os/guide/services/fapolicyd/fapolicy_default_deny/tests/deny_policy_but_permissive.fail.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 # packages = fapolicyd
-# remediation = none
-
-{{{ bash_shell_file_set("/etc/fapolicyd/fapolicyd.conf", "permissive", "1", "true") }}}
 
 if [ -f /etc/fapolicyd/compiled.rules ]; then
     active_rules_file="/etc/fapolicyd/compiled.rules"
@@ -11,6 +8,14 @@ else
 fi
 
 truncate -s 0 $active_rules_file
-
 echo "allow exe=/usr/bin/python3.7 : ftype=text/x-python" >> $active_rules_file
 echo "deny perm=any all : all" >> $active_rules_file
+
+{{{ set_config_file(path="/etc/fapolicyd/fapolicyd.conf",
+                    parameter="permissive",
+                    value="1",
+                    create=true,
+                    insensitive=true,
+                    separator=" = ",
+                    separator_regex="\s*=\s*",
+                    prefix_regex="^\s*") }}}

--- a/linux_os/guide/services/fapolicyd/fapolicy_default_deny/tests/deny_policy_commented.fail.sh
+++ b/linux_os/guide/services/fapolicyd/fapolicy_default_deny/tests/deny_policy_commented.fail.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 # packages = fapolicyd
-# remediation = none
-
-{{{ bash_shell_file_set("/etc/fapolicyd/fapolicyd.conf", "permissive", "1", "true") }}}
 
 if [ -f /etc/fapolicyd/compiled.rules ]; then
     active_rules_file="/etc/fapolicyd/compiled.rules"
@@ -11,8 +8,14 @@ else
 fi
 
 truncate -s 0 $active_rules_file
-
 echo "allow exe=/usr/bin/python3.7 : ftype=text/x-python" >> $active_rules_file
 echo "# deny perm=any all : all" >> $active_rules_file
 
-{{{ bash_shell_file_set("/etc/fapolicyd/fapolicyd.conf", "permissive", "0", "true") }}}
+{{{ set_config_file(path="/etc/fapolicyd/fapolicyd.conf",
+                    parameter="permissive",
+                    value="0",
+                    create=true,
+                    insensitive=true,
+                    separator=" = ",
+                    separator_regex="\s*=\s*",
+                    prefix_regex="^\s*") }}}

--- a/linux_os/guide/services/fapolicyd/fapolicy_default_deny/tests/deny_policy_not_ensured.fail.sh
+++ b/linux_os/guide/services/fapolicyd/fapolicy_default_deny/tests/deny_policy_not_ensured.fail.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 # packages = fapolicyd
-# remediation = none
-
-{{{ bash_shell_file_set("/etc/fapolicyd/fapolicyd.conf", "permissive", "1", "true") }}}
 
 if [ -f /etc/fapolicyd/compiled.rules ]; then
     active_rules_file="/etc/fapolicyd/compiled.rules"
@@ -11,8 +8,14 @@ else
 fi
 
 truncate -s 0 $active_rules_file
-
 echo "deny perm=any all : all" >> $active_rules_file
 echo "allow exe=/usr/bin/python3.7 : ftype=text/x-python" >> $active_rules_file
 
-{{{ bash_shell_file_set("/etc/fapolicyd/fapolicyd.conf", "permissive", "0", "true") }}}
+{{{ set_config_file(path="/etc/fapolicyd/fapolicyd.conf",
+                    parameter="permissive",
+                    value="0",
+                    create=true,
+                    insensitive=true,
+                    separator=" = ",
+                    separator_regex="\s*=\s*",
+                    prefix_regex="^\s*") }}}


### PR DESCRIPTION
#### Description:

Create Bash and Ansible remediation for `fapolicy_default_deny` rule.
The remediation ensures the `fapolicyd` is not working in permissive mode and also explicitly creates a final rule denying everything. Currently, STIG requires this explicit final rule.

Test scenarios were also reviewed and improved.

#### Rationale:

- There was no remediation for the rule, so this PR improves coverage.
- Fixes https://issues.redhat.com/browse/RHEL-1817
- https://access.redhat.com/solutions/7003854

#### Review Hints:

- There are more details in each commit description.
- automatus should be enough for technical tests. e.g.:

`./tests/automatus.py rule --libvirt qemu:///session rhel8 --datastream build/ssg-rhel8-ds.xml --dontclean --remediate-using bash fapolicy_default_deny`

`./tests/automatus.py rule --libvirt qemu:///session rhel9 --datastream build/ssg-rhel9-ds.xml --dontclean --remediate-using ansible fapolicy_default_deny`