### PR TITLE
Include dracut filter to audit_rules_privileged_commands

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
@@ -60,6 +60,10 @@
     <unix:sgid datatype="boolean">true</unix:sgid>
   </unix:file_state>
 
+  <unix:file_state id="state_dracut_tmp_files" version="1">
+    <unix:filepath operation="pattern match">^/var/tmp/dracut.*</unix:filepath>
+  </unix:file_state>
+
   <!-- This file_object will only find privileged commands located only in file systems that allow
        their execution. The recurse_file_system parameter is set to defined in order to make sure
        the probe doesn't leave the scope of that mount point. For example, when probing "/", the
@@ -73,6 +77,7 @@
       var_ref="var_audit_rules_privileged_commands_exec_mountpoints"/>
     <unix:filename operation="pattern match">^\w+</unix:filename>
     <filter action="include">state_setuid_or_setgid_set</filter>
+    <filter action="exclude">state_dracut_tmp_files</filter>
   </unix:file_object>
 
   <local_variable id="var_audit_rules_privileged_commands_priv_cmds" version="1"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
@@ -37,7 +37,6 @@
       operation="equals">noexec</linux:mount_options>
   </linux:partition_state>
 
-
   <!-- This object is created mainly to improve performance when collecting file objects.
        Here all mount points are collected and filtered to include only devices under /dev in
        order to ignore special file systems. Then, the mount options are checked to exclude

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_extra_rules_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_extra_rules_configured.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# packages = audit
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
+
+./generate_privileged_commands_rule.sh {{{ uid_min }}} privileged /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/notrelevant -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_ignore_dracut_tmp.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_ignore_dracut_tmp.pass.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# packages = audit
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
+
+./generate_privileged_commands_rule.sh {{{ uid_min }}} privileged /etc/audit/rules.d/privileged.rules
+
+# Create some files simulating dracut temporary files. See:
+# - https://github.com/ComplianceAsCode/content/issues/10938
+# - https://bugzilla.redhat.com/show_bug.cgi?id=1852337
+# - https://bugzilla.redhat.com/show_bug.cgi?id=2230306
+mount -o remount,suid,exec /var/tmp/
+for file in mount umount; do
+    path="/var/tmp/dracut.ksbFYD/initramfs/usr/bin"
+    filepath="$path/$file"
+    mkdir -p $path
+    touch $filepath
+    chmod 4755 $filepath
+done


### PR DESCRIPTION
#### Description:

During tests it was noticed that `dracut` creates random temporary files which impacts the OVAL assessment during the system installation or after rebooting the system.

The OVAL was extended to filter out `dracut` temporary files.
New test scenarios were included.

#### Rationale:

- Fixes #10938
- Fixes https://issues.redhat.com/browse/RHEL-11938

#### Review Hints:

Automatus tests should be enough.