### PR TITLE
Add Gate tests back to master

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -35,14 +35,14 @@ jobs:
       - name: Update CA certificates
         run: update-ca-certificates
       - name: Zypper add factory repo - to install bats and ShellCheck
-        run: zypper --non-interactive ar  https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-15-SP5/standard/openSUSE:Backports:SLE-15-SP5.repo     
+        run: zypper --non-interactive ar  https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-15-SP5/standard/openSUSE:Backports:SLE-15-SP5.repo
       - name: Zypper auto import keys
         run: zypper  --gpg-auto-import-keys --non-interactive ref
       - name: Zypper refs
         run: zypper refs
       - name: Zypper refresh
-        run: zypper refresh    
-      - name: Install Deps           
+        run: zypper refresh
+      - name: Install Deps
         run: zypper install -y git cmake make bats openscap-utils python3 python3-rpm python3-pip python3-devel python3-PyYAML python3-Jinja2 python3-setuptools libxslt-tools libxml2-tools ShellCheck
       - name: Upgrade pip python
         run: pip install pip --upgrade
@@ -134,52 +134,6 @@ jobs:
       - name: Test
         run: ctest -j2 --output-on-failure -E unique-stigids
         working-directory: ./build
-
-  validate-fedora:
-    name: Build, Test on Fedora Latest (Container)
-    runs-on: ubuntu-latest
-    container:
-      image: fedora:latest
-    steps:
-      - name: Install Deps
-        run: dnf install -y cmake make openscap-utils python3-pyyaml bats ansible python3-pip ShellCheck git gcc gcc-c++ python3-devel
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install deps python
-        run: pip install pcre2 -r requirements.txt -r test-requirements.txt
-      - name: Build
-        run: |-
-          ./build_product \
-              alinux2 \
-              alinux3 \
-              anolis23 \
-              anolis8 \
-              chromium \
-              fedora \
-              firefox \
-              rhcos4 \
-              rhel7 \
-              rhel8 \
-              rhel9 \
-              uos20 \
-              ocp4 \
-              eks
-        env:
-          ADDITIONAL_CMAKE_OPTIONS: "-DSSG_ANSIBLE_PLAYBOOKS_PER_RULE_ENABLED=ON -DSSG_OVAL_SCHEMATRON_VALIDATION_ENABLED=OFF"
-      - name: Test
-        run: ctest -j2 --output-on-failure -E unique-stigids
-        working-directory: ./build
-      - name: "Set git safe directory, ref: https://github.com/actions/checkout/issues/760"
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-      - name: Upload coverage to Code Climate  # Requires: git package
-        if: ${{ github.repository == 'ComplianceAsCode/content' }}
-        uses: paambaati/codeclimate-action@v5.0.0
-        env:
-          CC_TEST_REPORTER_ID: e67e068471d32b63f8e9561dba8f6a3f84dcc76b05ebfd98e44ced1a91cff854
-        with:
-          coverageLocations: build/tests/coverage.xml:coverage.py
-      - name: Validate gitmailmap
-        run: grep -E "\S" .mailmap | grep -Ev '^#' | git check-mailmap --stdin
 
   validate-fedora-rawhide:
     name: Build, Test on Fedora Rawhide (Container)

--- a/.github/workflows/gate_fedora.yml
+++ b/.github/workflows/gate_fedora.yml
@@ -1,0 +1,54 @@
+name: Gate
+on:
+  merge_group:
+    branches: [ 'master' ]
+  push:
+    branches: ['*', '!stabilization*', '!stable*', 'master' ]
+  pull_request:
+    branches: [ 'master', 'stabilization*' ]
+jobs:
+    validate-fedora:
+        name: Build, Test on Fedora Latest (Container)
+        runs-on: ubuntu-latest
+        container:
+            image: fedora:latest
+        steps:
+            -   name: Install Deps
+                run: dnf install -y cmake make openscap-utils python3-pyyaml bats ansible python3-pip ShellCheck git gcc gcc-c++ python3-devel
+            -   name: Checkout
+                uses: actions/checkout@v4
+            -   name: Install deps python
+                run: pip install pcre2 -r requirements.txt -r test-requirements.txt
+            -   name: Build
+                run: |-
+                    ./build_product \
+                        alinux2 \
+                        alinux3 \
+                        anolis23 \
+                        anolis8 \
+                        chromium \
+                        fedora \
+                        firefox \
+                        rhcos4 \
+                        rhel7 \
+                        rhel8 \
+                        rhel9 \
+                        uos20 \
+                        ocp4 \
+                        eks
+                env:
+                    ADDITIONAL_CMAKE_OPTIONS: "-DSSG_ANSIBLE_PLAYBOOKS_PER_RULE_ENABLED=ON -DSSG_OVAL_SCHEMATRON_VALIDATION_ENABLED=OFF"
+            -   name: Test
+                run: ctest -j2 --output-on-failure -E unique-stigids
+                working-directory: ./build
+            -   name: "Set git safe directory, ref: https://github.com/actions/checkout/issues/760"
+                run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+            -   name: Upload coverage to Code Climate  # Requires: git package
+                if: ${{ github.repository == 'ComplianceAsCode/content' }}
+                uses: paambaati/codeclimate-action@v5.0.0
+                env:
+                    CC_TEST_REPORTER_ID: e67e068471d32b63f8e9561dba8f6a3f84dcc76b05ebfd98e44ced1a91cff854
+                with:
+                    coverageLocations: build/tests/coverage.xml:coverage.py
+            -   name: Validate gitmailmap
+                run: grep -E "\S" .mailmap | grep -Ev '^#' | git check-mailmap --stdin


### PR DESCRIPTION

#### Description:

Adds a normal build back to master.

#### Rationale:
Since merge queues are not possible (currently) see https://github.com/ComplianceAsCode/content/discussions/11116. This commit adds the gate tests back to master. However, to prevent issues with the number of runners available this PR only adds tests for Fedora which is traditionally is the most complete testing ran in gating.

