### PR TITLE
We should raise NotImplementedError

### DIFF
--- a/utils/generate_profile.py
+++ b/utils/generate_profile.py
@@ -62,19 +62,19 @@ class Parser(abc.ABC):
 
     @abc.abstractmethod
     def __init__(self) -> None:
-        raise NotImplemented
+        raise NotImplementedError
 
     @abc.abstractmethod
     def get_name(self):
-        raise NotImplemented
+        raise NotImplementedError
 
     @abc.abstractmethod
     def get_version(self):
-        raise NotImplemented
+        raise NotImplementedError
 
     @abc.abstractmethod
     def parse(self):
-        raise NotImplemented
+        raise NotImplementedError
 
 
 class XLSXParser(Parser):


### PR DESCRIPTION


#### Description:

`NotImplemented` -> `NotImplementedError`

#### Rationale:

`NotImplemented` is a type not an error class, `NotImplementedError` is what should be raised.