### PR TITLE
Turn off blueprint for package_MFEhiplsm_installed

### DIFF
--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_hbss_software/package_MFEhiplsm_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_hbss_software/package_MFEhiplsm_installed/rule.yml
@@ -62,3 +62,4 @@ template:
         ansible: "off"
         bash: "off"
         puppet: "off"
+        blueprint: "off"


### PR DESCRIPTION


#### Description:
Turn off blueprint for package_MFEhiplsm_installed

#### Rationale:

Closes #11343
