### PR TITLE
Reference validation in OVAL document object

### DIFF
--- a/ssg/oval_object_model/oval_document.py
+++ b/ssg/oval_object_model/oval_document.py
@@ -1,12 +1,14 @@
 from __future__ import absolute_import
 
 import platform
+import logging
 
 from ..constants import OVAL_NAMESPACES, timestamp, xsi_namespace
 from ..utils import required_key
 from ..xml import ElementTree
 from .oval_container import OVALContainer
 from .oval_shorthand import OVALShorthand
+from .oval_definition_references import OVALDefinitionReference
 
 
 def _get_xml_el(tag_name, xml_el):
@@ -124,6 +126,18 @@ class OVALDocument(OVALContainer):
         full_name = required_key(env_yaml, "full_name")
         for definition in self.definitions.values():
             definition.metadata.finalize_affected_platforms(type_, full_name)
+
+    def validate_references(self):
+        ref = OVALDefinitionReference()
+        ref.save_definitions(self.definitions)
+        try:
+            self._process_definition_references(ref)
+            self._process_test_references(ref)
+            self._process_objects_states_variables_references(ref)
+        except MissingOVALComponent as error:
+            logging.warning("Missing OVAL component: {}".format(error))
+            return False
+        return True
 
     def get_xml_element(self):
         root = self._get_oval_definition_el()

--- a/ssg/oval_object_model/oval_document.py
+++ b/ssg/oval_object_model/oval_document.py
@@ -103,7 +103,7 @@ class OVALDocument(OVALContainer):
             raise MissingOVALComponent(component_id)
         return False
 
-    def load_shorthand(self, xml_string, product, rule_id=None):
+    def load_shorthand(self, xml_string, product=None, rule_id=None):
         shorthand = OVALShorthand()
         shorthand.load_shorthand(xml_string)
 

--- a/tests/unit/ssg-module/test_oval_object_model/test_oval_document.py
+++ b/tests/unit/ssg-module/test_oval_object_model/test_oval_document.py
@@ -56,3 +56,24 @@ def test_keep_referenced_components(oval_document):
     assert "oval:ssg-state_sshd_rekey_limit:ste:1" not in oval_document.states
     assert "oval:ssg-sshd_required:var:1" in oval_document.variables
     assert "oval:ssg-var_rekey_limit_size:var:1" not in oval_document.variables
+
+
+@pytest.mark.parametrize(
+    "path, expected_result",
+    [
+        (
+           OVAL_DOCUMENT_PATH, True,
+        ),
+        (
+            os.path.join(DATA_DIR, "oval_with_broken_extend_definition.xml"),
+            False
+        ),
+        (
+            os.path.join(DATA_DIR, "oval_with_correct_extend_definition.xml"),
+            True
+        )
+    ]
+)
+def test_validation(path, expected_result):
+    oval_doc = _load_oval_document(path)
+    assert oval_doc.validate_references() == expected_result


### PR DESCRIPTION
#### Description:

This PR creates a method that checks if all component references are present in an OVAL document.  This PR also changes the product argument of the `load_shorthand` method in the `OVALDocument` class to an optional argument. 

#### Rationale:

This PR is part of the modifications to the OVAL object model for integration into the `combine_ovals.py` script.

#### Review Hints:

You can use the test suite run with `tox` to test the changes. 