### PR TITLE
Fix value of sshd_strong_kex variable on Ubuntu

### DIFF
--- a/linux_os/guide/services/ssh/sshd_strong_kex.var
+++ b/linux_os/guide/services/ssh/sshd_strong_kex.var
@@ -16,4 +16,5 @@ options:
     cis_rhel7: curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
     cis_sle12: curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
     cis_sle15: curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
-    cis_ubuntu2004: ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256
+    cis_ubuntu2004: curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256
+    cis_ubuntu2204: curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256


### PR DESCRIPTION
#### Description:

This change fixes the value of the `sshd_strong_kex` variable on Ubuntu 20.04 and 22.04 by adding the `curve25519-sha256` and `curve25519-sha256@libssh.org` key exchange algorithms.

Consequently, the list of key exchange algorithms matches the list of key exchanges algorithms recommended in the [CIS Ubuntu Linux 20.04 and 22.04 LTS Benchmark](https://downloads.cisecurity.org/) documents.