### PR TITLE
Make `prodtype` Required in JSON Schema

### DIFF
--- a/shared/schemas/rule.json
+++ b/shared/schemas/rule.json
@@ -87,6 +87,7 @@
   "required": [
     "documentation_complete",
     "title",
+    "prodtype",
     "description",
     "rationale",
     "severity"


### PR DESCRIPTION
#### Description:

Make the `prodype` section required in the JSON Schema.

Since this is only a developer tool this shouldn't causes issues as it only show up as a warning in a participating developer's IDE.

#### Rationale:

Per the style guide make the `prodtype` now required in JSON schema.
