### PR TITLE
Fix ANSSI URL in control file and update RHEL profiles

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -2,7 +2,7 @@ policy: 'ANSSI-BP-028'
 title: 'Configuration Recommendations of a GNU/Linux System'
 id: anssi
 version: '2.0'
-source: https://www.ssi.gouv.fr/uploads/2019/02/linux_configuration-en-v2.pdf
+source: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
 levels:
   - id: minimal
   - id: intermediary

--- a/products/rhel7/profiles/anssi_nt28_enhanced.profile
+++ b/products/rhel7/profiles/anssi_nt28_enhanced.profile
@@ -1,5 +1,9 @@
 documentation_complete: true
 
+metadata:
+    SMEs:
+        - marcusburghardt
+
 title: 'ANSSI-BP-028 (enhanced)'
 
 description: |-
@@ -10,6 +14,9 @@ description: |-
 
     A copy of the ANSSI-BP-028 can be found at the ANSSI website:
     https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
+
+    An English version of the ANSSI-BP-028 can also be found at the ANSSI website:
+    https://cyber.gouv.fr/publications/configuration-recommendations-gnulinux-system
 
 selections:
     - anssi:all:enhanced

--- a/products/rhel7/profiles/anssi_nt28_high.profile
+++ b/products/rhel7/profiles/anssi_nt28_high.profile
@@ -1,5 +1,9 @@
 documentation_complete: true
 
+metadata:
+    SMEs:
+        - marcusburghardt
+
 title: 'ANSSI-BP-028 (high)'
 
 description: |-
@@ -10,6 +14,9 @@ description: |-
 
     A copy of the ANSSI-BP-028 can be found at the ANSSI website:
     https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
+
+    An English version of the ANSSI-BP-028 can also be found at the ANSSI website:
+    https://cyber.gouv.fr/publications/configuration-recommendations-gnulinux-system
 
 selections:
     - anssi:all:high

--- a/products/rhel7/profiles/anssi_nt28_intermediary.profile
+++ b/products/rhel7/profiles/anssi_nt28_intermediary.profile
@@ -1,5 +1,8 @@
-# Don't forget to enable build of tables in rhel7CMakeLists.txt when setting to true
 documentation_complete: true
+
+metadata:
+    SMEs:
+        - marcusburghardt
 
 title: 'ANSSI-BP-028 (intermediary)'
 
@@ -11,6 +14,9 @@ description: |-
 
     A copy of the ANSSI-BP-028 can be found at the ANSSI website:
     https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
+
+    An English version of the ANSSI-BP-028 can also be found at the ANSSI website:
+    https://cyber.gouv.fr/publications/configuration-recommendations-gnulinux-system
 
 selections:
     - anssi:all:intermediary

--- a/products/rhel7/profiles/anssi_nt28_minimal.profile
+++ b/products/rhel7/profiles/anssi_nt28_minimal.profile
@@ -1,5 +1,9 @@
 documentation_complete: true
 
+metadata:
+    SMEs:
+        - marcusburghardt
+
 title: 'ANSSI-BP-028 (minimal)'
 
 description: |-
@@ -10,6 +14,9 @@ description: |-
 
     A copy of the ANSSI-BP-028 can be found at the ANSSI website:
     https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
+
+    An English version of the ANSSI-BP-028 can also be found at the ANSSI website:
+    https://cyber.gouv.fr/publications/configuration-recommendations-gnulinux-system
 
 selections:
     - anssi:all:minimal

--- a/products/rhel8/profiles/anssi_bp28_enhanced.profile
+++ b/products/rhel8/profiles/anssi_bp28_enhanced.profile
@@ -2,6 +2,7 @@ documentation_complete: true
 
 metadata:
     SMEs:
+        - marcusburghardt
         - yuumasato
 
 title: 'ANSSI-BP-028 (enhanced)'
@@ -14,6 +15,9 @@ description: |-
 
     A copy of the ANSSI-BP-028 can be found at the ANSSI website:
     https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
+
+    An English version of the ANSSI-BP-028 can also be found at the ANSSI website:
+    https://cyber.gouv.fr/publications/configuration-recommendations-gnulinux-system
 
 selections:
     - anssi:all:enhanced

--- a/products/rhel8/profiles/anssi_bp28_high.profile
+++ b/products/rhel8/profiles/anssi_bp28_high.profile
@@ -2,6 +2,7 @@ documentation_complete: true
 
 metadata:
     SMEs:
+        - marcusburghardt
         - yuumasato
 
 title: 'ANSSI-BP-028 (high)'
@@ -14,6 +15,9 @@ description: |-
 
     A copy of the ANSSI-BP-028 can be found at the ANSSI website:
     https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
+
+    An English version of the ANSSI-BP-028 can also be found at the ANSSI website:
+    https://cyber.gouv.fr/publications/configuration-recommendations-gnulinux-system
 
 selections:
     - anssi:all:high

--- a/products/rhel8/profiles/anssi_bp28_intermediary.profile
+++ b/products/rhel8/profiles/anssi_bp28_intermediary.profile
@@ -2,6 +2,7 @@ documentation_complete: true
 
 metadata:
     SMEs:
+        - marcusburghardt
         - yuumasato
 
 title: 'ANSSI-BP-028 (intermediary)'
@@ -14,6 +15,9 @@ description: |-
 
     A copy of the ANSSI-BP-028 can be found at the ANSSI website:
     https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
+
+    An English version of the ANSSI-BP-028 can also be found at the ANSSI website:
+    https://cyber.gouv.fr/publications/configuration-recommendations-gnulinux-system
 
 selections:
   - anssi:all:intermediary

--- a/products/rhel8/profiles/anssi_bp28_minimal.profile
+++ b/products/rhel8/profiles/anssi_bp28_minimal.profile
@@ -2,6 +2,7 @@ documentation_complete: true
 
 metadata:
     SMEs:
+        - marcusburghardt
         - yuumasato
 
 title: 'ANSSI-BP-028 (minimal)'
@@ -15,6 +16,8 @@ description: |-
     A copy of the ANSSI-BP-028 can be found at the ANSSI website:
     https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
 
+    An English version of the ANSSI-BP-028 can also be found at the ANSSI website:
+    https://cyber.gouv.fr/publications/configuration-recommendations-gnulinux-system
+
 selections:
   - anssi:all:minimal
-

--- a/products/rhel9/profiles/anssi_bp28_enhanced.profile
+++ b/products/rhel9/profiles/anssi_bp28_enhanced.profile
@@ -2,6 +2,7 @@ documentation_complete: true
 
 metadata:
     SMEs:
+        - marcusburghardt
         - yuumasato
 
 title: 'ANSSI-BP-028 (enhanced)'
@@ -14,6 +15,9 @@ description: |-
 
     A copy of the ANSSI-BP-028 can be found at the ANSSI website:
     https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
+
+    An English version of the ANSSI-BP-028 can also be found at the ANSSI website:
+    https://cyber.gouv.fr/publications/configuration-recommendations-gnulinux-system
 
 selections:
     - anssi:all:enhanced

--- a/products/rhel9/profiles/anssi_bp28_high.profile
+++ b/products/rhel9/profiles/anssi_bp28_high.profile
@@ -2,6 +2,7 @@ documentation_complete: true
 
 metadata:
     SMEs:
+        - marcusburghardt
         - yuumasato
 
 title: 'ANSSI-BP-028 (high)'
@@ -14,6 +15,9 @@ description: |-
 
     A copy of the ANSSI-BP-028 can be found at the ANSSI website:
     https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
+
+    An English version of the ANSSI-BP-028 can also be found at the ANSSI website:
+    https://cyber.gouv.fr/publications/configuration-recommendations-gnulinux-system
 
 selections:
     - anssi:all:high

--- a/products/rhel9/profiles/anssi_bp28_intermediary.profile
+++ b/products/rhel9/profiles/anssi_bp28_intermediary.profile
@@ -2,6 +2,7 @@ documentation_complete: true
 
 metadata:
     SMEs:
+        - marcusburghardt
         - yuumasato
 
 title: 'ANSSI-BP-028 (intermediary)'
@@ -14,6 +15,9 @@ description: |-
 
     A copy of the ANSSI-BP-028 can be found at the ANSSI website:
     https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
+
+    An English version of the ANSSI-BP-028 can also be found at the ANSSI website:
+    https://cyber.gouv.fr/publications/configuration-recommendations-gnulinux-system
 
 selections:
   - anssi:all:intermediary

--- a/products/rhel9/profiles/anssi_bp28_minimal.profile
+++ b/products/rhel9/profiles/anssi_bp28_minimal.profile
@@ -2,6 +2,7 @@ documentation_complete: true
 
 metadata:
     SMEs:
+        - marcusburghardt
         - yuumasato
 
 title: 'ANSSI-BP-028 (minimal)'
@@ -15,6 +16,8 @@ description: |-
     A copy of the ANSSI-BP-028 can be found at the ANSSI website:
     https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
 
+    An English version of the ANSSI-BP-028 can also be found at the ANSSI website:
+    https://cyber.gouv.fr/publications/configuration-recommendations-gnulinux-system
+
 selections:
   - anssi:all:minimal
-


### PR DESCRIPTION
#### Description:

The URL for the ANSSI policy was broken in `anssi` control file.
The ANSSI profile description was also updated for RHEL products.

#### Rationale:

Correct links and more references in profiles.

#### Review Hints:

The changes are not technical so basically validating the links and text should be enough.
