### PR TITLE
Modified 'ensure_rsyslog_log_file_conf' OVAL to allow user/groupnames

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/rule.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/rule.yml
@@ -79,9 +79,9 @@ template:
   name: rsyslog_logfiles_attributes_modify
   vars:
     attribute: groupowner
-    value: 0
-    value@debian10: 4
-    value@debian11: 4
-    value@ubuntu1604: 4
-    value@ubuntu2004: 4
-    value@ubuntu2204: 4
+    value: root
+    value@debian10: adm
+    value@debian11: adm
+    value@ubuntu1604: adm
+    value@ubuntu2004: adm
+    value@ubuntu2204: adm

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/rule.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/rule.yml
@@ -87,6 +87,6 @@ template:
   name: rsyslog_logfiles_attributes_modify
   vars:
     attribute: owner
-    value: 0
-    value@ubuntu2004: 104
-    value@ubuntu2204: 104
+    value: root
+    value@ubuntu2004: syslog
+    value@ubuntu2204: syslog

--- a/shared/templates/rsyslog_logfiles_attributes_modify/oval.template
+++ b/shared/templates/rsyslog_logfiles_attributes_modify/oval.template
@@ -120,12 +120,61 @@
       var_ref="var_{{{ _RULE_ID }}}_log_files_paths"/>
   </unix:file_object>
 
+  {{% if ATTRIBUTE == "groupowner" %}}
+    {{% if VALUE is number %}}
+  <!-- store groupowner GID in variable -->
+  <constant_variable id="var_{{{ _RULE_ID }}}_{{{ ATTRIBUTE }}}_gid" datatype="int" version="1" comment="GID of {{{ ATTRIBUTE }}}"><value>{{{ VALUE }}}</value></constant_variable>
+
+    {{% else %}}
+  <!-- get groupowner GID from name -->
+  <ind:textfilecontent54_object id="obj_{{{ _RULE_ID }}}_{{{ ATTRIBUTE }}}_gid" version="1" comment="GID of group {{{ VALUE }}}">
+      {{# Copied from file_groupowner template, assuming logic is still valid #}}
+      {{%- if product in ["rhcos4","ocp4"] %}}
+    <ind:filepath>/usr/lib/group</ind:filepath>
+      {{%- else %}}
+    <ind:filepath>/etc/group</ind:filepath>
+      {{%- endif %}}
+    <ind:pattern operation="pattern match">^{{{ VALUE }}}:\w+:(\w+):.*</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <local_variable id="var_{{{ _RULE_ID }}}_{{{ ATTRIBUTE }}}_gid" datatype="int" version="1"
+      comment="GID of group {{{ VALUE }}}">
+    <object_component item_field="subexpression" object_ref="obj_{{{ _RULE_ID }}}_{{{ ATTRIBUTE }}}_gid"/>
+  </local_variable>
+    {{% endif %}}
+
+  {{% elif ATTRIBUTE == "owner" %}}
+    {{% if VALUE is number %}}
+  <!-- store owner UID in variable -->
+  <constant_variable id="var_{{{ _RULE_ID }}}_{{{ ATTRIBUTE }}}_uid" datatype="int" version="1" comment="UID of {{{ ATTRIBUTE }}}"><value>{{{ VALUE }}}</value></constant_variable>
+
+    {{% else %}}
+  <!-- get owner UID from name -->
+  <ind:textfilecontent54_object id="obj_{{{ _RULE_ID }}}_{{{ ATTRIBUTE }}}_uid" version="1" comment="UID of user {{{ VALUE }}}">
+      {{# Assuming same logic as above applies to users #}}
+      {{%- if product in ["rhcos4","ocp4"] %}}
+    <ind:filepath>/usr/lib/passwd</ind:filepath>
+      {{%- else %}}
+    <ind:filepath>/etc/passwd</ind:filepath>
+      {{%- endif %}}
+    <ind:pattern operation="pattern match">^{{{ VALUE }}}:\w+:(\w+):.*</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <local_variable id="var_{{{ _RULE_ID }}}_{{{ ATTRIBUTE }}}_uid" datatype="int" version="1"
+          comment="UID of user {{{ VALUE }}}">
+    <object_component item_field="subexpression" object_ref="obj_{{{ _RULE_ID }}}_{{{ ATTRIBUTE }}}_uid"/>
+  </local_variable>
+    {{% endif %}}
+  {{% endif %}}
+
   <unix:file_state id="state_{{{ _RULE_ID }}}" version="1">
     <unix:type operation="equals">regular</unix:type>
     {{% if ATTRIBUTE == "groupowner" %}}
-    <unix:group_id datatype="int">{{{ VALUE }}}</unix:group_id>
+    <unix:group_id datatype="int" var_ref="var_{{{ _RULE_ID }}}_{{{ ATTRIBUTE }}}_gid"></unix:group_id>
     {{% elif ATTRIBUTE == "owner" %}}
-    <unix:user_id datatype="int">{{{ VALUE }}}</unix:user_id>
+    <unix:user_id datatype="int" var_ref="var_{{{ _RULE_ID }}}_{{{ ATTRIBUTE }}}_uid"></unix:user_id>
     {{% else %}}
     {{{ STATEMODE | indent(4) }}}
    {{% endif %}}


### PR DESCRIPTION
#### Description:

The proposed modification checks if the provided `owner` and `groupowner` values are numbers (== UID/GID), and if not, it first extracts UID/GID information from /etc/passwd and /etc/group (or /usr/lib/ in case of CoreOS) based on the provided username/groupname values.

#### Rationale:

Currently, only UID/GIDs were supported in the template, which fails with Ubuntu 22.04 server.
This is because the server and desktop installations have different UIDs for syslog user (104/107), but have the same identifier in CaC.

- Fixes #11149 