### PR TITLE
Add missing group.yml

### DIFF
--- a/linux_os/guide/services/ldap/389_ds/group.yml
+++ b/linux_os/guide/services/ldap/389_ds/group.yml
@@ -1,0 +1,6 @@
+documentation_complete: true
+
+title: 389 Directory Server
+
+description: |-
+    389 Directory Server is a popular open-source LDAP server for Linux.


### PR DESCRIPTION
Due to a missing `group.yml` in the `linux_os/guide/services/ldap/389_ds` directory the rule `package_389-ds-base_removed` wasn't built to the data stream.

Fixes: #11372
