### PR TITLE
Fix TypeError in get_implemented_stigs

### DIFF
--- a/utils/build_stig_control.py
+++ b/utils/build_stig_control.py
@@ -100,10 +100,7 @@ def get_implemented_stigs(args):
 
         if args.reference in rule_obj['references'].keys():
             refs = rule_obj['references'][args.reference]
-            if ',' in refs:
-                refs = refs.split(',')
-            else:
-                refs = [refs]
+
             for ref in refs:
                 if ref in known_rules:
                     known_rules[ref].append(rule['id'])


### PR DESCRIPTION
#### Description:

- _Fix TypeError_

#### Rationale:

- _Fix TypeError: unhashable type: 'list'. As refs is a list we do not need this snippet_

