### PR TITLE
CMP-2365: Fix check for rotating kubelet server certificates

### DIFF
--- a/applications/openshift/controller/controller_rotate_kubelet_server_certs/rule.yml
+++ b/applications/openshift/controller/controller_rotate_kubelet_server_certs/rule.yml
@@ -28,6 +28,8 @@ description: |-
     ...
     </pre>
 
+    This feature gate is enabled by default as of Kubernetes 1.12.
+
 rationale: |-
     Enabling kubelet certificate rotation causes the kubelet to both request
     a serving certificate after bootstrapping its client credentials and rotate the
@@ -67,6 +69,10 @@ references:
     pcidss: Req-2.2
     srg: SRG-APP-000516-CTR-001325
 
+# Since RotateKubeletServerCertificate is enabled by default, let's make sure
+# it's not being disabled explicitly. If we only check for it to be enabled,
+# we'll miss clusters that rely on the default and result in a false positive
+# finding.
 template:
   name: yamlfile_value
   vars:
@@ -75,7 +81,7 @@ template:
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '[:]'
     values:
-    - value: 'RotateKubeletServerCertificate=true'
+    - value: 'RotateKubeletServerCertificate=false'
       type: "string"
       operation: "pattern match"
-      entity_check: "at least one"
+      entity_check: "none satisfy"


### PR DESCRIPTION
The controller_rotate_kubelet_server_certs rule was only checking that
RotateKubeletServerCertificate was enabled by making sure it's enabled
explicitly. This doesn't work for clusters that are relying on the fact
that RotateKubeletServerCertificate is enabled by default.

This commit updates the check to invert the logic, so we're checking
that it's not explicitly disabled.
