### PR TITLE
Make some improvements to bash remediation template

### DIFF
--- a/shared/templates/systemd_dropin_configuration/bash.template
+++ b/shared/templates/systemd_dropin_configuration/bash.template
@@ -20,6 +20,7 @@ function remove_{{{ COMPONENT }}}_{{{ PARAM }}}_configuration {
 
 function {{{ COMPONENT }}}_{{{ PARAM }}}_add_configuration {
     local COMPONENT_PARAM_REMEDY_CFG
+    mkdir -p "{{{ DROPIN_DIR }}}"
     COMPONENT_PARAM_REMEDY_CFG="{{{ DROPIN_DIR }}}/oscap-remedy.conf"
 
     cp "${COMPONENT_PARAM_REMEDY_CFG}" "${COMPONENT_PARAM_REMEDY_CFG}.bak"
@@ -28,10 +29,10 @@ function {{{ COMPONENT }}}_{{{ PARAM }}}_add_configuration {
     if [ -z "$line_number" ]; then
        # There was no match of '^#\s*{{{ PARAM }}}', insert at
        # the end of the file.
-       printf '%s\n' "{{{ PARAM }}}='{{{ VALUE }}}'" >> "${COMPONENT_PARAM_REMEDY_CFG}"
+       printf '%s\n' "{{{ PARAM }}}={{{ VALUE }}}" >> "${COMPONENT_PARAM_REMEDY_CFG}"
     else
         head -n "$(( line_number - 1 ))" "${COMPONENT_PARAM_REMEDY_CFG}.bak" > "${COMPONENT_PARAM_REMEDY_CFG}"
-        printf '%s\n' "{{{ PARAM }}}='{{{ VALUE }}}'" >> "{{{ MASTER_CFG_FILE }}}"
+        printf '%s\n' "{{{ PARAM }}}={{{ VALUE }}}" >> "{{{ MASTER_CFG_FILE }}}"
         tail -n "+$(( line_number ))" "${COMPONENT_PARAM_REMEDY_CFG}.bak" >> "${COMPONENT_PARAM_REMEDY_CFG}"
     fi
     # Clean up after ourselves.


### PR DESCRIPTION


#### Description:

- _Description here. Replace this text. Don't use the italics format!_

#### Rationale:

- Create drop in dir configuration for the file
- Drop quotes for values set in the drop in configuration

- Fixes issue  with creating drop-in directory for configuration file
