### PR TITLE
Allow spaces in rule sudo_custom_logfile

### DIFF
--- a/linux_os/guide/system/software/sudo/sudo_custom_logfile/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_custom_logfile/rule.yml
@@ -78,7 +78,7 @@ template:
         #
         # Finally, we check for regular word boundary (with \b), ensuring the
         # next character isn't yet another word character.
-        option_regex_suffix: '=("(?:\\"|\\\\|[^"\\\n])*"\B|[^"](?:(?:\\,|\\"|\\ |\\\\|[^", \\\n])*)\b)'
+        option_regex_suffix: '\s*=\s*("(?:\\"|\\\\|[^"\\\n])*"\B|[^"](?:(?:\\,|\\"|\\ |\\\\|[^", \\\n])*)\b)'
         variable_name: var_sudo_logfile
 
 platform: package[sudo]

--- a/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/logfile_enabled_spaces.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/logfile_enabled_spaces.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platform = multi_platform_all
+# packages = sudo
+
+# Test that OVAL check allows spaces around the equal sign
+# This test scenario is a regression test of https://issues.redhat.com/browse/RHEL-1904
+
+echo "Defaults logfile = /var/log/sudo.log" >> /etc/sudoers


### PR DESCRIPTION
We should allow spaces around equal sign in /etc/sudoers. The following should be a valid configuration.

Defaults logfile = /var/log/sudo

Also adds a test scenario that serves as a regression test.

Resolves: https://issues.redhat.com/browse/RHEL-1904


