### PR TITLE
remove calls to exit from Bash remediations

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/bash/shared.sh
@@ -38,5 +38,4 @@ else
     firewalld and NetworkManager services are not active. Remediation aborted!
     This remediation could not be applied because it depends on firewalld and NetworkManager services running.
     The service is not started by this remediation in order to prevent connection issues."
-    exit 1
 fi

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_restricted/bash/shared.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_restricted/bash/shared.sh
@@ -15,5 +15,4 @@ else
     firewalld service is not active. Remediation aborted!
     This remediation could not be applied because it depends on firewalld service running.
     The service is not started by this remediation in order to prevent connection issues."
-    exit 1
 fi

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_trusted/bash/shared.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_trusted/bash/shared.sh
@@ -14,5 +14,4 @@ else
     firewalld service is not active. Remediation aborted!
     This remediation could not be applied because it depends on firewalld service running.
     The service is not started by this remediation in order to prevent connection issues."
-    exit 1
 fi


### PR DESCRIPTION
#### Description:

- remove lines which call exit from some rules.
- The rule gui_login_dod_acknowledgement was kept in tact so far

#### Rationale:



- Fixes #11275 

#### Review Hints:

Build Bash playbooks and try executing them against a system. The playbook should not get aborted in case firewalld is not installed.

#### Remains to be done:

- review the rule gui_login_dod_acknowledgement
- review Bash Jinja macros
