### PR TITLE
Fix ubuntu remediation for pam_faildelay

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faildelay_delay/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faildelay_delay/bash/ubuntu.sh
@@ -2,4 +2,4 @@
 
 {{{ bash_instantiate_variables("var_password_pam_delay") }}}
 
-{{{ bash_ensure_pam_module_options('/etc/pam.d/common-auth', 'auth', 'required', 'pam_faildelay.so', 'delay', "$var_password_pam_delay", "$var_password_pam_delay") }}}
+{{{ bash_ensure_pam_module_option('/etc/pam.d/common-auth', 'auth', 'required', 'pam_faildelay.so', 'delay', "$var_password_pam_delay", 'BOF') }}}


### PR DESCRIPTION
#### Description:

- Fix ubuntu remediation for pam_faildelay by placing the module at beginning of stack

#### Rationale:

- pam_faildelay module was placed at end of /etc/pam.d/common-auth, after various statements with success=die, sufficient and requisite, and was thus never reached
