### PR TITLE
xccdf_org.ssgproject.content_rule_accounts_tmout: replace 'declare' by 'typeset'

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
@@ -16,7 +16,7 @@
   replace:
     path: /etc/bashrc
     regexp: '^[^#].*TMOUT=.*'
-    replace: declare -xr TMOUT={{ var_accounts_tmout }}
+    replace: typeset -xr TMOUT={{ var_accounts_tmout }}
   register: bashrc_replaced
 {{% endif %}}
 
@@ -24,8 +24,8 @@
   replace:
     path: /etc/profile
     regexp: '^[^#].*TMOUT=.*'
-    replace: declare -xr TMOUT={{ var_accounts_tmout }}
+    replace: typeset -xr TMOUT={{ var_accounts_tmout }}
   register: profile_replaced
 
-{{{ ansible_lineinfile("", "/etc/profile.d/tmout.sh", regex='TMOUT=', new_line='declare -xr TMOUT={{ var_accounts_tmout }}',
+{{{ ansible_lineinfile("", "/etc/profile.d/tmout.sh", regex='TMOUT=', new_line='typeset -xr TMOUT={{ var_accounts_tmout }}',
     create='yes', state='present', when="profile_replaced is defined and not profile_replaced.changed" + " and bashrc_replaced is defined and not bashrc_replaced.changed" if product in ["ol7", "rhel7"]) }}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
@@ -16,14 +16,12 @@ for f in /etc/profile /etc/profile.d/*.sh /etc/bashrc; do
 for f in /etc/profile /etc/profile.d/*.sh; do
 {{% endif %}}
     if grep --silent '^[^#].*TMOUT' $f; then
-        sed -i -E "s/^(.*)TMOUT\s*=\s*(\w|\$)*(.*)$/declare -xr TMOUT=$var_accounts_tmout\3/g" $f
+        sed -i -E "s/^(.*)TMOUT\s*=\s*(\w|\$)*(.*)$/typeset -xr TMOUT=$var_accounts_tmout\3/g" $f
         tmout_found=1
     fi
 done
 
 if [ $tmout_found -eq 0 ]; then
         echo -e "\n# Set TMOUT to $var_accounts_tmout per security requirements" >> /etc/profile.d/tmout.sh
-        echo "declare -xr TMOUT=$var_accounts_tmout" >> /etc/profile.d/tmout.sh
-        echo "readonly TMOUT" >> /etc/profile.d/tmout.sh
-        echo "export TMOUT" >> /etc/profile.d/tmout.sh
+        echo "typeset -xr TMOUT=$var_accounts_tmout" >> /etc/profile.d/tmout.sh
 fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
@@ -40,7 +40,7 @@
     {{% if product in ['sle12', 'sle15'] or "ubuntu" in product %}}
     <ind:pattern operation="pattern match">^[\s]*TMOUT=([\w$]+)[\s]*readonly TMOUT[\s]*export TMOUT$</ind:pattern>
     {{% else %}}
-    <ind:pattern operation="pattern match">^[\s]*declare[\s]+-xr[\s]+TMOUT=([\w$]+).*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*typeset[\s]+-xr[\s]+TMOUT=([\w$]+).*$</ind:pattern>
     {{% endif %}}
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
@@ -40,7 +40,7 @@
     {{% if product in ['sle12', 'sle15'] or "ubuntu" in product %}}
     <ind:pattern operation="pattern match">^[\s]*TMOUT=([\w$]+)[\s]*readonly TMOUT[\s]*export TMOUT$</ind:pattern>
     {{% else %}}
-    <ind:pattern operation="pattern match">^[\s]*typeset[\s]+-xr[\s]+TMOUT=([\w$]+).*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?:typeset|declare)[\s]+-xr[\s]+TMOUT=([\w$]+).*$</ind:pattern>
     {{% endif %}}
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/policy/stig/shared.yml
@@ -12,7 +12,7 @@ checktext: |-
 
     $ sudo grep -i tmout /etc/profile /etc/profile.d/*.sh
 
-    etc/profile.d/tmout.sh:declare -xr TMOUT=900
+    etc/profile.d/tmout.sh:typeset -xr TMOUT=900
 
     If "TMOUT" is not set to "900" or less in a script located in the /etc/profile.d/ directory to enforce session termination after inactivity, this is a finding.
 

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
@@ -27,6 +27,7 @@ description: |-
     <pre>typeset -xr TMOUT={{{ xccdf_value("var_accounts_tmout") }}}</pre>
     or
     <pre>declare -xr TMOUT={{{ xccdf_value("var_accounts_tmout") }}}</pre>
+    Using the <code>typeset</code> keyword is preferred for wider compatibility with ksh and other shells.
     {{% endif %}}
 
 rationale: |-

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
@@ -25,6 +25,8 @@ description: |-
     {{{- "or <tt>/etc/bashrc</tt>" if product in ["ol7", "rhel7"] }}}, e.g.
     <tt>/etc/profile.d/tmout.sh</tt> should read as follows:
     <pre>typeset -xr TMOUT={{{ xccdf_value("var_accounts_tmout") }}}</pre>
+    or
+    <pre>declare -xr TMOUT={{{ xccdf_value("var_accounts_tmout") }}}</pre>
     {{% endif %}}
 
 rationale: |-

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
@@ -24,7 +24,7 @@ description: |-
     setting in a file loaded by <tt>/etc/profile</tt>
     {{{- "or <tt>/etc/bashrc</tt>" if product in ["ol7", "rhel7"] }}}, e.g.
     <tt>/etc/profile.d/tmout.sh</tt> should read as follows:
-    <pre>declare -xr TMOUT={{{ xccdf_value("var_accounts_tmout") }}}</pre>
+    <pre>typeset -xr TMOUT={{{ xccdf_value("var_accounts_tmout") }}}</pre>
     {{% endif %}}
 
 rationale: |-

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/conflicting_values_diff_file.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/conflicting_values_diff_file.fail.sh
@@ -4,5 +4,5 @@
 
 sed -i "/.*TMOUT.*/d" /etc/profile /etc/profile.d/*.sh /etc/bashrc
 
-echo "declare -xr TMOUT=700" >> /etc/profile
-echo "declare -xr TMOUT=800" >> /etc/profile.d/tmout.sh
+echo "typeset -xr TMOUT=700" >> /etc/profile
+echo "typeset -xr TMOUT=800" >> /etc/profile.d/tmout.sh

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/conflicting_values_same_file.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/conflicting_values_same_file.fail.sh
@@ -4,5 +4,5 @@
 
 sed -i "/.*TMOUT.*/d" /etc/profile /etc/profile.d/*.sh /etc/bashrc
 
-echo "declare -xr TMOUT=700" >> /etc/profile
-echo "declare -xr TMOUT=800" >> /etc/profile
+echo "typeset -xr TMOUT=700" >> /etc/profile
+echo "typeset -xr TMOUT=800" >> /etc/profile

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/correct_value_bashrc.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/correct_value_bashrc.pass.sh
@@ -5,4 +5,4 @@
 
 sed -i "/.*TMOUT.*/d" /etc/profile /etc/profile.d/*.sh /etc/bashrc
 
-echo "declare -xr TMOUT=700" >> /etc/bashrc
+echo "typeset -xr TMOUT=700" >> /etc/bashrc

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/correct_value_profile.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/correct_value_profile.pass.sh
@@ -5,7 +5,7 @@
 sed -i "/.*TMOUT.*/d" /etc/profile.d/*.sh
 
 if grep -q "TMOUT" /etc/profile; then
-	sed -i "s/.*TMOUT.*/declare -xr TMOUT=700/" /etc/profile
+	sed -i "s/.*TMOUT.*/typeset -xr TMOUT=700/" /etc/profile
 else
-	echo "declare -xr TMOUT=700" >> /etc/profile
+	echo "typeset -xr TMOUT=700" >> /etc/profile
 fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/correct_value_profile_d.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/correct_value_profile_d.pass.sh
@@ -9,7 +9,7 @@ sed -i "/.*TMOUT.*/d" /etc/profile
 test -f $TEST_FILE || touch $TEST_FILE
 
 if grep -q "TMOUT" $TEST_FILE; then
-	sed -i "s/.*TMOUT.*/declare -xr TMOUT=700/" $TEST_FILE
+	sed -i "s/.*TMOUT.*/typeset -xr TMOUT=700/" $TEST_FILE
 else
-	echo "declare -xr TMOUT=700" >> $TEST_FILE
+	echo "typeset -xr TMOUT=700" >> $TEST_FILE
 fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/correct_value_profile_declare.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/correct_value_profile_declare.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# variables = var_accounts_tmout=700
+
+sed -i "/.*TMOUT.*/d" /etc/profile.d/*.sh
+
+if grep -q "TMOUT" /etc/profile; then
+	sed -i "s/.*TMOUT.*/declare -xr TMOUT=700/" /etc/profile
+else
+	echo "declare -xr TMOUT=700" >> /etc/profile
+fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/duplicate_correct_value_diff_files.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/duplicate_correct_value_diff_files.pass.sh
@@ -4,5 +4,5 @@
 
 sed -i "/.*TMOUT.*/d" /etc/profile /etc/profile.d/*.sh
 
-echo "declare -xr TMOUT=700" >> /etc/profile
-echo "declare -xr TMOUT=700" >> /etc/profile.d/tmout.sh
+echo "typeset -xr TMOUT=700" >> /etc/profile
+echo "typeset -xr TMOUT=700" >> /etc/profile.d/tmout.sh

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/duplicate_correct_value_profile.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/duplicate_correct_value_profile.pass.sh
@@ -5,9 +5,9 @@
 sed -i "/.*TMOUT.*/d" /etc/profile.d/*.sh
 
 if grep -q "TMOUT" /etc/profile; then
-	sed -i "s/.*TMOUT.*/declare -xr TMOUT=700/" /etc/profile
-	echo "declare -xr TMOUT=600" >> /etc/profile.d/tmout.sh
+	sed -i "s/.*TMOUT.*/typeset -xr TMOUT=700/" /etc/profile
+	echo "typeset -xr TMOUT=600" >> /etc/profile.d/tmout.sh
 else
-	echo "declare -xr TMOUT=700" >> /etc/profile
-	echo "declare -xr TMOUT=600" >> /etc/profile.d/tmout.sh
+	echo "typeset -xr TMOUT=700" >> /etc/profile
+	echo "typeset -xr TMOUT=600" >> /etc/profile.d/tmout.sh
 fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/duplicate_correct_value_profile_d.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/duplicate_correct_value_profile_d.pass.sh
@@ -5,9 +5,9 @@
 sed -i "/.*TMOUT.*/d" /etc/profile
 
 if grep -q "TMOUT" /etc/profile.d/tmout.sh; then
-	sed -i "s/.*TMOUT.*/declare -xr TMOUT=700/" /etc/profile.d/tmout.sh
-	echo "declare -xr TMOUT=600" >> /etc/profile.d/tmout.sh
+	sed -i "s/.*TMOUT.*/typeset -xr TMOUT=700/" /etc/profile.d/tmout.sh
+	echo "typeset -xr TMOUT=600" >> /etc/profile.d/tmout.sh
 else
-	echo "declare -xr TMOUT=700" >> /etc/profile.d/tmout.sh
-	echo "declare -xr TMOUT=600" >> /etc/profile.d/tmout.sh
+	echo "typeset -xr TMOUT=700" >> /etc/profile.d/tmout.sh
+	echo "typeset -xr TMOUT=600" >> /etc/profile.d/tmout.sh
 fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/supercompliance_profile.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/supercompliance_profile.pass.sh
@@ -5,7 +5,7 @@
 sed -i "/.*TMOUT.*/d" /etc/profile.d/*.sh
 
 if grep -q "TMOUT" /etc/profile; then
-	sed -i "s/.*TMOUT.*/declare -xr TMOUT=800/" /etc/profile
+	sed -i "s/.*TMOUT.*/typeset -xr TMOUT=800/" /etc/profile
 else
-	echo "declare -xr TMOUT=800" >> /etc/profile
+	echo "typeset -xr TMOUT=800" >> /etc/profile
 fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/supercompliance_profile_d.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/supercompliance_profile_d.pass.sh
@@ -9,7 +9,7 @@ sed -i "/.*TMOUT.*/d" /etc/profile
 test -f $TEST_FILE || touch $TEST_FILE
 
 if grep -q "TMOUT" $TEST_FILE; then
-	sed -i "s/.*TMOUT.*/declare -xr TMOUT=800/" $TEST_FILE
+	sed -i "s/.*TMOUT.*/typeset -xr TMOUT=800/" $TEST_FILE
 else
-	echo "declare -xr TMOUT=800" >> $TEST_FILE
+	echo "typeset -xr TMOUT=800" >> $TEST_FILE
 fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/wrong_value_bashrc.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/wrong_value_bashrc.fail.sh
@@ -5,4 +5,4 @@
 
 sed -i "/.*TMOUT.*/d" /etc/profile /etc/profile.d/*.sh /etc/bashrc
 
-echo "declare -xr TMOUT=800" >> /etc/bashrc
+echo "typeset -xr TMOUT=800" >> /etc/bashrc


### PR DESCRIPTION
#### Description:

On bash and zsh, these are synonyms, but **declare** is not known to **ksh**, causing an error message when having /etc/profile.d/tmout.sh loaded:
~~~
/etc/profile[68]: .: line 731: declare: not found
~~~

#### Rationale:

**typeset** works on every known sh shell, including ksh.


Resolves: https://issues.redhat.com/browse/RHEL-1811