### PR TITLE
Fix CI job after Fedora 39 release

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -142,7 +142,7 @@ jobs:
       image: fedora:latest
     steps:
       - name: Install Deps
-        run: dnf install -y cmake make openscap-utils python3-pyyaml bats ansible python3-pip ShellCheck git
+        run: dnf install -y cmake make openscap-utils python3-pyyaml bats ansible python3-pip ShellCheck git gcc gcc-c++ python3-devel
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install deps python


### PR DESCRIPTION
This commit fixes the GitHub Actions CI job  `Gate / Build, Test on Fedora Latest (Container) (pull_request)` which started to fail after the latest container has been upgraded to Fedora 39.

We need to add gcc-c++ and python3-devel to be able to build pcre2 Python package from pip3.

Example of a problem run: https://github.com/ComplianceAsCode/content/actions/runs/6795930422/job/18474989234?pr=11236