### PR TITLE
OCP4: Revert OVS rules

### DIFF
--- a/applications/openshift/master/file_groupowner_openvswitch/rule.yml
+++ b/applications/openshift/master/file_groupowner_openvswitch/rule.yml
@@ -20,8 +20,6 @@ severity: medium
 references:
     cis@ocp4: 1.1.10
 
-platform: ocp4-node-on-sdn or ocp4-node-on-ovn
-
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/.*", group="root") }}}'
 
 ocil: |-

--- a/applications/openshift/master/file_groupowner_ovs_conf_db/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Group Who Owns The Open vSwitch Configuration Database'
 
 description: |-
@@ -25,8 +27,6 @@ references:
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325
-
-platform: ocp4-node-on-sdn or ocp4-node-on-ovn
 
 ocil_clause: |-
   <code>/etc/openvswitch/conf.db</code> does not have a group owner of

--- a/applications/openshift/master/file_groupowner_ovs_conf_db/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: NOT-APPLICABLE
+default_result: PASS

--- a/applications/openshift/master/file_groupowner_ovs_conf_db_lock/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_lock/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Group Who Owns The Open vSwitch Configuration Database Lock'
 
 description: |-
@@ -25,8 +27,6 @@ references:
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325
-
-platform: ocp4-node-on-sdn or ocp4-node-on-ovn
 
 ocil_clause: |-
   <code>/etc/openvswitch/conf.db.~lock~</code> does not have a group owner of

--- a/applications/openshift/master/file_groupowner_ovs_conf_db_lock/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_lock/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: NOT-APPLICABLE
+default_result: PASS

--- a/applications/openshift/master/file_groupowner_ovs_conf_db_lock_not_s390x/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_lock_not_s390x/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node and not_s390x_arch
+
 title: 'Verify Group Who Owns The Open vSwitch Configuration Database Lock'
 
 description: |-
@@ -23,8 +25,6 @@ references:
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325
-
-platform: (ocp4-node-on-sdn or ocp4-node-on-ovn) and not_s390x_arch
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/.conf.db.~lock~", group="hugetlbfs") }}}'
 

--- a/applications/openshift/master/file_groupowner_ovs_conf_db_lock_not_s390x/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_lock_not_s390x/tests/ocp4/e2e.yml
@@ -1,3 +1,2 @@
 ---
-default_result: NOT-APPLICABLE
-
+default_result: PASS

--- a/applications/openshift/master/file_groupowner_ovs_conf_db_lock_s390x/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_lock_s390x/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node and s390x_arch
+
 title: 'Verify Group Who Owns The Open vSwitch Configuration Database Lock'
 
 description: |-
@@ -23,8 +25,6 @@ references:
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325
-
-platform: (ocp4-node-on-sdn or ocp4-node-on-ovn) and s390x_arch
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/.conf.db.~lock~", group="hugetlbfs") }}}'
 

--- a/applications/openshift/master/file_groupowner_ovs_conf_db_not_s390x/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_not_s390x/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node and not_s390x_arch
+
 title: 'Verify Group Who Owns The Open vSwitch Configuration Database'
 
 description: |-
@@ -23,8 +25,6 @@ references:
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325
-
-platform: (ocp4-node-on-sdn or ocp4-node-on-ovn) and not_s390x_arch
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/conf.db", group="hugetlbfs") }}}'
 

--- a/applications/openshift/master/file_groupowner_ovs_conf_db_not_s390x/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_not_s390x/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: NOT-APPLICABLE
+default_result: PASS

--- a/applications/openshift/master/file_groupowner_ovs_conf_db_s390x/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_s390x/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node and s390x_arch
+
 title: 'Verify Group Who Owns The Open vSwitch Configuration Database'
 
 description: |-
@@ -23,8 +25,6 @@ references:
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325
-
-platform: (ocp4-node-on-sdn or ocp4-node-on-ovn) and s390x_arch
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/conf.db", group="openvswitch") }}}'
 

--- a/applications/openshift/master/file_groupowner_ovs_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_pid/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Group Who Owns The Open vSwitch Process ID File'
 
 description: |-
@@ -25,8 +27,6 @@ references:
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325
-
-platform: ocp4-node-on-sdn or ocp4-node-on-ovn
 
 ocil_clause: '/var/run/openvswitch/ovs-vswitchd.pid has group owner openvswitch or hugetlbfs'
 

--- a/applications/openshift/master/file_groupowner_ovs_pid/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_ovs_pid/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: NOT-APPLICABLE
+default_result: PASS

--- a/applications/openshift/master/file_groupowner_ovs_sys_id_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_sys_id_conf/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Group Who Owns The Open vSwitch Persistent System ID'
 
 description: |-
@@ -25,8 +27,6 @@ references:
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325
-
-platform: ocp4-node-on-sdn or ocp4-node-on-ovn
 
 ocil_clause: |-
   <code>/etc/openvswitch/system-id.conf</code> does not have a group owner of

--- a/applications/openshift/master/file_groupowner_ovs_sys_id_conf/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_ovs_sys_id_conf/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: NOT-APPLICABLE
+default_result: PASS

--- a/applications/openshift/master/file_groupowner_ovs_sys_id_conf_not_s390x/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_sys_id_conf_not_s390x/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node and not_s390x_arch
+
 title: 'Verify Group Who Owns The Open vSwitch Persistent System ID'
 
 description: |-
@@ -23,8 +25,6 @@ references:
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325
-
-platform: (ocp4-node-on-sdn or ocp4-node-on-ovn) and not_s390x_arch
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/system-id.conf", group="hugetlbfs") }}}'
 

--- a/applications/openshift/master/file_groupowner_ovs_sys_id_conf_not_s390x/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_ovs_sys_id_conf_not_s390x/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: NOT-APPLICABLE
+default_result: PASS

--- a/applications/openshift/master/file_groupowner_ovs_sys_id_conf_s390x/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_sys_id_conf_s390x/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node and s390x_arch
+
 title: 'Verify Group Who Owns The Open vSwitch Persistent System ID'
 
 description: |-
@@ -23,8 +25,6 @@ references:
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325
-
-platform: (ocp4-node-on-sdn or ocp4-node-on-ovn) and s390x_arch
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/openvswitch/system-id.conf", group="hugetlbfs") }}}'
 

--- a/applications/openshift/master/file_groupowner_ovs_vswitchd_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_vswitchd_pid/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Group Who Owns The Open vSwitch Daemon PID File'
 
 description: |-
@@ -25,8 +27,6 @@ references:
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325
-
-platform: ocp4-node-on-sdn or ocp4-node-on-ovn
 
 ocil_clause: '/run/openvswitch/ovs-vswitchd.pid has group owner openvswitch or hugetlbfs'
 

--- a/applications/openshift/master/file_groupowner_ovs_vswitchd_pid/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_ovs_vswitchd_pid/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: NOT-APPLICABLE
+default_result: PASS

--- a/applications/openshift/master/file_groupowner_ovsdb_server_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovsdb_server_pid/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Group Who Owns The Open vSwitch Database Server PID'
 
 description: |-
@@ -25,8 +27,6 @@ references:
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325
-
-platform: ocp4-node-on-sdn or ocp4-node-on-ovn
 
 ocil_clause: '/run/openvswitch/ovsdb-server.pid has group owner openvswitch or hugetlbfs'
 

--- a/applications/openshift/master/file_groupowner_ovsdb_server_pid/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_ovsdb_server_pid/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: NOT-APPLICABLE
+default_result: PASS

--- a/applications/openshift/master/file_owner_openvswitch/rule.yml
+++ b/applications/openshift/master/file_owner_openvswitch/rule.yml
@@ -20,8 +20,6 @@ severity: medium
 references:
     cis@ocp4: 1.1.10
 
-platform: ocp4-node-on-sdn or ocp4-node-on-ovn
-
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/openvswitch/.*", owner="root") }}}'
 
 ocil: |-

--- a/applications/openshift/master/file_owner_ovs_conf_db/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_conf_db/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: ocp4
 
-platform: ocp4-node-on-sdn or ocp4-node-on-ovn
+platform: ocp4-node
 
 title: 'Verify User Who Owns The Open vSwitch Configuration Database'
 

--- a/applications/openshift/master/file_owner_ovs_conf_db/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_ovs_conf_db/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: NOT-APPLICABLE
+default_result: PASS

--- a/applications/openshift/master/file_owner_ovs_conf_db_lock/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_conf_db_lock/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: ocp4
 
-platform: ocp4-node-on-sdn or ocp4-node-on-ovn
+platform: ocp4-node
 
 title: 'Verify User Who Owns The Open vSwitch Configuration Database Lock'
 

--- a/applications/openshift/master/file_owner_ovs_conf_db_lock/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_ovs_conf_db_lock/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: NOT-APPLICABLE
+default_result: PASS

--- a/applications/openshift/master/file_owner_ovs_pid/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_pid/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: ocp4
 
-platform: ocp4-node-on-sdn or ocp4-node-on-ovn
+platform: ocp4-node
 
 title: 'Verify User Who Owns The Open vSwitch Process ID File'
 

--- a/applications/openshift/master/file_owner_ovs_pid/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_ovs_pid/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: NOT-APPLICABLE
+default_result: PASS

--- a/applications/openshift/master/file_owner_ovs_sys_id_conf/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_sys_id_conf/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: ocp4
 
-platform: ocp4-node-on-sdn or ocp4-node-on-ovn
+platform: ocp4-node
 
 title: 'Verify User Who Owns The Open vSwitch Persistent System ID'
 

--- a/applications/openshift/master/file_owner_ovs_sys_id_conf/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_ovs_sys_id_conf/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: NOT-APPLICABLE
+default_result: PASS

--- a/applications/openshift/master/file_owner_ovs_vswitchd_pid/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_vswitchd_pid/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: ocp4
 
-platform: ocp4-node-on-sdn or ocp4-node-on-ovn
+platform: ocp4-node
 
 title: 'Verify User Who Owns The Open vSwitch Daemon PID File'
 

--- a/applications/openshift/master/file_owner_ovs_vswitchd_pid/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_ovs_vswitchd_pid/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: NOT-APPLICABLE
+default_result: PASS

--- a/applications/openshift/master/file_owner_ovsdb_server_pid/rule.yml
+++ b/applications/openshift/master/file_owner_ovsdb_server_pid/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: ocp4
 
-platform: ocp4-node-on-sdn or ocp4-node-on-ovn
+platform: ocp4-node
 
 title: 'Verify User Who Owns The Open vSwitch Database Server PID'
 

--- a/applications/openshift/master/file_owner_ovsdb_server_pid/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_ovsdb_server_pid/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: NOT-APPLICABLE
+default_result: PASS

--- a/applications/openshift/master/file_permissions_openvswitch/rule.yml
+++ b/applications/openshift/master/file_permissions_openvswitch/rule.yml
@@ -21,8 +21,6 @@ severity: medium
 references:
     cis@ocp4: 1.4.9
 
-platform: ocp4-node-on-sdn
-
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/openvswitch/.*", perms="-rw-r--r--") }}}'
 
 ocil: |-

--- a/applications/openshift/master/file_permissions_ovs_conf_db/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_conf_db/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Permissions on the Open vSwitch Configuration Database'
 
 description: |-
@@ -23,8 +25,6 @@ references:
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325
-
-platform: ocp4-node-on-sdn
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/openvswitch/conf.db", perms="-rw-r-----") }}}'
 

--- a/applications/openshift/master/file_permissions_ovs_conf_db/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_ovs_conf_db/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: NOT-APPLICABLE
+default_result: PASS

--- a/applications/openshift/master/file_permissions_ovs_conf_db_lock/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_conf_db_lock/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Permissions on the Open vSwitch Configuration Database Lock'
 
 description: |-
@@ -23,8 +25,6 @@ references:
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325
-
-platform: ocp4-node-on-sdn
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/openvswitch/.conf.db.~lock~", perms="-rw-------") }}}'
 

--- a/applications/openshift/master/file_permissions_ovs_conf_db_lock/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_ovs_conf_db_lock/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: NOT-APPLICABLE
+default_result: PASS

--- a/applications/openshift/master/file_permissions_ovs_pid/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_pid/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Permissions on the Open vSwitch Process ID File'
 
 description: |-
@@ -23,8 +25,6 @@ references:
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325
-
-platform: ocp4-node-on-sdn
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/run/openvswitch/ovs-vswitchd.pid", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_ovs_pid/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_ovs_pid/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: NOT-APPLICABLE
+default_result: PASS

--- a/applications/openshift/master/file_permissions_ovs_sys_id_conf/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_sys_id_conf/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Permissions on the Open vSwitch Persistent System ID'
 
 description: |-
@@ -23,8 +25,6 @@ references:
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325
-
-platform: ocp4-node-on-sdn
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/openvswitch/system-id.conf", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_ovs_sys_id_conf/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_ovs_sys_id_conf/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: NOT-APPLICABLE
+default_result: PASS

--- a/applications/openshift/master/file_permissions_ovs_vswitchd_pid/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_vswitchd_pid/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Permissions on the Open vSwitch Daemon PID File'
 
 description: |-
@@ -23,8 +25,6 @@ references:
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325
-
-platform: ocp4-node-on-sdn
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/run/openvswitch/ovs-vswitchd.pid", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_ovs_vswitchd_pid/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_ovs_vswitchd_pid/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: NOT-APPLICABLE
+default_result: PASS

--- a/applications/openshift/master/file_permissions_ovsdb_server_pid/rule.yml
+++ b/applications/openshift/master/file_permissions_ovsdb_server_pid/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Permissions on the Open vSwitch Database Server PID'
 
 description: |-
@@ -23,8 +25,6 @@ references:
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325
-
-platform: ocp4-node-on-sdn
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/run/openvswitch/ovsdb-server.pid", perms="-rw-r--r--") }}}'
 

--- a/applications/openshift/master/file_permissions_ovsdb_server_pid/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_ovsdb_server_pid/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: NOT-APPLICABLE
+default_result: PASS


### PR DESCRIPTION
#### Description:

Revert commits in https://github.com/ComplianceAsCode/content/pull/10737

#### Rationale:

To fix a regression where all OVS rules are excluded from the profile when or are used in the platform.

