### PR TITLE
remove the task which deletes artifacts from automatus GH workflows

### DIFF
--- a/.github/workflows/automatus-cs8.yaml
+++ b/.github/workflows/automatus-cs8.yaml
@@ -168,12 +168,6 @@ jobs:
         with:
           name: logs_ansible
           path: logs_ansible/
-      - name: Delete datastream artifact
-        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        uses: geekyeggo/delete-artifact@v4
-        with:
-          name: ${{ env.DATASTREAM }}
-          useGlob: false
       - name: Fail in case of ERROR present in logs_bash/test_suite.log or logs_ansible/test_suite.log
         if: ${{ (steps.check_results_bash.outcome == 'success' || steps.check_results_ansible.outcome == 'success') && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: |

--- a/.github/workflows/automatus-cs9.yaml
+++ b/.github/workflows/automatus-cs9.yaml
@@ -168,12 +168,6 @@ jobs:
         with:
           name: logs_ansible
           path: logs_ansible/
-      - name: Delete datastream artifact
-        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        uses: geekyeggo/delete-artifact@v4
-        with:
-          name: ${{ env.DATASTREAM }}
-          useGlob: false
       - name: Fail in case of ERROR present in logs_bash/test_suite.log or logs_ansible/test_suite.log
         if: ${{ (steps.check_results_bash.outcome == 'success' || steps.check_results_ansible.outcome == 'success') && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: |

--- a/.github/workflows/automatus-sle15.yaml
+++ b/.github/workflows/automatus-sle15.yaml
@@ -176,12 +176,6 @@ jobs:
         with:
           name: logs_ansible
           path: logs_ansible/
-      - name: Delete datastream artifact
-        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        uses: geekyeggo/delete-artifact@v4
-        with:
-          name: ${{ env.DATASTREAM }}
-          useGlob: false
       - name: Fail in case of ERROR present in logs_bash/test_suite.log or logs_ansible/test_suite.log
         if: ${{ (steps.check_results_bash.outcome == 'success' || steps.check_results_ansible.outcome == 'success') && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: |

--- a/.github/workflows/automatus.yaml
+++ b/.github/workflows/automatus.yaml
@@ -166,12 +166,6 @@ jobs:
         with:
           name: logs_ansible
           path: logs_ansible/
-      - name: Delete datastream artifact
-        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        uses: geekyeggo/delete-artifact@v4
-        with:
-          name: ssg-${{steps.product.outputs.prop}}-ds.xml
-          useGlob: false
       - name: Fail in case of ERROR present in logs_bash/test_suite.log or logs_ansible/test_suite.log
         if: ${{ (steps.check_results_bash.outcome == 'success' || steps.check_results_ansible.outcome == 'success') && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: |


### PR DESCRIPTION
#### Description:

- remove the task which deletes the datastream used during Automatus Github actions

#### Rationale:

we are experiencing problems after upgrade of delete-artifact action to version 4 and they are degrading our ability to use CI efficiently. This will be probably only temporary fix before we figure out what is the problem with the GH action and its usage in our repository. At the same time removing this task should not pose any serious problems, old artifacts are deleted after 90 days.


#### Review Hints:

- create a PR based on this change and modify a remediation which will force Automatus actions to kick in.