### PR TITLE
Add reference title mapping

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -515,6 +515,12 @@ macro(ssg_build_sds PRODUCT)
     )
     set_tests_properties("xccdf-values-${PRODUCT}" PROPERTIES LABELS "quick")
 
+    add_test(
+        NAME "reference-titles-in-benchmark-${PRODUCT}"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tests/test_reference_titles_in_benchmark.py" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" "${CMAKE_BINARY_DIR}/${PRODUCT}/product.yml"
+    )
+    set_tests_properties("reference-titles-in-benchmark-${PRODUCT}" PROPERTIES LABELS quick)
+
     if("${PRODUCT}" MATCHES "rhel(7|8|9)|sle(12|15)")
         if("${PRODUCT}" MATCHES "sle(12|15)")
             add_test(

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -126,6 +126,17 @@ def add_reference_elements(element, references, ref_uri_dict):
             ref.text = ref_val
 
 
+def add_reference_title_elements(benchmark_el, env_yaml):
+    if env_yaml:
+        ref_uri_dict = env_yaml['reference_uris']
+    else:
+        ref_uri_dict = SSG_REF_URIS
+    for title, uri in ref_uri_dict.items():
+        reference = ET.SubElement(benchmark_el, "{%s}reference" % XCCDF12_NS)
+        reference.set("href", uri)
+        reference.text = title
+
+
 def add_benchmark_metadata(element, contributors_file):
     metadata = ET.SubElement(element, "{%s}metadata" % XCCDF12_NS)
 
@@ -356,6 +367,7 @@ class Benchmark(XCCDFEntity):
         notice.set('id', self.notice_id)
         add_sub_element(root, "front-matter", XCCDF12_NS, self.front_matter)
         add_sub_element(root, "rear-matter",  XCCDF12_NS, self.rear_matter)
+        add_reference_title_elements(root, env_yaml)
         # if there are no platforms, do not output platform-specification at all
         if len(self.product_cpes.platforms) > 0:
             cpe_platform_spec = ET.Element(

--- a/tests/test_reference_titles_in_benchmark.py
+++ b/tests/test_reference_titles_in_benchmark.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python3
+
+import argparse
+import xml.etree.ElementTree as ET
+import yaml
+
+from ssg.constants import datastream_namespace, XCCDF12_NS
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("datastream", help="SCAP source data stream")
+    parser.add_argument("product_yaml", help="Resolved product YAML")
+    return parser.parse_args()
+
+
+def get_references_in_benchmark(ds_path):
+    references = {}
+    root = ET.parse(ds_path).getroot()
+    benchmark_xpath = "./{%s}component/{%s}Benchmark" % (datastream_namespace, XCCDF12_NS)
+    benchmark_el = root.find(benchmark_xpath)
+    reference_xpath = "{%s}reference" % XCCDF12_NS
+    for reference_el in benchmark_el.findall(reference_xpath):
+        href = reference_el.get("href")
+        title = reference_el.text
+        references[title] = href
+    return references
+
+
+def get_references_in_product_yaml(product_yaml_path):
+    with open(product_yaml_path) as product_yaml_fd:
+        product_yaml = yaml.safe_load(product_yaml_fd)
+    product_yaml_references = product_yaml["reference_uris"]
+    return product_yaml_references
+
+
+def main():
+    args = parse_args()
+    references_in_benchmark = get_references_in_benchmark(args.datastream)
+    references_in_product_yaml = get_references_in_product_yaml(args.product_yaml)
+    assert references_in_benchmark == references_in_product_yaml
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This will add child `reference` elements to `Benchmark` element in XCCDF. The value of these `reference` elements will be the title or type of the reference and their `href` attribute will be set to the reference URI. This way we will have a mapping from a reference URI to reference title stored in our content. In future, we can use this mapping for easier work with references in OpenSCAP, oscap-report, etc.

This commit also adds a small test that ensures that this reference mapping in the built XCCDF file is the same as the contents of the `reference_uris` key in resolved product YAML
(`build/${PRODUCT}/product.yml`).

#### Review Hints:
1. build a product, eg. `./build_product -d rhel9`
2. open built SCAP source data stream `build/ssg-rhel9-ds.xml`
3. examine `reference` elements that are direct child of the `Benchmark` element within the XCCDF component
4. compare these `reference` elements with contents of the `reference_uris` key in resolved product YAML 
(`build/rhel9/product.yml`).
5. run the test `cd build && ctest --verbose -R reference-titles-in-benchmark`
