### PR TITLE
OCP: Fix e2e remediation for container_security_operator_exists

### DIFF
--- a/applications/openshift/risk-assessment/container_security_operator_exists/tests/ocp4/e2e-remediation.sh
+++ b/applications/openshift/risk-assessment/container_security_operator_exists/tests/ocp4/e2e-remediation.sh
@@ -14,3 +14,8 @@ done
 echo "waiting for container-security-operator deployment to be ready"
 oc wait -nopenshift-operators --for=condition=Available  --timeout=300s \
     deployment/container-security-operator
+
+echo "waiting the subscription to have .status.installedCSV"
+while [ -z "$(oc get subscription container-security-operator -nopenshift-operators -o jsonpath='{.status.installedCSV}')" ]; do
+    sleep 3
+done

--- a/ocp-resources/e2e/container-security-operator-install.yaml
+++ b/ocp-resources/e2e/container-security-operator-install.yaml
@@ -7,9 +7,9 @@ metadata:
   name: container-security-operator
   namespace: openshift-operators
 spec:
-  channel: stable-3.8
+  channel: stable-3.10
   installPlanApproval: Automatic
   name: container-security-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: container-security-operator.v3.8.2
+  startingCSV: container-security-operator.v3.10.3


### PR DESCRIPTION
We need to update the e2e remediation for container_security_operator_exists, so the CI works properly.
