### PR TITLE
Image Pruner Rule has inconsistent ocil text

### DIFF
--- a/applications/openshift/registry/image_pruner_active/rule.yml
+++ b/applications/openshift/registry/image_pruner_active/rule.yml
@@ -37,7 +37,7 @@ ocil_clause: 'ImagePruner is not active'
 ocil: |-
   Ensure that the imagepruner is configured and is not in a suspended state.
   <pre>oc get imagepruners.imageregistry.operator.openshift.io/cluster -o jsonpath='{.spec}{"\n"}'</pre
-  The output should be non-empty and the <tt>.spec.suspend</tt> field should not be set to false.
+  The output should be non-empty and the <tt>.spec.suspend</tt> field should be set to false.
 
 severity: medium
 


### PR DESCRIPTION
Image Pruner Rule has inconsistent ocil text

#### Description:

The text in the image pruner rule is inaccurate.

#### Rationale:

- _Rationale here. Replace this text. Don't use the italics format!_

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._

#### Review Hints:

- _Review hints here. Replace this text. Don't use the italics format!_

- _Use this optional section to give any relevant information which could help the reviewer to more quickly and assertively understand and test the changes._

- _Good examples are useful commands, if it is better to review all commits together or in a suggested sequence, any relevant discussion in other PRs or issues, etc._
