### PR TITLE
Sle15 fix ansible pci-dss remediations in check mode

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
@@ -18,7 +18,9 @@
 
 - name: {{{ rule_title }}} - Set List of Privileged Commands Found in Eligible Mount Points
   ansible.builtin.set_fact:
-    privileged_commands: "{{( result_privileged_commands_search.results | map(attribute='stdout_lines') | select() | list ) | sum(start=[]) }}"
+    privileged_commands: "{{ privileged_commands | default([]) + item.stdout_lines }}"
+  loop: "{{ result_privileged_commands_search.results }}"
+  when: item is not skipped
 
 - name: {{{ rule_title }}} - Privileged Commands are Present in the System
   block:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/ansible/shared.yml
@@ -12,17 +12,17 @@
 - name: Parse log file line
   command: awk -F '=' '/^log_file/ {print $2}' /etc/audit/auditd.conf
   register: log_file_line
-  when: (log_file_exists.stdout | length > 0)
+  when: log_file_exists is not skipped and (log_file_exists.stdout | length > 0)
 
 - name: Set default log_file if not set
   set_fact:
     log_file: "/var/log/audit/audit.log"
-  when: (log_file_exists is undefined) or (log_file_exists.stdout | length == 0)
+  when: (log_file_exists is skipped) or (log_file_exists is undefined) or (log_file_exists.stdout | length == 0)
 
 - name: Set log_file from log_file_line if not set already
   set_fact:
     log_file: "{{ log_file_line.stdout | trim }}"
-  when: (log_file_line.stdout is defined) and (log_file_line.stdout | length > 0)
+  when: (log_file_exists is not skipped) and (log_file_line.stdout is defined) and (log_file_line.stdout | length > 0)
 
 {{% if 'ol' not in product and "rhel" not in product %}}
 - name: Get log files group
@@ -33,13 +33,14 @@
 - name: Parse log group line
   command: awk -F '=' '/log_group/ {print $2}' /etc/audit/auditd.conf
   register: log_group
-  when: (log_group_line.stdout | length > 0)
+  when: (log_group_line is not skipped) and (log_group_line.stdout | length > 0)
 
 - name: Apply mode to log file when group root
   file:
     path: "{{ log_file }}"
     mode: (( log_group is defined ) and ( ( log_group.stdout | trim ) == 'root' )) | ternary( '0600', '0640')
   failed_when: false
+  when: log_group is not skipped
 
 - name: List all log file backups
   find:
@@ -53,6 +54,7 @@
     mode: (( log_group is defined ) and ( ( log_group.stdout | trim ) == 'root' ))  | ternary( '0400', '0440')
   loop: "{{ backup_files.files| map(attribute='path') | list }}"
   failed_when: false
+  when: backup_files is not skipped
 
 {{% else %}}
 - name: Apply mode to log file

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/ansible/shared.yml
@@ -23,4 +23,5 @@
     value: '1'
     no_extra_spaces: True
   # regex filters grep output for files ending in .repo and matching section names.
-  loop: "{{ repo_grep_results.stdout | regex_findall( '(.+\\.repo):\\[(.+)\\]\\n?' ) }}"
+  loop: "{{ repo_grep_results.stdout |regex_findall( '(.+\\.repo):\\[(.+)\\]\\n?' ) if repo_grep_results is not skipped else []}}"
+  when: repo_grep_results is not skipped

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1268,21 +1268,21 @@ Part of the grub2_bootloader_argument template.
     dest: /etc/default/grub
     create: yes
     mode: '0644'
-  when: argcheck.rc != 0 and linecheck.rc != 0
+  when: argcheck is not skipped and linecheck is not skipped and argcheck.rc != 0 and linecheck.rc != 0
 
 - name: Replace existing {{{ arg_name }}} argument
   replace:
       path: /etc/default/grub
       regexp: '{{{ arg_name }}}=\w+'
       replace: '{{{ arg_name_value }}}'
-  when: argcheck.rc == 0 and linecheck.rc == 0
+  when: argcheck is not skipped and linecheck is not skipped and argcheck.rc == 0 and linecheck.rc == 0
 
 - name: Add {{{ arg_name }}} argument
   replace:
       path: /etc/default/grub
       regexp: '(^\s*GRUB_CMDLINE_LINUX=.*)"'
       replace: '\1 {{{ arg_name_value }}}"'
-  when: argcheck.rc != 0 and linecheck.rc == 0
+  when: argcheck is not skipped and linecheck is not skipped and argcheck.rc != 0 and linecheck.rc == 0
 
 {{% endif -%}}
 
@@ -1316,7 +1316,7 @@ Part of the grub2_bootloader_argument_absent template.
       path: /etc/default/grub
       regexp: '\(^GRUB_CMDLINE_LINUX=".*\){{{ arg_name }}}=?[^[:space:]]*\(.*"\)'
       replace: '\1 \2'
-  when: argcheck.rc == 0
+  when: argcheck is not skipped and argcheck.rc == 0
 
 {{% endif -%}}
 

--- a/shared/templates/rsyslog_logfiles_attributes_modify/ansible.template
+++ b/shared/templates/rsyslog_logfiles_attributes_modify/ansible.template
@@ -27,6 +27,7 @@
 - name: '{{{ rule_title }}} - Aggregate rsyslog includes'
   ansible.builtin.set_fact:
     include_config_output: "{{ rsyslog_old_inc.stdout_lines + rsyslog_new_inc.stdout_lines }}"
+  when: rsyslog_old_inc is not skipped and rsyslog_new_inc is not skipped
 
 - name: '{{{ rule_title }}} - List all config files'
   ansible.builtin.find:
@@ -35,6 +36,7 @@
     hidden: no
     follow: yes
   loop: "{{ include_config_output | list + [rsyslog_etc_config] }}"
+  when: include_config_output is defined
   register: rsyslog_config_files
   failed_when: False
   changed_when: False
@@ -45,9 +47,10 @@
     grep -oP '^[^(\s|#|\$)]+[\s]+.*[\s]+-?(/+[^:;\s]+);*\.*$' {{ item.1.path }} | \
     awk '{print $NF}' | \
     sed -e 's/^-//' || true
-  loop: "{{ rsyslog_config_files.results | subelements('files') }}"
+  loop: "{{ rsyslog_config_files.results | default([]) | subelements('files') }}"
   register: log_files_old
   changed_when: False
+  when: rsyslog_config_files is not skipped
 
 - name: '{{{ rule_title }}} - Extract log files new format'
   ansible.builtin.shell: |
@@ -56,9 +59,10 @@
     grep -aoP "File\s*=\s*\"([/[:alnum:][:punct:]]*)\"\s*\)" | \
     grep -oE "\"([/[:alnum:][:punct:]]*)\"" | \
     tr -d "\""|| true
-  loop: "{{ rsyslog_config_files.results | subelements('files') }}"
+  loop: "{{ rsyslog_config_files.results | default([]) | subelements('files') }}"
   register: log_files_new
   changed_when: False
+  when: rsyslog_config_files is not skipped
 
 - name: '{{{ rule_title }}} - Sum all log files found'
   ansible.builtin.set_fact:


### PR DESCRIPTION
#### Description:

- When run in check mode ansible remediation scripts should be more isolated and need extra checks instead of assumptions

#### Rationale:

- Make sure required ansible steps are not skipped
