### PR TITLE
controleval.py: Return empty list when parameter is not found

### DIFF
--- a/utils/controleval.py
+++ b/utils/controleval.py
@@ -84,7 +84,7 @@ def get_parameter_from_yaml(yaml_file: str, section: str) -> list:
     with open(yaml_file, 'r') as file:
         try:
             yaml_content = yaml.safe_load(file)
-            return yaml_content[section]
+            return yaml_content.get(section, [])
         except yaml.YAMLError as e:
             print(e)
 


### PR DESCRIPTION

#### Description:

- This changes the function to return an empty list when the section is not found.
  It could also return `None`, but the expected return type is list.

#### Rationale:

- `get_parameter_from_yaml()` doesn't handle KeyErrors. 
- After https://github.com/ComplianceAsCode/content/pull/11268, profiles with no `selections` are known to be extending another profile, let's not count the control usage multiple times and consider `selections` as empty.

#### Review Hints:

- `Github Pages / Publish stats, tables and guides` Action is failing on #11241

