### PR TITLE
Account for non-existent 'build' dir in build_product

### DIFF
--- a/build_product
+++ b/build_product
@@ -415,6 +415,7 @@ fi
 
 
 set -e
+[ -d build ] || mkdir build
 rm -rf build/*
 cd build
 cmake .. "${CMAKE_OPTIONS[@]}"


### PR DESCRIPTION
#### Description:

In some cases, especially when built as an RPM, the empty 'build' directory may disappear, causing `./build_product` to fail on
```
./build_product: line 395: cd: build: No such file or directory
```

Since we're already removing its content, just remove it completely and re-create it from scratch. The `-f` of `rm` causes it to silently ignore non-existent 'build'.