### PR TITLE
Speed up build of thin data streams

### DIFF
--- a/build-scripts/build_xccdf.py
+++ b/build-scripts/build_xccdf.py
@@ -76,6 +76,7 @@ def link_oval(xccdftree, checks, output_file_name, build_ovals_dir):
     oval_linker.link()
     oval_linker.save_linked_tree()
     oval_linker.link_xccdf()
+    return oval_linker
 
 
 def link_ocil(xccdftree, checks, output_file_name, ocil):

--- a/build-scripts/build_xccdf.py
+++ b/build-scripts/build_xccdf.py
@@ -89,39 +89,19 @@ def link_ocil(xccdftree, checks, output_file_name, ocil):
     ocil_linker.link_xccdf()
 
 
-def link_benchmark(loader, xccdftree, args, benchmark=None):
-    checks = xccdftree.findall(".//{%s}check" % ssg.constants.XCCDF12_NS)
+def store_xccdf_per_profile(loader, oval_linker, thin_ds_components_dir):
+    for id_, xccdftree in loader.get_benchmark_xml_by_profile():
+        xccdf_file_name = os.path.join(thin_ds_components_dir, "xccdf_{}.xml".format(id_))
+        oval_file_name = os.path.join(thin_ds_components_dir, "oval_{}.xml".format(id_))
 
-    link_oval(xccdftree, checks, args.oval, args.build_ovals_dir)
+        checks = xccdftree.findall(".//{%s}check" % ssg.constants.XCCDF12_NS)
+        oval_linker.linked_fname = oval_file_name
+        oval_linker.linked_fname_basename = os.path.basename(oval_file_name)
+        oval_linker.checks_related_to_us = oval_linker.get_related_checks(checks)
 
-    ocil = loader.export_ocil_to_xml(benchmark)
-    if ocil is not None:
-        link_ocil(xccdftree, checks, args.ocil, ocil)
+        oval_linker.link_xccdf()
 
-    ssg.xml.ElementTree.ElementTree(xccdftree).write(args.xccdf, encoding="utf-8")
-
-
-def get_path(path, file_name):
-    return os.path.join(path, file_name)
-
-
-def link_benchmark_per_profile(loader, args):
-    if not os.path.exists(args.thin_ds_components_dir):
-        os.makedirs(args.thin_ds_components_dir)
-
-    loader.off_ocil = True
-
-    for id_, benchmark in loader.get_benchmark_by_profile():
-        xccdftree = benchmark.to_xml_element(loader.env_yaml)
-        p = Paths_(
-            xccdf=get_path(args.thin_ds_components_dir, "xccdf_{}.xml".format(id_)),
-            oval=get_path(args.thin_ds_components_dir, "oval_{}.xml".format(id_)),
-            ocil=get_path(args.thin_ds_components_dir, "ocil_{}.xml".format(id_)),
-            build_ovals_dir=args.build_ovals_dir
-        )
-        link_benchmark(loader, xccdftree, p, benchmark)
-
-    loader.off_ocil = False
+        ssg.xml.ElementTree.ElementTree(xccdftree).write(xccdf_file_name, encoding="utf-8")
 
 
 def main():
@@ -144,12 +124,23 @@ def main():
     loader.load_benchmark(benchmark_root)
 
     loader.add_fixes_to_rules()
+    xccdftree = loader.export_benchmark_to_xml()
+
+    checks = xccdftree.findall(".//{%s}check" % ssg.constants.XCCDF12_NS)
+
+    oval_linker = link_oval(xccdftree, checks, args.oval, args.build_ovals_dir)
+
+    ocil = loader.export_ocil_to_xml()
+    link_ocil(xccdftree, checks, args.ocil, ocil)
+
+    ssg.xml.ElementTree.ElementTree(xccdftree).write(args.xccdf, encoding="utf-8")
 
     if args.thin_ds_components_dir != "off":
-        link_benchmark_per_profile(loader, args)
-
-    xccdftree = loader.export_benchmark_to_xml()
-    link_benchmark(loader, xccdftree, args)
+        if not os.path.exists(args.thin_ds_components_dir):
+            os.makedirs(args.thin_ds_components_dir)
+        store_xccdf_per_profile(loader, oval_linker, args.thin_ds_components_dir)
+        oval_linker.build_ovals_dir = args.thin_ds_components_dir
+        oval_linker.save_oval_document_for_each_xccdf_rule("oval_")
 
 
 if __name__ == "__main__":

--- a/ssg/build_renumber.py
+++ b/ssg/build_renumber.py
@@ -141,16 +141,19 @@ class OVALFileLinker(FileLinker):
                 checkcontentref = get_content_ref_if_exists_and_not_remote(check)
                 if checkcontentref is None or check.get("system") != oval_cs:
                     continue
-
                 out.append(checkcontentref.get("name"))
         return out
 
-    def _save_oval_document_for_each_xccdf_rule(self):
+    def save_oval_document_for_each_xccdf_rule(self, file_name_prefix=""):
         for name in self._get_list_of_names_of_oval_checks():
+            if name in self.oval_document.definitions:
+                oval_def = self.oval_document.definitions[name]
+                name = oval_def.name
+
             oval_id = self._translate_name_to_oval_definition_id(name)
 
             refs = self.oval_document.get_all_references_of_definition(oval_id)
-            path = self._get_path_for_oval_document(name)
+            path = self._get_path_for_oval_document(file_name_prefix + name)
             with open(path, "wb+") as fd:
                 self.oval_document.save_as_xml(fd, refs)
 
@@ -165,7 +168,7 @@ class OVALFileLinker(FileLinker):
             self.oval_document.save_as_xml(fd)
 
         if self.build_ovals_dir:
-            self._save_oval_document_for_each_xccdf_rule()
+            self.save_oval_document_for_each_xccdf_rule()
 
     def link(self):
         self.oval_document = load_oval_document(parse_file(self.fname))
@@ -276,7 +279,7 @@ class OVALFileLinker(FileLinker):
         # Remove all OVAL checks that are not referenced by XCCDF Rules (checks)
         # or internally via extend-definition
 
-        xccdf_oval_check_refs = [name for name in self._get_list_of_names_of_oval_checks()]
+        xccdf_oval_check_refs = self._get_list_of_names_of_oval_checks()
         document_def_keys = list(self.oval_document.definitions.keys())
 
         references_from_xccdf_to_keep = OVALDefinitionReference()

--- a/ssg/build_renumber.py
+++ b/ssg/build_renumber.py
@@ -31,14 +31,14 @@ class FileLinker(object):
 
     def __init__(self, translator, xccdftree, checks, output_file_name):
         self.translator = translator
-        self.checks_related_to_us = self._get_related_checks(checks)
+        self.checks_related_to_us = self.get_related_checks(checks)
         self.fname = self._get_input_fname()
         self.tree = None
         self.linked_fname = output_file_name
         self.linked_fname_basename = os.path.basename(self.linked_fname)
         self.xccdftree = xccdftree
 
-    def _get_related_checks(self, checks):
+    def get_related_checks(self, checks):
         """
         Returns a list of checks which have the same check system as this
         class.
@@ -89,6 +89,7 @@ class FileLinker(object):
         pass
 
     def link_xccdf(self):
+
         for check in self.checks_related_to_us:
             checkcontentref = get_content_ref_if_exists_and_not_remote(check)
             if checkcontentref is None:

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -482,13 +482,13 @@ class Benchmark(XCCDFEntity):
     def __str__(self):
         return self.id_
 
-    def get_benchmark_for_profile(self, profile):
+    def get_benchmark_xml_for_profile(self, profile):
         profile.unselected_groups = []
         b = deepcopy(self)
         b.profiles = [profile]
         b.drop_rules_not_included_in_a_profile()
         b.unselect_empty_groups()
-        return profile.id_, b
+        return profile.id_, b.to_xml_element()
 
 
 class Group(XCCDFEntity):
@@ -1525,7 +1525,7 @@ class LinearLoader(object):
         self.benchmark.drop_rules_not_included_in_a_profile()
         self.benchmark.unselect_empty_groups()
 
-    def get_benchmark_by_profile(self):
+    def get_benchmark_xml_by_profile(self):
         if self.benchmark is None:
             raise Exception(
                 "Before generating benchmarks for each profile, you need to load "
@@ -1533,7 +1533,7 @@ class LinearLoader(object):
             )
 
         for profile in self.benchmark.profiles:
-            profile_id, benchmark = self.benchmark.get_benchmark_for_profile(profile)
+            profile_id, benchmark = self.benchmark.get_benchmark_xml_for_profile(profile)
             yield profile_id, benchmark
 
     def load_compiled_content(self):

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -504,7 +504,7 @@ class Benchmark(XCCDFEntity):
     def __str__(self):
         return self.id_
 
-    def get_benchmark_xml_for_profile(self, profile):
+    def get_benchmark_xml_for_profile(self, env_yaml, profile):
         rules, groups = self.get_components_not_included_in_a_profiles([profile])
         profiles = set(filter(
             lambda id_, profile_id=profile.id_: id_ != profile_id,
@@ -516,6 +516,7 @@ class Benchmark(XCCDFEntity):
                 "profiles": profiles
             }
         return profile.id_, self.to_xml_element(
+            env_yaml,
             components_to_not_include=components_to_not_include
         )
 
@@ -1597,7 +1598,9 @@ class LinearLoader(object):
             )
 
         for profile in self.benchmark.profiles:
-            profile_id, benchmark = self.benchmark.get_benchmark_xml_for_profile(profile)
+            profile_id, benchmark = self.benchmark.get_benchmark_xml_for_profile(
+                self.env_yaml, profile
+            )
             yield profile_id, benchmark
 
     def load_compiled_content(self):


### PR DESCRIPTION
#### Description:
This PR speeds up the build of thin data streams using the `--thin` flag. Before the changes, the build takes quite a long time: 48m31.2s. After changes, the build takes a total of 4m40s. 

The old build approach was to copy Benchmark instances with only one profile. Then the next build steps are performed with that copy. This leads to a slowdown due to deep copying of the Benchmark class and performing link steps for each thin DS. 

The new approach changes the way thin DSs are built. The first step is to create a Benchmark for the thick DS. Then the XML generation from the Benchmark for one profile is performed. Before the generation, a dictionary of components that will not be included in the XML is created. And then it is linked to OVAL. 

#### Review Hints:

To test the -`-thin` flag, you can run this script:
```bash
#!/bin/bash

./build_product fedora --thin

for filename in ./build/thin_ds/*.xml; do
    echo "$filename"
    oscap xccdf eval  --profile "(all)" --results-arf "arf_results/arf_$(basename -- $filename)" "$filename"
done
```
_The script generates a thin Datastream for each rule and then performs a scan using `oscap`.
This test takes more than an hour to run because there are approximately 1830 rules to process and some are memory intensive._

To test the speed up of the build, you can run this command:
```bash
./build_product fedora --thin -p
```
Flag `-p` enables profiling of the build.
