### PR TITLE
Minor update to default ini file in release_helper.py

### DIFF
--- a/utils/release_helper.py
+++ b/utils/release_helper.py
@@ -706,7 +706,7 @@ def parse_arguments():
         epilog="Example: release_helper.py -c ~/secrets.ini -r ComplianceAsCode/content stats",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument(
-        '-c', '--creds-file', default='~/secret.ini',
+        '-c', '--creds-file', default='~/secrets.ini',
         help="INI file containing Github token.")
     parser.add_argument(
         '-r', '--repository', action='store', default='ComplianceAsCode/content',


### PR DESCRIPTION
#### Description:

This file can be shared by different scripts and may contain different sections and secrets, so it was renamed from `secret.ini` (singular) to `secrets.ini` (plural).

#### Rationale:

Minor change just for better consistency.
