### PR TITLE
Fix configure_bashrc_exec_tmux missing parenthesis

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/bash/shared.sh
@@ -4,12 +4,12 @@
 # complexity = low
 # disruption = low
 
-if ! grep -x '  case "$name" in sshd|login) exec tmux ;; esac' /etc/bashrc; then
+if ! grep -x '  case "$name" in (sshd|login) exec tmux ;; esac' /etc/bashrc; then
     cat >> /etc/profile.d/tmux.sh <<'EOF'
 if [ "$PS1" ]; then
   parent=$(ps -o ppid= -p $$)
   name=$(ps -o comm= -p $parent)
-  case "$name" in sshd|login) exec tmux ;; esac
+  case "$name" in (sshd|login) exec tmux ;; esac
 fi
 EOF
     chmod 0644 /etc/profile.d/tmux.sh

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/oval/shared.xml
@@ -14,7 +14,7 @@
   <ind:textfilecontent54_object id="obj_configure_bashrc_exec_tmux" version="1">
     <ind:behaviors singleline="true" multiline="false" />
     <ind:filepath operation="pattern match">^/etc/bashrc$|^/etc/profile\.d/.*$</ind:filepath>
-    <ind:pattern operation="pattern match">if \[ "\$PS1" \]; then\n\s+parent=\$\(ps -o ppid= -p \$\$\)\n\s+name=\$\(ps -o comm= -p \$parent\)\n\s+case "\$name" in sshd\|login\) exec tmux ;; esac\nfi</ind:pattern>
+    <ind:pattern operation="pattern match">if \[ "\$PS1" \]; then\n\s+parent=\$\(ps -o ppid= -p \$\$\)\n\s+name=\$\(ps -o comm= -p \$parent\)\n\s+case "\$name" in \(?sshd\|login\) exec tmux ;; esac\nfi</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/rule.yml
@@ -64,7 +64,7 @@ fixtext: |-
     if [ "$PS1" ]; then
         parent=$(ps -o ppid= -p $$)
         name=$(ps -o comm= -p $parent)
-        case "$name" in sshd|login) exec tmux ;; esac
+        case "$name" in (sshd|login) exec tmux ;; esac
     fi
 
     Then, ensure a correct mode of /etc/profile.d/tmux.sh using this command:

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/tests/correct_value.pass.sh
@@ -5,7 +5,7 @@ cat >> /etc/bashrc <<'EOF'
 if [ "$PS1" ]; then
   parent=$(ps -o ppid= -p $$)
   name=$(ps -o comm= -p $parent)
-  case "$name" in sshd|login) exec tmux ;; esac
+  case "$name" in (sshd|login) exec tmux ;; esac
 fi
 EOF
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/tests/correct_value_d_directory.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/tests/correct_value_d_directory.pass.sh
@@ -6,7 +6,7 @@ cat >> /etc/profile.d/00-complianceascode.conf <<'EOF'
 if [ "$PS1" ]; then
   parent=$(ps -o ppid= -p $$)
   name=$(ps -o comm= -p $parent)
-  case "$name" in sshd|login) exec tmux ;; esac
+  case "$name" in (sshd|login) exec tmux ;; esac
 fi
 EOF
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/tests/duplicate_value_multiple_files.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/tests/duplicate_value_multiple_files.pass.sh
@@ -5,7 +5,7 @@ cat >> /etc/profile.d/00-complianceascode.conf <<'EOF'
 if [ "$PS1" ]; then
   parent=$(ps -o ppid= -p $$)
   name=$(ps -o comm= -p $parent)
-  case "$name" in sshd|login) exec tmux ;; esac
+  case "$name" in (sshd|login) exec tmux ;; esac
 fi
 EOF
 
@@ -13,7 +13,7 @@ cat >> /etc/bashrc <<'EOF'
 if [ "$PS1" ]; then
   parent=$(ps -o ppid= -p $$)
   name=$(ps -o comm= -p $parent)
-  case "$name" in sshd|login) exec tmux ;; esac
+  case "$name" in (sshd|login) exec tmux ;; esac
 fi
 EOF
 


### PR DESCRIPTION
#### Description:

Fix missing parentheses in configure_bashrc_exec_tmux

#### Rationale:

-  In PR #10472 a missing parentheses has been added to respect DISA STIG RHEL-08-020041, it hasn't been done on this rule .
