### PR TITLE
Update PR workflow actions to run only on latest push

### DIFF
--- a/.github/workflows/automatus-cs8.yaml
+++ b/.github/workflows/automatus-cs8.yaml
@@ -2,6 +2,9 @@ name: Automatus CS8
 on:
   pull_request:
     branches: [ master, 'stabilization*' ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
+  cancel-in-progress: true
 env:
   DATASTREAM: ssg-centos8-ds.xml
 jobs:

--- a/.github/workflows/automatus-cs9.yaml
+++ b/.github/workflows/automatus-cs9.yaml
@@ -2,6 +2,9 @@ name: Automatus CS9
 on:
   pull_request:
     branches: [ master, 'stabilization*' ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
+  cancel-in-progress: true
 env:
   DATASTREAM: ssg-cs9-ds.xml
 jobs:

--- a/.github/workflows/automatus-sanity.yaml
+++ b/.github/workflows/automatus-sanity.yaml
@@ -2,7 +2,9 @@ name: Automatus Sanity
 on:
   pull_request:
     branches: [ master, 'stabilization*' ]
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
+  cancel-in-progress: true
 env:
   DATASTREAM: ssg-fedora-ds.xml
 jobs:

--- a/.github/workflows/automatus-sle15.yaml
+++ b/.github/workflows/automatus-sle15.yaml
@@ -2,6 +2,9 @@ name: Automatus SLE15
 on:
   pull_request:
     branches: [ master, 'stabilization*' ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
+  cancel-in-progress: true
 env:
   DATASTREAM: ssg-sle15-ds.xml
 jobs:

--- a/.github/workflows/automatus.yaml
+++ b/.github/workflows/automatus.yaml
@@ -2,6 +2,9 @@ name: Automatus Fedora
 on:
   pull_request:
     branches: [ master, 'stabilization*' ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
+  cancel-in-progress: true
 jobs:
   build-content:
     name: Build Content

--- a/.github/workflows/gate-lint-ansible-roles.yaml
+++ b/.github/workflows/gate-lint-ansible-roles.yaml
@@ -2,6 +2,9 @@ name: Gate (AR / RHEL)
 on:
   pull_request:
     branches: [ 'master' ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
+  cancel-in-progress: true
 jobs:
   validate-fedora-ar:
     name: Build, Lint Ansible Roles on Fedora Latest (Container)

--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -6,6 +6,9 @@ on:
     branches: ['*', '!stabilization*', '!stable*', '!master' ]
   pull_request:
     branches: [ 'master', 'stabilization*' ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
+  cancel-in-progress: true
 jobs:
   validate-centos7:
     name: Build, Test on CentOS 7 (Container)

--- a/.github/workflows/gate_fedora.yml
+++ b/.github/workflows/gate_fedora.yml
@@ -6,6 +6,9 @@ on:
     branches: ['*', '!stabilization*', '!stable*', 'master' ]
   pull_request:
     branches: [ 'master', 'stabilization*' ]
+concurrency:
+  group: ${{ github.workflow }}-fedora-${{ github.event.number || github.run_id }}
+  cancel-in-progress: true
 jobs:
     validate-fedora:
         name: Build, Test on Fedora Latest (Container)

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -6,6 +6,9 @@ on:
     branches: [ 'master' ]
   merge_group:
     branches: [ 'master' ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
+  cancel-in-progress: true
 jobs:
   publish:
     name: Publish stats, tables and guides

--- a/.github/workflows/k8s-content-pr-trigger.yaml
+++ b/.github/workflows/k8s-content-pr-trigger.yaml
@@ -8,6 +8,10 @@ on:
     - reopened
     - synchronize
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   get-pr-number:
     name: Get PR number

--- a/.github/workflows/srg-mapping-table.yaml
+++ b/.github/workflows/srg-mapping-table.yaml
@@ -6,6 +6,9 @@ on:
     branches: [ 'master', 'stabilization*' ]
   merge_group:
     branches: [ 'master' ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
+  cancel-in-progress: true
 jobs:
   generate-data:
     name: SRG Mapping Table


### PR DESCRIPTION
#### Description:

Update all the PR-triggered workflows so they cancel previous action jobs in favor of new action jobs for the same PR when a new change is pushed
