### PR TITLE
Rename inconsistent shared OVAL IDs (Oracle Linux)

### DIFF
--- a/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_FIPS_certified/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_FIPS_certified/oval/shared.xml
@@ -8,7 +8,7 @@
       <extend_definition comment="Installed OS is RHEL8" definition_ref="installed_OS_is_rhel8" />
       <!--extend_definition comment="Installed OS is RHEL9" definition_ref="installed_OS_is_rhel9" /-->
       <extend_definition comment="Installed OS is RHCOS4" definition_ref="installed_OS_is_rhcos4" />
-      <extend_definition comment="Installed OS is OL7" definition_ref="installed_OS_is_ol7_family" />
+      <extend_definition comment="Installed OS is OL7" definition_ref="installed_OS_is_ol7" />
       <extend_definition comment="Installed OS is SLE12" definition_ref="installed_OS_is_sle12" />
       <extend_definition comment="Installed OS is SLE15" definition_ref="installed_OS_is_sle15" />
       <extend_definition comment="Installed OS is Ubuntu 16.04" definition_ref="installed_OS_is_ubuntu1604" />

--- a/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_vendor_supported/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_vendor_supported/oval/shared.xml
@@ -7,8 +7,8 @@
       <extend_definition comment="Installed OS is RHEL7" definition_ref="installed_OS_is_rhel7" />
       <extend_definition comment="Installed OS is RHEL8" definition_ref="installed_OS_is_rhel8" />
       <extend_definition comment="Installed OS is RHEL9" definition_ref="installed_OS_is_rhel9" />
-      <extend_definition comment="Installed OS is OL7" definition_ref="installed_OS_is_ol7_family" />
-      <extend_definition comment="Installed OS is OL8" definition_ref="installed_OS_is_ol8_family" />
+      <extend_definition comment="Installed OS is OL7" definition_ref="installed_OS_is_ol7" />
+      <extend_definition comment="Installed OS is OL8" definition_ref="installed_OS_is_ol8" />
       <extend_definition comment="Installed OS is SLE12" definition_ref="installed_OS_is_sle12" />
       <extend_definition comment="Installed OS is SLE15" definition_ref="installed_OS_is_sle15" />
     </criteria>

--- a/linux_os/guide/system/software/updating/ensure_oracle_gpgkey_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_oracle_gpgkey_installed/oval/shared.xml
@@ -5,7 +5,7 @@
     {{{ oval_metadata("The Oracle Linux key packages are required to be installed.") }}}
     <criteria comment="Oracle Vendor Keys" operator="AND">
       <criteria comment="Oracle Installed" operator="OR">
-        <extend_definition comment="{{{ product }}} installed" definition_ref="installed_OS_is_{{{ product }}}_family" />
+        <extend_definition comment="{{{ product }}} installed" definition_ref="installed_OS_is_{{{ product }}}" />
       </criteria>
       <criteria comment="Oracle Vendor Keys Installed" operator="OR">
         <criterion comment="package gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}} is installed"

--- a/products/ol7/product.yml
+++ b/products/ol7/product.yml
@@ -37,7 +37,7 @@ cpes:
   - ol7:
       name: "cpe:/o:oracle:linux:7"
       title: "Oracle Linux 7"
-      check_id: installed_OS_is_ol7_family
+      check_id: installed_OS_is_ol7
 
 # Mapping of CPE platform to package
 platform_package_overrides:

--- a/products/ol8/product.yml
+++ b/products/ol8/product.yml
@@ -37,7 +37,7 @@ cpes:
   - ol8:
       name: "cpe:/o:oracle:linux:8"
       title: "Oracle Linux 8"
-      check_id: installed_OS_is_ol8_family
+      check_id: installed_OS_is_ol8
 
 # Mapping of CPE platform to package
 platform_package_overrides:

--- a/products/ol9/product.yml
+++ b/products/ol9/product.yml
@@ -40,7 +40,7 @@ cpes:
   - ol9:
       name: "cpe:/o:oracle:linux:9"
       title: "Oracle Linux 9"
-      check_id: installed_OS_is_ol9_family
+      check_id: installed_OS_is_ol9
 
 # Mapping of CPE platform to package
 platform_package_overrides:

--- a/shared/checks/oval/installed_OS_is_ol7.xml
+++ b/shared/checks/oval/installed_OS_is_ol7.xml
@@ -1,6 +1,6 @@
 <def-group>
   <definition class="inventory"
-  id="installed_OS_is_ol7_family" version="1">
+  id="installed_OS_is_ol7" version="1">
     <metadata>
       <title>Oracle Linux 7</title>
       <affected family="unix">

--- a/shared/checks/oval/installed_OS_is_ol8.xml
+++ b/shared/checks/oval/installed_OS_is_ol8.xml
@@ -1,6 +1,6 @@
 <def-group>
   <definition class="inventory"
-  id="installed_OS_is_ol8_family" version="1">
+  id="installed_OS_is_ol8" version="1">
     <metadata>
       <title>Oracle Linux 8</title>
       <affected family="unix">

--- a/shared/checks/oval/installed_OS_is_ol9.xml
+++ b/shared/checks/oval/installed_OS_is_ol9.xml
@@ -1,6 +1,6 @@
 <def-group>
   <definition class="inventory"
-  id="installed_OS_is_ol9_family" version="1">
+  id="installed_OS_is_ol9" version="1">
     <metadata>
       <title>Oracle Linux 9</title>
       <affected family="unix">

--- a/tests/data/product_stability/ol7.yml
+++ b/tests/data/product_stability/ol7.yml
@@ -10,7 +10,7 @@ benchmark_root: ../../linux_os/guide
 chrony_conf_path: /etc/chrony.conf
 cpes:
 - ol7:
-    check_id: installed_OS_is_ol7_family
+    check_id: installed_OS_is_ol7
     name: cpe:/o:oracle:linux:7
     title: Oracle Linux 7
 cpes_root: ../../shared/applicability

--- a/tests/data/product_stability/ol8.yml
+++ b/tests/data/product_stability/ol8.yml
@@ -10,7 +10,7 @@ benchmark_root: ../../linux_os/guide
 chrony_conf_path: /etc/chrony.conf
 cpes:
 - ol8:
-    check_id: installed_OS_is_ol8_family
+    check_id: installed_OS_is_ol8
     name: cpe:/o:oracle:linux:8
     title: Oracle Linux 8
 cpes_root: ../../shared/applicability

--- a/tests/data/product_stability/ol9.yml
+++ b/tests/data/product_stability/ol9.yml
@@ -13,7 +13,7 @@ benchmark_root: ../../linux_os/guide
 chrony_conf_path: /etc/chrony.conf
 cpes:
 - ol9:
-    check_id: installed_OS_is_ol9_family
+    check_id: installed_OS_is_ol9
     name: cpe:/o:oracle:linux:9
     title: Oracle Linux 9
 cpes_root: ../../shared/applicability


### PR DESCRIPTION
#### Description:

The IDs are not uniform with other similar checks (RHEL, SUSE, Fedora etc), but there is no reason for them to be unique.

This is sort of a continuation of https://github.com/ComplianceAsCode/content/pull/11377.

#### Rationale:

- Less confusion
- It'd allow us to combine all these checks into a single platform template later
- This inconsistency is standing in the way of *gradual* `prodtype` removal

#### Review Hints:

- The change *per se* is purely cosmetic, it does not change any logic in OVALs