### PR TITLE
Use correct HTML element for inline code

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
@@ -98,7 +98,7 @@ warnings:
         </ul>
     - general: |-
         Note that OVAL check and Bash / Ansible remediation of this rule
-        explicitly excludes file systems mounted at <pre>/proc</pre> directory
+        explicitly excludes file systems mounted at <code>/proc</code> directory
         and its subdirectories. It is a virtual file system and it doesn't
         contain executable applications. At the same time, interacting with this
         file system during check or remediation caused undesirable errors.


### PR DESCRIPTION
For inline code entries the `<code>` element should be used instead of the `<pre>` element which is a block element.

Using an incorrect element causes inappropriate formatting across our HTML guides and reports. This problem has been discovered during work on issue:
https://github.com/OpenSCAP/openscap-report/issues/212

Before:
![image](https://github.com/ComplianceAsCode/content/assets/9050916/6bbf5f15-f9be-4f22-aa41-6815f4a8ef1c)

After:
![image](https://github.com/ComplianceAsCode/content/assets/9050916/0b1dac4d-3653-4623-a99b-64d069862c5d)
