### PR TITLE
Control Files' `level` key must be an array

### DIFF
--- a/controls/cis_ocp_1_4_0/section-1.yml
+++ b/controls/cis_ocp_1_4_0/section-1.yml
@@ -14,53 +14,53 @@ controls:
       status: automated
       rules:
         - file_permissions_kube_apiserver
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.1.2
       title: Ensure that the API server pod specification file ownership is set to root:root
       status: automated
       rules:
         - file_owner_kube_apiserver
         - file_groupowner_kube_apiserver
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.1.3
       title: Ensure that the controller manager pod specification file permissions are set to 600 or more restrictive
       status: automated
       rules:
         - file_permissions_kube_controller_manager
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.1.4
       title: Ensure that the controller manager pod specification file ownership is set to root:root
       status: automated
       rules:
         - file_owner_kube_controller_manager
         - file_groupowner_kube_controller_manager
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.1.5
       title: Ensure that the scheduler pod specification file permissions are set to 600 or more restrictive
       status: automated
       rules:
         - file_permissions_scheduler
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.1.6
       title: Ensure that the scheduler pod specification file ownership is set to root:root
       status: automated
       rules:
         - file_owner_kube_scheduler
         - file_groupowner_kube_scheduler
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.1.7
       title: Ensure that the etcd pod specification file permissions are set to 600 or more restrictive
       status: automated
       rules:
         - file_permissions_etcd_member
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.1.8
       title: Ensure that the etcd pod specification file ownership is set to root:root
       status: automated
       rules:
         - file_groupowner_etcd_member
         - file_owner_etcd_member
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.1.9
       title: Ensure that the Container Network Interface file permissions are set to 600 or more restrictive
       status: automated
@@ -77,7 +77,7 @@ controls:
         - file_permissions_ovsdb_server_pid
         - file_permissions_ovn_cni_server_sock
         - file_permissions_ovn_db_files
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.1.10
       title: Ensure that the Container Network Interface file ownership is set to root:root
       status: automated
@@ -106,14 +106,14 @@ controls:
         - file_owner_ovn_cni_server_sock
         - file_owner_ovn_db_files
         - file_groupowner_ovn_db_files
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.1.11
       title: Ensure that the etcd data directory permissions are set to 700 or more restrictive
       status: automated
       rules:
         - file_permissions_etcd_data_dir
         - file_permissions_etcd_data_files
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.1.12
       title: Ensure that the etcd data directory ownership is set to etcd:etcd
       status: automated
@@ -122,46 +122,46 @@ controls:
         - file_groupowner_etcd_data_dir
         - file_owner_etcd_data_files
         - file_groupowner_etcd_data_files
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.1.13
       title: Ensure that the kubeconfig file permissions are set to 600 or more restrictive
       status: automated
       rules:
         - file_permissions_master_admin_kubeconfigs
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.1.14
       title: Ensure that the kubeconfig file ownership is set to root:root
       status: automated
       rules:
         - file_owner_master_admin_kubeconfigs
         - file_groupowner_master_admin_kubeconfigs
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.1.15
       title: Ensure that the Scheduler kubeconfig file permissions are set to 600 or more restrictive
       status: automated
       rules:
         - file_permissions_scheduler_kubeconfig
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.1.16
       title: Ensure that the Scheduler kubeconfig file ownership is set to root:root
       status: automated
       rules:
         - file_owner_scheduler_kubeconfig
         - file_groupowner_scheduler_kubeconfig
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.1.17
       title: Ensure that the Controller Manager kubeconfig file permissions are set to 600 or more restrictive
       status: automated
       rules:
         - file_permissions_controller_manager_kubeconfig
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.1.18
       title: Ensure that the Controller Manager kubeconfig file ownership is set to root:root
       status: automated
       rules:
         - file_owner_controller_manager_kubeconfig
         - file_groupowner_controller_manager_kubeconfig
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.1.19
       title: Ensure that the OpenShift PKI directory and file ownership is set to root:root
       status: automated
@@ -172,20 +172,20 @@ controls:
         - file_groupowner_openshift_pki_cert_files
         - file_owner_etcd_pki_cert_files
         - file_groupowner_etcd_pki_cert_files
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.1.20
       title: Ensure that the OpenShift PKI certificate file permissions are set to 600 or more restrictive
       status: automated
       rules:
         - file_permissions_openshift_pki_cert_files
         - file_permissions_etcd_pki_cert_files
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.1.21
       title: Ensure that the OpenShift PKI key file permissions are set to 600
       status: automated
       rules:
         - file_permissions_openshift_pki_key_files
-      levels: level_1
+      levels: [ level_1, ]
   - id: '1.2'
     title: API Server
     status: pending
@@ -196,19 +196,19 @@ controls:
       status: automated
       rules:
         - api_server_anonymous_auth
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.2
       title: Ensure that the --basic-auth-file argument is not set
       status: automated
       rules:
         - api_server_basic_auth
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.3
       title: Ensure that the --token-auth-file parameter is not set
       status: automated
       rules:
         - api_server_token_auth
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.4
       title: Use https for kubelet connections
       status: automated
@@ -216,7 +216,7 @@ controls:
         - api_server_https_for_kubelet_conn
         - api_server_openshift_https_serving_cert
         - api_server_oauth_https_serving_cert
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.5
       title: Ensure that the kubelet uses certificates to authenticate
       status: automated
@@ -225,169 +225,169 @@ controls:
         - api_server_kubelet_client_cert_pre_4_9
         - api_server_kubelet_client_key
         - api_server_kubelet_client_key_pre_4_9
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.6
       title: Verify that the kubelet certificate authority is set as appropriate
       status: automated
       rules:
         - api_server_kubelet_certificate_authority
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.7
       title: Ensure that the --authorization-mode argument is not set to AlwaysAllow
       status: automated
       rules:
         - api_server_auth_mode_no_aa
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.8
       title: Verify that RBAC is enabled
       status: automated
       rules:
         - api_server_auth_mode_rbac
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.9
       title: Ensure that the APIPriorityAndFairness feature gate is enabled
       status: automated
       rules:
         - api_server_api_priority_gate_enabled
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.10
       title: Ensure that the admission control plugin AlwaysAdmit is not set
       status: automated
       rules:
         - api_server_admission_control_plugin_alwaysadmit
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.11
       title: Ensure that the admission control plugin AlwaysPullImages is not set
       status: automated
       rules:
         - api_server_admission_control_plugin_alwayspullimages
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.12
       title: Ensure that the admission control plugin ServiceAccount is set
       status: automated
       rules:
         - api_server_admission_control_plugin_service_account
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.13
       title: Ensure that the admission control plugin NamespaceLifecycle is set
       status: automated
       rules:
         - api_server_admission_control_plugin_namespacelifecycle
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.14
       title: Ensure that the admission control plugin SecurityContextConstraint is set
       status: automated
       rules:
         - api_server_admission_control_plugin_scc
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.15
       title: Ensure that the admission control plugin NodeRestriction is set
       status: automated
       rules:
         - api_server_admission_control_plugin_noderestriction
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.16
       title: Ensure that the --insecure-bind-address argument is not set
       status: automated
       rules:
         - api_server_insecure_bind_address
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.17
       title: Ensure that the --insecure-port argument is set to 0
       status: automated
       rules:
         - api_server_insecure_port
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.18
       title: Ensure that the --secure-port argument is not set to 0
       status: automated
       rules:
         - api_server_bind_address
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.19
       title: Ensure that the healthz endpoint is protected by RBAC
       status: automated
       rules:
         - api_server_profiling_protected_by_rbac
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.20
       title: Ensure that the --audit-log-path argument is set
       status: automated
       rules:
         - api_server_audit_log_path
         - openshift_api_server_audit_log_path
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.21
       title: Ensure that the audit logs are forwarded off the cluster for retention
       status: automated
       rules:
         - audit_log_forwarding_enabled
         - audit_log_forwarding_webhook
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.22
       title: Ensure that the maximumRetainedFiles argument is set to 10 or as appropriate
       status: automated
       rules:
         - api_server_audit_log_maxbackup
         - ocp_api_server_audit_log_maxbackup
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.23
       title: Ensure that the maximumFileSizeMegabytes argument is set to 100
       status: automated
       rules:
         - api_server_audit_log_maxsize
         - ocp_api_server_audit_log_maxsize
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.24
       title: Ensure that the --request-timeout argument is set
       status: automated
       rules:
         - api_server_request_timeout
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.25
       title: Ensure that the --service-account-lookup argument is set to true
       status: automated
       rules:
         - api_server_service_account_lookup
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.26
       title: Ensure that the --service-account-key-file argument is set as appropriate
       status: automated
       rules:
         - api_server_service_account_public_key
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.27
       title: Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate
       status: automated
       rules:
         - api_server_etcd_cert
         - api_server_etcd_key
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.28
       title: Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate
       status: automated
       rules:
         - api_server_tls_cert
         - api_server_tls_private_key
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.29
       title: Ensure that the --client-ca-file argument is set as appropriate
       status: automated
       rules:
         - api_server_client_ca
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.30
       title: Ensure that the --etcd-cafile argument is set as appropriate
       status: automated
       rules:
         - api_server_etcd_ca
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.31
       title: Ensure that encryption providers are appropriately configured
       status: partial
       rules:
         - api_server_encryption_provider_cipher
-      levels: level_1
+      levels: [ level_1, ]
       # Remove this comment once https://github.com/ComplianceAsCode/content/issues/10868 is fixed.
       # tickets:
       #   - https://issues.redhat.com/browse/CMP-1973
@@ -398,12 +398,12 @@ controls:
       status: automated
       rules:
         - api_server_tls_cipher_suites
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.2.33
       title: Ensure unsupported configuration overrides are not used
       status: pending
       rules: []
-      levels: level_1
+      levels: [ level_1, ]
   - id: '1.3'
     title: Controller Manager
     status: pending
@@ -414,32 +414,32 @@ controls:
       status: automated
       rules:
         - rbac_debug_role_protects_pprof
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.3.2
       title: Ensure that the --use-service-account-credentials argument is set to true
       status: automated
       rules:
         - controller_use_service_account
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.3.3
       title: Ensure that the --service-account-private-key-file argument is set as appropriate
       status: automated
       rules:
         - controller_service_account_private_key
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.3.4
       title: Ensure that the --root-ca-file argument is set as appropriate
       status: automated
       rules:
         - controller_service_account_ca
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.3.5
       title: Ensure that the --bind-address argument is set to 127.0.0.1
       status: automated
       rules:
         - controller_secure_port
         - controller_insecure_port_disabled
-      levels: level_1
+      levels: [ level_1, ]
   - id: '1.4'
     title: Scheduler
     status: automated
@@ -450,11 +450,11 @@ controls:
       status: automated
       rules:
         - scheduler_profiling_protected_by_rbac
-      levels: level_1
+      levels: [ level_1, ]
     - id: 1.4.2
       title: Verify that the scheduler API service is protected by RBAC
       status: automated
       rules:
         - scheduler_service_protected_by_rbac
-      levels: level_1
+      levels: [ level_1, ]
 

--- a/controls/cis_ocp_1_4_0/section-2.yml
+++ b/controls/cis_ocp_1_4_0/section-2.yml
@@ -10,42 +10,42 @@ controls:
     rules:
       - etcd_cert_file
       - etcd_key_file
-    levels: level_1
+    levels: [ level_1, ]
   - id: '2.2'
     title: Ensure that the --client-cert-auth argument is set to true
     status: automated
     rules:
       - etcd_client_cert_auth
-    levels: level_1
+    levels: [ level_1, ]
   - id: '2.3'
     title: Ensure that the --auto-tls argument is not set to true
     status: automated
     rules:
       - etcd_auto_tls
-    levels: level_1
+    levels: [ level_1, ]
   - id: '2.4'
     title: Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate
     status: automated
     rules:
       - etcd_peer_cert_file
       - etcd_peer_key_file
-    levels: level_1
+    levels: [ level_1, ]
   - id: '2.5'
     title: Ensure that the --peer-client-cert-auth argument is set to true
     status: automated
     rules:
       - etcd_peer_client_cert_auth
-    levels: level_1
+    levels: [ level_1, ]
   - id: '2.6'
     title: Ensure that the --peer-auto-tls argument is not set to true
     status: automated
     rules:
       - etcd_peer_auto_tls
-    levels: level_1
+    levels: [ level_1, ]
   - id: '2.7'
     title: Ensure that a unique Certificate Authority is used for etcd
     status: automated
     rules:
       - etcd_unique_ca
-    levels: level_2
+    levels: [ level_2, ]
 

--- a/controls/cis_ocp_1_4_0/section-3.yml
+++ b/controls/cis_ocp_1_4_0/section-3.yml
@@ -15,7 +15,7 @@ controls:
       rules:
         - idp_is_configured
         - kubeadmin_removed
-      levels: level_2
+      levels: [ level_2, ]
   - id: '3.2'
     title: Logging
     status: automated
@@ -26,11 +26,11 @@ controls:
       status: automated
       rules:
         - audit_profile_set
-      levels: level_1
+      levels: [ level_1, ]
     - id: 3.2.2
       title: Ensure that the audit policy covers key security concerns
       status: automated
       rules:
         - audit_profile_set
-      levels: level_2
+      levels: [ level_2, ]
 

--- a/controls/cis_ocp_1_4_0/section-4.yml
+++ b/controls/cis_ocp_1_4_0/section-4.yml
@@ -14,33 +14,33 @@ controls:
       status: automated
       rules:
         - file_permissions_worker_service
-      levels: level_1
+      levels: [ level_1, ]
     - id: 4.1.2
       title: Ensure that the kubelet service file ownership is set to root:root
       status: automated
       rules:
         - file_owner_worker_service
         - file_groupowner_worker_service
-      levels: level_1
+      levels: [ level_1, ]
     - id: 4.1.3
       title: If proxy kube proxy configuration file exists ensure permissions are set to 644 or more restrictive
       status: automated
       rules:
         - file_permissions_proxy_kubeconfig
-      levels: level_1
+      levels: [ level_1, ]
     - id: 4.1.4
       title: If proxy kubeconfig file exists ensure ownership is set to root:root
       status: automated
       rules:
         - file_owner_proxy_kubeconfig
         - file_groupowner_proxy_kubeconfig
-      levels: level_1
+      levels: [ level_1, ]
     - id: 4.1.5
       title: Ensure that the --kubeconfig kubelet.conf file permissions are set to 644 or more restrictive
       status: automated
       rules:
         - file_permissions_kubelet_conf
-      levels: level_1
+      levels: [ level_1, ]
     - id: 4.1.6
       title: Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root
       status: automated
@@ -49,33 +49,33 @@ controls:
         - file_owner_kubelet_conf
         #- file_groupowner_kubelet
         - file_owner_kubelet
-      levels: level_1
+      levels: [ level_1, ]
     - id: 4.1.7
       title: Ensure that the certificate authorities file permissions are set to 644 or more restrictive
       status: automated
       rules:
         - file_permissions_worker_ca
-      levels: level_1
+      levels: [ level_1, ]
     - id: 4.1.8
       title: Ensure that the client certificate authorities file ownership is set to root:root
       status: automated
       rules:
         - file_owner_worker_ca
         - file_groupowner_worker_ca
-      levels: level_1
+      levels: [ level_1, ]
     - id: 4.1.9
       title: Ensure that the kubelet --config configuration file has permissions set to 600 or more restrictive
       status: automated
       rules:
         - file_permissions_worker_kubeconfig
-      levels: level_1
+      levels: [ level_1, ]
     - id: 4.1.10
       title: Ensure that the kubelet configuration file ownership is set to root:root
       status: automated
       rules:
         - file_owner_worker_kubeconfig
         - file_groupowner_worker_kubeconfig
-      levels: level_1
+      levels: [ level_1, ]
   - id: '4.2'
     title: Kubelet
     status: pending
@@ -89,73 +89,73 @@ controls:
         - kubelet_eviction_thresholds_set_hard_nodefs_available
         - kubelet_eviction_thresholds_set_hard_nodefs_inodesfree
         - kubelet_eviction_thresholds_set_hard_imagefs_available
-      levels: level_1
+      levels: [ level_1, ]
     - id: 4.2.2
       title: Ensure that the --anonymous-auth argument is set to false
       status: automated
       rules:
         - kubelet_anonymous_auth
-      levels: level_1
+      levels: [ level_1, ]
     - id: 4.2.3
       title: Ensure that the --authorization-mode argument is not set to AlwaysAllow
       status: automated
       rules:
         - kubelet_authorization_mode
-      levels: level_1
+      levels: [ level_1, ]
     - id: 4.2.4
       title: Ensure that the --client-ca-file argument is set as appropriate
       status: automated
       rules:
         - kubelet_configure_client_ca
-      levels: level_1
+      levels: [ level_1, ]
     - id: 4.2.5
       title: Verify that the read only port is not used or is set to 0
       status: automated
       rules:
         - kubelet_disable_readonly_port
-      levels: level_1
+      levels: [ level_1, ]
     - id: 4.2.6
       title: Ensure that the --streaming-connection-idle-timeout argument is not set to 0
       status: automated
       rules:
         - kubelet_enable_streaming_connections
-      levels: level_1
+      levels: [ level_1, ]
     - id: 4.2.7
       title: Ensure that the --make-iptables-util-chains argument is set to true
       status: automated
       rules:
         - kubelet_enable_iptables_util_chains
-      levels: level_1
+      levels: [ level_1, ]
     - id: 4.2.8
       title: Ensure that the kubeAPIQPS [--event-qps] argument is set to 0 or a level which ensures appropriate event capture
       status: automated
       rules:
         - kubelet_configure_event_creation
-      levels: level_2
+      levels: [ level_2, ]
     - id: 4.2.9
       title: Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate
       status: automated
       rules:
         - kubelet_configure_tls_cert
         - kubelet_configure_tls_key
-      levels: level_1
+      levels: [ level_1, ]
     - id: 4.2.10
       title: Ensure that the --rotate-certificates argument is not set to false
       status: automated
       rules:
         - kubelet_enable_client_cert_rotation
         - kubelet_enable_cert_rotation
-      levels: level_1
+      levels: [ level_1, ]
     - id: 4.2.11
       title: Verify that the RotateKubeletServerCertificate argument is set to true
       status: automated
       rules:
         - kubelet_enable_server_cert_rotation
-      levels: level_1
+      levels: [ level_1, ]
     - id: 4.2.12
       title: Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers
       status: automated
       rules:
         - kubelet_configure_tls_cipher_suites
-      levels: level_1
+      levels: [ level_1, ]
 

--- a/controls/cis_ocp_1_4_0/section-5.yml
+++ b/controls/cis_ocp_1_4_0/section-5.yml
@@ -14,37 +14,37 @@ controls:
       status: manual
       rules:
         - rbac_limit_cluster_admin
-      levels: level_1
+      levels: [ level_1, ]
     - id: 5.1.2
       title: Minimize access to secrets
       status: manual
       rules:
         - rbac_limit_secrets_access
-      levels: level_1
+      levels: [ level_1, ]
     - id: 5.1.3
       title: Minimize wildcard use in Roles and ClusterRoles
       status: manual
       rules:
         - rbac_wildcard_use
-      levels: level_1
+      levels: [ level_1, ]
     - id: 5.1.4
       title: Minimize access to create pods
       status: manual
       rules:
         - rbac_pod_creation_access
-      levels: level_1
+      levels: [ level_1, ]
     - id: 5.1.5
       title: Ensure that default service accounts are not actively used.
       status: manual
       rules:
         - accounts_unique_service_account
-      levels: level_1
+      levels: [ level_1, ]
     - id: 5.1.6
       title: Ensure that Service Account Tokens are only mounted where necessary
       status: manual
       rules:
         - accounts_restrict_service_account_tokens
-      levels: level_1
+      levels: [ level_1, ]
   - id: '5.2'
     title: Security Context Constraints
     status: pending
@@ -55,61 +55,61 @@ controls:
       status: manual
       rules:
         - scc_limit_privileged_containers
-      levels: level_1
+      levels: [ level_1, ]
     - id: 5.2.2
       title: Minimize the admission of containers wishing to share the host process ID namespace
       status: manual
       rules:
         - scc_limit_process_id_namespace
-      levels: level_1
+      levels: [ level_1, ]
     - id: 5.2.3
       title: Minimize the admission of containers wishing to share the host IPC namespace
       status: manual
       rules:
         - scc_limit_ipc_namespace
-      levels: level_1
+      levels: [ level_1, ]
     - id: 5.2.4
       title: Minimize the admission of containers wishing to share the host network namespace
       status: manual
       rules:
         - scc_limit_network_namespace
-      levels: level_1
+      levels: [ level_1, ]
     - id: 5.2.5
       title: Minimize the admission of containers with allowPrivilegeEscalation
       status: manual
       rules:
         - scc_limit_privilege_escalation
-      levels: level_1
+      levels: [ level_1, ]
     - id: 5.2.6
       title: Minimize the admission of root containers
       status: manual
       rules:
         - scc_limit_root_containers
-      levels: level_2
+      levels: [ level_2, ]
     - id: 5.2.7
       title: Minimize the admission of containers with the NET_RAW capability
       status: manual
       rules:
         - scc_limit_net_raw_capability
-      levels: level_1
+      levels: [ level_1, ]
     - id: 5.2.8
       title: Minimize the admission of containers with added capabilities
       status: automated
       rules:
         - scc_limit_container_allowed_capabilities
-      levels: level_1
+      levels: [ level_1, ]
     - id: 5.2.9
       title: Minimize the admission of containers with capabilities assigned
       status: manual
       rules:
         - scc_drop_container_capabilities
-      levels: level_2
+      levels: [ level_2, ]
     - id: 5.2.10
       title: Minimize access to privileged Security Context Constraints
       status: manual
       rules:
         - rbac_least_privilege
-      levels: level_2
+      levels: [ level_2, ]
   - id: '5.3'
     title: Network Policies and CNI
     status: pending
@@ -120,14 +120,14 @@ controls:
       status: automated
       rules:
         - configure_network_policies
-      levels: level_1
+      levels: [ level_1, ]
     - id: 5.3.2
       title: Ensure that all Namespaces have Network Policies defined
       status: partial
       rules:
         - configure_network_policies_namespaces
         - configure_network_policies_hypershift_hosted
-      levels: level_2
+      levels: [ level_2, ]
   - id: '5.4'
     title: Secrets Management
     status: manual
@@ -138,13 +138,13 @@ controls:
       status: manual
       rules:
         - secrets_no_environment_variables
-      levels: level_1
+      levels: [ level_1, ]
     - id: 5.4.2
       title: Consider external secret storage
       status: manual
       rules:
         - secrets_consider_external_storage
-      levels: level_2
+      levels: [ level_2, ]
   - id: '5.5'
     title: Extensible Admission Control
     status: automated
@@ -158,7 +158,7 @@ controls:
         - ocp_allowed_registries_for_import
         - ocp_insecure_registries
         - ocp_insecure_allowed_registries_for_import
-      levels: level_2
+      levels: [ level_2, ]
   - id: '5.7'
     title: General Policies
     status: partial
@@ -169,23 +169,23 @@ controls:
       status: manual
       rules:
         - general_namespaces_in_use
-      levels: level_1
+      levels: [ level_1, ]
     - id: 5.7.2
       title: Ensure that the seccomp profile is set to docker/default in your pod definitions
       status: manual
       rules:
         - general_default_seccomp_profile
-      levels: level_2
+      levels: [ level_2, ]
     - id: 5.7.3
       title: Apply Security Context to Your Pods and Containers
       status: manual
       rules:
         - general_apply_scc
-      levels: level_2
+      levels: [ level_2, ]
     - id: 5.7.4
       title: The default namespace should not be used
       status: manual
       rules:
         - general_default_namespace_use
-      levels: level_2
+      levels: [ level_2, ]
 

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -158,6 +158,9 @@ class Control(ssg.entities.common.SelectionHandler, ssg.entities.common.XCCDFEnt
                 % (control.automated,  control.id, control.title))
             raise ValueError(msg)
         control.levels = control_dict.get("levels", default_level)
+        if type(control.levels) is not list:
+            msg = "Levels for %s must be an array" % control.id
+            raise ValueError(msg)
         control.notes = control_dict.get("notes", "")
         selections = control_dict.get("rules", {})
 

--- a/tests/unit/ssg-module/test_controls.py
+++ b/tests/unit/ssg-module/test_controls.py
@@ -511,3 +511,13 @@ def test_control_with_bad_key():
     except ValueError as e:
         assert type(e) is ValueError
     assert control_obj is None
+
+
+def test_control_with_bad_level():
+    control = {'id': 'abcd', 'levels': 'medium', }
+    control_obj = None
+    try:
+        control_obj = ssg.controls.Control.from_control_dict(control)
+    except ValueError as e:
+        assert type(e) is ValueError
+    assert control_obj is None

--- a/tests/unit/ssg-module/test_controls.py
+++ b/tests/unit/ssg-module/test_controls.py
@@ -1,12 +1,10 @@
 import pytest
-import logging
 import os
 import sys
 
 import ssg.controls
 import ssg.build_yaml
 from ssg.environment import open_environment
-from ssg.products import load_product_yaml
 
 ssg_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "data"))

--- a/utils/render_all_policies.py
+++ b/utils/render_all_policies.py
@@ -71,8 +71,8 @@ def load_policy(controls_dir: str, policy_id: str) -> ssg.controls.Policy:
 
 
 def render_policy(
-        policy: ssg.controls.Policy, product_id: str, rules: list,
-        values: list, output_dir: str) -> None:
+        policy: ssg.controls.Policy, product_id: str, rules: dict,
+        values: dict, output_dir: str) -> None:
     output_path = os.path.join(output_dir, policy.id + ".html")
     data = {
         "policy": policy,


### PR DESCRIPTION
#### Description:
* Require the `levels` key in the policy files to be an array
* Fix an existing policy

#### Rationale:
Fixes #11389 

#### Review Hints:
* Make the `levels` in your favorite control not an array and then try and build it. Notice the build failure. 
