### PR TITLE
Support drop-in config in journald rules on RHEL

### DIFF
--- a/linux_os/guide/system/logging/journald/journald_compress/rule.yml
+++ b/linux_os/guide/system/logging/journald/journald_compress/rule.yml
@@ -37,21 +37,27 @@ ocil: |-
     Storing logs with compression can help avoid filling the system disk.
     Run the following command to verify that journald is compressing logs.
     <pre>
+{{%- if product in ["fedora", "rhel8", "rhel9", "sle15"] %}}
+    grep "^\sCompress" /etc/systemd/journald.conf {{{ journald_conf_dir_path }}}/*.conf
+{{% else %}}
     grep "^\sCompress" /etc/systemd/journald.conf
+{{% endif %}}
     </pre>
     and it should return
     <pre>
     Compress=yes
     </pre>
-{{%- if product == "sle15" %}}
+
+{{%- if product in ["fedora", "rhel8", "rhel9", "sle15"] %}}
 template:
     name: systemd_dropin_configuration
     vars:
         component: journald
         master_cfg_file: /etc/systemd/journald.conf
-        dropin_dir: /etc/systemd/journal.d/
+        dropin_dir: {{{ journald_conf_dir_path }}}
         param: Compress
         value: yes
+        no_quotes: 'true'
 {{% else %}}
 template:
     name: shell_lineinfile

--- a/linux_os/guide/system/logging/journald/journald_forward_to_syslog/rule.yml
+++ b/linux_os/guide/system/logging/journald/journald_forward_to_syslog/rule.yml
@@ -37,22 +37,27 @@ ocil: |-
     Storing logs remotely protects the integrity of the data from local attacks.
     Run the following command to verify that journald is forwarding logs to a remote host.
     <pre>
+{{%- if product in ["rhel8", "rhel9", "sle15"] %}}
+    grep "^\sForwardToSyslog" /etc/systemd/journald.conf {{{ journald_conf_dir_path }}}/*.conf
+{{% else %}}
     grep "^\sForwardToSyslog" /etc/systemd/journald.conf
+{{% endif %}}
     </pre>
     and it should return
     <pre>
     ForwardToSyslog=yes
     </pre>
 
-{{%- if product == "sle15" %}}
+{{%- if product in ["rhel8", "rhel9", "sle15"] %}}
 template:
     name: systemd_dropin_configuration
     vars:
         component: journald
         master_cfg_file: /etc/systemd/journald.conf
-        dropin_dir: /etc/systemd/journal.d/
+        dropin_dir: {{{ journald_conf_dir_path }}}
         param: ForwardToSyslog
         value: yes
+        no_quotes: 'true'
 {{% else %}}
 template:
     name: shell_lineinfile

--- a/linux_os/guide/system/logging/journald/journald_storage/rule.yml
+++ b/linux_os/guide/system/logging/journald/journald_storage/rule.yml
@@ -36,22 +36,27 @@ ocil: |-
     Storing logs with persistent storage ensures they are available after a reboot or system crash.
     Run the command below to verify that logs are being persistently stored to disk.
     <pre>
+{{%- if product in ["fedora", "rhel8", "rhel9", "sle15"] %}}
+    grep "^\sStorage" /etc/systemd/journald.conf {{{ journald_conf_dir_path }}}/*.conf
+{{% else %}}
     grep "^\sStorage" /etc/systemd/journald.conf
+{{% endif %}}
     </pre>
     and it should return
     <pre>
     Storage=persistent
     </pre>
 
-{{%- if product == "sle15" %}}
+{{%- if product in ["fedora", "rhel8", "rhel9", "sle15"] %}}
 template:
     name: systemd_dropin_configuration
     vars:
         component: journald
         master_cfg_file: /etc/systemd/journald.conf
-        dropin_dir: /etc/systemd/journal.d/
+        dropin_dir: {{{ journald_conf_dir_path }}}
         param: Storage
         value: persistent
+        no_quotes: 'true'
 {{% else %}}
 template:
     name: shell_lineinfile

--- a/products/sle15/product.yml
+++ b/products/sle15/product.yml
@@ -48,3 +48,4 @@ reference_uris:
 dconf_gdm_dir: "gdm.d"
 
 sysctl_remediate_drop_in_file: "true"
+journald_conf_dir_path: "/etc/systemd/journal.d"

--- a/shared/templates/systemd_dropin_configuration/ansible.template
+++ b/shared/templates/systemd_dropin_configuration/ansible.template
@@ -30,7 +30,7 @@
 
 - name: Deduplicate values from {{{ COMPONENT }}} {{{ PARAM }}} dropin configuration
   ansible.builtin.lineinfile:
-    path: "{{ item }}"
+    path: "{{ item.path }}"
     create: false
     regexp: ^\s*{{{ PARAM }}}=
     state: absent

--- a/shared/templates/systemd_dropin_configuration/bash.template
+++ b/shared/templates/systemd_dropin_configuration/bash.template
@@ -6,7 +6,7 @@
 
 function remove_{{{ COMPONENT }}}_{{{ PARAM }}}_configuration {
     local COMPONENT_PARAM_CONFIG
-    COMPONENT_PARAM_CONFIG=$(ls {{{ DROPIN_DIR }}}/*.conf)
+    mapfile -t COMPONENT_PARAM_CONFIG < <(ls {{{ DROPIN_DIR }}}/*.conf)
     COMPONENT_PARAM_CONFIG+=("{{{ MASTER_CFG_FILE }}}")
 
     for f in "${COMPONENT_PARAM_CONFIG[@]}"
@@ -23,6 +23,9 @@ function {{{ COMPONENT }}}_{{{ PARAM }}}_add_configuration {
     mkdir -p "{{{ DROPIN_DIR }}}"
     COMPONENT_PARAM_REMEDY_CFG="{{{ DROPIN_DIR }}}/oscap-remedy.conf"
 
+    if [ ! -f "${COMPONENT_PARAM_REMEDY_CFG}" ] ; then
+        touch "${COMPONENT_PARAM_REMEDY_CFG}"
+    fi
     cp "${COMPONENT_PARAM_REMEDY_CFG}" "${COMPONENT_PARAM_REMEDY_CFG}.bak"
     # Insert before the line matching the regex '^#\s*Compress'.
     line_number="$(LC_ALL=C grep -n "^#\s*{{{ PARAM }}}" "${COMPONENT_PARAM_REMEDY_CFG}.bak" | LC_ALL=C sed 's/:.*//g')"

--- a/shared/templates/systemd_dropin_configuration/tests/correct_dir.pass.sh
+++ b/shared/templates/systemd_dropin_configuration/tests/correct_dir.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+PARAM="{{{ PARAM }}}"
+VALUE="{{{ VALUE }}}"
+DROPIN_DIR="{{{ DROPIN_DIR }}}"
+[ -d $DROPIN_DIR ] || mkdir -p $DROPIN_DIR
+echo "$PARAM=$VALUE" >> "$DROPIN_DIR/ssg.conf"

--- a/shared/templates/systemd_dropin_configuration/tests/correct_master.pass.sh
+++ b/shared/templates/systemd_dropin_configuration/tests/correct_master.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+PARAM="{{{ PARAM }}}"
+VALUE="{{{ VALUE }}}"
+MASTER_CFG_FILE="{{{ MASTER_CFG_FILE }}}"
+echo "$PARAM=$VALUE" >> "$MASTER_CFG_FILE"

--- a/shared/templates/systemd_dropin_configuration/tests/multiple_vals.fail.sh
+++ b/shared/templates/systemd_dropin_configuration/tests/multiple_vals.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+PARAM="{{{ PARAM }}}"
+VALUE="{{{ VALUE }}}"
+DROPIN_DIR="{{{ DROPIN_DIR }}}"
+MASTER_CFG_FILE="{{{ MASTER_CFG_FILE }}}"
+[ -d $DROPIN_DIR ] || mkdir -p $DROPIN_DIR
+echo "$PARAM=$VALUE" >> "$DROPIN_DIR/ssg.conf"
+echo "$PARAM=badval" >> "$DROPIN_DIR/gss.conf"
+echo "$PARAM=foobarzoo" >> "$MASTER_CFG_FILE"

--- a/shared/templates/systemd_dropin_configuration/tests/wrong_dir.fail.sh
+++ b/shared/templates/systemd_dropin_configuration/tests/wrong_dir.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+PARAM="{{{ PARAM }}}"
+DROPIN_DIR="{{{ DROPIN_DIR }}}"
+[ -d $DROPIN_DIR ] || mkdir -p $DROPIN_DIR
+echo "$PARAM=badval" >> "$DROPIN_DIR/ssg.conf"

--- a/shared/templates/systemd_dropin_configuration/tests/wrong_master.fail.sh
+++ b/shared/templates/systemd_dropin_configuration/tests/wrong_master.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+PARAM="{{{ PARAM }}}"
+VALUE="{{{ VALUE }}}"
+MASTER_CFG_FILE="{{{ MASTER_CFG_FILE }}}"
+echo "$PARAM=badval" >> "$MASTER_CFG_FILE"

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -477,6 +477,7 @@ DEFAULT_FAILLOCK_PATH = '/var/run/faillock'
 DEFAULT_SSH_DISTRIBUTED_CONFIG = 'false'
 DEFAULT_PRODUCT = 'example'
 DEFAULT_CHRONY_CONF_PATH = '/etc/chrony.conf'
+DEFAULT_JOURNALD_CONF_DIR_PATH='/etc/systemd/journald.conf.d'
 DEFAULT_AUDISP_CONF_PATH = '/etc/audit'
 DEFAULT_SYSCTL_REMEDIATE_DROP_IN_FILE = 'false'
 

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -477,7 +477,7 @@ DEFAULT_FAILLOCK_PATH = '/var/run/faillock'
 DEFAULT_SSH_DISTRIBUTED_CONFIG = 'false'
 DEFAULT_PRODUCT = 'example'
 DEFAULT_CHRONY_CONF_PATH = '/etc/chrony.conf'
-DEFAULT_JOURNALD_CONF_DIR_PATH='/etc/systemd/journald.conf.d'
+DEFAULT_JOURNALD_CONF_DIR_PATH = '/etc/systemd/journald.conf.d'
 DEFAULT_AUDISP_CONF_PATH = '/etc/audit'
 DEFAULT_SYSCTL_REMEDIATE_DROP_IN_FILE = 'false'
 

--- a/ssg/products.py
+++ b/ssg/products.py
@@ -12,6 +12,7 @@ from .constants import (DEFAULT_PRODUCT, product_directories,
                         DEFAULT_AIDE_BIN_PATH,
                         DEFAULT_SSH_DISTRIBUTED_CONFIG,
                         DEFAULT_CHRONY_CONF_PATH,
+                        DEFAULT_JOURNALD_CONF_DIR_PATH,
                         DEFAULT_AUDISP_CONF_PATH,
                         DEFAULT_FAILLOCK_PATH,
                         DEFAULT_SYSCTL_REMEDIATE_DROP_IN_FILE,
@@ -74,6 +75,9 @@ def _get_implied_properties(existing_properties):
 
     if "sysctl_remediate_drop_in_file" not in existing_properties:
         result["sysctl_remediate_drop_in_file"] = DEFAULT_SYSCTL_REMEDIATE_DROP_IN_FILE
+
+    if "journald_conf_dir_path" not in existing_properties:
+        result["journald_conf_dir_path"] = DEFAULT_JOURNALD_CONF_DIR_PATH
 
     return result
 

--- a/tests/data/product_stability/alinux2.yml
+++ b/tests/data/product_stability/alinux2.yml
@@ -23,6 +23,7 @@ grub2_boot_path: /boot/grub2
 grub2_uefi_boot_path: /boot/grub2
 grub_helper_executable: grubby
 init_system: systemd
+journald_conf_dir_path: /etc/systemd/journald.conf.d
 nobody_gid: 65534
 nobody_uid: 65534
 pkg_manager: yum

--- a/tests/data/product_stability/alinux3.yml
+++ b/tests/data/product_stability/alinux3.yml
@@ -23,6 +23,7 @@ grub2_boot_path: /boot/grub2
 grub2_uefi_boot_path: /boot/grub2
 grub_helper_executable: grubby
 init_system: systemd
+journald_conf_dir_path: /etc/systemd/journald.conf.d
 nobody_gid: 65534
 nobody_uid: 65534
 pkg_manager: yum

--- a/tests/data/product_stability/anolis8.yml
+++ b/tests/data/product_stability/anolis8.yml
@@ -23,6 +23,7 @@ grub2_boot_path: /boot/grub2
 grub2_uefi_boot_path: /boot/grub2
 grub_helper_executable: grubby
 init_system: systemd
+journald_conf_dir_path: /etc/systemd/journald.conf.d
 nobody_gid: 65534
 nobody_uid: 65534
 pkg_manager: yum

--- a/tests/data/product_stability/chromium.yml
+++ b/tests/data/product_stability/chromium.yml
@@ -22,6 +22,7 @@ groups: {}
 grub2_boot_path: /boot/grub2
 grub2_uefi_boot_path: /boot/grub2
 grub_helper_executable: grubby
+journald_conf_dir_path: /etc/systemd/journald.conf.d
 nobody_gid: 65534
 nobody_uid: 65534
 platform_package_overrides:

--- a/tests/data/product_stability/debian10.yml
+++ b/tests/data/product_stability/debian10.yml
@@ -26,6 +26,7 @@ grub2_boot_path: /boot/grub
 grub2_uefi_boot_path: /boot/grub2
 grub_helper_executable: update-grub
 init_system: systemd
+journald_conf_dir_path: /etc/systemd/journald.conf.d
 major_version_ordinal: 10
 nobody_gid: 65534
 nobody_uid: 65534

--- a/tests/data/product_stability/debian11.yml
+++ b/tests/data/product_stability/debian11.yml
@@ -26,6 +26,7 @@ grub2_boot_path: /boot/grub
 grub2_uefi_boot_path: /boot/grub2
 grub_helper_executable: update-grub
 init_system: systemd
+journald_conf_dir_path: /etc/systemd/journald.conf.d
 major_version_ordinal: 11
 nobody_gid: 65534
 nobody_uid: 65534

--- a/tests/data/product_stability/eks.yml
+++ b/tests/data/product_stability/eks.yml
@@ -31,6 +31,7 @@ grub2_boot_path: /boot/grub2
 grub2_uefi_boot_path: /boot/grub2
 grub_helper_executable: grubby
 init_system: systemd
+journald_conf_dir_path: /etc/systemd/journald.conf.d
 nobody_gid: 65534
 nobody_uid: 65534
 pkg_system: rpm

--- a/tests/data/product_stability/example.yml
+++ b/tests/data/product_stability/example.yml
@@ -24,6 +24,7 @@ grub2_boot_path: /boot/grub2
 grub2_uefi_boot_path: /boot/grub2
 grub_helper_executable: grubby
 init_system: systemd
+journald_conf_dir_path: /etc/systemd/journald.conf.d
 nobody_gid: 65534
 nobody_uid: 65534
 pkg_manager: dnf

--- a/tests/data/product_stability/fedora.yml
+++ b/tests/data/product_stability/fedora.yml
@@ -46,6 +46,7 @@ grub2_boot_path: /boot/grub2
 grub2_uefi_boot_path: /boot/grub2
 grub_helper_executable: grubby
 init_system: systemd
+journald_conf_dir_path: /etc/systemd/journald.conf.d
 latest_pkg_release: 6202d9c6
 latest_pkg_version: eb10b464
 latest_release_fingerprint: 6A51BBABBA3D5467B6171221809A8D7CEB10B464

--- a/tests/data/product_stability/firefox.yml
+++ b/tests/data/product_stability/firefox.yml
@@ -22,6 +22,7 @@ groups: {}
 grub2_boot_path: /boot/grub2
 grub2_uefi_boot_path: /boot/grub2
 grub_helper_executable: grubby
+journald_conf_dir_path: /etc/systemd/journald.conf.d
 nobody_gid: 65534
 nobody_uid: 65534
 platform_package_overrides:

--- a/tests/data/product_stability/macos1015.yml
+++ b/tests/data/product_stability/macos1015.yml
@@ -22,6 +22,7 @@ groups: {}
 grub2_boot_path: /boot/grub2
 grub2_uefi_boot_path: /boot/grub2
 grub_helper_executable: grubby
+journald_conf_dir_path: /etc/systemd/journald.conf.d
 nobody_gid: 65534
 nobody_uid: 65534
 platform_package_overrides:

--- a/tests/data/product_stability/ocp4.yml
+++ b/tests/data/product_stability/ocp4.yml
@@ -107,6 +107,7 @@ grub2_boot_path: /boot/grub2
 grub2_uefi_boot_path: /boot/grub2
 grub_helper_executable: grubby
 init_system: systemd
+journald_conf_dir_path: /etc/systemd/journald.conf.d
 nobody_gid: 65534
 nobody_uid: 65534
 pkg_system: rpm

--- a/tests/data/product_stability/ol7.yml
+++ b/tests/data/product_stability/ol7.yml
@@ -28,6 +28,7 @@ grub2_boot_path: /boot/grub2
 grub2_uefi_boot_path: /boot/efi/EFI/redhat
 grub_helper_executable: grubby
 init_system: systemd
+journald_conf_dir_path: /etc/systemd/journald.conf.d
 major_version_ordinal: 7
 nobody_gid: 65534
 nobody_uid: 65534

--- a/tests/data/product_stability/ol8.yml
+++ b/tests/data/product_stability/ol8.yml
@@ -28,6 +28,7 @@ grub2_boot_path: /boot/grub2
 grub2_uefi_boot_path: /boot/efi/EFI/redhat
 grub_helper_executable: grubby
 init_system: systemd
+journald_conf_dir_path: /etc/systemd/journald.conf.d
 major_version_ordinal: 8
 nobody_gid: 65534
 nobody_uid: 65534

--- a/tests/data/product_stability/ol9.yml
+++ b/tests/data/product_stability/ol9.yml
@@ -31,6 +31,7 @@ grub2_boot_path: /boot/grub2
 grub2_uefi_boot_path: /boot/grub2
 grub_helper_executable: grubby
 init_system: systemd
+journald_conf_dir_path: /etc/systemd/journald.conf.d
 major_version_ordinal: 9
 nobody_gid: 65534
 nobody_uid: 65534

--- a/tests/data/product_stability/opensuse.yml
+++ b/tests/data/product_stability/opensuse.yml
@@ -35,6 +35,7 @@ grub2_boot_path: /boot/grub2
 grub2_uefi_boot_path: /boot/grub2
 grub_helper_executable: grubby
 init_system: systemd
+journald_conf_dir_path: /etc/systemd/journald.conf.d
 nobody_gid: 65534
 nobody_uid: 65534
 pkg_manager: zypper

--- a/tests/data/product_stability/rhcos4.yml
+++ b/tests/data/product_stability/rhcos4.yml
@@ -25,6 +25,7 @@ grub2_boot_path: /boot/grub2
 grub2_uefi_boot_path: /boot/grub2
 grub_helper_executable: grubby
 init_system: systemd
+journald_conf_dir_path: /etc/systemd/journald.conf.d
 nobody_gid: 65534
 nobody_uid: 65534
 pkg_release: 4ae0493b

--- a/tests/data/product_stability/rhel7.yml
+++ b/tests/data/product_stability/rhel7.yml
@@ -51,6 +51,7 @@ grub2_boot_path: /boot/grub2
 grub2_uefi_boot_path: /boot/efi/EFI/redhat
 grub_helper_executable: grubby
 init_system: systemd
+journald_conf_dir_path: /etc/systemd/journald.conf.d
 major_version_ordinal: 7
 nobody_gid: 65534
 nobody_uid: 65534

--- a/tests/data/product_stability/rhel8.yml
+++ b/tests/data/product_stability/rhel8.yml
@@ -79,6 +79,7 @@ grub2_boot_path: /boot/grub2
 grub2_uefi_boot_path: /boot/efi/EFI/redhat
 grub_helper_executable: grubby
 init_system: systemd
+journald_conf_dir_path: /etc/systemd/journald.conf.d
 major_version_ordinal: 8
 nobody_gid: 65534
 nobody_uid: 65534

--- a/tests/data/product_stability/rhel9.yml
+++ b/tests/data/product_stability/rhel9.yml
@@ -35,6 +35,7 @@ grub2_boot_path: /boot/grub2
 grub2_uefi_boot_path: /boot/grub2
 grub_helper_executable: grubby
 init_system: systemd
+journald_conf_dir_path: /etc/systemd/journald.conf.d
 major_version_ordinal: 9
 nobody_gid: 65534
 nobody_uid: 65534

--- a/tests/data/product_stability/rhv4.yml
+++ b/tests/data/product_stability/rhv4.yml
@@ -30,6 +30,7 @@ grub2_boot_path: /boot/grub2
 grub2_uefi_boot_path: /boot/grub2
 grub_helper_executable: grubby
 init_system: systemd
+journald_conf_dir_path: /etc/systemd/journald.conf.d
 nobody_gid: 65534
 nobody_uid: 65534
 pkg_manager: yum

--- a/tests/data/product_stability/sle12.yml
+++ b/tests/data/product_stability/sle12.yml
@@ -29,6 +29,7 @@ grub2_boot_path: /boot/grub2
 grub2_uefi_boot_path: /boot/efi/EFI/sles
 grub_helper_executable: grub2-mkconfig
 init_system: systemd
+journald_conf_dir_path: /etc/systemd/journald.conf.d
 major_version_ordinal: 12
 nobody_gid: 65534
 nobody_uid: 65534

--- a/tests/data/product_stability/sle15.yml
+++ b/tests/data/product_stability/sle15.yml
@@ -29,6 +29,7 @@ grub2_boot_path: /boot/grub2
 grub2_uefi_boot_path: /boot/grub2
 grub_helper_executable: grub2-mkconfig
 init_system: systemd
+journald_conf_dir_path: /etc/systemd/journal.d
 major_version_ordinal: 15
 nobody_gid: 65534
 nobody_uid: 65534

--- a/tests/data/product_stability/ubuntu1604.yml
+++ b/tests/data/product_stability/ubuntu1604.yml
@@ -26,6 +26,7 @@ grub2_boot_path: /boot/grub
 grub2_uefi_boot_path: /boot/efi/EFI/ubuntu
 grub_helper_executable: update-grub
 init_system: systemd
+journald_conf_dir_path: /etc/systemd/journald.conf.d
 major_version_ordinal: 1604
 nobody_gid: 65534
 nobody_uid: 65534

--- a/tests/data/product_stability/ubuntu1804.yml
+++ b/tests/data/product_stability/ubuntu1804.yml
@@ -26,6 +26,7 @@ grub2_boot_path: /boot/grub
 grub2_uefi_boot_path: /boot/efi/EFI/ubuntu
 grub_helper_executable: update-grub
 init_system: systemd
+journald_conf_dir_path: /etc/systemd/journald.conf.d
 major_version_ordinal: 1804
 nobody_gid: 65534
 nobody_uid: 65534

--- a/tests/data/product_stability/ubuntu2004.yml
+++ b/tests/data/product_stability/ubuntu2004.yml
@@ -27,6 +27,7 @@ grub2_boot_path: /boot/grub
 grub2_uefi_boot_path: /boot/grub
 grub_helper_executable: update-grub
 init_system: systemd
+journald_conf_dir_path: /etc/systemd/journald.conf.d
 major_version_ordinal: 2004
 nobody_gid: 65534
 nobody_uid: 65534

--- a/tests/data/product_stability/ubuntu2204.yml
+++ b/tests/data/product_stability/ubuntu2204.yml
@@ -26,6 +26,7 @@ grub2_boot_path: /boot/grub
 grub2_uefi_boot_path: /boot/grub
 grub_helper_executable: update-grub
 init_system: systemd
+journald_conf_dir_path: /etc/systemd/journald.conf.d
 major_version_ordinal: 2204
 nobody_gid: 65534
 nobody_uid: 65534

--- a/tests/data/product_stability/uos20.yml
+++ b/tests/data/product_stability/uos20.yml
@@ -23,6 +23,7 @@ grub2_boot_path: /boot/grub2
 grub2_uefi_boot_path: /boot/grub2
 grub_helper_executable: grubby
 init_system: systemd
+journald_conf_dir_path: /etc/systemd/journald.conf.d
 nobody_gid: 65534
 nobody_uid: 65534
 pkg_manager: yum


### PR DESCRIPTION
This patch adds support for the drop-in configuration files in directory /etc/systemd/journald.conf.d/ to these rules configuring journald:
- journald_compress
- journald_forward_to_syslog
- journald_storage

This patch levarages the systemd_dropin_configuration template that is already in use on SLES 15.

This patch also adds some test scenarios for the
systemd_dropin_configuration template and fixes issues revealed by these test scenarios.

Resolves: https://issues.redhat.com/browse/RHEL-14484

