### PR TITLE
Remove bogus specifier from `audit_rules_privileged_commands_unix2_chkpwd`

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix2_chkpwd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix2_chkpwd/rule.yml
@@ -63,4 +63,4 @@ ocil: |-
 template:
     name: audit_rules_privileged_commands
     vars:
-        path@sle15: /sbin/unix2_chkpwd
+        path: /sbin/unix2_chkpwd


### PR DESCRIPTION
#### Description:

This `sle15` specifier is redundant and goes against the build system rules.

#### Rationale:

In a situation when rule's `prodtype` would be expanded build will fail.