### PR TITLE
RHEL 7: change how xwindows is disabled in CIS profile

### DIFF
--- a/controls/cis_rhel7.yml
+++ b/controls/cis_rhel7.yml
@@ -934,7 +934,8 @@ controls:
     notes: >-
       The rule also configures correct run level to prevent unbootable system.
     rules:
-    - xwindows_remove_packages
+    - package_xorg-x11-server-common_removed
+    - xwindows_runlevel_target
 
   - id: 2.2.21
     title: Ensure mail transfer agents are configured for local-only mode (Automated)

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/rule.yml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/rule.yml
@@ -36,7 +36,6 @@ identifiers:
 references:
     cis@alinux2: 2.1.2
     cis@alinux3: 2.2.2
-    cis@rhel7: 2.2.20
     cis@sle12: 2.2.2
     cis@sle15: 2.2.2
     disa: CCI-000366

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/rule.yml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/rule.yml
@@ -29,7 +29,7 @@ identifiers:
 
 references:
     cis-csc: 12,15,8
-    cis@rhel7: 2.2.2
+    cis@rhel7: 2.2.20
     cis@rhel8: 2.2.2
     cobit5: APO13.01,DSS01.04,DSS05.02,DSS05.03
     disa: CCI-000366


### PR DESCRIPTION
#### Description:

- align with the policy
- modify references in relevant rules

#### Rationale:

- to keep alignment with the policy 


#### Review Hints:

- install RHEL 7 VM
- harden with the cis profile (server level 2)
- reboot
- check that the login through text console works