### PR TITLE
Add a warning to sshd_limit_user_access

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_limit_user_access/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_limit_user_access/rule.yml
@@ -70,3 +70,8 @@ references:
     nist-csf: PR.AC-4,PR.AC-6,PR.PT-3
     pcidss: Req-2.2.4
     pcidss4: "2.2.6"
+
+warnings:
+    - general: |-
+        Automated remediation is not available for this configuration check
+        because each system has unique user names and group names.


### PR DESCRIPTION
This rule can't have a remediation because the configuration depends on specific user names and group names on the system.

We need to add a warning about this so that people reviewing the HTML report can easily investigate the failure reason and identify appropriate manual remediation.


