### PR TITLE
Stabilization - Remove restrictions in sshd_use_approved_ciphers remediation

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Oracle Linux 7,multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Oracle Linux 7,multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_all
 
 {{{ bash_instantiate_variables("sshd_approved_ciphers") }}}
 


### PR DESCRIPTION
#### Description:

Backport https://github.com/ComplianceAsCode/content/pull/11527 to stabilization-0.1.72 branch.
