### PR TITLE
Turn off remedations for `/dev/shm`

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nodev/rule.yml
@@ -66,6 +66,7 @@ template:
         type@sle12: ''
     backends:
         anaconda: 'off'
+        blueprint: 'off'
 
 
 fixtext: |-

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/rule.yml
@@ -73,3 +73,4 @@ template:
         type@sle12: ''
     backends:
         anaconda: 'off'
+        blueprint: 'off'

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nosuid/rule.yml
@@ -66,6 +66,7 @@ template:
         type@sle12: ''
     backends:
         anaconda: 'off'
+        blueprint: 'off'
 
 fixtext: |-
     {{{ fixtext_mount_option("/dev/shm", "nosuid") }}}

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_dev_shm/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_dev_shm/rule.yml
@@ -3,19 +3,19 @@ documentation_complete: true
 title: 'Ensure /dev/shm is configured'
 
 description: |-
-    The <tt>/dev/shm</tt> is a traditional shared memory concept. 
-    One program will create a memory portion, which other processes 
-    (if permitted) can access. If <tt>/dev/shm</tt> is not configured, 
+    The <tt>/dev/shm</tt> is a traditional shared memory concept.
+    One program will create a memory portion, which other processes
+    (if permitted) can access. If <tt>/dev/shm</tt> is not configured,
     tmpfs will be mounted to /dev/shm by systemd.
 
 rationale: |-
-    Any user can upload and execute files inside the <tt>/dev/shm</tt> similar to 
-    the <tt>/tmp</tt> partition. Configuring <tt>/dev/shm</tt> allows an administrator 
-    to set the noexec option on the mount, making /dev/shm useless for an attacker to 
-    install executable code. It would also prevent an attacker from establishing a 
-    hardlink to a system setuid program and wait for it to be updated. Once the program 
-    was updated, the hardlink would be broken and the attacker would have his own copy 
-    of the program. If the program happened to have a security vulnerability, the attacker 
+    Any user can upload and execute files inside the <tt>/dev/shm</tt> similar to
+    the <tt>/tmp</tt> partition. Configuring <tt>/dev/shm</tt> allows an administrator
+    to set the noexec option on the mount, making /dev/shm useless for an attacker to
+    install executable code. It would also prevent an attacker from establishing a
+    hardlink to a system setuid program and wait for it to be updated. Once the program
+    was updated, the hardlink would be broken and the attacker would have his own copy
+    of the program. If the program happened to have a security vulnerability, the attacker
     could continue to exploit the known flaw.
 
 severity: low
@@ -39,8 +39,15 @@ fixtext: '{{{ fixtext_separate_partition(part="/dev/shm") }}}'
 
 platform: machine
 
+warnings:
+- general: |-
+    This rule does not have a remedation.
+    It is expected that this will be managed by systemd and will be a tmpfs partition.
+
 template:
     name: mount
     vars:
         mountpoint: /dev/shm
-        min_size: 2147483648
+    backends:
+        blueprint: 'off'
+        anaconda: 'off'


### PR DESCRIPTION
#### Description:

* Disable anaconda and blueprint on `mount_option_dev_shm_noexec`
* Disable blueprint (anaconda is already disabled) on `mount_option_dev_shm_*`

#### Rationale:
Fixes #11344 
Fixes [RHEL-16801](https://issues.redhat.com/browse/RHEL-16801) and [RHEL-17386](https://issues.redhat.com/browse/RHEL-17386)

It should be fine since default this will be tmpfs partition managed by systemd. 

