### PR TITLE
k8s content image:  Fix output reference to `pr-number` variable and its assignment

### DIFF
--- a/.github/workflows/k8s-content-pr.yaml
+++ b/.github/workflows/k8s-content-pr.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Get PR number
     runs-on: ubuntu-latest
     outputs:
-      pr-number: ${{ steps.get-pr-number.outputs.pr-number }}
+      pr-number: ${{ steps.read-pr-number.outputs.pr-number }}
     steps:
       - name: 'Download artifacts'
         uses: actions/github-script@v7
@@ -37,7 +37,7 @@ jobs:
         run: unzip pr_number.zip
       - name: 'Read PR number'
         run: |
-          echo "::set-output name=pr-number::$(cat pr/pr_number)"
+          echo "pr-number=$(cat pr/pr_number)" >> "$GITHUB_OUTPUT"
 
   container-main:
     needs: 


### PR DESCRIPTION


#### Description:

- Fix the definition of  `pr-number` output. It should reference the step name, not the jobs name.
- Use `$GITHUB_OUTPUT` instead of `set-output`, which is deprecated