### PR TITLE
Move to /bin/false in Ubuntu remediation for wireless_disable_interface

### DIFF
--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/bash/ubuntu.sh
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/bash/ubuntu.sh
@@ -8,7 +8,7 @@ elif [ -n "$(find /sys/class/net/*/ -type d -name wireless)" ]; then
     for i in $interfaces; do
         ip link set dev "$i" down
         drivers=$(basename "$(readlink -f /sys/class/net/"$i"/device/driver)")
-        echo "install $drivers /bin/true" >> /etc/modprobe.d/disable_wireless.conf
+        echo "install $drivers /bin/false" >> /etc/modprobe.d/disable_wireless.conf
         modprobe -r "$drivers"
      done
 fi


### PR DESCRIPTION
#### Description:

- Move from `/bin/true` to `/bin/false` in remediation for `wireless_disable_interface` (UBTU-20-010455)
- Part of Ubuntu 20.04 STIG V1R11 update
- See also PR #11475 