### PR TITLE
Use commit hash for image tag

### DIFF
--- a/.github/workflows/k8s-content.yaml
+++ b/.github/workflows/k8s-content.yaml
@@ -14,7 +14,7 @@ jobs:
     uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main
     with:
       name: k8scontent
-      tag: ${GITHUB_REF_NAME}
+      tag: ${GITHUB_SHA}
       latest: true
       registry_org: complianceascode
       dockerfile_path: ./Dockerfiles/ocp4_content

--- a/.github/workflows/k8s-content.yaml
+++ b/.github/workflows/k8s-content.yaml
@@ -14,7 +14,8 @@ jobs:
     uses: metal-toolbox/container-push/.github/workflows/container-push.yml@main
     with:
       name: k8scontent
-      tag: latest
+      tag: ${GITHUB_REF_NAME}
+      latest: true
       registry_org: complianceascode
       dockerfile_path: ./Dockerfiles/ocp4_content
       licenses: BSD


### PR DESCRIPTION
#### Description:

Currently all published images can only be referenced by image digest. These image digests cannot be linked to the actual commit or tag it was built for. The [workflow recommends](https://github.com/metal-toolbox/container-push/blob/07cae2e438d773ff489f8223ecf492f142797859/.github/workflows/container-push.yml#L10-L18) to use the `GITHUB_REF_NAME` environment variable for the tag. Unforuntiatly that value would end up being just the branch name of `master`. Instead suggest to use the `GITHUB_SHA` variable to tag every image built with the commit hash. This change will still tag the head of the `master` branch as `latest`.

#### Rationale:

By using the git reference variable for the tag, it makes it clear which commit/tag the image was built from in the image versions list: https://github.com/ComplianceAsCode/content/pkgs/container/k8scontent/versions