### PR TITLE
Fix ssh-keysign path for Ubuntu 22.04

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/rule.yml
@@ -83,3 +83,4 @@ template:
         path@sle12: /usr/lib/ssh/ssh-keysign
         path@sle15: /usr/lib/ssh/ssh-keysign
         path@ubuntu2004: /usr/lib/openssh/ssh-keysign
+        path@ubuntu2204: /usr/lib/openssh/ssh-keysign


### PR DESCRIPTION
#### Description:

- This is a continuation from PR #11082 

#### Rationale:

- Missing for Ubuntu 22.04