### PR TITLE
Make additional check if selinux is enabled and operational

### DIFF
--- a/shared/applicability/oval/selinux_is_enabled.xml
+++ b/shared/applicability/oval/selinux_is_enabled.xml
@@ -10,6 +10,7 @@
     </metadata>
     <criteria operator="AND">
       <criterion comment="enforce is disabled" test_ref="test_etc_selinux_configured" />
+      <criterion comment="/sys/fs/selinux is present" test_ref="test_selinux_sys_fs_exist" />
     </criteria>
   </definition>
 
@@ -29,4 +30,12 @@
     <ind:subexpression datatype="string"
       operation="pattern match">^(enforcing|permissive)$</ind:subexpression>
   </ind:textfilecontent54_state>
+  <unix:file_test check="all" check_existence="all_exist" comment="check if /sys/fs/selinux exists" id="test_selinux_sys_fs_exist" version="1">
+    <unix:object object_ref="object_selinux_sys_fs_exist" />
+  </unix:file_test>
+
+  <unix:file_object comment="/sys/fs/selinux" id="object_selinux_sys_fs_exist" version="1">
+    <unix:path>/sys/fs/selinux</unix:path>
+    <unix:filename xsi:nil="true" />
+  </unix:file_object>
 </def-group>


### PR DESCRIPTION
#### Description:

- Make sure oscap does not crash due to missing selinux in sysfs

#### Rationale:

- In case selinux might be configured but not enabled, i.e. system not yet restarted, or there is dummy /selinux directory, the oscap tool fails like:
```
sles-15-sp5:/src/content/build # oscap xccdf eval \
> --profile anssi_bp28_intermediary \
> --rule xccdf_org.ssgproject.content_rule_sebool_polyinstantiation_enabled \
> --results /tmp/results.xml \
> ssg-sle15-ds.xml
WARNING: Datastream component 'scap_org.open-scap_cref_pub-projects-security-oval-suse.linux.enterprise.15.xml' points out to the remote 'https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.15.xml'. Use '--fetch-remote-resources' option to download it.
WARNING: Skipping 'https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.15.xml' file which is referenced from datastream
WARNING: Skipping ./pub-projects-security-oval-suse.linux.enterprise.15.xml file which is referenced from XCCDF content
--- Starting Evaluation ---

Title   Configure the polyinstantiation_enabled SELinux Boolean
Rule    xccdf_org.ssgproject.content_rule_sebool_polyinstantiation_enabled
Ident   CCE-91238-6
W: oscap:     Can't receive message: 125, Operation canceled.
E: oscap:     Recv: retry limit (0) reached.
Result  unknown

OpenSCAP Error: Probe at sd=1 (selinuxboolean) reported an error: Invalid type, value or format [/home/abuild/rpmbuild/BUILD/openscap-1.3.6/src/OVAL/oval_probe_ext.c:384]
Unable to receive a message from probe [/home/abuild/rpmbuild/BUILD/openscap-1.3.6/src/OVAL/oval_probe_ext.c:572]
Invalid oval result type: -1. [/home/abuild/rpmbuild/BUILD/openscap-1.3.6/src/OVAL/results/oval_resultTest.c:181]
sles-15-sp5:/src/content/build # ls -al /selinux/
total 0
drwxr-xr-x 1 root root   0 Mar 15  2022 .
drwxr-xr-x 1 root root 176 Jan 15 01:37 ..
``` 


- To prevent the above added additional check that the selinux exists in sysfs, that has the following effect in same situation:
```
oscap xccdf eval \
--profile anssi_bp28_intermediary \
--rule xccdf_org.ssgproject.content_rule_sebool_polyinstantiation_enabled \
--results /tmp/results.xml \
/src/content/build/ssg-sle15-ds.xml

WARNING: Datastream component 'scap_org.open-scap_cref_pub-projects-security-oval-suse.linux.enterprise.15.xml' points out to the remote 'https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.15.xml'. Use '--fetch-remote-resources' option to download it.
WARNING: Skipping 'https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.15.xml' file which is referenced from datastream
WARNING: Skipping ./pub-projects-security-oval-suse.linux.enterprise.15.xml file which is referenced from XCCDF content
--- Starting Evaluation ---

Title   Configure the polyinstantiation_enabled SELinux Boolean
Rule    xccdf_org.ssgproject.content_rule_sebool_polyinstantiation_enabled
Ident   CCE-91238-6
Result  notapplicable
```

#### Review Hints:

- The reason of oscap check returning unknown is due to oscap tool crashing discussed in OpenSCAP/openscap#1959
