### PR TITLE
OCPBUGS-24594: audit_rule_login_events - handle `path_is_variable` in Kubernetes remediation

### DIFF
--- a/controls/nist_rhcos4.yml
+++ b/controls/nist_rhcos4.yml
@@ -1022,6 +1022,7 @@ controls:
   - audit_rules_login_events_tallylog
   - audit_rules_privileged_commands_umount
   - audit_rules_login_events_faillock
+  - var_accounts_passwords_pam_faillock_dir=run
   - audit_rules_privileged_commands_crontab
   - audit_rules_execution_setsebool
   - audit_rules_etc_group_open_by_handle_at
@@ -2553,6 +2554,7 @@ controls:
   - audit_rules_execution_semanage
   - audit_rules_unsuccessful_file_modification_chmod
   - audit_rules_login_events_faillock
+  - var_accounts_passwords_pam_faillock_dir=run
   - audit_rules_unsuccessful_file_modification_open
   - audit_rules_unsuccessful_file_modification_open_by_handle_at_o_creat
   - audit_rules_privileged_commands_chage
@@ -3541,6 +3543,7 @@ controls:
   - audit_rules_execution_semanage
   - audit_rules_unsuccessful_file_modification_chmod
   - audit_rules_login_events_faillock
+  - var_accounts_passwords_pam_faillock_dir=run
   - audit_rules_unsuccessful_file_modification_open
   - audit_rules_unsuccessful_file_modification_open_by_handle_at_o_creat
   - audit_rules_privileged_commands_chage
@@ -5077,6 +5080,7 @@ controls:
   - sysctl_net_ipv4_conf_default_rp_filter
   - audit_rules_unsuccessful_file_modification_chmod
   - audit_rules_login_events_faillock
+  - var_accounts_passwords_pam_faillock_dir=run
   - audit_rules_unsuccessful_file_modification_open
   - audit_rules_unsuccessful_file_modification_open_by_handle_at_o_creat
   - audit_rules_privileged_commands_chage

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/ocp4/e2e.yaml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/ocp4/e2e.yaml
@@ -1,0 +1,2 @@
+default_result: FAIL
+result_after_remediation: PASS

--- a/products/rhcos4/profiles/e8.profile
+++ b/products/rhcos4/profiles/e8.profile
@@ -51,6 +51,7 @@ selections:
   - auditd_name_format
   - audit_rules_login_events_tallylog
   - audit_rules_login_events_faillock
+  - var_accounts_passwords_pam_faillock_dir=run
   - audit_rules_login_events_lastlog
   - audit_rules_login_events
   - audit_rules_time_adjtimex

--- a/products/rhcos4/profiles/stig-v1r1.profile
+++ b/products/rhcos4/profiles/stig-v1r1.profile
@@ -21,6 +21,7 @@ selections:
   - var_sshd_set_keepalive=0
   - var_selinux_policy_name=targeted
   - var_selinux_state=enforcing
+  - var_accounts_passwords_pam_faillock_dir=run
   # Let's mark the vsyscall argument as info - the check and the fix is there, but setting this
   # karg is not suitable for people who still run legacy 32bit apps.
   - coreos_vsyscall_kernel_argument.role=unscored

--- a/shared/templates/audit_rules_login_events/kubernetes.template
+++ b/shared/templates/audit_rules_login_events/kubernetes.template
@@ -12,7 +12,11 @@ spec:
     storage:
       files:
       - contents:
+{{% if PATH_IS_VARIABLE %}}
+          source: data:,-w%20{{ {{{ url_encode("{{.var_accounts_passwords_pam_faillock_dir}}") }}} }}%20-p%20wa%20-k%20logins%0A
+{{% else %}}
           source: data:,-w%20{{{ PATH }}}%20-p%20wa%20-k%20logins%0A
+{{% endif %}}
         mode: 0644
         path: /etc/audit/rules.d/75-{{{ NAME }}}_login_events.rules
         overwrite: true

--- a/shared/templates/audit_rules_login_events/kubernetes.template
+++ b/shared/templates/audit_rules_login_events/kubernetes.template
@@ -18,5 +18,5 @@ spec:
           source: data:,-w%20{{{ PATH }}}%20-p%20wa%20-k%20logins%0A
 {{% endif %}}
         mode: 0644
-        path: /etc/audit/rules.d/75-{{{ NAME }}}_login_events.rules
+        path: /etc/audit/rules.d/75-{{{ rule_id }}}.rules
         overwrite: true


### PR DESCRIPTION


#### Description:

- Update audit_rules_login_events kubernetes template to handle new parameter 'path_is_variable'.
  When the path is a variable, CO needs to fetch the variables value and render the MachineConfig.

#### Rationale:

- The Kubernetes remediation is outputting the variable name instead of the variable value.


#### Review Hints:

- Scan and auto remediate with `stig` or `e8` profile and check result of the rule, for example:
```
oc get ccr | grep faillock
upstream-rhcos4-stig-master-audit-rules-login-events-faillock                              PASS     medium
upstream-rhcos4-stig-worker-audit-rules-login-events-faillock                              PASS     medium
```
