### PR TITLE
Do not change comments by remediations

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/bash/shared.sh
@@ -1,10 +1,4 @@
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle,multi_platform_ubuntu
 
 {{{ bash_instantiate_variables("var_password_hashing_algorithm") }}}
-
-if grep --silent ^ENCRYPT_METHOD /etc/login.defs ; then
-	sed -i "s/^ENCRYPT_METHOD .*/ENCRYPT_METHOD $var_password_hashing_algorithm/g" /etc/login.defs
-else
-	echo "" >> /etc/login.defs
-	echo "ENCRYPT_METHOD $var_password_hashing_algorithm" >> /etc/login.defs
-fi
+{{{ bash_replace_or_append('/etc/login.defs', '^ENCRYPT_METHOD', "$var_password_hashing_algorithm", '%s %s') }}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/bash/shared.sh
@@ -1,9 +1,4 @@
 # platform = multi_platform_all
 
 {{{ bash_instantiate_variables("var_accounts_maximum_age_login_defs") }}}
-
-grep -q ^PASS_MAX_DAYS /etc/login.defs && \
-  sed -i "s/PASS_MAX_DAYS.*/PASS_MAX_DAYS     $var_accounts_maximum_age_login_defs/g" /etc/login.defs
-if ! [ $? -eq 0 ]; then
-    echo "PASS_MAX_DAYS      $var_accounts_maximum_age_login_defs" >> /etc/login.defs
-fi
+{{{ bash_replace_or_append('/etc/login.defs', '^PASS_MAX_DAYS', "$var_accounts_maximum_age_login_defs", '%s %s') }}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_minimum_age_login_defs/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_minimum_age_login_defs/bash/shared.sh
@@ -1,9 +1,4 @@
 # platform = multi_platform_all
 
 {{{ bash_instantiate_variables("var_accounts_minimum_age_login_defs") }}}
-
-grep -q ^PASS_MIN_DAYS /etc/login.defs && \
-  sed -i "s/PASS_MIN_DAYS.*/PASS_MIN_DAYS     $var_accounts_minimum_age_login_defs/g" /etc/login.defs
-if ! [ $? -eq 0 ]; then
-    echo "PASS_MIN_DAYS      $var_accounts_minimum_age_login_defs" >> /etc/login.defs
-fi
+{{{ bash_replace_or_append('/etc/login.defs', '^PASS_MIN_DAYS', "$var_accounts_minimum_age_login_defs", '%s %s') }}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/bash/shared.sh
@@ -1,10 +1,4 @@
 # platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle
 
 {{{ bash_instantiate_variables("var_accounts_password_minlen_login_defs") }}}
-
-grep -q ^PASS_MIN_LEN /etc/login.defs && \
-sed -i "s/PASS_MIN_LEN.*/PASS_MIN_LEN\t$var_accounts_password_minlen_login_defs/g" /etc/login.defs
-if ! [ $? -eq 0 ]
-then
-  echo -e "PASS_MIN_LEN\t$var_accounts_password_minlen_login_defs" >> /etc/login.defs
-fi
+{{{ bash_replace_or_append('/etc/login.defs', '^PASS_MIN_LEN', "$var_accounts_password_minlen_login_defs", '%s %s') }}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/bash/shared.sh
@@ -1,10 +1,4 @@
 # platform = multi_platform_all
 
 {{{ bash_instantiate_variables("var_accounts_password_warn_age_login_defs") }}}
-
-grep -q ^PASS_WARN_AGE /etc/login.defs && \
-sed -i "s/PASS_WARN_AGE.*/PASS_WARN_AGE\t$var_accounts_password_warn_age_login_defs/g" /etc/login.defs
-if ! [ $? -eq 0 ]
-then
-  echo -e "PASS_WARN_AGE\t$var_accounts_password_warn_age_login_defs" >> /etc/login.defs
-fi
+{{{ bash_replace_or_append('/etc/login.defs', '^PASS_WARN_AGE', "$var_accounts_password_warn_age_login_defs", '%s %s') }}}


### PR DESCRIPTION
Some Bash remediations that modify `/etc/login.defs` are accidentally changing also the explanatory comments that are in this files shipped by default. There is no reason to change these comments because they don't have any effect and changing them only increases noise in diffs.

The issue will be fixed by using the Jinja macro
`bash_replace_or_append` instead of custom remediations.

Resolves: https://issues.redhat.com/browse/RHEL-1484

