### PR TITLE
CMP-2366: Update service_autofs_disabled default e2e result

### DIFF
--- a/linux_os/guide/system/permissions/mounting/service_autofs_disabled/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/permissions/mounting/service_autofs_disabled/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: PASS
+default_result: NOT-APPLICABLE


### PR DESCRIPTION
Since
https://github.com/ComplianceAsCode/content/commit/1ce0c75b2d9e33f659301874450286b6d9c69dc4
landed, this rule is only invoked if the autofs package is installed. By
default, at least with OpenShift 4.13+, it isn't installed which means
the default result is NOT-APPLICABLE.

This commit updates the default testing result for the rule to match
what happens in real clusters since we're being more selective about
when to run the rule.
