### PR TITLE
Reduce XML reformatting

### DIFF
--- a/build-scripts/build_xccdf.py
+++ b/build-scripts/build_xccdf.py
@@ -133,7 +133,8 @@ def main():
     ocil = loader.export_ocil_to_xml()
     link_ocil(xccdftree, checks, args.ocil, ocil)
 
-    ssg.xml.ElementTree.ElementTree(xccdftree).write(args.xccdf, encoding="utf-8")
+    ssg.xml.ElementTree.ElementTree(xccdftree).write(
+        args.xccdf, xml_declaration=True, encoding="utf-8")
 
     if args.thin_ds_components_dir != "off":
         if not os.path.exists(args.thin_ds_components_dir):

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -290,7 +290,6 @@ macro(ssg_build_oval_unlinked PRODUCT)
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml"
         COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/combine_ovals.py" --log "${LOG_LEVEL}" --include-benchmark --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_BINARY_DIR}/product.yml" --output "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml" ${OVAL_COMBINE_PATHS}
-        COMMAND "${XMLLINT_EXECUTABLE}" --format --output "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml" "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml"
         DEPENDS generate-internal-templated-content-${PRODUCT} "${CMAKE_CURRENT_BINARY_DIR}/templated-content-${PRODUCT}"
         COMMENT "[${PRODUCT}-content] generating oval-unlinked.xml"
     )
@@ -304,7 +303,6 @@ macro(ssg_build_cpe_oval_unlinked PRODUCT)
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/cpe-oval-unlinked.xml"
         COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/combine_ovals.py" --log "${LOG_LEVEL}" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_BINARY_DIR}/product.yml" --output "${CMAKE_CURRENT_BINARY_DIR}/cpe-oval-unlinked.xml" --build-ovals-dir "${CMAKE_CURRENT_BINARY_DIR}/checks/oval" "${CMAKE_CURRENT_BINARY_DIR}/checks_from_templates/cpe-oval" "${SSG_SHARED}/checks/oval" "${SSG_SHARED}/applicability/oval"
-        COMMAND "${XMLLINT_EXECUTABLE}" --format --output "${CMAKE_CURRENT_BINARY_DIR}/cpe-oval-unlinked.xml" "${CMAKE_CURRENT_BINARY_DIR}/cpe-oval-unlinked.xml"
         DEPENDS generate-internal-templated-content-${PRODUCT} "${CMAKE_CURRENT_BINARY_DIR}/templated-content-${PRODUCT}"
         COMMENT "[${PRODUCT}-content] generating cpe-oval-unlinked.xml"
     )

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -425,15 +425,26 @@ macro(ssg_build_xccdf_final PRODUCT)
 
 endmacro()
 
-# Apply a final xmllint pass over the OVAL document to pretty-format the output
-# OVAL document for the product.
+# If built with Python older than 3.9, apply a final xmllint pass over the
+# OVAL document to pretty-format the output OVAL document for the product.
+# If Python 3.9 or newer is used for the build, the output OVAL is already
+# generated pretty and doesn't need to be reformatted.
 macro(ssg_build_oval_final PRODUCT)
-    add_custom_command(
-        OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"
-        COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"
-        DEPENDS generate-${PRODUCT}-xccdf-oval-ocil "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
-        COMMENT "[${PRODUCT}-content] generating ssg-${PRODUCT}-oval.xml"
-    )
+    if (PYTHON_VERSION_MAJOR LESS 3 OR PYTHON_VERSION_MINOR LESS 9)
+        add_custom_command(
+            OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"
+            COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"
+            DEPENDS generate-${PRODUCT}-xccdf-oval-ocil "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
+            COMMENT "[${PRODUCT}-content] generating ssg-${PRODUCT}-oval.xml"
+        )
+    else()
+        add_custom_command(
+            OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"
+            COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"
+            DEPENDS generate-${PRODUCT}-xccdf-oval-ocil "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
+            COMMENT "[${PRODUCT}-content] generating ssg-${PRODUCT}-oval.xml"
+        )
+    endif()
     add_custom_target(
         generate-ssg-${PRODUCT}-oval.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -458,15 +458,26 @@ macro(ssg_build_oval_final PRODUCT)
     endif()
 endmacro()
 
-# Apply a final xmllint pass over the OCIL document to pretty-format the output
-# OCIL document for the product.
+# If built with Python older than 3.9, apply a final xmllint pass over the
+# OCIL document to pretty-format the output OCIL document for the product.
+# If Python 3.9 or newer is used for the build, the output OVAL is already
+# generated pretty and doesn't need to be reformatted.
 macro(ssg_build_ocil_final PRODUCT)
-    add_custom_command(
-        OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
-        COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
-        DEPENDS generate-${PRODUCT}-xccdf-oval-ocil "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
-        COMMENT "[${PRODUCT}-content] generating ssg-${PRODUCT}-ocil.xml"
-    )
+    if (PYTHON_VERSION_MAJOR LESS 3 OR PYTHON_VERSION_MINOR LESS 9)
+        add_custom_command(
+            OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
+            COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
+            DEPENDS generate-${PRODUCT}-xccdf-oval-ocil "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
+            COMMENT "[${PRODUCT}-content] generating ssg-${PRODUCT}-ocil.xml"
+        )
+    else()
+        add_custom_command(
+            OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
+            COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
+            DEPENDS generate-${PRODUCT}-xccdf-oval-ocil "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
+            COMMENT "[${PRODUCT}-content] generating ssg-${PRODUCT}-ocil.xml"
+        )
+    endif()
     add_custom_target(
         generate-ssg-${PRODUCT}-ocil.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -410,87 +410,28 @@ macro(ssg_build_cpe_dictionary PRODUCT)
 endmacro()
 
 # If built with Python older than 3.9, apply a final xmllint pass over the
-# XCCDF document to pretty-format the output XCCDF document for the product.
-# If Python 3.9 or newer is used for the build, the output XCCDF is already
+# XML document to pretty-format the output XML document for the product.
+# If Python 3.9 or newer is used for the build, the output XML is already
 # generated pretty and doesn't need to be reformatted.
-macro(ssg_build_xccdf_final PRODUCT)
-    if (PYTHON_VERSION_MAJOR LESS 3 OR PYTHON_VERSION_MINOR LESS 9)
+macro(ssg_build_xml_final PRODUCT LANGUAGE)
+    if(PYTHON_VERSION_MAJOR LESS 3 OR PYTHON_VERSION_MINOR LESS 9)
         add_custom_command(
-            OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
-            COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
+            OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-${LANGUAGE}.xml"
+            COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-${LANGUAGE}.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-${LANGUAGE}.xml"
             DEPENDS generate-${PRODUCT}-xccdf-oval-ocil "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
-            COMMENT "[${PRODUCT}-content] generating ssg-${PRODUCT}-xccdf.xml"
+            COMMENT "[${PRODUCT}-content] generating ssg-${PRODUCT}-${LANGUAGE}.xml"
         )
     else()
         add_custom_command(
-            OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
-            COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
+            OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-${LANGUAGE}.xml"
+            COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-${LANGUAGE}.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-${LANGUAGE}.xml"
             DEPENDS generate-${PRODUCT}-xccdf-oval-ocil "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
-            COMMENT "[${PRODUCT}-content] generating ssg-${PRODUCT}-xccdf.xml"
+            COMMENT "[${PRODUCT}-content] generating ssg-${PRODUCT}-${LANGUAGE}.xml"
         )
     endif()
     add_custom_target(
-        generate-ssg-${PRODUCT}-xccdf.xml
-        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
-    )
-endmacro()
-
-# If built with Python older than 3.9, apply a final xmllint pass over the
-# OVAL document to pretty-format the output OVAL document for the product.
-# If Python 3.9 or newer is used for the build, the output OVAL is already
-# generated pretty and doesn't need to be reformatted.
-macro(ssg_build_oval_final PRODUCT)
-    if (PYTHON_VERSION_MAJOR LESS 3 OR PYTHON_VERSION_MINOR LESS 9)
-        add_custom_command(
-            OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"
-            COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"
-            DEPENDS generate-${PRODUCT}-xccdf-oval-ocil "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
-            COMMENT "[${PRODUCT}-content] generating ssg-${PRODUCT}-oval.xml"
-        )
-    else()
-        add_custom_command(
-            OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"
-            COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"
-            DEPENDS generate-${PRODUCT}-xccdf-oval-ocil "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
-            COMMENT "[${PRODUCT}-content] generating ssg-${PRODUCT}-oval.xml"
-        )
-    endif()
-    add_custom_target(
-        generate-ssg-${PRODUCT}-oval.xml
-        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"
-    )
-    define_validate_product("${PRODUCT}")
-    if("${VALIDATE_PRODUCT}" OR "${FORCE_VALIDATE_EVERYTHING}")
-        add_test(
-            NAME "validate-ssg-${PRODUCT}-oval.xml"
-            COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" oval validate ${OSCAP_OVAL_SCHEMATRON_OPTION} "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"
-        )
-    endif()
-endmacro()
-
-# If built with Python older than 3.9, apply a final xmllint pass over the
-# OCIL document to pretty-format the output OCIL document for the product.
-# If Python 3.9 or newer is used for the build, the output OVAL is already
-# generated pretty and doesn't need to be reformatted.
-macro(ssg_build_ocil_final PRODUCT)
-    if (PYTHON_VERSION_MAJOR LESS 3 OR PYTHON_VERSION_MINOR LESS 9)
-        add_custom_command(
-            OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
-            COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
-            DEPENDS generate-${PRODUCT}-xccdf-oval-ocil "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
-            COMMENT "[${PRODUCT}-content] generating ssg-${PRODUCT}-ocil.xml"
-        )
-    else()
-        add_custom_command(
-            OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
-            COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
-            DEPENDS generate-${PRODUCT}-xccdf-oval-ocil "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
-            COMMENT "[${PRODUCT}-content] generating ssg-${PRODUCT}-ocil.xml"
-        )
-    endif()
-    add_custom_target(
-        generate-ssg-${PRODUCT}-ocil.xml
-        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
+        generate-ssg-${PRODUCT}-${LANGUAGE}.xml
+        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-${LANGUAGE}.xml"
     )
 endmacro()
 
@@ -805,10 +746,18 @@ macro(ssg_build_product PRODUCT)
     ssg_build_cpe_oval_unlinked(${PRODUCT})
     ssg_build_manifest(${PRODUCT})
     ssg_build_cpe_dictionary(${PRODUCT})
-    ssg_build_xccdf_final(${PRODUCT})
-    ssg_build_oval_final(${PRODUCT})
-    ssg_build_ocil_final(${PRODUCT})
+    ssg_build_xml_final(${PRODUCT} xccdf)
+    ssg_build_xml_final(${PRODUCT} oval)
+    ssg_build_xml_final(${PRODUCT} ocil)
     ssg_build_sds(${PRODUCT})
+
+    define_validate_product("${PRODUCT}")
+    if("${VALIDATE_PRODUCT}" OR "${FORCE_VALIDATE_EVERYTHING}")
+        add_test(
+            NAME "validate-ssg-${PRODUCT}-oval.xml"
+            COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" oval validate ${OSCAP_OVAL_SCHEMATRON_OPTION} "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"
+        )
+    endif()
 
     add_custom_target(${PRODUCT} ALL)
     add_dependencies(${PRODUCT} ${PRODUCT}-content)

--- a/ssg/build_renumber.py
+++ b/ssg/build_renumber.py
@@ -80,7 +80,9 @@ class FileLinker(object):
         """
         assert self.tree is not None, \
             "There is no tree to save, you have probably skipped the linking phase"
-        ET.ElementTree(self.tree).write(self.linked_fname)
+        if hasattr(ET, "indent"):
+            ET.indent(self.tree, space="  ", level=0)
+        ET.ElementTree(self.tree).write(self.linked_fname, xml_declaration=True, encoding="utf-8")
 
     def _get_checkid_string(self):
         raise NotImplementedError()

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -472,7 +472,7 @@ class Benchmark(XCCDFEntity):
         self._add_rules_xml(root, components_to_not_include.get("rules", set()),  env_yaml,)
 
         if hasattr(ET, "indent"):
-            ET.indent(root, space=" ", level=0)
+            ET.indent(root, space="  ", level=0)
         return root
 
     def to_file(self, file_name, env_yaml=None):

--- a/ssg/oval_object_model/oval_document.py
+++ b/ssg/oval_object_model/oval_document.py
@@ -183,7 +183,7 @@ class OVALDocument(OVALContainer):
     def save_as_xml(self, fd, oval_definition_references=None):
         root = self.get_xml_element(oval_definition_references)
         if hasattr(ElementTree, "indent"):
-            ElementTree.indent(root, space=" ", level=0)
+            ElementTree.indent(root, space="  ", level=0)
         ElementTree.ElementTree(root).write(fd, xml_declaration=True, encoding="utf-8")
 
     def _get_component_el(self, tag, component_dict, id_selection):


### PR DESCRIPTION
#### Description:

This PR removes xmllint reformat steps when they are not needed.

First, we don't need to reformat the XMLs of the internal steps that aren't shipped to the users, ie. oval-unlinked.xml and ocil-unlinked.xml. Second, if we use Python 3.9 or newer, the outputs are generated already formatted so we don't need to reformat them.

For more details, please read commit messages of all commits.

#### Rationale:
small speed up (1 - 2 seconds)

