### PR TITLE
remove prodtype from add_kubernetes_rule

### DIFF
--- a/utils/add_kubernetes_rule.py
+++ b/utils/add_kubernetes_rule.py
@@ -170,7 +170,6 @@ def which(program):
 def create_base_rule(args, url=None, node_rule=False):
     rule_yaml = dict()
     rule_yaml['documentation_complete'] = True
-    rule_yaml['prodtype'] = 'ocp4'
     rule_yaml['title'] = args.title
     if node_rule:
         rule_yaml['platform'] = 'ocp4-node'


### PR DESCRIPTION
#### Description:

- remove prodtype from add_kubernetes_rule

#### Rationale:

- as prodtype was removed from the rules, new rules using the util should not add it again