### PR TITLE
Hide profiles not in good shape for RHEL

### DIFF
--- a/products/rhel8/profiles/cjis.profile
+++ b/products/rhel8/profiles/cjis.profile
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+hidden: true
+
 metadata:
     version: 5.4
     SMEs:

--- a/products/rhel8/profiles/rht-ccp.profile
+++ b/products/rhel8/profiles/rht-ccp.profile
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+hidden: true
+
 title: 'Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)'
 
 description: |-

--- a/products/rhel8/profiles/standard.profile
+++ b/products/rhel8/profiles/standard.profile
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+hidden: true
+
 title: 'Standard System Security Profile for Red Hat Enterprise Linux 8'
 
 description: |-


### PR DESCRIPTION
#### Description:

There are some profiles introduced long time ago but no longer maintained. For compatibility purposes they are not removed from datastream but are now hidden to prevent people from using them.

#### Rationale:

- Discourage the use of profiles no longer maintained and not in good shape.

#### Review Hints:

./build_product rhel7 rhel8
oscap info build/ssg-rhel7-ds.xml
oscap info build/ssg-rhel8-ds.xml