### PR TITLE
Improve ANSSI references

### DIFF
--- a/docs/workshop/data/accounts_tmout/rule_yml
+++ b/docs/workshop/data/accounts_tmout/rule_yml
@@ -24,7 +24,7 @@ identifiers:
     cce@sle15: CCE-83269-1
 
 references:
-    anssi: BP28(R29)
+    anssi: R29
     cis-csc: 1,12,15,16
     cis@rhel7: 5.5.4
     cis@rhel8: 5.5.3

--- a/shared/transforms/shared_constants.xslt
+++ b/shared/transforms/shared_constants.xslt
@@ -7,7 +7,7 @@
 <xsl:variable name="cceuri">https://ncp.nist.gov/cce</xsl:variable>
 
 <!-- abbreviated as references in the XCCDF-->
-<xsl:variable name="anssiuri">http://www.ssi.gouv.fr/administration/bonnes-pratiques/</xsl:variable>
+<xsl:variable name="anssiuri">https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf</xsl:variable>
 <xsl:variable name="bsiuri">https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf</xsl:variable>
 <xsl:variable name="cjisd-its-uri">https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf</xsl:variable>
 <xsl:variable name="cnss1253uri">http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf</xsl:variable>

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1006,8 +1006,6 @@ class Rule(XCCDFEntity, Templatable):
             ident.text = ident_val
 
     def add_extra_reference(self, ref_type, ref_value):
-        if ref_type == "anssi":
-            ref_value = "BP28(%s)" % ref_value
         if ref_type in self.references:
             self.references[ref_type].append(ref_value)
         else:

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -11,7 +11,7 @@ SSG_PROJECT_NAME = "SCAP Security Guide Project"
 SSG_BENCHMARK_LATEST_URI = "https://github.com/ComplianceAsCode/content/releases/latest"
 
 SSG_REF_URIS = {
-    'anssi': 'http://www.ssi.gouv.fr/administration/bonnes-pratiques/',
+    'anssi': 'https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf',
     'bsi': 'https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf',
     'nist': 'http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf',
     'nist-csf': 'https://nvlpubs.nist.gov/nistpubs/CSWP/NIST.CSWP.04162018.pdf',
@@ -90,7 +90,7 @@ cce_uri = "https://ncp.nist.gov/cce"
 stig_ns = "https://public.cyber.mil/stigs/srg-stig-tools/"
 cis_ns = "https://www.cisecurity.org/benchmark/red_hat_linux/"
 hipaa_ns = "https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf"
-anssi_ns = "http://www.ssi.gouv.fr/administration/bonnes-pratiques/"
+anssi_ns = "https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf"
 ospp_ns = "https://www.niap-ccevs.org/Profile/PP.cfm"
 cui_ns = 'http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf'
 stig_refs = 'https://public.cyber.mil/stigs/'
@@ -247,7 +247,7 @@ Reference = collections.namedtuple("Reference", ("id", "name", "url", "regex_wit
 REFERENCES = dict(
     anssi=Reference(
         id="anssi", name="ANSSI", url=anssi_ns,
-        regex_with_groups=r"BP28\(R(\d+)\)"),
+        regex_with_groups=r"R(\d+)"),
     ccn=Reference(
         id="ccn", name="CCN", url="",
         regex_with_groups=r"A\.(\d+)\.SEC-(\w+)(\d+)"),

--- a/tests/data/product_stability/alinux2.yml
+++ b/tests/data/product_stability/alinux2.yml
@@ -31,7 +31,7 @@ platform_package_overrides: {aarch64_arch: null, grub2: grub2-common, login_defs
   s390x_arch: null, sssd: sssd-common, sssd-ldap: null, uefi: null, zipl: s390utils-base}
 product: alinux2
 profiles_root: ./profiles
-reference_uris: {anssi: 'http://www.ssi.gouv.fr/administration/bonnes-pratiques/',
+reference_uris: {anssi: 'https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf',
   app-srg: 'https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers',
   bsi: 'https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf',
   cis-csc: 'https://www.cisecurity.org/controls/', cjis: 'https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf',

--- a/tests/data/product_stability/alinux3.yml
+++ b/tests/data/product_stability/alinux3.yml
@@ -31,7 +31,7 @@ platform_package_overrides: {aarch64_arch: null, grub2: grub2-common, login_defs
   s390x_arch: null, sssd: sssd-common, sssd-ldap: null, uefi: null, zipl: s390utils-base}
 product: alinux3
 profiles_root: ./profiles
-reference_uris: {anssi: 'http://www.ssi.gouv.fr/administration/bonnes-pratiques/',
+reference_uris: {anssi: 'https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf',
   app-srg: 'https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers',
   bsi: 'https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf',
   cis-csc: 'https://www.cisecurity.org/controls/', cjis: 'https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf',

--- a/tests/data/product_stability/anolis23.yml
+++ b/tests/data/product_stability/anolis23.yml
@@ -45,7 +45,7 @@ platform_package_overrides:
 product: anolis23
 profiles_root: ./profiles
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis-csc: https://www.cisecurity.org/controls/

--- a/tests/data/product_stability/anolis8.yml
+++ b/tests/data/product_stability/anolis8.yml
@@ -45,7 +45,7 @@ platform_package_overrides:
 product: anolis8
 profiles_root: ./profiles
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis-csc: https://www.cisecurity.org/controls/

--- a/tests/data/product_stability/chromium.yml
+++ b/tests/data/product_stability/chromium.yml
@@ -41,7 +41,7 @@ platform_package_overrides:
 product: chromium
 profiles_root: ./profiles
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis-csc: https://www.cisecurity.org/controls/

--- a/tests/data/product_stability/debian10.yml
+++ b/tests/data/product_stability/debian10.yml
@@ -53,7 +53,7 @@ platform_package_overrides:
 product: debian10
 profiles_root: ./profiles
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: https://benchmarks.cisecurity.org/tools2/linux/CIS_Debian_Benchmark_v1.0.pdf

--- a/tests/data/product_stability/debian11.yml
+++ b/tests/data/product_stability/debian11.yml
@@ -53,7 +53,7 @@ platform_package_overrides:
 product: debian11
 profiles_root: ./profiles
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: https://benchmarks.cisecurity.org/tools2/linux/CIS_Debian_Benchmark_v1.0.pdf

--- a/tests/data/product_stability/debian12.yml
+++ b/tests/data/product_stability/debian12.yml
@@ -53,7 +53,7 @@ platform_package_overrides:
 product: debian12
 profiles_root: ./profiles
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis-csc: https://www.cisecurity.org/controls/

--- a/tests/data/product_stability/eks.yml
+++ b/tests/data/product_stability/eks.yml
@@ -51,7 +51,7 @@ platform_package_overrides:
 product: eks
 profiles_root: ./profiles
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: https://www.cisecurity.org/benchmark/kubernetes/

--- a/tests/data/product_stability/example.yml
+++ b/tests/data/product_stability/example.yml
@@ -46,7 +46,7 @@ platform_package_overrides:
 product: example
 profiles_root: ./profiles
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis-csc: https://www.cisecurity.org/controls/

--- a/tests/data/product_stability/fedora.yml
+++ b/tests/data/product_stability/fedora.yml
@@ -81,7 +81,7 @@ rawhide_pkg_version: a15b79cc
 rawhide_release_fingerprint: 115DF9AEF857853EE8445D0A0727707EA15B79CC
 rawhide_version: 40
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis-csc: https://www.cisecurity.org/controls/

--- a/tests/data/product_stability/firefox.yml
+++ b/tests/data/product_stability/firefox.yml
@@ -41,7 +41,7 @@ platform_package_overrides:
 product: firefox
 profiles_root: ./profiles
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis-csc: https://www.cisecurity.org/controls/

--- a/tests/data/product_stability/macos1015.yml
+++ b/tests/data/product_stability/macos1015.yml
@@ -41,7 +41,7 @@ platform_package_overrides:
 product: macos1015
 profiles_root: ./profiles
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis-csc: https://www.cisecurity.org/controls/

--- a/tests/data/product_stability/ocp4.yml
+++ b/tests/data/product_stability/ocp4.yml
@@ -127,7 +127,7 @@ platform_package_overrides:
 product: ocp4
 profiles_root: ./profiles
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: https://www.cisecurity.org/benchmark/kubernetes/

--- a/tests/data/product_stability/ol7.yml
+++ b/tests/data/product_stability/ol7.yml
@@ -55,7 +55,7 @@ platform_package_overrides:
 product: ol7
 profiles_root: ./profiles
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: https://www.cisecurity.org/benchmark/oracle_linux/

--- a/tests/data/product_stability/ol8.yml
+++ b/tests/data/product_stability/ol8.yml
@@ -54,7 +54,7 @@ platform_package_overrides:
 product: ol8
 profiles_root: ./profiles
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: https://www.cisecurity.org/benchmark/oracle_linux/

--- a/tests/data/product_stability/ol9.yml
+++ b/tests/data/product_stability/ol9.yml
@@ -57,7 +57,7 @@ platform_package_overrides:
 product: ol9
 profiles_root: ./profiles
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: ''

--- a/tests/data/product_stability/openembedded.yml
+++ b/tests/data/product_stability/openembedded.yml
@@ -49,7 +49,7 @@ platform_package_overrides:
 product: openembedded
 profiles_root: ./profiles
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis-csc: https://www.cisecurity.org/controls/

--- a/tests/data/product_stability/opensuse.yml
+++ b/tests/data/product_stability/opensuse.yml
@@ -57,7 +57,7 @@ platform_package_overrides:
 product: opensuse
 profiles_root: ./profiles
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis-csc: https://www.cisecurity.org/controls/

--- a/tests/data/product_stability/rhcos4.yml
+++ b/tests/data/product_stability/rhcos4.yml
@@ -49,7 +49,7 @@ platform_package_overrides:
 product: rhcos4
 profiles_root: ./profiles
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis-csc: https://www.cisecurity.org/controls/

--- a/tests/data/product_stability/rhel7.yml
+++ b/tests/data/product_stability/rhel7.yml
@@ -77,7 +77,7 @@ platform_package_overrides:
 product: rhel7
 profiles_root: ./profiles
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: https://www.cisecurity.org/benchmark/red_hat_linux/

--- a/tests/data/product_stability/rhel8.yml
+++ b/tests/data/product_stability/rhel8.yml
@@ -105,7 +105,7 @@ platform_package_overrides:
 product: rhel8
 profiles_root: ./profiles
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: https://www.cisecurity.org/benchmark/red_hat_linux/

--- a/tests/data/product_stability/rhel9.yml
+++ b/tests/data/product_stability/rhel9.yml
@@ -61,7 +61,7 @@ platform_package_overrides:
 product: rhel9
 profiles_root: ./profiles
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   ccn: https://www.ccn-cert.cni.es/pdf/guias/series-ccn-stic/guias-de-acceso-publico-ccn-stic/6768-ccn-stic-610a22-perfilado-de-seguridad-red-hat-enterprise-linux-9-0/file.html

--- a/tests/data/product_stability/rhv4.yml
+++ b/tests/data/product_stability/rhv4.yml
@@ -54,7 +54,7 @@ platform_package_overrides:
 product: rhv4
 profiles_root: ./profiles
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis-csc: https://www.cisecurity.org/controls/

--- a/tests/data/product_stability/sle12.yml
+++ b/tests/data/product_stability/sle12.yml
@@ -53,7 +53,7 @@ platform_package_overrides:
 product: sle12
 profiles_root: ./profiles
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: https://www.cisecurity.org/benchmark/suse_linux/

--- a/tests/data/product_stability/sle15.yml
+++ b/tests/data/product_stability/sle15.yml
@@ -57,7 +57,7 @@ platform_package_overrides:
 product: sle15
 profiles_root: ./profiles
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: https://www.cisecurity.org/benchmark/suse_linux/

--- a/tests/data/product_stability/ubuntu1604.yml
+++ b/tests/data/product_stability/ubuntu1604.yml
@@ -57,7 +57,7 @@ platform_package_overrides:
 product: ubuntu1604
 profiles_root: ./profiles
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: https://www.cisecurity.org/benchmark/ubuntu_linux/

--- a/tests/data/product_stability/ubuntu1804.yml
+++ b/tests/data/product_stability/ubuntu1804.yml
@@ -56,7 +56,7 @@ platform_package_overrides:
 product: ubuntu1804
 profiles_root: ./profiles
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: https://www.cisecurity.org/benchmark/ubuntu_linux/

--- a/tests/data/product_stability/ubuntu2004.yml
+++ b/tests/data/product_stability/ubuntu2004.yml
@@ -58,7 +58,7 @@ platform_package_overrides:
 product: ubuntu2004
 profiles_root: ./profiles
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: https://www.cisecurity.org/benchmark/ubuntu_linux/

--- a/tests/data/product_stability/ubuntu2204.yml
+++ b/tests/data/product_stability/ubuntu2204.yml
@@ -59,7 +59,7 @@ platform_package_overrides:
 product: ubuntu2204
 profiles_root: ./profiles
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: https://www.cisecurity.org/benchmark/ubuntu_linux/

--- a/tests/data/product_stability/uos20.yml
+++ b/tests/data/product_stability/uos20.yml
@@ -45,7 +45,7 @@ platform_package_overrides:
 product: uos20
 profiles_root: ./profiles
 reference_uris:
-  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis-csc: https://www.cisecurity.org/controls/

--- a/tests/unit/ssg-module/data/accounts_tmout.xml
+++ b/tests/unit/ssg-module/data/accounts_tmout.xml
@@ -9,7 +9,7 @@ The <html:code>TMOUT</html:code>
 setting in a file loaded by <html:code>/etc/profile</html:code>, e.g.
 <html:code>/etc/profile.d/tmout.sh</html:code> should read as follows:
 <html:pre>declare -xr TMOUT=<ns0:sub idref="xccdf_org.ssgproject.content_value_var_accounts_tmout" use="legacy"/></html:pre></ns0:description>
-  <ns0:reference href="http://www.ssi.gouv.fr/administration/bonnes-pratiques/">BP28(R29)</ns0:reference>
+  <ns0:reference href="https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf">R29</ns0:reference>
   <ns0:reference href="https://www.cisecurity.org/controls/">1</ns0:reference>
   <ns0:reference href="https://www.cisecurity.org/controls/">12</ns0:reference>
   <ns0:reference href="https://www.cisecurity.org/controls/">15</ns0:reference>

--- a/tests/unit/ssg-module/data/accounts_tmout.yml
+++ b/tests/unit/ssg-module/data/accounts_tmout.yml
@@ -22,7 +22,7 @@ rationale: 'Terminating an idle session within a short time period reduces
     left unattended.'
 severity: medium
 references:
-    anssi: BP28(R29)
+    anssi: R29
     cis-csc: 1,12,15,16
     cobit5: DSS05.04,DSS05.10,DSS06.10
     cui: 3.1.11

--- a/tests/unit/ssg-module/data/accounts_tmout_without_ocil.yml
+++ b/tests/unit/ssg-module/data/accounts_tmout_without_ocil.yml
@@ -22,7 +22,7 @@ rationale: 'Terminating an idle session within a short time period reduces
     left unattended.'
 severity: medium
 references:
-    anssi: BP28(R29)
+    anssi: R29
     cis-csc: 1,12,15,16
     cobit5: DSS05.04,DSS05.10,DSS06.10
     cui: 3.1.11

--- a/tests/unit/ssg-module/test_playbook_builder_data/guide/selinux_state/rule.yml
+++ b/tests/unit/ssg-module/test_playbook_builder_data/guide/selinux_state/rule.yml
@@ -20,7 +20,7 @@ rationale: |-
 severity: medium
 
 references:
-    anssi: BP28(R4),BP28(R66)
+    anssi: R4,R66
     cis-csc: 1,11,12,13,14,15,16,18,3,4,5,6,8,9
     cis@rhel7: 1.6.1.4,1.6.1.5
     cis@rhel8: 1.6.1.5


### PR DESCRIPTION
Use the URL that points directly to the PDF document with the ANSSI Configuration Recommendations of a GNU/Linux System policy instead of using the more generic link to ANSSI portal. This is similar to how we link other benchmarks eg. PCIDSS. It allows users of HTML outputs to directly navigate to the document to find the requirement text easily. Also, this commit adds couple minor improvements, removal of additional BP28 prefix, and tests updates.


