### PR TITLE
Fix Automatus in CI

### DIFF
--- a/.github/workflows/automatus-cs8.yaml
+++ b/.github/workflows/automatus-cs8.yaml
@@ -135,7 +135,7 @@ jobs:
         if: ${{steps.bash.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: tests/test_rule_in_container.sh --no-remove-machine-only --dontclean --logdir logs_bash --remediate-using bash --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
         env:
-          ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --add-product-to-fips-certified centos8 --product rhel8"
+          ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --remove-fips-certified --product rhel8"
       - name: Check for ERROR in logs
         if: ${{steps.bash.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: grep -q "^ERROR" logs_bash/test_suite.log
@@ -156,7 +156,7 @@ jobs:
         if: ${{ steps.ansible.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: tests/test_rule_in_container.sh --no-remove-machine-only --dontclean --logdir logs_ansible --remediate-using ansible --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
         env:
-          ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --add-product-to-fips-certified centos8 --product rhel8"
+          ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --remove-fips-certified --product rhel8"
       - name: Check for ERROR in logs
         if: ${{steps.ansible.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: grep -q "^ERROR" logs_ansible/test_suite.log

--- a/.github/workflows/automatus-cs9.yaml
+++ b/.github/workflows/automatus-cs9.yaml
@@ -135,7 +135,7 @@ jobs:
         if: ${{steps.bash.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: tests/test_rule_in_container.sh --no-remove-machine-only --dontclean --logdir logs_bash --remediate-using bash --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
         env:
-          ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --add-product-to-fips-certified centos9 --product rhel9"
+          ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --remove-fips-certified --product rhel9"
       - name: Check for ERROR in logs
         if: ${{steps.bash.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: grep -q "^ERROR" logs_bash/test_suite.log
@@ -156,7 +156,7 @@ jobs:
         if: ${{ steps.ansible.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: tests/test_rule_in_container.sh --no-remove-machine-only --dontclean --logdir logs_ansible --remediate-using ansible --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
         env:
-          ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --add-product-to-fips-certified centos9 --product rhel9"
+          ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --remove-fips-certified --product rhel9"
       - name: Check for ERROR in logs
         if: ${{steps.ansible.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: grep -q "^ERROR" logs_ansible/test_suite.log

--- a/.github/workflows/automatus-sle15.yaml
+++ b/.github/workflows/automatus-sle15.yaml
@@ -143,7 +143,7 @@ jobs:
         if: ${{steps.bash.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: tests/test_rule_in_container.sh --no-remove-machine-only --dontclean --logdir logs_bash --remediate-using bash --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
         env:
-          ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --add-product-to-fips-certified sle15 --product sle15"
+          ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --remove-fips-certified --product sle15"
       - name: Check for ERROR in logs
         if: ${{steps.bash.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: grep -q "^ERROR" logs_bash/test_suite.log
@@ -164,7 +164,7 @@ jobs:
         if: ${{ steps.ansible.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: tests/test_rule_in_container.sh --no-remove-machine-only --dontclean --logdir logs_ansible --remediate-using ansible --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
         env:
-          ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --add-product-to-fips-certified sle15 --product sle15"
+          ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --remove-fips-certified --product sle15"
       - name: Check for ERROR in logs
         if: ${{steps.ansible.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: grep -q "^ERROR" logs_ansible/test_suite.log

--- a/.github/workflows/automatus.yaml
+++ b/.github/workflows/automatus.yaml
@@ -133,7 +133,7 @@ jobs:
         if: ${{steps.bash.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: tests/test_rule_in_container.sh --no-remove-machine-only --dontclean --logdir logs_bash --remediate-using bash --name ssg_test_suite --datastream ssg-${{steps.product.outputs.prop}}-ds.xml ${{join(fromJSON(steps.rules.outputs.prop))}}
         env:
-          ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --add-product-to-fips-certified fedora"
+          ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --remove-fips-certified"
       - name: Check for ERROR in logs
         if: ${{steps.bash.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: grep -q "^ERROR" logs_bash/test_suite.log
@@ -154,7 +154,7 @@ jobs:
         if: ${{ steps.ansible.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: tests/test_rule_in_container.sh --no-remove-machine-only --dontclean --logdir logs_ansible --remediate-using ansible --name ssg_test_suite --datastream ssg-${{steps.product.outputs.prop}}-ds.xml ${{join(fromJSON(steps.rules.outputs.prop))}}
         env:
-          ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --add-product-to-fips-certified fedora"
+          ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --remove-fips-certified"
       - name: Check for ERROR in logs
         if: ${{steps.ansible.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: grep -q "^ERROR" logs_ansible/test_suite.log

--- a/.gitpod.launch.json
+++ b/.gitpod.launch.json
@@ -59,8 +59,7 @@
           "${input:pickRemediationType}",
           "--remove-machine-only",
           "--remove-ocp4-only",
-          "--add-product-to-fips-certified",
-          "fedora",
+          "--remove-fips-certified",
           "--remove-platforms",
           "${command:content-navigator.getRuleId}"
       ],
@@ -85,7 +84,7 @@
           "${command:content-navigator.getRuleId}"
       ],
       "env": {
-        "ADDITIONAL_SSGTS_OPTIONS": "--debug --duplicate-templates --add-product-to-fips-certified fedora",
+        "ADDITIONAL_SSGTS_OPTIONS": "--debug --duplicate-templates --remove-fips-certified",
         "SSH_ADDITIONAL_OPTIONS": "-o IdentityFile=${workspaceFolder}/&&PRIVATE_KEY_FILEPATH&&"
       }
     }

--- a/tests/automatus.py
+++ b/tests/automatus.py
@@ -84,6 +84,11 @@ def parse_args():
             help="Add installed_OS_is_$product extend_definition to the "
             "installed_OS_is_FIPS_certified OVAL criteria definition.")
     common_parser.add_argument(
+        "--remove-fips-certified",
+        action="store_true",
+        help="Remove dependencies on rule installed_OS_is_FIPS_certified from "
+        "all OVAL definitions that depend on it.")
+    common_parser.add_argument(
             "--remove-platforms",
             default=False,
             action="store_true",
@@ -511,6 +516,8 @@ def main():
             if options.add_product_to_fips_certified:
                 xml_operations.add_product_to_fips_certified(
                     root, options.add_product_to_fips_certified)
+            if options.remove_fips_certified:
+                xml_operations.remove_fips_certified(root)
 
         options.func(options)
 

--- a/tests/automatus.py
+++ b/tests/automatus.py
@@ -79,11 +79,6 @@ def parse_args():
             "as a literal CPE, and added as a platform. "
             "For example, use 'cpe:/o:fedoraproject:fedora:30' or 'enterprise_linux'.")
     common_parser.add_argument(
-            "--add-product-to-fips-certified",
-            default=None,
-            help="Add installed_OS_is_$product extend_definition to the "
-            "installed_OS_is_FIPS_certified OVAL criteria definition.")
-    common_parser.add_argument(
         "--remove-fips-certified",
         action="store_true",
         help="Remove dependencies on rule installed_OS_is_FIPS_certified from "
@@ -513,9 +508,6 @@ def main():
                 xml_operations.remove_ocp4_platforms(root)
             if options.add_platform:
                 xml_operations.add_platform_to_benchmark(root, options.add_platform)
-            if options.add_product_to_fips_certified:
-                xml_operations.add_product_to_fips_certified(
-                    root, options.add_product_to_fips_certified)
             if options.remove_fips_certified:
                 xml_operations.remove_fips_certified(root)
 

--- a/tests/ssg_test_suite/xml_operations.py
+++ b/tests/ssg_test_suite/xml_operations.py
@@ -232,6 +232,15 @@ def add_product_to_fips_certified(root, product="fedora"):
         criteria.append(e)
 
 
+def remove_fips_certified(root):
+    def_id = "oval:ssg-installed_OS_is_FIPS_certified:def:1"
+    parent_query = ".//oval-def:extend_definition[@definition_ref='{0}']/..".format(def_id)
+    child_query = "oval-def:extend_definition[@definition_ref='{0}']".format(def_id)
+    for parent in root.findall(parent_query, PREFIX_TO_NS):
+        for child in parent.findall(child_query, PREFIX_TO_NS):
+            parent.remove(child)
+
+
 def _get_benchmark_node(datastream, benchmark_id, logging):
     root = ET.parse(datastream).getroot()
     benchmark_node = root.find(

--- a/tests/ssg_test_suite/xml_operations.py
+++ b/tests/ssg_test_suite/xml_operations.py
@@ -220,18 +220,6 @@ def add_platform_to_benchmark(root, cpe_regex):
             benchmark.insert(platform_index, e)
 
 
-def add_product_to_fips_certified(root, product="fedora"):
-    query = OVAL_DEF_QUERY + "/{0}".format(
-        "oval-def:definition[@id='oval:ssg-installed_OS_is_FIPS_certified:def:1']/"
-        "oval-def:criteria")
-    criteria = root.find(query, PREFIX_TO_NS)
-    if criteria:
-        e = ET.Element("oval-def:extend_definition",
-                       comment="Installed OS is {0}".format(product),
-                       definition_ref="oval:ssg-installed_OS_is_{0}:def:1".format(product))
-        criteria.append(e)
-
-
 def remove_fips_certified(root):
     def_id = "oval:ssg-installed_OS_is_FIPS_certified:def:1"
     parent_query = ".//oval-def:extend_definition[@definition_ref='{0}']/..".format(def_id)


### PR DESCRIPTION
#### Description:

Some rules depend on rule `installed_OS_is_FIPS_certified` which makes
it difficult to run test scenarios of these rules on different systems
that aren't certified by FIPS. For example, this happens when you run
test scenarios on Fedora container or CentOS container.

This situation is currently handled by a feature of Automatus using the
`--add-product-to-fips-certified` option which extends the OVAL in rule
`installed_OS_is_FIPS_certified` to make it pass on a selected platform.
Unfortunately, this depends on assumption that there exist an OVAL
definition `installed_OS_is_${product}`. After recent changes in build
system, it doesn't have to be true, because if this definition isn't
used by any rule, it gets removed by code that filters out unused
definitions.

This option depends on assumption that the given SCAP source data
stream contains definitions of all possible products which might
not be the case if the definiton isn't used by any rule in that
data stream. The feature is fragile

We will add a new Automatus option '--remove-fips-certified' which will
remove all `<oval-def:extend_definition>` elements that reference OVAL
definition for rule `installed_OS_is_FIPS_certified` from all other
rules. As a result, no rule will depend on
`installed_OS_is_FIPS_certifed` when this option will be used.

#### Review Hints:
```
python3 tests/automatus.py rule --libvirt qemu:///system ssgts_rhel8 --remove-fips-certified --scenario  correct_value.pass.sh sshd_use_approved_ciphers
```

Check the Automatus CI jobs.

