### PR TITLE
k8s image content from PRs: Fix `id` in job step

### DIFF
--- a/.github/workflows/k8s-content-pr.yaml
+++ b/.github/workflows/k8s-content-pr.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Get PR number
     runs-on: ubuntu-latest
     outputs:
-      pr-number: ${{ steps.read-pr-number.outputs.pr-number }}
+      pr-number: ${{ steps.pr_number.outputs.pr-number }}
     steps:
       - name: 'Download artifacts'
         uses: actions/github-script@v7
@@ -36,6 +36,7 @@ jobs:
       - name: 'Unzip artifact'
         run: unzip pr_number.zip
       - name: 'Read PR number'
+        id: pr_number
         run: |
           echo "pr-number=$(cat pr_number)" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/k8s-content-pr.yaml
+++ b/.github/workflows/k8s-content-pr.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Get PR number
     runs-on: ubuntu-latest
     outputs:
-      pr-number: ${{ steps.pr_number.outputs.pr-number }}
+      pr-number: ${{ steps.pr_number.outputs.pr_number }}
     steps:
       - name: 'Download artifacts'
         uses: actions/github-script@v7
@@ -38,7 +38,7 @@ jobs:
       - name: 'Read PR number'
         id: pr_number
         run: |
-          echo "pr-number=$(cat pr_number)" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$(cat pr_number)" >> "$GITHUB_OUTPUT"
 
   container-main:
     needs: 


### PR DESCRIPTION
#### Description:

- Assign an explicit `id` to the step which the output value comes from.
- Renames shell variable name from `pr-number` to `pr_number` to avoid issues in `step.run`'s shell environment.

#### Rationale:
- The output `pr-number` is empty when used in `container-main` job. 
  - Ref: https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs

- Hopefully fixes [runs](https://github.com/ComplianceAsCode/content/actions/runs/7958116618/job/21722321674) `Kubernetes content image for PR`

#### Review Hints:

- Needs to be merged to take effect.
- The `workflow_run` always executes what is on the `master` branch.