### PR TITLE
OCPBUGS-8041: Remove info override for vsyscall kernerl argument

### DIFF
--- a/controls/nist_rhcos4.yml
+++ b/controls/nist_rhcos4.yml
@@ -5244,8 +5244,6 @@ controls:
   - sysctl_net_ipv4_tcp_syncookies
   - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
   - coreos_vsyscall_kernel_argument
-  - coreos_vsyscall_kernel_argument.role=unscored
-  - coreos_vsyscall_kernel_argument.severity=info
   - kernel_module_squashfs_disabled
   - sysctl_net_ipv4_conf_default_send_redirects
   - kernel_module_hfsplus_disabled

--- a/linux_os/guide/system/bootloader-grub2/coreos_vsyscall_kernel_argument/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/bootloader-grub2/coreos_vsyscall_kernel_argument/tests/ocp4/e2e.yml
@@ -1,2 +1,3 @@
 ---
-default_result: INFO
+default_result: FAIL
+result_after_remediation: PASS


### PR DESCRIPTION
This rule actually has the ability to check the kernel arguments, and
generates a remediation if necessary.

Let's remove the overrides, so that it doesn't always so up as `INFO`
and generate a remediation that users can't do anything with.
