### PR TITLE
Add support to disable wifi interfaces via wicked

### DIFF
--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/ansible/shared.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/ansible/shared.yml
@@ -4,6 +4,29 @@
 # complexity = low
 # disruption = medium
 
+- name: Service facts
+  ansible.builtin.service_facts:
+
+{{% if product in ["sle12", "sle15"] %}}
+
+- name: Wicked Deactivate Wireless Network Interfaces
+  command: wicked ifdown {{ item }}
+  loop: '{{ ansible_facts.interfaces }}'
+  when:
+    - ansible_facts.services['wickedd.service'].state == 'running'
+    - 'item.startswith("wl")'
+
+- name: Wicked Disable Wireless Network Interfaces
+  lineinfile:
+    path: /etc/sysconfig/network/ifcfg-{{ item }}
+    regexp: '^STARTMODE='
+    line: STARTMODE=off
+  loop: '{{ ansible_facts.interfaces }}'
+  when:
+    - ansible_facts.services['wickedd.service'].state == 'running'
+    - 'item.startswith("wl")'
+{{%- else %}}
+
 - name: Ensure NetworkManager is installed
   ansible.builtin.package:
     name: "{{ item }}"
@@ -11,6 +34,10 @@
   with_items:
     - NetworkManager
 
-- name: Deactivate Wireless Network Interfaces
+{{%- endif %}}
+
+- name: NetworkManager Deactivate Wireless Network Interfaces
   command: nmcli radio wifi off
-  when: "'NetworkManager' in ansible_facts.packages"
+  when:
+    - "'NetworkManager' in ansible_facts.packages"
+    - ansible_facts.services['NetworkManager.service'].state == 'running'

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/bash/shared.sh
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/bash/shared.sh
@@ -2,4 +2,16 @@
 
 {{{ bash_package_install("NetworkManager") }}}
 
-nmcli radio all off
+if command -v nmcli >/dev/null 2>&1 && systemctl is-active NetworkManager >/dev/null 2>&1; then
+    nmcli radio all off
+fi
+
+if command -v wicked >/dev/null 2>&1 && systemctl is-active wickedd >/dev/null 2>&1; then
+  if [ -n "$(find /sys/class/net/*/ -type d -name wireless)" ]; then
+    interfaces=$(find /sys/class/net/*/wireless -type d -name wireless | xargs -0 dirname | xargs basename)
+    for iface in $interfaces; do
+      wicked ifdown $iface
+      sed -i 's/STARTMODE=.*/STARTMODE=off/' /etc/sysconfig/network/ifcfg-$iface
+    done
+  fi
+fi


### PR DESCRIPTION

#### Description:

- Use wicked interface to disable wifi in SLE

#### Rationale:

- On SLES wicked can be used to manage network interfaces instead of NetworkManager, so adding support for that interface to disable wifi.

