### PR TITLE
OCP4: use utf-8 as default xml encoding

### DIFF
--- a/build-scripts/build_xccdf.py
+++ b/build-scripts/build_xccdf.py
@@ -97,7 +97,7 @@ def link_benchmark(loader, xccdftree, args, benchmark=None):
     if ocil is not None:
         link_ocil(xccdftree, checks, args.ocil, ocil)
 
-    ssg.xml.ElementTree.ElementTree(xccdftree).write(args.xccdf)
+    ssg.xml.ElementTree.ElementTree(xccdftree).write(args.xccdf, encoding="utf-8")
 
 
 def get_path(path, file_name):

--- a/build-scripts/compose_ds.py
+++ b/build-scripts/compose_ds.py
@@ -282,10 +282,10 @@ def upgrade_ds_to_scap_13(ds):
 
 def _store_ds(ds, output_13, output_12):
     if output_12:
-        ds.write(output_12, xml_declaration=True)
+        ds.write(output_12, xml_declaration=True, encoding="utf-8")
 
     ds_13 = upgrade_ds_to_scap_13(ds)
-    ds_13.write(output_13, xml_declaration=True)
+    ds_13.write(output_13, xml_declaration=True, encoding="utf-8")
 
 
 def append_id_to_file_name(path, id_):

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -426,7 +426,7 @@ class Benchmark(XCCDFEntity):
     def to_file(self, file_name, env_yaml=None):
         root = self.to_xml_element(env_yaml)
         tree = ET.ElementTree(root)
-        tree.write(file_name)
+        tree.write(file_name, encoding="utf-8")
 
     def add_value(self, value):
         if value is None:
@@ -1590,7 +1590,7 @@ class LinearLoader(object):
         if root is None:
             return
         tree = ET.ElementTree(root)
-        tree.write(filename, xml_declaration=True)
+        tree.write(filename, encoding="utf-8", xml_declaration=True)
 
 
 class Platform(XCCDFEntity):


### PR DESCRIPTION
This commit make UTF-8 as default xml encoding. In a recent change to the build system, xml encoding was changed from not specific(UTF-8) to US-ASCII . 

When writing XCCDF XML file, python xml uses the output encoding US-ASCII as default if not set, however this causes issues in Compliance Operator parser, using US-ASCII, the parser is not able to get the prefix of xml node, therefore crash the parser pod.

snippet of XCCDF print out using utf-8
```
 <?xml version="1.0" encoding="utf-8"?>
```
parsed into
```
ds:data-stream-collection
ds:data-stream-collection/ds:data-stream
ds:data-stream-collection/ds:data-stream/ds:dictionaries
ds:data-stream-collection/ds:data-stream/ds:dictionaries/ds:component-ref
ds:data-stream-collection/ds:data-stream/ds:dictionaries/ds:component-ref/cat:catalog
ds:data-stream-collection/ds:data-stream/ds:dictionaries/ds:component-ref/cat:catalog/cat:uri
ds:data-stream-collection/ds:data-stream/ds:checklists
ds:data-stream-collection/ds:data-stream/ds:checklists/ds:component-ref
ds:data-stream-collection/ds:data-stream/ds:checklists/ds:component-ref/cat:catalog
ds:data-stream-collection/ds:data-stream/ds:checklists/ds:component-ref/cat:catalog/cat:uri
ds:data-stream-collection/ds:data-stream/ds:checks
ds:data-stream-collection/ds:data-stream/ds:checks/ds:component-ref
```

snippet of XCCDF print out using us-ascii parsed into:
```
<?xml version="1.0" encoding="us-ascii"?>
```

```
data-stream-collection
data-stream-collection/data-stream
data-stream-collection/data-stream/dictionaries
data-stream-collection/data-stream/dictionaries/component-ref
data-stream-collection/data-stream/dictionaries/component-ref/catalog
data-stream-collection/data-stream/dictionaries/component-ref/catalog/uri
data-stream-collection/data-stream/checklists
data-stream-collection/data-stream/checklists/component-ref
data-stream-collection/data-stream/checklists/component-ref/catalog
data-stream-collection/data-stream/checklists/component-ref/catalog/uri
data-stream-collection/data-stream/checks
data-stream-collection/data-stream/checks/component-ref
```