### PR TITLE
remove sle15 from package_samba_common_installed

### DIFF
--- a/linux_os/guide/services/smb/configuring_samba/package_samba-common_installed/rule.yml
+++ b/linux_os/guide/services/smb/configuring_samba/package_samba-common_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
+prodtype: rhcos4,rhel7,rhel8,rhel9,rhv4
 
 title: 'Install the Samba Common Package'
 


### PR DESCRIPTION
#### Description:

remove sle15 from package_samba_common_installed since samba-common doesn't exist on sles