### PR TITLE
Fix Ansible compatibility with sysctl module

### DIFF
--- a/linux_os/guide/system/network/network-nftables/set_nftables_loopback_traffic/ansible/shared.yml
+++ b/linux_os/guide/system/network/network-nftables/set_nftables_loopback_traffic/ansible/shared.yml
@@ -16,11 +16,7 @@
   register: ipv6_status
 
 - name: Check sysctl value of net.ipv6.conf.all.disable_ipv6
-{{% if product == "rhel7" %}}
-  ansible.builtin.sysctl:
-{{% else %}}
-  ansible.posix.sysctl:
-{{%endif %}}
+  sysctl:
     name: net.ipv6.conf.all.disable_ipv6
     state: present
     value: "1"
@@ -28,11 +24,7 @@
   register: sysctl_ipv6_all
 
 - name: Check sysctl value of net.ipv6.conf.default.disable_ipv6
-{{% if product == "rhel7" %}}
-  ansible.builtin.sysctl:
-{{% else %}}
-  ansible.posix.sysctl:
-{{%endif %}}
+  sysctl:
     name: net.ipv6.conf.default.disable_ipv6
     state: present
     value: "1"


### PR DESCRIPTION
#### Description:

In older versions of Ansible, such as the version included with RHEL7, the `sysctl` module was part of the `ansible.builtin` collection. But in most recent versions it belongs to the `ansible.posix` collection.
Since explicit collection is not mandatory, we can leave it implicit for this particular case so each Ansible version can manage it properly.

#### Rationale:

- Fixes #11529
