### PR TITLE
k8s image content from PRs: fix execution and add instruction how to use the image

### DIFF
--- a/.github/workflows/k8s-content-pr.yaml
+++ b/.github/workflows/k8s-content-pr.yaml
@@ -37,7 +37,7 @@ jobs:
         run: unzip pr_number.zip
       - name: 'Read PR number'
         run: |
-          echo "pr-number=$(cat pr/pr_number)" >> "$GITHUB_OUTPUT"
+          echo "pr-number=$(cat pr_number)" >> "$GITHUB_OUTPUT"
 
   container-main:
     needs: 

--- a/.github/workflows/k8s-content-pr.yaml
+++ b/.github/workflows/k8s-content-pr.yaml
@@ -101,16 +101,24 @@ jobs:
       - container-main
       - get-pr-number
     runs-on: ubuntu-latest
-    name: Comment on the PR
+    name: Upsert comment on the PR
     steps:
-      - uses: actions/github-script@v7
+      - uses: thollander/actions-comment-pull-request@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: ${{ needs.get-pr-number.outputs.pr-number }},
-              body: ':robot: The image for this PR is available at:
-            `ghcr.io/complianceascode/k8scontent:${{ needs.get-pr-number.outputs.pr-number }}`'
-            });
+          message: |
+            :robot: A k8s content image for this PR is available at:
+            `ghcr.io/complianceascode/k8scontent:${{ needs.get-pr-number.outputs.pr-number }}`
+
+            <details>
+            <summary>Click here to see how to deploy it</summary>
+
+            If you alread have Compliance Operator deployed:
+            ```utils/build_ds_container.py -i ghcr.io/complianceascode/k8scontent:${{ needs.get-pr-number.outputs.pr-number }}```
+
+            Otherwise deploy the content and operator together by checking out ComplianceAsCode/compliance-operator and:
+            ```CONTENT_IMAGE=ghcr.io/complianceascode/k8scontent:${{ needs.get-pr-number.outputs.pr-number }} make deploy-local```
+
+            </details>
+          comment_tag: kubernetes_content_image
+          pr_number: ${{ needs.get-pr-number.outputs.pr-number }}

--- a/utils/build_ds_container.py
+++ b/utils/build_ds_container.py
@@ -43,6 +43,11 @@ parser.add_argument(
     action='store_true',
     default=False)
 parser.add_argument(
+    '-i', '--push-content-image',
+    help=(
+        'Do not build any content. Create profile bundles from the referenced k8s content image'),
+    )
+parser.add_argument(
     '-d', '--debug',
     help=(
         'Provide debug output during the build process. This option is '
@@ -269,6 +274,10 @@ def get_image_repository():
     image_repo = subprocess.run(command, check=True, capture_output=True).stdout
     return image_repo.decode().strip()
 
+
+if args.push_content_image:
+    create_profile_bundles(args.products, args.push_content_image)
+    sys.exit(0)
 
 log.info(f'Building content for {", ".join(args.products)}')
 ensure_namespace_exists()


### PR DESCRIPTION
#### Description:

- Fix invalid reference when checking out
- Add an option to `utils/build_ds_container.py` just creates `ProfileBundle` based on a k8s content image.
- Add instructions to the image tag comment on how to use the image.

#### Rationale:

- Make it visible how one can deploy and use a k8s content image from the PR.
- This PR'r source repos is the remote to allow the action changes to apply unhinged.

#### Review Hints:

- Grab a cluster and run the commands.
