### PR TITLE
Add Ubuntu to audit_rules_kernel_module_loading tests

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/tests/correct_rules.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = audit
 
-{{% if "ol" in product or 'rhel' in product %}}
+{{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
 echo "-a always,exit -F arch=b32 -S finit_module -F auid>={{{ uid_min }}} -F auid!=unset -k modules" >> /etc/audit/rules.d/modules.rules
 echo "-a always,exit -F arch=b64 -S finit_module -F auid>={{{ uid_min }}} -F auid!=unset -k modules" >> /etc/audit/rules.d/modules.rules
 {{% else %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/tests/missing_auid_filter.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/tests/missing_auid_filter.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_ubuntu
 # packages = audit
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/tests/correct_rules.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = audit
 
-{{% if "ol" in product or 'rhel' in product %}}
+{{% if "ol" in product or 'rhel' in product or 'ubuntu' in product %}}
 echo "-a always,exit -F arch=b32 -S init_module -F auid>={{{ uid_min }}} -F auid!=unset -k modules" >> /etc/audit/rules.d/modules.rules
 echo "-a always,exit -F arch=b64 -S init_module -F auid>={{{ uid_min }}} -F auid!=unset -k modules" >> /etc/audit/rules.d/modules.rules
 {{% else %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/tests/missing_auid_filter.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/tests/missing_auid_filter.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_ubuntu
 # packages = audit
 
 rm -f /etc/audit/rules.d/*


### PR DESCRIPTION
#### Description:

- Continuation of PR #11080 

#### Rationale:

- Ubuntu missing from tests