### PR TITLE
k8s content image: Image from PR should not be tagged `latest`

### DIFF
--- a/.github/workflows/k8s-content-pr.yaml
+++ b/.github/workflows/k8s-content-pr.yaml
@@ -111,6 +111,7 @@ jobs:
           message: |
             :robot: A k8s content image for this PR is available at:
             `ghcr.io/complianceascode/k8scontent:${{ needs.get-pr-number.outputs.pr-number }}`
+            This image was built from commit: ${{ github.event.workflow_run.head_sha }}
 
             <details>
             <summary>Click here to see how to deploy it</summary>

--- a/.github/workflows/k8s-content-pr.yaml
+++ b/.github/workflows/k8s-content-pr.yaml
@@ -71,6 +71,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/complianceascode/k8scontent
+          flavor: |
+            latest=false
           tags: |
             type=raw,value=${{ needs.get-pr-number.outputs.pr-number }}
             type=sha,format=long


### PR DESCRIPTION
#### Description:

- Do not tag images built from PRs as `latest`. Set action metadata input `flavor latest=false`
  - https://github.com/docker/metadata-action?tab=readme-ov-file#flavor-input
- Mention in the comment what commit was used to build.
  - This allows us to know whether the latest push to a PR was built already.

#### Rationale:

- The `latest` tag should be used on images built from merged changes.
    - Note that the `latest`  tag is assigned to the same image that has a PR number tag (This won't be noticeable if a PR was merged and no PR was updated after that).
    - https://github.com/ComplianceAsCode/content/pkgs/container/k8scontent/versions 
- From the comment in a PR we cannot know what commit was used to build the image.

#### Review Hints:
- Unfortunately the PR needs to merged to have effect
- Reference
  - https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_run

