### PR TITLE
Update ANSSI R29 requirement

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -688,16 +688,31 @@ controls:
   - id: R29
     title: Access Restrictions on /boot
     levels:
-    - enhanced
+      - enhanced
     description: >-
-      When possible, the /boot partition should not be mounted. In any case, access to
-      the /boot directory must only be allowed to the root user.
+      When possible, it is recommended not to automatically mount the /boot partition.
+      In any case, access to the /boot folder should only be allowed for the root user.
     notes: >-
-      The rule disabling auto-mount for /boot is commented until the rules checking for other
-      /boot mount options are updated to handle this usecase.
-    status: supported
-    #rules:
-    #- mount_option_boot_noauto
+      The /boot partition mounted is essential to perform certain administrative actions, for
+      example updating the kernel. Therefore, for better stability, in this requirement only rules
+      to restrict the access to /boot are selected. It is not changed how the /boot is mounted.
+    status: partial
+    rules:
+      - file_groupowner_efi_grub2_cfg
+      - file_groupowner_grub2_cfg
+      - file_owner_efi_grub2_cfg
+      - file_owner_grub2_cfg
+      - file_permissions_efi_grub2_cfg
+      - file_permissions_grub2_cfg
+      - file_groupowner_efi_user_cfg
+      - file_groupowner_user_cfg
+      - file_owner_efi_user_cfg
+      - file_owner_user_cfg
+      - file_permissions_efi_user_cfg
+      - file_permissions_user_cfg
+    related_rules:
+      - file_permissions_systemmap # missing remediation
+      - mount_option_boot_noauto
 
   - id: R30
     title: Removal of unused user accounts

--- a/products/rhel9/profiles/anssi_bp28_enhanced.profile
+++ b/products/rhel9/profiles/anssi_bp28_enhanced.profile
@@ -46,3 +46,10 @@ selections:
     - '!cracklib_accounts_password_pam_minlen'
     - '!cracklib_accounts_password_pam_dcredit'
     - '!ensure_oracle_gpgkey_installed'
+    # RHEL9 unified the paths for grub2 files. These rules are selected in control file by R29.
+    - '!file_groupowner_efi_grub2_cfg'
+    - '!file_owner_efi_grub2_cfg'
+    - '!file_permissions_efi_grub2_cfg'
+    - '!file_groupowner_efi_user_cfg'
+    - '!file_owner_efi_user_cfg'
+    - '!file_permissions_efi_user_cfg'


### PR DESCRIPTION
#### Description:

Updated description and selected rules to restrict files in /boot.
OBS.: In a separate PR I intend to review the `file_permissions_systemmap` rule and use templates.

#### Rationale:

Better ANSSI alignment.
