### PR TITLE
add XSLT_PATH prefix with environment override

### DIFF
--- a/build-scripts/generate_guides.py
+++ b/build-scripts/generate_guides.py
@@ -10,7 +10,9 @@ import ssg.build_guides
 
 BenchmarkData = collections.namedtuple(
     "BenchmarkData", ["title", "profiles", "product"])
-XSLT_PATH = "/usr/share/openscap/xsl/xccdf-guide.xsl"
+
+XSLT_PREFIX = os.getenv('XSLT_PREFIX', default='/usr')
+XSLT_PATH = os.path.join(XSLT_PREFIX, "share/openscap/xsl/xccdf-guide.xsl")
 
 
 def get_benchmarks(ds, product):


### PR DESCRIPTION
#### Description:

- split hard-coded path string into default `/usr` prefix and relative install path
- use XSLT_PREFIX environment variable to override prefix

#### Rationale:

- allows development workflows using a virtual environment for installed dependencies

#### Review Hints:

- see tox example [here](https://github.com/VCTLabs/scap-security-guide/blob/dd5a71a76b3a951b13891323a6b56ef381fc9a7f/tox-dev.ini#L65)
