### PR TITLE
Update Ubuntu STIG-20-010072 and fix faillock rules

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle,multi_platform_ubuntu
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle,multi_platform_ubuntu
 
 {{{ bash_pam_faillock_enable() }}}
 {{{ bash_pam_faillock_parameter_value("audit", authfail=False)}}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/oval/ubuntu.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/oval/ubuntu.xml
@@ -1,0 +1,180 @@
+{{# Very similar OVAL is used in several rules, differing primarily in faillock.so parameter. #}}
+{{# For transferability, we define the parameter and corresponding regular expressions in jinja. #}}
+{{# The rules should ideally use a single template. #}}
+
+{{% set prm_name = "audit" %}}
+{{% set prm_regex_conf = "^[\s]*audit" %}}
+{{% set prm_regex_pamd = "^[\s]*auth[\s]+.+[\s]+pam_faillock.so[\s]+[^\n]*audit" %}}
+{{% set description = "Account Lockouts Must Be Logged" %}}
+
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="4">
+    {{{ oval_metadata(description) }}}
+    <criteria operator="AND" comment="Check the proper configuration of pam_faillock.so">
+      <criteria operator="AND" comment="Check if pam_faillock.so is properly enabled">
+        <!-- pam_unix.so is a control module present in all realistic scenarios and also used
+             as reference for the correct position of pam_faillock.so in auth section. If the
+             system is properly configured, it must appear only once in auth section. -->
+        <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_unix_auth"
+            comment="pam_unix.so appears only once in auth section of common-auth"/>
+        <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_auth"
+            comment="pam_faillock.so is properly defined in auth section of common-auth"/>
+        <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_account"
+            comment="pam_faillock.so is properly defined in common-account"/>
+      </criteria>
+
+      <!-- pam_faillock.so parameters should be defined in /etc/security/faillock.conf whenever
+           possible. But due to backwards compatibility, they are also allowed in pam files
+           directly. In case they are defined in both places, pam files have precedence and this
+           may confuse the assessment. The following tests ensure only one option is used. -->
+      <criteria operator="OR" comment="Check expected value for pam_faillock.so {{{ prm_name }}} parameter">
+        <criteria operator="AND"
+            comment="Check expected pam_faillock.so {{{ prm_name }}} parameter in pam files">
+          <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_pamd_common"
+              comment="Check the {{{ prm_name }}} parameter is present common-auth file"/>
+          <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_no_faillock_conf"
+              comment="Ensure the {{{ prm_name }}} parameter is not present in /etc/security/faillock.conf"/>
+        </criteria>
+        <criteria operator="AND"
+            comment="Check expected pam_faillock.so {{{ prm_name }}} parameter in faillock.conf">
+          <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_no_pamd_common"
+              comment="Check the {{{ prm_name }}} parameter is not present common-auth file"/>
+          <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_faillock_conf"
+              comment="Ensure the {{{ prm_name }}} parameter is present in /etc/security/faillock.conf"/>
+        </criteria>
+      </criteria>
+    </criteria>
+  </definition>
+
+  <!-- The following tests demand complex regex which are necessary more than once.
+       These variables make simpler the usage of regex patterns. -->
+  <constant_variable id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_unix_regex"
+                datatype="string" version="1"
+                comment="regex to identify pam_unix.so in auth section of pam files">
+    <value>^\s*auth.*pam_unix\.so</value>
+  </constant_variable>
+
+  <constant_variable id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_auth_regex"
+                datatype="string" version="1"
+                comment="regex to identify pam_faillock.so entries in auth section of pam files">
+      <value>^\s*auth\s+required\s+pam_faillock\.so.*preauth.*[\s\S]*^\s*auth.*pam_unix\.so[\s\S]*^\s*auth\s+\[default=die\]\s+pam_faillock\.so\s+authfail[\s\S]*^\s*auth\s+sufficient\s+pam_faillock\.so\s+authsucc</value>
+  </constant_variable>
+
+  <constant_variable id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_account_regex"
+                datatype="string" version="1"
+                comment="regex to identify pam_faillock.so entry in account section of pam files">
+    <value>^\s*account\s+required\s+pam_faillock\.so\s*(#.*)?$</value>
+  </constant_variable>
+
+  <constant_variable
+    id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_{{{ prm_name }}}_parameter_regex"
+    datatype="string" version="1"
+    comment="regex to identify pam_faillock.so {{{ prm_name }}} entry in auth section of pam files">
+    <value>{{{ prm_regex_pamd }}}</value>
+  </constant_variable>
+
+  <constant_variable
+              id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_faillock_conf_{{{ prm_name }}}_parameter_regex"
+              datatype="string" version="1"
+              comment="regex to identify {{{ prm_name }}} entry in /etc/security/faillock.conf">
+    <value>{{{ prm_regex_conf }}}</value>
+  </constant_variable>
+
+  <!-- Check occurrences of pam_unix.so in auth section of common-auth file -->
+  <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_unix_auth"
+        comment="No more than one pam_unix.so is expected in auth section of common-auth">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_unix_auth"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object version="1"
+        id="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_unix_auth"
+        comment="Get the second and subsequent occurrences of pam_unix.so in auth section of common-auth">
+    <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
+    <ind:pattern operation="pattern match"
+                 var_ref="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_unix_regex"/>
+    <ind:instance datatype="int" operation="greater than">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- Check common definition of pam_faillock.so in common-auth -->
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists" version="1"
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_auth"
+        comment="One and only one occurrence is expected in auth section of common-auth">
+    <ind:object
+        object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_auth"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object version="1"
+        id="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_auth"
+        comment="Check common definition of pam_faillock.so in auth section of common-auth">
+    <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
+    <ind:pattern operation="pattern match"
+                 var_ref="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_auth_regex"/>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- Check common definition of pam_faillock.so in common-account -->
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists" version="1"
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_account"
+        comment="One and only one occurrence is expected in common-account">
+    <ind:object
+        object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_account"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object version="1"
+        id="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_account"
+        comment="Check common definition of pam_faillock.so in account section of common-account">
+    <ind:filepath>/etc/pam.d/common-account</ind:filepath>
+    <ind:pattern operation="pattern match"
+                 var_ref="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_account_regex"/>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+
+  <!-- Check absence of {{{ prm_name }}} parameter in common-auth -->
+  <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_no_pamd_common"
+        comment="Check the absence of {{{ prm_name }}} parameter in common-auth">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_pamd_common"/>
+  </ind:textfilecontent54_test>
+
+  <!-- Check expected value of {{{ prm_name }}} parameter in common-auth -->
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" version="1"
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_pamd_common"
+        comment="Check the expected {{{ prm_name }}} value in common-auth">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_pamd_common"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object version="1"
+        id="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_pamd_common"
+        comment="Get the pam_faillock.so {{{ prm_name }}} parameter from common-auth file">
+    <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
+    <ind:pattern operation="pattern match"
+                 var_ref="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_{{{ prm_name }}}_parameter_regex"/>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+
+  <!-- Check absence of {{{ prm_name }}} parameter in /etc/security/faillock.conf -->
+  <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_no_faillock_conf"
+        comment="Check the absence of {{{ prm_name }}} parameter in /etc/security/faillock.conf">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_faillock_conf"/>
+  </ind:textfilecontent54_test>
+
+  <!-- Check expected value of {{{ prm_name }}} parameter in /etc/security/faillock.conf -->
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" version="1"
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_faillock_conf"
+        comment="Check the expected {{{ prm_name }}} value in /etc/security/faillock.conf">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_faillock_conf"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object version="1"
+      id="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_faillock_conf"
+      comment="Check the expected pam_faillock.so {{{ prm_name }}} parameter in /etc/security/faillock.conf">
+    <ind:filepath>/etc/security/faillock.conf</ind:filepath>
+    <ind:pattern operation="pattern match"
+          var_ref="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_faillock_conf_{{{ prm_name }}}_parameter_regex"/>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/rule.yml
@@ -21,6 +21,7 @@ references:
     stigid@ol8: OL08-00-020021
     stigid@rhel8: RHEL-08-020021
     stigid@rhel9: RHEL-09-412045
+    stigid@ubuntu2004: UBTU-20-010072
 
 {{% if product == "rhel8" %}}
 platform: os_linux[rhel]>=8.2

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/common.sh
@@ -1,4 +1,3 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 pam_files=("password-auth" "system-auth")
 
 authselect create-profile testingProfile --base-on minimal

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/common.sh
@@ -1,3 +1,4 @@
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 pam_files=("password-auth" "system-auth")
 
 authselect create-profile testingProfile --base-on minimal

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/conflicting_settings_authselect.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/conflicting_settings_authselect.fail.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 # packages = authselect,pam
 # platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/expected_pam_files.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/expected_pam_files.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # packages = authselect,pam
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 
 source common.sh
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/missing_parameter.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/missing_parameter.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 # packages = authselect,pam
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 
 source common.sh

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/ubuntu_common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/ubuntu_common.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Create passing pam.d files based on defaults from a clean installation of Ubuntu 20.04 LTS
+
+cat >/etc/pam.d/common-auth <<EOF
+# here are the per-package modules (the "Primary" block)
+    auth required  pam_faillock.so     preauth 
+auth    [success=2 default=ignore]      pam_unix.so nullok
+auth    [success=1 default=ignore]      pam_sss.so use_first_pass
+  #
+ auth [default=die]  pam_faillock.so authfail 
+auth sufficient     pam_faillock.so authsucc 
+  #
+# here's the fallback if no module succeeds
+auth    requisite                       pam_deny.so
+# prime the stack with a positive return value if there isn't one already;
+# this avoids us returning an error just because nothing sets a success code
+# since the modules above will each just jump around
+auth    required                        pam_permit.so
+# and here are more per-package modules (the "Additional" block)
+auth    optional                        pam_cap.so 
+# end of pam-auth-update config
+EOF
+
+
+cat >/etc/pam.d/common-account <<EOF
+# here are the per-package modules (the "Primary" block)
+account [success=1 new_authtok_reqd=done default=ignore]        pam_unix.so 
+# here's the fallback if no module succeeds
+account requisite                       pam_deny.so
+# prime the stack with a positive return value if there isn't one already;
+# this avoids us returning an error just because nothing sets a success code
+# since the modules above will each just jump around
+account required                        pam_permit.so
+# and here are more per-package modules (the "Additional" block)
+account sufficient                      pam_localuser.so 
+account [default=bad success=ok user_unknown=ignore]    pam_sss.so 
+# end of pam-auth-update config
+
+  account required  pam_faillock.so 
+EOF

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/ubuntu_correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/ubuntu_correct.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+source ubuntu_common.sh
+
+echo "audit" > /etc/security/faillock.conf

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/ubuntu_correct_pamd.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/ubuntu_correct_pamd.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+source ubuntu_common.sh
+
+sed -i 's/\(.*pam_faillock.so.*\)/\1 audit/g' /etc/pam.d/common-auth
+

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/ubuntu_empty_faillock_conf.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/ubuntu_empty_faillock_conf.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+# This test should fail because neither pam.d or faillock.conf have audit defined
+
+source ubuntu_common.sh
+
+echo > /etc/security/faillock.conf

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/ubuntu_multiple_pam_unix.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/ubuntu_multiple_pam_unix.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# remediation = none
+
+# Multiple instances of pam_unix.so in auth section may, intentionally or not, interfere
+# in the expected behaviour of pam_faillock.so. Remediation does not solve this automatically
+# in order to preserve intentional changes.
+
+source ubuntu_common.sh
+
+echo "auth        sufficient       pam_unix.so" >> /etc/pam.d/common-auth

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/oval/ubuntu.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/oval/ubuntu.xml
@@ -1,159 +1,201 @@
+{{# Very similar OVAL is used in several rules, differing primarily in faillock.so parameter. #}}
+{{# For transferability, we define the parameter and corresponding regular expressions in jinja. #}}
+{{# The rules should ideally use a single template. #}}
+
+{{% set prm_name = "deny" %}}
+{{% set prm_regex_conf = "^[\s]*deny[\s]*=[\s]*([0-9]+)" %}}
+{{% set prm_regex_pamd = "^[\s]*auth[\s]+.+[\s]+pam_faillock.so[\s]+[^\n]*deny=([0-9]+)" %}}
+{{% set ext_variable = "var_accounts_passwords_pam_faillock_deny" %}}
+{{% set description = "Lockout account after failed login attempts." %}}
+
 <def-group>
-  <definition class="compliance" id="{{{ rule_id }}}" version="1">
-    {{{ oval_metadata("Lockout account after failed login attempts") }}}
+  <definition class="compliance" id="{{{ rule_id }}}" version="2">
+    {{{ oval_metadata(description) }}}
     <criteria operator="AND" comment="Check the proper configuration of pam_faillock.so">
       <criteria operator="AND" comment="Check if pam_faillock.so is properly enabled">
         <!-- pam_unix.so is a control module present in all realistic scenarios and also used
              as reference for the correct position of pam_faillock.so in auth section. If the
              system is properly configured, it must appear only once in auth section. -->
-        <criterion test_ref="test_accounts_passwords_pam_faillock_deny_common_pam_unix_auth"
+        <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_unix_auth"
             comment="pam_unix.so appears only once in auth section of common-auth"/>
-        <criterion test_ref="test_accounts_passwords_pam_faillock_deny_common_pam_faillock_auth"
+        <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_auth"
             comment="pam_faillock.so is properly defined in auth section of common-auth"/>
-        <criterion test_ref="test_accounts_passwords_pam_faillock_deny_common_pam_faillock_account"
+        <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_account"
             comment="pam_faillock.so is properly defined in common-account"/>
       </criteria>
-      <criteria operator="AND"
-          comment="Check expected pam_faillock.so deny parameter in faillock.conf">
-        <criterion test_ref="test_accounts_passwords_pam_faillock_deny_parameter_no_pamd_common"
-            comment="Check the deny parameter is not present in common-auth file"/>
-        <criterion  test_ref="test_accounts_passwords_pam_faillock_deny_parameter_faillock_conf"
-            comment="Ensure the deny parameter is present in /etc/security/faillock.conf"/>
+
+      <!-- pam_faillock.so parameters should be defined in /etc/security/faillock.conf whenever
+           possible. But due to backwards compatibility, they are also allowed in pam files
+           directly. In case they are defined in both places, pam files have precedence and this
+           may confuse the assessment. The following tests ensure only one option is used. -->
+      <criteria operator="OR" comment="Check expected value for pam_faillock.so {{{ prm_name }}} parameter">
+        <criteria operator="AND"
+            comment="Check expected pam_faillock.so {{{ prm_name }}} parameter in pam files">
+          <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_pamd_common"
+              comment="Check the {{{ prm_name }}} parameter is present common-auth file"/>
+          <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_no_faillock_conf"
+              comment="Ensure the {{{ prm_name }}} parameter is not present in /etc/security/faillock.conf"/>
         </criteria>
+        <criteria operator="AND"
+            comment="Check expected pam_faillock.so {{{ prm_name }}} parameter in faillock.conf">
+          <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_no_pamd_common"
+              comment="Check the {{{ prm_name }}} parameter is not present common-auth file"/>
+          <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_faillock_conf"
+              comment="Ensure the {{{ prm_name }}} parameter is present in /etc/security/faillock.conf"/>
+        </criteria>
+      </criteria>
     </criteria>
   </definition>
 
   <!-- The following tests demand complex regex which are necessary more than once.
        These variables make simpler the usage of regex patterns. -->
-  <constant_variable id="var_accounts_passwords_pam_faillock_deny_pam_unix_regex"
+  <constant_variable id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_unix_regex"
                 datatype="string" version="1"
                 comment="regex to identify pam_unix.so in auth section of pam files">
     <value>^\s*auth.*pam_unix\.so</value>
   </constant_variable>
 
-  <constant_variable id="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_regex"
+  <constant_variable id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_auth_regex"
                 datatype="string" version="1"
                 comment="regex to identify pam_faillock.so entries in auth section of pam files">
-    <value>^\s*auth\s+required\s+pam_faillock\.so.*preauth.*[\s\S]*^\s*auth.*pam_unix\.so[\s\S]*^\s*auth\s+\[default=die\]\s+pam_faillock\.so\s+authfail[\s\S]*^\s*auth\s+sufficient\s+pam_faillock\.so\s+authsucc</value>
+      <value>^\s*auth\s+required\s+pam_faillock\.so.*preauth.*[\s\S]*^\s*auth.*pam_unix\.so[\s\S]*^\s*auth\s+\[default=die\]\s+pam_faillock\.so\s+authfail[\s\S]*^\s*auth\s+sufficient\s+pam_faillock\.so\s+authsucc</value>
   </constant_variable>
 
-  <constant_variable id="var_accounts_passwords_pam_faillock_deny_pam_faillock_account_regex"
+  <constant_variable id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_account_regex"
                 datatype="string" version="1"
                 comment="regex to identify pam_faillock.so entry in account section of pam files">
     <value>^\s*account\s+required\s+pam_faillock\.so\s*(#.*)?$</value>
   </constant_variable>
 
   <constant_variable
-              id="var_accounts_passwords_pam_faillock_deny_pam_faillock_deny_parameter_regex"
-              datatype="string" version="1"
-              comment="regex to identify pam_faillock.so deny entry in auth section of pam files">
-    <value>^[\s]*auth[\s]+.+[\s]+pam_faillock.so[\s]+[^\n]*deny=([0-9]+)</value>
+    id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_{{{ prm_name }}}_parameter_regex"
+    datatype="string" version="1"
+    comment="regex to identify pam_faillock.so {{{ prm_name }}} entry in auth section of pam files">
+    <value>{{{ prm_regex_pamd }}}</value>
   </constant_variable>
 
   <constant_variable
-              id="var_accounts_passwords_pam_faillock_deny_faillock_conf_deny_parameter_regex"
+              id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_faillock_conf_{{{ prm_name }}}_parameter_regex"
               datatype="string" version="1"
-              comment="regex to identify deny entry in /etc/security/faillock.conf">
-    <value>^[\s]*deny[\s]*=[\s]*([0-9]+)</value>
+              comment="regex to identify {{{ prm_name }}} entry in /etc/security/faillock.conf">
+    <value>{{{ prm_regex_conf }}}</value>
   </constant_variable>
 
-  <!-- Check occurrences of pam_unix.so in auth section in common-auth -->
+  <!-- Check occurrences of pam_unix.so in auth section of common-auth file -->
   <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
-        id="test_accounts_passwords_pam_faillock_deny_common_pam_unix_auth"
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_unix_auth"
         comment="No more than one pam_unix.so is expected in auth section of common-auth">
-    <ind:object object_ref="object_accounts_passwords_pam_faillock_deny_common_pam_unix_auth"/>
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_unix_auth"/>
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object version="1"
-        id="object_accounts_passwords_pam_faillock_deny_common_pam_unix_auth"
+        id="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_unix_auth"
         comment="Get the second and subsequent occurrences of pam_unix.so in auth section of common-auth">
     <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
     <ind:pattern operation="pattern match"
-                 var_ref="var_accounts_passwords_pam_faillock_deny_pam_unix_regex"/>
+                 var_ref="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_unix_regex"/>
     <ind:instance datatype="int" operation="greater than">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <!-- Check common definition of pam_faillock.so in common-auth -->
   <ind:textfilecontent54_test check="all" check_existence="only_one_exists" version="1"
-        id="test_accounts_passwords_pam_faillock_deny_common_pam_faillock_auth"
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_auth"
         comment="One and only one occurrence is expected in auth section of common-auth">
     <ind:object
-        object_ref="object_accounts_passwords_pam_faillock_deny_common_pam_faillock_auth"/>
+        object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_auth"/>
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object version="1"
-        id="object_accounts_passwords_pam_faillock_deny_common_pam_faillock_auth"
+        id="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_auth"
         comment="Check common definition of pam_faillock.so in auth section of common-auth">
     <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
     <ind:pattern operation="pattern match"
-                 var_ref="var_accounts_passwords_pam_faillock_deny_pam_faillock_auth_regex"/>
+                 var_ref="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_auth_regex"/>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <!-- Check account definition of pam_faillock.so in common-account -->
+  <!-- Check common definition of pam_faillock.so in common-account -->
   <ind:textfilecontent54_test check="all" check_existence="only_one_exists" version="1"
-        id="test_accounts_passwords_pam_faillock_deny_common_pam_faillock_account"
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_account"
         comment="One and only one occurrence is expected in common-account">
     <ind:object
-        object_ref="object_accounts_passwords_pam_faillock_deny_common_pam_faillock_account"/>
+        object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_account"/>
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object version="1"
-        id="object_accounts_passwords_pam_faillock_deny_common_pam_faillock_account"
-        comment="Check common definition of pam_faillock.so in account section of common-auth">
+        id="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_account"
+        comment="Check common definition of pam_faillock.so in account section of common-account">
     <ind:filepath>/etc/pam.d/common-account</ind:filepath>
     <ind:pattern operation="pattern match"
-                 var_ref="var_accounts_passwords_pam_faillock_deny_pam_faillock_account_regex"/>
+                 var_ref="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_account_regex"/>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
+
 
   <!-- boundaries to test the parameter value -->
   <!-- Specify the required external variable & create corresponding state from it -->
-  <external_variable id="var_accounts_passwords_pam_faillock_deny" datatype="int"
+  <external_variable id="{{{ ext_variable }}}" datatype="int"
                      comment="number of failed login attempts allowed" version="1"/>
 
   <ind:textfilecontent54_state version="1"
-        id="state_accounts_passwords_pam_faillock_deny_parameter_upper_bound">
+        id="state_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_upper_bound">
     <ind:subexpression datatype="int" operation="less than or equal"
-                       var_ref="var_accounts_passwords_pam_faillock_deny"/>
+          var_ref="{{{ ext_variable }}}"/>
   </ind:textfilecontent54_state>
 
   <ind:textfilecontent54_state version="1"
-        id="state_accounts_passwords_pam_faillock_deny_parameter_lower_bound">
+        id="state_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_lower_bound">
     <ind:subexpression datatype="int" operation="greater than">0</ind:subexpression>
   </ind:textfilecontent54_state>
 
-  <!-- Check the pam_faillock.so no deny parameter in common-auth -->
+  <!-- Check absence of {{{ prm_name }}} parameter in common-auth -->
   <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
-        id="test_accounts_passwords_pam_faillock_deny_parameter_no_pamd_common"
-        comment="Check the absence of deny parameter in common-auth">
-    <ind:object object_ref="object_accounts_passwords_pam_faillock_deny_parameter_pamd_common"/>
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_no_pamd_common"
+        comment="Check the absence of {{{ prm_name }}} parameter in common-auth">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_pamd_common"/>
+  </ind:textfilecontent54_test>
+
+  <!-- Check expected value of {{{ prm_name }}} parameter in common-auth -->
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" version="1"
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_pamd_common"
+        comment="Check the expected {{{ prm_name }}} value in common-auth">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_pamd_common"/>
+    <ind:state state_ref="state_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_upper_bound"/>
+    <ind:state state_ref="state_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_lower_bound"/>
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object version="1"
-        id="object_accounts_passwords_pam_faillock_deny_parameter_pamd_common"
-        comment="Get the pam_faillock.so deny parameter from common-auth file">
+        id="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_pamd_common"
+        comment="Get the pam_faillock.so {{{ prm_name }}} parameter from common-auth file">
     <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
     <ind:pattern operation="pattern match"
-                 var_ref="var_accounts_passwords_pam_faillock_deny_pam_faillock_deny_parameter_regex"/>
+                 var_ref="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_{{{ prm_name }}}_parameter_regex"/>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <!-- Check pam_faillock.so deny parameter in /etc/security/faillock.conf -->
+
+  <!-- Check absence of {{{ prm_name }}} parameter in /etc/security/faillock.conf -->
+  <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_no_faillock_conf"
+        comment="Check the absence of {{{ prm_name }}} parameter in /etc/security/faillock.conf">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_faillock_conf"/>
+  </ind:textfilecontent54_test>
+
+  <!-- Check expected value of {{{ prm_name }}} parameter in /etc/security/faillock.conf -->
   <ind:textfilecontent54_test check="all" check_existence="all_exist" version="1"
-        id="test_accounts_passwords_pam_faillock_deny_parameter_faillock_conf"
-        comment="Check the expected deny value in in /etc/security/faillock.conf">
-    <ind:object object_ref="object_accounts_passwords_pam_faillock_deny_parameter_faillock_conf"/>
-    <ind:state state_ref="state_accounts_passwords_pam_faillock_deny_parameter_upper_bound"/>
-    <ind:state state_ref="state_accounts_passwords_pam_faillock_deny_parameter_lower_bound"/>
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_faillock_conf"
+        comment="Check the expected {{{ prm_name }}} value in /etc/security/faillock.conf">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_faillock_conf"/>
+    <ind:state state_ref="state_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_upper_bound"/>
+    <ind:state state_ref="state_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_lower_bound"/>
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object version="1"
-      id="object_accounts_passwords_pam_faillock_deny_parameter_faillock_conf"
-      comment="Check the expected pam_faillock.so deny parameter in /etc/security/faillock.conf">
+      id="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_faillock_conf"
+      comment="Check the expected pam_faillock.so {{{ prm_name }}} parameter in /etc/security/faillock.conf">
     <ind:filepath>/etc/security/faillock.conf</ind:filepath>
     <ind:pattern operation="pattern match"
-                 var_ref="var_accounts_passwords_pam_faillock_deny_faillock_conf_deny_parameter_regex"/>
+          var_ref="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_faillock_conf_{{{ prm_name }}}_parameter_regex"/>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,ubuntu2204
+prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,ubuntu2004,ubuntu2204
 
 title: 'Lock Accounts After Failed Password Attempts'
 
@@ -66,6 +66,7 @@ references:
     stigid@rhel7: RHEL-07-010320
     stigid@rhel8: RHEL-08-020011
     stigid@rhel9: RHEL-09-411075
+    stigid@ubuntu2004: UBTU-20-010072
 
 platform: package[pam]
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/pam_faillock_disabled.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/pam_faillock_disabled.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_fedora,multi_platform_rhel,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 {{%- if product in ["rhel7"] %}}
 # packages = authconfig
 {{%- else %}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/pam_faillock_not_required_pam_files.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/pam_faillock_not_required_pam_files.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_fedora,multi_platform_rhel,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 {{%- if product in ["rhel7"] %}}
 # packages = authconfig
 {{%- else %}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/ubuntu_common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/ubuntu_common.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Create passing pam.d files based on defaults from a clean installation of Ubuntu 20.04 LTS
+
+cat >/etc/pam.d/common-auth <<EOF
+# here are the per-package modules (the "Primary" block)
+    auth required  pam_faillock.so     preauth 
+auth    [success=2 default=ignore]      pam_unix.so nullok
+auth    [success=1 default=ignore]      pam_sss.so use_first_pass
+  #
+ auth [default=die]  pam_faillock.so authfail 
+auth sufficient     pam_faillock.so authsucc 
+  #
+# here's the fallback if no module succeeds
+auth    requisite                       pam_deny.so
+# prime the stack with a positive return value if there isn't one already;
+# this avoids us returning an error just because nothing sets a success code
+# since the modules above will each just jump around
+auth    required                        pam_permit.so
+# and here are more per-package modules (the "Additional" block)
+auth    optional                        pam_cap.so 
+# end of pam-auth-update config
+EOF
+
+
+cat >/etc/pam.d/common-account <<EOF
+# here are the per-package modules (the "Primary" block)
+account [success=1 new_authtok_reqd=done default=ignore]        pam_unix.so 
+# here's the fallback if no module succeeds
+account requisite                       pam_deny.so
+# prime the stack with a positive return value if there isn't one already;
+# this avoids us returning an error just because nothing sets a success code
+# since the modules above will each just jump around
+account required                        pam_permit.so
+# and here are more per-package modules (the "Additional" block)
+account sufficient                      pam_localuser.so 
+account [default=bad success=ok user_unknown=ignore]    pam_sss.so 
+# end of pam-auth-update config
+
+  account required  pam_faillock.so 
+EOF

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/ubuntu_correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/ubuntu_correct.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+source ubuntu_common.sh
+
+echo "deny=1" > /etc/security/faillock.conf

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/ubuntu_correct_pamd.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/ubuntu_correct_pamd.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+source ubuntu_common.sh
+
+sed -i 's/\(.*pam_faillock.so.*\)/\1 deny=1/g' /etc/pam.d/common-auth
+

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/ubuntu_empty_faillock_conf.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/ubuntu_empty_faillock_conf.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+# This test should fail because neither pam.d or faillock.conf have deny defined
+
+source ubuntu_common.sh
+
+echo > /etc/security/faillock.conf

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/ubuntu_multiple_pam_unix.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/ubuntu_multiple_pam_unix.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# remediation = none
+
+# Multiple instances of pam_unix.so in auth section may, intentionally or not, interfere
+# in the expected behaviour of pam_faillock.so. Remediation does not solve this automatically
+# in order to preserve intentional changes.
+
+source ubuntu_common.sh
+
+echo "auth        sufficient       pam_unix.so" >> /etc/pam.d/common-auth

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/ubuntu_wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/ubuntu_wrong_value.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+source ubuntu_common.sh
+
+echo "deny=999" > /etc/security/faillock.conf

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/oval/ubuntu.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/oval/ubuntu.xml
@@ -1,153 +1,195 @@
+{{# Very similar OVAL is used in several rules, differing primarily in faillock.so parameter. #}}
+{{# For transferability, we define the parameter and corresponding regular expressions in jinja. #}}
+{{# The rules should ideally use a single template. #}}
+
+{{% set prm_name = "fail_interval" %}}
+{{% set prm_regex_conf = "^[\s]*fail_interval[\s]*=[\s]*([0-9]+)" %}}
+{{% set prm_regex_pamd = "^[\s]*auth[\s]+.+[\s]+pam_faillock.so[\s]+[^\n]*fail_interval=([0-9]+)" %}}
+{{% set ext_variable = "var_accounts_passwords_pam_faillock_fail_interval" %}}
+{{% set description = "The number of allowed failed logins should be set correctly." %}}
+
 <def-group>
-  <definition class="compliance" id="{{{ rule_id }}}" version="3">
-    {{{ oval_metadata("The number of allowed failed logins should be set correctly.") }}}
+  <definition class="compliance" id="{{{ rule_id }}}" version="4">
+    {{{ oval_metadata(description) }}}
     <criteria operator="AND" comment="Check the proper configuration of pam_faillock.so">
       <criteria operator="AND" comment="Check if pam_faillock.so is properly enabled">
         <!-- pam_unix.so is a control module present in all realistic scenarios and also used
              as reference for the correct position of pam_faillock.so in auth section. If the
              system is properly configured, it must appear only once in auth section. -->
-        <criterion test_ref="test_accounts_passwords_pam_faillock_interval_common_pam_unix_auth"
+        <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_unix_auth"
             comment="pam_unix.so appears only once in auth section of common-auth"/>
-        <criterion test_ref="test_accounts_passwords_pam_faillock_interval_common_pam_faillock_auth"
-             comment="pam_faillock.so is properly defined in auth section of common-auth"/>
-        <criterion test_ref="test_accounts_passwords_pam_faillock_interval_common_pam_faillock_account"
-             comment="pam_faillock.so is properly defined in common-account"/>
+        <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_auth"
+            comment="pam_faillock.so is properly defined in auth section of common-auth"/>
+        <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_account"
+            comment="pam_faillock.so is properly defined in common-account"/>
       </criteria>
-      <criteria operator="AND"
-                comment="Check expected value for pam_faillock.so fail_interval parameter">
-        <criterion test_ref="test_accounts_passwords_pam_faillock_interval_parameter_no_pamd_common"
-              comment="Check the fail_interval parameter is not present common-auth file"/>
-        <criterion test_ref="test_accounts_passwords_pam_faillock_interval_parameter_faillock_conf"
-          comment="Ensure the fail_interval parameter is present in /etc/security/faillock.conf"/>
+
+      <!-- pam_faillock.so parameters should be defined in /etc/security/faillock.conf whenever
+           possible. But due to backwards compatibility, they are also allowed in pam files
+           directly. In case they are defined in both places, pam files have precedence and this
+           may confuse the assessment. The following tests ensure only one option is used. -->
+      <criteria operator="OR" comment="Check expected value for pam_faillock.so {{{ prm_name }}} parameter">
+        <criteria operator="AND"
+            comment="Check expected pam_faillock.so {{{ prm_name }}} parameter in pam files">
+          <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_pamd_common"
+              comment="Check the {{{ prm_name }}} parameter is present common-auth file"/>
+          <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_no_faillock_conf"
+              comment="Ensure the {{{ prm_name }}} parameter is not present in /etc/security/faillock.conf"/>
+        </criteria>
+        <criteria operator="AND"
+            comment="Check expected pam_faillock.so {{{ prm_name }}} parameter in faillock.conf">
+          <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_no_pamd_common"
+              comment="Check the {{{ prm_name }}} parameter is not present common-auth file"/>
+          <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_faillock_conf"
+              comment="Ensure the {{{ prm_name }}} parameter is present in /etc/security/faillock.conf"/>
+        </criteria>
       </criteria>
     </criteria>
   </definition>
 
   <!-- The following tests demand complex regex which are necessary more than once.
        These variables make simpler the usage of regex patterns. -->
-  <constant_variable id="var_accounts_passwords_pam_faillock_interval_pam_unix_regex"
+  <constant_variable id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_unix_regex"
                 datatype="string" version="1"
                 comment="regex to identify pam_unix.so in auth section of pam files">
     <value>^\s*auth.*pam_unix\.so</value>
   </constant_variable>
 
-  <constant_variable id="var_accounts_passwords_pam_faillock_interval_pam_faillock_auth_regex"
+  <constant_variable id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_auth_regex"
                 datatype="string" version="1"
                 comment="regex to identify pam_faillock.so entries in auth section of pam files">
-    <value>^\s*auth\s+required\s+pam_faillock\.so.*preauth.*[\s\S]*^\s*auth.*pam_unix\.so[\s\S]*^\s*auth\s+\[default=die\]\s+pam_faillock\.so\s+authfail[\s\S]*^\s*auth\s+sufficient\s+pam_faillock\.so\s+authsucc</value>
+      <value>^\s*auth\s+required\s+pam_faillock\.so.*preauth.*[\s\S]*^\s*auth.*pam_unix\.so[\s\S]*^\s*auth\s+\[default=die\]\s+pam_faillock\.so\s+authfail[\s\S]*^\s*auth\s+sufficient\s+pam_faillock\.so\s+authsucc</value>
   </constant_variable>
 
-  <constant_variable id="var_accounts_passwords_pam_faillock_interval_pam_faillock_account_regex"
+  <constant_variable id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_account_regex"
                 datatype="string" version="1"
                 comment="regex to identify pam_faillock.so entry in account section of pam files">
     <value>^\s*account\s+required\s+pam_faillock\.so\s*(#.*)?$</value>
   </constant_variable>
 
   <constant_variable
-     id="var_accounts_passwords_pam_faillock_interval_pam_faillock_fail_interval_parameter_regex"
-     datatype="string" version="1"
-     comment="regex to identify pam_faillock.so fail_interval entry in auth section of pam files">
-     <value>^[\s]*auth[\s]+.+[\s]+pam_faillock.so[\s]+[^\n]*fail_interval=([0-9]+)</value>
+    id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_{{{ prm_name }}}_parameter_regex"
+    datatype="string" version="1"
+    comment="regex to identify pam_faillock.so {{{ prm_name }}} entry in auth section of pam files">
+    <value>{{{ prm_regex_pamd }}}</value>
   </constant_variable>
 
   <constant_variable
-              id="var_accounts_passwords_pam_faillock_interval_faillock_conf_fail_interval_parameter_regex"
+              id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_faillock_conf_{{{ prm_name }}}_parameter_regex"
               datatype="string" version="1"
-              comment="regex to identify fail_interval entry in /etc/security/faillock.conf">
-    <value>^[\s]*fail_interval[\s]*=[\s]*([0-9]+)</value>
+              comment="regex to identify {{{ prm_name }}} entry in /etc/security/faillock.conf">
+    <value>{{{ prm_regex_conf }}}</value>
   </constant_variable>
 
-  <!-- Check occurrences of pam_unix.so in auth section in common-auth -->
+  <!-- Check occurrences of pam_unix.so in auth section of common-auth file -->
   <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
-        id="test_accounts_passwords_pam_faillock_interval_common_pam_unix_auth"
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_unix_auth"
         comment="No more than one pam_unix.so is expected in auth section of common-auth">
-    <ind:object object_ref="object_accounts_passwords_pam_faillock_interval_common_pam_unix_auth"/>
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_unix_auth"/>
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object version="1"
-        id="object_accounts_passwords_pam_faillock_interval_common_pam_unix_auth"
+        id="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_unix_auth"
         comment="Get the second and subsequent occurrences of pam_unix.so in auth section of common-auth">
     <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
     <ind:pattern operation="pattern match"
-                 var_ref="var_accounts_passwords_pam_faillock_interval_pam_unix_regex"/>
+                 var_ref="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_unix_regex"/>
     <ind:instance datatype="int" operation="greater than">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <!-- Check common definition of pam_faillock.so in common-auth -->
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" version="1"
-        id="test_accounts_passwords_pam_faillock_interval_common_pam_faillock_auth"
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists" version="1"
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_auth"
         comment="One and only one occurrence is expected in auth section of common-auth">
     <ind:object
-        object_ref="object_accounts_passwords_pam_faillock_interval_common_pam_faillock_auth"/>
+        object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_auth"/>
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object version="1"
-        id="object_accounts_passwords_pam_faillock_interval_common_pam_faillock_auth"
+        id="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_auth"
         comment="Check common definition of pam_faillock.so in auth section of common-auth">
     <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
     <ind:pattern operation="pattern match"
-                 var_ref="var_accounts_passwords_pam_faillock_interval_pam_faillock_auth_regex"/>
+                 var_ref="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_auth_regex"/>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <!-- Check account definition of pam_faillock.so in common-account -->
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" version="1"
-        id="test_accounts_passwords_pam_faillock_interval_common_pam_faillock_account"
-        comment="One and only one occurrence is expected in auth section of common-account">
+  <!-- Check common definition of pam_faillock.so in common-account -->
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists" version="1"
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_account"
+        comment="One and only one occurrence is expected in common-account">
     <ind:object
-        object_ref="object_accounts_passwords_pam_faillock_interval_common_pam_faillock_account"/>
+        object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_account"/>
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object version="1"
-        id="object_accounts_passwords_pam_faillock_interval_common_pam_faillock_account"
+        id="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_account"
         comment="Check common definition of pam_faillock.so in account section of common-account">
     <ind:filepath>/etc/pam.d/common-account</ind:filepath>
     <ind:pattern operation="pattern match"
-                 var_ref="var_accounts_passwords_pam_faillock_interval_pam_faillock_account_regex"/>
+                 var_ref="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_account_regex"/>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
+
 
   <!-- boundaries to test the parameter value -->
   <!-- Specify the required external variable & create corresponding state from it -->
-  <external_variable id="var_accounts_passwords_pam_faillock_fail_interval" datatype="int"
+  <external_variable id="{{{ ext_variable }}}" datatype="int"
                      comment="number of failed login attempts allowed" version="1"/>
 
   <ind:textfilecontent54_state version="1"
-        id="state_accounts_passwords_pam_faillock_interval_parameter_lower_bound">
+        id="state_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_lower_bound">
     <ind:subexpression datatype="int" operation="greater than or equal"
-                       var_ref="var_accounts_passwords_pam_faillock_fail_interval"/>
+          var_ref="{{{ ext_variable }}}"/>
   </ind:textfilecontent54_state>
 
-  <!-- Check the pam_faillock.so no fail_interval parameter in common-auth -->
+
+  <!-- Check absence of {{{ prm_name }}} parameter in common-auth -->
   <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
-        id="test_accounts_passwords_pam_faillock_interval_parameter_no_pamd_common"
-        comment="Check the absence of fail_interval parameter in common-auth">
-    <ind:object object_ref="object_accounts_passwords_pam_faillock_interval_parameter_pamd_common"/>
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_no_pamd_common"
+        comment="Check the absence of {{{ prm_name }}} parameter in common-auth">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_pamd_common"/>
+  </ind:textfilecontent54_test>
+
+  <!-- Check expected value of {{{ prm_name }}} parameter in common-auth -->
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" version="1"
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_pamd_common"
+        comment="Check the expected {{{ prm_name }}} value in common-auth">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_pamd_common"/>
+    <ind:state state_ref="state_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_lower_bound"/>
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object version="1"
-        id="object_accounts_passwords_pam_faillock_interval_parameter_pamd_common"
-        comment="Get the pam_faillock.so fail_interval parameter from common-auth file">
-    <ind:filepath>/etc/pam.d/comon-auth</ind:filepath>
+        id="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_pamd_common"
+        comment="Get the pam_faillock.so {{{ prm_name }}} parameter from common-auth file">
+    <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
     <ind:pattern operation="pattern match"
-                 var_ref="var_accounts_passwords_pam_faillock_interval_pam_faillock_fail_interval_parameter_regex"/>
+                 var_ref="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_{{{ prm_name }}}_parameter_regex"/>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <!-- Check pam_faillock.so fail_interval parameter in /etc/security/faillock.conf -->
+
+  <!-- Check absence of {{{ prm_name }}} parameter in /etc/security/faillock.conf -->
+  <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_no_faillock_conf"
+        comment="Check the absence of {{{ prm_name }}} parameter in /etc/security/faillock.conf">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_faillock_conf"/>
+  </ind:textfilecontent54_test>
+
+  <!-- Check expected value of {{{ prm_name }}} parameter in /etc/security/faillock.conf -->
   <ind:textfilecontent54_test check="all" check_existence="all_exist" version="1"
-        id="test_accounts_passwords_pam_faillock_interval_parameter_faillock_conf"
-        comment="Check the expected fail_interval value in in /etc/security/faillock.conf">
-    <ind:object object_ref="object_accounts_passwords_pam_faillock_interval_parameter_faillock_conf"/>
-    <ind:state state_ref="state_accounts_passwords_pam_faillock_interval_parameter_lower_bound"/>
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_faillock_conf"
+        comment="Check the expected {{{ prm_name }}} value in /etc/security/faillock.conf">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_faillock_conf"/>
+    <ind:state state_ref="state_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_lower_bound"/>
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object version="1"
-      id="object_accounts_passwords_pam_faillock_interval_parameter_faillock_conf"
-      comment="Check the expected pam_faillock.so fail_interval parameter in /etc/security/faillock.conf">
+      id="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_faillock_conf"
+      comment="Check the expected pam_faillock.so {{{ prm_name }}} parameter in /etc/security/faillock.conf">
     <ind:filepath>/etc/security/faillock.conf</ind:filepath>
     <ind:pattern operation="pattern match"
-          var_ref="var_accounts_passwords_pam_faillock_interval_faillock_conf_fail_interval_parameter_regex"/>
+          var_ref="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_faillock_conf_{{{ prm_name }}}_parameter_regex"/>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,ubuntu2204
+prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,ubuntu2004,ubuntu2204
 
 title: 'Set Interval For Counting Failed Password Attempts'
 
@@ -56,6 +56,7 @@ references:
     stigid@rhel7: RHEL-07-010320
     stigid@rhel8: RHEL-08-020012,RHEL-08-020013
     stigid@rhel9: RHEL-09-411085
+    stigid@ubuntu2004: UBTU-20-010072
 
 platform: package[pam]
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/tests/pam_faillock_disabled.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/tests/pam_faillock_disabled.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_fedora,multi_platform_rhel,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 {{%- if product in ["rhel7"] %}}
 # packages = authconfig
 {{%- else %}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/tests/pam_faillock_not_required_pam_files.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/tests/pam_faillock_not_required_pam_files.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_fedora,multi_platform_rhel,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 {{%- if product in ["rhel7"] %}}
 # packages = authconfig
 {{%- else %}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/tests/ubuntu_common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/tests/ubuntu_common.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Create passing pam.d files based on defaults from a clean installation of Ubuntu 20.04 LTS
+
+cat >/etc/pam.d/common-auth <<EOF
+# here are the per-package modules (the "Primary" block)
+    auth required  pam_faillock.so     preauth 
+auth    [success=2 default=ignore]      pam_unix.so nullok
+auth    [success=1 default=ignore]      pam_sss.so use_first_pass
+  #
+ auth [default=die]  pam_faillock.so authfail 
+auth sufficient     pam_faillock.so authsucc 
+  #
+# here's the fallback if no module succeeds
+auth    requisite                       pam_deny.so
+# prime the stack with a positive return value if there isn't one already;
+# this avoids us returning an error just because nothing sets a success code
+# since the modules above will each just jump around
+auth    required                        pam_permit.so
+# and here are more per-package modules (the "Additional" block)
+auth    optional                        pam_cap.so 
+# end of pam-auth-update config
+EOF
+
+
+cat >/etc/pam.d/common-account <<EOF
+# here are the per-package modules (the "Primary" block)
+account [success=1 new_authtok_reqd=done default=ignore]        pam_unix.so 
+# here's the fallback if no module succeeds
+account requisite                       pam_deny.so
+# prime the stack with a positive return value if there isn't one already;
+# this avoids us returning an error just because nothing sets a success code
+# since the modules above will each just jump around
+account required                        pam_permit.so
+# and here are more per-package modules (the "Additional" block)
+account sufficient                      pam_localuser.so 
+account [default=bad success=ok user_unknown=ignore]    pam_sss.so 
+# end of pam-auth-update config
+
+  account required  pam_faillock.so 
+EOF

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/tests/ubuntu_correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/tests/ubuntu_correct.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+source ubuntu_common.sh
+
+echo "fail_interval=900" > /etc/security/faillock.conf

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/tests/ubuntu_correct_pamd.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/tests/ubuntu_correct_pamd.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+source ubuntu_common.sh
+
+sed -i 's/\(.*pam_faillock.so.*\)/\1 fail_interval=900/g' /etc/pam.d/common-auth
+

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/tests/ubuntu_empty_faillock_conf.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/tests/ubuntu_empty_faillock_conf.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+# This test should fail because neither pam.d or faillock.conf have fail_interval defined
+
+source ubuntu_common.sh
+
+echo > /etc/security/faillock.conf

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/tests/ubuntu_multiple_pam_unix.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/tests/ubuntu_multiple_pam_unix.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# remediation = none
+
+# Multiple instances of pam_unix.so in auth section may, intentionally or not, interfere
+# in the expected behaviour of pam_faillock.so. Remediation does not solve this automatically
+# in order to preserve intentional changes.
+
+source ubuntu_common.sh
+
+echo "auth        sufficient       pam_unix.so" >> /etc/pam.d/common-auth

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/tests/ubuntu_wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/tests/ubuntu_wrong_value.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+source ubuntu_common.sh
+
+echo "fail_interval=100" > /etc/security/faillock.conf

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/bash/shared.sh
@@ -2,6 +2,10 @@
 
 {{{ bash_pam_faillock_enable() }}}
 
+{{% if "ubuntu" in product %}}
+{{{ bash_pam_faillock_parameter_value("silent", authfail=False)}}}
+
+{{% else %}}
 AUTH_FILES=("/etc/pam.d/system-auth" "/etc/pam.d/password-auth")
 FAILLOCK_CONF="/etc/security/faillock.conf"
 if [ -f $FAILLOCK_CONF ]; then
@@ -18,3 +22,4 @@ else
         fi
     done
 fi
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/oval/ubuntu.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/oval/ubuntu.xml
@@ -1,0 +1,180 @@
+{{# Very similar OVAL is used in several rules, differing primarily in faillock.so parameter. #}}
+{{# For transferability, we define the parameter and corresponding regular expressions in jinja. #}}
+{{# The rules should ideally use a single template. #}}
+
+{{% set prm_name = "silent" %}}
+{{% set prm_regex_conf = "^[\s]*silent" %}}
+{{% set prm_regex_pamd = "^[\s]*auth[\s]+.+[\s]+pam_faillock.so[\s]+[^\n]*silent" %}}
+{{% set description = "Prevent System Messages When Three Unsuccessful Logon Attempts Occur" %}}
+
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="4">
+    {{{ oval_metadata(description) }}}
+    <criteria operator="AND" comment="Check the proper configuration of pam_faillock.so">
+      <criteria operator="AND" comment="Check if pam_faillock.so is properly enabled">
+        <!-- pam_unix.so is a control module present in all realistic scenarios and also used
+             as reference for the correct position of pam_faillock.so in auth section. If the
+             system is properly configured, it must appear only once in auth section. -->
+        <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_unix_auth"
+            comment="pam_unix.so appears only once in auth section of common-auth"/>
+        <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_auth"
+            comment="pam_faillock.so is properly defined in auth section of common-auth"/>
+        <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_account"
+            comment="pam_faillock.so is properly defined in common-account"/>
+      </criteria>
+
+      <!-- pam_faillock.so parameters should be defined in /etc/security/faillock.conf whenever
+           possible. But due to backwards compatibility, they are also allowed in pam files
+           directly. In case they are defined in both places, pam files have precedence and this
+           may confuse the assessment. The following tests ensure only one option is used. -->
+      <criteria operator="OR" comment="Check expected value for pam_faillock.so {{{ prm_name }}} parameter">
+        <criteria operator="AND"
+            comment="Check expected pam_faillock.so {{{ prm_name }}} parameter in pam files">
+          <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_pamd_common"
+              comment="Check the {{{ prm_name }}} parameter is present common-auth file"/>
+          <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_no_faillock_conf"
+              comment="Ensure the {{{ prm_name }}} parameter is not present in /etc/security/faillock.conf"/>
+        </criteria>
+        <criteria operator="AND"
+            comment="Check expected pam_faillock.so {{{ prm_name }}} parameter in faillock.conf">
+          <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_no_pamd_common"
+              comment="Check the {{{ prm_name }}} parameter is not present common-auth file"/>
+          <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_faillock_conf"
+              comment="Ensure the {{{ prm_name }}} parameter is present in /etc/security/faillock.conf"/>
+        </criteria>
+      </criteria>
+    </criteria>
+  </definition>
+
+  <!-- The following tests demand complex regex which are necessary more than once.
+       These variables make simpler the usage of regex patterns. -->
+  <constant_variable id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_unix_regex"
+                datatype="string" version="1"
+                comment="regex to identify pam_unix.so in auth section of pam files">
+    <value>^\s*auth.*pam_unix\.so</value>
+  </constant_variable>
+
+  <constant_variable id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_auth_regex"
+                datatype="string" version="1"
+                comment="regex to identify pam_faillock.so entries in auth section of pam files">
+      <value>^\s*auth\s+required\s+pam_faillock\.so.*preauth.*[\s\S]*^\s*auth.*pam_unix\.so[\s\S]*^\s*auth\s+\[default=die\]\s+pam_faillock\.so\s+authfail[\s\S]*^\s*auth\s+sufficient\s+pam_faillock\.so\s+authsucc</value>
+  </constant_variable>
+
+  <constant_variable id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_account_regex"
+                datatype="string" version="1"
+                comment="regex to identify pam_faillock.so entry in account section of pam files">
+    <value>^\s*account\s+required\s+pam_faillock\.so\s*(#.*)?$</value>
+  </constant_variable>
+
+  <constant_variable
+    id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_{{{ prm_name }}}_parameter_regex"
+    datatype="string" version="1"
+    comment="regex to identify pam_faillock.so {{{ prm_name }}} entry in auth section of pam files">
+    <value>{{{ prm_regex_pamd }}}</value>
+  </constant_variable>
+
+  <constant_variable
+              id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_faillock_conf_{{{ prm_name }}}_parameter_regex"
+              datatype="string" version="1"
+              comment="regex to identify {{{ prm_name }}} entry in /etc/security/faillock.conf">
+    <value>{{{ prm_regex_conf }}}</value>
+  </constant_variable>
+
+  <!-- Check occurrences of pam_unix.so in auth section of common-auth file -->
+  <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_unix_auth"
+        comment="No more than one pam_unix.so is expected in auth section of common-auth">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_unix_auth"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object version="1"
+        id="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_unix_auth"
+        comment="Get the second and subsequent occurrences of pam_unix.so in auth section of common-auth">
+    <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
+    <ind:pattern operation="pattern match"
+                 var_ref="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_unix_regex"/>
+    <ind:instance datatype="int" operation="greater than">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- Check common definition of pam_faillock.so in common-auth -->
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists" version="1"
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_auth"
+        comment="One and only one occurrence is expected in auth section of common-auth">
+    <ind:object
+        object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_auth"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object version="1"
+        id="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_auth"
+        comment="Check common definition of pam_faillock.so in auth section of common-auth">
+    <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
+    <ind:pattern operation="pattern match"
+                 var_ref="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_auth_regex"/>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- Check common definition of pam_faillock.so in common-account -->
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists" version="1"
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_account"
+        comment="One and only one occurrence is expected in common-account">
+    <ind:object
+        object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_account"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object version="1"
+        id="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_account"
+        comment="Check common definition of pam_faillock.so in account section of common-account">
+    <ind:filepath>/etc/pam.d/common-account</ind:filepath>
+    <ind:pattern operation="pattern match"
+                 var_ref="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_account_regex"/>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+
+  <!-- Check absence of {{{ prm_name }}} parameter in common-auth -->
+  <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_no_pamd_common"
+        comment="Check the absence of {{{ prm_name }}} parameter in common-auth">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_pamd_common"/>
+  </ind:textfilecontent54_test>
+
+  <!-- Check expected value of {{{ prm_name }}} parameter in common-auth -->
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" version="1"
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_pamd_common"
+        comment="Check the expected {{{ prm_name }}} value in common-auth">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_pamd_common"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object version="1"
+        id="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_pamd_common"
+        comment="Get the pam_faillock.so {{{ prm_name }}} parameter from common-auth file">
+    <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
+    <ind:pattern operation="pattern match"
+                 var_ref="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_{{{ prm_name }}}_parameter_regex"/>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+
+  <!-- Check absence of {{{ prm_name }}} parameter in /etc/security/faillock.conf -->
+  <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_no_faillock_conf"
+        comment="Check the absence of {{{ prm_name }}} parameter in /etc/security/faillock.conf">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_faillock_conf"/>
+  </ind:textfilecontent54_test>
+
+  <!-- Check expected value of {{{ prm_name }}} parameter in /etc/security/faillock.conf -->
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" version="1"
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_faillock_conf"
+        comment="Check the expected {{{ prm_name }}} value in /etc/security/faillock.conf">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_faillock_conf"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object version="1"
+      id="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_faillock_conf"
+      comment="Check the expected pam_faillock.so {{{ prm_name }}} parameter in /etc/security/faillock.conf">
+    <ind:filepath>/etc/security/faillock.conf</ind:filepath>
+    <ind:pattern operation="pattern match"
+          var_ref="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_faillock_conf_{{{ prm_name }}}_parameter_regex"/>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol8,rhel8,rhel9
+prodtype: ol8,rhel8,rhel9,ubuntu2004
 
 title: 'Do Not Show System Messages When Unsuccessful Logon Attempts Occur'
 
@@ -31,6 +31,7 @@ references:
     srg: SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005
     stigid@ol8: OL08-00-020019
     stigid@rhel8: RHEL-08-020018,RHEL-08-020019
+    stigid@ubuntu2004: UBTU-20-010072
 
 ocil_clause: 'the system shows messages when three unsuccessful logon attempts occur'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/common.sh
@@ -1,4 +1,3 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 pam_files=("password-auth" "system-auth")
 
 authselect create-profile testingProfile --base-on minimal

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/common.sh
@@ -1,3 +1,4 @@
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 pam_files=("password-auth" "system-auth")
 
 authselect create-profile testingProfile --base-on minimal

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/expected_pam_files.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/expected_pam_files.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # packages = authselect
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 
 source common.sh
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/missing_parameter.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/missing_parameter.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 # packages = authselect
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 
 source common.sh

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_common.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Create passing pam.d files based on defaults from a clean installation of Ubuntu 20.04 LTS
+
+cat >/etc/pam.d/common-auth <<EOF
+# here are the per-package modules (the "Primary" block)
+    auth required  pam_faillock.so     preauth 
+auth    [success=2 default=ignore]      pam_unix.so nullok
+auth    [success=1 default=ignore]      pam_sss.so use_first_pass
+  #
+ auth [default=die]  pam_faillock.so authfail 
+auth sufficient     pam_faillock.so authsucc 
+  #
+# here's the fallback if no module succeeds
+auth    requisite                       pam_deny.so
+# prime the stack with a positive return value if there isn't one already;
+# this avoids us returning an error just because nothing sets a success code
+# since the modules above will each just jump around
+auth    required                        pam_permit.so
+# and here are more per-package modules (the "Additional" block)
+auth    optional                        pam_cap.so 
+# end of pam-auth-update config
+EOF
+
+
+cat >/etc/pam.d/common-account <<EOF
+# here are the per-package modules (the "Primary" block)
+account [success=1 new_authtok_reqd=done default=ignore]        pam_unix.so 
+# here's the fallback if no module succeeds
+account requisite                       pam_deny.so
+# prime the stack with a positive return value if there isn't one already;
+# this avoids us returning an error just because nothing sets a success code
+# since the modules above will each just jump around
+account required                        pam_permit.so
+# and here are more per-package modules (the "Additional" block)
+account sufficient                      pam_localuser.so 
+account [default=bad success=ok user_unknown=ignore]    pam_sss.so 
+# end of pam-auth-update config
+
+  account required  pam_faillock.so 
+EOF

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_correct.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+source ubuntu_common.sh
+
+echo "silent" > /etc/security/faillock.conf

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_correct_pamd.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_correct_pamd.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+source ubuntu_common.sh
+
+sed -i 's/\(.*pam_faillock.so.*\)/\1 silent/g' /etc/pam.d/common-auth
+

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_empty_faillock_conf.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_empty_faillock_conf.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+# This test should fail because neither pam.d or faillock.conf have silent defined
+
+source ubuntu_common.sh
+
+echo > /etc/security/faillock.conf

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_multiple_pam_unix.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_multiple_pam_unix.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# remediation = none
+
+# Multiple instances of pam_unix.so in auth section may, intentionally or not, interfere
+# in the expected behaviour of pam_faillock.so. Remediation does not solve this automatically
+# in order to preserve intentional changes.
+
+source ubuntu_common.sh
+
+echo "auth        sufficient       pam_unix.so" >> /etc/pam.d/common-auth

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/ubuntu.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/ubuntu.xml
@@ -1,16 +1,26 @@
+{{# Very similar OVAL is used in several rules, differing primarily in faillock.so parameter. #}}
+{{# For transferability, we define the parameter and corresponding regular expressions in jinja. #}}
+{{# The rules should ideally use a single template. #}}
+
+{{% set prm_name = "unlock_time" %}}
+{{% set prm_regex_conf = "^[\s]*unlock_time[\s]*=[\s]*([0-9]+)" %}}
+{{% set prm_regex_pamd = "^[\s]*auth[\s]+.+[\s]+pam_faillock.so[\s]+[^\n]*unlock_time=([0-9]+)" %}}
+{{% set ext_variable = "var_accounts_passwords_pam_faillock_unlock_time" %}}
+{{% set description = "The unlock time after number of failed logins should be set correctly." %}}
+
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="3">
-    {{{ oval_metadata("The unlock time after number of failed logins should be set correctly.") }}}
+    {{{ oval_metadata(description) }}}
     <criteria operator="AND" comment="Check the proper configuration of pam_faillock.so">
       <criteria operator="AND" comment="Check if pam_faillock.so is properly enabled">
         <!-- pam_unix.so is a control module present in all realistic scenarios and also used
              as reference for the correct position of pam_faillock.so in auth section. If the
              system is properly configured, it must appear only once in auth section. -->
-        <criterion test_ref="test_accounts_passwords_pam_faillock_unlock_time_common_pam_unix_auth"
+        <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_unix_auth"
             comment="pam_unix.so appears only once in auth section of common-auth"/>
-        <criterion test_ref="test_accounts_passwords_pam_faillock_unlock_time_common_pam_faillock_auth"
+        <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_auth"
             comment="pam_faillock.so is properly defined in auth section of common-auth"/>
-        <criterion test_ref="test_accounts_passwords_pam_faillock_unlock_time_common_pam_faillock_account"
+        <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_account"
             comment="pam_faillock.so is properly defined in common-account"/>
       </criteria>
 
@@ -18,20 +28,20 @@
            possible. But due to backwards compatibility, they are also allowed in pam files
            directly. In case they are defined in both places, pam files have precedence and this
            may confuse the assessment. The following tests ensure only one option is used. -->
-      <criteria operator="OR" comment="Check expected value for pam_faillock.so unlock_time parameter">
+      <criteria operator="OR" comment="Check expected value for pam_faillock.so {{{ prm_name }}} parameter">
         <criteria operator="AND"
-            comment="Check expected pam_faillock.so unlock_time parameter in pam files">
-          <criterion test_ref="test_accounts_passwords_pam_faillock_unlock_time_parameter_pamd_common"
-              comment="Check the unlock_time parameter is present common-auth file"/>
-          <criterion test_ref="test_accounts_passwords_pam_faillock_unlock_time_parameter_no_faillock_conf"
-              comment="Ensure the unlock_time parameter is not present in /etc/security/faillock.conf"/>
+            comment="Check expected pam_faillock.so {{{ prm_name }}} parameter in pam files">
+          <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_pamd_common"
+              comment="Check the {{{ prm_name }}} parameter is present common-auth file"/>
+          <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_no_faillock_conf"
+              comment="Ensure the {{{ prm_name }}} parameter is not present in /etc/security/faillock.conf"/>
         </criteria>
         <criteria operator="AND"
-            comment="Check expected pam_faillock.so unlock_time parameter in faillock.conf">
-          <criterion test_ref="test_accounts_passwords_pam_faillock_unlock_time_parameter_no_pamd_common"
-              comment="Check the unlock_time parameter is not present common-auth file"/>
-          <criterion test_ref="test_accounts_passwords_pam_faillock_unlock_time_parameter_faillock_conf"
-              comment="Ensure the unlock_time parameter is present in /etc/security/faillock.conf"/>
+            comment="Check expected pam_faillock.so {{{ prm_name }}} parameter in faillock.conf">
+          <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_no_pamd_common"
+              comment="Check the {{{ prm_name }}} parameter is not present common-auth file"/>
+          <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_faillock_conf"
+              comment="Ensure the {{{ prm_name }}} parameter is present in /etc/security/faillock.conf"/>
         </criteria>
       </criteria>
     </criteria>
@@ -39,147 +49,147 @@
 
   <!-- The following tests demand complex regex which are necessary more than once.
        These variables make simpler the usage of regex patterns. -->
-  <constant_variable id="var_accounts_passwords_pam_faillock_unlock_time_pam_unix_regex"
+  <constant_variable id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_unix_regex"
                 datatype="string" version="1"
                 comment="regex to identify pam_unix.so in auth section of pam files">
     <value>^\s*auth.*pam_unix\.so</value>
   </constant_variable>
 
-  <constant_variable id="var_accounts_passwords_pam_faillock_unlock_time_pam_faillock_auth_regex"
+  <constant_variable id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_auth_regex"
                 datatype="string" version="1"
                 comment="regex to identify pam_faillock.so entries in auth section of pam files">
       <value>^\s*auth\s+required\s+pam_faillock\.so.*preauth.*[\s\S]*^\s*auth.*pam_unix\.so[\s\S]*^\s*auth\s+\[default=die\]\s+pam_faillock\.so\s+authfail[\s\S]*^\s*auth\s+sufficient\s+pam_faillock\.so\s+authsucc</value>
   </constant_variable>
 
-  <constant_variable id="var_accounts_passwords_pam_faillock_unlock_time_pam_faillock_account_regex"
+  <constant_variable id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_account_regex"
                 datatype="string" version="1"
                 comment="regex to identify pam_faillock.so entry in account section of pam files">
     <value>^\s*account\s+required\s+pam_faillock\.so\s*(#.*)?$</value>
   </constant_variable>
 
   <constant_variable
-    id="var_accounts_passwords_pam_faillock_unlock_time_pam_faillock_unlock_time_parameter_regex"
+    id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_{{{ prm_name }}}_parameter_regex"
     datatype="string" version="1"
-    comment="regex to identify pam_faillock.so unlock_time entry in auth section of pam files">
-    <value>^[\s]*auth[\s]+.+[\s]+pam_faillock.so[\s]+[^\n]*unlock_time=([0-9]+)</value>
+    comment="regex to identify pam_faillock.so {{{ prm_name }}} entry in auth section of pam files">
+    <value>{{{ prm_regex_pamd }}}</value>
   </constant_variable>
 
   <constant_variable
-              id="var_accounts_passwords_pam_faillock_unlock_time_faillock_conf_unlock_time_parameter_regex"
+              id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_faillock_conf_{{{ prm_name }}}_parameter_regex"
               datatype="string" version="1"
-              comment="regex to identify unlock_time entry in /etc/security/faillock.conf">
-    <value>^[\s]*unlock_time[\s]*=[\s]*([0-9]+)</value>
+              comment="regex to identify {{{ prm_name }}} entry in /etc/security/faillock.conf">
+    <value>{{{ prm_regex_conf }}}</value>
   </constant_variable>
 
   <!-- Check occurrences of pam_unix.so in auth section of common-auth file -->
   <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
-        id="test_accounts_passwords_pam_faillock_unlock_time_common_pam_unix_auth"
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_unix_auth"
         comment="No more than one pam_unix.so is expected in auth section of common-auth">
-    <ind:object object_ref="object_accounts_passwords_pam_faillock_unlock_time_common_pam_unix_auth"/>
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_unix_auth"/>
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object version="1"
-        id="object_accounts_passwords_pam_faillock_unlock_time_common_pam_unix_auth"
+        id="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_unix_auth"
         comment="Get the second and subsequent occurrences of pam_unix.so in auth section of common-auth">
     <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
     <ind:pattern operation="pattern match"
-                 var_ref="var_accounts_passwords_pam_faillock_unlock_time_pam_unix_regex"/>
+                 var_ref="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_unix_regex"/>
     <ind:instance datatype="int" operation="greater than">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <!-- Check common definition of pam_faillock.so in common-auth -->
   <ind:textfilecontent54_test check="all" check_existence="all_exist" version="1"
-        id="test_accounts_passwords_pam_faillock_unlock_time_common_pam_faillock_auth"
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_auth"
         comment="One and only one occurrence is expected in auth section of common-auth">
     <ind:object
-        object_ref="object_accounts_passwords_pam_faillock_unlock_time_common_pam_faillock_auth"/>
+        object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_auth"/>
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object version="1"
-        id="object_accounts_passwords_pam_faillock_unlock_time_common_pam_faillock_auth"
+        id="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_auth"
         comment="Check common definition of pam_faillock.so in auth section of common-auth">
     <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
     <ind:pattern operation="pattern match"
-                 var_ref="var_accounts_passwords_pam_faillock_unlock_time_pam_faillock_auth_regex"/>
+                 var_ref="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_auth_regex"/>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <!-- Check account definition of pam_faillock.so in common-account -->
   <ind:textfilecontent54_test check="all" check_existence="all_exist" version="1"
-        id="test_accounts_passwords_pam_faillock_unlock_time_common_pam_faillock_account"
-        comment="One and only one occurrence is expected in auth section of common-account">
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_account"
+        comment="One and only one occurrence is expected in common-account">
     <ind:object
-        object_ref="object_accounts_passwords_pam_faillock_unlock_time_common_pam_faillock_account"/>
+        object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_account"/>
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object version="1"
-        id="object_accounts_passwords_pam_faillock_unlock_time_common_pam_faillock_account"
+        id="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_account"
         comment="Check common definition of pam_faillock.so in account section of common-account">
     <ind:filepath>/etc/pam.d/common-account</ind:filepath>
     <ind:pattern operation="pattern match"
-                 var_ref="var_accounts_passwords_pam_faillock_unlock_time_pam_faillock_account_regex"/>
+                 var_ref="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_account_regex"/>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 
 
   <!-- boundaries to test the parameter value -->
   <!-- Specify the required external variable & create corresponding state from it -->
-  <external_variable id="var_accounts_passwords_pam_faillock_unlock_time" datatype="int"
+  <external_variable id="{{{ ext_variable }}}" datatype="int"
                      comment="number of failed login attempts allowed" version="1"/>
 
   <ind:textfilecontent54_state version="1"
-        id="state_accounts_passwords_pam_faillock_unlock_time_parameter_lower_bound">
+        id="state_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_lower_bound">
     <ind:subexpression datatype="int" operation="greater than or equal"
-                       var_ref="var_accounts_passwords_pam_faillock_unlock_time"/>
+          var_ref="{{{ ext_variable }}}"/>
   </ind:textfilecontent54_state>
 
 
-  <!-- Check absence of unlock_time parameter in common-auth -->
+  <!-- Check absence of {{{ prm_name }}} parameter in common-auth -->
   <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
-        id="test_accounts_passwords_pam_faillock_unlock_time_parameter_no_pamd_common"
-        comment="Check the absence of unlock_time parameter in common-auth">
-    <ind:object object_ref="object_accounts_passwords_pam_faillock_unlock_time_parameter_pamd_common"/>
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_no_pamd_common"
+        comment="Check the absence of {{{ prm_name }}} parameter in common-auth">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_pamd_common"/>
   </ind:textfilecontent54_test>
 
-  <!-- Check expected value of unlock_time parameter in common-auth -->
+  <!-- Check expected value of {{{ prm_name }}} parameter in common-auth -->
   <ind:textfilecontent54_test check="all" check_existence="all_exist" version="1"
-        id="test_accounts_passwords_pam_faillock_unlock_time_parameter_pamd_common"
-        comment="Check the expected unlock_time value in common-auth">
-    <ind:object object_ref="object_accounts_passwords_pam_faillock_unlock_time_parameter_pamd_common"/>
-    <ind:state state_ref="state_accounts_passwords_pam_faillock_unlock_time_parameter_lower_bound"/>
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_pamd_common"
+        comment="Check the expected {{{ prm_name }}} value in common-auth">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_pamd_common"/>
+    <ind:state state_ref="state_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_lower_bound"/>
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object version="1"
-        id="object_accounts_passwords_pam_faillock_unlock_time_parameter_pamd_common"
-        comment="Get the pam_faillock.so unlock_time parameter from common-auth file">
+        id="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_pamd_common"
+        comment="Get the pam_faillock.so {{{ prm_name }}} parameter from common-auth file">
     <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
     <ind:pattern operation="pattern match"
-                 var_ref="var_accounts_passwords_pam_faillock_unlock_time_pam_faillock_unlock_time_parameter_regex"/>
+                 var_ref="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_{{{ prm_name }}}_parameter_regex"/>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 
 
-  <!-- Check absence of unlock_time parameter in /etc/security/faillock.conf -->
+  <!-- Check absence of {{{ prm_name }}} parameter in /etc/security/faillock.conf -->
   <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
-        id="test_accounts_passwords_pam_faillock_unlock_time_parameter_no_faillock_conf"
-        comment="Check the absence of unlock_time parameter in in /etc/security/faillock.conf">
-    <ind:object object_ref="object_accounts_passwords_pam_faillock_unlock_time_parameter_faillock_conf"/>
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_no_faillock_conf"
+        comment="Check the absence of {{{ prm_name }}} parameter in /etc/security/faillock.conf">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_faillock_conf"/>
   </ind:textfilecontent54_test>
 
-  <!-- Check expected value of unlock_time parameter in /etc/security/faillock.conf -->
+  <!-- Check expected value of {{{ prm_name }}} parameter in /etc/security/faillock.conf -->
   <ind:textfilecontent54_test check="all" check_existence="all_exist" version="1"
-        id="test_accounts_passwords_pam_faillock_unlock_time_parameter_faillock_conf"
-        comment="Check the expected unlock_time value in in /etc/security/faillock.conf">
-    <ind:object object_ref="object_accounts_passwords_pam_faillock_unlock_time_parameter_faillock_conf"/>
-    <ind:state state_ref="state_accounts_passwords_pam_faillock_unlock_time_parameter_lower_bound"/>
+        id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_faillock_conf"
+        comment="Check the expected {{{ prm_name }}} value in /etc/security/faillock.conf">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_faillock_conf"/>
+    <ind:state state_ref="state_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_lower_bound"/>
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object version="1"
-      id="object_accounts_passwords_pam_faillock_unlock_time_parameter_faillock_conf"
-      comment="Check the expected pam_faillock.so unlock_time parameter in /etc/security/faillock.conf">
+      id="object_accounts_passwords_pam_faillock_{{{ prm_name }}}_parameter_faillock_conf"
+      comment="Check the expected pam_faillock.so {{{ prm_name }}} parameter in /etc/security/faillock.conf">
     <ind:filepath>/etc/security/faillock.conf</ind:filepath>
     <ind:pattern operation="pattern match"
-          var_ref="var_accounts_passwords_pam_faillock_unlock_time_faillock_conf_unlock_time_parameter_regex"/>
+          var_ref="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_faillock_conf_{{{ prm_name }}}_parameter_regex"/>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/ubuntu.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/ubuntu.xml
@@ -13,12 +13,26 @@
         <criterion test_ref="test_accounts_passwords_pam_faillock_unlock_time_common_pam_faillock_account"
             comment="pam_faillock.so is properly defined in common-account"/>
       </criteria>
-      <criteria operator="OR"
-                comment="Check expected value for pam_faillock.so unlock_time parameter">
-        <criterion test_ref="test_accounts_passwords_pam_faillock_unlock_time_parameter_no_pamd_common"
-            comment="Check the unlock_time parameter is not present common-auth file"/>
-        <criterion test_ref="test_accounts_passwords_pam_faillock_unlock_time_parameter_faillock_conf"
-            comment="Ensure the unlock_time parameter is present in /etc/security/faillock.conf"/>
+
+      <!-- pam_faillock.so parameters should be defined in /etc/security/faillock.conf whenever
+           possible. But due to backwards compatibility, they are also allowed in pam files
+           directly. In case they are defined in both places, pam files have precedence and this
+           may confuse the assessment. The following tests ensure only one option is used. -->
+      <criteria operator="OR" comment="Check expected value for pam_faillock.so unlock_time parameter">
+        <criteria operator="AND"
+            comment="Check expected pam_faillock.so unlock_time parameter in pam files">
+          <criterion test_ref="test_accounts_passwords_pam_faillock_unlock_time_parameter_pamd_common"
+              comment="Check the unlock_time parameter is present common-auth file"/>
+          <criterion test_ref="test_accounts_passwords_pam_faillock_unlock_time_parameter_no_faillock_conf"
+              comment="Ensure the unlock_time parameter is not present in /etc/security/faillock.conf"/>
+        </criteria>
+        <criteria operator="AND"
+            comment="Check expected pam_faillock.so unlock_time parameter in faillock.conf">
+          <criterion test_ref="test_accounts_passwords_pam_faillock_unlock_time_parameter_no_pamd_common"
+              comment="Check the unlock_time parameter is not present common-auth file"/>
+          <criterion test_ref="test_accounts_passwords_pam_faillock_unlock_time_parameter_faillock_conf"
+              comment="Ensure the unlock_time parameter is present in /etc/security/faillock.conf"/>
+        </criteria>
       </criteria>
     </criteria>
   </definition>
@@ -107,6 +121,7 @@
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 
+
   <!-- boundaries to test the parameter value -->
   <!-- Specify the required external variable & create corresponding state from it -->
   <external_variable id="var_accounts_passwords_pam_faillock_unlock_time" datatype="int"
@@ -118,11 +133,20 @@
                        var_ref="var_accounts_passwords_pam_faillock_unlock_time"/>
   </ind:textfilecontent54_state>
 
-  <!-- Check the pam_faillock.so no unlock_time parameter in common-auth -->
+
+  <!-- Check absence of unlock_time parameter in common-auth -->
   <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
         id="test_accounts_passwords_pam_faillock_unlock_time_parameter_no_pamd_common"
         comment="Check the absence of unlock_time parameter in common-auth">
     <ind:object object_ref="object_accounts_passwords_pam_faillock_unlock_time_parameter_pamd_common"/>
+  </ind:textfilecontent54_test>
+
+  <!-- Check expected value of unlock_time parameter in common-auth -->
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" version="1"
+        id="test_accounts_passwords_pam_faillock_unlock_time_parameter_pamd_common"
+        comment="Check the expected unlock_time value in common-auth">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_unlock_time_parameter_pamd_common"/>
+    <ind:state state_ref="state_accounts_passwords_pam_faillock_unlock_time_parameter_lower_bound"/>
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object version="1"
@@ -134,7 +158,15 @@
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <!-- Check pam_faillock.so unlock_time parameter in /etc/security/faillock.conf -->
+
+  <!-- Check absence of unlock_time parameter in /etc/security/faillock.conf -->
+  <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
+        id="test_accounts_passwords_pam_faillock_unlock_time_parameter_no_faillock_conf"
+        comment="Check the absence of unlock_time parameter in in /etc/security/faillock.conf">
+    <ind:object object_ref="object_accounts_passwords_pam_faillock_unlock_time_parameter_faillock_conf"/>
+  </ind:textfilecontent54_test>
+
+  <!-- Check expected value of unlock_time parameter in /etc/security/faillock.conf -->
   <ind:textfilecontent54_test check="all" check_existence="all_exist" version="1"
         id="test_accounts_passwords_pam_faillock_unlock_time_parameter_faillock_conf"
         comment="Check the expected unlock_time value in in /etc/security/faillock.conf">

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/ubuntu.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/oval/ubuntu.xml
@@ -9,7 +9,7 @@
 {{% set description = "The unlock time after number of failed logins should be set correctly." %}}
 
 <def-group>
-  <definition class="compliance" id="{{{ rule_id }}}" version="3">
+  <definition class="compliance" id="{{{ rule_id }}}" version="4">
     {{{ oval_metadata(description) }}}
     <criteria operator="AND" comment="Check the proper configuration of pam_faillock.so">
       <criteria operator="AND" comment="Check if pam_faillock.so is properly enabled">
@@ -98,7 +98,7 @@
   </ind:textfilecontent54_object>
 
   <!-- Check common definition of pam_faillock.so in common-auth -->
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" version="1"
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists" version="1"
         id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_auth"
         comment="One and only one occurrence is expected in auth section of common-auth">
     <ind:object
@@ -115,7 +115,7 @@
   </ind:textfilecontent54_object>
 
   <!-- Check account definition of pam_faillock.so in common-account -->
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" version="1"
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists" version="1"
         id="test_accounts_passwords_pam_faillock_{{{ prm_name }}}_common_pam_faillock_account"
         comment="One and only one occurrence is expected in common-account">
     <ind:object

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,ubuntu2204
+prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,ubuntu2004,ubuntu2204
 
 title: 'Set Lockout Time for Failed Password Attempts'
 
@@ -68,6 +68,7 @@ references:
     stigid@rhel7: RHEL-07-010320
     stigid@rhel8: RHEL-08-020014,RHEL-08-020015
     stigid@rhel9: RHEL-09-411090
+    stigid@ubuntu2004: UBTU-20-010072
 
 platform: package[pam]
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/pam_faillock_disabled.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/pam_faillock_disabled.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_fedora,multi_platform_rhel,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 {{%- if product in ["rhel7"] %}}
 # packages = authconfig
 {{%- else %}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/pam_faillock_not_required_pam_files.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/pam_faillock_not_required_pam_files.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_fedora,multi_platform_rhel,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 {{%- if product in ["rhel7"] %}}
 # packages = authconfig
 {{%- else %}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/ubuntu_common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/ubuntu_common.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Create passing pam.d files based on defaults from a clean installation of Ubuntu 20.04 LTS
+
+cat >/etc/pam.d/common-auth <<EOF
+# here are the per-package modules (the "Primary" block)
+    auth required  pam_faillock.so     preauth 
+auth    [success=2 default=ignore]      pam_unix.so nullok
+auth    [success=1 default=ignore]      pam_sss.so use_first_pass
+  #
+ auth [default=die]  pam_faillock.so authfail 
+auth sufficient     pam_faillock.so authsucc 
+  #
+# here's the fallback if no module succeeds
+auth    requisite                       pam_deny.so
+# prime the stack with a positive return value if there isn't one already;
+# this avoids us returning an error just because nothing sets a success code
+# since the modules above will each just jump around
+auth    required                        pam_permit.so
+# and here are more per-package modules (the "Additional" block)
+auth    optional                        pam_cap.so 
+# end of pam-auth-update config
+EOF
+
+
+cat >/etc/pam.d/common-account <<EOF
+# here are the per-package modules (the "Primary" block)
+account [success=1 new_authtok_reqd=done default=ignore]        pam_unix.so 
+# here's the fallback if no module succeeds
+account requisite                       pam_deny.so
+# prime the stack with a positive return value if there isn't one already;
+# this avoids us returning an error just because nothing sets a success code
+# since the modules above will each just jump around
+account required                        pam_permit.so
+# and here are more per-package modules (the "Additional" block)
+account sufficient                      pam_localuser.so 
+account [default=bad success=ok user_unknown=ignore]    pam_sss.so 
+# end of pam-auth-update config
+
+  account required  pam_faillock.so 
+EOF

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/ubuntu_correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/ubuntu_correct.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+source ubuntu_common.sh
+
+echo "unlock_time=1000" > /etc/security/faillock.conf

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/ubuntu_correct_pamd.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/ubuntu_correct_pamd.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+source ubuntu_common.sh
+
+sed -i 's/\(.*pam_faillock.so.*\)/\1 unlock_time=1000/g' /etc/pam.d/common-auth
+

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/ubuntu_empty_faillock_conf.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/ubuntu_empty_faillock_conf.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+# This test should fail because neither pam.d or faillock.conf have unlock_time defined
+
+source ubuntu_common.sh
+
+echo > /etc/security/faillock.conf

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/ubuntu_multiple_pam_unix.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/ubuntu_multiple_pam_unix.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# remediation = none
+
+# Multiple instances of pam_unix.so in auth section may, intentionally or not, interfere
+# in the expected behaviour of pam_faillock.so. Remediation does not solve this automatically
+# in order to preserve intentional changes.
+
+source ubuntu_common.sh
+
+echo "auth        sufficient       pam_unix.so" >> /etc/pam.d/common-auth

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -153,7 +153,14 @@ selections:
     - accounts_password_pam_unix_remember
 
     # UBTU-20-010072 The Ubuntu operating system must automatically lock an account until the locked account is released by an administrator when three unsuccessful logon attempts have been made.
-    - accounts_passwords_pam_tally2
+    - var_accounts_passwords_pam_faillock_deny=3
+    - var_accounts_passwords_pam_faillock_fail_interval=900
+    - var_accounts_passwords_pam_faillock_unlock_time=never
+    - accounts_passwords_pam_faillock_audit
+    - accounts_passwords_pam_faillock_silent
+    - accounts_passwords_pam_faillock_deny
+    - accounts_passwords_pam_faillock_interval
+    - accounts_passwords_pam_faillock_unlock_time
 
     # UBTU-20-010074 The Ubuntu operating system must be configured so that the script which runs each 30 days or less to check file integrity is the default one.
     - aide_periodic_cron_checking


### PR DESCRIPTION
#### Description:

1) Rewrite of PR #11074
2) Add missing platform stanzas to existing tests and add Ubuntu-specific tests 
3) Fix logic in Ubuntu OVALs in `accounts_passwords_pam_faillock_...` 
4) Refactor Ubuntu OVALs in `accounts_passwords_pam_faillock_...` to use jinja parameters for parameter name, regex, etc.
5) Update Ubuntu STIG-20-010072 to use `pam_faillock` instead of `pam_tally2`

#### Rationale:

1) Rewritten primarily to keep Ubuntu OVALs separate from shared OVALs for sake of readability 
2) Existing tests are not applicable to Ubuntu thus need to be restricted to other platforms
3) The OVAL check passed when the parameter was not defined in either pam.d or faillock.conf
4) This makes the OVAL easily reusable across different rules. TODO: switch to template.
5) Part of STIG update v1r1 -> v1r9