### PR TITLE
Require SRG Reference for Rules with STIG Reference

### DIFF
--- a/docs/manual/developer/08_content_tests.md
+++ b/docs/manual/developer/08_content_tests.md
@@ -75,3 +75,12 @@ To enable this test pass following options to cmake:
 You will need to replace `/opt/scapval/SCAP-Content-Validation-Tool-1.3.5/scapval-1.3.5.jar` with the actual path the SCAPVAL jar on your system.
 
 SCAPVal can be run with ctest using the following command `ctest -R 'scapval' --output-on-failure`.
+
+## SRG and STIG Mapping
+This test ensures that rules with `stigid` reference also have a `srg` reference.
+This test is an opt-in test per product, but ran by default.
+This uses the build datastreams so the project must be rebuilt in order for changes to be reflected in the results.
+
+The macro `stig_srg_mapping` in `tests/CMakeList.txt` should be used when adding a product for this test.
+
+This script uses `tests/stig_srg_mapping.py` to run the test.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -229,7 +229,7 @@ macro(ssg_refcheck_test PRODUCT PROFILE KEY)
     set_tests_properties("refchecker-${PRODUCT}-${PROFILE}" PROPERTIES LABELS quick)
 endmacro()
 
-macro(stig_srg_mapping PRODUCT)
+macro(stig_srg_mapping_test PRODUCT)
     add_test(
         NAME "stig-srg-mapping-${PRODUCT}"
         COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/stig_srg_mapping.py" --prefix "SRG-OS" --build-root "${CMAKE_BINARY_DIR}" --root "${CMAKE_SOURCE_DIR}" ${PRODUCT}
@@ -247,7 +247,7 @@ if(PYTHON_VERSION_MAJOR GREATER 2 AND SSG_PRODUCT_RHEL9)
     ssg_refcheck_test("rhel9" "ccn_advanced" "ccn")
     # This exclude can be removed once enable_authselect has a stigid
     ssg_refcheck_test("rhel9" "stig" "stigid" "enable_authselect")
-    stig_srg_mapping("rhel9")
+    stig_srg_mapping_test("rhel9")
 endif()
 
 if(PYTHON_VERSION_MAJOR GREATER 2 AND SSG_PRODUCT_RHEL8)
@@ -255,7 +255,7 @@ if(PYTHON_VERSION_MAJOR GREATER 2 AND SSG_PRODUCT_RHEL8)
     ssg_refcheck_test("rhel8" "cis_workstation_l2" "cis")
     ssg_refcheck_test("rhel8" "cis_server_l1" "cis")
     ssg_refcheck_test("rhel8" "cis" "cis")
-    stig_srg_mapping("rhel8")
+    stig_srg_mapping_test("rhel8")
 endif()
 
 if(PYTHON_VERSION_MAJOR GREATER 2 AND SSG_PRODUCT_RHEL7)
@@ -263,7 +263,7 @@ if(PYTHON_VERSION_MAJOR GREATER 2 AND SSG_PRODUCT_RHEL7)
     ssg_refcheck_test("rhel7" "cis_workstation_l2" "cis")
     ssg_refcheck_test("rhel7" "cis_server_l1" "cis")
     ssg_refcheck_test("rhel7" "cis" "cis")
-    stig_srg_mapping("rhel7")
+    stig_srg_mapping_test("rhel7")
 endif()
 
 macro(ssg_controlrefcheck_test PRODUCT CONTROL KEY)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -229,6 +229,15 @@ macro(ssg_refcheck_test PRODUCT PROFILE KEY)
     set_tests_properties("refchecker-${PRODUCT}-${PROFILE}" PROPERTIES LABELS quick)
 endmacro()
 
+macro(stig_srg_mapping PRODUCT)
+    add_test(
+        NAME "stig-srg-mapping-${PRODUCT}"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/stig_srg_mapping.py" --prefix "SRG-OS" --build-root "${CMAKE_BINARY_DIR}" --root "${CMAKE_SOURCE_DIR}" ${PRODUCT}
+    )
+    set_tests_properties("stig-srg-mapping-${PRODUCT}" PROPERTIES LABELS quick)
+endmacro()
+
+
 if(PYTHON_VERSION_MAJOR GREATER 2 AND SSG_PRODUCT_RHEL9)
     ssg_refcheck_test("rhel9" "cis_workstation_l1" "cis")
     ssg_refcheck_test("rhel9" "cis_workstation_l2" "cis")
@@ -238,6 +247,7 @@ if(PYTHON_VERSION_MAJOR GREATER 2 AND SSG_PRODUCT_RHEL9)
     ssg_refcheck_test("rhel9" "ccn_advanced" "ccn")
     # This exclude can be removed once enable_authselect has a stigid
     ssg_refcheck_test("rhel9" "stig" "stigid" "enable_authselect")
+    stig_srg_mapping("rhel9")
 endif()
 
 if(PYTHON_VERSION_MAJOR GREATER 2 AND SSG_PRODUCT_RHEL8)
@@ -245,6 +255,7 @@ if(PYTHON_VERSION_MAJOR GREATER 2 AND SSG_PRODUCT_RHEL8)
     ssg_refcheck_test("rhel8" "cis_workstation_l2" "cis")
     ssg_refcheck_test("rhel8" "cis_server_l1" "cis")
     ssg_refcheck_test("rhel8" "cis" "cis")
+    stig_srg_mapping("rhel8")
 endif()
 
 if(PYTHON_VERSION_MAJOR GREATER 2 AND SSG_PRODUCT_RHEL7)
@@ -252,6 +263,7 @@ if(PYTHON_VERSION_MAJOR GREATER 2 AND SSG_PRODUCT_RHEL7)
     ssg_refcheck_test("rhel7" "cis_workstation_l2" "cis")
     ssg_refcheck_test("rhel7" "cis_server_l1" "cis")
     ssg_refcheck_test("rhel7" "cis" "cis")
+    stig_srg_mapping("rhel7")
 endif()
 
 macro(ssg_controlrefcheck_test PRODUCT CONTROL KEY)

--- a/tests/stig_srg_mapping.py
+++ b/tests/stig_srg_mapping.py
@@ -1,0 +1,127 @@
+#!/usr/bin/python3
+
+import argparse
+import os
+import sys
+import xml.etree.cElementTree as ET
+
+try:
+    import ssg.constants
+    import ssg.xccdf
+    import ssg.xml
+except ImportError:
+    print("The ssg module could not be found.", file=sys.stderr)
+    print(
+        "Run .pyenv.sh available in the project root directory,"
+        " or add it to PYTHONPATH manually.",
+        file=sys.stderr,
+    )
+    print("$ source .pyenv.sh", file=sys.stderr)
+    exit(2)
+
+SSG_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+BINARY_DIR = os.path.join(SSG_ROOT, "build")
+PREFIX = "xccdf_org.ssgproject.content_"
+SRG_GPOS_URL = "https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cgeneral-purpose-os"
+SRG_PREFIX = "SRG-OS"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-r",
+        "--root",
+        help=f"Root of the project. Defaults to {SSG_ROOT}",
+        default=SSG_ROOT,
+    )
+    parser.add_argument(
+        "-b",
+        "--build-root",
+        help=f"Path to the root the cmake " f"build directory.Defaults to {BINARY_DIR}",
+        default=BINARY_DIR,
+    )
+    parser.add_argument(
+        "-u",
+        "--srg-url",
+        help="URL for the SRG reference defaults to {SRG_GPOS_URL}",
+        default=SRG_GPOS_URL,
+    )
+    parser.add_argument(
+        "--prefix",
+        help=f"Prefix used for the SRG reference defaults to {SRG_PREFIX}",
+        default=SRG_PREFIX,
+    )
+    parser.add_argument("product")
+    return parser.parse_args()
+
+
+def _print_missing(missing):
+    if len(missing) != 0:
+        for rule in missing:
+            content_id = rule.replace(f"{PREFIX}rule_", "")
+            print(f"Missing SRG in {content_id}")
+        exit(3)
+
+
+def _get_srg_rules(ref_url, root, srg_prefix):
+    srg_rule = set()
+    for rule in root.findall(".//xccdf-1.2:Rule", ssg.constants.PREFIX_TO_NS):
+        ref = rule.find(
+            f".//xccdf-1.2:reference[@href='{ref_url}']", ssg.constants.PREFIX_TO_NS
+        )
+        if ref is not None and ref.text.startswith(srg_prefix):
+            srg_rule.add(rule.attrib.get("id"))
+    return srg_rule
+
+
+def _get_stig_rules(stig_profile):
+    stig_rules = set()
+    for rule in stig_profile.findall(
+        "xccdf-1.2:select[@selected='true']", ssg.constants.PREFIX_TO_NS
+    ):
+        stig_rules.add(rule.attrib.get("idref"))
+    return stig_rules
+
+
+def _get_stig_profile(root):
+    profile_id = f"{PREFIX}profile_stig"
+    stig_profile = root.find(
+        f".//xccdf-1.2:Profile[@id='{profile_id}']", ssg.constants.PREFIX_TO_NS
+    )
+    return stig_profile
+
+
+def _get_root(build_root, product):
+    filename = f"ssg-{product}-ds.xml"
+    datastream_path = os.path.join(build_root, filename)
+    root = ET.parse(datastream_path).getroot()
+    if not os.path.exists(datastream_path):
+        print(
+            f"Product {product} datastream dose not exist. Has it been built?",
+            file=sys.stderr,
+        )
+        exit(1)
+    return root
+
+
+def main():
+    ssg.xml.register_namespaces()
+    args = _parse_args()
+
+    product = args.product
+    build_root = args.build_root
+    root = _get_root(build_root, product)
+    ref_url = args.srg_url
+    srg_prefix = args.prefix
+
+    stig_profile = _get_stig_profile(root)
+
+    stig_rules = _get_stig_rules(stig_profile)
+    srg_rules = _get_srg_rules(ref_url, root, srg_prefix)
+
+    missing = stig_rules - srg_rules
+    _print_missing(missing)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/stig_srg_mapping.py
+++ b/tests/stig_srg_mapping.py
@@ -27,7 +27,9 @@ SRG_PREFIX = "SRG-OS"
 
 
 def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        description="Ensure that rules with STIG IDs also have SRG references."
+    )
     parser.add_argument(
         "-r",
         "--root",
@@ -37,18 +39,18 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "-b",
         "--build-root",
-        help=f"Path to the root the cmake " f"build directory.Defaults to {BINARY_DIR}",
+        help=f"Path to the root the cmake build directory. Defaults to {BINARY_DIR}.",
         default=BINARY_DIR,
     )
     parser.add_argument(
         "-u",
         "--srg-url",
-        help="URL for the SRG reference defaults to {SRG_GPOS_URL}",
+        help=f"URL for the SRG reference. Defaults to {SRG_GPOS_URL.replace('%', '%%')}.",
         default=SRG_GPOS_URL,
     )
     parser.add_argument(
         "--prefix",
-        help=f"Prefix used for the SRG reference defaults to {SRG_PREFIX}",
+        help=f"Prefix used for the SRG reference. Defaults to {SRG_PREFIX}.",
         default=SRG_PREFIX,
     )
     parser.add_argument("product")


### PR DESCRIPTION
#### Description:
This PR adds a new test that requires rules with a STIG ID for RHEL7-9 must also have an SRG ID.
 
#### Rationale:

Ensure that our rule references have the required information. 

#### Review Hints:
Remove a `srg` key from your favorite rule, rebuild, run the tests and see the failure. 