### PR TITLE
Add SRG id to `file_owner_grub2_cfg` for RHEL 9 STIG

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/rule.yml
@@ -45,6 +45,7 @@ references:
     nist-csf: PR.AC-4,PR.DS-5
     pcidss: Req-7.1
     pcidss4: "2.2.6"
+    srg: SRG-OS-000480-GPOS-00227
     stigid@rhel9: RHEL-09-212030
 
 ocil_clause: '{{{ ocil_clause_file_owner(file=grub2_boot_path ~ "/grub.cfg", owner="root") }}}'


### PR DESCRIPTION
#### Description:

Add SRG id to `file_owner_grub2_cfg` for RHEL 9 STIG

#### Rationale:
* So that all STIG rules have an SRG ID
