### PR TITLE
sysctl template: allow skipping of runtime checks

### DIFF
--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -894,6 +894,9 @@ The selected value can be changed in the profile (consult the actual variable fo
     -   **sysctlval_regex** - if **operation** is `pattern match`, this
         parameter is used instead of **sysctlval**.
 
+    -   **check_runtime** - whether to generate checks for runtime configuration.
+        Default value: `true`.
+
     In case the **sysctl_remediate_drop_in_file** property is set to true in the product file,
     the remediation scripts will set the variable with correct value to a drop-in file in
     `/etc/sysctl.d/var_name.conf` file.

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra/rule.yml
@@ -52,3 +52,4 @@ template:
     vars:
         sysctlvar: net.ipv6.conf.all.accept_ra
         datatype: int
+        check_runtime@rhcos4: "false"

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_redirects/rule.yml
@@ -54,3 +54,4 @@ template:
     vars:
         sysctlvar: net.ipv6.conf.all.accept_redirects
         datatype: int
+        check_runtime@rhcos4: "false"

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra/rule.yml
@@ -52,3 +52,4 @@ template:
     vars:
         sysctlvar: net.ipv6.conf.default.accept_ra
         datatype: int
+        check_runtime@rhcos4: "false"

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_redirects/rule.yml
@@ -56,3 +56,4 @@ template:
     vars:
         sysctlvar: net.ipv6.conf.default.accept_redirects
         datatype: int
+        check_runtime@rhcos4: "false"

--- a/linux_os/guide/system/permissions/restrictions/sysctl_net_core_bpf_jit_harden/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_net_core_bpf_jit_harden/rule.yml
@@ -42,3 +42,4 @@ template:
         sysctlvar: net.core.bpf_jit_harden
         sysctlval: '2'
         datatype: int
+        check_runtime@rhcos4: "false"

--- a/shared/templates/sysctl/oval.template
+++ b/shared/templates/sysctl/oval.template
@@ -24,12 +24,14 @@
 
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="3">
-    {{{ oval_metadata("The '" + SYSCTLVAR + "' kernel parameter should be set to the appropriate value in both system configuration and system runtime.") }}}
+    {{{ oval_metadata("The '" + SYSCTLVAR + "' kernel parameter should be set to the appropriate value in system configuration" + (" and system runtime." if CHECK_RUNTIME == "true" else ".")) }}}
     <criteria operator="AND">
       <extend_definition comment="{{{ SYSCTLVAR }}} configuration setting check"
                          definition_ref="{{{ rule_id }}}_static"/>
+{{% if CHECK_RUNTIME == "true" %}}
       <extend_definition comment="{{{ SYSCTLVAR }}} runtime setting check"
                          definition_ref="{{{ rule_id }}}_runtime"/>
+{{%- endif %}}
     </criteria>
   </definition>
 </def-group>
@@ -38,7 +40,7 @@
 
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="4">
-    {{{ oval_metadata("The kernel '" + SYSCTLVAR + "' parameter should be set to the appropriate value in both system configuration and system runtime.") }}}
+    {{{ oval_metadata("The kernel '" + SYSCTLVAR + "' parameter should be set to the appropriate value in system configuration" + (" and system runtime." if CHECK_RUNTIME == "true" else ".")) }}}
     <criteria comment="IPv6 disabled or {{{ SYSCTLVAR }}} set correctly" operator="OR">
 {{% if product in ["ubuntu1604", "ubuntu1804"] %}}
       <extend_definition comment="is IPv6 enabled?"
@@ -50,8 +52,10 @@
       <criteria operator="AND">
         <extend_definition comment="{{{ SYSCTLVAR }}} configuration setting check"
                            definition_ref="{{{ rule_id }}}_static"/>
+{{% if CHECK_RUNTIME == "true" %}}
         <extend_definition comment="{{{ SYSCTLVAR }}} runtime setting check"
                            definition_ref="{{{ rule_id }}}_runtime"/>
+{{%- endif %}}
       </criteria>
     </criteria>
   </definition>
@@ -60,6 +64,7 @@
 {{%- endif %}}
 {{%- if "R" in FLAGS -%}}
 
+{{% if CHECK_RUNTIME == "true" %}}
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}_runtime" version="3">
     {{{ oval_metadata("The kernel '" + SYSCTLVAR + "' parameter should be set to " + COMMENT_VALUE + " in the system runtime.") }}}
@@ -114,6 +119,7 @@
 {{% endfor %}}
 {{% endif %}}
 </def-group>
+{{% endif %}}
 
 {{%- endif -%}}
 {{%- if "S" in FLAGS -%}}

--- a/shared/templates/sysctl/template.py
+++ b/shared/templates/sysctl/template.py
@@ -40,4 +40,7 @@ def preprocess(data, lang):
             data["sysctl_wrong_value"] = str((int(data["sysctlval"])+1) % 2)
         elif data["datatype"] == "string":
             data["sysctl_wrong_value"] = "wrong_value"
+
+    if "check_runtime" not in data:
+        data["check_runtime"] = "true"
     return data


### PR DESCRIPTION

#### Description:

- Add new configuration to `sysctl` template:
  - When `check_runtime` is `"false"` the template will not generate checks for the runtime configuration.
  - By default the runtime checks are always generated.
- Skip generation of runtime checks in rules whose sysctl value is not represented accurately on the scanning pod.
  - `net.core.bpf_jit_harden`
  - `net.ipv6.conf.all.accept_ra`
  - `net.ipv6.conf.all.accept_redirects`
  - `net.ipv6.conf.default.accept_ra`
  - `net.ipv6.conf.default.accept_redirects`

#### Rationale:

- The goal of these rules is to check for both disk and runtime sysctl configurations. But the way CO checks for runtime sysctls may not be the most reliable. Some sysctls are not represented with fidelity on the openscap pod, despite being correctly configured and in effect in the underlying node OS.

* Fixes https://issues.redhat.com/browse/CMP-2367 
* Fixes https://issues.redhat.com/browse/CMP-2368 
* Fixes https://issues.redhat.com/browse/CMP-2369 
* Fixes https://issues.redhat.com/browse/CMP-2370 
* Fixes https://issues.redhat.com/browse/CMP-2371

#### Review Hints:

- Run a `rhco4-high` scan with auto-remediation.
- Check the OpenShift CI results for `rhcos4-high`
