### PR TITLE
Update OL8 STIG id references

### DIFF
--- a/linux_os/guide/services/rng/service_rngd_enabled/rule.yml
+++ b/linux_os/guide/services/rng/service_rngd_enabled/rule.yml
@@ -23,7 +23,7 @@ references:
     disa: CCI-000366
     ospp: FCS_RBG_EXT.1
     srg: SRG-OS-000480-GPOS-00227
-    stigid@ol8: OL08-00-010471
+    stigid@ol8: OL08-00-010473
     stigid@rhel8: RHEL-08-010471
     stigid@rhel9: RHEL-09-211035
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/rule.yml
@@ -22,7 +22,7 @@ references:
     disa: CCI-000044
     nist: AC-7 (a)
     srg: SRG-OS-000021-GPOS-00005
-    stigid@ol8: OL08-00-020027
+    stigid@ol8: OL08-00-020027,OL08-00-020028
     stigid@rhel8: RHEL-08-020027,RHEL-08-020028
     stigid@rhel9: RHEL-09-431020
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/rule.yml
@@ -18,7 +18,7 @@ references:
     disa: CCI-000044
     nist: AC-7 (a)
     srg: SRG-OS-000021-GPOS-00005
-    stigid@ol8: OL08-00-020021
+    stigid@ol8: OL08-00-020020,OL08-00-020021
     stigid@rhel8: RHEL-08-020021
     stigid@rhel9: RHEL-09-412045
     stigid@ubuntu2004: UBTU-20-010072

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
@@ -62,7 +62,7 @@ references:
     pcidss4: "8.3.4"
     srg: SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005
     stigid@ol7: OL07-00-010320
-    stigid@ol8: OL08-00-020010
+    stigid@ol8: OL08-00-020010,OL08-00-020011
     stigid@rhel7: RHEL-07-010320
     stigid@rhel8: RHEL-08-020011
     stigid@rhel9: RHEL-09-411075

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/rule.yml
@@ -41,7 +41,7 @@ references:
     ospp: FMT_MOF_EXT.1
     srg: SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005
     stigid@ol7: OL07-00-010330
-    stigid@ol8: OL08-00-020022
+    stigid@ol8: OL08-00-020022,OL08-00-020023
     stigid@rhel7: RHEL-07-010330
     stigid@rhel8: RHEL-08-020023
     stigid@rhel9: RHEL-09-411080

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
@@ -52,7 +52,7 @@ references:
     ospp: FIA_AFL.1
     srg: SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005
     stigid@ol7: OL07-00-010320
-    stigid@ol8: OL08-00-020012
+    stigid@ol8: OL08-00-020012,OL08-00-020013
     stigid@rhel7: RHEL-07-010320
     stigid@rhel8: RHEL-08-020012,RHEL-08-020013
     stigid@rhel9: RHEL-09-411085

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/rule.yml
@@ -29,7 +29,7 @@ identifiers:
 references:
     disa: CCI-002238,CCI-000044
     srg: SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005
-    stigid@ol8: OL08-00-020019
+    stigid@ol8: OL08-00-020018,OL08-00-020019
     stigid@rhel8: RHEL-08-020018,RHEL-08-020019
     stigid@ubuntu2004: UBTU-20-010072
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
@@ -64,7 +64,7 @@ references:
     pcidss4: "8.3.4"
     srg: SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005
     stigid@ol7: OL07-00-010320
-    stigid@ol8: OL08-00-020014
+    stigid@ol8: OL08-00-020014,OL08-00-020015
     stigid@rhel7: RHEL-07-010320
     stigid@rhel8: RHEL-08-020014,RHEL-08-020015
     stigid@rhel9: RHEL-09-411090

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/rule.yml
@@ -53,7 +53,7 @@ references:
     ospp: FMT_MOF_EXT.1
     srg: SRG-OS-000069-GPOS-00037,SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-010119
-    stigid@ol8: OL08-00-020104
+    stigid@ol8: OL08-00-020102,OL08-00-020103,OL08-00-020104
     stigid@rhel7: RHEL-07-010119
     stigid@rhel8: RHEL-08-020104
     stigid@rhel9: RHEL-09-611010

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/rule.yml
@@ -54,7 +54,7 @@ references:
     pcidss4: '8.3.1'
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-010290
-    stigid@ol8: OL08-00-020331
+    stigid@ol8: OL08-00-020331,OL08-00-020332
     stigid@rhel7: RHEL-07-010290
     stigid@rhel8: RHEL-08-020331,RHEL-08-020332
     stigid@rhel9: RHEL-09-611025

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/rule.yml
@@ -56,7 +56,7 @@ references:
     pcidss4: "8.2.8"
     srg: SRG-OS-000028-GPOS-00009,SRG-OS-000030-GPOS-00011
     stigid@ol7: OL07-00-010060
-    stigid@ol8: OL08-00-020030
+    stigid@ol8: OL08-00-020030,OL08-00-020082
     stigid@rhel7: RHEL-07-010060
     stigid@rhel8: RHEL-08-020030
     stigid@rhel9: RHEL-09-271060,RHEL-09-271055


### PR DESCRIPTION
#### Description:

- Updated STIG ids for OL8 product

#### Rationale:

- With the newish update to allow multiple STIG IDs in the same rule, the OL8 references became outdated, this addresses that