### PR TITLE
Add STIG Tables for RHEL 9

### DIFF
--- a/products/rhel9/CMakeLists.txt
+++ b/products/rhel9/CMakeLists.txt
@@ -15,7 +15,9 @@ if(SSG_SRG_XLSX_EXPORT)
     ssg_build_xlsx_srg_export(${PRODUCT} "srg_gpos")
 endif()
 
-# ssg_build_html_stig_tables(${PRODUCT} "stig")
+ssg_build_html_stig_tables(${PRODUCT})
+ssg_build_html_stig_tables_per_profile(${PRODUCT} "stig")
+ssg_build_html_stig_tables_per_profile(${PRODUCT} "stig_gui")
 
 #ssg_build_html_stig_tables(${PRODUCT} "ospp")
 


### PR DESCRIPTION
#### Description:

* Add STIG Tables for RHEL 9

#### Rationale:

* Easier to see coverage of our profiles vs the STIG

