### PR TITLE
Generate OVAL document for each rule

### DIFF
--- a/build-scripts/build_xccdf.py
+++ b/build-scripts/build_xccdf.py
@@ -44,6 +44,11 @@ def parse_args():
         help="Output OVAL file. "
         "e.g.:  ~/scap-security-guide/build/rhel7/ssg-rhel7-oval.xml"
     )
+    parser.add_argument(
+        "--build-ovals-dir",
+        dest="build_ovals_dir",
+        help="Directory to store OVAL document for each rule.",
+    )
     parser.add_argument("--resolved-base",
                         help="To which directory to put processed rule/group/value YAMLs.")
     return parser.parse_args()
@@ -78,6 +83,7 @@ def main():
 
     oval_linker = ssg.build_renumber.OVALFileLinker(
         translator, xccdftree, checks, args.oval)
+    oval_linker.build_ovals_dir = args.build_ovals_dir
     oval_linker.link()
     oval_linker.save_linked_tree()
     oval_linker.link_xccdf()

--- a/build-scripts/combine_ovals.py
+++ b/build-scripts/combine_ovals.py
@@ -42,7 +42,6 @@ def parse_args():
     )
     p.add_argument(
         "--build-ovals-dir",
-        required=True,
         dest="build_ovals_dir",
         help="Directory to store intermediate built OVAL files.",
     )

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -289,7 +289,7 @@ macro(ssg_build_oval_unlinked PRODUCT)
     set(OVAL_COMBINE_PATHS "${SSG_SHARED}/checks/oval" "${BUILD_CHECKS_DIR}/oval")
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/combine_ovals.py" --log "${LOG_LEVEL}" --include-benchmark --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_BINARY_DIR}/product.yml" --output "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml" --build-ovals-dir "${CMAKE_CURRENT_BINARY_DIR}/checks/oval" ${OVAL_COMBINE_PATHS}
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/combine_ovals.py" --log "${LOG_LEVEL}" --include-benchmark --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_BINARY_DIR}/product.yml" --output "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml" ${OVAL_COMBINE_PATHS}
         COMMAND "${XMLLINT_EXECUTABLE}" --format --output "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml" "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml"
         DEPENDS generate-internal-templated-content-${PRODUCT} "${CMAKE_CURRENT_BINARY_DIR}/templated-content-${PRODUCT}"
         COMMENT "[${PRODUCT}-content] generating oval-unlinked.xml"

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -146,7 +146,7 @@ macro(ssg_build_xccdf_oval_ocil PRODUCT)
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/build_xccdf.py" --resolved-base "${CMAKE_CURRENT_BINARY_DIR}" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_BINARY_DIR}/product.yml" --xccdf "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" --oval "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" --ocil "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/build_xccdf.py" --build-ovals-dir "${CMAKE_CURRENT_BINARY_DIR}/checks/oval" --resolved-base "${CMAKE_CURRENT_BINARY_DIR}" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_BINARY_DIR}/product.yml" --xccdf "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" --oval "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" --ocil "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
         COMMAND sync
         DEPENDS ${PRODUCT}-compile-all "${CMAKE_CURRENT_BINARY_DIR}/ssg_build_compile_all-${PRODUCT}"
         DEPENDS generate-internal-${PRODUCT}-all-fixes "${CMAKE_CURRENT_BINARY_DIR}/collect-remediations-${PRODUCT}"

--- a/ssg/oval_object_model/__init__.py
+++ b/ssg/oval_object_model/__init__.py
@@ -15,3 +15,4 @@ from .oval_entities import (
     ExceptionDuplicateObjectReferenceInTest,
     ExceptionMissingObjectReferenceInTest,
 )
+from .oval_definition_references import OVALDefinitionReference

--- a/ssg/oval_object_model/oval_document.py
+++ b/ssg/oval_object_model/oval_document.py
@@ -13,7 +13,7 @@ from .oval_definition_references import OVALDefinitionReference
 
 def _get_xml_el(tag_name, xml_el):
     el = xml_el.find("./{%s}%s" % (OVAL_NAMESPACES.definition, tag_name))
-    return el if el else ElementTree.Element("empty-element")
+    return el if el is not None else ElementTree.Element("empty-element")
 
 
 def _load_definitions(oval_document, oval_document_xml_el):

--- a/ssg/oval_object_model/oval_document.py
+++ b/ssg/oval_object_model/oval_document.py
@@ -62,6 +62,13 @@ def load_oval_document(oval_document_xml_el):
     return oval_document
 
 
+def selection_of_oval_components_generator(component_dict, id_selection):
+    for component_id, component in component_dict.items():
+        if component_id not in id_selection:
+            continue
+        yield component_id, component
+
+
 class MissingOVALComponent(Exception):
     pass
 
@@ -139,28 +146,48 @@ class OVALDocument(OVALContainer):
             return False
         return True
 
-    def get_xml_element(self):
+    def get_xml_element(self, oval_definition_references=None):
+        definitions_selection = self.definitions.keys()
+        tests_selection = self.tests.keys()
+        objects_selection = self.objects.keys()
+        states_selection = self.states.keys()
+        variables_selection = self.variables.keys()
+        if oval_definition_references is not None:
+            definitions_selection = oval_definition_references.definitions
+            tests_selection = oval_definition_references.tests
+            objects_selection = oval_definition_references.objects
+            states_selection = oval_definition_references.states
+            variables_selection = oval_definition_references.variables
+
         root = self._get_oval_definition_el()
         root.append(self._get_generator_el())
-        root.append(self._get_component_el("definitions", self.definitions.values()))
-        root.append(self._get_component_el("tests", self.tests.values()))
-        root.append(self._get_component_el("objects", self.objects.values()))
-        if self.states:
-            root.append(self._get_component_el("states", self.states.values()))
-        if self.variables:
-            root.append(self._get_component_el("variables", self.variables.values()))
+        root.append(
+            self._get_component_el(
+                "definitions", self.definitions, definitions_selection
+            )
+        )
+        root.append(self._get_component_el("tests", self.tests, tests_selection))
+        root.append(self._get_component_el("objects", self.objects, objects_selection))
+        if states_selection:
+            root.append(self._get_component_el("states", self.states, states_selection))
+        if variables_selection:
+            root.append(
+                self._get_component_el("variables", self.variables, variables_selection)
+            )
         return root
 
-    def save_as_xml(self, fd):
-        root = self.get_xml_element()
+    def save_as_xml(self, fd, oval_definition_references=None):
+        root = self.get_xml_element(oval_definition_references)
         if hasattr(ElementTree, "indent"):
             ElementTree.indent(root, space=" ", level=0)
         ElementTree.ElementTree(root).write(fd, xml_declaration=True, encoding="utf-8")
 
-    def _get_component_el(self, tag, values):
+    def _get_component_el(self, tag, component_dict, id_selection):
         xml_el = ElementTree.Element("{%s}%s" % (OVAL_NAMESPACES.definition, tag))
-        for val in values:
-            xml_el.append(val.get_xml_element())
+        for _, component in selection_of_oval_components_generator(
+            component_dict, id_selection
+        ):
+            xml_el.append(component.get_xml_element())
         return xml_el
 
     def _get_generator_el(self):

--- a/tests/unit/ssg-module/test_oval_object_model/test_oval_document.py
+++ b/tests/unit/ssg-module/test_oval_object_model/test_oval_document.py
@@ -1,5 +1,6 @@
 import pytest
 import os
+import tempfile
 
 from test_load_and_store import _load_oval_document
 
@@ -8,6 +9,7 @@ DATA_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "data")
 OVAL_DOCUMENT_PATH = os.path.join(
     DATA_DIR, "minimal_oval_of_oval_ssg-sshd_rekey_limit_def.xml"
 )
+TEST_BUILD_DIR = tempfile.mkdtemp()
 
 
 @pytest.fixture
@@ -41,21 +43,24 @@ def test_all_references_of_definition(oval_document):
     ]
 
 
+def _assert_filtered_oval_document(oval_document_, def_id):
+    assert def_id in oval_document_.definitions
+    assert "oval:ssg-sshd_rekey_limit:def:1" not in oval_document_.definitions
+    assert "oval:ssg-test_sshd_not_required:tst:1" in oval_document_.tests
+    assert "oval:ssg-test_sshd_rekey_limit:tst:1" not in oval_document_.tests
+    assert "oval:ssg-object_sshd_requirement_unknown:obj:1" in oval_document_.objects
+    assert "oval:ssg-obj_sshd_rekey_limit:obj:1" not in oval_document_.objects
+    assert "oval:ssg-state_sshd_requirement_unset:ste:1" in oval_document_.states
+    assert "oval:ssg-state_sshd_rekey_limit:ste:1" not in oval_document_.states
+    assert "oval:ssg-sshd_required:var:1" in oval_document_.variables
+    assert "oval:ssg-var_rekey_limit_size:var:1" not in oval_document_.variables
+
+
 def test_keep_referenced_components(oval_document):
     def_id = "oval:ssg-sshd_not_required_or_unset:def:1"
     ref = oval_document.get_all_references_of_definition(def_id)
     oval_document.keep_referenced_components(ref)
-
-    assert def_id in oval_document.definitions
-    assert "oval:ssg-sshd_rekey_limit:def:1" not in oval_document.definitions
-    assert "oval:ssg-test_sshd_not_required:tst:1" in oval_document.tests
-    assert "oval:ssg-test_sshd_rekey_limit:tst:1" not in oval_document.tests
-    assert "oval:ssg-object_sshd_requirement_unknown:obj:1" in oval_document.objects
-    assert "oval:ssg-obj_sshd_rekey_limit:obj:1" not in oval_document.objects
-    assert "oval:ssg-state_sshd_requirement_unset:ste:1" in oval_document.states
-    assert "oval:ssg-state_sshd_rekey_limit:ste:1" not in oval_document.states
-    assert "oval:ssg-sshd_required:var:1" in oval_document.variables
-    assert "oval:ssg-var_rekey_limit_size:var:1" not in oval_document.variables
+    _assert_filtered_oval_document(oval_document, def_id)
 
 
 @pytest.mark.parametrize(
@@ -77,3 +82,15 @@ def test_keep_referenced_components(oval_document):
 def test_validation(path, expected_result):
     oval_doc = _load_oval_document(path)
     assert oval_doc.validate_references() == expected_result
+
+
+def test_save_as_xml(oval_document):
+    oval_doc_path = os.path.join(TEST_BUILD_DIR, "oval.xml")
+    def_id = "oval:ssg-sshd_not_required_or_unset:def:1"
+
+    with open(oval_doc_path, "wb") as fd:
+        refs = oval_document.get_all_references_of_definition(def_id)
+        oval_document.save_as_xml(fd, refs)
+
+    filtered_oval_document = _load_oval_document(oval_doc_path)
+    _assert_filtered_oval_document(filtered_oval_document, def_id)


### PR DESCRIPTION
#### Description:
This PR creates a new function that generates an OVAL document for each rule. Generating an OVAL document for each rule replaces the generation of intermediate OVAL files (called shorthands). OVAL documents are stored in the directory: `build/${product}/checks/oval/`.

#### Review Hints:
To check the functionality of the changes, you can build content using `./build_product fedora`. 

Depends on: #11290 

