### PR TITLE
Fix docs for utils.add_kubernetes_rule

### DIFF
--- a/docs/modules/utils.rst
+++ b/docs/modules/utils.rst
@@ -1,10 +1,10 @@
 utils package
 =============
 
-utils.add\_platform\_rule module
+utils.add\_kubernetes\_rule module
 --------------------------------
 
-.. automodule:: utils.add_platform_rule
+.. automodule:: utils.add_kubernetes_rule
    :members:
    :undoc-members:
    :show-inheritance:


### PR DESCRIPTION

#### Description:
`utils.add_platform_rule` -> `utils.add_kubernetes_rule`

#### Rationale:
So the docs work better.

The script was renamed in #11194 
