### PR TITLE
Update sssd ldap related rules to check /etc/sssd/conf.d/*.conf files

### DIFF
--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/oval/shared.xml
@@ -21,8 +21,8 @@
   <external_variable comment="External variable: path of the X.509 certificates in /etc/sssd/sssd.conf"
   datatype="string" id="var_sssd_ldap_tls_ca_dir" version="1" />
 
-  <ind:textfilecontent54_object id="object_sssd_ldap_tls_ca_dir" version="1">
-    <ind:filepath>/etc/sssd/sssd.conf</ind:filepath>
+  <ind:textfilecontent54_object id="object_sssd_ldap_tls_ca_dir" version="2">
+    <ind:filepath operation="pattern match">/etc/sssd/(sssd\.conf|conf.d/[^/]+\.conf)</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*\[domain\/[^]]*](?:[^\n[\]]*\n+)+?[\s]*ldap_tls_cacertdir[\s]+=[\s]+([^\s]+)[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/tests/ldap_tls_cacertdir_bad_value_conf_d.fail.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/tests/ldap_tls_cacertdir_bad_value_conf_d.fail.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+. $SHARED/setup_config_files.sh
+setup_correct_sssd_config
+
+systemctl enable sssd
+
+mkdir -p /etc/sssd/conf.d/
+
+cat > "/etc/sssd/conf.d/unused.conf" << EOF
+[domain/default]
+
+ldap_tls_cacertdir = /tmp/etc/openldap/cacerts
+EOF

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/tests/ldap_tls_cacertdir_bad_value_conf_d.fail.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/tests/ldap_tls_cacertdir_bad_value_conf_d.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # packages = /usr/lib/systemd/system/sssd.service
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/setup_config_files.sh
 setup_correct_sssd_config

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/tests/ldap_tls_cacertdir_conf_d.pass.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/tests/ldap_tls_cacertdir_conf_d.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # packages = /usr/lib/systemd/system/sssd.service
-# profiles = xccdf_org.ssgproject.content_profile_stig
 
 . $SHARED/setup_config_files.sh
 setup_correct_sssd_config

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/tests/ldap_tls_cacertdir_conf_d.pass.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_ca_dir/tests/ldap_tls_cacertdir_conf_d.pass.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+. $SHARED/setup_config_files.sh
+setup_correct_sssd_config
+
+systemctl enable sssd
+
+
+sed -i '/ldap_tls_cacertdir/d' /etc/sssd/sssd.conf
+
+mkdir -p /etc/sssd/conf.d/
+
+cat > "/etc/sssd/conf.d/unused.conf" << EOF
+[domain/default]
+
+ldap_id_use_start_tls = True
+id_provider = ldap
+autofs_provider = ldap
+auth_provider = krb5
+chpass_provider = krb5
+ldap_search_base = dc=com
+ldap_tls_cacertdir = /etc/openldap/cacerts
+cache_credentials = True
+krb5_store_password_if_offline = True
+ldap_tls_reqcert = demand
+EOF

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_reqcert/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_reqcert/oval/shared.xml
@@ -11,11 +11,17 @@
   comment="Ensures that LDAP TLS requires certificate is set"
   id="test_sssd_ldap_tls_reqcert" version="1">
     <ind:object object_ref="object_sssd_ldap_tls_reqcert" />
+    <ind:state state_ref="state_sssd_ldap_tls_reqcert" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="object_sssd_ldap_tls_reqcert" version="1">
+  <ind:textfilecontent54_object id="object_sssd_ldap_tls_reqcert" version="2">
     <ind:filepath operation="pattern match">^\/etc\/sssd\/(sssd.conf|conf\.d\/.+\.conf)$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*\[domain\/[^]]*]([^\n\[\]]*\n+)+?[\s]*ldap_tls_reqcert[ \t]*=[ \t]*((?i)demand)[ \t]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*\[domain\/[^]]*](?:[^\n\[\]]*\n+)+?[\s]*ldap_tls_reqcert[ \t]*=[ \t]*(\w+)[ \t]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_sssd_ldap_tls_reqcert" version="1">
+    <ind:subexpression operation="pattern match">(?i)demand</ind:subexpression>
+  </ind:textfilecontent54_state>
+
 </def-group>

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_reqcert/tests/correct_value_conf_d.pass.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_reqcert/tests/correct_value_conf_d.pass.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+. $SHARED/setup_config_files.sh
+setup_correct_sssd_config
+
+sed -i '/ldap_tls_reqcert/d' /etc/sssd/sssd.conf
+
+mkdir -p /etc/sssd/conf.d/
+
+cat > "/etc/sssd/conf.d/unused.conf" << EOF
+[domain/default]
+
+ldap_id_use_start_tls = True
+id_provider = ldap
+autofs_provider = ldap
+auth_provider = krb5
+chpass_provider = krb5
+ldap_search_base = dc=com
+ldap_tls_cacertdir = /etc/openldap/cacerts
+cache_credentials = True
+krb5_store_password_if_offline = True
+ldap_tls_reqcert = demand
+EOF

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_reqcert/tests/correct_value_conf_d.pass.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_reqcert/tests/correct_value_conf_d.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = sssd-ldap
 
 . $SHARED/setup_config_files.sh
 setup_correct_sssd_config

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_reqcert/tests/ldap_id_provider_and_reqcert_never_conf_d.fail.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_reqcert/tests/ldap_id_provider_and_reqcert_never_conf_d.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+. $SHARED/setup_config_files.sh
+setup_correct_sssd_config
+
+mkdir -p /etc/sssd/conf.d/
+
+cat > "/etc/sssd/conf.d/unused.conf" << EOF
+[domain/default]
+
+ldap_id_use_start_tls = never
+EOF

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_reqcert/tests/ldap_id_provider_and_reqcert_never_conf_d.fail.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_configure_tls_reqcert/tests/ldap_id_provider_and_reqcert_never_conf_d.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = sssd-ldap
 
 . $SHARED/setup_config_files.sh
 setup_correct_sssd_config
@@ -8,5 +9,5 @@ mkdir -p /etc/sssd/conf.d/
 cat > "/etc/sssd/conf.d/unused.conf" << EOF
 [domain/default]
 
-ldap_id_use_start_tls = never
+ldap_tls_reqcert = never
 EOF

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/oval/shared.xml
@@ -10,11 +10,17 @@
   comment="Ensures that LDAP uses STARTTLS"
   id="test_use_starttls" version="1">
     <ind:object object_ref="object_use_starttls_sssd_conf" />
+    <ind:state state_ref="state_use_starttls_sssd_conf" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="object_use_starttls_sssd_conf" version="1">
+  <ind:textfilecontent54_object id="object_use_starttls_sssd_conf" version="2">
     <ind:filepath operation="pattern match">^\/etc\/sssd\/(sssd.conf|conf\.d\/.+\.conf)$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*\[domain\/[^]]*]([^\n\[\]]*\n+)+?[\s]*ldap_id_use_start_tls[ \t]*=[ \t]*((?i)true)[ \t]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*\[domain\/[^]]*](?:[^\n\[\]]*\n+)+?[\s]*ldap_id_use_start_tls[ \t]*=[ \t]*((?i)\w+)[ \t]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_use_starttls_sssd_conf" version="1">
+    <ind:subexpression operation="pattern match">(?i)true</ind:subexpression>
+  </ind:textfilecontent54_state>
+
 </def-group>

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/rule.yml
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/rule.yml
@@ -12,7 +12,7 @@ description: |-
     <br /><br />
     To check if LDAP is configured to use TLS when <tt>id_provider</tt> is
     set to <tt>ldap</tt> or <tt>ipa</tt>, use the following command:
-    <pre>$ sudo grep -i ldap_id_use_start_tls /etc/sssd/sssd.conf</pre>
+    <pre>$ sudo grep -i ldap_id_use_start_tls /etc/sssd/sssd.conf /etc/sssd/conf.d/*.conf</pre>
 
 rationale: |-
     Without cryptographic integrity protections, information can be

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/tests/correct_value_conf_d.pass.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/tests/correct_value_conf_d.pass.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
+
+. $SHARED/setup_config_files.sh
+setup_correct_sssd_config
+
+systemctl enable sssd
+
+mkdir -p /etc/sssd/conf.d/
+
+sed -i '/ldap_id_use_start_tls/d' /etc/sssd/sssd.conf
+
+cat > "/etc/sssd/conf.d/unused.conf" << EOF
+[domain/default]
+
+ldap_id_use_start_tls = True
+id_provider = ldap
+autofs_provider = ldap
+auth_provider = krb5
+chpass_provider = krb5
+ldap_search_base = dc=com
+ldap_tls_cacertdir = /etc/openldap/cacerts
+cache_credentials = True
+krb5_store_password_if_offline = True
+ldap_tls_reqcert = demand
+EOF
+

--- a/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/tests/ldap_id_provider_and_tls_false_conf_d.fail.sh
+++ b/linux_os/guide/services/sssd/sssd-ldap/sssd_ldap_start_tls/tests/ldap_id_provider_and_tls_false_conf_d.fail.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# packages = /usr/lib/systemd/system/sssd.service
+
+. $SHARED/setup_config_files.sh
+setup_correct_sssd_config
+
+systemctl enable sssd
+
+mkdir -p /etc/sssd/conf.d/
+
+cat > "/etc/sssd/conf.d/unused.conf" << EOF
+[domain/default]
+
+ldap_id_use_start_tls = False
+EOF

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -707,6 +707,20 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
     - test_grep_domain.stdout | length > 0
     - test_id_provider.stdout is defined
     - test_id_provider.stdout | length < 1
+
+- name: Find all the conf files inside /etc/sssd/conf.d/
+  find:
+    paths: "/etc/sssd/conf.d/"
+    patterns: "*.conf"
+  register: sssd_conf_d_files
+
+- name: Set {{{ parameter }}} to {{{ value }}} in /etc/sssd/conf.d/ if exists
+  ansible.builtin.replace:
+    path: "{{ item.path }}"
+    regexp: '[^#]*{{{ parameter }}}.*'
+    replace: '{{{ parameter }}} = {{{ value }}}'
+  with_items: "{{ sssd_conf_d_files.files }}"
+
 {{%- endmacro %}}
 
 

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1296,7 +1296,7 @@ if grep -qvzosP $AD_REGEX $SSSD_CONF; then
         fi
 fi
 
-readarray -t SSSD_CONF_D_FILES < <(find /etc/sssd/conf.d/ -name *.conf)
+readarray -t SSSD_CONF_D_FILES < <(find /etc/sssd/conf.d/ -name "*.conf")
 for SSSD_CONF_D_FILE in "${SSSD_CONF_D_FILES[@]}"; do
     sed -i "s#{{{ parameter }}}[^(\n)]*#{{{ parameter }}} = {{{ value }}}#" "$SSSD_CONF_D_FILE"
 done

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1269,7 +1269,6 @@ for f in /etc/sudoers /etc/sudoers.d/* ; do
 done
 {{%- endmacro -%}}
 
-
 {{% macro bash_sssd_ldap_config(parameter, value) -%}}
 SSSD_CONF="/etc/sssd/sssd.conf"
 LDAP_REGEX='[[:space:]]*\[domain\/[^]]*]([^(\n)]*(\n)+)+?[[:space:]]*{{{ parameter }}}'
@@ -1296,6 +1295,12 @@ if grep -qvzosP $AD_REGEX $SSSD_CONF; then
                 fi
         fi
 fi
+
+readarray -t SSSD_CONF_D_FILES < <(find /etc/sssd/conf.d/ -name *.conf)
+for SSSD_CONF_D_FILE in "${SSSD_CONF_D_FILES[@]}"; do
+    sed -i "s#{{{ parameter }}}[^(\n)]*#{{{ parameter }}} = {{{ value }}}#" "$SSSD_CONF_D_FILE"
+done
+
 {{%- endmacro %}}
 
 


### PR DESCRIPTION
#### Description:

- Add /etc/sssd/conf.d/*.conf files as a possibility to find the configurations. Update affects:
  - OVAL
  - Ansible
  - Bash
  - Tests

#### Rationale:

- These configurations can be place there as noted in latest OL7 STIG V1R14

#### Review Hints:

- New tests should cover new addition
