### PR TITLE
configure_bashrc_*_tmux: escape braces within regex in Ansible

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/ansible/shared.yml
@@ -8,14 +8,14 @@
   ansible.builtin.find:
     paths: '/etc'
     patterns: 'bashrc'
-    contains: '.*case "$name" in sshd|login) exec tmux ;; esac.*'
+    contains: '.*case "$name" in sshd|login\) exec tmux ;; esac.*'
   register: tmux_in_bashrc
 
 - name: "{{{ rule_title }}}: Determine If the Tmux Launch Script Is Present in /etc/profile.d/*.sh"
   ansible.builtin.find:
     paths: '/etc/profile.d'
     patterns: '*.sh'
-    contains: .*case "$name" in sshd|login) exec tmux ;; esac.*
+    contains: .*case "$name" in sshd|login\) exec tmux ;; esac.*
   register: tmux_in_profile_d
 
 - name: "{{{ rule_title }}}: Insert the Correct Script into /etc/profile.d/tmux.sh"

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_tmux/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_tmux/ansible/shared.yml
@@ -8,14 +8,14 @@
   ansible.builtin.find:
     paths: '/etc'
     patterns: 'bashrc'
-    contains: '.*case "$name" in (sshd|login) tmux ;; esac.*'
+    contains: '.*case "$name" in \(sshd|login\) tmux ;; esac.*'
   register: tmux_in_bashrc
 
 - name: "{{{ rule_title }}}: Determine if the Tmux launch script is present in /etc/profile.d/*.sh"
   ansible.builtin.find:
     paths: '/etc/profile.d'
     patterns: '*.sh'
-    contains: .*case "$name" in (sshd|login) tmux ;; esac.*
+    contains: .*case "$name" in \(sshd|login\) tmux ;; esac.*
   register: tmux_in_profile_d
 
 - name: "{{{ rule_title }}}: Insert the correct script into /etc/profile.d/tmux.sh"


### PR DESCRIPTION
#### Description:

- modify Ansible remediations so that braces are escaped when they are used as part of "contains" statement

#### Rationale:

- this was causing problems when run with Ansible because it reported about unmatched braces and it refused to process the statement

#### Review Hints:

1. clone the master before the fix
2. build the rhel8 content
3. on RHEL 8.9 system,  try running OSPP playbook, you can choose the rule configure_bashrc_exec_tmux only with --tags parameter
4. observe the warning
5. build this branch and retest
6. warning should be gone
