### PR TITLE
[Stabilization] fix regex used in Ansible remediation of configure_ssh_crypto_policy

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/ansible/shared.yml
@@ -8,4 +8,4 @@
   lineinfile:
     dest: /etc/sysconfig/sshd
     state: absent
-    regexp: ^(?i)\s*CRYPTO_POLICY.*$
+    regexp: (?i)^\s*CRYPTO_POLICY.*$


### PR DESCRIPTION
#### Description:

- move the (?i) extension to the very beginning of the string

#### Rationale:

- this regex can be treated as invalid


#### Review Hints:

- _Review hints here. Replace this text. Don't use the italics format!_

- _Use this optional section to give any relevant information which could help the reviewer to more quickly and assertively understand and test the changes._

- _Good examples are useful commands, if it is better to review all commits together or in a suggested sequence, any relevant discussion in other PRs or issues, etc._
