### PR TITLE
Add automation to enable faillock rules

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/ansible/shared.yml
@@ -1,0 +1,7 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = enable
+# complexity = low
+# disruption = low
+
+{{{ ansible_pam_faillock_enable() }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/bash/shared.sh
@@ -1,0 +1,7 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = enable
+# complexity = low
+# disruption = low
+
+{{{ bash_pam_faillock_enable() }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/oval/shared.xml
@@ -8,7 +8,7 @@
                 as reference for the correct position of pam_faillock.so in auth section. If the
                 system is properly configured, it must appear only once in auth section. -->
             <criterion test_ref="test_pam_faillock_password_auth_pam_unix_auth"
-                        comment="pam_unix.so appears only once in auth section of password-auth"/>
+                comment="pam_unix.so appears only once in auth section of password-auth"/>
             <criterion
                 test_ref="test_pam_faillock_password_auth_pam_faillock_auth"
                 comment="pam_faillock.so is defined in auth section of password-auth"/>
@@ -19,13 +19,13 @@
     </definition>
 
     <constant_variable id="var_pam_faillock_password_auth_pam_faillock_auth_regex"
-                    datatype="string" version="1"
-                    comment="regex to identify pam_faillock.so entries in auth section of pam files">
+            datatype="string" version="1"
+            comment="regex to identify pam_faillock.so entries in auth section of pam files">
         <value>^[\s]*auth[\s]+(required|\[(?=.*?\bsuccess=ok\b)(?=.*?\bnew_authtok_reqd=ok\b)(?=.*?\bignore=ignore\b)(?=.*?\bdefault=bad\b).*\])[\s]+pam_faillock\.so[\s\w\d=]+preauth[\s\S]*^[\s]*auth[\s]+(sufficient|\[(?=.*\bsuccess=done\b)(?=.*?\bnew_authtok_reqd=done\b)(?=.*?\bdefault=ignore\b).*\])[\s]+pam_unix\.so[\s\S]*^[\s]*auth[\s]+(required|\[(?=.*?\bsuccess=ok\b)(?=.*?\bnew_authtok_reqd=ok\b)(?=.*?\bignore=ignore\b)(?=.*?\bdefault=bad\b).*\])[\s]+pam_faillock\.so[\s\w\d=]+authfail</value>
     </constant_variable>
     <constant_variable id="var_pam_faillock_password_auth_pam_faillock_account_regex"
-                    datatype="string" version="1"
-                    comment="regex to identify pam_faillock.so entry in account section of pam files">
+            datatype="string" version="1"
+            comment="regex to identify pam_faillock.so entry in account section of pam files">
         <value>^[\s]*account[\s]+(required|\[(?=.*?\bsuccess=ok\b)(?=.*?\bnew_authtok_reqd=ok\b)(?=.*?\bignore=ignore\b)(?=.*?\bdefault=bad\b).*\])[\s]+pam_faillock\.so[\s\S]*^[\s]*account[\s]+(required|\[(?=.*?\bsuccess=ok\b)(?=.*?\bnew_authtok_reqd=ok\b)(?=.*?\bignore=ignore\b)(?=.*?\bdefault=bad\b).*\])[\s]+pam_unix\.so</value>
     </constant_variable>
 
@@ -52,13 +52,12 @@
             object_ref="obj_pam_faillock_password_auth_pam_faillock_auth"/>
     </ind:textfilecontent54_test>
 
-
     <ind:textfilecontent54_object version="1"
             id="obj_pam_faillock_password_auth_pam_faillock_auth"
             comment="Check common definition of pam_faillock.so in auth section of password-auth">
         <ind:filepath operation="pattern match">^/etc/pam.d/password-auth$</ind:filepath>
         <ind:pattern operation="pattern match"
-                    var_ref="var_pam_faillock_password_auth_pam_faillock_auth_regex"/>
+            var_ref="var_pam_faillock_password_auth_pam_faillock_auth_regex"/>
         <ind:instance datatype="int" operation="equals">1</ind:instance>
     </ind:textfilecontent54_object>
 
@@ -74,7 +73,7 @@
             comment="Check common definition of pam_faillock.so in account section of password-auth">
         <ind:filepath operation="pattern match">^/etc/pam.d/password-auth$</ind:filepath>
         <ind:pattern operation="pattern match"
-                    var_ref="var_pam_faillock_password_auth_pam_faillock_account_regex"/>
+            var_ref="var_pam_faillock_password_auth_pam_faillock_account_regex"/>
         <ind:instance datatype="int" operation="equals">1</ind:instance>
     </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/oval/shared.xml
@@ -3,22 +3,78 @@
     {{{ oval_metadata(
         "Configure the use of the pam_faillock.so module in the /etc/pam.d/password-auth file.")
     }}}
-        <criteria>
-            <criterion test_ref="test_{{{ rule_id }}}"
-                    comment="The faillock module is present in /etc/pam.d/password-auth"/>
+        <criteria operator="AND">
+            <!-- pam_unix.so is a control module present in all realistic scenarios and also used
+                as reference for the correct position of pam_faillock.so in auth section. If the
+                system is properly configured, it must appear only once in auth section. -->
+            <criterion test_ref="test_pam_faillock_password_auth_pam_unix_auth"
+                        comment="pam_unix.so appears only once in auth section of password-auth"/>
+            <criterion
+                test_ref="test_pam_faillock_password_auth_pam_faillock_auth"
+                comment="pam_faillock.so is defined in auth section of password-auth"/>
+            <criterion
+                test_ref="test_pam_faillock_password_auth_pam_faillock_account"
+                comment="pam_faillock.so is defined in account section of password-auth"/>
         </criteria>
     </definition>
-    <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists" version="1"
-    id="test_{{{ rule_id }}}"
-    comment="Check the presence of pam_faillock.so in password-auth">
-        <ind:object
-        object_ref="obj_{{{ rule_id }}}"/>
+
+    <constant_variable id="var_pam_faillock_password_auth_pam_faillock_auth_regex"
+                    datatype="string" version="1"
+                    comment="regex to identify pam_faillock.so entries in auth section of pam files">
+        <value>^[\s]*auth[\s]+(required|\[(?=.*?\bsuccess=ok\b)(?=.*?\bnew_authtok_reqd=ok\b)(?=.*?\bignore=ignore\b)(?=.*?\bdefault=bad\b).*\])[\s]+pam_faillock\.so[\s\w\d=]+preauth[\s\S]*^[\s]*auth[\s]+(sufficient|\[(?=.*\bsuccess=done\b)(?=.*?\bnew_authtok_reqd=done\b)(?=.*?\bdefault=ignore\b).*\])[\s]+pam_unix\.so[\s\S]*^[\s]*auth[\s]+(required|\[(?=.*?\bsuccess=ok\b)(?=.*?\bnew_authtok_reqd=ok\b)(?=.*?\bignore=ignore\b)(?=.*?\bdefault=bad\b).*\])[\s]+pam_faillock\.so[\s\w\d=]+authfail</value>
+    </constant_variable>
+    <constant_variable id="var_pam_faillock_password_auth_pam_faillock_account_regex"
+                    datatype="string" version="1"
+                    comment="regex to identify pam_faillock.so entry in account section of pam files">
+        <value>^[\s]*account[\s]+(required|\[(?=.*?\bsuccess=ok\b)(?=.*?\bnew_authtok_reqd=ok\b)(?=.*?\bignore=ignore\b)(?=.*?\bdefault=bad\b).*\])[\s]+pam_faillock\.so[\s\S]*^[\s]*account[\s]+(required|\[(?=.*?\bsuccess=ok\b)(?=.*?\bnew_authtok_reqd=ok\b)(?=.*?\bignore=ignore\b)(?=.*?\bdefault=bad\b).*\])[\s]+pam_unix\.so</value>
+    </constant_variable>
+
+    <!-- Check occurrences of pam_unix.so in auth section in password-auth -->
+    <ind:textfilecontent54_test check="all" check_existence="only_one_exists" version="1"
+            id="test_pam_faillock_password_auth_pam_unix_auth"
+            comment="No more than one pam_unix.so is expected in auth section of password-auth">
+        <ind:object object_ref="obj_pam_faillock_password_auth_pam_unix_auth"/>
     </ind:textfilecontent54_test>
-    <ind:textfilecontent54_object id="obj_{{{ rule_id }}}"
-    comment="Obtain pam_faillock.so ocurrences in password-auth" version="1">
-        <ind:filepath >/etc/pam.d/password-auth</ind:filepath>
-        <!-- pam_faillock.so needs to be before pam_unix\.so -->
-        <ind:pattern operation="pattern match">\s*auth\s*\S+\s*pam_faillock\.so\s*preauth[\s\S]*?pam_unix\.so</ind:pattern>
+
+    <ind:textfilecontent54_object version="1"
+            id="obj_pam_faillock_password_auth_pam_unix_auth"
+            comment="Get all occurrences of pam_unix.so in auth section of password-auth">
+        <ind:filepath operation="pattern match">^/etc/pam.d/password-auth$</ind:filepath>
+        <ind:pattern operation="pattern match">^[\s]*auth\N+pam_unix\.so</ind:pattern>
         <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    </ind:textfilecontent54_object>
+
+    <!-- Check common definition of pam_faillock.so in password-auth -->
+    <ind:textfilecontent54_test check="all" check_existence="only_one_exists" version="1"
+            id="test_pam_faillock_password_auth_pam_faillock_auth"
+            comment="One and only one occurrence is expected in auth section of password-auth">
+        <ind:object
+            object_ref="obj_pam_faillock_password_auth_pam_faillock_auth"/>
+    </ind:textfilecontent54_test>
+
+
+    <ind:textfilecontent54_object version="1"
+            id="obj_pam_faillock_password_auth_pam_faillock_auth"
+            comment="Check common definition of pam_faillock.so in auth section of password-auth">
+        <ind:filepath operation="pattern match">^/etc/pam.d/password-auth$</ind:filepath>
+        <ind:pattern operation="pattern match"
+                    var_ref="var_pam_faillock_password_auth_pam_faillock_auth_regex"/>
+        <ind:instance datatype="int" operation="equals">1</ind:instance>
+    </ind:textfilecontent54_object>
+
+    <ind:textfilecontent54_test check="all" check_existence="only_one_exists" version="1"
+            id="test_pam_faillock_password_auth_pam_faillock_account"
+            comment="One and only one occurrence is expected in auth section of password-auth">
+        <ind:object
+            object_ref="obj_pam_faillock_password_auth_pam_faillock_account"/>
+    </ind:textfilecontent54_test>
+
+    <ind:textfilecontent54_object version="1"
+            id="obj_pam_faillock_password_auth_pam_faillock_account"
+            comment="Check common definition of pam_faillock.so in account section of password-auth">
+        <ind:filepath operation="pattern match">^/etc/pam.d/password-auth$</ind:filepath>
+        <ind:pattern operation="pattern match"
+                    var_ref="var_pam_faillock_password_auth_pam_faillock_account_regex"/>
+        <ind:instance datatype="int" operation="equals">1</ind:instance>
     </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/oval/shared.xml
@@ -1,0 +1,24 @@
+<def-group>
+    <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata(
+        "Configure the use of the pam_faillock.so module in the /etc/pam.d/password-auth file.")
+    }}}
+        <criteria>
+            <criterion test_ref="test_{{{ rule_id }}}"
+                    comment="The faillock module is present in /etc/pam.d/password-auth"/>
+        </criteria>
+    </definition>
+    <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists" version="1"
+    id="test_{{{ rule_id }}}"
+    comment="Check the presence of pam_faillock.so in password-auth">
+        <ind:object
+        object_ref="obj_{{{ rule_id }}}"/>
+    </ind:textfilecontent54_test>
+    <ind:textfilecontent54_object id="obj_{{{ rule_id }}}"
+    comment="Obtain pam_faillock.so ocurrences in password-auth" version="1">
+        <ind:filepath >/etc/pam.d/password-auth</ind:filepath>
+        <!-- pam_faillock.so needs to be before pam_unix\.so -->
+        <ind:pattern operation="pattern match">\s*auth\s*\S+\s*pam_faillock\.so\s*preauth[\s\S]*?pam_unix\.so</ind:pattern>
+        <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/rule.yml
@@ -20,6 +20,7 @@ references:
     disa: CCI-000044
     nist: AC-7 (a)
     srg: SRG-OS-000021-GPOS-00005
+    stigid@ol8: OL08-00-020026
     stigid@rhel8: RHEL-08-020026
     stigid@rhel9: RHEL-09-611035
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/tests/correct_value.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# packages = authselect,pam
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+authselect create-profile test_profile -b sssd
+authselect select "custom/test_profile" --force
+
+authselect enable-feature with-faillock
+
+authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/tests/no_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/tests/no_value.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# packages = authselect,pam
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+authselect create-profile test_profile -b sssd
+authselect select "custom/test_profile" --force
+
+authselect disable-feature with-faillock
+
+authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_system_auth/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_system_auth/ansible/shared.yml
@@ -1,0 +1,7 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = enable
+# complexity = low
+# disruption = low
+
+{{{ ansible_pam_faillock_enable() }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_system_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_system_auth/bash/shared.sh
@@ -1,0 +1,7 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = enable
+# complexity = low
+# disruption = low
+
+{{{ bash_pam_faillock_enable() }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_system_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_system_auth/oval/shared.xml
@@ -1,0 +1,24 @@
+<def-group>
+    <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata(
+        "Configure the use of the pam_faillock.so module in the /etc/pam.d/system-auth file.")
+    }}}
+        <criteria>
+            <criterion test_ref="test_{{{ rule_id }}}"
+                    comment="The faillock module is present in /etc/pam.d/system-auth"/>
+        </criteria>
+    </definition>
+    <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists" version="1"
+    id="test_{{{ rule_id }}}"
+    comment="Check the presence of pam_faillock.so in system-auth">
+        <ind:object
+        object_ref="obj_{{{ rule_id }}}"/>
+    </ind:textfilecontent54_test>
+    <ind:textfilecontent54_object id="obj_{{{ rule_id }}}"
+    comment="Obtain pam_faillock.so ocurrences in system-auth" version="1">
+        <ind:filepath >/etc/pam.d/system-auth</ind:filepath>
+        <!-- pam_faillock.so needs to be before pam_unix\.so -->
+        <ind:pattern operation="pattern match">\s*auth\s*\S+\s*pam_faillock\.so\s*preauth[\s\S]*?pam_unix\.so</ind:pattern>
+        <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_system_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_system_auth/oval/shared.xml
@@ -3,22 +3,78 @@
     {{{ oval_metadata(
         "Configure the use of the pam_faillock.so module in the /etc/pam.d/system-auth file.")
     }}}
-        <criteria>
-            <criterion test_ref="test_{{{ rule_id }}}"
-                    comment="The faillock module is present in /etc/pam.d/system-auth"/>
+        <criteria operator="AND">
+            <!-- pam_unix.so is a control module present in all realistic scenarios and also used
+                as reference for the correct position of pam_faillock.so in auth section. If the
+                system is properly configured, it must appear only once in auth section. -->
+            <criterion test_ref="test_pam_faillock_system_auth_pam_unix_auth"
+                        comment="pam_unix.so appears only once in auth section of system-auth"/>
+            <criterion
+                test_ref="test_pam_faillock_system_auth_pam_faillock_auth"
+                comment="pam_faillock.so is defined in auth section of system-auth"/>
+            <criterion
+                test_ref="test_pam_faillock_system_auth_pam_faillock_account"
+                comment="pam_faillock.so is defined in account section of system-auth"/>
         </criteria>
     </definition>
-    <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists" version="1"
-    id="test_{{{ rule_id }}}"
-    comment="Check the presence of pam_faillock.so in system-auth">
-        <ind:object
-        object_ref="obj_{{{ rule_id }}}"/>
+
+    <constant_variable id="var_pam_faillock_system_auth_pam_faillock_auth_regex"
+                    datatype="string" version="1"
+                    comment="regex to identify pam_faillock.so entries in auth section of pam files">
+        <value>^[\s]*auth[\s]+(required|\[(?=.*?\bsuccess=ok\b)(?=.*?\bnew_authtok_reqd=ok\b)(?=.*?\bignore=ignore\b)(?=.*?\bdefault=bad\b).*\])[\s]+pam_faillock\.so[\s\w\d=]+preauth[\s\S]*^[\s]*auth[\s]+(sufficient|\[(?=.*\bsuccess=done\b)(?=.*?\bnew_authtok_reqd=done\b)(?=.*?\bdefault=ignore\b).*\])[\s]+pam_unix\.so[\s\S]*^[\s]*auth[\s]+(required|\[(?=.*?\bsuccess=ok\b)(?=.*?\bnew_authtok_reqd=ok\b)(?=.*?\bignore=ignore\b)(?=.*?\bdefault=bad\b).*\])[\s]+pam_faillock\.so[\s\w\d=]+authfail</value>
+    </constant_variable>
+    <constant_variable id="var_pam_faillock_system_auth_pam_faillock_account_regex"
+                    datatype="string" version="1"
+                    comment="regex to identify pam_faillock.so entry in account section of pam files">
+        <value>^[\s]*account[\s]+(required|\[(?=.*?\bsuccess=ok\b)(?=.*?\bnew_authtok_reqd=ok\b)(?=.*?\bignore=ignore\b)(?=.*?\bdefault=bad\b).*\])[\s]+pam_faillock\.so[\s\S]*^[\s]*account[\s]+(required|\[(?=.*?\bsuccess=ok\b)(?=.*?\bnew_authtok_reqd=ok\b)(?=.*?\bignore=ignore\b)(?=.*?\bdefault=bad\b).*\])[\s]+pam_unix\.so</value>
+    </constant_variable>
+
+    <!-- Check occurrences of pam_unix.so in auth section in system-auth -->
+    <ind:textfilecontent54_test check="all" check_existence="only_one_exists" version="1"
+            id="test_pam_faillock_system_auth_pam_unix_auth"
+            comment="No more than one pam_unix.so is expected in auth section of system-auth">
+        <ind:object object_ref="obj_pam_faillock_system_auth_pam_unix_auth"/>
     </ind:textfilecontent54_test>
-    <ind:textfilecontent54_object id="obj_{{{ rule_id }}}"
-    comment="Obtain pam_faillock.so ocurrences in system-auth" version="1">
-        <ind:filepath >/etc/pam.d/system-auth</ind:filepath>
-        <!-- pam_faillock.so needs to be before pam_unix\.so -->
-        <ind:pattern operation="pattern match">\s*auth\s*\S+\s*pam_faillock\.so\s*preauth[\s\S]*?pam_unix\.so</ind:pattern>
+
+    <ind:textfilecontent54_object version="1"
+            id="obj_pam_faillock_system_auth_pam_unix_auth"
+            comment="Get all occurrences of pam_unix.so in auth section of system-auth">
+        <ind:filepath operation="pattern match">^/etc/pam.d/system-auth$</ind:filepath>
+        <ind:pattern operation="pattern match">^[\s]*auth\N+pam_unix\.so</ind:pattern>
         <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    </ind:textfilecontent54_object>
+
+    <!-- Check common definition of pam_faillock.so in system-auth -->
+    <ind:textfilecontent54_test check="all" check_existence="only_one_exists" version="1"
+            id="test_pam_faillock_system_auth_pam_faillock_auth"
+            comment="One and only one occurrence is expected in auth section of system-auth">
+        <ind:object
+            object_ref="obj_pam_faillock_system_auth_pam_faillock_auth"/>
+    </ind:textfilecontent54_test>
+
+
+    <ind:textfilecontent54_object version="1"
+            id="obj_pam_faillock_system_auth_pam_faillock_auth"
+            comment="Check common definition of pam_faillock.so in auth section of system-auth">
+        <ind:filepath operation="pattern match">^/etc/pam.d/system-auth$</ind:filepath>
+        <ind:pattern operation="pattern match"
+                    var_ref="var_pam_faillock_system_auth_pam_faillock_auth_regex"/>
+        <ind:instance datatype="int" operation="equals">1</ind:instance>
+    </ind:textfilecontent54_object>
+
+    <ind:textfilecontent54_test check="all" check_existence="only_one_exists" version="1"
+            id="test_pam_faillock_system_auth_pam_faillock_account"
+            comment="One and only one occurrence is expected in auth section of system-auth">
+        <ind:object
+            object_ref="obj_pam_faillock_system_auth_pam_faillock_account"/>
+    </ind:textfilecontent54_test>
+
+    <ind:textfilecontent54_object version="1"
+            id="obj_pam_faillock_system_auth_pam_faillock_account"
+            comment="Check common definition of pam_faillock.so in account section of system-auth">
+        <ind:filepath operation="pattern match">^/etc/pam.d/system-auth$</ind:filepath>
+        <ind:pattern operation="pattern match"
+                    var_ref="var_pam_faillock_system_auth_pam_faillock_account_regex"/>
+        <ind:instance datatype="int" operation="equals">1</ind:instance>
     </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_system_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_system_auth/oval/shared.xml
@@ -8,7 +8,7 @@
                 as reference for the correct position of pam_faillock.so in auth section. If the
                 system is properly configured, it must appear only once in auth section. -->
             <criterion test_ref="test_pam_faillock_system_auth_pam_unix_auth"
-                        comment="pam_unix.so appears only once in auth section of system-auth"/>
+                comment="pam_unix.so appears only once in auth section of system-auth"/>
             <criterion
                 test_ref="test_pam_faillock_system_auth_pam_faillock_auth"
                 comment="pam_faillock.so is defined in auth section of system-auth"/>
@@ -19,13 +19,13 @@
     </definition>
 
     <constant_variable id="var_pam_faillock_system_auth_pam_faillock_auth_regex"
-                    datatype="string" version="1"
-                    comment="regex to identify pam_faillock.so entries in auth section of pam files">
+            datatype="string" version="1"
+            comment="regex to identify pam_faillock.so entries in auth section of pam files">
         <value>^[\s]*auth[\s]+(required|\[(?=.*?\bsuccess=ok\b)(?=.*?\bnew_authtok_reqd=ok\b)(?=.*?\bignore=ignore\b)(?=.*?\bdefault=bad\b).*\])[\s]+pam_faillock\.so[\s\w\d=]+preauth[\s\S]*^[\s]*auth[\s]+(sufficient|\[(?=.*\bsuccess=done\b)(?=.*?\bnew_authtok_reqd=done\b)(?=.*?\bdefault=ignore\b).*\])[\s]+pam_unix\.so[\s\S]*^[\s]*auth[\s]+(required|\[(?=.*?\bsuccess=ok\b)(?=.*?\bnew_authtok_reqd=ok\b)(?=.*?\bignore=ignore\b)(?=.*?\bdefault=bad\b).*\])[\s]+pam_faillock\.so[\s\w\d=]+authfail</value>
     </constant_variable>
     <constant_variable id="var_pam_faillock_system_auth_pam_faillock_account_regex"
-                    datatype="string" version="1"
-                    comment="regex to identify pam_faillock.so entry in account section of pam files">
+            datatype="string" version="1"
+            comment="regex to identify pam_faillock.so entry in account section of pam files">
         <value>^[\s]*account[\s]+(required|\[(?=.*?\bsuccess=ok\b)(?=.*?\bnew_authtok_reqd=ok\b)(?=.*?\bignore=ignore\b)(?=.*?\bdefault=bad\b).*\])[\s]+pam_faillock\.so[\s\S]*^[\s]*account[\s]+(required|\[(?=.*?\bsuccess=ok\b)(?=.*?\bnew_authtok_reqd=ok\b)(?=.*?\bignore=ignore\b)(?=.*?\bdefault=bad\b).*\])[\s]+pam_unix\.so</value>
     </constant_variable>
 
@@ -52,13 +52,12 @@
             object_ref="obj_pam_faillock_system_auth_pam_faillock_auth"/>
     </ind:textfilecontent54_test>
 
-
     <ind:textfilecontent54_object version="1"
             id="obj_pam_faillock_system_auth_pam_faillock_auth"
             comment="Check common definition of pam_faillock.so in auth section of system-auth">
         <ind:filepath operation="pattern match">^/etc/pam.d/system-auth$</ind:filepath>
         <ind:pattern operation="pattern match"
-                    var_ref="var_pam_faillock_system_auth_pam_faillock_auth_regex"/>
+            var_ref="var_pam_faillock_system_auth_pam_faillock_auth_regex"/>
         <ind:instance datatype="int" operation="equals">1</ind:instance>
     </ind:textfilecontent54_object>
 
@@ -74,7 +73,7 @@
             comment="Check common definition of pam_faillock.so in account section of system-auth">
         <ind:filepath operation="pattern match">^/etc/pam.d/system-auth$</ind:filepath>
         <ind:pattern operation="pattern match"
-                    var_ref="var_pam_faillock_system_auth_pam_faillock_account_regex"/>
+            var_ref="var_pam_faillock_system_auth_pam_faillock_account_regex"/>
         <ind:instance datatype="int" operation="equals">1</ind:instance>
     </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_system_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_system_auth/rule.yml
@@ -20,6 +20,7 @@ references:
     disa: CCI-000044
     nist: AC-7 (a)
     srg: SRG-OS-000021-GPOS-00005
+    stigid@ol8: OL08-00-020025
     stigid@rhel8: RHEL-08-020025
     stigid@rhel9: RHEL-09-611030
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_system_auth/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_system_auth/tests/correct_value.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# packages = authselect,pam
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+authselect create-profile test_profile -b sssd
+authselect select "custom/test_profile" --force
+
+authselect enable-feature with-faillock
+
+authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_system_auth/tests/no_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_system_auth/tests/no_value.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# packages = authselect,pam
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+authselect create-profile test_profile -b sssd
+authselect select "custom/test_profile" --force
+
+authselect disable-feature with-faillock
+
+authselect apply-changes

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -489,7 +489,7 @@ selections:
     # OL08-00-020000
     - account_temp_expire_date
 
-    # OL08-00-020010, OL08-00-020011, OL08-00-020025, OL08-00-020026
+    # OL08-00-020010, OL08-00-020011
     - accounts_passwords_pam_faillock_deny
 
     # OL08-00-020012, OL08-00-020013
@@ -513,6 +513,12 @@ selections:
 
     # OL08-00-020024
     - accounts_max_concurrent_login_sessions
+
+    # OL08-00-020025
+    - account_password_pam_faillock_system_auth
+
+    # OL08-00-020026
+    - account_password_pam_faillock_password_auth
 
     # OL08-00-020027, OL08-00-020028
     - account_password_selinux_faillock_dir


### PR DESCRIPTION
#### Description:

- Add OVAL, bash and ansible for rules `account_password_pam_faillock_system_auth`
& `account_password_pam_faillock_password_auth`
- Add these rules to OL8 STIG profile, and add STIG IDs for OL8 to the rules
- Add tests for these rules

#### Rationale:

- These are a better fit for the mentioned OL8 STIG ids
