### PR TITLE
Update contributors list for v0.1.72 release

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1,5 +1,5 @@
 <!---This file is generated using the contributors.py script. DO NOT MANUALLY EDIT!!!!
-Last Modified: 2023-11-28 11:44 UTC
+Last Modified: 2024-01-25 14:57 UTC
 --->
 
 The following people have contributed to the SCAP Security Guide project
@@ -50,6 +50,8 @@ The following people have contributed to the SCAP Security Guide project
 * Eric Christensen <echriste@redhat.com>
 * Dan Clark <danclark@redhat.com>
 * Jayson Cofell <1051437+70k10@users.noreply.github.com>
+* David du Colombier <djc@datadoghq.com>
+* Commandcracker <lukas.fricke.dev@gmail.com>
 * Caleb Cooper <coopercd@ornl.gov>
 * cortesana <acortes@redhat.com>
 * Richard Maciel Costa <richard.maciel.costa@canonical.com>
@@ -73,6 +75,7 @@ The following people have contributed to the SCAP Security Guide project
 * François Duthilleul <francoisduthilleul@gmail.com>
 * Greg Elin <gregelin@gitmachines.com>
 * eradot4027 <jrtonmac@gmail.com>
+* ermeratos <manuel.ermer@atos.net>
 * Alexis Facques <alexis.facques@mythalesgroup.io>
 * Henry Finucane <hfinucane@zscaler.com>
 * Leah Fisher <lfisher047@gmail.com>
@@ -158,6 +161,7 @@ The following people have contributed to the SCAP Security Guide project
 * Takuya Mishina <tmishina@jp.ibm.com>
 * Mixer9 <35545791+Mixer9@users.noreply.github.com>
 * mmosel <mmosel@kde.example.com>
+* Thomas Montague <montague.thomas@gmail.com>
 * Zbynek Moravec <zmoravec@redhat.com>
 * Kazuo Moriwaka <moriwaka@users.noreply.github.com>
 * Michael Moseley <michael@eclipse.ncsc.mil>
@@ -184,6 +188,7 @@ The following people have contributed to the SCAP Security Guide project
 * piggyvenus <piggyvenus@gmail.com>
 * Vojtech Polasek <vpolasek@redhat.com>
 * Orion Poplawski <orion@nwra.com>
+* Jennifer Power <barnabei.jennifer@gmail.com>
 * Nick Poyant <npoyant@redhat.com>
 * Martin Preisler <mpreisle@redhat.com>
 * Wesley Ceraso Prudencio <wcerasop@redhat.com>
@@ -202,12 +207,14 @@ The following people have contributed to the SCAP Security Guide project
 * Pat Riehecky <riehecky@fnal.gov>
 * rlucente-se-jboss <rlucente@redhat.com>
 * Juan Antonio Osorio Robles <juan.osoriorobles@eu.equinix.com>
+* Paul Roche <paul.roche@menlosecurity.com>
 * Jan Rodak <hony.com@seznam.cz>
 * Matt Rogers <mrogers@redhat.com>
 * Jesse Roland <jesse.roland@onyxpoint.com>
 * Joshua Roys <roysjosh@gmail.com>
 * rrenshaw <bofh69@yahoo.com>
 * Chris Ruffalo <chris.ruffalo@gmail.com>
+* Benjamin Ruland <benjamin.ruland@gmail.com>
 * rumch-se <77793453+rumch-se@users.noreply.github.com>
 * Rutvik <32413084+rutvik23@users.noreply.github.com>
 * rutvik23 <rutksh@gmail.com>
@@ -234,6 +241,7 @@ The following people have contributed to the SCAP Security Guide project
 * Jindrich Skacel <102800748+jskacel@users.noreply.github.com>
 * Alexandre Skrzyniarz <alexandre.skrzyniarz@laposte.net>
 * Francisco Slavin <fslavin@tresys.com>
+* sluetze <13255307+sluetze@users.noreply.github.com>
 * Dave Smith <dsmith@eclipse.ncsc.mil>
 * David Smith <dsmith@fornax.eclipse.ncsc.mil>
 * Kevin Spargur <kspargur@redhat.com>

--- a/Contributors.xml
+++ b/Contributors.xml
@@ -1,5 +1,5 @@
 <!--This file is generated using the contributors.py script. DO NOT MANUALLY EDIT!!!!
-Last Modified: 2023-11-28 11:44 UTC
+Last Modified: 2024-01-25 14:57 UTC
 -->
 
 <text>
@@ -48,6 +48,8 @@ Last Modified: 2023-11-28 11:44 UTC
 <contributor>Eric Christensen &lt;echriste@redhat.com&gt;</contributor>
 <contributor>Dan Clark &lt;danclark@redhat.com&gt;</contributor>
 <contributor>Jayson Cofell &lt;1051437+70k10@users.noreply.github.com&gt;</contributor>
+<contributor>David du Colombier &lt;djc@datadoghq.com&gt;</contributor>
+<contributor>Commandcracker &lt;lukas.fricke.dev@gmail.com&gt;</contributor>
 <contributor>Caleb Cooper &lt;coopercd@ornl.gov&gt;</contributor>
 <contributor>cortesana &lt;acortes@redhat.com&gt;</contributor>
 <contributor>Richard Maciel Costa &lt;richard.maciel.costa@canonical.com&gt;</contributor>
@@ -71,6 +73,7 @@ Last Modified: 2023-11-28 11:44 UTC
 <contributor>François Duthilleul &lt;francoisduthilleul@gmail.com&gt;</contributor>
 <contributor>Greg Elin &lt;gregelin@gitmachines.com&gt;</contributor>
 <contributor>eradot4027 &lt;jrtonmac@gmail.com&gt;</contributor>
+<contributor>ermeratos &lt;manuel.ermer@atos.net&gt;</contributor>
 <contributor>Alexis Facques &lt;alexis.facques@mythalesgroup.io&gt;</contributor>
 <contributor>Henry Finucane &lt;hfinucane@zscaler.com&gt;</contributor>
 <contributor>Leah Fisher &lt;lfisher047@gmail.com&gt;</contributor>
@@ -156,6 +159,7 @@ Last Modified: 2023-11-28 11:44 UTC
 <contributor>Takuya Mishina &lt;tmishina@jp.ibm.com&gt;</contributor>
 <contributor>Mixer9 &lt;35545791+Mixer9@users.noreply.github.com&gt;</contributor>
 <contributor>mmosel &lt;mmosel@kde.example.com&gt;</contributor>
+<contributor>Thomas Montague &lt;montague.thomas@gmail.com&gt;</contributor>
 <contributor>Zbynek Moravec &lt;zmoravec@redhat.com&gt;</contributor>
 <contributor>Kazuo Moriwaka &lt;moriwaka@users.noreply.github.com&gt;</contributor>
 <contributor>Michael Moseley &lt;michael@eclipse.ncsc.mil&gt;</contributor>
@@ -182,6 +186,7 @@ Last Modified: 2023-11-28 11:44 UTC
 <contributor>piggyvenus &lt;piggyvenus@gmail.com&gt;</contributor>
 <contributor>Vojtech Polasek &lt;vpolasek@redhat.com&gt;</contributor>
 <contributor>Orion Poplawski &lt;orion@nwra.com&gt;</contributor>
+<contributor>Jennifer Power &lt;barnabei.jennifer@gmail.com&gt;</contributor>
 <contributor>Nick Poyant &lt;npoyant@redhat.com&gt;</contributor>
 <contributor>Martin Preisler &lt;mpreisle@redhat.com&gt;</contributor>
 <contributor>Wesley Ceraso Prudencio &lt;wcerasop@redhat.com&gt;</contributor>
@@ -200,12 +205,14 @@ Last Modified: 2023-11-28 11:44 UTC
 <contributor>Pat Riehecky &lt;riehecky@fnal.gov&gt;</contributor>
 <contributor>rlucente-se-jboss &lt;rlucente@redhat.com&gt;</contributor>
 <contributor>Juan Antonio Osorio Robles &lt;juan.osoriorobles@eu.equinix.com&gt;</contributor>
+<contributor>Paul Roche &lt;paul.roche@menlosecurity.com&gt;</contributor>
 <contributor>Jan Rodak &lt;hony.com@seznam.cz&gt;</contributor>
 <contributor>Matt Rogers &lt;mrogers@redhat.com&gt;</contributor>
 <contributor>Jesse Roland &lt;jesse.roland@onyxpoint.com&gt;</contributor>
 <contributor>Joshua Roys &lt;roysjosh@gmail.com&gt;</contributor>
 <contributor>rrenshaw &lt;bofh69@yahoo.com&gt;</contributor>
 <contributor>Chris Ruffalo &lt;chris.ruffalo@gmail.com&gt;</contributor>
+<contributor>Benjamin Ruland &lt;benjamin.ruland@gmail.com&gt;</contributor>
 <contributor>rumch-se &lt;77793453+rumch-se@users.noreply.github.com&gt;</contributor>
 <contributor>Rutvik &lt;32413084+rutvik23@users.noreply.github.com&gt;</contributor>
 <contributor>rutvik23 &lt;rutksh@gmail.com&gt;</contributor>
@@ -232,6 +239,7 @@ Last Modified: 2023-11-28 11:44 UTC
 <contributor>Jindrich Skacel &lt;102800748+jskacel@users.noreply.github.com&gt;</contributor>
 <contributor>Alexandre Skrzyniarz &lt;alexandre.skrzyniarz@laposte.net&gt;</contributor>
 <contributor>Francisco Slavin &lt;fslavin@tresys.com&gt;</contributor>
+<contributor>sluetze &lt;13255307+sluetze@users.noreply.github.com&gt;</contributor>
 <contributor>Dave Smith &lt;dsmith@eclipse.ncsc.mil&gt;</contributor>
 <contributor>David Smith &lt;dsmith@fornax.eclipse.ncsc.mil&gt;</contributor>
 <contributor>Kevin Spargur &lt;kspargur@redhat.com&gt;</contributor>


### PR DESCRIPTION
Thank you all for the contributions.

Welcome to the new contributors:

- David du Colombier <djc@datadoghq.com>
- Commandcracker <lukas.fricke.dev@gmail.com>
- ermeratos <manuel.ermer@atos.net>
- Thomas Montague <montague.thomas@gmail.com>
- Jennifer Power <barnabei.jennifer@gmail.com>
- Paul Roche <paul.roche@menlosecurity.com>
- Benjamin Ruland <benjamin.ruland@gmail.com>
- sluetze <13255307+sluetze@users.noreply.github.com>