### PR TITLE
Fix grub2_bootloader_argument to check /etc/default/grub.d on Ubuntu

### DIFF
--- a/shared/checks/oval/bootloader_disable_recovery_set_to_true.xml
+++ b/shared/checks/oval/bootloader_disable_recovery_set_to_true.xml
@@ -24,7 +24,11 @@
 
   <ind:textfilecontent54_object id="object_bootloader_disable_recovery_argument"
   version="1">
+    {{%- if 'ubuntu' in product %}}
+    <ind:filepath operation="pattern match">^/etc/default/grub(\.d/[^/]+\.cfg)?$</ind:filepath>
+    {{%- else %}}
     <ind:filepath>/etc/default/grub</ind:filepath>
+    {{%- endif %}}
     <ind:pattern operation="pattern match">^\s*GRUB_DISABLE_RECOVERY=(.*)$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/shared/templates/grub2_bootloader_argument/oval.template
+++ b/shared/templates/grub2_bootloader_argument/oval.template
@@ -88,7 +88,11 @@
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" version="1">
+    {{%- if 'ubuntu' in product %}}
+    <ind:filepath operation="pattern match">^/etc/default/grub(\.d/[^/]+\.cfg)?$</ind:filepath>
+    {{%- else %}}
     <ind:filepath>/etc/default/grub</ind:filepath>
+    {{%- endif %}}
     <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX="(.*)"$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
@@ -102,7 +106,11 @@
 
   <ind:textfilecontent54_object id="object_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_default"
   version="1">
+    {{%- if 'ubuntu' in product %}}
+    <ind:filepath operation="pattern match">^/etc/default/grub(\.d/[^/]+\.cfg)?$</ind:filepath>
+    {{%- else %}}
     <ind:filepath>/etc/default/grub</ind:filepath>
+    {{%- endif %}}
     <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX_DEFAULT="(.*)"$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/shared/templates/grub2_bootloader_argument/tests/arg_not_there_etcdefaultgrub.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/arg_not_there_etcdefaultgrub.fail.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_ubuntu
+{{%- if 'ubuntu' in product %}}
+# packages = grub2
+{{%- else %}}
 # packages = grub2,grubby
+{{%- endif %}}
 
 source common.sh
 

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value.pass.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
 # platform = multi_platform_all
+{{%- if 'ubuntu' in product %}}
+# packages = grub2
+{{%- else %}}
 # packages = grub2,grubby
+{{%- endif %}}
+
 {{%- if ARG_VARIABLE %}}
 # variables = {{{ ARG_VARIABLE }}}=correct_value
 {{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_configdir.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_configdir.pass.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# platform = multi_platform_ubuntu
+# packages = grub2
+
+{{%- if ARG_VARIABLE %}}
+# variables = {{{ ARG_VARIABLE }}}=correct_value
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+{{%- endif %}}
+
+source common.sh
+
+echo > /etc/default/grub
+rm -f /etc/default/grub.d/*
+
+echo "GRUB_CMDLINE_LINUX=\"\$GRUB_CMDLINE_LINUX {{{ ARG_NAME_VALUE }}}\"" > /etc/default/grub.d/custom.cfg
+
+{{{ grub_command("update") }}}
+


### PR DESCRIPTION
#### Description:

- Modify OVAL in `grub2_bootloader_argument` template to also check the configs in `/etc/default/grub.d` on Ubuntu
- Add and fix ubuntu tests

#### Rationale:

- The old OVAL checked the compiled config in `/boot` and the config in `/etc/default/grub`, but not the configs `/etc/default/grub.d/*.cfg`, which are also sourced when running `grub-mkconfig`.
- Fixes https://bugs.launchpad.net/usg/+bug/2053240