### PR TITLE
Set status for ANSSI R79 to partial

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -1507,7 +1507,7 @@ controls:
       basic integrity checking. System logs are configured as part of R43.
       Hardening of particular services should be done on a case by case basis and is
       not automated by this content.
-    status: automated
+    status: partial
     rules:
     - selinux_state
     - var_selinux_state=enforcing


### PR DESCRIPTION


#### Description:
R79 status to `partial`.

#### Rationale:
As stated in the notes some manual checking is necessary for R79.
