### PR TITLE
Add check if to continue with ansible task

### DIFF
--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/ansible/shared.yml
@@ -21,6 +21,7 @@
   ansible.builtin.set_fact:
     world_writable_dirs: '{{ world_writable_dirs | union(item.stdout_lines) | list }}'
   loop: "{{ result_found_dirs.results }}"
+  when: item is not skipped
 
 - name: "{{{ rule_title }}} - Ensure root Ownership on Local World Writable Directories"
   ansible.builtin.file:

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/ansible/shared.yml
@@ -21,6 +21,7 @@
   ansible.builtin.set_fact:
     world_writable_dirs: '{{ world_writable_dirs | union(item.stdout_lines) | list }}'
   loop: "{{ result_found_dirs.results }}"
+  when: result_found_dirs is not skipped and item is not skipped
 
 - name: "{{{ rule_title }}} - Ensure Sticky Bit is Set on Local World Writable Directories"
   ansible.builtin.file:


### PR DESCRIPTION
#### Description:

- When run in check mode ansible remediation scripts should be more isolated and need extra checks instead of assumptions

#### Rationale:

- Fix ansible remediations run in check mode for rules part of the SLE ANSSI profile
