### PR TITLE
[Stabilization] remove timer_logrotate_enabled from some pci-dss profiles

### DIFF
--- a/linux_os/guide/system/logging/log_rotation/timer_logrotate_enabled/rule.yml
+++ b/linux_os/guide/system/logging/log_rotation/timer_logrotate_enabled/rule.yml
@@ -54,3 +54,11 @@ template:
     vars:
         timername: logrotate
         packagename: logrotate
+
+{{% if product in ["rhel7", "rhel8"] %}}
+warnings:
+    - general:
+        The Systemd unit <tt>logrotate.timer</tt> does not exist in
+        {{{ full_name }}}. The rule <tt>ensure_logrotate_activated</tt> is
+        suggested instead.
+{{% endif %}}

--- a/products/rhel7/profiles/pci-dss.profile
+++ b/products/rhel7/profiles/pci-dss.profile
@@ -30,3 +30,4 @@ selections:
     - '!service_ntp_enabled'
     - '!set_ipv6_loopback_traffic'
     - '!set_loopback_traffic'
+    - '!timer_logrotate_enabled'

--- a/products/rhel8/profiles/pci-dss.profile
+++ b/products/rhel8/profiles/pci-dss.profile
@@ -33,3 +33,4 @@ selections:
     - '!set_ipv6_loopback_traffic'
     - '!set_loopback_traffic'
     - '!service_ntpd_enabled'
+    - '!timer_logrotate_enabled'

--- a/tests/data/profile_stability/rhel8/pci-dss.profile
+++ b/tests/data/profile_stability/rhel8/pci-dss.profile
@@ -145,7 +145,6 @@ selections:
 - file_permissions_var_log_audit
 - package_telnet-server_removed
 - file_permissions_unauthorized_world_writable
-- timer_logrotate_enabled
 - package_tftp-server_removed
 - file_permissions_sshd_private_key
 - sshd_disable_tcp_forwarding


### PR DESCRIPTION
#### Description:

- add a warning to timer_logrotate_enabled
- remove the rule from RHEL 7 and RHEL 8 PCI-DSS because the rule does not make sense on those products

#### Rationale:

The Systemd unit logrotate.timer does not exist on RHEL 8 and RHEL 7.

