### PR TITLE
Add Ubuntu tests and remediation to rule accounts_password_pam_unix_remember

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/ansible/ubuntu.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/ansible/ubuntu.yml
@@ -1,0 +1,48 @@
+# platform = multi_platform_ubuntu
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = medium
+
+{{{ ansible_instantiate_variables("var_password_pam_unix_remember") }}}
+
+# Modified version of macro ansible_ensure_pam_module_option(pam_file, group, control, module, option, value='', after_match='').
+# The original macro is designed to search/replace also the control field thus treating the field as a constant and escaping the regex.
+# Here we adapt the code to allow using regex on the control field.
+
+{{% set pam_file='/etc/pam.d/common-password' %}}
+{{% set group='password' %}}
+{{% set control='\[success=[A-Za-z0-9].*\]' %}}
+{{% set module='pam_unix.so' %}}
+{{% set option='remember' %}}
+{{% set value='{{ var_password_pam_unix_remember }}' %}}
+
+- name: '{{{ rule_title }}} - Check if the required PAM module option is present in {{{ pam_file }}}'
+  ansible.builtin.lineinfile:
+    path: "{{{ pam_file }}}"
+    regexp: ^\s*{{{ group }}}\s+{{{ control }}}\s+{{{ module }}}\s*.*\s{{{ option }}}\b
+    state: absent
+  check_mode: true
+  changed_when: false
+  register: result_pam_module_{{{ option }}}_option_present
+
+- name: '{{{ rule_title }}} - Ensure the "{{{ option }}}" PAM option for "{{{ module }}}" is included in {{{ pam_file }}}'
+  ansible.builtin.lineinfile:
+    path: "{{{ pam_file }}}"
+    backrefs: true
+    regexp: ^(\s*{{{ group }}}\s+{{{ control }}}\s+{{{ module }}}.*)
+    line: \1 {{{ option }}}={{{ value }}}
+    state: present
+  register: result_pam_{{{ option }}}_add
+  when:
+    - result_pam_module_{{{ option }}}_option_present.found == 0
+
+- name: '{{{ rule_title }}} - Ensure the required value for "{{{ option }}}" PAM option from "{{{ module }}}" in {{{ pam_file }}}'
+  ansible.builtin.lineinfile:
+    path: "{{{ pam_file }}}"
+    backrefs: true
+    regexp: ^(\s*{{{ group }}}\s+{{{ control }}}\s+{{{ module }}}\s+.*)({{{ option }}})=[0-9a-zA-Z]+\s*(.*)
+    line: \1\2={{{ value }}} \3
+  register: result_pam_{{{ option }}}_edit
+  when:
+    - result_pam_module_{{{ option }}}_option_present.found > 0

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/ubuntu_arg_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/ubuntu_arg_missing.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+config_file=/etc/pam.d/common-password
+if grep -q "pam_unix\.so.*remember=" "${config_file}" ; then
+    sed -i "/pam_unix\.so/ s/\bremember=\S*//" "${config_file}"
+fi

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/ubuntu_correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/ubuntu_correct_value.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# variables = var_password_pam_unix_remember=5
+
+config_file=/etc/pam.d/common-password
+remember_cnt=5
+sed -i "s/password.*pam_unix.so.*/password [success=1 default=ignore] pam_unix.so obscure sha512 shadow remember=${remember_cnt} rounds=5000/" "${config_file}"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/ubuntu_wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/ubuntu_wrong_value.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# variables = var_password_pam_unix_remember=5
+
+config_file=/etc/pam.d/common-password
+remember_cnt=3
+sed -i "s/password.*pam_unix.so.*/password [success=1 default=ignore] pam_unix.so obscure sha512 shadow remember=${remember_cnt} rounds=5000/" "${config_file}"
+


### PR DESCRIPTION
#### Description:

- Add tests for Ubuntu to rule `accounts_password_pam_unix_remember` (STIG UBTU-20-010070)
- Add ansible remediation for Ubuntu

#### Rationale:

- Rewrite of original PR 11067 without modifying the OVAL (adds unnecessary complexity) and not using hardcoded values in ansible remediation
