### PR TITLE
Minor modifications to RHEL STIG profiles

### DIFF
--- a/controls/stig_rhel9.yml
+++ b/controls/stig_rhel9.yml
@@ -4114,7 +4114,7 @@ controls:
             - medium
         title: RHEL 9 audit system must protect logon UIDs from unauthorized change.
         rules:
-            - audit_immutable_login_uids
+            - audit_rules_immutable_login_uids
         status: automated
 
     -   id: RHEL-09-654275

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/passwd_system-auth_substack/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/passwd_system-auth_substack/rule.yml
@@ -19,7 +19,6 @@ references:
     nist: IA-5(1)(a),IA-5(1).1(v),IA-5(1)(a)
     srg: SRG-OS-000069-GPOS-00037
     stigid@ol7: OL07-00-010118
-    stigid@rhel7: RHEL-07-010118
 
 ocil_clause: '/etc/pam.d/passwd does not implement /etc/pam.d/system-auth'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable_login_uids/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable_login_uids/rule.yml
@@ -33,6 +33,7 @@ references:
     disa: CCI-000162,CCI-000163,CCI-000164
     srg: SRG-OS-000462-GPOS-00206,SRG-OS-000475-GPOS-00220,SRG-OS-000057-GPOS-00027,SRG-OS-000058-GPOS-00028,SRG-OS-000059-GPOS-00029
     stigid@rhel8: RHEL-08-030122
+    stigid@rhel9: RHEL-09-654270
 
 ocil_clause: 'the system is not configured to make login UIDs immutable'
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/rule.yml
@@ -35,7 +35,6 @@ references:
     ospp: FAU_GEN.1.2
     srg: SRG-OS-000462-GPOS-00206,SRG-OS-000475-GPOS-00220,SRG-OS-000057-GPOS-00027,SRG-OS-000058-GPOS-00028,SRG-OS-000059-GPOS-00029,SRG-APP-000121-CTR-000255,SRG-APP-000495-CTR-001235
     stigid@ol8: OL08-00-030122
-    stigid@rhel8: RHEL-08-030122
     stigid@rhel9: RHEL-09-654270
 
 ocil_clause: 'the file does not exist or the content differs'

--- a/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/rule.yml
@@ -35,7 +35,6 @@ references:
     ospp: FAU_GEN.1.2
     srg: SRG-OS-000462-GPOS-00206,SRG-OS-000475-GPOS-00220,SRG-OS-000057-GPOS-00027,SRG-OS-000058-GPOS-00028,SRG-OS-000059-GPOS-00029,SRG-APP-000121-CTR-000255,SRG-APP-000495-CTR-001235
     stigid@ol8: OL08-00-030122
-    stigid@rhel9: RHEL-09-654270
 
 ocil_clause: 'the file does not exist or the content differs'
 


### PR DESCRIPTION
#### Description:

- remove RHEL 8 STIG reference from the rule audit_immutable_login_uids because it is no longer selected in the profile
- replace audit_immutable_login_uids rule with audit_rules_immutable_login_uids in RHEL 9 STIG profile
- remove RHEL 7 STIG reference from the rule passwd_system-auth_substack because it is currently not selected in the relevant profile; I will create an issue to evaluate if this rule should be added to the profile.
- remove RHEL8 STIG reference from the rule package_libreport-plugin-rhtsupport_removed because it is not part of the relevant profile
- 

#### Rationale:

Cleaning up rule references. It can create confusions when comparing reports of our content with the content provided by DISA.



#### Review Hints:

