### PR TITLE
Fix Debian 10 CI

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: Update the package repository
         run: apt-get update
       - name: Install Deps
-        run: apt-get install -y ansible-lint bats check cmake libopenscap8 libxml2-utils ninja-build python3-github python3-pip xsltproc libxslt1-dev libxml2-dev
+        run: apt-get install -y ansible-lint bats check cmake libopenscap8 libxml2-utils ninja-build python3-github python3-pip xsltproc libxslt1-dev libxml2-dev zlib1g-dev
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install deps python

--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: Update the package repository
         run: apt-get update
       - name: Install Deps
-        run: apt-get install -y ansible-lint bats check cmake libopenscap8 libxml2-utils ninja-build python3-github python3-pip xsltproc
+        run: apt-get install -y ansible-lint bats check cmake libopenscap8 libxml2-utils ninja-build python3-github python3-pip xsltproc libxslt1-dev libxml2-dev
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install deps python


### PR DESCRIPTION
#### Description:

Add the following packages to the deps list:
* libxslt1-dev 
* libxml2-dev 
* zlib1g-dev
#### Rationale:

As it was causing CI failures due to failure to install the Python package lxml.

