### PR TITLE
Fix Ubuntu remediation for smartcard_pam_enabled

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/bash/shared.sh
@@ -1,6 +1,6 @@
 # platform = multi_platform_sle,multi_platform_ubuntu
 {{% if 'ubuntu' in product %}}
-{{{ bash_ensure_pam_module_options('/etc/pam.d/common-auth', 'auth', '[success=2 default=ignore]', 'pam_pkcs11.so', '', '', '') }}}
+{{{ bash_ensure_pam_module_option('/etc/pam.d/common-auth', 'auth', '[success=2 default=ignore]', 'pam_pkcs11.so', '', '', '# here are the per-package modules') }}}
 {{% else %}}
 {{{ bash_ensure_pam_module_options('/etc/pam.d/common-auth', 'auth','sufficient', 'pam_pkcs11.so', '', '', '') }}}
 {{% endif %}}


### PR DESCRIPTION
#### Description:

- Fix Ubuntu remediation for rule `smartcard_pam_enabled` to correctly position `pam_pkcs11` module in stack.

#### Rationale:

- The line `auth    [success=2 default=ignore] pam_pkcs11.so` is incorrectly inserted at the bottom of the pam file instead of above `pam_unix.so`. Solution is to use another macro, which supports appending lines after a specific match.
