### PR TITLE
Add platform machine to systctl.d rules

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/directory_groupowner_etc_sysctld/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/directory_groupowner_etc_sysctld/rule.yml
@@ -26,6 +26,8 @@ fixtext: '{{{ fixtext_file_group_owner(file="/etc/sysctl.d", group="root") }}}'
 
 srg_requirement: '{{{ srg_requirement_file_group_owner(file="/etc/sysctl.d", group="root") }}}'
 
+platform: machine
+
 template:
     name: file_groupowner
     vars:

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/directory_owner_etc_sysctld/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/directory_owner_etc_sysctld/rule.yml
@@ -26,6 +26,8 @@ fixtext: '{{{ fixtext_file_owner(file="/etc/sysctl.d", owner="root") }}}'
 
 srg_requirement: '{{{ srg_requirement_file_owner(file="/etc/sysctl.d", owner="root") }}}'
 
+platform: machine
+
 template:
     name: file_owner
     vars:

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/directory_permissions_etc_sysctld/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/directory_permissions_etc_sysctld/rule.yml
@@ -26,6 +26,8 @@ fixtext: '{{{ fixtext_file_permissions(file="/etc/sysctl.d", mode="0755") }}}'
 
 srg_requirement: '{{{ srg_requirement_file_permission(file="/etc/sysctl.d", mode="0755") }}}'
 
+platform: machine
+
 template:
     name: file_permissions
     vars:


### PR DESCRIPTION
#### Description:

Add platform machine to systctl.d rules

#### Rationale:

They are not applicable on containers.