### PR TITLE
Fix for rsyslog_logfiles_attributes_modify remediation for Ubuntu 

### DIFF
--- a/shared/templates/rsyslog_logfiles_attributes_modify/bash.template
+++ b/shared/templates/rsyslog_logfiles_attributes_modify/bash.template
@@ -7,7 +7,14 @@ RSYSLOG_ETC_CONFIG="/etc/rsyslog.conf"
 #   (store the result into array for the case there's shell glob used as value of IncludeConfig)
 readarray -t OLD_INC < <(grep -e "\$IncludeConfig[[:space:]]\+[^[:space:];]\+" /etc/rsyslog.conf | cut -d ' ' -f 2)
 readarray -t RSYSLOG_INCLUDE_CONFIG < <(for INCPATH in "${OLD_INC[@]}"; do eval printf '%s\\n' "${INCPATH}"; done)
+
+{{# ubuntu ships with mawk which doesn't support gensub; use sed instead #}}
+{{% if product in ["ubuntu2004", "ubuntu2204"] %}}
+readarray -t NEW_INC < <(sed -n '/include/,/)/Ip' /etc/rsyslog.conf | sed -n 's@.*file\s*=\s*"\([/[:alnum:][:punct:]]*\)".*@\1@Ip')
+{{% else %}}
 readarray -t NEW_INC < <(awk '/)/{f=0} /include\(/{f=1} f{nf=gensub("^(include\\(|\\s*)file=\"(\\S+)\".*","\\2",1); if($0!=nf){print nf}}' /etc/rsyslog.conf)
+{{% endif %}}
+
 readarray -t RSYSLOG_INCLUDE < <(for INCPATH in "${NEW_INC[@]}"; do eval printf '%s\\n' "${INCPATH}"; done)
 
 # Declare an array to hold the final list of different log file paths

--- a/shared/templates/rsyslog_logfiles_attributes_modify/tests/legacy_lenient_attr.fail.sh
+++ b/shared/templates/rsyslog_logfiles_attributes_modify/tests/legacy_lenient_attr.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle,multi_platform_ubuntu
 
 # Declare variables used for the tests and define the create_rsyslog_test_logs function
 source $SHARED/rsyslog_log_utils.sh

--- a/shared/templates/rsyslog_logfiles_attributes_modify/tests/legacy_lenient_attr_include.fail.sh
+++ b/shared/templates/rsyslog_logfiles_attributes_modify/tests/legacy_lenient_attr_include.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle,multi_platform_ubuntu
 
 # Declare variables used for the tests and define the create_rsyslog_test_logs function
 source $SHARED/rsyslog_log_utils.sh

--- a/shared/templates/rsyslog_logfiles_attributes_modify/tests/mixed_lenient_attr_cloudinit.fail.sh
+++ b/shared/templates/rsyslog_logfiles_attributes_modify/tests/mixed_lenient_attr_cloudinit.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle,multi_platform_ubuntu
 
 # Declare variables used for the tests and define the create_rsyslog_test_logs function
 source $SHARED/rsyslog_log_utils.sh

--- a/shared/templates/rsyslog_logfiles_attributes_modify/tests/mixed_lenient_attr_legacy.fail.sh
+++ b/shared/templates/rsyslog_logfiles_attributes_modify/tests/mixed_lenient_attr_legacy.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle,multi_platform_ubuntu
 
 # Declare variables used for the tests and define the create_rsyslog_test_logs function
 source $SHARED/rsyslog_log_utils.sh

--- a/shared/templates/rsyslog_logfiles_attributes_modify/tests/mixed_lenient_attr_legacy_include.fail.sh
+++ b/shared/templates/rsyslog_logfiles_attributes_modify/tests/mixed_lenient_attr_legacy_include.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle,multi_platform_ubuntu
 
 # Declare variables used for the tests and define the create_rsyslog_test_logs function
 source $SHARED/rsyslog_log_utils.sh

--- a/shared/templates/rsyslog_logfiles_attributes_modify/tests/mixed_lenient_attr_rainer.fail.sh
+++ b/shared/templates/rsyslog_logfiles_attributes_modify/tests/mixed_lenient_attr_rainer.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle,multi_platform_ubuntu
 
 # Declare variables used for the tests and define the create_rsyslog_test_logs function
 source $SHARED/rsyslog_log_utils.sh

--- a/shared/templates/rsyslog_logfiles_attributes_modify/tests/mixed_lenient_attr_rainer_include.fail.sh
+++ b/shared/templates/rsyslog_logfiles_attributes_modify/tests/mixed_lenient_attr_rainer_include.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle,multi_platform_ubuntu
 
 # Declare variables used for the tests and define the create_rsyslog_test_logs function
 source $SHARED/rsyslog_log_utils.sh

--- a/shared/templates/rsyslog_logfiles_attributes_modify/tests/rainer_lenient_attr.fail.sh
+++ b/shared/templates/rsyslog_logfiles_attributes_modify/tests/rainer_lenient_attr.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle,multi_platform_ubuntu
 
 # Declare variables used for the tests and define the create_rsyslog_test_logs function
 source $SHARED/rsyslog_log_utils.sh

--- a/shared/templates/rsyslog_logfiles_attributes_modify/tests/rainer_lenient_attr_include.fail.sh
+++ b/shared/templates/rsyslog_logfiles_attributes_modify/tests/rainer_lenient_attr_include.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle,multi_platform_ubuntu
 
 # Declare variables used for the tests and define the create_rsyslog_test_logs function
 source $SHARED/rsyslog_log_utils.sh


### PR DESCRIPTION
#### Description:

Fix for remediation for rule `rsyslog_logfiles_attributes_modify` on Ubuntu platforms.

#### Rationale:

Ubuntu ships with mawk which doesn't support gawk's gensub function.
Instead, a sed-based approach is used to extract rsyslog config files which are defined in Include() statements.