### PR TITLE
CMP-2247: Add a new profile for CIS OpenShift 1.5.0

### DIFF
--- a/products/ocp4/profiles/cis-1-5.profile
+++ b/products/ocp4/profiles/cis-1-5.profile
@@ -2,7 +2,7 @@ documentation_complete: true
 
 title: 'CIS Red Hat OpenShift Container Platform 4 Benchmark'
 
-platform: ocp4-node
+platform: ocp4
 
 metadata:
     SMEs:
@@ -21,9 +21,19 @@ description: |-
     This profile includes Center for Internet Security®
     Red Hat OpenShift Container Platform 4 CIS Benchmarks™ content.
 
-    Note that this part of the profile is meant to run on the Operating System that
+    Note that this part of the profile is meant to run on the Platform that
     Red Hat OpenShift Container Platform 4 runs on top of.
 
     This profile is applicable to OpenShift versions 4.12 and greater.
 
-extends: cis-node-1-5
+filter_rules: '"ocp4-node" not in platforms and "ocp4-master-node" not in platforms and "ocp4-node-on-sdn" not in platforms and "ocp4-node-on-ovn" not in platforms'
+
+selections:
+    - cis_ocp_1_4_0:all
+    ### Variables
+    - var_openshift_audit_profile=WriteRequestBodies
+    - var_event_record_qps=50
+    ### Helper Rules
+    ### This is a helper rule to fetch the required api resource for detecting OCP version
+    - version_detect_in_ocp
+    - version_detect_in_hypershift

--- a/products/ocp4/profiles/cis-node-1-5.profile
+++ b/products/ocp4/profiles/cis-node-1-5.profile
@@ -26,4 +26,7 @@ description: |-
 
     This profile is applicable to OpenShift versions 4.12 and greater.
 
-extends: cis-node-1-5
+filter_rules: '"ocp4-node" in platforms or "ocp4-master-node" in platforms or "ocp4-node-on-sdn" in platforms or "ocp4-node-on-ovn" in platforms'
+
+selections:
+    - cis_ocp_1_4_0:all

--- a/products/ocp4/profiles/cis.profile
+++ b/products/ocp4/profiles/cis.profile
@@ -11,11 +11,12 @@ metadata:
         - jhrozek
         - rhmdnd
         - Vincent056
-    version: 1.4.0
+        - yuumasato
+    version: 1.5.0
 
 description: |-
     This profile defines a baseline that aligns to the Center for Internet Security®
-    Red Hat OpenShift Container Platform 4 Benchmark™, V1.4.
+    Red Hat OpenShift Container Platform 4 Benchmark™, V1.5.
 
     This profile includes Center for Internet Security®
     Red Hat OpenShift Container Platform 4 CIS Benchmarks™ content.
@@ -23,6 +24,6 @@ description: |-
     Note that this part of the profile is meant to run on the Platform that
     Red Hat OpenShift Container Platform 4 runs on top of.
 
-    This profile is applicable to OpenShift versions 4.10 and greater.
+    This profile is applicable to OpenShift versions 4.12 and greater.
 
-extends: cis-1-4
+extends: cis-1-5


### PR DESCRIPTION
CIS released version 1.5.0 in December 2023. There are no technical
differences between version 1.4.0 and 1.5.0. This change simplify
updates the version to reflect the latest version of the CIS OpenShift
benchmark.

It also keeps version available for people who may want to pin their
scans to that version.
