### PR TITLE
Check iptables service when firewalld service is disabled

### DIFF
--- a/linux_os/guide/system/network/network-iptables/iptables_activation/service_iptables_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/service_iptables_enabled/rule.yml
@@ -11,8 +11,6 @@ rationale: |-
 
 severity: medium
 
-platform: package[iptables]
-
 identifiers:
     cce@rhel8: CCE-85961-1
     cce@rhel9: CCE-85962-9
@@ -33,7 +31,7 @@ references:
     nist: AC-4,CM-7(b),CA-3(5),SC-7(21),CM-6(a)
     nist-csf: DE.AE-1,ID.AM-3,PR.AC-5,PR.DS-5,PR.IP-1,PR.PT-3,PR.PT-4
 
-platform: machine
+platform: machine and package[iptables] and service_disabled[firewalld]
 
 ocil: |-
     {{{ ocil_service_enabled(service="iptables") }}}


### PR DESCRIPTION

#### Description:

- iptables  and firewalld service are mutually exclusive 

#### Rationale:

- Consider checking for iptables service only if we don't have firewalld service enabled

- Also unit the platform clauses to avoid duplication
