### PR TITLE
[Stabilization] remove irrelevant rules from PCI-DSS profiles

### DIFF
--- a/linux_os/guide/services/ntp/service_ntpd_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_ntpd_enabled/rule.yml
@@ -52,3 +52,10 @@ template:
         packagename: ntp
 
 platform: package[ntp]
+
+{{% if prodtype in ["rhel8", "rhel9", "sle15"] %}}
+warnings:
+    - general:
+        The <pre>ntp</pre> package is not available in {{{ full_name }}}. Please
+        consider the <pre>chrony</pre> package instead together with the respective <pre>service_chronyd_enabled</pre> rule.
+{{% endif %}}

--- a/products/rhel8/profiles/pci-dss.profile
+++ b/products/rhel8/profiles/pci-dss.profile
@@ -32,3 +32,4 @@ selections:
     - '!ntpd_specify_multiple_servers'
     - '!set_ipv6_loopback_traffic'
     - '!set_loopback_traffic'
+    - '!service_ntpd_enabled'

--- a/products/rhel9/profiles/pci-dss.profile
+++ b/products/rhel9/profiles/pci-dss.profile
@@ -35,3 +35,4 @@ selections:
     - '!ntpd_specify_multiple_servers'
     - '!set_ipv6_loopback_traffic'
     - '!set_loopback_traffic'
+    - '!service_ntpd_enabled'

--- a/tests/data/profile_stability/rhel8/pci-dss.profile
+++ b/tests/data/profile_stability/rhel8/pci-dss.profile
@@ -232,7 +232,6 @@ selections:
 - audit_rules_sysadmin_actions
 - display_login_attempts
 - file_permissions_backup_etc_shadow
-- service_ntpd_enabled
 - audit_rules_dac_modification_fremovexattr
 - sshd_disable_x11_forwarding
 - file_at_deny_not_exist


### PR DESCRIPTION
#### Description:

- remove rule service_ntpd_enabled from RHEL 8 and RHEL 9 PCI-DSS profiles
- add warning to the rule

#### Rationale:

The rule does not make sense on RHEL >= 8 because there is no ntp package nor ntpd service.

