### PR TITLE
Update crypto_policy test scenario for CIS RHEL8

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/cis_l2.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/cis_l2.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8
 # profiles = xccdf_org.ssgproject.content_profile_cis,xccdf_org.ssgproject.content_profile_cis_workstation_l2
 # packages = crypto-policies-scripts
 
-update-crypto-policies --set "DEFAULT"
+update-crypto-policies --set "DEFAULT:NO-SHA1"

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/policy_default_cis_l1.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/policy_default_cis_l1.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 9
 # profiles = xccdf_org.ssgproject.content_profile_cis_server_l1,xccdf_org.ssgproject.content_profile_cis_workstation_l1
 # packages = crypto-policies-scripts
 


### PR DESCRIPTION
#### Description:

The CIS requirement for RHEL8 was changed in the release 3.0.0. This commit align the test scenario script with the policy.

#### Rationale:

Keep the test scenario aligned with the CIS policy for RHEL 8.