### PR TITLE
Fix OpenEmbedded name in test stability

### DIFF
--- a/tests/data/product_stability/openembedded.yml
+++ b/tests/data/product_stability/openembedded.yml
@@ -20,7 +20,7 @@ cpes:
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
 faillock_path: /var/run/faillock
-full_name: OpemEmbedded
+full_name: OpenEmbedded
 gid_min: 1000
 groups: {}
 grub2_boot_path: /boot/grub2


### PR DESCRIPTION
#### Description:

Fix OpenEmbedded name in test stability

#### Rationale:

So the nightly build passes



