### PR TITLE
Access to enable the logging of the `combine_oval.py` script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 set(LOG_LEVEL "WARNING")
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+if(SSG_LOG)
     set(LOG_LEVEL "DEBUG")
 endif()
 
@@ -228,6 +228,7 @@ message(STATUS "build type: ${CMAKE_BUILD_TYPE}")
 message(STATUS "generator: ${CMAKE_GENERATOR}")
 message(STATUS "source directory: ${CMAKE_SOURCE_DIR}")
 message(STATUS "build directory: ${CMAKE_BINARY_DIR}")
+message(STATUS "Logging: ${SSG_LOG}")
 message(STATUS " ")
 
 message(STATUS "Tools:")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,11 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
         "MinSizeRel" "RelWithDebInfo")
 endif()
 
+set(LOG_LEVEL "WARNING")
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(LOG_LEVEL "DEBUG")
+endif()
+
 project(scap-security-guide NONE)
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")

--- a/build_product
+++ b/build_product
@@ -78,6 +78,7 @@ _arg_ansible_playbooks="on"
 _arg_bash_scripts="on"
 _arg_datastream_only="off"
 _arg_profiling="off"
+_arg_log="off"
 
 
 print_help()
@@ -94,6 +95,7 @@ print_help()
 	printf '\t%s\n' "--bash-scripts, --no-bash-scripts: Build Bash remediation scripts for every profile (on by default)"
 	printf '\t%s\n' "-d, --datastream-only, --no-datastream-only: Build the data stream only. Do not build any of the guides, tables, etc (off by default)"
 	printf '\t%s\n' "-p, --profiling, --no-profiling: Use ninja and call the build_profiler.sh util (off by default)"
+	printf '\t%s\n' "-l, --log, --no-log: Logs all debugging messages (off by default)"
 	printf '\t%s\n' "-h, --help: Prints help"
 	printf '\nEnvironment variables that are supported:\n'
 	printf '\t%s\n' "ADDITIONAL_CMAKE_OPTIONS: Whitespace-separated string of arguments to pass to CMake."
@@ -179,6 +181,18 @@ parse_commandline()
 				if test -n "$_next" -a "$_next" != "$_key"
 				then
 					{ begins_with_short_option "$_next" && shift && set -- "-p" "-${_next}" "$@"; } || die "The short option '$_key' can't be decomposed to ${_key:0:2} and -${_key:2}, because ${_key:0:2} doesn't accept value and '-${_key:2:1}' doesn't correspond to a short option."
+				fi
+				;;
+			-l|--no-log|--log)
+				_arg_log="on"
+				test "${1:0:5}" = "--no-" && _arg_log="off"
+				;;
+			-l*)
+				_arg_log="on"
+				_next="${_key##-l}"
+				if test -n "$_next" -a "$_next" != "$_key"
+				then
+					{ begins_with_short_option "$_next" && shift && set -- "-l" "-${_next}" "$@"; } || die "The short option '$_key' can't be decomposed to ${_key:0:2} and -${_key:2}, because ${_key:0:2} doesn't accept value and '-${_key:2:1}' doesn't correspond to a short option."
 				fi
 				;;
 			-h|--help)
@@ -391,6 +405,13 @@ if [ "$_arg_bash_scripts" = off ] ; then
 fi
 EXPLICIT_BUILD_TARGETS=()
 set_explict_build_targets
+
+if [ "$_arg_log" = on ] ; then
+	CMAKE_OPTIONS+=("-DSSG_LOG:BOOL=ON")
+else
+	CMAKE_OPTIONS+=("-DSSG_LOG:BOOL=OFF")
+fi
+
 
 set -e
 rm -rf build/*

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -289,7 +289,7 @@ macro(ssg_build_oval_unlinked PRODUCT)
     set(OVAL_COMBINE_PATHS "${SSG_SHARED}/checks/oval" "${BUILD_CHECKS_DIR}/oval")
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/combine_ovals.py" --include-benchmark --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_BINARY_DIR}/product.yml" --output "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml" --build-ovals-dir "${CMAKE_CURRENT_BINARY_DIR}/checks/oval" ${OVAL_COMBINE_PATHS}
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/combine_ovals.py" --log "${LOG_LEVEL}" --include-benchmark --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_BINARY_DIR}/product.yml" --output "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml" --build-ovals-dir "${CMAKE_CURRENT_BINARY_DIR}/checks/oval" ${OVAL_COMBINE_PATHS}
         COMMAND "${XMLLINT_EXECUTABLE}" --format --output "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml" "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml"
         DEPENDS generate-internal-templated-content-${PRODUCT} "${CMAKE_CURRENT_BINARY_DIR}/templated-content-${PRODUCT}"
         COMMENT "[${PRODUCT}-content] generating oval-unlinked.xml"
@@ -303,7 +303,7 @@ endmacro()
 macro(ssg_build_cpe_oval_unlinked PRODUCT)
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/cpe-oval-unlinked.xml"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/combine_ovals.py" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_BINARY_DIR}/product.yml" --output "${CMAKE_CURRENT_BINARY_DIR}/cpe-oval-unlinked.xml" --build-ovals-dir "${CMAKE_CURRENT_BINARY_DIR}/checks/oval" "${CMAKE_CURRENT_BINARY_DIR}/checks_from_templates/cpe-oval" "${SSG_SHARED}/checks/oval" "${SSG_SHARED}/applicability/oval"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/combine_ovals.py" --log "${LOG_LEVEL}" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_BINARY_DIR}/product.yml" --output "${CMAKE_CURRENT_BINARY_DIR}/cpe-oval-unlinked.xml" --build-ovals-dir "${CMAKE_CURRENT_BINARY_DIR}/checks/oval" "${CMAKE_CURRENT_BINARY_DIR}/checks_from_templates/cpe-oval" "${SSG_SHARED}/checks/oval" "${SSG_SHARED}/applicability/oval"
         COMMAND "${XMLLINT_EXECUTABLE}" --format --output "${CMAKE_CURRENT_BINARY_DIR}/cpe-oval-unlinked.xml" "${CMAKE_CURRENT_BINARY_DIR}/cpe-oval-unlinked.xml"
         DEPENDS generate-internal-templated-content-${PRODUCT} "${CMAKE_CURRENT_BINARY_DIR}/templated-content-${PRODUCT}"
         COMMENT "[${PRODUCT}-content] generating cpe-oval-unlinked.xml"

--- a/ssg/oval_object_model/oval_container.py
+++ b/ssg/oval_object_model/oval_container.py
@@ -54,7 +54,7 @@ def _handle_existing_id(component, component_dict):
             (
                 "OVAL ID {} is used multiple times and should represent "
                 "the same elements.\nRewrite the OVAL checks. Place the identical IDs"
-                " into their own definition and extend this definition by it.\n"
+                " into their own definition and extend this definition by it."
             ).format(component.id_)
         )
 


### PR DESCRIPTION
#### Description:

This PR enables `debug` and `info` messages while the `combine_oval.py` script is running if the build is run as a debug build.
#### Review Hints:

run the build using the following command:
```bash
./build_product --log fedora
```