### PR TITLE
Fix Secure Boot Automatus VM Installs 

### DIFF
--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -325,6 +325,8 @@ def get_virt_install_command(data):
                 "loader.secure=yes",
             ])
             features_opts.append("smm=on")
+        else:
+            boot_opts.append("loader.secure=no")
 
     command.extend(join_extented_opt("--boot", ",", boot_opts))
     command.extend(join_extented_opt("--extra-args", " ", extra_args_opts))

--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -322,9 +322,7 @@ def get_virt_install_command(data):
         boot_opts.append("uefi")
         if data.uefi == "secureboot":
             boot_opts.extend([
-                "loader_secure=yes",
-                "loader=/usr/share/edk2/ovmf/OVMF_CODE.secboot.fd",
-                "nvram_template=/usr/share/edk2/ovmf/OVMF_VARS.secboot.fd",
+                "loader.secure=yes",
             ])
             features_opts.append("smm=on")
 


### PR DESCRIPTION

#### Description:

Make the secure boot flag  in `install_vm.py` work.

#### Rationale:

FIxes #11237 
