### PR TITLE
Flush automatus test logs before outputting results

### DIFF
--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -129,6 +129,7 @@ class TestEnv(object):
         remote_dest = "root@{ip}".format(ip=self.domain_ip)
         result = common.retry_with_stdout_logging(
             "ssh", tuple(self.ssh_additional_options) + (remote_dest, command), log_file)
+        log_file.flush()
         if result.returncode:
             error_msg = error_msg_template.format(
                 command=command, remote_dest=remote_dest,


### PR DESCRIPTION
#### Description:

This ensures that logs contain all the test stdout/stderr outputs at the moment of automatus.py announcing their results on its output.

The flushing is done here and not deeper, because it seems unnecessary to flush after every 'retry' attempt, only when the test is done running and its result is about to be announced by automatus.py.

#### Rationale:

This is useful for an external automatus.py wrapper, which parses its output in real-time, while also processing the logs in real-time. Without this change, the wrapper will get empty logs in some cases.