### PR TITLE
Remove broken test for Ubuntu in template kernel_module_disabled

### DIFF
--- a/shared/templates/kernel_module_disabled/tests/correct_value_modprobe_conf.pass.sh
+++ b/shared/templates/kernel_module_disabled/tests/correct_value_modprobe_conf.pass.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-# platform = multi_platform_ubuntu
-
-echo "install {{{ KERNMODULE }}} /bin/true" > /etc/modprobe.conf


### PR DESCRIPTION
#### Description:

- Remove broken test for Ubuntu in template kernel_module_disabled

#### Rationale:

- Test uses /etc/modprobe.conf which is not present on Ubuntu
