### PR TITLE
Fix Ansible in rule ensure_redhat_gpgkey_installed

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/ansible/shared.yml
@@ -28,7 +28,9 @@
 
 - name: Set Fact - Valid fingerprints
   set_fact:
-    gpg_valid_fingerprints: ("{{{ release_key_fingerprint }}}" "{{{ auxiliary_key_fingerprint }}}")
+    gpg_valid_fingerprints:
+    - "{{{ release_key_fingerprint }}}"
+    - "{{{ auxiliary_key_fingerprint }}}"
 
 - name: Import RedHat GPG key
   rpm_key:


### PR DESCRIPTION
We have discovered that in some Ansible Playbooks that we generate, for example in `rhel8-playbook-anssi_bp28_high.yml`, the remediation for rule `ensure_redhat_gpgkey_installed` doesn't ensure that Red Hat GPG key is installed.

Specifically, the Ansible Task `Import RedHat GPG key` is skipped during the Playbook execution because the condition `(gpg_installed_fingerprints | difference(gpg_valid_fingerprints)) | length == 0` that is part of the `when` statement in that task is evaluated as `false`. The root cause is that the `gpg_installed_fingerprints` fact is a list but the `gpg_valid_fingerprints` is a tuple. Starting from Ansible 2.16, the `difference` filter changed behavior when its operands are each of a different type. Therefore a list of different items of a non-zero length is produced. An easy fix to this is to define both aforementioned facts as same data types, eg. lists.

Fixes: #11399, #11409

#### Review Hints:

1. Get a machine running RHEL 8 (for example RHEL-8.10.0-20240101.1) that contains ansible-core-2.16.2-1.el8.x86_64
2. Install the scap-security-guide built by Packit job rpm-build:centos-stream-8-x86_64 in this PR to that machine
3. Run the contest test /hardening/ansible/anssi_bp28_high on that machine
4. check that the Ansible Playbook that was run during the test finished completely and haven't terminated soon
5. check that the rule ensure_redhat_gpgkey_installed is PASS in the after scan