### PR TITLE
Remove prodtype from rule schema

### DIFF
--- a/shared/schemas/rule.json
+++ b/shared/schemas/rule.json
@@ -9,9 +9,6 @@
     "title": {
       "type": "string"
     },
-    "prodtype": {
-      "type": "string"
-    },
     "description": {
       "type": "string"
     },


### PR DESCRIPTION
#### Description:
Remove prodtype from rule schema

#### Rationale:

So that my IDE stops telling me there is something missing.
