### PR TITLE
Prevent conflicts in references

### DIFF
--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -388,6 +388,16 @@ class Policy(ssg.entities.common.XCCDFEntity):
                     levels[l] = ""
         return list(levels.keys())
 
+    def _check_conflict_in_rules(self, rules):
+        for rule_id, rule in rules.items():
+            if self.reference_type in rule.references:
+                msg = (
+                    "Rule %s contains %s reference, but this reference "
+                    "type is provided by %s controls. Please remove the "
+                    "reference from rule.yml." % (
+                        rule_id, self.reference_type, self.id))
+                raise ValueError(msg)
+
     def add_references(self, rules):
         if not self.reference_type:
             return
@@ -398,6 +408,7 @@ class Policy(ssg.entities.common.XCCDFEntity):
         if self.reference_type not in allowed_reference_types:
             msg = "Unknown reference type %s" % (self.reference_type)
             raise(ValueError(msg))
+        self._check_conflict_in_rules(rules)
         for control in self.controls_by_id.values():
             control.add_references(self.reference_type, rules)
 


### PR DESCRIPTION
#### Description:
If a reference type is provided by a control file it shouldn't be set in rule.yml. We add a build time check that interrupts the build if there is a conflict. 

#### Rationale:
This check ensures that the references are centralized in control files.


#### Review Hints:
Add a reference that should be generated by control file to your favorite rule and then build the product. Check that the build fails. For example, add `cis@rhel9: 1.2.3.4` to `references:` in `linux_os/guide/system/selinux/selinux_state/rule.yml` and run `./build_product -d rhel9`.