### PR TITLE
Add group.yml file for firewalld_deactivation rules

### DIFF
--- a/linux_os/guide/system/network/network-firewalld/firewalld_deactivation/group.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_deactivation/group.yml
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'Dectivate firewalld Rules'
+
+description: |-
+    Firewalls can be used to separate networks into different zones
+    based on the level of trust the user has decided to place on the devices and
+    traffic within that network.
+    Firewalls can be implemented using variety of software tools and services,
+    i.e. iptables, nftables, firewalld, ufw, SuSEFirewall2 etc.
+    Having more than one service controlling the firewall functionality may lead
+    to conflicts and misconfiguration.
+    Therefore, in case one uses iptables or nftables firewalld service should
+    be disabled.


### PR DESCRIPTION
#### Description:

- Add group.yml file for firewalld_deactivation group of rules

#### Rationale:

- In case we have a group of rules in a subdirectory, lacking of group.yml definition prevents build script to build the rules in that subdirectory.

#### Review Hints:

- The case that got me fixing that is a complaint that group.yml does not exist for firewalld_deactivation subdirectory. Coudn't find other subdirs of the same case, using a fast and dirty find|grep utility:
```
find linux_os/guide -mindepth 2  -type d '!' -exec sh -c ' ls -1 "{}"|egrep -i -q "(kubernetes|ansible|bash|tests|oval|policy|stig|ocp4|group.yml|shared.yml|.\.xml|shared.sh|.\.sh|rule.yml|e2e.yml|e2e.yaml|.\.anaconda|.\.pp|test_config.yml|(ol|sle.*|rhel.*|debian.*|ubuntu.*|[\.\d]*).yml|shared.toml)$"' ';' -print
```
, for sure can be done better
 but maybe a good idea to add a test about that, although not sure where in the suites it fits in or if it worths adding it as an exception in the build procedure, when traversing recursively subdirectories.
