### PR TITLE
Update OL8 stig selection for OL08-00-040259

### DIFF
--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_forwarding/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_forwarding/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9
+prodtype: ol8,ol9,rhel7,rhel8,rhel9
 
 title: 'Disable Kernel Parameter for IPv4 Forwarding on all IPv4 Interfaces'
 
@@ -22,6 +22,7 @@ references:
     disa: CCI-000366
     nist: CM-6(b)
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol8: OL08-00-040259
     stigid@rhel8: RHEL-08-040259
     stigid@rhel9: RHEL-09-253075
 

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_ip_forward/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_ip_forward/rule.yml
@@ -48,7 +48,6 @@ references:
     pcidss4: '1.4.3'
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-040740
-    stigid@ol8: OL08-00-040259
     stigid@rhel7: RHEL-07-040740
     stigid@sle12: SLES-12-030430
     stigid@sle15: SLES-15-040380

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -1144,7 +1144,7 @@ selections:
     - sysctl_net_ipv6_conf_default_accept_source_route
 
     # OL08-00-040259
-    - sysctl_net_ipv4_ip_forward
+    - sysctl_net_ipv4_conf_all_forwarding
 
     # OL08-00-040260
     - sysctl_net_ipv6_conf_all_forwarding


### PR DESCRIPTION
#### Description:

- Replaced rule `sysctl_net_ipv4_ip_forward` with `sysctl_net_ipv4_conf_all_forwarding` in STIG profile to cover `OL08-00-040259` requirement.

#### Rationale:

- The rule `sysctl_net_ipv4_conf_all_forwarding` is actually the one that covers the requirement