### PR TITLE
set_firewalld_default_zone: add a bash remediation

### DIFF
--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/set_firewalld_default_zone/bash/shared.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/set_firewalld_default_zone/bash/shared.sh
@@ -1,0 +1,13 @@
+# platform = multi_platform_all
+
+for interface_path in /sys/class/net/*; do
+	interface="${interface_path##/sys/class/net/}"
+	[[ ${interface} == lo ]] && continue
+
+	# If the interface is already in a zone, remove it
+	zone=$(firewall-cmd --permanent --get-zone-of-interface="$interface")
+	[[ $? -eq 0 ]] && firewall-cmd --permanent --remove-interface="$interface" --zone="$zone"
+	firewall-cmd --permanent --add-interface="$interface" --zone=drop
+done
+
+sed -i -e 's/DefaultZone=public/DefaultZone=drop/g' /etc/firewalld/firewalld.conf


### PR DESCRIPTION
Hello, this bash remediation for `set_firewalld_default_zone` switches all the network zones to the `drop` firewalld zone.
Note that this may be dangerous on a running system, as one could lock oneself out of its own system.

I'm more than open to discussions on whether that should be dropped (in which case the whole OVAL check + bash remediation) could probably be replaced by a simple call to the `line_in_file` template.