### PR TITLE
Add package_firewalld_installed to RHEL 9 CIS

### DIFF
--- a/controls/cis_rhel9.yml
+++ b/controls/cis_rhel9.yml
@@ -1087,6 +1087,7 @@ controls:
     status: automated
     rules:
       - service_firewalld_enabled
+      - package_firewalld_installed
       - service_nftables_disabled
 
   - id: 3.4.2.1

--- a/linux_os/guide/system/network/network-firewalld/firewalld_activation/package_firewalld_installed/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_activation/package_firewalld_installed/rule.yml
@@ -31,6 +31,7 @@ references:
     cis@alinux3: 3.4.1.1
     cis@rhel7: 3.5.1.1
     cis@rhel8: 3.4.1.1
+    cis@rhel9: 3.4.1.2
     cis@sle15: 3.5.1.1
     disa: CCI-002314
     nist: CM-6(a)


### PR DESCRIPTION

#### Description:

Add rule `package_firewalld_installed` to  the RHEL 9 CIS profile.
#### Rationale:

Closes #11340


