### PR TITLE
Automated Reference Assignment: Allow Skippping of Controls

### DIFF
--- a/controls/stig_rhel9.yml
+++ b/controls/stig_rhel9.yml
@@ -13,6 +13,7 @@ controls:
     -   id: needed_rules
         levels:
             - medium
+        skip_reference: true
         rules:
             - enable_authselect
             - var_authselect_profile=sssd

--- a/docs/manual/developer/03_creating_content.md
+++ b/docs/manual/developer/03_creating_content.md
@@ -1097,6 +1097,22 @@ product: rhel9
 reference_type: cis
 ```
 
+#### Skipping automated reference assignment on individual Controls
+
+Sometimes we don't want a specific control to be added as a reference to the rules it is selecting.
+For example, the RHEL9 STIG selects rules that are not directly related to a STIG ID, but still are necessary for the correct evaluation of the Profile.
+
+To skip a control from assigning references to its rules, add the `skip_reference: true` to it:
+```
+    -   id: needed_rules
+        levels:
+            - medium
+        skip_reference: true
+        rules:
+            - enable_authselect
+            - var_authselect_profile=sssd
+```
+
 ### Using controls in profiles
 
 Later, we can use the policy requirements in profile YAML. Let's say that we

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -90,6 +90,7 @@ class Control(ssg.entities.common.SelectionHandler, ssg.entities.common.XCCDFEnt
         related_rules=list,
         rules=list,
         controls=list,
+        skip_reference=bool,
     )
 
     MANDATORY_KEYS = {
@@ -148,6 +149,7 @@ class Control(ssg.entities.common.SelectionHandler, ssg.entities.common.XCCDFEnt
         control.original_title = control_dict.get('original_title')
         control.related_rules = control_dict.get('related_rules')
         control.rules = control_dict.get('rules')
+        control.skip_reference = control_dict.get('skip_reference', False)
 
         if control.status == "automated":
             control.automated = "yes"
@@ -177,6 +179,9 @@ class Control(ssg.entities.common.SelectionHandler, ssg.entities.common.XCCDFEnt
         return data
 
     def add_references(self, reference_type, rules):
+        if self.skip_reference:
+            return
+
         for selection in self.rules:
             if "=" in selection:
                 continue


### PR DESCRIPTION
#### Description:

- Add a new key that allows `Controls` to be skipped from automated "referencing" during build.

#### Rationale:

- This is useful when a control is added only to select rules that, strictly speaking, are not  in the Policy but are required to function properly.
- Fixes strange references in the RHEL9 data stream
  `<xccdf-1.2:reference href="https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux">needed_rules</xccdf-1.2:reference>`
- ~This will also be useful for OCP4 STIG control file from #11593~
- Follow up of https://github.com/ComplianceAsCode/content/pull/11594

#### Review Hints:

- Build content before and after PR and check that STIG `needed_rules` references are gone.