### PR TITLE
Red Hat product security is on the path of deprecating the OVAL CVE feed

### DIFF
--- a/products/rhel7/product.yml
+++ b/products/rhel7/product.yml
@@ -26,7 +26,6 @@ aux_pkg_version: "2fa658e0"
 
 release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
 auxiliary_key_fingerprint: "43A6E49C4A38F4BE9ABF2A5345689C882FA658E0"
-oval_feed_url: "https://access.redhat.com/security/data/oval/v2/RHEL7/rhel-7.oval.xml.bz2"
 
 audisp_conf_path: "/etc/audisp"
 

--- a/products/rhel8/product.yml
+++ b/products/rhel8/product.yml
@@ -26,7 +26,6 @@ aux_pkg_version: "d4082792"
 
 release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
 auxiliary_key_fingerprint: "6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792"
-oval_feed_url: "https://access.redhat.com/security/data/oval/v2/RHEL8/rhel-8.oval.xml.bz2"
 
 groups:
   dedicated_ssh_keyowner:

--- a/products/rhel9/product.yml
+++ b/products/rhel9/product.yml
@@ -38,7 +38,6 @@ aux_pkg_version: "5a6340b3"
 
 release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
 auxiliary_key_fingerprint: "7E4624258C406535D56D6F135054E4A45A6340B3"
-oval_feed_url: "https://access.redhat.com/security/data/oval/v2/RHEL9/rhel-9.oval.xml.bz2"
 
 cpes_root: "../../shared/applicability"
 cpes:

--- a/tests/data/product_stability/rhel7.yml
+++ b/tests/data/product_stability/rhel7.yml
@@ -54,7 +54,6 @@ init_system: systemd
 major_version_ordinal: 7
 nobody_gid: 65534
 nobody_uid: 65534
-oval_feed_url: https://access.redhat.com/security/data/oval/v2/RHEL7/rhel-7.oval.xml.bz2
 pkg_manager: yum
 pkg_manager_config_file: /etc/yum.conf
 pkg_release: 4ae0493b

--- a/tests/data/product_stability/rhel8.yml
+++ b/tests/data/product_stability/rhel8.yml
@@ -83,7 +83,6 @@ journald_conf_dir_path: /etc/systemd/journald.conf.d
 major_version_ordinal: 8
 nobody_gid: 65534
 nobody_uid: 65534
-oval_feed_url: https://access.redhat.com/security/data/oval/v2/RHEL8/rhel-8.oval.xml.bz2
 pkg_manager: yum
 pkg_manager_config_file: /etc/yum.conf
 pkg_release: 4ae0493b

--- a/tests/data/product_stability/rhel9.yml
+++ b/tests/data/product_stability/rhel9.yml
@@ -39,7 +39,6 @@ journald_conf_dir_path: /etc/systemd/journald.conf.d
 major_version_ordinal: 9
 nobody_gid: 65534
 nobody_uid: 65534
-oval_feed_url: https://access.redhat.com/security/data/oval/v2/RHEL9/rhel-9.oval.xml.bz2
 pkg_manager: dnf
 pkg_manager_config_file: /etc/dnf/dnf.conf
 pkg_release: 4ae0493b


### PR DESCRIPTION
#### Description:

We'll go ahead and remove the link to figure out if it breaks something (here or downstream).

#### Rationale:

We want to understand how it could affect everyone.

#### Review Hints:

- The `linux_os/guide/system/software/updating/security_patches_up_to_date` rule has all the mechanics to deal with empty product property.