### PR TITLE
Add a warning to rule service_rngd_enabled

### DIFF
--- a/linux_os/guide/services/rng/service_rngd_enabled/rule.yml
+++ b/linux_os/guide/services/rng/service_rngd_enabled/rule.yml
@@ -42,6 +42,11 @@ srg_requirement: '{{{ srg_requirement_service_disabled("rngd") }}}'
 
 {{% if product == "rhel8" %}}
 platform: os_linux[rhel]<=8.3
+warnings:
+  - general: |-
+      For RHEL versions 8.4 and above running with kernel FIPS mode enabled this rule is not applicable.
+      The in-kernel deterministic random bit generator (DRBG) is used in FIPS mode instead.
+      Consequently, the rngd service can't be started in FIPS mode.
 {{% endif %}}
 
 


### PR DESCRIPTION
This rule is used in STIG profile but the requirement isn't applicable to RHEL 8.4 and newer.
See https://stigaview.com/products/rhel8/v1r12/RHEL-08-010471/

The applicability of the rule has already been fixed in https://github.com/ComplianceAsCode/Content/commit/00513accd140621f730bd47297996a6d3b212fdf This commit adds an warning explaining the reason for the limited applicability.

Related to: https://issues.redhat.com/browse/RHEL-1819
