### PR TITLE
Remove `BuildRequire /usr/bin/python3` from spec

### DIFF
--- a/scap-security-guide.spec
+++ b/scap-security-guide.spec
@@ -25,7 +25,7 @@ BuildArch:	noarch
 %if 0%{?_rhel_like} == 7
 BuildRequires:  libxslt, openscap-scanner >= 1.2.5, cmake >= 2.8, python, python-jinja2, PyYAML, python-setuptools
 %else
-BuildRequires:  libxslt, openscap-scanner >= 1.2.5, cmake >= 2.8, /usr/bin/python3, python%{python3_pkgversion}, python%{python3_pkgversion}-jinja2, python%{python3_pkgversion}-PyYAML, python%{python3_pkgversion}-setuptools
+BuildRequires:  libxslt, openscap-scanner >= 1.2.5, cmake >= 2.8, python%{python3_pkgversion}, python%{python3_pkgversion}-jinja2, python%{python3_pkgversion}-PyYAML, python%{python3_pkgversion}-setuptools
 %endif
 Requires:	xml-common, openscap-scanner >= 1.2.5
 


### PR DESCRIPTION


#### Description:
Remove `BuildRequire /usr/bin/python3` from spec

#### Rationale:
Fixes [RHEL-2244](https://issues.redhat.com/browse/RHEL-2244)
