### PR TITLE
Fix STIG Version for RHEL 8

### DIFF
--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -1,7 +1,7 @@
 documentation_complete: true
 
 metadata:
-    version: V1R12
+    version: V1R13
     SMEs:
         - mab879
         - ggbecker
@@ -12,7 +12,7 @@ title: 'DISA STIG for Red Hat Enterprise Linux 8'
 
 description: |-
     This profile contains configuration checks that align to the
-    DISA STIG for Red Hat Enterprise Linux 8 V1R12.
+    DISA STIG for Red Hat Enterprise Linux 8 V1R13.
 
     In addition to being applicable to Red Hat Enterprise Linux 8, DISA recognizes this
     configuration baseline as applicable to the operating system tier of

--- a/products/rhel8/profiles/stig_gui.profile
+++ b/products/rhel8/profiles/stig_gui.profile
@@ -1,7 +1,7 @@
 documentation_complete: true
 
 metadata:
-    version: V1R12
+    version: V1R13
     SMEs:
         - mab879
         - ggbecker
@@ -12,7 +12,7 @@ title: 'DISA STIG with GUI for Red Hat Enterprise Linux 8'
 
 description: |-
     This profile contains configuration checks that align to the
-    DISA STIG with GUI for Red Hat Enterprise Linux 8 V1R12.
+    DISA STIG with GUI for Red Hat Enterprise Linux 8 V1R13.
 
     In addition to being applicable to Red Hat Enterprise Linux 8, DISA recognizes this
     configuration baseline as applicable to the operating system tier of


### PR DESCRIPTION


#### Description:

Fix STIG Version for RHEL 8

#### Rationale:
It appears that only the stable profile data was updated in https://github.com/ComplianceAsCode/content/pull/11478.

