### PR TITLE
fix regex in Ansible remediation of configure_ssh_crypto_policy

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/ansible/shared.yml
@@ -8,4 +8,4 @@
   lineinfile:
     dest: /etc/sysconfig/sshd
     state: absent
-    regexp: ^(?i)\s*CRYPTO_POLICY.*$
+    regexp: (?i)^\s*CRYPTO_POLICY.*$


### PR DESCRIPTION
#### Description:

- move the special extension string to the very beginning of the regex

#### Rationale:

- the original regex is invalid

