### PR TITLE
Review rpm_verify_permissions rule

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/oval/shared.xml
@@ -1,17 +1,20 @@
 <def-group>
-  <definition class="compliance" id="rpm_verify_permissions" version="3">
-    {{{ oval_metadata("Verify the permissions of installed packages
-      by comparing the installed files with information about the
-      files taken from the package metadata stored in the RPM
-      database.") }}}
+  <definition class="compliance" id="{{{ rule_id }}}" version="3">
+    {{{ oval_metadata("Verify the permissions of installed packages by comparing the installed
+        files with information about the files taken from the package metadata stored in the RPM
+        database.") }}}
     <criteria>
-      <criterion test_ref="test_verify_all_rpms_mode" comment="mode of all files matches local rpm database" />
+      <criterion test_ref="test_rpm_verify_permissions"
+        comment="mode of all files matches local rpm database"/>
     </criteria>
   </definition>
-  <linux:rpmverifyfile_test check_existence="none_exist" id="test_verify_all_rpms_mode" version="1" check="all" comment="mode of all files matches local rpm database">
-    <linux:object object_ref="object_files_fail_mode"/>
-  </linux:rpmverifyfile_test>
-  <linux:rpmverifyfile_object id="object_files_fail_mode" version="1" comment="rpm verify of all files">
+
+  <linux:rpmverifyfile_state id="state_rpm_verify_permissions_files_fail_mode" version="1">
+    <linux:mode_differs>fail</linux:mode_differs>
+  </linux:rpmverifyfile_state>
+
+  <linux:rpmverifyfile_object id="object_rpm_verify_permissions_files_fail_mode" version="1"
+    comment="rpm verify permissions of all files">
     <linux:behaviors nomd5="true" noghostfiles="true"/>
     <linux:name operation="pattern match">.*</linux:name>
     <linux:epoch operation="pattern match">.*</linux:epoch>
@@ -19,9 +22,12 @@
     <linux:release operation="pattern match">.*</linux:release>
     <linux:arch operation="pattern match">.*</linux:arch>
     <linux:filepath operation="pattern match">.*</linux:filepath>
-    <filter action="include">state_files_fail_mode</filter>
+    <filter action="include">state_rpm_verify_permissions_files_fail_mode</filter>
   </linux:rpmverifyfile_object>
-  <linux:rpmverifyfile_state id="state_files_fail_mode" version="1">
-    <linux:mode_differs>fail</linux:mode_differs>
-  </linux:rpmverifyfile_state>
+
+  <linux:rpmverifyfile_test id="test_rpm_verify_permissions" version="1"
+    check="all" check_existence="none_exist"
+    comment="mode of all files matches local rpm database">
+    <linux:object object_ref="object_rpm_verify_permissions_files_fail_mode"/>
+  </linux:rpmverifyfile_test>
 </def-group>

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/rule.yml
@@ -86,4 +86,7 @@ warnings:
         This rule can take a long time to perform the check and might consume a considerable
         amount of resources depending on the number of packages present on the system. It is not a
         problem in most cases, but especially systems with a large number of installed packages
-        can be affected. See <code>https://access.redhat.com/articles/6999111</code>.
+        can be affected.
+        {{% if "rhel" in product %}}
+        See <code>https://access.redhat.com/articles/6999111</code>.
+        {{% endif %}}

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_permissions/rule.yml
@@ -5,27 +5,24 @@ prodtype: alinux2,alinux3,anolis23,anolis8,fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8
 title: 'Verify and Correct File Permissions with RPM'
 
 description: |-
-    The RPM package management system can check file access permissions
-    of installed software packages, including many that are important
-    to system security.
-    Verify that the file permissions of system files
-    and commands match vendor values. Check the file permissions
-    with the following command:
+    The RPM package management system can check file access permissions of installed software
+    packages, including many that are important to system security. Verify that the file
+    permissions of system files and commands match vendor values. Check the file permissions with
+    the following command:
     <pre>$ sudo rpm -Va | awk '{ if (substr($0,2,1)=="M") print $NF }'</pre>
     Output indicates files that do not match vendor defaults.
-    After locating a file with incorrect permissions,
-    run the following command to determine which package owns it:
+
+    After locating a file with incorrect permissions, run the following command to determine which
+    package owns it:
     <pre>$ rpm -qf <i>FILENAME</i></pre>
     <br />
-    Next, run the following command to reset its permissions to
-    the correct values:
+    Next, run the following command to reset its permissions to the correct values:
     <pre>$ sudo rpm --setperms <i>PACKAGENAME</i></pre>
 
 rationale: |-
-    Permissions on system binaries and configuration files that are too generous
-    could allow an unauthorized user to gain privileges that they should not have.
-    The permissions set by the vendor should be maintained. Any deviations from
-    this baseline should be investigated.
+    Permissions on system binaries and configuration files that are too generous could allow an
+    unauthorized user to gain privileges that they should not have. The permissions set by the
+    vendor should be maintained. Any deviations from this baseline should be investigated.
 
 severity: high
 
@@ -74,7 +71,6 @@ fixtext: |-
 
     $ sudo rpm -qf [path to file]
 
-
     Reset the permissions of files within a package with the following command:
 
     $ sudo rpm --setperms [package]
@@ -83,7 +79,11 @@ srg_requirement: '{{{ full_name }}} must be configured so that the file permissi
 
 warnings:
     - general: |-
-        Profiles may require that specific files have stricter file permissions than defined by the
-        vendor.
-        Such files will be reported as a finding and need to be evaluated according to your policy
-        and deployment environment.
+        Profiles may require that specific files have stricter file permissions than defined by
+        the vendor. Such files will be reported as a finding and need to be evaluated according to
+        your policy and deployment environment.
+    - general: |-
+        This rule can take a long time to perform the check and might consume a considerable
+        amount of resources depending on the number of packages present on the system. It is not a
+        problem in most cases, but especially systems with a large number of installed packages
+        can be affected. See <code>https://access.redhat.com/articles/6999111</code>.


### PR DESCRIPTION
#### Description:

This PR extract the commits related to `rpm_verify_permissions` from https://github.com/ComplianceAsCode/content/pull/11319

It:
- Updates the rule description and includes a warning about performance in some specific scenarios
- Improve the OVAL readability without changing its logic

#### Rationale:

Better description and awareness of possible performance issues in the rule.
Better OVAL readability.

#### Review Hints:

Automatus tests should be enough.
