### PR TITLE
Fix kernel_module_disabled template for Ubuntu

### DIFF
--- a/shared/templates/kernel_module_disabled/oval.template
+++ b/shared/templates/kernel_module_disabled/oval.template
@@ -3,7 +3,7 @@
   id="kernel_module_{{{ KERNMODULE }}}_disabled" version="1">
     {{{ oval_metadata("The kernel module " + KERNMODULE + " should be disabled.") }}}
     <criteria operator="OR">
-      {{% if product in ["rhcos4", "sle12", "sle15"] or 'ol' in product or 'rhel' in product %}}
+      {{% if product in ["rhcos4", "sle12", "sle15"] or 'ol' in product or 'rhel' in product or 'ubuntu' in product %}}
       <criteria operator="AND">
         <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_blacklisted"
         comment="kernel module {{{ KERNMODULE }}} blacklisted in modprobe.d" />
@@ -44,7 +44,7 @@
     <value>/usr/lib/modules-load.d</value>
   </constant_variable>
 
-{{% if product in ["rhcos4", "sle12", "sle15"] or 'ol' in product or 'rhel' in product %}}
+{{% if product in ["rhcos4", "sle12", "sle15"] or 'ol' in product or 'rhel' in product  or 'ubuntu' in product %}}
   <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_blacklisted" version="1" check="all"
   comment="kernel module {{{ KERNMODULE }}} blacklisted">
     <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_blacklisted" />

--- a/shared/templates/kernel_module_disabled/tests/correct_value_modprobe_d.pass.sh
+++ b/shared/templates/kernel_module_disabled/tests/correct_value_modprobe_d.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 echo "install {{{ KERNMODULE }}} /bin/true" > /etc/modprobe.d/{{{ KERNMODULE }}}.conf
-{{% if "ol" in product or 'rhel' in product %}}
+{{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
 echo "blacklist {{{ KERNMODULE }}}" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
 {{% endif %}}

--- a/shared/templates/kernel_module_disabled/tests/correct_value_modules_load_d.pass.sh
+++ b/shared/templates/kernel_module_disabled/tests/correct_value_modules_load_d.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 echo "install {{{ KERNMODULE }}} /bin/true" > /etc/modules-load.d/{{{ KERNMODULE }}}.conf
-{{% if "ol" in product or 'rhel' in product %}}
+{{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
 echo "blacklist {{{ KERNMODULE }}}" >> /etc/modules-load.d/{{{ KERNMODULE }}}.conf
 {{% endif %}}

--- a/shared/templates/kernel_module_disabled/tests/correct_value_run_modprobe_d.pass.sh
+++ b/shared/templates/kernel_module_disabled/tests/correct_value_run_modprobe_d.pass.sh
@@ -4,6 +4,6 @@ if [[ ! -d /run/modprobe.d ]]; then
     mkdir -p /run/modprobe.d
 fi
 echo "install {{{ KERNMODULE }}} /bin/true" > /run/modprobe.d/{{{ KERNMODULE }}}.conf
-{{% if "ol" in product or 'rhel' in product %}}
+{{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
 echo "blacklist {{{ KERNMODULE }}}" >> /run/modprobe.d/{{{ KERNMODULE }}}.conf
 {{% endif %}}

--- a/shared/templates/kernel_module_disabled/tests/correct_value_run_modules_load_d.pass.sh
+++ b/shared/templates/kernel_module_disabled/tests/correct_value_run_modules_load_d.pass.sh
@@ -5,6 +5,6 @@ if [[ ! -d /run/modules-load.d ]]; then
 fi
 
 echo "install {{{ KERNMODULE }}} /bin/true" > /run/modules-load.d/{{{ KERNMODULE }}}.conf
-{{% if "ol" in product or 'rhel' in product %}}
+{{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
 echo "blacklist {{{ KERNMODULE }}}" >> /run/modules-load.d/{{{ KERNMODULE }}}.conf
 {{% endif %}}

--- a/shared/templates/kernel_module_disabled/tests/correct_value_usr_lib_modprobe_d.pass.sh
+++ b/shared/templates/kernel_module_disabled/tests/correct_value_usr_lib_modprobe_d.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 echo "install {{{ KERNMODULE }}} /bin/true" > /usr/lib/modprobe.d/{{{ KERNMODULE }}}.conf
-{{% if "ol" in product or 'rhel' in product %}}
+{{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
 echo "blacklist {{{ KERNMODULE }}}" >> /usr/lib/modprobe.d/{{{ KERNMODULE }}}.conf
 {{% endif %}}

--- a/shared/templates/kernel_module_disabled/tests/correct_value_usr_lib_modules_load_d.pass.sh
+++ b/shared/templates/kernel_module_disabled/tests/correct_value_usr_lib_modules_load_d.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 echo "install {{{ KERNMODULE }}} /bin/true" > /usr/lib/modules-load.d/{{{ KERNMODULE }}}.conf
-{{% if "ol" in product or 'rhel' in product %}}
+{{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
 echo "blacklist {{{ KERNMODULE }}}" >> /usr/lib/modules-load.d/{{{ KERNMODULE }}}.conf
 {{% endif %}}

--- a/shared/templates/kernel_module_disabled/tests/missing_blacklist.fail.sh
+++ b/shared/templates/kernel_module_disabled/tests/missing_blacklist.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_rhel,multi_platform_ol
+# platform = multi_platform_rhel,multi_platform_ol,multi_platform_ubuntu
 
 echo > /etc/modprobe.d/{{{ KERNMODULE }}}.conf
 echo "install {{{ KERNMODULE }}} /bin/true" > /etc/modprobe.d/{{{ KERNMODULE }}}.conf


### PR DESCRIPTION
#### Description:

- Fix kernel_module_disabled template oval and tests to check for blacklisted modules in Ubuntu

#### Rationale:

PR #11062 included blacklisting of kernel modules in Ubuntu, as prescribed by rule STIG UBTU-20-010461
and analogous rules in latest CIS benchmarks (20.04 v2.0.1 and 22.04 v1.0.0), but failed to include
changes to OVAL and tests.

