### PR TITLE
oauth_or_oauthclient_token_maxage: Use variable for remediation of rule

### DIFF
--- a/applications/openshift/authentication/oauth_or_oauthclient_token_maxage/kubernetes/shared.yml
+++ b/applications/openshift/authentication/oauth_or_oauthclient_token_maxage/kubernetes/shared.yml
@@ -5,4 +5,4 @@ metadata:
   name: cluster
 spec:
   tokenConfig:
-    accessTokenMaxAgeSeconds: 28800
+    accessTokenMaxAgeSeconds: {{.var_oauth_token_maxage}}


### PR DESCRIPTION


#### Description:

- As the rule is parametrized to use a variable, the check should use it for remediation.

#### Rationale:

- The rule's extended definition checks are leveragin the variable for the check, so the remediation should also use it.
- Follow up from #11423


#### Review Hints:

- Check the [CI results](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-ComplianceAsCode-content-master-4.16-e2e-aws-ocp4-high-weekly/1758989735516180480) for the rule before patch. 