### PR TITLE
[Stabilization] remove /dev/shm partition definitions from kickstarts

### DIFF
--- a/products/rhel7/kickstart/ssg-rhel7-cis-ks.cfg
+++ b/products/rhel7/kickstart/ssg-rhel7-cis-ks.cfg
@@ -117,8 +117,6 @@ logvol /var --fstype=xfs --name=var --vgname=VolGroup --size=2048
 logvol /var/log --fstype=xfs --name=varlog --vgname=VolGroup --size=1024
 # Ensure /var/log/audit Located On Separate Partition
 logvol /var/log/audit --fstype=xfs --name=varlogaudit --vgname=VolGroup --size=512
-# Ensure /dev/shm Located on Separate Partition
-logvol /dev/shm --name=devshm --vgname=VolGroup --size=512 --fsoptions="nodev,nosuid,noexec"
 logvol swap --name=swap --vgname=VolGroup --size=2016
 
 

--- a/products/rhel7/kickstart/ssg-rhel7-cis_server_l1-ks.cfg
+++ b/products/rhel7/kickstart/ssg-rhel7-cis_server_l1-ks.cfg
@@ -117,8 +117,6 @@ logvol /var --fstype=xfs --name=var --vgname=VolGroup --size=2048
 logvol /var/log --fstype=xfs --name=varlog --vgname=VolGroup --size=1024
 # Ensure /var/log/audit Located On Separate Partition
 logvol /var/log/audit --fstype=xfs --name=varlogaudit --vgname=VolGroup --size=512
-# Ensure /dev/shm Located on Separate Partition
-logvol /dev/shm --name=devshm --vgname=VolGroup --size=512 --fsoptions="nodev,nosuid,noexec"
 logvol swap --name=swap --vgname=VolGroup --size=2016
 
 

--- a/products/rhel7/kickstart/ssg-rhel7-cis_workstation_l1-ks.cfg
+++ b/products/rhel7/kickstart/ssg-rhel7-cis_workstation_l1-ks.cfg
@@ -117,8 +117,6 @@ logvol /var --fstype=xfs --name=var --vgname=VolGroup --size=2048
 logvol /var/log --fstype=xfs --name=varlog --vgname=VolGroup --size=1024
 # Ensure /var/log/audit Located On Separate Partition
 logvol /var/log/audit --fstype=xfs --name=varlogaudit --vgname=VolGroup --size=512
-# Ensure /dev/shm Located on Separate Partition
-logvol /dev/shm --name=devshm --vgname=VolGroup --size=512 --fsoptions="nodev,nosuid,noexec"
 logvol swap --name=swap --vgname=VolGroup --size=2016
 
 

--- a/products/rhel7/kickstart/ssg-rhel7-cis_workstation_l2-ks.cfg
+++ b/products/rhel7/kickstart/ssg-rhel7-cis_workstation_l2-ks.cfg
@@ -117,8 +117,6 @@ logvol /var --fstype=xfs --name=var --vgname=VolGroup --size=2048
 logvol /var/log --fstype=xfs --name=varlog --vgname=VolGroup --size=1024
 # Ensure /var/log/audit Located On Separate Partition
 logvol /var/log/audit --fstype=xfs --name=varlogaudit --vgname=VolGroup --size=512
-# Ensure /dev/shm Located on Separate Partition
-logvol /dev/shm --name=devshm --vgname=VolGroup --size=512 --fsoptions="nodev,nosuid,noexec"
 logvol swap --name=swap --vgname=VolGroup --size=2016
 
 

--- a/products/rhel9/kickstart/ssg-rhel9-ccn_advanced-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-ccn_advanced-ks.cfg
@@ -88,9 +88,6 @@ clearpart --linux --initlabel
 part /boot --fstype=xfs --size=512
 part pv.01 --grow --size=1
 
-# Ensure /dev/shm is a separate partition
-part /dev/shm --fstype=tmpfs --fsoptions="nodev,nosuid,noexec" --size=512
-
 # Create a Logical Volume Management (LVM) group (optional)
 volgroup VolGroup pv.01
 

--- a/products/rhel9/kickstart/ssg-rhel9-ccn_basic-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-ccn_basic-ks.cfg
@@ -88,9 +88,6 @@ clearpart --linux --initlabel
 part /boot --fstype=xfs --size=512
 part pv.01 --grow --size=1
 
-# Ensure /dev/shm is a separate partition
-part /dev/shm --fstype=tmpfs --fsoptions="nodev,nosuid,noexec" --size=512
-
 # Create a Logical Volume Management (LVM) group (optional)
 volgroup VolGroup pv.01
 

--- a/products/rhel9/kickstart/ssg-rhel9-ccn_intermediate-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-ccn_intermediate-ks.cfg
@@ -88,9 +88,6 @@ clearpart --linux --initlabel
 part /boot --fstype=xfs --size=512
 part pv.01 --grow --size=1
 
-# Ensure /dev/shm is a separate partition
-part /dev/shm --fstype=tmpfs --fsoptions="nodev,nosuid,noexec" --size=512
-
 # Create a Logical Volume Management (LVM) group (optional)
 volgroup VolGroup pv.01
 

--- a/products/rhel9/kickstart/ssg-rhel9-cis-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-cis-ks.cfg
@@ -91,9 +91,6 @@ clearpart --linux --initlabel
 part /boot --fstype=xfs --size=512
 part pv.01 --grow --size=1
 
-# Ensure /dev/shm is a separate partition
-part /dev/shm --fstype=tmpfs --fsoptions="nodev,nosuid,noexec" --size=512
-
 # Create a Logical Volume Management (LVM) group (optional)
 volgroup VolGroup pv.01
 

--- a/products/rhel9/kickstart/ssg-rhel9-cis_server_l1-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-cis_server_l1-ks.cfg
@@ -91,9 +91,6 @@ clearpart --linux --initlabel
 part /boot --fstype=xfs --size=512
 part pv.01 --grow --size=1
 
-# Ensure /dev/shm is a separate partition
-part /dev/shm --fstype=tmpfs --fsoptions="nodev,nosuid,noexec" --size=512
-
 # Create a Logical Volume Management (LVM) group (optional)
 volgroup VolGroup pv.01
 

--- a/products/rhel9/kickstart/ssg-rhel9-cis_workstation_l1-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-cis_workstation_l1-ks.cfg
@@ -91,9 +91,6 @@ clearpart --linux --initlabel
 part /boot --fstype=xfs --size=512
 part pv.01 --grow --size=1
 
-# Ensure /dev/shm is a separate partition
-part /dev/shm --fstype=tmpfs --fsoptions="nodev,nosuid,noexec" --size=512
-
 # Create a Logical Volume Management (LVM) group (optional)
 volgroup VolGroup pv.01
 

--- a/products/rhel9/kickstart/ssg-rhel9-cis_workstation_l2-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-cis_workstation_l2-ks.cfg
@@ -91,9 +91,6 @@ clearpart --linux --initlabel
 part /boot --fstype=xfs --size=512
 part pv.01 --grow --size=1
 
-# Ensure /dev/shm is a separate partition
-part /dev/shm --fstype=tmpfs --fsoptions="nodev,nosuid,noexec" --size=512
-
 # Create a Logical Volume Management (LVM) group (optional)
 volgroup VolGroup pv.01
 


### PR DESCRIPTION
#### Description:

- remove lines defining /dev/shm from RHEL 7 and RHEL 9 kickstarts

#### Rationale:

- the /dev/shm is not a real partition, it is a temporary one and it should not be handled by Anaconda

#### Review Hints:

Perform installation and hardening of RHEL 7 and RHEL 9 systems with CIS profile and observe behavior related to /dev/shm