### PR TITLE
Fix ShellCheck Issues in CPE Checks

### DIFF
--- a/shared/applicability/runtime_kernel_fips_enabled.yml
+++ b/shared/applicability/runtime_kernel_fips_enabled.yml
@@ -1,4 +1,4 @@
 name: cpe:/a:runtime-kernel-fips-enabled
 title: Running kernel has fips mode enabled
 check_id: runtime_kernel_fips_enabled
-bash_conditional: '[ $(sysctl -a | grep -c fips_enabled.*1) -eq 1 ]'
+bash_conditional: "[ \"$(sysctl -a | grep -c 'fips_enabled.*1')\" -eq 1 ]"

--- a/shared/applicability/secure_boot.yml
+++ b/shared/applicability/secure_boot.yml
@@ -1,5 +1,5 @@
 name: cpe:/a:secure-boot
 title: System secure boot is enabled
 check_id: secure_boot_enabled
-bash_conditional: "[ $(mokutil --sb-state | awk '{print $NF}') == 'enabled' ]"
+bash_conditional: "[ \"$(mokutil --sb-state | awk '{print $NF}')\" == 'enabled' ]"
 


### PR DESCRIPTION
#### Description:

Fix two CPE issues in CPE checks

#### Rationale:

Fix ctest errors

#### Review Hints:
Build the OL8 product and run the tests.