### PR TITLE
Fix and modify UBTU-20-010463 (no_empty_passwords)

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/ansible/shared.yml
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = medium
 {{% if 'ubuntu' in product %}}
-{{%- set pam_config_paths = "['/etc/pam.d/common-password']" %}}
+{{%- set pam_config_paths = "['/etc/pam.d/common-password', '/etc/pam.d/common-auth']" %}}
 {{% else %}}
 {{%- set pam_config_paths = "['/etc/pam.d/system-auth', '/etc/pam.d/password-auth']" -%}}
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/bash/shared.sh
@@ -11,10 +11,9 @@ for FILE in ${NULLOK_FILES}; do
    sed --follow-symlinks -i 's/\<nullok\>//g' ${FILE}
 done
 {{% elif 'ubuntu' in product %}}
-COMMON_PASSWORD_PATH="/etc/pam.d/common-password"
-if grep -l "nullok.*" ${COMMON_PASSWORD_PATH}; then
-    sed -i 's/nullok.*//g' ${COMMON_PASSWORD_PATH}
-fi
+for FILE in "/etc/pam.d/common-auth" "/etc/pam.d/common-password"; do
+    sed -i 's/\(.*pam_unix\.so.*\)\s\<nullok\>\(.*\)/\1\2/g' ${FILE}
+done
 {{% else %}}
 if [ -f /usr/bin/authselect ]; then
     {{{ bash_enable_authselect_feature('without-nullok') }}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/oval/shared.xml
@@ -15,7 +15,7 @@
 {{% if product in ['sle12', 'sle15'] %}}
     <ind:filepath operation="pattern match">^/etc/pam.d/.*$</ind:filepath>
 {{% elif 'ubuntu' in product %}}
-    <ind:filepath operation="pattern match">^/etc/pam.d/common-password</ind:filepath>
+    <ind:filepath operation="pattern match">^/etc/pam.d/common-(auth|password)</ind:filepath>
 {{% else %}}
     <ind:filepath operation="pattern match">^/etc/pam.d/(system|password)-auth$</ind:filepath>
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/no_nullok.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/no_nullok.pass.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ubuntu
 
+{{% if 'ubuntu' in product %}}
+sed -i --follow-symlinks '/nullok/d' /etc/pam.d/common-auth
+sed -i --follow-symlinks '/nullok/d' /etc/pam.d/common-password
+{{% else %}}
 sed -i --follow-symlinks '/nullok/d' /etc/pam.d/system-auth
 sed -i --follow-symlinks '/nullok/d' /etc/pam.d/password-auth
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_present.fail.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
-# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ubuntu
 
+{{% if 'ubuntu' in product %}}
+for FILE in "/etc/pam.d/common-auth" "/etc/pam.d/common-password"; do
+    if ! grep -q "^[^#].*pam_unix\.so.*nullok" ${FILE}; then
+        sed -i 's/\([\s]pam_unix\.so\)/\1 nullok/g' ${FILE}
+    fi
+done
+{{% else %}}
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 
 if ! $(grep -q "^[^#].*pam_unix\.so.*nullok" $SYSTEM_AUTH_FILE); then
     sed -i --follow-symlinks 's/\([\s].*pam_unix\.so.*\)\s\(try_first_pass.*\)/\1nullok \2/' $SYSTEM_AUTH_FILE
 fi
+{{% endif %}}
+

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -591,11 +591,11 @@ selections:
     - disable_ctrlaltdel_reboot
     - disable_ctrlaltdel_burstaction
 
-    # UBTU-20-010462 The Ubuntu operating system must not have accounts configured with blank or null passwords.
-    - no_empty_passwords_etc_shadow
-
     # UBTU-20-010461 The Ubuntu operating system must disable automatic mounting of Universal Serial Bus (USB) mass storage driver.
     - kernel_module_usb-storage_disabled
+
+    # UBTU-20-010462 The Ubuntu operating system must not have accounts configured with blank or null passwords.
+    - no_empty_passwords_etc_shadow
 
     # UBTU-20-010463 The Ubuntu operating system must not allow accounts configured with blank or null passwords.
     - no_empty_passwords


### PR DESCRIPTION
#### Description:

- Fix for original remediation which removed the `nullok` keyword and everything after it
- Modification of STIG rule to include removing nullok also from /etc/pam.d/common-auth

#### Rationale for modifying UBTU-20-010463:
- /etc/pam.d/common-password does not contain nullok by default, nor
  does the keyword have any effect on changing passwords with `passwd`
  (empty passwords are not allowed with or without nullok keyword)
- /etc/pam.d/common-auth contains nullok by default and thus allows
  logins to accounts with empty passwords

DISA was notified of the issue. Some concerns were raised regarding effect on
multifactor authentication, however, it was shown to work regardless of
nullok keyword being present in /etc/pam.d/common-auth:pam_unix.so or
not.
