### PR TITLE
Improve Performance on rules probing the whole file system

### DIFF
--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/oval/shared.xml
@@ -1,22 +1,39 @@
 <def-group>
-  <definition class="compliance" id="dir_perms_world_writable_sticky_bits" version="1">
+  <definition class="compliance" id="{{{ rule_id }}}" version="2">
     {{{ oval_metadata("The sticky bit should be set for all world-writable directories.") }}}
     <criteria>
-      <criterion comment="all local world writable directories have sticky bit set" test_ref="test_dir_perms_world_writable_sticky_bits" negate="true" />
+      <criterion test_ref="test_dir_perms_world_writable_sticky_bits"
+        comment="All local world-writable directories have sticky bit set"/>
     </criteria>
   </definition>
-  <unix:file_test check="all" check_existence="all_exist" comment="all local world-writable directories have sticky bit set" id="test_dir_perms_world_writable_sticky_bits" version="1">
-    <unix:object object_ref="object_only_local_directories" />
-    <unix:state state_ref="state_world_writable_and_not_sticky" />
-  </unix:file_test>
-  <unix:file_object comment="only local directories" id="object_only_local_directories" version="1">
-    <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
-    <unix:path operation="equals">/</unix:path>
-    <unix:filename xsi:nil="true" />
-    <filter action="include">state_world_writable_and_not_sticky</filter>
-  </unix:file_object>
-  <unix:file_state id="state_world_writable_and_not_sticky" version="1">
+
+  <unix:file_state id="state_dir_perms_world_writable_sticky_bits" version="1">
     <unix:sticky datatype="boolean">false</unix:sticky>
     <unix:owrite datatype="boolean">true</unix:owrite>
   </unix:file_state>
+
+  {{%- set var_local_mount_points = "var_" ~ rule_id ~ "_local_mountpoints" -%}}
+  {{{ create_local_mount_points_list(var_local_mount_points) }}}
+
+  <!--
+    This file_object will only find files located in local and not special file systems. The
+    recurse_file_system parameter is set to defined in order to make sure the probe doesn't
+    leave the scope of that mount point. For example, when probing "/", the probe will ignore
+    any child directory which is a mount point for any other partition. This will ensure
+    considerable performance improvement. -->
+  <unix:file_object id="object_dir_perms_world_writable_sticky_bits" version="1"
+    comment="All world-writable directories without sticky bits">
+    <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1"
+      recurse_file_system="defined"/>
+      <unix:path operation="equals" var_check="at least one"
+        var_ref="{{{ var_local_mount_points }}}"/>
+    <unix:filename xsi:nil="true"/>
+    <filter action="include">state_dir_perms_world_writable_sticky_bits</filter>
+  </unix:file_object>
+
+  <unix:file_test id="test_dir_perms_world_writable_sticky_bits" version="2"
+    check="all" check_existence="none_exist"
+    comment="Check the existence of world-writable directories without sticky bits">
+    <unix:object object_ref="object_dir_perms_world_writable_sticky_bits"/>
+  </unix:file_test>
 </def-group>

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/rule.yml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/rule.yml
@@ -3,30 +3,25 @@ documentation_complete: true
 title: 'Verify that All World-Writable Directories Have Sticky Bits Set'
 
 description: |-
-    When the so-called 'sticky bit' is set on a directory,
-    only the owner of a given file may remove that file from the
-    directory. Without the sticky bit, any user with write access to a
-    directory may remove any file in the directory. Setting the sticky
-    bit prevents users from removing each other's files. In cases where
-    there is no reason for a directory to be world-writable, a better
-    solution is to remove that permission rather than to set the sticky
-    bit. However, if a directory is used by a particular application,
-    consult that application's documentation instead of blindly
-    changing modes.
+    When the so-called 'sticky bit' is set on a directory, only the owner of a given file may
+    remove that file from the directory. Without the sticky bit, any user with write access to a
+    directory may remove any file in the directory. Setting the sticky bit prevents users from
+    removing each other's files. In cases where there is no reason for a directory to be
+    world-writable, a better solution is to remove that permission rather than to set the sticky
+    bit. However, if a directory is used by a particular application, consult that application's
+    documentation instead of blindly changing modes.
     <br />
-    To set the sticky bit on a world-writable directory <i>DIR</i>, run the
-    following command:
+    To set the sticky bit on a world-writable directory <i>DIR</i>, run the following command:
     <pre>$ sudo chmod +t <i>DIR</i></pre>
 
 rationale: |-
-    Failing to set the sticky bit on public directories allows unauthorized
-    users to delete files in the directory structure.
+    Failing to set the sticky bit on public directories allows unauthorized users to delete files
+    in the directory structure.
     <br /><br />
-    The only authorized public directories are those temporary directories
-    supplied with the system, or those designed to be temporary file
-    repositories. The setting is normally reserved for directories used by the
-    system, by users for temporary file storage (such as <tt>/tmp</tt>), and
-    for directories requiring global read/write access.
+    The only authorized public directories are those temporary directories supplied with the
+    system, or those designed to be temporary file repositories. The setting is normally reserved
+    for directories used by the system, by users for temporary file storage (such as <tt>/tmp</tt>),
+    and for directories requiring global read/write access.
 
 severity: medium
 
@@ -102,3 +97,10 @@ fixtext: |-
 
 srg_requirement:
     A sticky bit must be set on all {{{ full_name }}} public directories to prevent unauthorized and unintended information transferred via shared system resources.
+
+warnings:
+    - general: |-
+        This rule can take a long time to perform the check and might consume a considerable
+        amount of resources depending on the number of directories present on the system. It is
+        not a problem in most cases, but especially systems with a large number of directories can
+        be affected. See <code>https://access.redhat.com/articles/6999111</code>.

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/tests/correct.pass.sh
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/tests/correct.pass.sh
@@ -10,6 +10,6 @@ df --local -P | awk '{if (NR!=1) print $6}' \
 mkdir -p /test_dir_1
 chmod 1770 /test_dir_1
 
-# Create a new dir that is word-writable but doesn't have sticky bit
+# Create a new dir that is word-readable and doesn't have sticky bit
 mkdir -p /test_dir_2
 chmod 0774 /test_dir_2

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_system_owned/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_system_owned/oval/shared.xml
@@ -1,22 +1,40 @@
 <def-group>
-  <definition class="compliance" id="dir_perms_world_writable_system_owned" version="1">
-    {{{ oval_metadata("All world writable directories should be owned by a system user.") }}}
-    <criteria comment="check for local directories that are world writable and have uid greater than or equal to {{{ auid }}}" negate="true">
-      <criterion comment="check for local directories that are world writable and have uid greater than or equal to {{{ auid }}}" test_ref="test_dir_world_writable_uid_gt_value" />
+  <definition class="compliance" id="{{{ rule_id }}}" version="2">
+    {{{ oval_metadata("All world writable directories should be owned by a system account.") }}}
+    <criteria>
+      <criterion test_ref="test_dir_perms_world_writable_system_owned"
+        comment="Check world-writable directories with uid greater than or equal to {{{ uid_min }}}"/>
     </criteria>
   </definition>
-  <unix:file_test check="all" comment="check for local directories that are world writable and have uid greater than or equal to {{{ auid }}}" id="test_dir_world_writable_uid_gt_value" version="1">
-    <unix:object object_ref="all_local_directories_uid" />
-    <unix:state state_ref="state_uid_is_user_and_world_writable" />
-  </unix:file_test>
-  <unix:file_object comment="all local directories" id="all_local_directories_uid" version="1">
-    <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
-    <unix:path operation="equals">/</unix:path>
-    <unix:filename xsi:nil="true" />
-    <filter action="include">state_uid_is_user_and_world_writable</filter>
-  </unix:file_object>
-  <unix:file_state comment="uid greater than or equal to {{{ auid }}} and world writable" id="state_uid_is_user_and_world_writable" version="1">
-    <unix:user_id datatype="int" operation="greater than or equal">{{{ auid }}}</unix:user_id>
+
+  <unix:file_state id="state_dir_perms_world_writable_system_owned" version="1"
+    comment="uid greater than or equal to {{{ uid_min }}} and world writable">
+    <unix:user_id datatype="int" operation="greater than or equal">{{{ uid_min }}}</unix:user_id>
     <unix:owrite datatype="boolean">true</unix:owrite>
   </unix:file_state>
+
+  {{%- set var_local_mount_points = "var_" ~ rule_id ~ "_local_mountpoints" -%}}
+  {{{ create_local_mount_points_list(var_local_mount_points) }}}
+
+  <!--
+    This file_object will only find files located in local and not special file systems. The
+    recurse_file_system parameter is set to defined in order to make sure the probe doesn't
+    leave the scope of that mount point. For example, when probing "/", the probe will ignore
+    any child directory which is a mount point for any other partition. This will ensure
+    considerable performance improvement. -->
+  <unix:file_object id="object_dir_perms_world_writable_system_owned" version="1"
+    comment="All world-writable directories.">
+    <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1"
+      recurse_file_system="defined"/>
+      <unix:path operation="equals" var_check="at least one"
+        var_ref="{{{ var_local_mount_points }}}"/>
+    <unix:filename xsi:nil="true"/>
+    <filter action="include">state_dir_perms_world_writable_system_owned</filter>
+  </unix:file_object>
+
+  <unix:file_test id="test_dir_perms_world_writable_system_owned" version="2"
+    check="all" check_existence="none_exist"
+    comment="Check the existence of world-writable directories not owned by system accounts.">
+    <unix:object object_ref="object_dir_perms_world_writable_system_owned"/>
+  </unix:file_test>
 </def-group>

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_system_owned/rule.yml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_system_owned/rule.yml
@@ -5,18 +5,15 @@ prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
 title: 'Ensure All World-Writable Directories Are Owned by a System Account'
 
 description: |-
-    All directories in local partitions which are
-    world-writable should be owned by root or another
-    system account. If any world-writable directories are not
-    owned by a system account, this should be investigated.
-    Following this, the files should be deleted or assigned to an
+    All directories in local partitions which are world-writable should be owned by root or
+    another system account. If any world-writable directories are not owned by a system account,
+    this should be investigated. Following this, the files should be deleted or assigned to an
     appropriate owner.
 
 rationale: |-
-    Allowing a user account to own a world-writable directory is
-    undesirable because it allows the owner of that directory to remove
-    or replace any files that may be placed in the directory by other
-    users.
+    Allowing a user account to own a world-writable directory is undesirable because it allows the
+    owner of that directory to remove or replace any files that may be placed in the directory by
+    other users.
 
 severity: medium
 
@@ -40,7 +37,14 @@ references:
 ocil_clause: 'there is output'
 
 ocil: |-
-    The following command will discover and print world-writable directories that
-    are not owned by a system account, given the assumption that only system
-    accounts have a uid lower than 500.  Run it once for each local partition <i>PART</i>:
-    <pre>$ sudo find <i>PART</i> -xdev -type d -perm -0002 -uid +499 -print</pre>
+    The following command will discover and print world-writable directories that are not owned by
+    a system account, given the assumption that only system accounts have a uid lower than 500.
+    Run it once for each local partition <i>PART</i>:
+    <pre>$ sudo find <i>PART</i> -xdev -type d -perm -0002 -uid +{{{ uid_min }}} -print</pre>
+
+warnings:
+    - general: |-
+        This rule can take a long time to perform the check and might consume a considerable
+        amount of resources depending on the number of directories present on the system. It is
+        not a problem in most cases, but especially systems with a large number of directories can
+        be affected. See <code>https://access.redhat.com/articles/6999111</code>.

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_sgid/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_sgid/oval/shared.xml
@@ -1,53 +1,77 @@
 <def-group>
-    <definition id="file_permissions_unauthorized_sgid" version="1" class="compliance">
+    <definition class="compliance" id="{{{ rule_id }}}" version="1">
         {{{ oval_metadata("Evaluates to true if all files with SGID set are owned by RPM packages.") }}}
         <criteria>
-            <criterion comment="Check all sgid files" test_ref="test_file_permissions_unauthorized_sgid"/>
+            <criterion test_ref="test_file_permissions_unauthorized_sgid"
+                comment="Check if all sgid files present in the system are authorized"/>
         </criteria>
     </definition>
 
-    <unix:file_test check="all" check_existence="none_exist" comment="sgid files outside system RPMs" id="test_file_permissions_unauthorized_sgid" version="1">
-        <unix:object object_ref="obj_file_permissions_unauthorized_sgid_unowned" />
-    </unix:file_test>
+    <!-- Collect all sgid files in the system. -->
+    <unix:file_state id="state_file_permissions_unauthorized_sgid_set" version="1">
+        <unix:sgid datatype="boolean">true</unix:sgid>
+    </unix:file_state>
 
-    <unix:file_object comment="files with sgid set which are not owned by any RPM package" id="obj_file_permissions_unauthorized_sgid_unowned" version="1">
-        <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
-        <unix:path operation="equals">/</unix:path>
+    {{%- set var_local_mount_points = "var_" ~ rule_id ~ "_local_mountpoints" -%}}
+    {{{ create_local_mount_points_list(var_local_mount_points) }}}
+
+    <!-- This file_object will only find files located in local and not special file systems. The
+         recurse_file_system parameter is set to defined in order to make sure the probe doesn't
+         leave the scope of that mount point. For example, when probing "/", the probe will ignore
+         any child directory which is a mount point for any other partition. This will ensure
+         considerable performance improvement. -->
+    <unix:file_object id="object_file_permissions_unauthorized_sgid_all_sgid_files" version="1"
+        comment="all files with sgid set">
+        <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1"
+            recurse_file_system="defined"/>
+            <unix:path operation="equals" var_check="at least one"
+                var_ref="{{{ var_local_mount_points }}}"/>
         <unix:filename operation="pattern match">^.*$</unix:filename>
-        <filter action="include">state_file_permissions_unauthorized_sgid_sgid_set</filter>
-        <filter action="exclude">state_file_permissions_unauthorized_sgid_filepaths</filter>
+        <filter action="include">state_file_permissions_unauthorized_sgid_set</filter>
     </unix:file_object>
 
-    <linux:rpmverifyfile_object id="obj_file_permissions_unauthorized_sgid_rpms" version="1" comment="all files with sgid set that come from a RPM package">
-        <linux:behaviors nolinkto="true" nomd5="true" nosize="true" nouser="true" nogroup="true" nomtime="true" nomode="true" nordev="true" />
+    <local_variable id="var_file_permissions_unauthorized_sgid_all_sgid_files" version="1"
+        datatype="string" comment="all files with sgid set">
+        <object_component item_field="filepath"
+            object_ref="object_file_permissions_unauthorized_sgid_all_sgid_files"/>
+    </local_variable>
+
+    <!-- Locate all rpm packages including located system sgid files. -->
+    <linux:rpmverifyfile_object id="object_file_permissions_unauthorized_sgid_rpms" version="1"
+        comment="all files with sgid set that come from a RPM package">
+        <linux:behaviors nolinkto="true" nomd5="true" nosize="true" nouser="true" nogroup="true"
+            nomtime="true" nomode="true" nordev="true"/>
         <linux:name operation="pattern match">.*</linux:name>
         <linux:epoch operation="pattern match">.*</linux:epoch>
         <linux:version operation="pattern match">.*</linux:version>
         <linux:release operation="pattern match">.*</linux:release>
         <linux:arch operation="pattern match">.*</linux:arch>
-        <linux:filepath var_ref="var_file_permissions_unauthorized_sgid_all" operation="equals" var_check="all" />
+        <linux:filepath operation="equals" var_check="all"
+            var_ref="var_file_permissions_unauthorized_sgid_all_sgid_files"/>
     </linux:rpmverifyfile_object>
 
-    <unix:file_object comment="all files with sgid set" id="obj_file_permissions_unauthorized_sgid_files" version="1">
-        <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
-        <unix:path operation="equals">/</unix:path>
-        <unix:filename operation="pattern match">^.*$</unix:filename>
-        <filter action="include">state_file_permissions_unauthorized_sgid_sgid_set</filter>
-    </unix:file_object>
-
-    <unix:file_state id="state_file_permissions_unauthorized_sgid_sgid_set" version="1">
-        <unix:sgid datatype="boolean">true</unix:sgid>
-    </unix:file_state>
-
-    <unix:file_state id="state_file_permissions_unauthorized_sgid_filepaths" version="1">
-        <unix:filepath var_ref="var_file_permissions_unauthorized_sgid_rpms" var_check="at least one" />
-    </unix:file_state>
-
-    <local_variable id="var_file_permissions_unauthorized_sgid_rpms" datatype="string" version="1" comment="all files with sgid set that come from a RPM package">
-        <object_component item_field="filepath" object_ref="obj_file_permissions_unauthorized_sgid_rpms" />
+    <!-- Extract the filepaths of rpm packages containing system sgid files. -->
+    <local_variable id="var_file_permissions_unauthorized_sgid_rpms" version="1"
+        datatype="string" comment="all files with sgid set that are managed by a RPM package">
+        <object_component item_field="filepath"
+            object_ref="object_file_permissions_unauthorized_sgid_rpms"/>
     </local_variable>
 
-    <local_variable id="var_file_permissions_unauthorized_sgid_all" datatype="string" version="1" comment="all files with sgid set">
-        <object_component item_field="filepath" object_ref="obj_file_permissions_unauthorized_sgid_files" />
-    </local_variable>
+    <!-- Convert the local variable to a variable state which will be used below as a filter. -->
+    <ind:variable_state id="state_file_permissions_unauthorized_sgid_rpm_filepaths" version="1">
+        <ind:value datatype="string" operation="equals" var_check="at least one"
+            var_ref="var_file_permissions_unauthorized_sgid_rpms"/>
+    </ind:variable_state>
+
+    <!-- Variable object containing only system sgid files not include in rpm packages. -->
+    <ind:variable_object id="object_file_permissions_unauthorized_sgid_no_rpm_files" version="1">
+        <ind:var_ref>var_file_permissions_unauthorized_sgid_all_sgid_files</ind:var_ref>
+        <filter action="exclude">state_file_permissions_unauthorized_sgid_rpm_filepaths</filter>
+    </ind:variable_object>
+
+    <ind:variable_test id="test_file_permissions_unauthorized_sgid" version="1"
+        check="all" check_existence="none_exist"
+        comment="Check the existence of sgid files not included in rpm packages.">
+        <ind:object object_ref="object_file_permissions_unauthorized_sgid_no_rpm_files"/>
+    </ind:variable_test>
 </def-group>

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_sgid/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_sgid/rule.yml
@@ -5,22 +5,19 @@ title: 'Ensure All SGID Executables Are Authorized'
 prodtype: alinux3,anolis23,anolis8,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,sle12,sle15,uos20
 
 description: |-
-    The SGID (set group id) bit should be set only on files that were
-    installed via authorized means. A straightforward means of identifying
-    unauthorized SGID files is determine if any were not installed as part of an
-    RPM package, which is cryptographically verified. Investigate the origin
-    of any unpackaged SGID files.
-    This configuration check considers authorized SGID files which were installed via RPM.
-    It is assumed that when an individual has sudo access to install an RPM
-    and all packages are signed with an organizationally-recognized GPG key,
-    the software should be considered an approved package on the system.
-    Any SGID file not deployed through an RPM will be flagged for further review.
+    The SGID (set group id) bit should be set only on files that were installed via authorized
+    means. A straightforward means of identifying unauthorized SGID files is determine if any were
+    not installed as part of an RPM package, which is cryptographically verified. Investigate the
+    origin of any unpackaged SGID files. This configuration check considers authorized SGID files
+    those which were installed via RPM. It is assumed that when an individual has sudo access to
+    install an RPM and all packages are signed with an organizationally-recognized GPG key, the
+    software should be considered an approved package on the system. Any SGID file not deployed
+    through an RPM will be flagged for further review.
 
 rationale: |-
-    Executable files with the SGID permission run with the privileges of
-    the owner of the file. SGID files of uncertain provenance could allow for
-    unprivileged users to elevate privileges. The presence of these files should be
-    strictly controlled on the system.
+    Executable files with the SGID permission run with the privileges of the owner of the file.
+    SGID files of uncertain provenance could allow for unprivileged users to elevate privileges.
+    The presence of these files should be strictly controlled on the system.
 
 severity: medium
 
@@ -52,3 +49,10 @@ ocil_clause: 'there is output'
 ocil: |-
     To find SGID files, run the following command:
     <pre>$ sudo find / -xdev -type f -perm -2000</pre>
+
+warnings:
+    - general: |-
+        This rule can take a long time to perform the check and might consume a considerable
+        amount of resources depending on the number of files present on the system. It is not a
+        problem in most cases, but especially systems with a large number of files can be affected.
+        See <code>https://access.redhat.com/articles/6999111</code>.

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_suid/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_suid/oval/shared.xml
@@ -1,53 +1,73 @@
 <def-group>
-    <definition id="file_permissions_unauthorized_suid" version="1" class="compliance">
+    <definition class="compliance" id="{{{ rule_id }}}" version="1">
         {{{ oval_metadata("Evaluates to true if all files with SUID set are owned by RPM packages.") }}}
         <criteria>
-            <criterion comment="Check all suid files" test_ref="test_file_permissions_unauthorized_suid"/>
+            <criterion test_ref="test_file_permissions_unauthorized_suid"
+                comment="Check if all suid files present in the system are authorized"/>
         </criteria>
     </definition>
 
-    <unix:file_test check="all" check_existence="none_exist" comment="suid files outside system RPMs" id="test_file_permissions_unauthorized_suid" version="1">
+    <!-- Collect all suid files in the system. -->
+    <unix:file_state id="state_file_permissions_unauthorized_suid_suid_set" version="1">
+        <unix:suid datatype="boolean">true</unix:suid>
+    </unix:file_state>
+
+    <unix:file_object id="obj_file_permissions_unauthorized_suid_all_suid_files" version="1"
+        comment="all files with suid set">
+        <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1"
+            recurse_file_system="local"/>
+        <unix:path operation="equals">/</unix:path>
+        <unix:filename operation="pattern match">^.*$</unix:filename>
+        <filter action="include">state_file_permissions_unauthorized_suid_suid_set</filter>
+    </unix:file_object>
+
+    <local_variable id="var_file_permissions_unauthorized_suid_all_suid_files" version="1"
+        datatype="string" comment="all files with suid set">
+        <object_component item_field="filepath"
+            object_ref="obj_file_permissions_unauthorized_suid_all_suid_files"/>
+    </local_variable>
+
+    <!-- Locate all rpm packages including system suid files. -->
+    <linux:rpmverifyfile_object id="obj_file_permissions_unauthorized_suid_rpms" version="1"
+        comment="all files with suid set that come from a RPM package">
+        <linux:behaviors nolinkto="true" nomd5="true" nosize="true" nouser="true" nogroup="true"
+            nomtime="true" nomode="true" nordev="true"/>
+        <linux:name operation="pattern match">.*</linux:name>
+        <linux:epoch operation="pattern match">.*</linux:epoch>
+        <linux:version operation="pattern match">.*</linux:version>
+        <linux:release operation="pattern match">.*</linux:release>
+        <linux:arch operation="pattern match">.*</linux:arch>
+        <linux:filepath operation="equals" var_check="all"
+            var_ref="var_file_permissions_unauthorized_suid_all_suid_files"/>
+    </linux:rpmverifyfile_object>
+
+    <!-- Extract the filepaths of rpm packages containing system suid files. -->
+    <local_variable id="var_file_permissions_unauthorized_suid_rpms" version="1"
+        datatype="string" comment="all files with suid set that come from a RPM package">
+        <object_component item_field="filepath"
+            object_ref="obj_file_permissions_unauthorized_suid_rpms"/>
+    </local_variable>
+
+
+    <unix:file_state id="state_file_permissions_unauthorized_suid_filepaths" version="1">
+        <unix:filepath var_check="at least one"
+            var_ref="var_file_permissions_unauthorized_suid_rpms"/>
+    </unix:file_state>
+
+    <unix:file_test id="test_file_permissions_unauthorized_suid" version="1"
+        check="all" check_existence="none_exist"
+        comment="There is no suid files outside system RPMs">
         <unix:object object_ref="obj_file_permissions_unauthorized_suid_unowned" />
     </unix:file_test>
 
-    <unix:file_object comment="files with suid set which are not owned by any RPM package" id="obj_file_permissions_unauthorized_suid_unowned" version="1">
-        <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
+    <unix:file_object id="obj_file_permissions_unauthorized_suid_unowned" version="1"
+        comment="files with suid set which are not owned by any RPM package">
+        <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1"
+            recurse_file_system="local"/>
         <unix:path operation="equals">/</unix:path>
         <unix:filename operation="pattern match">^.*$</unix:filename>
         <filter action="include">state_file_permissions_unauthorized_suid_suid_set</filter>
         <filter action="exclude">state_file_permissions_unauthorized_suid_filepaths</filter>
     </unix:file_object>
 
-    <linux:rpmverifyfile_object id="obj_file_permissions_unauthorized_suid_rpms" version="1" comment="all files with suid set that come from a RPM package">
-        <linux:behaviors nolinkto="true" nomd5="true" nosize="true" nouser="true" nogroup="true" nomtime="true" nomode="true" nordev="true" />
-        <linux:name operation="pattern match">.*</linux:name>
-        <linux:epoch operation="pattern match">.*</linux:epoch>
-        <linux:version operation="pattern match">.*</linux:version>
-        <linux:release operation="pattern match">.*</linux:release>
-        <linux:arch operation="pattern match">.*</linux:arch>
-        <linux:filepath var_ref="var_file_permissions_unauthorized_suid_all" operation="equals" var_check="all" />
-    </linux:rpmverifyfile_object>
-
-    <unix:file_object comment="all files with suid set" id="obj_file_permissions_unauthorized_suid_files" version="1">
-        <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
-        <unix:path operation="equals">/</unix:path>
-        <unix:filename operation="pattern match">^.*$</unix:filename>
-        <filter action="include">state_file_permissions_unauthorized_suid_suid_set</filter>
-    </unix:file_object>
-
-    <unix:file_state id="state_file_permissions_unauthorized_suid_suid_set" version="1">
-        <unix:suid datatype="boolean">true</unix:suid>
-    </unix:file_state>
-
-    <unix:file_state id="state_file_permissions_unauthorized_suid_filepaths" version="1">
-        <unix:filepath var_ref="var_file_permissions_unauthorized_suid_rpms" var_check="at least one" />
-    </unix:file_state>
-
-    <local_variable id="var_file_permissions_unauthorized_suid_rpms" datatype="string" version="1" comment="all files with suid set that come from a RPM package">
-        <object_component item_field="filepath" object_ref="obj_file_permissions_unauthorized_suid_rpms" />
-    </local_variable>
-
-    <local_variable id="var_file_permissions_unauthorized_suid_all" datatype="string" version="1" comment="all files with suid set">
-        <object_component item_field="filepath" object_ref="obj_file_permissions_unauthorized_suid_files" />
-    </local_variable>
 </def-group>

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_suid/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_suid/oval/shared.xml
@@ -12,7 +12,7 @@
         <unix:suid datatype="boolean">true</unix:suid>
     </unix:file_state>
 
-    <unix:file_object id="obj_file_permissions_unauthorized_suid_all_suid_files" version="1"
+    <unix:file_object id="object_file_permissions_unauthorized_suid_all_suid_files" version="1"
         comment="all files with suid set">
         <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1"
             recurse_file_system="local"/>
@@ -24,11 +24,11 @@
     <local_variable id="var_file_permissions_unauthorized_suid_all_suid_files" version="1"
         datatype="string" comment="all files with suid set">
         <object_component item_field="filepath"
-            object_ref="obj_file_permissions_unauthorized_suid_all_suid_files"/>
+            object_ref="object_file_permissions_unauthorized_suid_all_suid_files"/>
     </local_variable>
 
-    <!-- Locate all rpm packages including system suid files. -->
-    <linux:rpmverifyfile_object id="obj_file_permissions_unauthorized_suid_rpms" version="1"
+    <!-- Locate all rpm packages including located system suid files. -->
+    <linux:rpmverifyfile_object id="object_file_permissions_unauthorized_suid_rpms" version="1"
         comment="all files with suid set that come from a RPM package">
         <linux:behaviors nolinkto="true" nomd5="true" nosize="true" nouser="true" nogroup="true"
             nomtime="true" nomode="true" nordev="true"/>
@@ -43,31 +43,26 @@
 
     <!-- Extract the filepaths of rpm packages containing system suid files. -->
     <local_variable id="var_file_permissions_unauthorized_suid_rpms" version="1"
-        datatype="string" comment="all files with suid set that come from a RPM package">
+        datatype="string" comment="all files with suid set that are managed by a RPM package">
         <object_component item_field="filepath"
-            object_ref="obj_file_permissions_unauthorized_suid_rpms"/>
+            object_ref="object_file_permissions_unauthorized_suid_rpms"/>
     </local_variable>
 
-
-    <unix:file_state id="state_file_permissions_unauthorized_suid_filepaths" version="1">
-        <unix:filepath var_check="at least one"
+    <!-- Convert the local variable to a variable state which will be used below as a filter. -->
+    <ind:variable_state id="state_file_permissions_unauthorized_suid_rpm_filepaths" version="1">
+        <ind:value datatype="string" operation="equals" var_check="at least one"
             var_ref="var_file_permissions_unauthorized_suid_rpms"/>
-    </unix:file_state>
+    </ind:variable_state>
 
-    <unix:file_test id="test_file_permissions_unauthorized_suid" version="1"
+    <!-- Variable object containing only system suid files not include in rpm packages. -->
+    <ind:variable_object id="object_file_permissions_unauthorized_suid_no_rpm_files" version="1">
+        <ind:var_ref>var_file_permissions_unauthorized_suid_all_suid_files</ind:var_ref>
+        <filter action="exclude">state_file_permissions_unauthorized_suid_rpm_filepaths</filter>
+    </ind:variable_object>
+
+    <ind:variable_test id="test_file_permissions_unauthorized_suid" version="1"
         check="all" check_existence="none_exist"
-        comment="There is no suid files outside system RPMs">
-        <unix:object object_ref="obj_file_permissions_unauthorized_suid_unowned" />
-    </unix:file_test>
-
-    <unix:file_object id="obj_file_permissions_unauthorized_suid_unowned" version="1"
-        comment="files with suid set which are not owned by any RPM package">
-        <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1"
-            recurse_file_system="local"/>
-        <unix:path operation="equals">/</unix:path>
-        <unix:filename operation="pattern match">^.*$</unix:filename>
-        <filter action="include">state_file_permissions_unauthorized_suid_suid_set</filter>
-        <filter action="exclude">state_file_permissions_unauthorized_suid_filepaths</filter>
-    </unix:file_object>
-
+        comment="Check the existence of suid files not included in rpm packages.">
+        <ind:object object_ref="object_file_permissions_unauthorized_suid_no_rpm_files"/>
+    </ind:variable_test>
 </def-group>

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_suid/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_suid/oval/shared.xml
@@ -8,17 +8,26 @@
     </definition>
 
     <!-- Collect all suid files in the system. -->
-    <unix:file_state id="state_file_permissions_unauthorized_suid_suid_set" version="1">
+    <unix:file_state id="state_file_permissions_unauthorized_suid_set" version="1">
         <unix:suid datatype="boolean">true</unix:suid>
     </unix:file_state>
 
+    {{%- set var_local_mount_points = "var_" ~ rule_id ~ "_local_mountpoints" -%}}
+    {{{ create_local_mount_points_list(var_local_mount_points) }}}
+
+    <!-- This file_object will only find files located in local and not special file systems. The
+         recurse_file_system parameter is set to defined in order to make sure the probe doesn't
+         leave the scope of that mount point. For example, when probing "/", the probe will ignore
+         any child directory which is a mount point for any other partition. This will ensure
+         considerable performance improvement. -->
     <unix:file_object id="object_file_permissions_unauthorized_suid_all_suid_files" version="1"
         comment="all files with suid set">
         <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1"
-            recurse_file_system="local"/>
-        <unix:path operation="equals">/</unix:path>
+            recurse_file_system="defined"/>
+            <unix:path operation="equals" var_check="at least one"
+                var_ref="{{{ var_local_mount_points }}}"/>
         <unix:filename operation="pattern match">^.*$</unix:filename>
-        <filter action="include">state_file_permissions_unauthorized_suid_suid_set</filter>
+        <filter action="include">state_file_permissions_unauthorized_suid_set</filter>
     </unix:file_object>
 
     <local_variable id="var_file_permissions_unauthorized_suid_all_suid_files" version="1"

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_suid/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_suid/rule.yml
@@ -5,22 +5,19 @@ title: 'Ensure All SUID Executables Are Authorized'
 prodtype: alinux3,anolis23,anolis8,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,sle12,sle15,uos20
 
 description: |-
-    The SUID (set user id) bit should be set only on files that were
-    installed via authorized means. A straightforward means of identifying
-    unauthorized SUID files is determine if any were not installed as part of an
-    RPM package, which is cryptographically verified. Investigate the origin
-    of any unpackaged SUID files.
-    This configuration check considers authorized SUID files which were installed via RPM.
-    It is assumed that when an individual has sudo access to install an RPM
-    and all packages are signed with an organizationally-recognized GPG key,
-    the software should be considered an approved package on the system.
-    Any SUID file not deployed through an RPM will be flagged for further review.
+    The SUID (set user id) bit should be set only on files that were installed via authorized
+    means. A straightforward means of identifying unauthorized SUID files is determine if any were
+    not installed as part of an RPM package, which is cryptographically verified. Investigate the
+    origin of any unpackaged SUID files. This configuration check considers authorized SUID files
+    those which were installed via RPM. It is assumed that when an individual has sudo access to
+    install an RPM and all packages are signed with an organizationally-recognized GPG key, the
+    software should be considered an approved package on the system. Any SUID file not deployed
+    through an RPM will be flagged for further review.
 
 rationale: |-
-    Executable files with the SUID permission run with the privileges of
-    the owner of the file. SUID files of uncertain provenance could allow for
-    unprivileged users to elevate privileges. The presence of these files should be
-    strictly controlled on the system.
+    Executable files with the SUID permission run with the privileges of the owner of the file.
+    SUID files of uncertain provenance could allow for unprivileged users to elevate privileges.
+    The presence of these files should be strictly controlled on the system.
 
 severity: medium
 
@@ -52,3 +49,10 @@ ocil_clause: 'only authorized files appear in the output of the find command'
 ocil: |-
     To find SUID files, run the following command:
     <pre>$ sudo find / -xdev -type f -perm -4000</pre>
+
+warnings:
+    - general: |-
+        This rule can take a long time to perform the check and might consume a considerable
+        amount of resources depending on the number of files present on the system. It is not a
+        problem in most cases, but especially systems with a large number of files can be affected.
+        See <code>https://access.redhat.com/articles/6999111</code>.

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/bash/shared.sh
@@ -1,3 +1,16 @@
 # platform = multi_platform_all
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
 
-find / -xdev -type f -perm -002 -exec chmod o-w {} \;
+FILTER_NODEV=$(awk '/nodev/ { print $2 }' /proc/filesystems | paste -sd,)
+PARTITIONS=$(findmnt -n -l -k -it $FILTER_NODEV | awk '{ print $1 }')
+for PARTITION in $PARTITIONS; do
+  find "${PARTITION}" -xdev -type f -perm -002 -exec chmod o-w {} \; 2>/dev/null
+done
+
+# Ensure /tmp is also fixed whem tmpfs is used.
+if grep "^tmpfs /tmp" /proc/mounts; then
+  find /tmp -xdev -type f -perm -002 -exec chmod o-w {} \; 2>/dev/null
+fi

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/oval/shared.xml
@@ -1,38 +1,45 @@
 <def-group>
-  <definition class="compliance" id="file_permissions_unauthorized_world_writable" version="1">
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("The world-write permission should be disabled for all files.") }}}
     <criteria>
-      <criterion test_ref="test_file_permissions_unauthorized_world_write" />
+      <criterion test_ref="test_file_permissions_unauthorized_world_write"/>
     </criteria>
   </definition>
-  <!-- NOTE: It is impossible for an OVAL check to determine which world writable files are authorized or not. -->
-  <!-- This checks basically fails if any world writable files exist on the system. A default RHEL install -->
-  <!-- does not have any world writable files but this many not be the case for other systems. It will be up to -->
-  <!-- the system administrator to determine which world writable files are approved for use. -->
-  <unix:file_test check="all" check_existence="none_exist" comment="world writable files" id="test_file_permissions_unauthorized_world_write" version="1">
-    <unix:object object_ref="object_file_permissions_unauthorized_world_write" />
-  </unix:file_test>
-  <unix:file_object comment="world writable" id="object_file_permissions_unauthorized_world_write" version="1">
-    <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
-    <unix:path operation="equals">/</unix:path>
-    <unix:filename operation="pattern match">^.*$</unix:filename>
-    <filter action="include">state_file_permissions_unauthorized_world_write</filter>
-    <!-- don't search /proc, /sys, and some special files from /selinux -->
-    <filter action="exclude">state_file_permissions_unauthorized_world_write_exclude_special_selinux_files</filter>
-    <filter action="exclude">state_file_permissions_unauthorized_world_write_exclude_proc</filter>
-    <filter action="exclude">state_file_permissions_unauthorized_world_write_exclude_sys</filter>
-  </unix:file_object>
+
   <unix:file_state id="state_file_permissions_unauthorized_world_write" version="1">
     <unix:type operation="equals">regular</unix:type>
     <unix:owrite datatype="boolean">true</unix:owrite>
   </unix:file_state>
-  <unix:file_state id="state_file_permissions_unauthorized_world_write_exclude_special_selinux_files" version="1">
-    <unix:filepath operation="pattern match">^/selinux/(?:(?:member)|(?:user)|(?:relabel)|(?:create)|(?:access)|(?:context))$</unix:filepath>
+
+  <unix:file_state id="state_file_permissions_unauthorized_world_write_special_selinux_files"
+    version="1">
+    <unix:filepath
+      operation="pattern match">^/selinux/(?:(?:member)|(?:user)|(?:relabel)|(?:create)|(?:access)|(?:context))$</unix:filepath>
   </unix:file_state>
-  <unix:file_state id="state_file_permissions_unauthorized_world_write_exclude_proc" version="1">
-    <unix:filepath operation="pattern match">^/proc/.*$</unix:filepath>
-  </unix:file_state>
-  <unix:file_state id="state_file_permissions_unauthorized_world_write_exclude_sys" version="1">
-    <unix:filepath operation="pattern match">^/sys/.*$</unix:filepath>
-  </unix:file_state>
+
+  {{%- set var_local_mount_points = "var_" ~ rule_id ~ "_local_mountpoints" -%}}
+  {{{ create_local_mount_points_list(var_local_mount_points) }}}
+
+  <!--
+    This file_object will only find files located in local and not special file systems. The
+    recurse_file_system parameter is set to defined in order to make sure the probe doesn't
+    leave the scope of that mount point. For example, when probing "/", the probe will ignore
+    any child directory which is a mount point for any other partition. This will ensure
+    considerable performance improvement. -->
+  <unix:file_object id="object_file_permissions_unauthorized_world_write" version="1"
+    comment="All files with world-write permission.">
+    <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1"
+      recurse_file_system="defined"/>
+      <unix:path operation="equals" var_check="at least one"
+        var_ref="{{{ var_local_mount_points }}}"/>
+    <unix:filename operation="pattern match">^.*$</unix:filename>
+    <filter action="include">state_file_permissions_unauthorized_world_write</filter>
+    <filter action="exclude">state_file_permissions_unauthorized_world_write_special_selinux_files</filter>
+  </unix:file_object>
+
+  <unix:file_test id="test_file_permissions_unauthorized_world_write" version="1"
+    check="all" check_existence="none_exist"
+    comment="Check the existence of world-writable files">
+    <unix:object object_ref="object_file_permissions_unauthorized_world_write" />
+  </unix:file_test>
 </def-group>

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/rule.yml
@@ -3,20 +3,16 @@ documentation_complete: true
 title: 'Ensure No World-Writable Files Exist'
 
 description: |-
-    It is generally a good idea to remove global (other) write
-    access to a file when it is discovered. However, check with
-    documentation for specific applications before making changes.
-    Also, monitor for recurring world-writable files, as these may be
-    symptoms of a misconfigured application or user account. Finally,
-    this applies to real files and not virtual files that are a part of
-    pseudo file systems such as <tt>sysfs</tt> or <tt>procfs</tt>.
+    It is generally a good idea to remove global (other) write access to a file when it is
+    discovered. However, check with documentation for specific applications before making changes.
+    Also, monitor for recurring world-writable files, as these may be symptoms of a misconfigured
+    application or user account. Finally, this applies to real files and not virtual files that
+    are a part of pseudo file systems such as <tt>sysfs</tt> or <tt>procfs</tt>.
 
 rationale: |-
-    Data in world-writable files can be modified by any
-    user on the system. In almost all circumstances, files can be
-    configured using a combination of user and group permissions to
-    support whatever legitimate access is needed without the risk
-    caused by world-writable files.
+    Data in world-writable files can be modified by any user on the system. In almost all
+    circumstances, files can be configured using a combination of user and group permissions to
+    support whatever legitimate access is needed without the risk caused by world-writable files.
 
 severity: medium
 
@@ -53,3 +49,10 @@ ocil_clause: 'there is output'
 ocil: |-
     To find world-writable files, run the following command:
     <pre>$ sudo find / -xdev -type f -perm -002</pre>
+
+warnings:
+    - general: |-
+        This rule can take a long time to perform the check and might consume a considerable
+        amount of resources depending on the number of files present on the system. It is not a
+        problem in most cases, but especially systems with a large number of files can be affected.
+        See <code>https://access.redhat.com/articles/6999111</code>.

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/oval/shared.xml
@@ -3,41 +3,65 @@
     {{{ oval_metadata("All files should be owned by a group") }}}
     <criteria>
       <criterion test_ref="test_file_permissions_ungroupowned"
-        comment="Check all files and make sure they are owned by a group"/>
+        comment="Check all local files and make sure they are owned by a group"/>
     </criteria>
   </definition>
 
-  <unix:file_test id="test_file_permissions_ungroupowned" version="1"
-    check="all" check_existence="none_exist" comment="files with no group owner">
-    <unix:object object_ref="object_file_permissions_ungroupowned"/>
-  </unix:file_test>
-
-  <unix:file_state id="state_file_permissions_ungroupowned" version="1"
-    comment="Files that are owned by a group.">
-    <unix:group_id datatype="int" var_check="at least one"
-      var_ref="variable_file_permissions_ungroupowned"/>
-  </unix:file_state>
-
-  <unix:file_object id="object_file_permissions_ungroupowned" version="1"
-    comment="all local files">
-    <!-- We can't traverse symlinks here since e.g. /sys file system might contain symlink loops
-         resulting into excessive memory use by the scanner process & possible subsequent OOM killer
-         termination of it. See e.g.: https://www.redhat.com/archives/open-scap-list/2014-May/msg00005.html
-         Therefore traverse only directories -->
-    <unix:behaviors recurse="directories" recurse_direction="down" recurse_file_system="local"/>
-    <unix:path>/</unix:path>
-    <unix:filename operation="pattern match">.*</unix:filename>
-    <filter action="exclude">state_file_permissions_ungroupowned</filter>
-  </unix:file_object>
-
-  <ind:textfilecontent54_object id="etc_group_object" version="1">
+  <!-- Create a file_state to filter out files group-owned by known groups. -->
+  <ind:textfilecontent54_object id="etc_group_objects" version="1">
     <ind:filepath>/etc/group</ind:filepath>
     <ind:pattern operation="pattern match">^[^:]+:[^:]*:([\d]+):[^:]*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <local_variable id="variable_file_permissions_ungroupowned" version="1"
-    datatype="int" comment="all GIDs on the target system">
-    <object_component object_ref="etc_group_object" item_field="subexpression"/>
+  <local_variable id="var_all_local_gids" version="1"
+    datatype="int" comment="all GIDs extracted from /etc/group on the target system">
+    <object_component object_ref="etc_group_objects" item_field="subexpression"/>
   </local_variable>
+
+  <unix:file_state id="state_file_permissions_ungroupowned_local_group_owner" version="1"
+    comment="Used to filter out all files group-owned by a group defined in /etc/group">
+    <unix:group_id datatype="int" var_check="at least one" var_ref="var_all_local_gids"/>
+  </unix:file_state>
+
+  <!-- Create a partition_state to filter out remote and special file systems. -->
+  <linux:partition_state id="state_file_permissions_ungroupowned_dev_partitons" version="1">
+    <linux:device operation="pattern match">^/dev/.*$</linux:device>
+  </linux:partition_state>
+
+  <!-- This object is created mainly to improve performance when collecting file objects.
+       Here all mount points are collected and filtered to include only devices under /dev in
+       order to ignore special file systems. -->
+  <linux:partition_object id="object_file_permissions_ungroupowned_local_partitions" version="1">
+    <linux:mount_point operation="pattern match">.*</linux:mount_point>
+    <filter action="include">state_file_permissions_ungroupowned_dev_partitons</filter>
+  </linux:partition_object>
+
+  <!-- Create a variable composed by mount points to local and not special file systems. -->
+  <local_variable id="var_file_permissions_ungroupowned_local_mountpoints" version="1"
+    datatype="string" comment="Mount points for local devices">
+    <object_component item_field="mount_point"
+      object_ref="object_file_permissions_ungroupowned_local_partitions"/>
+  </local_variable>
+
+  <!-- This file_object will only find files located in local and not special file systems. The
+       recurse_file_system parameter is set to defined in order to make sure the probe doesn't
+       leave the scope of that mount point. For example, when probing "/", the probe will ignore
+       any child directory which is a mount point for any other partition. This will ensure
+       considerable performance improvement. -->
+  <unix:file_object id="object_file_permissions_ungroupowned" version="2"
+    comment="all local files without a known group owner">
+    <unix:behaviors recurse="directories" recurse_direction="down"
+      recurse_file_system="defined" max_depth="-1"/>
+    <unix:path operation="equals" var_check="at least one"
+      var_ref="var_file_permissions_ungroupowned_local_mountpoints"/>
+    <unix:filename operation="pattern match">.*</unix:filename>
+    <filter action="exclude">state_file_permissions_ungroupowned_local_group_owner</filter>
+  </unix:file_object>
+
+  <unix:file_test id="test_file_permissions_ungroupowned" version="1"
+    check="all" check_existence="none_exist"
+    comment="there are no files with group owner different than local groups">
+    <unix:object object_ref="object_file_permissions_ungroupowned"/>
+  </unix:file_test>
 </def-group>

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/oval/shared.xml
@@ -1,51 +1,43 @@
 <def-group>
-  <definition class="compliance" id="file_permissions_ungroupowned" version="2">
+  <definition class="compliance" id="{{{ rule_id }}}" version="2">
     {{{ oval_metadata("All files should be owned by a group") }}}
     <criteria>
-      <criterion comment="Check all files and make sure they are owned by a group"
-      test_ref="test_file_permissions_ungroupowned" />
+      <criterion test_ref="test_file_permissions_ungroupowned"
+        comment="Check all files and make sure they are owned by a group"/>
     </criteria>
   </definition>
-  <unix:file_test xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix"
-  check="all" comment="files with no group owner" check_existence="none_exist"
-  id="test_file_permissions_ungroupowned" version="1">
-    <!-- OVAL 5.11 rc-2 within the effort to add oval-def:NotesType construct also to variables
-         moved NotesType construct to the oval-common-schema:
-         [1] https://github.com/OVALProject/Language/issues/6
-         [2] https://github.com/OVALProject/Language/commit/c34abb871ee446d9fd9e50a8ccbc8a8e2af5db20
-         But this change broke backward-compatibility as reported in:
-         [3] https://github.com/OVALProject/Language/issues/237
-         [4] http://making-security-measurable.1364806.n2.nabble.com/5-11-backwards-incompatibility-issue-Suspect-the-fix-for-issue-6-was-the-culprit-tp7586190.html
-         Therefore as a temporary workaround to have both OVAL 5.10 and also OVAL 5.11 valid content,
-         temporarily comment out the <notes> construct below till the issue [3] is fixed in OVAL 5.11.1
-         version.
-    <notes>
-      <note>This will enumerate all files on local partitions</note>
-    </notes> -->
-    <unix:object object_ref="object_file_permissions_ungroupowned" />
+
+  <unix:file_test id="test_file_permissions_ungroupowned" version="1"
+    check="all" check_existence="none_exist" comment="files with no group owner">
+    <unix:object object_ref="object_file_permissions_ungroupowned"/>
   </unix:file_test>
-  <unix:file_state comment="Files that are owned by a group."
-  id="state_file_permissions_ungroupowned" version="1">
-    <unix:group_id datatype="int" var_ref="variable_file_permissions_ungroupowned" var_check="at least one"/>
+
+  <unix:file_state id="state_file_permissions_ungroupowned" version="1"
+    comment="Files that are owned by a group.">
+    <unix:group_id datatype="int" var_check="at least one"
+      var_ref="variable_file_permissions_ungroupowned"/>
   </unix:file_state>
 
-  <unix:file_object comment="all local files" id="object_file_permissions_ungroupowned" version="1">
+  <unix:file_object id="object_file_permissions_ungroupowned" version="1"
+    comment="all local files">
     <!-- We can't traverse symlinks here since e.g. /sys file system might contain symlink loops
          resulting into excessive memory use by the scanner process & possible subsequent OOM killer
          termination of it. See e.g.: https://www.redhat.com/archives/open-scap-list/2014-May/msg00005.html
          Therefore traverse only directories -->
-    <unix:behaviors recurse="directories" recurse_direction="down" recurse_file_system="local" />
+    <unix:behaviors recurse="directories" recurse_direction="down" recurse_file_system="local"/>
     <unix:path>/</unix:path>
     <unix:filename operation="pattern match">.*</unix:filename>
     <filter action="exclude">state_file_permissions_ungroupowned</filter>
   </unix:file_object>
+
   <ind:textfilecontent54_object id="etc_group_object" version="1">
-        <ind:filepath>/etc/group</ind:filepath>
-        <ind:pattern operation="pattern match">^[^:]+:[^:]*:([\d]+):[^:]*$</ind:pattern>
-        <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+    <ind:filepath>/etc/group</ind:filepath>
+    <ind:pattern operation="pattern match">^[^:]+:[^:]*:([\d]+):[^:]*$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-   <local_variable id="variable_file_permissions_ungroupowned" datatype="int" version="1" comment="all GIDs on the target system">
-        <object_component object_ref="etc_group_object" item_field="subexpression"/>
-   </local_variable>
+  <local_variable id="variable_file_permissions_ungroupowned" version="1"
+    datatype="int" comment="all GIDs on the target system">
+    <object_component object_ref="etc_group_object" item_field="subexpression"/>
+  </local_variable>
 </def-group>

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/oval/shared.xml
@@ -24,25 +24,8 @@
     <unix:group_id datatype="int" var_check="at least one" var_ref="var_all_local_gids"/>
   </unix:file_state>
 
-  <!-- Create a partition_state to filter out remote and special file systems. -->
-  <linux:partition_state id="state_file_permissions_ungroupowned_dev_partitons" version="1">
-    <linux:device operation="pattern match">^/dev/.*$</linux:device>
-  </linux:partition_state>
-
-  <!-- This object is created mainly to improve performance when collecting file objects.
-       Here all mount points are collected and filtered to include only devices under /dev in
-       order to ignore special file systems. -->
-  <linux:partition_object id="object_file_permissions_ungroupowned_local_partitions" version="1">
-    <linux:mount_point operation="pattern match">.*</linux:mount_point>
-    <filter action="include">state_file_permissions_ungroupowned_dev_partitons</filter>
-  </linux:partition_object>
-
-  <!-- Create a variable composed by mount points to local and not special file systems. -->
-  <local_variable id="var_file_permissions_ungroupowned_local_mountpoints" version="1"
-    datatype="string" comment="Mount points for local devices">
-    <object_component item_field="mount_point"
-      object_ref="object_file_permissions_ungroupowned_local_partitions"/>
-  </local_variable>
+  {{%- set var_local_mount_points = "var_" ~ rule_id ~ "_local_mountpoints" -%}}
+  {{{ create_local_mount_points_list(var_local_mount_points) }}}
 
   <!-- This file_object will only find files located in local and not special file systems. The
        recurse_file_system parameter is set to defined in order to make sure the probe doesn't
@@ -54,7 +37,7 @@
     <unix:behaviors recurse="directories" recurse_direction="down"
       recurse_file_system="defined" max_depth="-1"/>
     <unix:path operation="equals" var_check="at least one"
-      var_ref="var_file_permissions_ungroupowned_local_mountpoints"/>
+      var_ref="{{{ var_local_mount_points }}}"/>
     <unix:filename operation="pattern match">.*</unix:filename>
     <filter action="exclude">state_file_permissions_ungroupowned_local_group_owner</filter>
   </unix:file_object>

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/rule.yml
@@ -5,24 +5,23 @@ prodtype: alinux2,alinux3,anolis23,anolis8,fedora,ol7,ol8,ol9,openembedded,rhel7
 title: 'Ensure All Files Are Owned by a Group'
 
 description: |-
-    If any files are not owned by a group, then the
-    cause of their lack of group-ownership should be investigated.
-    Following this, the files should be deleted or assigned to an
-    appropriate group. The following command will discover and print
-    any files on local partitions which do not belong to a valid group:
-    <pre>$ df --local -P | awk '{if (NR!=1) print $6}' | sudo xargs -I '{}' find '{}' -xdev -nogroup</pre>
-    To search all filesystems on a system including network mounted
-    filesystems the following command can be run manually for each partition:
-    <pre>$ sudo find PARTITION -xdev -nogroup</pre>
+    If any file is not group-owned by a group present in /etc/group, the cause of the lack of
+    group-ownership must be investigated. Following this, those files should be deleted or
+    assigned to an appropriate group.
+
+    Locate the mount points related to local devices by the following command:
+    <pre>$ findmnt -n -l -k -it $(awk '/nodev/ { print $2 }' /proc/filesystems | paste -sd,)</pre>
+
+    For all mount points listed by the previous command, it is necessary to search for files which
+    do not belong to a valid group using the following command:
+    <pre>$ sudo find <i>MOUNTPOINT</i> -xdev -nogroup 2&gt;/dev/null</pre>
 
 rationale: |-
-    Unowned files do not directly imply a security problem, but they are generally
-    a sign that something is amiss. They may
-    be caused by an intruder, by incorrect software installation or
-    draft software removal, or by failure to remove all files belonging
-    to a deleted account. The files should be repaired so they
-    will not cause problems when accounts are created in the future,
-    and the cause should be discovered and addressed.
+    Unowned files do not directly imply a security problem, but they are generally a sign that
+    something is amiss. They may be caused by an intruder, by incorrect software installation or
+    draft software removal, or by failure to remove all files belonging to a deleted account, or
+    other similar cases. The files should be repaired so they will not cause problems when
+    accounts are created in the future, and the cause should be discovered and addressed.
 
 severity: medium
 
@@ -65,13 +64,15 @@ references:
 ocil_clause: 'there is output'
 
 ocil: |-
-    The following command will discover and print any
-    files on local partitions which do not belong to a valid group.
-    <pre>$ df --local -P | awk '{if (NR!=1) print $6}' | sudo xargs -I '{}' find '{}' -xdev -nogroup</pre>
-    <br />
-    Either remove all files and directories from the system that do not have a valid group,
-    or assign a valid group with the chgrp command:
-    <pre>$ sudo chgrp <i>group</i> <i>file</i></pre>
+    The following command will locate the mount points related to local devices:
+    <pre>$ findmnt -n -l -k -it $(awk '/nodev/ { print $2 }' /proc/filesystems | paste -sd,)</pre>
+
+    The following command will show files which do not belong to a valid group:
+    <pre>$ sudo find <i>MOUNTPOINT</i> -xdev -nogroup 2&gt;/dev/null</pre>
+
+    Replace <i>MOUNTPOINT</i> by the mount points listed by the fist command.
+
+    No files without a valid group should be located.
 
 fixtext: |-
     Either remove all files and directories from {{{ full_name }}} that do not have a valid group, or assign a valid group to all files and directories on the system with the "chgrp" command:
@@ -82,5 +83,5 @@ srg_requirement: 'All {{{ full_name }}} local files and directories must have a 
 
 warnings:
     - general: |-
-        This rule only considers local groups.
+        This rule only considers local groups and valid groups.
         If you have your groups defined outside <code>/etc/group</code>, the rule won't consider those.

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/rule.yml
@@ -83,5 +83,10 @@ srg_requirement: 'All {{{ full_name }}} local files and directories must have a 
 
 warnings:
     - general: |-
-        This rule only considers local groups and valid groups.
+        This rule only considers local groups as valid groups.
         If you have your groups defined outside <code>/etc/group</code>, the rule won't consider those.
+    - general: |-
+        This rule can take a long time to perform the check and might consume a considerable
+        amount of resources depending on the number of files present on the system. It is not a
+        problem in most cases, but especially systems with a large number of files can be affected.
+        See <code>https://access.redhat.com/articles/6999111</code>.

--- a/linux_os/guide/system/permissions/files/no_files_unowned_by_user/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/no_files_unowned_by_user/oval/shared.xml
@@ -1,34 +1,49 @@
 <def-group>
-  <definition class="compliance" id="no_files_unowned_by_user" version="1">
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("All files should be owned by a user") }}}
     <criteria>
-      <criterion comment="Check all files and make sure they are owned by a user" test_ref="no_files_unowned_by_user_test" />
+      <criterion test_ref="test_no_files_unowned_by_user"
+        comment="Check all files and make sure they are owned by a user"/>
     </criteria>
   </definition>
 
-  <unix:file_state id="file_permissions_unowned_userid_list_match" version="1">
-    <unix:user_id var_check="at least one" var_ref="file_permissions_unowned_userid_list" datatype="int" />
-  </unix:file_state>
-
-  <local_variable id="file_permissions_unowned_userid_list" comment="List of valid user ids" datatype="int" version="1">
-    <object_component item_field="user_id" object_ref="file_permissions_unowned_userid_list_object" />
-  </local_variable>
-
-  <unix:password_object id="file_permissions_unowned_userid_list_object" version="1">
+  <!-- Create a file_state to filter out files owned by known users. -->
+  <unix:password_object id="object_no_files_unowned_by_user_all_users" version="2">
     <unix:username datatype="string" operation="pattern match">.*</unix:username>
   </unix:password_object>
 
-  <unix:file_object comment="all local files" id="file_permissions_unowned_object" version="1">
-    <unix:behaviors recurse="directories" recurse_direction="down" recurse_file_system="local" />
-    <unix:path>/</unix:path>
+  <local_variable id="var_no_files_unowned_by_user_uids_list" version="1"
+    datatype="int" comment="List of valid user ids">
+    <object_component item_field="user_id"
+      object_ref="object_no_files_unowned_by_user_all_users"/>
+  </local_variable>
+
+  <unix:file_state id="state_no_files_unowned_by_user_uids_list" version="1">
+    <unix:user_id var_check="at least one" datatype="int"
+      var_ref="var_no_files_unowned_by_user_uids_list"/>
+  </unix:file_state>
+
+  {{%- set var_local_mount_points = "var_" ~ rule_id ~ "_local_mountpoints" -%}}
+  {{{ create_local_mount_points_list(var_local_mount_points) }}}
+
+  <!-- This file_object will only find files located in local and not special file systems. The
+       recurse_file_system parameter is set to defined in order to make sure the probe doesn't
+       leave the scope of that mount point. For example, when probing "/", the probe will ignore
+       any child directory which is a mount point for any other partition. This will ensure
+       considerable performance improvement. -->
+  <unix:file_object id="object_no_files_unowned_by_user" version="2"
+    comment="all local files without a known owner">
+    <unix:behaviors recurse="directories" recurse_direction="down"
+      recurse_file_system="defined" max_depth="-1"/>
+    <unix:path operation="equals" var_check="at least one"
+      var_ref="{{{ var_local_mount_points }}}"/>
     <unix:filename operation="pattern match">.*</unix:filename>
-    <filter action="exclude">file_permissions_unowned_userid_list_match</filter>
+    <filter action="exclude">state_no_files_unowned_by_user_uids_list</filter>
   </unix:file_object>
-  
-  <unix:file_test xmlns:unix="http://oval.mitre.org/XMLSchema/oval-definitions-5#unix"
-  check="all" check_existence="none_exist" comment="Check user ids on all files on the system"
-  id="no_files_unowned_by_user_test" version="1">
-    <unix:object object_ref="file_permissions_unowned_object" />
+
+  <unix:file_test id="test_no_files_unowned_by_user" version="2"
+    check="all" check_existence="none_exist"
+    comment="there are no files without a known owner">
+    <unix:object object_ref="object_no_files_unowned_by_user"/>
   </unix:file_test>
 </def-group>
-  

--- a/linux_os/guide/system/permissions/files/no_files_unowned_by_user/rule.yml
+++ b/linux_os/guide/system/permissions/files/no_files_unowned_by_user/rule.yml
@@ -5,24 +5,22 @@ prodtype: alinux2,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu20
 title: 'Ensure All Files Are Owned by a User'
 
 description: |-
-    If any files are not owned by a user, then the
-    cause of their lack of ownership should be investigated.
-    Following this, the files should be deleted or assigned to an
-    appropriate user. The following command will discover and print
-    any files on local partitions which do not belong to a valid user:
-    <pre>$ df --local -P | awk {'if (NR!=1) print $6'} | sudo xargs -I '{}' find '{}' -xdev -nouser</pre>
-    To search all filesystems on a system including network mounted
-    filesystems the following command can be run manually for each partition:
-    <pre>$ sudo find PARTITION -xdev -nouser</pre>
+    If any files are not owned by a user, then the cause of their lack of ownership should be
+    investigated. Following this, the files should be deleted or assigned to an appropriate user.
+
+    Locate the mount points related to local devices by the following command:
+    <pre>$ findmnt -n -l -k -it $(awk '/nodev/ { print $2 }' /proc/filesystems | paste -sd,)</pre>
+
+    For all mount points listed by the previous command, it is necessary to search for files which
+    do not belong to a valid user using the following command:
+    <pre>$ sudo find <i>MOUNTPOINT</i> -xdev -nouser 2&gt;/dev/null</pre>
 
 rationale: |-
-    Unowned files do not directly imply a security problem, but they are generally
-    a sign that something is amiss. They may
-    be caused by an intruder, by incorrect software installation or
-    draft software removal, or by failure to remove all files belonging
-    to a deleted account. The files should be repaired so they
-    will not cause problems when accounts are created in the future,
-    and the cause should be discovered and addressed.
+    Unowned files do not directly imply a security problem, but they are generally a sign that
+    something is amiss. They may be caused by an intruder, by incorrect software installation or
+    draft software removal, or by failure to remove all files belonging to a deleted account, or
+    other similar cases. The files should be repaired so they will not cause problems when
+    accounts are created in the future, and the cause should be discovered and addressed.
 
 severity: medium
 
@@ -67,14 +65,15 @@ platform: machine
 ocil_clause: 'files exist that are not owned by a valid user'
 
 ocil: |-
-    The following command will discover and print any
-    files on local partitions which do not belong to a valid user.
-    <pre>$ df --local -P | awk {'if (NR!=1) print $6'} | sudo xargs -I '{}' find '{}' -xdev -nouser</pre>
-    <br /><br />
-    Either remove all files and directories from the system that do not have a
-    valid user, or assign a valid user to all unowned files and directories on
-    the system with the <tt>chown</tt> command:
-    <pre>$ sudo chown <tt>user</tt> <tt>file</tt></pre>
+    The following command will locate the mount points related to local devices:
+    <pre>$ findmnt -n -l -k -it $(awk '/nodev/ { print $2 }' /proc/filesystems | paste -sd,)</pre>
+
+    The following command will show files which do not belong to a valid user:
+    <pre>$ sudo find <i>MOUNTPOINT</i> -xdev -nouser 2&gt;/dev/null</pre>
+
+    Replace <i>MOUNTPOINT</i> by the mount points listed by the fist command.
+
+    No files without a valid user should be located.
 
 fixtext: |-
     Either remove all files and directories from the system that do not have a valid user, or assign a valid user to all unowned files and directories on {{{ full_name }}} with the "chown" command:
@@ -89,6 +88,8 @@ warnings:
         so that running the command <pre>getent passwd</pre> returns a list of all users in your organization.
         If using the System Security Services Daemon (SSSD), <pre>enumerate = true</pre> must be configured
         in your organization's domain to return a complete list of users
-    - performance: |-
-        Enabling this rule will result in slower scan times depending on the size of your organization
-        and number of centralized users.
+    - general: |-
+        This rule can take a long time to perform the check and might consume a considerable
+        amount of resources depending on the number of files present on the system. It is not a
+        problem in most cases, but especially systems with a large number of files can be affected.
+        See <code>https://access.redhat.com/articles/6999111</code>.

--- a/shared/macros/10-oval.jinja
+++ b/shared/macros/10-oval.jinja
@@ -1176,6 +1176,7 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
   </unix:password_state>
 {{%- endmacro %}}
 
+
 {{#
   Extract from /etc/passwd a list of specified fields of local interactive users.
   The list contains only items related to non-system UIDs and is filtered to exclude some special usernames and users with /sbin/nologin shell.
@@ -1230,6 +1231,7 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
   </ind:textfilecontent54_state>
 
 {{%- endmacro %}}
+
 
 {{#
   Extract from /etc/passwd a list of home directories of local interactive users.
@@ -1287,6 +1289,7 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
   second_literal_component_regex=":)(?:[^:]*:){2}([^:]+):(?:[^:]*:){2}[^:]*$") }}}
 {{%- endmacro %}}
 
+
 {{#
   Extract from /etc/passwd a list composed of password objects related to system UIDs.
   This list is then filtered to exclude some special usernames.
@@ -1313,6 +1316,51 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
   <unix:password_state id="state_{{{ rule_id }}}_users_ignored" version="1">
     <unix:username datatype="string" operation="pattern match">^{{{ ignored_users_list }}}$</unix:username>
   </unix:password_state>
+{{%- endmacro %}}
+
+
+{{#
+  Check the system partition table and create a list of mount points referring to devices in /dev.
+  The filtered list of mount_points is stored in a local variable to be used in the "path"
+  parameter of "file_object" objects.
+
+  When using this variable in the "path" parameter of a "file_object" also make sure the
+  "recurse_file_system" parameter is set to "defined" in order to make sure the probe doesn't
+  leave the scope of that mount point. For example, when probing "/", the probe will ignore any
+  child directory which is a mount point for any other partition. Check the
+  "file_permissions_ungroupowned" rule for a reference.
+
+  Using this filtered list of mount points should increate performance and optimize resources
+  by skipping the check of a lot unnecessary file objects.
+
+  The macro receives a string as parameter, which is used as the local_variable id in the rule.
+
+:param variable_id: Variable id to be created.
+:type variable_id: str
+
+#}}
+{{%- macro create_local_mount_points_list(variable_id) -%}}
+  <!-- Create a partition_state to filter out remote and special file systems. -->
+  <linux:partition_state id="state_{{{ rule_id }}}_dev_partitons" version="1">
+    <linux:device operation="pattern match">^/dev/.*$</linux:device>
+  </linux:partition_state>
+
+  <!-- This object is created mainly to improve performance when collecting file objects.
+       Here all mount points are discovered and filtered to include only devices under /dev in
+       order to ignore special and remote file systems. -->
+  <linux:partition_object id="object_{{{ rule_id }}}_local_partitions" version="1">
+    <linux:mount_point operation="pattern match">.*</linux:mount_point>
+    <filter action="include">state_{{{ rule_id }}}_dev_partitons</filter>
+  </linux:partition_object>
+
+  <!-- Create a variable composed by mount points referring to devices in /dev.
+       There are cases where distributed or remote file systems are also represented as a /dev
+       device. For example, when using CEPH. These cases will also be treated as local devices. -->
+  <local_variable id="{{{ variable_id }}}" version="1"
+    datatype="string" comment="Mount points for local devices">
+    <object_component item_field="mount_point"
+      object_ref="object_{{{ rule_id }}}_local_partitions"/>
+  </local_variable>
 {{%- endmacro %}}
 
 
@@ -1356,6 +1404,7 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 {{%- endmacro %}}
+
 
 {{#
 Generates an OVAL check that checks a particular field in the "/etc/shadow" file.


### PR DESCRIPTION
#### Description:

There are rules in the project used to check some files properties in the system.
These rules need to probe all files in a system in order to ensure compliance.
However, there are particular systems with a huge number of files and in these systems the scanner (openscap) can hit some system resource limits during the assessment, specially related to memory usage.

The intention of this PR is to review and optimize the performance of all mapped rules that may consume high system resources while probing file systems:

- [x] - rpm_verify_hashes - Moved to https://github.com/ComplianceAsCode/content/pull/11332
- [x] - rpm_verify_ownership - Moved to https://github.com/ComplianceAsCode/content/pull/11333
- [x] - rpm_verify_permissions - Moved to https://github.com/ComplianceAsCode/content/pull/11335
- [x] - file_permissions_unauthorized_world_writable
- [x] - no_files_unowned_by_user
- [x] - dir_perms_world_writable_system_owned
- [x] - file_permissions_unauthorized_suid
- [x] - file_permissions_unauthorized_sgid
- [x] - file_permissions_ungroupowned
- [x] - dir_perms_world_writable_sticky_bits

The improvements consist of:

- Creating and using a macro to select only relevant mount points to be searched
  - The macro skip all mount points related to remote file systems
  - The macro skip pseudo file systems, like /proc and /sys.
- Adopt the macro in all rules so the behavior for aligned among all rules and is easier to maintain
- Refactoring the OVAL in some rules to improve their efficiency by removing unnecessary probes or objects duplication.
- Improve readability of reviewed rules.

#### Rationale:

- This PR is one of the initiatives combined with other improvements to mitigate memory issues in systems with huge number of files:
  - https://github.com/OpenSCAP/openscap/pull/2051
  - https://github.com/OpenSCAP/openscap/pull/2052

It is expected a considerable performance improvement after reviewing all these rules, specially when multiple of these rules are used in the same profile.
In a small test, it was created a VM and included about 500.000 files in a local mount point. The automatus tests were executed using the `file_permissions_unauthorized_suid` before and after the improvements. Here is the result:

Before the improvements:
```
time ./tests/automatus.py rule --libvirt qemu:///session rhel9-nightly --datastream build/ssg-rhel9-ds.xml --dontclean --remediate-using bash file_permissions_unauthorized_suid
INFO - xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_suid
INFO - Script no_unpackaged_suid.pass.sh using profile (all) OK
INFO - Script unpackaged_suid.fail.sh using profile (all) OK

real	2m25.382s
user	0m7.554s
sys	0m0.789s
```

After the improvements:
```
time ./tests/automatus.py rule --libvirt qemu:///session rhel9-nightly --datastream build/ssg-rhel9-ds.xml --dontclean --remediate-using bash file_permissions_unauthorized_suid
Setting console output to log level INFO
INFO - xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_suid
INFO - Script no_unpackaged_suid.pass.sh using profile (all) OK
INFO - Script unpackaged_suid.fail.sh using profile (all) OK

real	1m45.165s
user	0m7.696s
sys	0m0.750s
```

#### Review Hints:

Automatus tests should be enough to testing the rules technically.
For context about the changes, check the commit messages.
