### PR TITLE
Typo in product.yml

### DIFF
--- a/products/openembedded/product.yml
+++ b/products/openembedded/product.yml
@@ -1,5 +1,5 @@
 product: openembedded
-full_name: OpemEmbedded 
+full_name: OpenEmbedded 
 type: platform
 
 benchmark_id: OPENEMBEDDED


### PR DESCRIPTION
Just a typo in the name "OpenEmbedded".