### PR TITLE
add rhel8 and rhel9 prodtypes to some rules

### DIFF
--- a/linux_os/guide/services/ntp/ntpd_specify_multiple_servers/rule.yml
+++ b/linux_os/guide/services/ntp/ntpd_specify_multiple_servers/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhv4,sle12,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Specify Additional Remote NTP Servers'
 

--- a/linux_os/guide/services/ntp/ntpd_specify_remote_server/rule.yml
+++ b/linux_os/guide/services/ntp/ntpd_specify_remote_server/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhv4,sle12,sle15
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Specify a Remote NTP Server'
 

--- a/linux_os/guide/services/ntp/service_ntp_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_ntp_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian10,debian11,debian12,sle12,sle15,ubuntu1604,ubuntu1804,ubuntu2004,ubuntu2204
+prodtype: debian10,debian11,debian12,rhel8,rhel9,sle12,sle15,ubuntu1604,ubuntu1804,ubuntu2004,ubuntu2204
 
 title: 'Enable the NTP Daemon'
 
@@ -49,3 +49,10 @@ template:
     name: service_enabled
     vars:
         servicename: ntp
+
+{{% if prodtype in ["rhel8", "rhel9"] %}}
+warnings:
+    - general:
+        The <pre>ntp</pre> package is not available in {{{ full_name }}}. Please
+        consider the <pre>chrony</pre> package instead.
+{{% endif %}}

--- a/linux_os/guide/system/auditing/package_audit-audispd-plugins_installed/rule.yml
+++ b/linux_os/guide/system/auditing/package_audit-audispd-plugins_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol9,rhel9,sle12,sle15,ubuntu2004
+prodtype: fedora,ol9,rhel8,rhel9,sle12,sle15,ubuntu2004
 
 title: 'Ensure the default plugins for the audit dispatcher are Installed'
 
@@ -34,3 +34,10 @@ template:
         pkgname@ubuntu1604: audispd-plugins
         pkgname@ubuntu1804: audispd-plugins
         pkgname@ubuntu2004: audispd-plugins
+
+{{% if prodtype in ["rhel8", "rhel9"] %}}
+warnings:
+    - general:
+        This package is not available in {{{ full_name }}}. The correct package
+        is called audispd-plugins.
+{{% endif %}}

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_ipv6_loopback_traffic/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_ipv6_loopback_traffic/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: sle12,sle15,ubuntu2004,ubuntu2204
+prodtype: rhel8,rhel9,sle12,sle15,ubuntu2004,ubuntu2204
 
 title: 'Set configuration for IPv6 loopback traffic'
 

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_loopback_traffic/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_loopback_traffic/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,sle12,sle15,ubuntu2004,ubuntu2204
+prodtype: alinux2,rhel8,rhel9,sle12,sle15,ubuntu2004,ubuntu2204
 
 title: 'Set configuration for loopback traffic'
 

--- a/products/rhel8/profiles/pci-dss.profile
+++ b/products/rhel8/profiles/pci-dss.profile
@@ -25,3 +25,10 @@ selections:
     # More tests are needed to identify which rule is conflicting with rpm_verify_permissions.
     # https://github.com/ComplianceAsCode/content/issues/11285
     - '!rpm_verify_permissions'
+    # these rules does not apply to RHEL but it has to keep the prodtype for historical reasons
+    - '!package_audit-audispd-plugins_installed'
+    - '!service_ntp_enabled'
+    - '!ntpd_specify_remote_server'
+    - '!ntpd_specify_multiple_servers'
+    - '!set_ipv6_loopback_traffic'
+    - '!set_loopback_traffic'

--- a/products/rhel9/profiles/pci-dss.profile
+++ b/products/rhel9/profiles/pci-dss.profile
@@ -28,3 +28,10 @@ selections:
     # More tests are needed to identify which rule is conflicting with rpm_verify_permissions.
     # https://github.com/ComplianceAsCode/content/issues/11285
     - '!rpm_verify_permissions'
+    # these rules does not apply to RHEL but it has to keep the prodtype for historical reasons
+    - '!package_audit-audispd-plugins_installed'
+    - '!service_ntp_enabled'
+    - '!ntpd_specify_remote_server'
+    - '!ntpd_specify_multiple_servers'
+    - '!set_ipv6_loopback_traffic'
+    - '!set_loopback_traffic'

--- a/tests/data/profile_stability/rhel8/pci-dss.profile
+++ b/tests/data/profile_stability/rhel8/pci-dss.profile
@@ -52,7 +52,6 @@ selections:
 - dconf_gnome_session_idle_user_locks
 - sshd_set_maxstartups
 - audit_rules_time_stime
-- ntpd_specify_remote_server
 - accounts_password_pam_pwhistory_remember_system_auth
 - service_rpcbind_disabled
 - chronyd_run_as_chrony_user
@@ -200,7 +199,6 @@ selections:
 - package_telnet_removed
 - audit_sudo_log_events
 - package_ypbind_removed
-- ntpd_specify_multiple_servers
 - dconf_gnome_screensaver_idle_activation_enabled
 - sysctl_net_ipv4_tcp_syncookies
 - sshd_set_max_auth_tries


### PR DESCRIPTION
#### Description:

- Add rhel8 and rhel9 prodtypes to some rules which lost them during #11267 
- add warnings for rules which do not make sense on RHEL 8 or RHEL 9
- remove such rules from PCI-DSS profile so that they stay in the datastream but they are not selected in any profile

#### Rationale:

In #11267 , prodtypes of some rules were made explicit. However, this caused them to be removed from RHEL 8 and RHEL 9 datastreams. This should not happen because of compatibility reasons.
Therefore, these rules stay in the datastream, but they are not selected in any profile.

#### Review Hints:

Try using utils/compare_ds.py with --only-rules switch.