### PR TITLE
Fix rpm python package SLE15 Automatus docker file

### DIFF
--- a/Dockerfiles/test_suite-sle15
+++ b/Dockerfiles/test_suite-sle15
@@ -7,7 +7,7 @@ ARG ADDITIONAL_PACKAGES
 
 RUN true \
         && zypper --non-interactive in openssh-clients openssh-server openscap-utils \
-        python3 python-rpm tar \
+        python3 python3-rpm tar \
         $ADDITIONAL_PACKAGES \
 && true
 


### PR DESCRIPTION
#### Description:

- `python-rpm` -> `python3-rpm` in the SLES15 Automatus Docker file

#### Rationale:

So the Automatus container builds.
