### PR TITLE
Add RHEL 9 to Ansible Gating

### DIFF
--- a/.github/workflows/gate-lint-ansible-roles.yaml
+++ b/.github/workflows/gate-lint-ansible-roles.yaml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Configure
-        run: cmake -DSSG_PRODUCT_DEFAULT=OFF -DSSG_PRODUCT_RHEL7=ON -DSSG_PRODUCT_RHEL8=ON -G Ninja ..
+        run: cmake -DSSG_PRODUCT_DEFAULT=OFF -DSSG_PRODUCT_RHEL7=ON -DSSG_PRODUCT_RHEL8=ON -DSSG_PRODUCT_RHEL9=ON -G Ninja ..
         working-directory: ./build
       - name: Build
-        run: ninja -j2 rhel8-profile-playbooks rhel7-profile-playbooks
+        run: ninja -j2 rhel9-profile-playbooks rhel8-profile-playbooks rhel7-profile-playbooks
         working-directory: ./build
       - name: Build Ansible Roles
         run: PYTHONPATH=. python3 utils/ansible_playbook_to_role.py --build-playbooks-dir ./build/ansible/ --dry-run ./build/ansible_roles


### PR DESCRIPTION
#### Description:

Adds RHEL9 to the Ansible Gating.

#### Rationale:

Ensure that RHEL 9 playbooks are checked.
