### PR TITLE
enable sshd_distributed_config for ubuntu2204

### DIFF
--- a/products/ubuntu2204/product.yml
+++ b/products/ubuntu2204/product.yml
@@ -19,6 +19,7 @@ pkg_manager_config_file: "/etc/apt/apt.conf"
 init_system: "systemd"
 oval_feed_url: "https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.jammy.cve.oval.xml"
 
+sshd_distributed_config: "true"
 
 aide_bin_path: "/usr/bin/aide"
 aide_conf_path: "/etc/aide/aide.conf"

--- a/tests/data/product_stability/ubuntu2204.yml
+++ b/tests/data/product_stability/ubuntu2204.yml
@@ -83,7 +83,7 @@ reference_uris:
   pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
   stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
   stigref: https://public.cyber.mil/stigs/srg-stig-tools/
-sshd_distributed_config: 'false'
+sshd_distributed_config: 'true'
 sysctl_remediate_drop_in_file: 'false'
 type: platform
 uid_min: 1000


### PR DESCRIPTION
#### Description:

- enable sshd_distributed_config for ubuntu2204

#### Rationale:

- ubuntu2204 default sshd config references a distributed config directory
https://manpages.ubuntu.com/manpages/jammy/en/man5/sshd_config.5.html

#### Review Hints:

from my local testing:

```
oscap-ssh --sudo ubuntu@test-host 22 xccdf eval --profile xccdf_org.ssgproject.content_profile_cis_level1_server --check-engine-results --rule xccdf_org.ssgproject.content_rule_sshd_disable_empty_passwords /scap-security-guide/ssg-ubuntu2204-sshd-ds.xml

Title   Disable SSH Access via Empty Passwords
Rule    xccdf_org.ssgproject.content_rule_sshd_disable_empty_passwords
Result  pass
```

without:
```
oscap-ssh --sudo ubuntu@test-host 22 xccdf eval --profile xccdf_org.ssgproject.content_profile_cis_level1_server --check-engine-results --rule xccdf_org.ssgproject.content_rule_sshd_disable_empty_passwords /scap-security-guide/ssg-ubuntu2204-ds.xml

Title   Disable SSH Access via Empty Passwords
Rule    xccdf_org.ssgproject.content_rule_sshd_disable_empty_passwords
Result  fail
```
