### PR TITLE
Remove restrictions in sshd_use_approved_ciphers remediation

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Oracle Linux 7,multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Oracle Linux 7,multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_all
 
 {{{ bash_instantiate_variables("sshd_approved_ciphers") }}}
 


### PR DESCRIPTION
#### Description:

There were platform limitations on Bash and Ansible remediation besides the rule be expected to be used by other products.
Update the platform header to `multi_platform_all`.

#### Rationale:

More flexibility for remediation.
There are other means to restrict the whole rule instead of just the remediation.