### PR TITLE
Move to /bin/false for disabling kernel modules

### DIFF
--- a/shared/templates/kernel_module_disabled/ansible.template
+++ b/shared/templates/kernel_module_disabled/ansible.template
@@ -8,7 +8,7 @@
     create: yes
     dest: "/etc/modprobe.d/{{{ KERNMODULE }}}.conf"
     regexp: 'install\s+{{{ KERNMODULE }}}'
-    line: "install {{{ KERNMODULE }}} /bin/true"
+    line: "install {{{ KERNMODULE }}} /bin/false"
 {{% if product in ["sle12", "sle15"] or 'ol' in product or 'rhel' in product or 'ubuntu' in product %}}
 - name: Ensure kernel module '{{{ KERNMODULE }}}' is blacklisted
   lineinfile:

--- a/shared/templates/kernel_module_disabled/bash.template
+++ b/shared/templates/kernel_module_disabled/bash.template
@@ -10,7 +10,7 @@ if LC_ALL=C grep -q -m 1 "^install {{{ KERNMODULE }}}" /etc/modprobe.d/{{{ KERNM
 	sed -i 's#^install {{{ KERNMODULE }}}.*#install {{{ KERNMODULE }}} /bin/true#g' /etc/modprobe.d/{{{ KERNMODULE }}}.conf
 else
 	echo -e "\n# Disable per security requirements" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
-	echo "install {{{ KERNMODULE }}} /bin/true" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
+	echo "install {{{ KERNMODULE }}} /bin/false" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
 fi
 {{% if product in ["sle12", "sle15"] or 'ol' in product or 'rhel' in product or 'ubuntu' in product %}}
 if ! LC_ALL=C grep -q -m 1 "^blacklist {{{ KERNMODULE }}}$" /etc/modprobe.d/{{{ KERNMODULE }}}.conf ; then


### PR DESCRIPTION

#### Description:

Move to /bin/false for disabling kernel modules.

#### Rationale:

It makes better error messages and follows vendor guidance.
The OVAL accepts both.

The STIG for [RHEL](https://stigaview.com/products/rhel9/v1r2/RHEL-09-213055/), and [OL](https://stigaview.com/products/ol8/v1r9/OL08-00-040020/), [Ubuntu](https://stigaview.com/products/ubuntu2004/v1r11/UBTU-20-010455/) all use this format.