### PR TITLE
Add a better Error Message For Undefined Identifier Types

### DIFF
--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -514,3 +514,8 @@ BENCHMARKS = {
     "products/chromium/guide",
     "products/firefox/guide",
 }
+
+
+SSG_IDENT_URIS = {
+    'cce': cce_uri
+}


### PR DESCRIPTION
The build system will now throw if there will be an unsupported identifier used in the `identifiers` key in `rule.yml` files.

The responsible code is refactored out to a separate method to reduce code complexity and increase readability.

Fixes: #11183
