### PR TITLE
fix: service_timesyncd_configured

### DIFF
--- a/linux_os/guide/services/ntp/service_timesyncd_configured/bash/shared.sh
+++ b/linux_os/guide/services/ntp/service_timesyncd_configured/bash/shared.sh
@@ -23,7 +23,7 @@ done
 # Create /etc/systemd/timesyncd.d if it doesn't exist
 if [ ! -d "/etc/systemd/timesyncd.d" ]
 then 
-    mkdir etc/systemd/timesyncd.d
+    mkdir /etc/systemd/timesyncd.d
 fi
 # Set primary fallback NTP servers in drop-in configuration
 echo "NTP=$preferred_ntp_servers" >> "$config_file"

--- a/linux_os/guide/services/ntp/service_timesyncd_configured/bash/shared.sh
+++ b/linux_os/guide/services/ntp/service_timesyncd_configured/bash/shared.sh
@@ -20,6 +20,11 @@ do
     sed -i 's/^NTP/#&/g' "$current_cfg"
     sed -i 's/^FallbackNTP/#&/g' "$current_cfg"
 done
+# Create /etc/systemd/timesyncd.d if it doesn't exist
+if [ ! -d "/etc/systemd/timesyncd.d" ]
+then 
+    mkdir etc/systemd/timesyncd.d
+fi
 # Set primary fallback NTP servers in drop-in configuration
 echo "NTP=$preferred_ntp_servers" >> "$config_file"
 echo "FallbackNTP=$fallback_ntp_servers" >> "$config_file"


### PR DESCRIPTION
If timesync.d directory does not exist the script failed to apply

#### Description:

- Check if the directory under /etc/systemd/timesync.d exist, if not create it
