### PR TITLE
Disable remediation for accounts_umask_interactive_users on Ubuntu

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_all
+# platform = multi_platform_rhel,multi_platform_ol,multi_platform_sle,multi_platform_rhv4
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_all
+# platform = multi_platform_rhel,multi_platform_ol,multi_platform_sle,multi_platform_rhv4
 # reboot = false
 # strategy = restrict
 # complexity = low


### PR DESCRIPTION
#### Description:

- Disable remediation for rule `accounts_umask_interactive_users` on Ubuntu by redefining the platform keyword.

#### Rationale:

- Remediation is too intrusive and modifies files in user's home directory.
- The CIS guide (Ubuntu 22.04 v1, also RHEL8 v3), although it mentions `~/.bashrc` and `~/.profile`, does not actually audit or fix files in user's home directory. In this PR we only remove the fix and retain the audit as it can be useful to the user and is not intrusive. 

#### Additional information

Individual platforms are defined based on the following output. Note that in many cases, the rule is listed under 'related_rules' and is thus not used to generate the content.
```
$ git grep "- accounts_umask_interactive_users" products/ controls/
controls/cis_rhel7.yml:      - accounts_umask_interactive_users
controls/cis_rhel8.yml:      - accounts_umask_interactive_users
controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml:            - accounts_umask_interactive_users
controls/stig_rhel9.yml:            - accounts_umask_interactive_users
products/ol7/profiles/stig.profile:    - accounts_umask_interactive_users
products/ol8/profiles/stig.profile:    - accounts_umask_interactive_users
products/rhel7/profiles/rhelh-stig.profile:    - accounts_umask_interactive_users
products/rhel7/profiles/stig.profile:    - accounts_umask_interactive_users
products/rhel8/profiles/stig.profile:    - accounts_umask_interactive_users
products/rhv4/profiles/rhvh-stig.profile:    - accounts_umask_interactive_users
products/sle15/profiles/default.profile:    - accounts_umask_interactive_users
products/ubuntu2004/profiles/cis_level1_server.profile:    - accounts_umask_interactive_users
products/ubuntu2204/profiles/cis_level1_server.profile:    - accounts_umask_interactive_users
```
