### PR TITLE
Add var_networkmanager_dns_mode to RHEL 9 STIG

### DIFF
--- a/controls/stig_rhel9.yml
+++ b/controls/stig_rhel9.yml
@@ -1516,6 +1516,7 @@ controls:
         title: RHEL 9 must configure a DNS processing mode set be Network Manager.
         rules:
             - networkmanager_dns_mode
+            - var_networkmanager_dns_mode=none
         status: automated
 
     -   id: RHEL-09-252045


### PR DESCRIPTION
#### Description:

Add `var_networkmanager_dns_mode` to the RHEL 9 STIG.
#### Rationale:
Ensure that all variables are configured.