### PR TITLE
Ansible: change the sysctl module fqcn for rhel7 product

### DIFF
--- a/linux_os/guide/system/network/network-nftables/set_nftables_loopback_traffic/ansible/shared.yml
+++ b/linux_os/guide/system/network/network-nftables/set_nftables_loopback_traffic/ansible/shared.yml
@@ -16,7 +16,11 @@
   register: ipv6_status
 
 - name: Check sysctl value of net.ipv6.conf.all.disable_ipv6
+{{% if product == "rhel7" %}}
+  ansible.builtin.sysctl:
+{{% else %}}
   ansible.posix.sysctl:
+{{%endif %}}
     name: net.ipv6.conf.all.disable_ipv6
     state: present
     value: "1"
@@ -24,7 +28,11 @@
   register: sysctl_ipv6_all
 
 - name: Check sysctl value of net.ipv6.conf.default.disable_ipv6
+{{% if product == "rhel7" %}}
+  ansible.builtin.sysctl:
+{{% else %}}
   ansible.posix.sysctl:
+{{%endif %}}
     name: net.ipv6.conf.default.disable_ipv6
     state: present
     value: "1"


### PR DESCRIPTION
#### Description:

- in case the full fqcn for sysctl module is used, use the ansible.builtin.sysctl when building for rhel7 product

#### Rationale:

- the version of Ansible shipped with RHEL 7 contains modules before the ansible.posix started being used

- Fixes #11460 

#### Review Hints:

- build the rhel7 product
- provision RHEL 7 system
- oscap xccdf generate fix --fix-type ansible--output ansible.yml --profile '(all)' ssg-rhel7-ds.xml
- ansible-playbook --syntax-check ansible.yml
