### PR TITLE
Sle15 fix ansible hipaa remediation

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/ansible/shared.yml
@@ -45,6 +45,7 @@
       regexp: '\(^GRUB_CMDLINE_LINUX=".*\)noexec=?[^[:space:]]*\(.*"\)'
       replace: '\1 \2'
   when:
+    - argcheck is not skipped
     - argcheck.rc == 0
     - kexec_arch == "b64"
 


### PR DESCRIPTION
#### Description:

- When run in check mode ansible remediation scripts should be more isolated and need extra checks instead of assumptions

#### Rationale:

- Make sure required step is not skipped