### PR TITLE
Fix Ubuntu remediation for pam_faillock rules

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/ubuntu_commented_values.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/ubuntu_commented_values.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+source ubuntu_common.sh
+
+sed -i 's/\(^.*pam_faillock\.so.*\)/# \1/' /etc/pam.d/common-auth
+sed -i 's/\(^.*pam_faillock\.so.*\)/# \1/' /etc/pam.d/common-account
+
+echo "#audit" > /etc/security/faillock.conf

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/ubuntu_common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/ubuntu_common.sh
@@ -1,16 +1,25 @@
 #!/bin/bash
 
-# Create passing pam.d files based on defaults from a clean installation of Ubuntu 20.04 LTS
+# Create passing pam.d files based on defaults from a clean installation of Ubuntu 22.04 LTS
+# Extra comments and whitespaces were added to test for edge cases
 
 cat >/etc/pam.d/common-auth <<EOF
+ ## Leading and trailing whitespaces should be ok
+ auth required  pam_faillock.so     preauth 
 # here are the per-package modules (the "Primary" block)
-    auth required  pam_faillock.so     preauth 
 auth    [success=2 default=ignore]      pam_unix.so nullok
+## Several lines of comments should not
+## break faillock remediation logic
+## Nor should commented pam_unix
+#auth    [success=2 default=ignore]      pam_unix.so nullok
+
 auth    [success=1 default=ignore]      pam_sss.so use_first_pass
-  #
+
+ ## Some more user comments
  auth [default=die]  pam_faillock.so authfail 
-auth sufficient     pam_faillock.so authsucc 
-  #
+ ## and some more
+ auth sufficient     pam_faillock.so authsucc 
+
 # here's the fallback if no module succeeds
 auth    requisite                       pam_deny.so
 # prime the stack with a positive return value if there isn't one already;

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/ubuntu_missing_pamd.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/ubuntu_missing_pamd.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+source ubuntu_common.sh
+
+sed -i '/pam_faillock\.so/d' /etc/pam.d/common-auth
+sed -i '/pam_faillock\.so/d' /etc/pam.d/common-account
+
+echo "audit" > /etc/security/faillock.conf

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/ubuntu_commented_values.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/ubuntu_commented_values.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+source ubuntu_common.sh
+
+sed -i 's/\(^.*pam_faillock\.so.*\)/# \1/' /etc/pam.d/common-auth
+sed -i 's/\(^.*pam_faillock\.so.*\)/# \1/' /etc/pam.d/common-account
+
+echo "#deny=1" > /etc/security/faillock.conf

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/ubuntu_common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/ubuntu_common.sh
@@ -1,16 +1,25 @@
 #!/bin/bash
 
-# Create passing pam.d files based on defaults from a clean installation of Ubuntu 20.04 LTS
+# Create passing pam.d files based on defaults from a clean installation of Ubuntu 22.04 LTS
+# Extra comments and whitespaces were added to test for edge cases
 
 cat >/etc/pam.d/common-auth <<EOF
+ ## Leading and trailing whitespaces should be ok
+ auth required  pam_faillock.so     preauth 
 # here are the per-package modules (the "Primary" block)
-    auth required  pam_faillock.so     preauth 
 auth    [success=2 default=ignore]      pam_unix.so nullok
+## Several lines of comments should not
+## break faillock remediation logic
+## Nor should commented pam_unix
+#auth    [success=2 default=ignore]      pam_unix.so nullok
+
 auth    [success=1 default=ignore]      pam_sss.so use_first_pass
-  #
+
+ ## Some more user comments
  auth [default=die]  pam_faillock.so authfail 
-auth sufficient     pam_faillock.so authsucc 
-  #
+ ## and some more
+ auth sufficient     pam_faillock.so authsucc 
+
 # here's the fallback if no module succeeds
 auth    requisite                       pam_deny.so
 # prime the stack with a positive return value if there isn't one already;

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/ubuntu_missing_pamd.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/ubuntu_missing_pamd.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+source ubuntu_common.sh
+
+sed -i '/pam_faillock\.so/d' /etc/pam.d/common-auth
+sed -i '/pam_faillock\.so/d' /etc/pam.d/common-account
+
+echo "deny=1" > /etc/security/faillock.conf

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/tests/ubuntu_commented_values.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/tests/ubuntu_commented_values.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+source ubuntu_common.sh
+
+sed -i 's/\(^.*pam_faillock\.so.*\)/# \1/' /etc/pam.d/common-auth
+sed -i 's/\(^.*pam_faillock\.so.*\)/# \1/' /etc/pam.d/common-account
+
+echo "#fail_interval=900" > /etc/security/faillock.conf

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/tests/ubuntu_common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/tests/ubuntu_common.sh
@@ -1,16 +1,25 @@
 #!/bin/bash
 
-# Create passing pam.d files based on defaults from a clean installation of Ubuntu 20.04 LTS
+# Create passing pam.d files based on defaults from a clean installation of Ubuntu 22.04 LTS
+# Extra comments and whitespaces were added to test for edge cases
 
 cat >/etc/pam.d/common-auth <<EOF
+ ## Leading and trailing whitespaces should be ok
+ auth required  pam_faillock.so     preauth 
 # here are the per-package modules (the "Primary" block)
-    auth required  pam_faillock.so     preauth 
 auth    [success=2 default=ignore]      pam_unix.so nullok
+## Several lines of comments should not
+## break faillock remediation logic
+## Nor should commented pam_unix
+#auth    [success=2 default=ignore]      pam_unix.so nullok
+
 auth    [success=1 default=ignore]      pam_sss.so use_first_pass
-  #
+
+ ## Some more user comments
  auth [default=die]  pam_faillock.so authfail 
-auth sufficient     pam_faillock.so authsucc 
-  #
+ ## and some more
+ auth sufficient     pam_faillock.so authsucc 
+
 # here's the fallback if no module succeeds
 auth    requisite                       pam_deny.so
 # prime the stack with a positive return value if there isn't one already;

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/tests/ubuntu_missing_pamd.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/tests/ubuntu_missing_pamd.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+source ubuntu_common.sh
+
+sed -i '/pam_faillock\.so/d' /etc/pam.d/common-auth
+sed -i '/pam_faillock\.so/d' /etc/pam.d/common-account
+
+echo "fail_interval=900" > /etc/security/faillock.conf

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_commented_values.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_commented_values.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+source ubuntu_common.sh
+
+sed -i 's/\(^.*pam_faillock\.so.*\)/# \1/' /etc/pam.d/common-auth
+sed -i 's/\(^.*pam_faillock\.so.*\)/# \1/' /etc/pam.d/common-account
+
+echo "#silent" > /etc/security/faillock.conf

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_common.sh
@@ -1,16 +1,25 @@
 #!/bin/bash
 
-# Create passing pam.d files based on defaults from a clean installation of Ubuntu 20.04 LTS
+# Create passing pam.d files based on defaults from a clean installation of Ubuntu 22.04 LTS
+# Extra comments and whitespaces were added to test for edge cases
 
 cat >/etc/pam.d/common-auth <<EOF
+ ## Leading and trailing whitespaces should be ok
+ auth required  pam_faillock.so     preauth 
 # here are the per-package modules (the "Primary" block)
-    auth required  pam_faillock.so     preauth 
 auth    [success=2 default=ignore]      pam_unix.so nullok
+## Several lines of comments should not
+## break faillock remediation logic
+## Nor should commented pam_unix
+#auth    [success=2 default=ignore]      pam_unix.so nullok
+
 auth    [success=1 default=ignore]      pam_sss.so use_first_pass
-  #
+
+ ## Some more user comments
  auth [default=die]  pam_faillock.so authfail 
-auth sufficient     pam_faillock.so authsucc 
-  #
+ ## and some more
+ auth sufficient     pam_faillock.so authsucc 
+
 # here's the fallback if no module succeeds
 auth    requisite                       pam_deny.so
 # prime the stack with a positive return value if there isn't one already;

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_missing_pamd.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_missing_pamd.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+source ubuntu_common.sh
+
+sed -i '/pam_faillock\.so/d' /etc/pam.d/common-auth
+sed -i '/pam_faillock\.so/d' /etc/pam.d/common-account
+
+echo "silent" > /etc/security/faillock.conf

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/ubuntu_commented_values.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/ubuntu_commented_values.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+source ubuntu_common.sh
+
+sed -i 's/\(^.*pam_faillock\.so.*\)/# \1/' /etc/pam.d/common-auth
+sed -i 's/\(^.*pam_faillock\.so.*\)/# \1/' /etc/pam.d/common-account
+
+echo "#unlock_time=1000" > /etc/security/faillock.conf

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/ubuntu_common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/ubuntu_common.sh
@@ -1,16 +1,25 @@
 #!/bin/bash
 
-# Create passing pam.d files based on defaults from a clean installation of Ubuntu 20.04 LTS
+# Create passing pam.d files based on defaults from a clean installation of Ubuntu 22.04 LTS
+# Extra comments and whitespaces were added to test for edge cases
 
 cat >/etc/pam.d/common-auth <<EOF
+ ## Leading and trailing whitespaces should be ok
+ auth required  pam_faillock.so     preauth 
 # here are the per-package modules (the "Primary" block)
-    auth required  pam_faillock.so     preauth 
 auth    [success=2 default=ignore]      pam_unix.so nullok
+## Several lines of comments should not
+## break faillock remediation logic
+## Nor should commented pam_unix
+#auth    [success=2 default=ignore]      pam_unix.so nullok
+
 auth    [success=1 default=ignore]      pam_sss.so use_first_pass
-  #
+
+ ## Some more user comments
  auth [default=die]  pam_faillock.so authfail 
-auth sufficient     pam_faillock.so authsucc 
-  #
+ ## and some more
+ auth sufficient     pam_faillock.so authsucc 
+
 # here's the fallback if no module succeeds
 auth    requisite                       pam_deny.so
 # prime the stack with a positive return value if there isn't one already;

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/ubuntu_missing_pamd.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/ubuntu_missing_pamd.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+source ubuntu_common.sh
+
+sed -i '/pam_faillock\.so/d' /etc/pam.d/common-auth
+sed -i '/pam_faillock\.so/d' /etc/pam.d/common-account
+
+echo "unlock_time=1000" > /etc/security/faillock.conf

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -790,15 +790,19 @@ if ! grep -qE '^\s*auth\s+required\s+pam_faillock\.so\s+preauth.*$' "$pam_file" 
     sed -i --follow-symlinks '/^# here are the per-package modules/i auth        required      pam_faillock.so preauth' "$pam_file"
 fi
 if ! grep -qE '^\s*auth\s+\[default=die\]\s+pam_faillock\.so\s+authfail.*$' "$pam_file" ; then
-    num_lines=$(sed -n 's/^auth.*success=\([0-9]\).*pam_unix\.so.*/\1/p' "$pam_file")
+
+    num_lines=$(sed -n 's/^\s*auth.*success=\([1-9]\).*pam_unix\.so.*/\1/p' "$pam_file")
     if [ ! -z "$num_lines" ]; then
-        echo "$num_lines"
-        pattern=""
-        for ((i=1; i <= num_lines; i++)); do
-            pattern="${pattern}n;"
-        done;
-        sed -i --follow-symlinks '/^auth.*pam_unix\.so.*/{'$pattern'a auth        [default=die]      pam_faillock.so authfail
- }' "$pam_file"
+
+        # Add pam_faillock (authfail) module below pam_unix, skipping N-1 lines, where N is
+        # the number of jumps in the pam_unix success=N statement. Ignore commented and empty lines.
+
+        append_position=$(cat -n "${pam_file}" \
+                          | grep -P "^\s+\d+\s+auth\s+.*$" \
+                          | grep -w "pam_unix.so" -A $(( num_lines - 1 )) \
+                          | tail -n 1 | cut -f 1 | tr -d ' '
+                         )
+        sed -i --follow-symlinks ''${append_position}'a auth        [default=die]      pam_faillock.so authfail' "$pam_file"
     else
         sed -i --follow-symlinks '/^auth.*pam_unix\.so.*/a auth        [default=die]      pam_faillock.so authfail' "$pam_file"
     fi

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -786,7 +786,8 @@ authselect enable-feature {{{ feature }}}
 {{% if 'ubuntu' in product %}}
 pam_file="/etc/pam.d/common-auth"
 if ! grep -qE '^\s*auth\s+required\s+pam_faillock\.so\s+preauth.*$' "$pam_file" ; then
-    sed -i --follow-symlinks '/^auth.*pam_unix\.so.*/i auth        required      pam_faillock.so preauth' "$pam_file"
+    # insert at the top
+    sed -i --follow-symlinks '/^# here are the per-package modules/i auth        required      pam_faillock.so preauth' "$pam_file"
 fi
 if ! grep -qE '^\s*auth\s+\[default=die\]\s+pam_faillock\.so\s+authfail.*$' "$pam_file" ; then
     num_lines=$(sed -n 's/^auth.*success=\([0-9]\).*pam_unix\.so.*/\1/p' "$pam_file")


### PR DESCRIPTION
#### Description:

- Fix Ubuntu remediations for pam_faillock rules to correctly position `pam_faillock authfail` module in modified pam files.
- Fix Ubuntu remediations for pam_faillock rules to add `pam_faillock preauth` above the Primary block instead of above `pam_unix`. 
- Clean up and add a few more tests.
- This affects rules in Ubuntu 22.04 CIS and Ubuntu 20.04 STIG

#### Rationale:

- The remediation wrongly positions the `pam_faillock authfail` module when the pam file contains commented or empty lines, potentially locking the system.
- Placing the `pam_faillock preauth` module directly above `pam_unix` interferes with modules from other rules, specifically, `pam_pkcs11` in `smartcard_pam_enabled`.

Example /etc/pam.d/common-auth on Ubuntu 22.04 after remediation:
```
# here are the per-package modules (the "Primary" block)
auth        required      pam_faillock.so preauth
auth    [success=2 default=ignore]      pam_unix.so nullok
# random user comment 
auth        [default=die]      pam_faillock.so authfail
auth        sufficient      pam_faillock.so authsucc
auth    [success=1 default=ignore]      pam_sss.so use_first_pass
# here's the fallback if no module succeeds
auth    requisite                       pam_deny.so
```
After fix:
```
auth        required      pam_faillock.so preauth
# here are the per-package modules (the "Primary" block)
auth    [success=2 default=ignore]      pam_unix.so nullok
# random user comment 
auth    [success=1 default=ignore]      pam_sss.so use_first_pass
auth        [default=die]      pam_faillock.so authfail
auth        sufficient      pam_faillock.so authsucc
# here's the fallback if no module succeeds
auth    requisite                       pam_deny.so
```