### PR TITLE
Update Oracle Linux anssi profiles

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_sudo_log_events/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_sudo_log_events/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel8,rhel9,sle12,sle15,ubuntu2004,ubuntu2204
+prodtype: fedora,ol8,ol9,rhel8,rhel9,sle12,sle15,ubuntu2004,ubuntu2204
 
 title: 'Record Attempts to perform maintenance activities'
 

--- a/linux_os/guide/system/bootloader-grub2/grub2_mds_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_mds_argument/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel9
+prodtype: fedora,ol9,rhel9
 
 title: 'Configure Microarchitectural Data Sampling mitigation'
 

--- a/linux_os/guide/system/permissions/files/sysctl_fs_protected_fifos/rule.yml
+++ b/linux_os/guide/system/permissions/files/sysctl_fs_protected_fifos/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel9
+prodtype: fedora,ol9,rhel9
 
 title: 'Enable Kernel Parameter to Enforce DAC on FIFOs'
 

--- a/linux_os/guide/system/permissions/files/sysctl_fs_protected_regular/rule.yml
+++ b/linux_os/guide/system/permissions/files/sysctl_fs_protected_regular/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel9
+prodtype: fedora,ol9,rhel9
 
 title: 'Enable Kernel Parameter to Enforce DAC on Regular files'
 

--- a/products/ol9/profiles/anssi_bp28_enhanced.profile
+++ b/products/ol9/profiles/anssi_bp28_enhanced.profile
@@ -13,4 +13,3 @@ description: |-
 
 selections:
     - anssi:all:enhanced
-    - '!mount_option_nodev_nonroot_local_partitions'

--- a/products/ol9/profiles/anssi_bp28_high.profile
+++ b/products/ol9/profiles/anssi_bp28_high.profile
@@ -13,4 +13,3 @@ description: |-
 
 selections:
     - anssi:all:high
-    - '!mount_option_nodev_nonroot_local_partitions'

--- a/products/ol9/profiles/anssi_bp28_intermediary.profile
+++ b/products/ol9/profiles/anssi_bp28_intermediary.profile
@@ -13,4 +13,3 @@ description: |-
 
 selections:
     - anssi:all:intermediary
-    - '!mount_option_nodev_nonroot_local_partitions'


### PR DESCRIPTION
#### Description:

- Add ol8 & ol9 prodtype to applicable rules from anssi controls
- Delete removal of rule `mount_option_nodev_nonroot_local_partitions`

#### Rationale:

- Align better Oracle linux products with Anssi controls rules
