### PR TITLE
Fix duplicate OVAL ids (gpgkey package, GDM login)

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_unattended_automatic_login/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_unattended_automatic_login/oval/shared.xml
@@ -3,17 +3,17 @@
     {{{ oval_metadata("Disable the GNOME Display Manager (GDM) ability to allow users to
       automatically login.") }}}
     <criteria operator="AND">
-      <criterion comment="Disable GDM Automatic Login" test_ref="test_disable_automatic_login" />
+      <criterion comment="Disable GDM Automatic Login" test_ref="test_disable_unattended_automatic_login" />
       <criterion comment="Disable GDM Password Less Login" test_ref="test_disable_unattended_login" />
     </criteria>
   </definition>
 
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
   comment="Disable GDM Automatic Login"
-  id="test_disable_automatic_login" version="1">
-    <ind:object object_ref="obj_disable_automatic_login" />
+  id="test_disable_unattended_automatic_login" version="1">
+    <ind:object object_ref="obj_disable_unattended_automatic_login" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="obj_disable_automatic_login"
+  <ind:textfilecontent54_object id="obj_disable_unattended_automatic_login"
   version="1">
     <ind:filepath>/etc/sysconfig/displaymanager</ind:filepath>
     <ind:pattern operation="pattern match">^DISPLAYMANAGER_AUTOLOGIN=""$</ind:pattern>

--- a/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/oval/shared.xml
@@ -1,18 +1,18 @@
 {{% macro fedora_gpgkey_criterion(fedora_version, pkg_release, pkg_version) %}}
    <criterion comment="Fedora {{{ fedora_version }}} package gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}} is installed"
-        test_ref="test_package_gpgkey-{{{ pkg_version }}}-{{{ pkg_release }}}_installed" />
+        test_ref="test_fedora_package_gpgkey-{{{ pkg_version }}}-{{{ pkg_release }}}_installed" />
 {{% endmacro %}}
 
 {{% macro fedora_gpgkey_check(fedora_version, pkg_release, pkg_version) %}}
   <!-- Test for Fedora {{{ fedora_version }}} release key -->
   <linux:rpminfo_test check="only one" check_existence="at_least_one_exists"
-  id="test_package_gpgkey-{{{ pkg_version }}}-{{{ pkg_release }}}_installed" version="1"
+  id="test_fedora_package_gpgkey-{{{ pkg_version }}}-{{{ pkg_release }}}_installed" version="1"
   comment="Fedora {{{ pkg_version }}} release key package is installed">
-    <linux:object object_ref="object_package_gpg-pubkey" />
-    <linux:state state_ref="state_package_gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}}" />
+    <linux:object object_ref="object_fedora_package_gpg-pubkey" />
+    <linux:state state_ref="state_fedora_package_gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}}" />
   </linux:rpminfo_test>
 
-  <linux:rpminfo_state id="state_package_gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}}" version="1">
+  <linux:rpminfo_state id="state_fedora_package_gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}}" version="1">
     <linux:release>{{{ pkg_release }}}</linux:release>
     <linux:version>{{{ pkg_version }}}</linux:version>
   </linux:rpminfo_state>
@@ -32,8 +32,8 @@
     </criteria>
   </definition>
 
-  <!-- First define global "object_package_gpg-pubkey" to be shared (reused) across multiple tests -->
-  <linux:rpminfo_object id="object_package_gpg-pubkey" version="1">
+  <!-- First define global "object_fedora_package_gpg-pubkey" to be shared (reused) across multiple tests -->
+  <linux:rpminfo_object id="object_fedora_package_gpg-pubkey" version="1">
     <linux:name>gpg-pubkey</linux:name>
   </linux:rpminfo_object>
 

--- a/linux_os/guide/system/software/updating/ensure_oracle_gpgkey_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_oracle_gpgkey_installed/oval/shared.xml
@@ -9,29 +9,29 @@
       </criteria>
       <criteria comment="Oracle Vendor Keys Installed" operator="OR">
         <criterion comment="package gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}} is installed"
-            test_ref="test_package_gpgkey-{{{ pkg_version }}}-{{{ pkg_release }}}_installed" />
+            test_ref="test_oracle_package_gpgkey-{{{ pkg_version }}}-{{{ pkg_release }}}_installed" />
         {{% if aux_pkg_version %}}
         <criterion comment="package gpg-pubkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}} is installed"
-            test_ref="test_package_gpgkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}}_installed" />
+            test_ref="test_oracle_package_gpgkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}}_installed" />
         {{% endif %}}
       </criteria>
     </criteria>
   </definition>
 
-  <!-- First define global "object_package_gpg-pubkey" to be shared (reused) across multiple tests -->
-  <linux:rpminfo_object id="object_package_gpg-pubkey" version="1">
+  <!-- First define global "object_oracle_package_gpg-pubkey" to be shared (reused) across multiple tests -->
+  <linux:rpminfo_object id="object_oracle_package_gpg-pubkey" version="1">
     <linux:name>gpg-pubkey</linux:name>
   </linux:rpminfo_object>
 
   <!-- Test for Oracle release key -->
   <linux:rpminfo_test check="only one" check_existence="at_least_one_exists"
-      id="test_package_gpgkey-{{{ pkg_version }}}-{{{ pkg_release }}}_installed" version="1"
+      id="test_oracle_package_gpgkey-{{{ pkg_version }}}-{{{ pkg_release }}}_installed" version="1"
       comment="Oracle release key package is installed">
-    <linux:object object_ref="object_package_gpg-pubkey" />
-    <linux:state state_ref="state_package_gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}}" />
+    <linux:object object_ref="object_oracle_package_gpg-pubkey" />
+    <linux:state state_ref="state_oracle_package_gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}}" />
   </linux:rpminfo_test>
 
-  <linux:rpminfo_state id="state_package_gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}}" version="1">
+  <linux:rpminfo_state id="state_oracle_package_gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}}" version="1">
     <linux:release>{{{ pkg_release }}}</linux:release>
     <linux:version>{{{ pkg_version }}}</linux:version>
   </linux:rpminfo_state>
@@ -39,13 +39,13 @@
   <!-- Test for Oracle auxiliary key -->
   {{% if aux_pkg_version %}}
   <linux:rpminfo_test check="only one" check_existence="at_least_one_exists"
-  id="test_package_gpgkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}}_installed" version="1"
+  id="test_oracle_package_gpgkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}}_installed" version="1"
   comment="Oracle auxiliary key package is installed">
-    <linux:object object_ref="object_package_gpg-pubkey" />
-    <linux:state state_ref="state_package_gpg-pubkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}}" />
+    <linux:object object_ref="object_oracle_package_gpg-pubkey" />
+    <linux:state state_ref="state_oracle_package_gpg-pubkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}}" />
   </linux:rpminfo_test>
 
-  <linux:rpminfo_state id="state_package_gpg-pubkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}}" version="1">
+  <linux:rpminfo_state id="state_oracle_package_gpg-pubkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}}" version="1">
     <linux:release>{{{ aux_pkg_release }}}</linux:release>
     <linux:version>{{{ aux_pkg_version }}}</linux:version>
   </linux:rpminfo_state>

--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/oval/shared.xml
@@ -12,63 +12,63 @@
           <extend_definition comment="{{{ product }}} installed" definition_ref="installed_OS_is_{{{ product }}}" />
         </criteria>
         <criterion comment="package gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}} is installed"
-        test_ref="test_package_gpgkey-{{{ pkg_version }}}-{{{ pkg_release }}}_installed" />
+        test_ref="test_redhat_package_gpgkey-{{{ pkg_version }}}-{{{ pkg_release }}}_installed" />
         <criteria comment="Auxiliary Red Hat Key Installed" operator="OR">
           <criterion comment="package gpg-pubkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}} is installed"
-          test_ref="test_package_gpgkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}}_installed" />
+          test_ref="test_redhat_package_gpgkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}}_installed" />
         </criteria>
       </criteria>
       {{%- if centos_major_version %}}
       <criteria comment="CentOS Vendor Keys" operator="AND">
         <extend_definition comment="CentOS{{{ centos_major_version }}} installed" definition_ref="installed_OS_is_centos{{{ centos_major_version }}}" />
         <criterion comment="package gpg-pubkey-{{{ centos_pkg_version }}}-{{{ centos_pkg_release }}} is installed"
-        test_ref="test_package_gpgkey-{{{ centos_pkg_version }}}-{{{ centos_pkg_release }}}_installed" />
+        test_ref="test_redhat_package_gpgkey-{{{ centos_pkg_version }}}-{{{ centos_pkg_release }}}_installed" />
       </criteria>
       {{%- endif %}}
     </criteria>
   </definition>
 
-  <!-- First define global "object_package_gpg-pubkey" to be shared (reused) across multiple tests -->
-  <linux:rpminfo_object id="object_package_gpg-pubkey" version="1">
+  <!-- First define global "object_redhat_package_gpg-pubkey" to be shared (reused) across multiple tests -->
+  <linux:rpminfo_object id="object_redhat_package_gpg-pubkey" version="1">
     <linux:name>gpg-pubkey</linux:name>
   </linux:rpminfo_object>
 
   <!-- Perform the particular tests themselves -->
   <!-- Test for Red Hat release key -->
   <linux:rpminfo_test check="only one" check_existence="at_least_one_exists"
-  id="test_package_gpgkey-{{{ pkg_version }}}-{{{ pkg_release }}}_installed" version="1"
+  id="test_redhat_package_gpgkey-{{{ pkg_version }}}-{{{ pkg_release }}}_installed" version="1"
   comment="Red Hat release key package is installed">
-    <linux:object object_ref="object_package_gpg-pubkey" />
-    <linux:state state_ref="state_package_gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}}" />
+    <linux:object object_ref="object_redhat_package_gpg-pubkey" />
+    <linux:state state_ref="state_redhat_package_gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}}" />
   </linux:rpminfo_test>
 
-  <linux:rpminfo_state id="state_package_gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}}" version="1">
+  <linux:rpminfo_state id="state_redhat_package_gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}}" version="1">
     <linux:release>{{{ pkg_release }}}</linux:release>
     <linux:version>{{{ pkg_version }}}</linux:version>
   </linux:rpminfo_state>
 
   <!-- Test for Red Hat auxiliary key -->
   <linux:rpminfo_test check="only one" check_existence="at_least_one_exists"
-  id="test_package_gpgkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}}_installed" version="1"
+  id="test_redhat_package_gpgkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}}_installed" version="1"
   comment="Red Hat auxiliary key package is installed">
-    <linux:object object_ref="object_package_gpg-pubkey" />
-    <linux:state state_ref="state_package_gpg-pubkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}}" />
+    <linux:object object_ref="object_redhat_package_gpg-pubkey" />
+    <linux:state state_ref="state_redhat_package_gpg-pubkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}}" />
   </linux:rpminfo_test>
 
-  <linux:rpminfo_state id="state_package_gpg-pubkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}}" version="1">
+  <linux:rpminfo_state id="state_redhat_package_gpg-pubkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}}" version="1">
     <linux:release>{{{ aux_pkg_release }}}</linux:release>
     <linux:version>{{{ aux_pkg_version }}}</linux:version>
   </linux:rpminfo_state>
 
   {{%- if centos_major_version %}}
   <linux:rpminfo_test check="only one" check_existence="at_least_one_exists"
-  id="test_package_gpgkey-{{{ centos_pkg_version }}}-{{{ centos_pkg_release }}}_installed" version="1"
+  id="test_redhat_package_gpgkey-{{{ centos_pkg_version }}}-{{{ centos_pkg_release }}}_installed" version="1"
   comment="CentOS{{{ centos_major_version }}} key package is installed">
-    <linux:object object_ref="object_package_gpg-pubkey" />
-    <linux:state state_ref="state_package_gpg-pubkey-{{{ centos_pkg_version }}}-{{{ centos_pkg_release }}}" />
+    <linux:object object_ref="object_redhat_package_gpg-pubkey" />
+    <linux:state state_ref="state_redhat_package_gpg-pubkey-{{{ centos_pkg_version }}}-{{{ centos_pkg_release }}}" />
   </linux:rpminfo_test>
 
-  <linux:rpminfo_state id="state_package_gpg-pubkey-{{{ centos_pkg_version }}}-{{{ centos_pkg_release }}}" version="1">
+  <linux:rpminfo_state id="state_redhat_package_gpg-pubkey-{{{ centos_pkg_version }}}-{{{ centos_pkg_release }}}" version="1">
     <linux:release>{{{ centos_pkg_release }}}</linux:release>
     <linux:version>{{{ centos_pkg_version }}}</linux:version>
   </linux:rpminfo_state>

--- a/linux_os/guide/system/software/updating/ensure_suse_gpgkey_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_suse_gpgkey_installed/oval/shared.xml
@@ -9,26 +9,26 @@
           <extend_definition comment="{{{ product }}} installed" definition_ref="installed_OS_is_{{{ product }}}" />
         </criteria>
         <criterion comment="package gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}} is installed"
-        test_ref="test_package_gpgkey-{{{ pkg_version }}}-{{{ pkg_release }}}_installed" />
+        test_ref="test_suse_package_gpgkey-{{{ pkg_version }}}-{{{ pkg_release }}}_installed" />
       </criteria>
     </criteria>
   </definition>
 
-  <!-- First define global "object_package_gpg-pubkey" to be shared (reused) across multiple tests -->
-  <linux:rpminfo_object id="object_package_gpg-pubkey" version="1">
+  <!-- First define global "object_suse_package_gpg-pubkey" to be shared (reused) across multiple tests -->
+  <linux:rpminfo_object id="object_suse_package_gpg-pubkey" version="1">
     <linux:name>gpg-pubkey</linux:name>
   </linux:rpminfo_object>
 
   <!-- Perform the particular tests themselves -->
   <!-- Test for SUSE release key -->
   <linux:rpminfo_test check="only one" check_existence="at_least_one_exists"
-  id="test_package_gpgkey-{{{ pkg_version }}}-{{{ pkg_release }}}_installed" version="1"
+  id="test_suse_package_gpgkey-{{{ pkg_version }}}-{{{ pkg_release }}}_installed" version="1"
   comment="SUSE build key package is installed">
-    <linux:object object_ref="object_package_gpg-pubkey" />
-    <linux:state state_ref="state_package_gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}}" />
+    <linux:object object_ref="object_suse_package_gpg-pubkey" />
+    <linux:state state_ref="state_suse_package_gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}}" />
   </linux:rpminfo_test>
 
-  <linux:rpminfo_state id="state_package_gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}}" version="1">
+  <linux:rpminfo_state id="state_suse_package_gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}}" version="1">
     <linux:release>{{{ pkg_release }}}</linux:release>
     <linux:version>{{{ pkg_version }}}</linux:version>
   </linux:rpminfo_state>


### PR DESCRIPTION
#### Description:

- These rules share same IDs in their OVAL sub-components. If they ever meet in the same DS conflict is imminent.

#### Rationale:

- The only thing that prevents them from colliding is `prodtype`. As we are going to get rid of it we shall get prepared.

#### Review Hints:

- The `gnome_gdm_disable_unattended_automatic_login` rule is in conflicts with `gnome_gdm_disable_automatic_login`.