### PR TITLE
fix ansible SLES stig remediations in check mode

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/ansible/shared.yml
@@ -14,10 +14,10 @@
 {{% if product in ["rhel7", "ol7"] %}}
   ansible.builtin.command:
     cmd: chage -M {{ var_accounts_maximum_age_login_defs }} {{ item }}
-{{% elif product in ["sle12","sle15"] %}}    
+{{% elif product in ["sle12","sle15"] %}}
   ansible.builtin.command:
     cmd:  passwd -q -x {{ var_accounts_maximum_age_login_defs }} {{ item }}
-{{% else %}}        
+{{% else %}}
   ansible.builtin.user:
     user: '{{ item }}'
     password_expire_max: '{{ var_accounts_maximum_age_login_defs }}'

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/ansible/shared.yml
@@ -18,6 +18,6 @@
 {{% else %}}
   command: >
     chage -m {{ var_accounts_minimum_age_login_defs }} {{ item }}
-{{% endif %}}    
+{{% endif %}}
   with_items: "{{ user_names.stdout_lines }}"
   when: user_names.stdout_lines | length > 0

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/ansible/shared.yml
@@ -13,5 +13,4 @@
   command: >
     passwd -l {{ item }}
   with_items: "{{ users_nopasswd.stdout_lines }}"
-  when: users_nopasswd.stdout_lines | length > 0
-
+  when: users_nopasswd is not skipped and users_nopasswd.stdout_lines | length > 0

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/sle12.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/sle12.yml
@@ -13,3 +13,4 @@
   file:
     path: /etc/profile.d/autologout.sh
     mode: '0755'
+  when: lookup('ansible.builtin.file', '/etc/profile.d/autologout.sh', errors='warn')

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/sle15.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/sle15.yml
@@ -13,3 +13,4 @@
   file:
     path: /etc/profile.d/autologout.sh
     mode: '0755'
+  when: lookup('ansible.builtin.file', '/etc/profile.d/autologout.sh', errors='warn')

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/ansible/shared.yml
@@ -50,7 +50,7 @@
   register: augenrules_audit_rules_privilege_function_update_result
   with_items: "{{ suid_audit_rules }}"
 
-- name: Update Update /etc/audit/audit.rules to audit privileged functions
+- name: Update /etc/audit/audit.rules to audit privileged functions
   ansible.builtin.lineinfile:
     path: /etc/audit/audit.rules
     line: "{{  item.rule  }}"

--- a/linux_os/guide/system/logging/ensure_rtc_utc_configuration/ansible/shared.yml
+++ b/linux_os/guide/system/logging/ensure_rtc_utc_configuration/ansible/shared.yml
@@ -5,8 +5,8 @@
     timedatectl status | grep -i 'Time zone'| grep -iv 'UTC\|GMT' || true
   register: check_tz
   failed_when: "check_tz.rc not in [ 0 , 1 ]"
- 
+
 - name: Configure OS to use 'UTC' timezone
-  command: timedatectl set-timezone UTC 
+  command: timedatectl set-timezone UTC
   become: yes
   when: check_tz.rc == 0

--- a/linux_os/guide/system/network/network_sniffer_disabled/ansible/shared.yml
+++ b/linux_os/guide/system/network/network_sniffer_disabled/ansible/shared.yml
@@ -13,4 +13,5 @@
   ansible.builtin.command:
     cmd: ip link set dev {{ item.split(':')[1] }} multicast off promisc off
   loop: "{{ network_interfaces.stdout_lines }}"
-  when: "item.split(':')"
+  when: network_interfaces.stdout_lines is defined and "item.split(':') | length == 3"
+

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/ansible/shared.yml
@@ -3,6 +3,12 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+- name: "{{{ rule_title }}} - Gather List of Packages"
+  tags:
+  - aide_check_audit_tools
+  ansible.builtin.package_facts:
+    manager: auto
+
 
 - name: Ensure aide is installed
   package:

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/ansible/shared.yml
@@ -35,6 +35,7 @@
     line: "{{ item }} {{{ aide_string() }}}"
   with_items: "{{ audit_tools }}"
 
+
 - name: Configure AIDE to properly protect audit tools
   lineinfile:
     path: {{{ aide_conf_path }}}

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/ansible/shared.yml
@@ -20,5 +20,5 @@
     path: /etc/aide.conf
     regexp: (^\s*{{ item }}\s*=\s*)(?!.*acl)([^\s]*)
     replace: \g<1>\g<2>+acl
-  when: "'aide' in ansible_facts.packages"
+  when: find_rules_groups_results is not skipped and "'aide' in ansible_facts.packages"
   with_items: "{{ find_rules_groups_results.stdout_lines | map('trim') | list }}"

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/ansible/shared.yml
@@ -20,6 +20,5 @@
     path: /etc/aide.conf
     regexp: (^\s*{{ item }}\s*=\s*)(?!.*xattrs)([^\s]*)
     replace: \g<1>\g<2>+xattrs
-  when: "'aide' in ansible_facts.packages"
+  when: find_rules_groups_results is not skipped and "'aide' in ansible_facts.packages"
   with_items: "{{ find_rules_groups_results.stdout_lines | map('trim') | list }}"
-

--- a/products/sle12/product.yml
+++ b/products/sle12/product.yml
@@ -36,6 +36,7 @@ platform_package_overrides:
   login_defs: "shadow"
   grub2: "grub2"
   sssd: "sssd"
+  passwd: "shadow"
 
 reference_uris:
   cis: 'https://www.cisecurity.org/benchmark/suse_linux/'

--- a/products/sle12/profiles/pci-dss-4.profile
+++ b/products/sle12/profiles/pci-dss-4.profile
@@ -14,7 +14,8 @@ description: |-
 selections:
     -  pcidss_3:all:base
     -  var_multiple_time_servers=suse
-    -  var_multiple_time_pools=suse      
+    -  var_multiple_time_pools=suse
+    -  var_accounts_tmout=15_min
     -  account_unique_id
     -  coredump_disable_backtraces
     -  coredump_disable_storage

--- a/products/sle15/product.yml
+++ b/products/sle15/product.yml
@@ -41,6 +41,7 @@ platform_package_overrides:
   grub2: "grub2"
   sssd: "sssd"
   crontabs: "cronie"
+  passwd: "shadow"
 
 reference_uris:
   cis: 'https://www.cisecurity.org/benchmark/suse_linux/'

--- a/products/sle15/profiles/pci-dss-4.profile
+++ b/products/sle15/profiles/pci-dss-4.profile
@@ -16,10 +16,10 @@ selections:
     -  ensure_pam_wheel_group_empty
     -  sshd_strong_kex=pcidss
     -  sshd_approved_macs=cis_sle15
-    -  sshd_approved_ciphers=cis_sle15 
+    -  sshd_approved_ciphers=cis_sle15
     -  var_multiple_time_servers=suse
-    -  var_multiple_time_pools=suse      
-# Exclude from PCI DISS profile all rules related to ntp and timesyncd and keep only 
+    -  var_multiple_time_pools=suse
+# Exclude from PCI DISS profile all rules related to ntp and timesyncd and keep only
 # rules related to chrony
     - '!ntpd_specify_multiple_servers'
     - '!ntpd_specify_remote_server'
@@ -30,7 +30,8 @@ selections:
     - '!use_pam_wheel_for_su'
     -  use_pam_wheel_group_for_su
     -  var_pam_wheel_group_for_su=cis
-    # Following rules once had a prodtype incompatible with the sle15 product
+    -  var_accounts_tmout=15_min
+# Following rules once had a prodtype incompatible with the sle15 product
     - '!aide_periodic_cron_checking'
     - '!accounts_password_pam_dcredit'
     - '!dconf_gnome_screensaver_lock_delay'
@@ -62,3 +63,4 @@ selections:
     - '!dconf_gnome_disable_automount_open'
     - '!network_nmcli_permissions'
     - '!package_cryptsetup-luks_installed'
+

--- a/shared/templates/pam_options/ansible.template
+++ b/shared/templates/pam_options/ansible.template
@@ -33,7 +33,7 @@
     path: {{{ PATH }}}
     line: '{{{ TYPE }}} {{{ CONTROL_FLAG }}} {{{ MODULE }}}'
     state: present
-  when: check_pam_module_result is not skipped and '"{{{ MODULE }}}" not in check_pam_module_result.stdout'
+  when: check_pam_module_result.stdout is defined and '"{{{ MODULE }}}" not in check_pam_module_result.stdout'
 
 - name: Ensure '{{{ MODULE }}}' module has conforming control flag
   lineinfile:

--- a/tests/data/product_stability/sle12.yml
+++ b/tests/data/product_stability/sle12.yml
@@ -45,6 +45,7 @@ platform_package_overrides:
   not_aarch64_arch: null
   not_s390x_arch: null
   ovirt: null
+  passwd: shadow
   s390x_arch: null
   sssd: sssd
   sssd-ldap: null

--- a/tests/data/product_stability/sle15.yml
+++ b/tests/data/product_stability/sle15.yml
@@ -49,6 +49,7 @@ platform_package_overrides:
   not_aarch64_arch: null
   not_s390x_arch: null
   ovirt: null
+  passwd: shadow
   s390x_arch: null
   sssd: sssd
   sssd-ldap: null


### PR DESCRIPTION
#### Description:

- When run in check mode ansible remediation scripts should be more isolated and need extra checks instead of assumptions

#### Rationale:

- Fix ansible remediations run in check mode for rules part of the SLE STIG profile

- Add var_accounts_tmout variable definition for PCI profile used in accounts_tmout rule
