### PR TITLE
Fix macro for extracting local interactive users

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/interactive_user_nologin_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/interactive_user_nologin_ignored.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-USER="cac_user"
-useradd -m -s /sbin/nologin $USER
-touch /home/$USER/.bashrc
-chgrp 10005 /home/$USER/.bashrc
+. "$SHARED/accounts_common.sh"
+
+run_foreach_noninteractive_shell_account "touch /home/\$user/.bashrc; chgrp 10005 /home/\$user/.bashrc"

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/tests/interactive_user_nologin_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/tests/interactive_user_nologin_ignored.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-USER="cac_user"
-useradd -m -s /sbin/nologin $USER
-touch /home/$USER/.bashrc
-chown 10005 /home/$USER/.bashrc
+. "$SHARED/accounts_common.sh"
+
+run_foreach_noninteractive_shell_account "touch /home/\$user/.bashrc; chown 10005 /home/\$user/.bashrc"
+

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/tests/interactive_user_nologin_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/tests/interactive_user_nologin_ignored.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
-USER="cac_user"
-useradd -M -s /sbin/nologin $USER
+. "$SHARED/accounts_common.sh"
+
+run_foreach_noninteractive_shell_account "rm -rf /home/\$user"

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/tests/interactive_user_nologin_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/tests/interactive_user_nologin_ignored.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-USER="cac_user"
-useradd -m -s /sbin/nologin $USER
-echo "$USER" > /home/$USER/$USER.txt
-chgrp 10005 /home/$USER/$USER.txt
+. "$SHARED/accounts_common.sh"
+
+run_foreach_noninteractive_shell_account "echo \$user > /home/\$user/\$user.txt; chgrp 10005 /home/\$user/\$user.txt"

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/tests/interactive_user_nologin_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/tests/interactive_user_nologin_ignored.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-USER="cac_user"
-useradd -m -s /sbin/nologin $USER
-echo "$USER" > /home/$USER/$USER.txt
-chown 10005 /home/$USER/$USER.txt
+. "$SHARED/accounts_common.sh"
+
+run_foreach_noninteractive_shell_account "echo \$user > /home/\$user/\$user.txt; chown 10005 /home/\$user/\$user.txt"

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_permissions/tests/interactive_user_nologin_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_permissions/tests/interactive_user_nologin_ignored.pass.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-USER="cac_user"
-useradd -m -s /sbin/nologin $USER
-echo "$USER" > /home/$USER/$USER.txt
-chmod -Rf 700 /home/$USER/.*
-chmod -f o+r /home/$USER/$USER.txt
+. "$SHARED/accounts_common.sh"
+
+run_foreach_noninteractive_shell_account "echo \$user > /home/\$user/\$user.txt; chmod -Rf 700 /home/\$user/.*; chmod -f o+r /home/\$user/\$user.txt"

--- a/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/tests/interactive_user_nologin_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/tests/interactive_user_nologin_ignored.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-USER="cac_user"
-useradd -m -s /sbin/nologin $USER
-chgrp 10005 /home/$USER
+. "$SHARED/accounts_common.sh"
+
+run_foreach_noninteractive_shell_account "chgrp 10005 /home/\$user"

--- a/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/tests/interactive_user_nologin_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/tests/interactive_user_nologin_ignored.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-USER="cac_user"
-useradd -m -s /sbin/nologin $USER
-chown 10005 /home/$USER
+. "$SHARED/accounts_common.sh"
+
+run_foreach_noninteractive_shell_account "chown 10005 /home/\$user"

--- a/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/tests/interactive_user_nologin_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/tests/interactive_user_nologin_ignored.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-USER="cac_user"
-useradd -m -s /sbin/nologin $USER
-chmod 755 /home/$USER
+. "$SHARED/accounts_common.sh"
+
+run_foreach_noninteractive_shell_account "chmod 755 /home/\$user"

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/tests/interactive_user_nologin_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/tests/interactive_user_nologin_ignored.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-USER="cac_user"
-useradd -m -s /sbin/nologin $USER
-echo "umask 022" >> /home/$USER/.bashrc
+. "$SHARED/accounts_common.sh"
+
+run_foreach_noninteractive_shell_account "echo 'umask 022' >> /home/\$user/.bashrc"

--- a/shared/macros/10-oval.jinja
+++ b/shared/macros/10-oval.jinja
@@ -1179,7 +1179,7 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
 
 {{#
   Extract from /etc/passwd a list of specified fields of local interactive users.
-  The list contains only items related to non-system UIDs and is filtered to exclude some special usernames and users with /sbin/nologin shell.
+  The list contains only items related to non-system UIDs and is filtered to exclude some special usernames and users with /sbin/nologin and /bin/false shell.
 
   Unlike macro create_interactive_users_list_object, this macro gives list that contains only local users, because it doesn't use the OVAL "unix:password_object" element, but it merely parses /etc/passwd using "ind:textfilecontent54_object".
 
@@ -1220,7 +1220,7 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
       regular expression which ensures that the third field in the entry
       contains at least 4 digits (or more) and therefore the regular
       expression doesn't match entries with values 999 or less. -->
-    <ind:pattern operation="pattern match">^([^:]*):[^:]*:\d{4,}:(?:[^:]*:){3}(?!\/sbin\/nologin)[^:]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^([^:]*):[^:]*:\d{4,}:(?:[^:]*:){3}(?!(\/usr)?(\/sbin\/nologin|\/bin\/false))[^:]*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
     <filter action="exclude">state_{{{ object_id }}}_users_ignored</filter>
   </ind:textfilecontent54_object>
@@ -1235,7 +1235,7 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
 
 {{#
   Extract from /etc/passwd a list of home directories of local interactive users.
-  The list contains only items related to non-system UIDs and is filtered to exclude some special usernames and users with /sbin/nologin shell.
+  The list contains only items related to non-system UIDs and is filtered to exclude some special usernames and users with /sbin/nologin and /bin/false shell.
 
   Unlike macro create_interactive_users_list_object, this macro gives list that contains only local users, because it doesn't use the OVAL "unix:password_object" element, but it merely parses /etc/passwd using "ind:textfilecontent54_object".
 
@@ -1254,7 +1254,7 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
 
 {{#
   Extract from /etc/passwd a list of User IDs of local interactive users.
-  The list contains only items related to non-system UIDs and is filtered to exclude some special usernames and users with /sbin/nologin shell.
+  The list contains only items related to non-system UIDs and is filtered to exclude some special usernames and users with /sbin/nologin and /bin/false shell.
 
   Unlike macro create_interactive_users_list_object, this macro gives list that contains only local users, because it doesn't use the OVAL "unix:password_object" element, but it merely parses /etc/passwd using "ind:textfilecontent54_object".
 
@@ -1273,7 +1273,7 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
 
 {{#
   Extract from /etc/passwd a list of Group IDs of local interactive users.
-  The list contains only items related to non-system UIDs and is filtered to exclude some special usernames and users with /sbin/nologin shell.
+  The list contains only items related to non-system UIDs and is filtered to exclude some special usernames and users with /sbin/nologin and /bin/false shell.
 
   Unlike macro create_interactive_users_list_object, this macro gives list that contains only local users, because it doesn't use the OVAL "unix:password_object" element, but it merely parses /etc/passwd using "ind:textfilecontent54_object".
 

--- a/tests/shared/accounts_common.sh
+++ b/tests/shared/accounts_common.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# for each noninteractive shell, create user account
+# and eval ommands which are passed in as function arguments
+function run_foreach_noninteractive_shell_account {
+  for shell in "/sbin/nologin" \
+               "/usr/sbin/nologin" \
+               "/bin/false" \
+               "/usr/bin/false"; do
+
+    user=cac_user${shell//\//_}
+    useradd -m -s $shell $user
+
+    eval "$*"
+  done
+}


### PR DESCRIPTION
#### Description:

Fix regex used in OVAL macro `create_local_interactive_users_object` to include other shell paths.

#### Rationale:

This macro is used to extract specific fields from /etc/passwd.
Only local interactive users are considered, excluding those with shell /sbin/nologin.

This fix excludes also users with following shells:
- /bin/false
- /usr/bin/false
- /usr/sbin/nologin

#### Additional information:

This macro is used in the following rules:

- accounts_user_dot_group_ownership
- accounts_user_dot_user_ownership
- accounts_user_interactive_home_directory_exists
- accounts_users_home_files_groupownership
- accounts_users_home_files_ownership
- accounts_users_home_files_permissions
- file_groupownership_home_directories
- file_ownership_home_directories
- file_permissions_home_directories
- accounts_umask_interactive_users

I adapted the test for checking ignored shells accordingly.