### PR TITLE
Fix description for auditd_max_log_file_action

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/rule.yml
@@ -16,8 +16,8 @@ description: |-
     <li><tt>rotate</tt></li>
     <li><tt>keep_logs</tt></li>
     </ul>
-    Set the <tt><i>ACTION</i></tt> to <tt>rotate</tt> to ensure log rotation
-    occurs. This is the default. The setting is case-insensitive.
+    Set the <tt><i>ACTION</i></tt> to <tt>{{{ xccdf_value("var_auditd_max_log_file_action") }}}</tt>.
+    The setting is case-insensitive.
 
 rationale: |-
     Automatically rotating logs (by setting this to <tt>rotate</tt>)


### PR DESCRIPTION
#### Description:

- Replace hardcoded value `rotate` with variable `var_auditd_max_log_file_action`.

#### Rationale:

- Many profiles use values other than 'rotate', such as `keep_logs` and `syslog`.