### PR TITLE
Update Ansible Lint Config

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -1,19 +1,22 @@
 skip_list:
-  - fqcn-builtins # We should be using fqcn
-  - key-order[task]
-  - no-free-form
-  - risky-file-permissions
-  - no-changed-when
-  - var-naming
-  - ignore-errors
-  - schema[meta]
+    - fqcn-builtins # We should be using fqcn
+    - key-order[task]
+    - no-free-form
+    - risky-file-permissions
+    - no-changed-when
+    - var-naming
+    - ignore-errors
+    - schema[meta]
+    - yaml[indentation]  # Violations reported by yamllint.
+    - jinja[spacing]  # Rule that looks inside jinja2 templates.
+    - name[template]  # Rule for checking task and play names.
+    - fqcn[action]  # Use FQCN for builtin actions.
+
 warn_list:
-  - name[missing]  # Rule for checking task and play names.
-  - template-instead-of-copy  # Templated files should use template instead of copy
-  - yaml[empty-lines]  # Violations reported by yamllint.
-  - yaml[indentation]  # Violations reported by yamllint.
-  - yaml[line-length]  # Violations reported by yamllint.
-  - jinja[spacing]  # Rule that looks inside jinja2 templates.
-  - name[casing]  # Rule for checking task and play names.
-  - fqcn[action]  # Use FQCN for builtin actions.
-  - name[template]  # Rule for checking task and play names.
+    - name[missing]  # Rule for checking task and play names.
+    - template-instead-of-copy  # Templated files should use template instead of copy
+    - yaml[empty-lines]  # Violations reported by yamllint.
+    - yaml[line-length]  # Violations reported by yamllint.
+    - name[casing]  # Rule for checking task and play names.
+    - no-handler
+    - risky-shell-pipe


### PR DESCRIPTION
#### Description:
Get the Ansible lint config so that errors are usable.

#### Rationale:

So that the job passes.

This puts the errors on the warn list that #11266 is trying to fix. 
