### PR TITLE
align description of audit_rules_kernel_module_loading

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/rule.yml
@@ -51,6 +51,7 @@ references:
 
 ocil: |-
     {{{ ocil_audit_syscall(syscall="init_module") }}}
+    {{{ ocil_audit_syscall(syscall="finit_module") }}}
     {{{ ocil_audit_syscall(syscall="delete_module") }}}
 
 {{{ ocil_clause_entry_audit_syscall() }}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/rule.yml
@@ -8,7 +8,7 @@ description: |-
     To capture kernel module loading and unloading events, use following lines, setting ARCH to
     either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:
     <pre>
-    -a always,exit -F arch=<i>ARCH</i> -S init_module,finit_module,delete_module -F key=modules
+    -a always,exit -F arch=<i>ARCH</i> -S init_module,finit_module,delete_module {{% if 'ol' in product or 'rhel' in product %}}-F auid>=1000 -F auid!=unset {{% endif %}}-F key=modules
     </pre>
 
     The place to add the lines depends on a way <tt>auditd</tt> daemon is configured. If it is configured


### PR DESCRIPTION
#### Description:

- add the part of the line restricting UIDs for RHEL* and OL* products
- add OCIL macro for finit_module

#### Rationale:

- aligns rule description with check and remediations
- completes OCIL

#### Review Hints:

- compile e.g. rhel9 and sle15 product
- compare their remediations, check and rule description, differences should be the same
