### PR TITLE
Update test-check-eof for smoke test

### DIFF
--- a/utils/check_eof.py
+++ b/utils/check_eof.py
@@ -34,7 +34,7 @@ def get_all_files(paths: list) -> list:
         p = pathlib.Path(path)
         if not p.exists():
             sys.stderr.write(f"The path {p.absolute()} does not exist!\n")
-            exit(3)
+            continue
         files.extend(get_files(p))
     return files
 


### PR DESCRIPTION
We have recently add the `/.github` directory to the list of paths checked by `check_eof.py` as a part of the `test-check-eof` CTest test. The unpredicted consequence of this is that the smoke test in the downstream Fedora CI started to fail. The reason is that we don't ship the `/.github` directory as a part of our released tarball. It doesn't make sense to ship this directory as a part of the tarballs because this contains the upstream CI configurations etc. OTOH it makes sense to skip this directory when it isn't present.

See for example the CI results of the smoke test in: https://src.fedoraproject.org/rpms/scap-security-guide/pull-request/34

Addressing:
```
118/333 Test #118: test-check-eof ...................................................***Failed    4.33 sec
The path /root/rpmbuild/BUILD/scap-security-guide-0.1.71/.github does not exist!
```

