### PR TITLE
profile_tool.py: Fix traceback in sub command

### DIFF
--- a/utils/profile_tool/sub.py
+++ b/utils/profile_tool/sub.py
@@ -1,5 +1,6 @@
 import os
 import jinja2
+from ssg.build_cpe import ProductCPEs
 from ssg.build_yaml import Profile
 from ssg.environment import open_environment
 
@@ -7,9 +8,13 @@ from ssg.environment import open_environment
 def command_sub(args):
     product_yaml = os.path.join(args.ssg_root, "products", args.product, "product.yml")
     env_yaml = open_environment(args.build_config_yaml, product_yaml)
+
+    product_cpes = ProductCPEs()
+    product_cpes.load_product_cpes(env_yaml)
+    product_cpes.load_content_cpes(env_yaml)
     try:
-        profile1 = Profile.from_yaml(args.profile1, env_yaml)
-        profile2 = Profile.from_yaml(args.profile2, env_yaml)
+        profile1 = Profile.from_yaml(args.profile1, env_yaml, product_cpes)
+        profile2 = Profile.from_yaml(args.profile2, env_yaml, product_cpes)
     except jinja2.exceptions.TemplateNotFound as e:
         print("Error: Profile {} could not be found.".format(str(e)))
         exit(1)


### PR DESCRIPTION
#### Description:

- Fix traceback when diffing `ocp4` profiles.
```console
$ build-scripts/profile_tool.py sub --build-config-yaml ./build/build_config.yml --ssg-root ./ --product ocp4 --profile2 products/ocp4/profiles/high-rev-4.profile --profile1 products/ocp4/profiles/moderate.profile                                                                             
Traceback (most recent call last):
  File "/home/wsato/git/content/ssg/entities/common.py", line 274, in from_yaml
    data_dict = cls.parse_yaml_into_processed_dict(yaml_file, local_env_yaml, product_cpes)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wsato/git/content/ssg/entities/common.py", line 244, in parse_yaml_into_processed_dict
    processed_data = cls.process_input_dict(yaml_data, env_yaml, product_cpes)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wsato/git/content/ssg/entities/profile_base.py", line 74, in process_input_dict
    new_cpe_name = product_cpes.get_cpe_name(platform)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get_cpe_name'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/wsato/git/content/build-scripts/profile_tool.py", line 331, in <module>
    main()
  File "/home/wsato/git/content/build-scripts/profile_tool.py", line 327, in main
    SUBCMDS[args.subcommand](args)
  File "/home/wsato/git/content/utils/profile_tool/sub.py", line 11, in command_sub
    profile1 = Profile.from_yaml(args.profile1, env_yaml)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wsato/git/content/ssg/entities/common.py", line 281, in from_yaml
    raise RuntimeError(msg)
RuntimeError: Error loading a Profile from products/ocp4/profiles/moderate.profile: 'NoneType' object has no attribute 'get_cpe_name'
```

#### Rationale:
- I don't know why the tool doesn't segfault when diffing `rhel8` or `rhel9` profiles
- This tool is pretty handy to compare rule selection differences in profiles.
  - It can compare source profile files and compiled(rendered) profile files.

#### Review Hints:

- Build the content  (`./build/build_config.yml` needs to be generated)
  - e.g: `$ ./build_product ocp4`
- Diff two profiles:
```console
$ build-scripts/profile_tool.py sub --build-config-yaml ./build/build_config.yml --ssg-root ./ --product ocp4 --profile2 products/ocp4/profiles/high-rev-4.profile --profile1 products/ocp4/profiles/moderate.profile
Subtraction would produce an empty profile. No new profile was generated
```

```console
$ build-scripts/profile_tool.py sub --build-config-yaml ./build/build_config.yml --ssg-root ./ --product ocp4 --profile2 products/ocp4/profiles/high-rev-4.profile --profile1 products/ocp4/profiles/e8.profile
12 rules were left after subtraction.
0 variables were left after subtraction.
Creating a new profile containing the exclusive selections: e8_sub_high-rev-4.profile
Profile e8_sub_high-rev-4.profile was created successfully
```

When control files are used it makes more sense to compare compiled profile files:
```console
$ build-scripts/profile_tool.py sub --build-config-yaml ./build/build_config.yml --ssg-root ./ --product ocp4 --profile1 build/ocp4/profiles/high-rev-4.profile --profile2 build/ocp4/profiles/e8.profile
122 rules were left after subtraction.
3 variables were left after subtraction.
Creating a new profile containing the exclusive selections: high-rev-4_sub_e8.profile
Profile high-rev-4_sub_e8.profile was created successfully
```