### PR TITLE
Add alternatives to mandatory keys

### DIFF
--- a/ssg/entities/common.py
+++ b/ssg/entities/common.py
@@ -153,6 +153,8 @@ class XCCDFEntity(object):
 
     MANDATORY_KEYS = set()
 
+    ALTERNATIVE_KEYS = dict()
+
     GENERIC_FILENAME = ""
     ID_LABEL = "id"
 
@@ -192,6 +194,8 @@ class XCCDFEntity(object):
         """
         data = dict()
 
+        # Lets keep a list of the initial keys for alternative comparison
+        initial_input_keys = input_contents.keys()
         for key, default in cls.KEYS.items():
             if key in input_contents:
                 if input_contents[key] is not None:
@@ -201,6 +205,10 @@ class XCCDFEntity(object):
 
             if key not in cls.MANDATORY_KEYS:
                 data[key] = cls.KEYS[key]()
+            elif key in cls.ALTERNATIVE_KEYS:
+                if cls.ALTERNATIVE_KEYS[key] in initial_input_keys:
+                    data[key] = cls.KEYS[key]()
+                    continue
             else:
                 msg = (
                     "Key '{key}' is mandatory for definition of '{class_name}'."

--- a/ssg/entities/profile_base.py
+++ b/ssg/entities/profile_base.py
@@ -55,6 +55,10 @@ class Profile(XCCDFEntity, SelectionHandler):
         "selections",
     }
 
+    ALTERNATIVE_KEYS = {
+        "selections": "extends",
+    }
+
     @classmethod
     def process_input_dict(cls, input_contents, env_yaml, product_cpes):
         input_contents = super(Profile, cls).process_input_dict(input_contents, env_yaml)
@@ -245,7 +249,9 @@ class Profile(XCCDFEntity, SelectionHandler):
         profile_rules = set(self.selected)
         is_empty, empty_groups = self._find_empty_groups(root_group, profile_rules)
         if is_empty:
-            msg = "Profile {0} unselects all groups.".format(self.id_)
+            msg = ("Profile {0} unselects all groups. "
+                   "Check whether it selects any rule or extends any profile."
+                   .format(self.id_))
             raise ValueError(msg)
         self.unselected_groups.extend(sorted(empty_groups))
 


### PR DESCRIPTION
#### Description:

- Don't require profiles to have `selections` if they have an `extends`.

#### Rationale:

- The OCP profiles aim to have versioned profiles and non-versioned profiles, with the non-versioned profiles being used as the profile for anyone who wants to automatically "roll over" to the latest version when new versions are added.:
  #11241 
-  This allows a profile to just extend another one without having to add any selection. Making it possible to have non-versioned profiles extend versioned profiles.
-  Profiles with no rules selected (that unselect all groups) are already caught by the build system.


#### Review Hints:

- Add an `extends` to any profile and remove the whole `selections` key.
- Check the linked PR for reference.
