### PR TITLE
Fix rule audit_rules_networkconfig_modification for Ubuntu

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/ansible/shared.yml
@@ -63,5 +63,13 @@
 {{{ ansible_audit_auditctl_add_watch_rule(path='/etc/issue.net', permissions='wa', key='audit_rules_networkconfig_modification') }}}
 {{{ ansible_audit_augenrules_add_watch_rule(path='/etc/hosts', permissions='wa', key='audit_rules_networkconfig_modification') }}}
 {{{ ansible_audit_auditctl_add_watch_rule(path='/etc/hosts', permissions='wa', key='audit_rules_networkconfig_modification') }}}
+
+{{% if 'ubuntu' in product -%}}
+{{{ ansible_audit_augenrules_add_watch_rule(path='/etc/networks', permissions='wa', key='audit_rules_networkconfig_modification') }}}
+{{{ ansible_audit_auditctl_add_watch_rule(path='/etc/networks', permissions='wa', key='audit_rules_networkconfig_modification') }}}
+{{{ ansible_audit_augenrules_add_watch_rule(path='/etc/network/', permissions='wa', key='audit_rules_networkconfig_modification') }}}
+{{{ ansible_audit_auditctl_add_watch_rule(path='/etc/network/', permissions='wa', key='audit_rules_networkconfig_modification') }}}
+{{% else -%}}
 {{{ ansible_audit_augenrules_add_watch_rule(path='/etc/sysconfig/network', permissions='wa', key='audit_rules_networkconfig_modification') }}}
 {{{ ansible_audit_auditctl_add_watch_rule(path='/etc/sysconfig/network', permissions='wa', key='audit_rules_networkconfig_modification') }}}
+{{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/bash/shared.sh
@@ -25,5 +25,13 @@ done
 {{{ bash_fix_audit_watch_rule("augenrules", "/etc/issue.net", "wa", "audit_rules_networkconfig_modification") }}}
 {{{ bash_fix_audit_watch_rule("auditctl", "/etc/hosts", "wa", "audit_rules_networkconfig_modification") }}}
 {{{ bash_fix_audit_watch_rule("augenrules", "/etc/hosts", "wa", "audit_rules_networkconfig_modification") }}}
+
+{{% if 'ubuntu' in product -%}}
+{{{ bash_fix_audit_watch_rule("auditctl", "/etc/networks", "wa", "audit_rules_networkconfig_modification") }}}
+{{{ bash_fix_audit_watch_rule("augenrules", "/etc/networks", "wa", "audit_rules_networkconfig_modification") }}}
+{{{ bash_fix_audit_watch_rule("auditctl", "/etc/network/", "wa", "audit_rules_networkconfig_modification") }}}
+{{{ bash_fix_audit_watch_rule("augenrules", "/etc/network/", "wa", "audit_rules_networkconfig_modification") }}}
+{{% else -%}}
 {{{ bash_fix_audit_watch_rule("auditctl", "/etc/sysconfig/network", "wa", "audit_rules_networkconfig_modification") }}}
 {{{ bash_fix_audit_watch_rule("augenrules", "/etc/sysconfig/network", "wa", "audit_rules_networkconfig_modification") }}}
+{{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/oval/ubuntu.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/oval/ubuntu.xml
@@ -1,0 +1,125 @@
+<def-group>
+  <definition class="compliance" id="audit_rules_networkconfig_modification" version="1">
+    {{{ oval_metadata("The network environment should not be modified by anything other than
+      administrator action. Any change to network parameters should be audited.") }}}
+
+    <criteria operator="OR">
+
+      <!-- Test the augenrules case -->
+      <criteria operator="AND">
+        <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
+        <criterion comment="audit /etc/issue augenrules" test_ref="test_arnm_etc_issue_augenrules" />
+        <criterion comment="audit /etc/issue.net augenrules" test_ref="test_arnm_etc_issue_net_augenrules" />
+        <criterion comment="audit /etc/hosts augenrules" test_ref="test_arnm_etc_hosts_augenrules" />
+        <criterion comment="audit /etc/networks augenrules" test_ref="test_arnm_etc_networks_augenrules" />
+        <criterion comment="audit /etc/network/ augenrules" test_ref="test_arnm_etc_networkdir_augenrules" />
+        <extend_definition comment="audit augenrules sethostname" definition_ref="audit_rules_networkconfig_modification_hostname" />
+        <extend_definition comment="audit augenrules setdomainname" definition_ref="audit_rules_networkconfig_modification_domainname" />
+      </criteria>
+
+      <!-- Test the auditctl case -->
+      <criteria operator="AND">
+        <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
+        <criterion comment="audit /etc/issue auditctl" test_ref="test_arnm_etc_issue_auditctl" />
+        <criterion comment="audit /etc/issue.net auditctl" test_ref="test_arnm_etc_issue_net_auditctl" />
+        <criterion comment="audit /etc/hosts auditctl" test_ref="test_arnm_etc_hosts_auditctl" />
+        <criterion comment="audit /etc/networks auditctl" test_ref="test_arnm_etc_networks_auditctl" />
+        <criterion comment="audit /etc/network/ auditctl" test_ref="test_arnm_etc_networkdir_auditctl" />
+        <extend_definition comment="audit augenrules sethostname" definition_ref="audit_rules_networkconfig_modification_hostname" />
+        <extend_definition comment="audit augenrules setdomainname" definition_ref="audit_rules_networkconfig_modification_domainname" />
+      </criteria>
+
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" comment="audit /etc/issue augenrules" id="test_arnm_etc_issue_augenrules" version="1">
+    <ind:object object_ref="object_arnm_etc_issue_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_arnm_etc_issue_augenrules" version="1">
+    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w[\s]+/etc/issue[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit /etc/issue.net augenrules" id="test_arnm_etc_issue_net_augenrules" version="1">
+    <ind:object object_ref="object_arnm_etc_issue_net_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_arnm_etc_issue_net_augenrules" version="1">
+    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w[\s]+/etc/issue\.net[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit /etc/hosts augenrules" id="test_arnm_etc_hosts_augenrules" version="1">
+    <ind:object object_ref="object_arnm_etc_hosts_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_arnm_etc_hosts_augenrules" version="1">
+    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w[\s]+/etc/hosts[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit /etc/networks augenrules" id="test_arnm_etc_networks_augenrules" version="1">
+    <ind:object object_ref="object_arnm_etc_networks_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_arnm_etc_networks_augenrules" version="1">
+    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w[\s]+/etc/networks[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit /etc/network/ augenrules" id="test_arnm_etc_networkdir_augenrules" version="1">
+    <ind:object object_ref="object_arnm_etc_networkdir_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_arnm_etc_networkdir_augenrules" version="1">
+    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w[\s]+/etc/network/[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit /etc/issue auditctl" id="test_arnm_etc_issue_auditctl" version="1">
+    <ind:object object_ref="object_arnm_etc_issue_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_arnm_etc_issue_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w[\s]+/etc/issue[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit /etc/issue.net auditctl" id="test_arnm_etc_issue_net_auditctl" version="1">
+    <ind:object object_ref="object_arnm_etc_issue_net_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_arnm_etc_issue_net_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w[\s]+/etc/issue\.net[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit /etc/hosts auditctl" id="test_arnm_etc_hosts_auditctl" version="1">
+    <ind:object object_ref="object_arnm_etc_hosts_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_arnm_etc_hosts_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w[\s]+/etc/hosts[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit /etc/networks auditctl" id="test_arnm_etc_networks_auditctl" version="1">
+    <ind:object object_ref="object_arnm_etc_networks_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_arnm_etc_networks_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w[\s]+/etc/networks[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit /etc/network/ auditctl" id="test_arnm_etc_networkdir_auditctl" version="1">
+    <ind:object object_ref="object_arnm_etc_networkdir_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_arnm_etc_networkdir_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w[\s]+/etc/network/[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/rule.yml
@@ -12,7 +12,12 @@ description: |-
     -w /etc/issue -p wa -k audit_rules_networkconfig_modification
     -w /etc/issue.net -p wa -k audit_rules_networkconfig_modification
     -w /etc/hosts -p wa -k audit_rules_networkconfig_modification
+    {{% if 'ubuntu' in product -%}}
+    -w /etc/networks -p wa -k audit_rules_networkconfig_modification
+    -w /etc/network/ -p wa -k audit_rules_networkconfig_modification</pre>
+    {{% else -%}}
     -w /etc/sysconfig/network -p wa -k audit_rules_networkconfig_modification</pre>
+    {{% endif %}}
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file, setting ARCH to either b32 or b64 as
@@ -21,7 +26,12 @@ description: |-
     -w /etc/issue -p wa -k audit_rules_networkconfig_modification
     -w /etc/issue.net -p wa -k audit_rules_networkconfig_modification
     -w /etc/hosts -p wa -k audit_rules_networkconfig_modification
+    {{% if 'ubuntu' in product -%}}
+    -w /etc/networks -p wa -k audit_rules_networkconfig_modification
+    -w /etc/network/ -p wa -k audit_rules_networkconfig_modification</pre>
+    {{% else -%}}
     -w /etc/sysconfig/network -p wa -k audit_rules_networkconfig_modification</pre>
+    {{% endif %}}
 
 rationale: |-
     The network environment should not be modified by anything other
@@ -61,7 +71,11 @@ ocil_clause: 'the system is not configured to audit changes of the network confi
 ocil: |-
     To determine if the system is configured to audit changes to its network configuration,
     run the following command:
+    {{% if 'ubuntu' in product -%}}
+    <pre>auditctl -l | grep -E '(/etc/issue|/etc/issue.net|/etc/hosts|/etc/networks|/etc/network/)'</pre>
+    {{% else -%}}
     <pre>auditctl -l | grep -E '(/etc/issue|/etc/issue.net|/etc/hosts|/etc/sysconfig/network)'</pre>
+    {{% endif %}}
     If the system is configured to watch for network configuration changes, a line should be returned for
     each file specified (and <tt>perm=wa</tt> should be indicated for each).
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/auditctl_correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/auditctl_correct_rules.pass.sh
@@ -14,4 +14,9 @@ echo "-a always,exit -F arch=b64 -S sethostname,setdomainname -F key=audit_rules
 echo "-w /etc/issue -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/audit.rules
 echo "-w /etc/issue.net -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/audit.rules
 echo "-w /etc/hosts -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/audit.rules
+{{% if 'ubuntu' in product -%}}
+echo "-w /etc/networks -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/audit.rules
+echo "-w /etc/network/ -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/audit.rules
+{{% else -%}}
 echo "-w /etc/sysconfig/network -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/audit.rules
+{{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/auditctl_correct_rules_watch_rules_without_key.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/auditctl_correct_rules_watch_rules_without_key.pass.sh
@@ -14,4 +14,9 @@ echo "-a always,exit -F arch=b64 -S sethostname,setdomainname -F key=audit_rules
 echo "-w /etc/issue -p wa" >> /etc/audit/audit.rules
 echo "-w /etc/issue.net -p wa" >> /etc/audit/audit.rules
 echo "-w /etc/hosts -p wa" >> /etc/audit/audit.rules
+{{% if 'ubuntu' in product -%}}
+echo "-w /etc/networks -p wa" >> /etc/audit/audit.rules
+echo "-w /etc/network/ -p wa" >> /etc/audit/audit.rules
+{{% else -%}}
 echo "-w /etc/sysconfig/network -p wa" >> /etc/audit/audit.rules
+{{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/augen_correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/augen_correct_rules.pass.sh
@@ -7,4 +7,9 @@ echo "-a always,exit -F arch=b64 -S sethostname,setdomainname -F key=audit_rules
 echo "-w /etc/issue -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/rules.d/networkconfig.rules
 echo "-w /etc/issue.net -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/rules.d/networkconfig.rules
 echo "-w /etc/hosts -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/rules.d/networkconfig.rules
+{{% if 'ubuntu' in product -%}}
+echo "-w /etc/networks -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/rules.d/networkconfig.rules
+echo "-w /etc/network/ -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/rules.d/networkconfig.rules
+{{% else -%}}
 echo "-w /etc/sysconfig/network -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/rules.d/networkconfig.rules
+{{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/augen_correct_rules_watch_rules_without_key.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/augen_correct_rules_watch_rules_without_key.pass.sh
@@ -6,4 +6,9 @@ echo "-a always,exit -F arch=b64 -S sethostname,setdomainname -F key=audit_rules
 echo "-w /etc/issue -p wa" >> /etc/audit/rules.d/networkconfig.rules
 echo "-w /etc/issue.net -p wa" >> /etc/audit/rules.d/networkconfig.rules
 echo "-w /etc/hosts -p wa" >> /etc/audit/rules.d/networkconfig.rules
+{{% if 'ubuntu' in product -%}}
+echo "-w /etc/networks -p wa" >> /etc/audit/rules.d/networkconfig.rules
+echo "-w /etc/network/ -p wa" >> /etc/audit/rules.d/networkconfig.rules
+{{% else -%}}
 echo "-w /etc/sysconfig/network -p wa" >> /etc/audit/rules.d/networkconfig.rules
+{{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/partial_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/partial_rules.fail.sh
@@ -7,4 +7,9 @@ echo "-a always,exit -F arch=b64 -S sethostname,setdomainname -F key=audit_rules
 echo "-w /etc/issue -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/audit.rules
 echo "-w /etc/issue.net -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/audit.rules
 echo "-w /etc/hosts -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/audit.rules
+{{% if 'ubuntu' in product -%}}
+echo "-w /etc/networks -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/audit.rules
+echo "-w /etc/network/ -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/audit.rules
+{{% else -%}}
 echo "-w /etc/sysconfig/network -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/audit.rules
+{{% endif %}}


### PR DESCRIPTION
#### Description:

- Fix rule audit_rules_networkconfig_modification to use correct paths on Ubuntu platform

#### Rationale:

- The paths '/etc/networks' and /etc/network/' should be monitored by auditd in Ubuntu instead of '/etc/sysconfig/network'