### PR TITLE
Add not UEFI platform for mount_option_boot_nodev

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_nodev/rule.yml
@@ -32,7 +32,7 @@ references:
     srg: SRG-OS-000368-GPOS-00154
     stigid@rhel9: RHEL-09-231095
 
-platform: machine
+platform: machine and not uefi
 
 template:
     name: mount_option


### PR DESCRIPTION
#### Description:

This rule could break UEFI installs as `/boot/efi` could fail to mount with this rule being enabled on UEFI systems.

#### Rationale:
RHEL 9 STIG and system functionality 

