### PR TITLE
Daily prod fix: add enable_authselect rule to pci-dss control file

### DIFF
--- a/controls/pcidss_4.yml
+++ b/controls/pcidss_4.yml
@@ -2043,6 +2043,7 @@ controls:
         - base
       status: automated
       rules:
+        - enable_authselect
         - accounts_passwords_pam_faillock_deny
         - var_accounts_passwords_pam_faillock_deny=10
         - accounts_passwords_pam_faillock_unlock_time

--- a/tests/data/profile_stability/rhel8/pci-dss.profile
+++ b/tests/data/profile_stability/rhel8/pci-dss.profile
@@ -19,6 +19,7 @@ metadata:
     - vojtapolasek
 reference: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
 selections:
+- enable_authselect
 - package_sudo_installed
 - sshd_set_loglevel_verbose
 - accounts_password_warn_age_login_defs


### PR DESCRIPTION
#### Description:

- add enable_authselect to pci-dss 4 control file
- the authselect variable is left default, i.e. "minimal" profile is selected

#### Rationale:

- With the rule missing, the Authselect profile is not configured and many PAM related rules error out.

#### Review Hints:

Try to perform remediation with Ansible playbook before and after the commit.