### PR TITLE
Add ubuntu 20.04 to audit_rules_kernel_module_loading_delete tests

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/correct_rules.pass.sh
@@ -3,7 +3,7 @@
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules
-{{% if "ol" in product or 'rhel' in product %}}
+{{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
 echo "-a always,exit -F arch=b32 -S delete_module -F auid>={{{ uid_min }}} -F auid!=unset -F key=modules" >> /etc/audit/rules.d/modules.rules
 echo "-a always,exit -F arch=b64 -S delete_module -F auid>={{{ uid_min }}} -F auid!=unset -F key=modules" >> /etc/audit/rules.d/modules.rules
 {{% else %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/missing_auid_filter.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/missing_auid_filter.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 8,Ubuntu 20.04
+# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_ubuntu
 # packages = audit
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/missing_auid_filter.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/missing_auid_filter.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 8,Ubuntu 20.04
 # packages = audit
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/wrong_list_action.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/wrong_list_action.fail.sh
@@ -3,7 +3,7 @@
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules\
-{{% if "ol" in product or 'rhel' in product %}}
+{{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
 echo "-a never,exit -F arch=b32 -S delete_module -F auid>={{{ uid_min }}} -F auid!=unset -F key=modules" >> /etc/audit/rules.d/modules.rules
 echo "-a never,exit -F arch=b64 -S delete_module -F auid>={{{ uid_min }}} -F auid!=unset -F key=modules" >> /etc/audit/rules.d/modules.rules
 {{% else %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/wrong_syscall.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/wrong_syscall.fail.sh
@@ -3,7 +3,7 @@
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules
-{{% if "ol" in product or 'rhel' in product %}}
+{{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
 echo "-a always,exit -F arch=b32 -S delete -F auid>={{{ uid_min }}} -F auid!=unset -F key=modules" >> /etc/audit/rules.d/modules.rules
 echo "-a always,exit -F arch=b64 -S delete -F auid>={{{ uid_min }}} -F auid!=unset -F key=modules" >> /etc/audit/rules.d/modules.rules
 {{% else %}}


### PR DESCRIPTION
#### Description:

- Add Ubuntu to `audit_rules_kernel_module_loading_delete` tests (STIG UBTU-20-010181)
- See PR #11057 