### PR TITLE
Add a note to ANSSI R23

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -572,8 +572,7 @@ controls:
     levels:
     - high
     notes: >-
-      As R18 configures hardened management of kernel modules we don't check nor remediate
-      for CONFIG_MODULES=n
+      If the system can function without support for kernel modules, module support should be disabled by setting CONFIG_MODULES=n.
     status: automated
     rules:
     - kernel_config_kexec


### PR DESCRIPTION
This PR supersedes https://github.com/ComplianceAsCode/content/pull/11558 where we discovered that if we create a special rule for CONFIG_MODULES and put it only to related_rules the rule won't be useful because it won't get into the built data stream.


