### PR TITLE
Do not check for yum on dnf systems

### DIFF
--- a/components/dnf.yml
+++ b/components/dnf.yml
@@ -4,5 +4,8 @@ packages:
 - dnf-automatic
 - dnf-plugin-subscription-manager
 rules:
+- clean_components_post_updating
+- ensure_gpgcheck_globally_activated
+- ensure_gpgcheck_local_packages
 - package_dnf-automatic_installed
 - package_dnf-plugin-subscription-manager_installed

--- a/linux_os/guide/system/software/updating/clean_components_post_updating/rule.yml
+++ b/linux_os/guide/system/software/updating/clean_components_post_updating/rule.yml
@@ -94,9 +94,6 @@ fixtext: |-
 srg_requirement: |-
     {{{ full_name }}} must remove all software components after updated versions have been installed.
 
-{{% if 'sle' in product %}}
-platform: package[zypper]
-{{% elif 'ubuntu' in product %}}
-{{% else %}}
-platform: package[yum]
+{{% if 'ubuntu' not in product %}}
+platform: package[{{{ pkg_manager }}}]
 {{% endif %}}

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/rule.yml
@@ -80,11 +80,7 @@ ocil: |-
 
     If "gpgcheck" is not set to "1", or if the option is missing or commented out, ask the System Administrator how the certificates for patches and other operating system components are verified.
 
-{{% if 'sle' in product %}}
-platform: package[zypper]
-{{% else %}}
-platform: package[yum]
-{{% endif %}}
+platform: package[{{{ pkg_manager }}}]
 
 fixtext: |-
     Configure {{{ full_name }}} to always check package signatures before installation.

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/rule.yml
@@ -57,7 +57,7 @@ ocil: |-
 
     If "localpkg_gpgcheck" is not set to "1", or if the option is missing or commented out, ask the System Administrator how the certificates for patches and other operating system components are verified.
 
-platform: package[yum]
+platform: package[{{{ pkg_manager }}}]
 
 fixtext: |-
     Configure {{{ full_name }}} to always check package signatures before installation of local packages.

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_repo_metadata/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_repo_metadata/rule.yml
@@ -56,4 +56,4 @@ ocil: |-
     The output should return something similar to:
     <pre>repo_gpgcheck=1</pre>
 
-platform: package[yum]
+platform: package[{{{ pkg_manager }}}]

--- a/shared/applicability/package.yml
+++ b/shared/applicability/package.yml
@@ -26,6 +26,8 @@ args:
     pkgname: bash
   chrony:
     pkgname: chrony
+  dnf:
+    pkgname: dnf
   firewalld:
     pkgname: firewalld
   gdm:


### PR DESCRIPTION
Some RHEL 9 rules use a `package[yum]` platform which makes them not applicable because they instead should check for `dnf` package.

We can fix this bug transparently by substituting in the `pkg_manager` product property by Jinja.

Resolves: https://issues.redhat.com/browse/RHEL-17417

