### PR TITLE
k8s image content from PRs: remove token from action parameters

### DIFF
--- a/.github/workflows/k8s-content-pr.yaml
+++ b/.github/workflows/k8s-content-pr.yaml
@@ -105,7 +105,6 @@ jobs:
     steps:
       - uses: thollander/actions-comment-pull-request@v2
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           message: |
             :robot: A k8s content image for this PR is available at:
             `ghcr.io/complianceascode/k8scontent:${{ needs.get-pr-number.outputs.pr-number }}`


### PR DESCRIPTION

#### Description:

- Remove `github-token` from the `Upsert comment on the PR` job.

#### Rationale:

- Addresses two warning: https://github.com/ComplianceAsCode/content/actions/runs/7961404888
- It seems that the default value of `${{ github.token }}` is enough.
  - The action was able to comment on the PR.
- Follow up from #11604

#### Review Hints:

- Needs to be merged to take effect.
- The workflow_run always executes what is on the master branch.

