### PR TITLE
Fix sudo_require_reauthentication remediations edge case 

### DIFF
--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/ansible/shared.yml
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/ansible/shared.yml
@@ -34,3 +34,10 @@
     line: 'Defaults timestamp_timeout={{ var_sudo_timestamp_timeout }}'
     validate: /usr/sbin/visudo -cf %s
   when: edit_sudoers_timestamp_timeout_option is defined and not edit_sudoers_timestamp_timeout_option.changed
+
+- name: Remove timestamp_timeout wrong values in /etc/sudoers
+  lineinfile:
+    path: /etc/sudoers
+    regexp: '^[\s]*Defaults\s.*\btimestamp_timeout[\s]*=[\s]*(?!{{ var_sudo_timestamp_timeout }}\b)[-]?\w+\b.*$'
+    state: absent
+    validate: /usr/sbin/visudo -cf %s

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/ansible/shared.yml
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/ansible/shared.yml
@@ -5,22 +5,23 @@
 # disruption = low
 
 {{{ ansible_instantiate_variables("var_sudo_timestamp_timeout") }}}
-- name: "Find out if /etc/sudoers.d/* files contain 'Defaults timestamp_timeout' to be deduplicated"
-  find:
+
+- name: "{{{ rule_title }}} - Find /etc/sudoers.d/* files containing 'Defaults timestamp_timeout'"
+  ansible.builtin.find:
     path: "/etc/sudoers.d"
     patterns: "*"
     contains: '^[\s]*Defaults\s.*\btimestamp_timeout[\s]*=.*'
   register: sudoers_d_defaults_timestamp_timeout
 
-- name: "Remove found occurrences of 'Defaults timestamp_timeout' from /etc/sudoers.d/* files"
-  lineinfile:
+- name: "{{{ rule_title }}} - Remove 'Defaults timestamp_timeout' from /etc/sudoers.d/* files"
+  ansible.builtin.lineinfile:
     path: "{{ item.path }}"
     regexp: '^[\s]*Defaults\s.*\btimestamp_timeout[\s]*=.*'
     state: absent
   with_items: "{{ sudoers_d_defaults_timestamp_timeout.files }}"
 
-- name: Ensure timestamp_timeout is enabled with the appropriate value in /etc/sudoers
-  lineinfile:
+- name: "{{{ rule_title }}} - Ensure timestamp_timeout has the appropriate value in /etc/sudoers"
+  ansible.builtin.lineinfile:
     path: /etc/sudoers
     regexp: '^[\s]*Defaults\s(.*)\btimestamp_timeout[\s]*=[\s]*[-]?\w+\b(.*)$'
     line: 'Defaults \1timestamp_timeout={{ var_sudo_timestamp_timeout }}\2'
@@ -28,16 +29,19 @@
     backrefs: yes
   register: edit_sudoers_timestamp_timeout_option
 
-- name: Enable timestamp_timeout option with appropriate value in /etc/sudoers
-  lineinfile: # noqa 503
+- name: "{{{ rule_title }}} - Enable timestamp_timeout option with correct value in /etc/sudoers"
+  ansible.builtin.lineinfile: # noqa 503
     path: /etc/sudoers
     line: 'Defaults timestamp_timeout={{ var_sudo_timestamp_timeout }}'
     validate: /usr/sbin/visudo -cf %s
-  when: edit_sudoers_timestamp_timeout_option is defined and not edit_sudoers_timestamp_timeout_option.changed
+  when: >
+    edit_sudoers_timestamp_timeout_option is defined and
+    not edit_sudoers_timestamp_timeout_option.changed
 
-- name: Remove timestamp_timeout wrong values in /etc/sudoers
-  lineinfile:
+- name: "{{{ rule_title }}} - Remove timestamp_timeout wrong values in /etc/sudoers"
+  ansible.builtin.lineinfile:
     path: /etc/sudoers
-    regexp: '^[\s]*Defaults\s.*\btimestamp_timeout[\s]*=[\s]*(?!{{ var_sudo_timestamp_timeout }}\b)[-]?\w+\b.*$'
+    regexp: '^[\s]*Defaults\s.*\btimestamp_timeout[\s]*=[\s]*(?!{{
+            var_sudo_timestamp_timeout }}\b)[-]?\w+\b.*$'
     state: absent
     validate: /usr/sbin/visudo -cf %s

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/bash/shared.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/bash/shared.sh
@@ -17,9 +17,8 @@ if /usr/sbin/visudo -qcf /etc/sudoers; then
         # sudoers file doesn't define Option timestamp_timeout
         echo "Defaults timestamp_timeout=${var_sudo_timestamp_timeout}" >> /etc/sudoers
     else
-        # sudoers file defines Option timestamp_timeout, remediate if appropriate value is not set
-        if ! grep -P "^[\s]*Defaults.*timestamp_timeout[\s]*=[\s]*${var_sudo_timestamp_timeout}.*$" /etc/sudoers; then
-            
+        # sudoers file defines Option timestamp_timeout, remediate wrong values if present
+        if grep -qP "^[\s]*Defaults\s.*\btimestamp_timeout[\s]*=[\s]*(?!${var_sudo_timestamp_timeout}\b)[-]?\w+\b.*$" /etc/sudoers; then
             sed -Ei "s/(^[[:blank:]]*Defaults.*timestamp_timeout[[:blank:]]*=)[[:blank:]]*[-]?\w+(.*$)/\1${var_sudo_timestamp_timeout}\2/" /etc/sudoers
         fi
     fi

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/conflicting_values_main_file.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/conflicting_values_main_file.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# packages = sudo
+# variables = var_sudo_timestamp_timeout=0
+
+if grep -q 'timestamp_timeout' /etc/sudoers; then
+	sed -i 's/.*timestamp_timeout.*/Defaults timestamp_timeout=-1/' /etc/sudoers
+else
+	echo "Defaults timestamp_timeout=-1" >> /etc/sudoers 
+fi
+echo "Defaults timestamp_timeout=0" >> /etc/sudoers 


### PR DESCRIPTION
#### Description:

- Update bash and ansible of `sudo_require_reauthentication` to ensure no conflicting configurations are present in /etc/sudoers directly

#### Rationale:

-  Previously the remediations looked for conflicting configurations in different files, but it is also possible to find different values in the same file

#### Review Hints:

- The added test is intended to cover this scenario