### PR TITLE
Added missing variables to ubuntu profiles

### DIFF
--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -420,6 +420,7 @@ selections:
     - var_nftables_base_chain_types=chain_types
     - var_nftables_base_chain_hooks=chain_hooks
     - var_nftables_base_chain_priorities=chain_priorities
+    - var_nftables_base_chain_policies=chain_policies
     - set_nftables_base_chain
 
     #### 3.5.2.6 Ensure loopback traffic is configured (Automated)

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -453,6 +453,7 @@ selections:
     - var_nftables_base_chain_types=chain_types
     - var_nftables_base_chain_hooks=chain_hooks
     - var_nftables_base_chain_priorities=chain_priorities
+    - var_nftables_base_chain_policies=chain_policies
     - set_nftables_base_chain
 
     #### 3.5.2.6 Ensure nftables loopback traffic is configured (Automated)


### PR DESCRIPTION
#### Description:

- Missing variable `var_nftables_base_chain_policies` in ubuntu profiles
 