### PR TITLE
CMP-2372: Remove info override for virtual syscall rules

### DIFF
--- a/products/rhcos4/profiles/stig-v1r1.profile
+++ b/products/rhcos4/profiles/stig-v1r1.profile
@@ -22,10 +22,6 @@ selections:
   - var_selinux_policy_name=targeted
   - var_selinux_state=enforcing
   - var_accounts_passwords_pam_faillock_dir=run
-  # Let's mark the vsyscall argument as info - the check and the fix is there, but setting this
-  # karg is not suitable for people who still run legacy 32bit apps.
-  - coreos_vsyscall_kernel_argument.role=unscored
-  - coreos_vsyscall_kernel_argument.severity=info
   # Following rules once had a prodtype incompatible with the rhcos4 product
   - '!audit_rules_suid_privilege_function'
   - '!audit_rules_sudoers'


### PR DESCRIPTION
The STIG has controls that ensure virtual system calls are disabled,
because they pose a security risk. However, the rule was previously
overridden to always inform users, instead of actually checking the
functionality was disabled.

This commit removes the override so that we evaluate the kernel argument
appropriately. If a user still needs to disable this check (e.g., to
make it easier to run 32 bit applications) then they can still exclude
the rule using a TailoredProfile.
