### PR TITLE
Add ocp platforms to some eks shared OVALs

### DIFF
--- a/shared/applicability/oval/installed_app_is_eks.xml
+++ b/shared/applicability/oval/installed_app_is_eks.xml
@@ -4,7 +4,8 @@
     <metadata>
       <title>Amazon Elastic Kubernetes Service</title>
       <affected family="unix">
-        <platform>Amazon Elastic Kubernetes Service</platform>
+        <platform>multi_platform_eks</platform>
+        <platform>multi_platform_ocp</platform>
       </affected>
       <reference ref_id="cpe:/a:amazon:elastic_kubernetes_service:1" source="CPE" />
       <description>The application installed installed on the system is EKS.</description>

--- a/shared/applicability/oval/installed_app_is_eks_node.xml
+++ b/shared/applicability/oval/installed_app_is_eks_node.xml
@@ -3,7 +3,8 @@
     <metadata>
       <title>Amazon Elastic Kubernetes Service Node</title>
       <affected family="unix">
-        <platform>Amazon Elastic Kubernetes Service Node</platform>
+        <platform>multi_platform_eks</platform>
+        <platform>multi_platform_ocp</platform>
       </affected>
       <reference ref_id="cpe:/o:amazon:elastic_kubernetes_service_node:1" source="CPE" />
       <description>The application installed installed on the system is EKS 4.</description>


### PR DESCRIPTION
#### Description:

Shared OVALs may get into content of a wider range of products, and it is better to preventatively include those checks, as the project can't do that on-demand at this time.

See https://github.com/ComplianceAsCode/content/pull/10610.