### PR TITLE
Update grub2_mitigation_argument

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/grub2_mitigation_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_mitigation_argument/rule.yml
@@ -5,13 +5,8 @@ prodtype: ol8
 title: 'System Must Avoid Meltdown and Spectre Exploit Vulnerabilities in Modern Processors'
 
 description: |-
-    Determine the default kernel:
-    <pre>$ sudo grubby --default-kernel
-
-    /boot/vmlinuz-5.4.17-2011.1.2.el8uek.x86_64</pre>
-
-    Using the default kernel, verify that Meltdown mitigations are not disabled:
-    <pre>$ sudo grubby --info=<i>path-to-default-kernel</i> | grep mitigations</pre>
+    Verify that Meltdown mitigations are not disabled:
+    <pre>$ sudo grubby --info=ALL | grep mitigations</pre>
 
     The mitigations must not be set to "off".
 
@@ -35,25 +30,15 @@ platform: grub2
 ocil_clause: 'mitigations is set to off'
 
 ocil: |-
-    Make sure that the kernel is not disabling mitigations with the following
-    commands.
-    <pre>$ sudo grubby --default-kernel</pre>
-    <pre>/boot/vmlinuz-5.4.17-2011.1.2.el8uek.x86_64</pre>
+    Verify that Meltdown mitigations are not disabled in any kernel:
 
-    Using the default kernel, verify that Meltdown mitigations are not disabled:
-
-    <pre>$ sudo grubby --info={path-to-default-kernel} | grep mitigations</pre>
+    <pre>$ sudo grubby --info=ALL | grep mitigations</pre>
 
 
 fixtext: |-
-    Determine the default kernel:
+    Remove the Meltdown mitigations:
 
-    <pre>$ sudo grubby --default-kernel
-    /boot/vmlinuz-5.4.17-2011.1.2.el8uek.x86_64</pre>
-
-    Using the default kernel, remove the Meltdown mitigations:
-
-    <pre>$ sudo grubby --update-kernel=<path-to-default-kernel> --remove-args=mitigations=off</pre>
+    <pre>$ sudo grubby --update-kernel=ALL --remove-args=mitigations=off</pre>
 
     Reboot the system for the change to take effect.
 

--- a/linux_os/guide/system/bootloader-grub2/grub2_mitigation_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_mitigation_argument/rule.yml
@@ -11,9 +11,9 @@ description: |-
     /boot/vmlinuz-5.4.17-2011.1.2.el8uek.x86_64</pre>
 
     Using the default kernel, verify that Meltdown mitigations are not disabled:
-    <pre>$ sudo grubby --info=<i>path-to-default-kernel</i> | grep mitigation</pre>
+    <pre>$ sudo grubby --info=<i>path-to-default-kernel</i> | grep mitigations</pre>
 
-    The mitigation must be set to "on".
+    The mitigations must not be set to "off".
 
 rationale: |-
     Hardware vulnerabilities allow programs to steal data that is currently processed on the
@@ -32,17 +32,32 @@ references:
 
 platform: grub2
 
-ocil_clause: 'mitigation is not set to on'
+ocil_clause: 'mitigations is set to off'
 
 ocil: |-
-    {{{ ocil_grub2_argument("mitigation=on") | indent(4) }}}
+    Make sure that the kernel is not disabling mitigations with the following
+    commands.
+    <pre>$ sudo grubby --default-kernel</pre>
+    <pre>/boot/vmlinuz-5.4.17-2011.1.2.el8uek.x86_64</pre>
+
+    Using the default kernel, verify that Meltdown mitigations are not disabled:
+
+    <pre>$ sudo grubby --info={path-to-default-kernel} | grep mitigations</pre>
 
 
 fixtext: |-
-    {{{ describe_grub2_argument("mitigation=on") | indent(4) }}}
+    Determine the default kernel:
+
+    <pre>$ sudo grubby --default-kernel
+    /boot/vmlinuz-5.4.17-2011.1.2.el8uek.x86_64</pre>
+
+    Using the default kernel, remove the Meltdown mitigations:
+
+    <pre>$ sudo grubby --update-kernel=<path-to-default-kernel> --remove-args=mitigations=off</pre>
+
+    Reboot the system for the change to take effect.
 
 template:
-    name: grub2_bootloader_argument
+    name: grub2_bootloader_argument_absent
     vars:
-        arg_name: mitigation
-        arg_value: 'on'
+        arg_name: 'mitigations=off'


### PR DESCRIPTION
#### Description:

- Update `grub2_mitigation_argument` to use `grub2_bootloader_argument_absent` template instead of `grub2_bootloader_argument`. As STIG actually required 'not be off'

#### Rationale:

- There was a typo on DISA STIG requirement instead of `mitigation` the option shoud be `mitigations`
- STIG actually required mitigations to not be set to off, didn't ask for any specific value
