### PR TITLE
OCP4: Add option to deploy profile without upstream prefix

### DIFF
--- a/utils/build_ds_container.py
+++ b/utils/build_ds_container.py
@@ -42,6 +42,16 @@ parser.add_argument(
         '--product and --debug flags.'),
     action='store_true',
     default=False)
+# with upstream prefix option as default
+parser.add_argument(
+    '-np', '--no-upstream-prefix',
+    help=(
+        'The prefix for bundle names. The default is "upstream" if not specified. '
+        'To disable prefix, use --no-upstream-prefix.',
+        'This option is ignored when building content in the cluster using '
+        '--build-in-cluster.'),
+    action='store_true',
+    default=False)
 parser.add_argument(
     '-d', '--debug',
     help=(
@@ -216,7 +226,10 @@ def create_profile_bundles(products, content_image=None):
     """
     for product in products:
         content_file = 'ssg-' + product + '-ds.xml'
-        product_name = 'upstream-' + product
+        if args.no_upstream_prefix:
+            product_name = product
+        else:
+            product_name = 'upstream-' + product
         profile_bundle_update = {
             'apiVersion': 'compliance.openshift.io/v1alpha1',
             'kind': 'ProfileBundle',


### PR DESCRIPTION
This pr add the ability to deploy profile without upstream prefix. ex. when you run the script to deploy ocp4 profile bundle, all the profiles will have upstream in the name prefix, upstream-ocp4-cis, and with -np option, we do not add upstream prefix to it automatically.
