### PR TITLE
Rework of `cpe_generate.py`

### DIFF
--- a/build-scripts/cpe_generate.py
+++ b/build-scripts/cpe_generate.py
@@ -60,8 +60,6 @@ def process_cpe_oval(oval_file_path):
     oval_document = ssg.oval_object_model.load_oval_document(ssg.xml.parse_file(oval_file_path))
     oval_document.product_name = os.path.basename(__file__)
 
-    # extract inventory definitions
-    # making (dubious) assumption that all inventory defs are CPE
     references_to_keep = ssg.oval_object_model.OVALDefinitionReference()
     for oval_def in oval_document.definitions.values():
         if oval_def.class_ != "inventory":
@@ -70,7 +68,6 @@ def process_cpe_oval(oval_file_path):
 
     oval_document.keep_referenced_components(references_to_keep)
 
-    # turn IDs into meaningless numbers
     translator = ssg.id_translate.IDTranslator("ssg")
     oval_document = translator.translate_oval_document(oval_document, store_defname=True)
 
@@ -87,7 +84,7 @@ def get_benchmark_cpe_names(xccdf_file):
         if cpe_name.startswith("#"):
             continue
         benchmark_cpe_names.add(cpe_name)
-    # add CPE names used by factref elements in CPEAL platforms
+
     for fact_ref in xccdf_el_root_xml.findall(
         ".//{%s}fact-ref" % ssg.constants.PREFIX_TO_NS["cpe-lang"]
     ):
@@ -122,7 +119,6 @@ def main():
     oval_document = process_cpe_oval(args.ovalfile)
     oval_document.save_as_xml(oval_file_path)
 
-    # Lets scrape the shorthand for the list of platforms referenced
     benchmark_cpe_names = get_benchmark_cpe_names(args.xccdfFile)
     cpe_dict = load_cpe_dictionary(benchmark_cpe_names, product_yaml, args.cpe_items_dir)
     cpe_dict.translate_cpe_oval_def_ids()

--- a/build-scripts/cpe_generate.py
+++ b/build-scripts/cpe_generate.py
@@ -25,24 +25,38 @@ cpe_ns = "http://cpe.mitre.org/dictionary/2.0"
 
 
 def parse_args():
-    p = argparse.ArgumentParser(description="This script takes as input an "
-        "OVAL file and a CPE dictionary file and extracts any inventory "
-        "definitions and the tests, states objects and variables it "
-        "references, and then write them into a standalone OVAL CPE file, "
-        "along with a synchronized CPE dictionary file.")
+    p = argparse.ArgumentParser(
+        description="This script takes as input an OVAL file and a CPE dictionary file "
+        "and extracts any inventory definitions and the tests, states objects and variables it "
+        "references, and then write them into a standalone OVAL CPE file, along with "
+        "a synchronized CPE dictionary file."
+    )
     p.add_argument(
         "--product-yaml",
         help="YAML file with information about the product we are building. "
         "e.g.: ~/scap-security-guide/rhel7/product.yml "
         "needed for autodetection of profile root"
     )
-    p.add_argument("idname", help="Identifier prefix")
-    p.add_argument("cpeoutdir", help="Artifact output directory")
-    p.add_argument("shorthandfile", help="shorthand xml to generate "
-                   "the CPE dictionary from")
-    p.add_argument("ovalfile", help="OVAL file to process")
-    p.add_argument("--cpe-items-dir", help="the directory where compiled CPE items are stored")
-
+    p.add_argument(
+        "idname",
+        help="Identifier prefix"
+    )
+    p.add_argument(
+        "cpeoutdir",
+        help="Artifact output directory"
+    )
+    p.add_argument(
+        "shorthandfile",
+        help="shorthand xml to generate the CPE dictionary from"
+    )
+    p.add_argument(
+        "ovalfile",
+        help="OVAL file to process"
+    )
+    p.add_argument(
+        "--cpe-items-dir",
+        help="the directory where compiled CPE items are stored"
+    )
     return p.parse_args()
 
 

--- a/build-scripts/cpe_generate.py
+++ b/build-scripts/cpe_generate.py
@@ -38,10 +38,6 @@ def parse_args():
         "needed for autodetection of profile root"
     )
     p.add_argument(
-        "idname",
-        help="Identifier prefix"
-    )
-    p.add_argument(
         "cpeoutdir",
         help="Artifact output directory"
     )
@@ -75,7 +71,7 @@ def load_oval(args):
     oval_document.keep_referenced_components(references_to_keep)
 
     # turn IDs into meaningless numbers
-    translator = ssg.id_translate.IDTranslator(args.idname)
+    translator = ssg.id_translate.IDTranslator("ssg")
     oval_document = translator.translate_oval_document(oval_document, store_defname=True)
 
     return oval_document
@@ -106,7 +102,6 @@ def load_cpe_dictionary(benchmark_cpe_names, product_yaml, args):
     cpe_list = ssg.build_cpe.CPEList()
     for cpe_name in benchmark_cpe_names:
         cpe_item = product_cpes.get_cpe(cpe_name)
-        cpe_item.content_id = args.idname
         cpe_list.add(cpe_item)
     return cpe_list
 
@@ -117,7 +112,7 @@ def main():
     product_yaml = ssg.products.load_product_yaml(args.product_yaml)
     product = product_yaml["product"]
 
-    oval_filename = "{}-{}-{}".format(args.idname, product, os.path.basename(args.ovalfile))
+    oval_filename = "ssg-{}-{}".format(product, os.path.basename(args.ovalfile))
     oval_filename = oval_filename.replace("cpe-oval-unlinked", "cpe-oval")
     oval_file_path = os.path.join(args.cpeoutdir, oval_filename)
 

--- a/build-scripts/cpe_generate.py
+++ b/build-scripts/cpe_generate.py
@@ -117,11 +117,11 @@ def main():
     product_yaml = ssg.products.load_product_yaml(args.product_yaml)
     product = product_yaml["product"]
 
-    oval_filename = args.idname + "-" + product + "-" + os.path.basename(args.ovalfile)
+    oval_filename = "{}-{}-{}".format(args.idname, product, os.path.basename(args.ovalfile))
     oval_filename = oval_filename.replace("cpe-oval-unlinked", "cpe-oval")
     oval_file_path = os.path.join(args.cpeoutdir, oval_filename)
 
-    cpe_dict_filename = "ssg-" + product + "-cpe-dictionary.xml"
+    cpe_dict_filename = "ssg-{}-cpe-dictionary.xml".format(product)
     cpe_dict_path = os.path.join(args.cpeoutdir, cpe_dict_filename)
 
     oval_document = load_oval(args)

--- a/build-scripts/cpe_generate.py
+++ b/build-scripts/cpe_generate.py
@@ -106,7 +106,9 @@ def load_cpe_dictionary(benchmark_cpe_names, product_yaml, args):
     product_cpes.load_cpes_from_directory_tree(args.cpe_items_dir, product_yaml)
     cpe_list = ssg.build_cpe.CPEList()
     for cpe_name in benchmark_cpe_names:
-        cpe_list.add(product_cpes.get_cpe(cpe_name))
+        cpe_item = product_cpes.get_cpe(cpe_name)
+        cpe_item.content_id = args.idname
+        cpe_list.add(cpe_item)
     return cpe_list
 
 

--- a/build-scripts/cpe_generate.py
+++ b/build-scripts/cpe_generate.py
@@ -56,8 +56,8 @@ def parse_args():
     return p.parse_args()
 
 
-def load_oval(args):
-    oval_document = ssg.oval_object_model.load_oval_document(ssg.xml.parse_file(args.ovalfile))
+def load_oval(oval_file_path):
+    oval_document = ssg.oval_object_model.load_oval_document(ssg.xml.parse_file(oval_file_path))
     oval_document.product_name = os.path.basename(__file__)
 
     # extract inventory definitions
@@ -96,9 +96,9 @@ def get_benchmark_cpe_names(xccdf_file):
     return benchmark_cpe_names
 
 
-def load_cpe_dictionary(benchmark_cpe_names, product_yaml, args):
+def load_cpe_dictionary(benchmark_cpe_names, product_yaml, cpe_items_dir):
     product_cpes = ssg.build_cpe.ProductCPEs()
-    product_cpes.load_cpes_from_directory_tree(args.cpe_items_dir, product_yaml)
+    product_cpes.load_cpes_from_directory_tree(cpe_items_dir, product_yaml)
     cpe_list = ssg.build_cpe.CPEList()
     for cpe_name in benchmark_cpe_names:
         cpe_item = product_cpes.get_cpe(cpe_name)
@@ -119,12 +119,12 @@ def main():
     cpe_dict_filename = "ssg-{}-cpe-dictionary.xml".format(product)
     cpe_dict_path = os.path.join(args.cpeoutdir, cpe_dict_filename)
 
-    oval_document = load_oval(args)
+    oval_document = load_oval(args.ovalfile)
     oval_document.save_as_xml(oval_file_path)
 
     # Lets scrape the shorthand for the list of platforms referenced
     benchmark_cpe_names = get_benchmark_cpe_names(args.xccdfFile)
-    cpe_dict = load_cpe_dictionary(benchmark_cpe_names, product_yaml, args)
+    cpe_dict = load_cpe_dictionary(benchmark_cpe_names, product_yaml, args.cpe_items_dir)
     cpe_dict.translate_cpe_oval_def_ids()
     cpe_dict.to_file(cpe_dict_path, oval_filename)
 

--- a/build-scripts/cpe_generate.py
+++ b/build-scripts/cpe_generate.py
@@ -56,7 +56,7 @@ def parse_args():
     return p.parse_args()
 
 
-def load_oval(oval_file_path):
+def process_cpe_oval(oval_file_path):
     oval_document = ssg.oval_object_model.load_oval_document(ssg.xml.parse_file(oval_file_path))
     oval_document.product_name = os.path.basename(__file__)
 
@@ -119,7 +119,7 @@ def main():
     cpe_dict_filename = "ssg-{}-cpe-dictionary.xml".format(product)
     cpe_dict_path = os.path.join(args.cpeoutdir, cpe_dict_filename)
 
-    oval_document = load_oval(args.ovalfile)
+    oval_document = process_cpe_oval(args.ovalfile)
     oval_document.save_as_xml(oval_file_path)
 
     # Lets scrape the shorthand for the list of platforms referenced

--- a/build-scripts/cpe_generate.py
+++ b/build-scripts/cpe_generate.py
@@ -62,7 +62,7 @@ def parse_args():
 
 def load_oval(args):
     oval_document = ssg.oval_object_model.load_oval_document(ssg.xml.parse_file(args.ovalfile))
-    oval_document.product_name = __file__
+    oval_document.product_name = os.path.basename(__file__)
 
     # extract inventory definitions
     # making (dubious) assumption that all inventory defs are CPE

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -385,7 +385,7 @@ macro(ssg_build_cpe_dictionary PRODUCT)
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml"
         OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/cpe_generate.py" --product-yaml "${CMAKE_CURRENT_BINARY_DIR}/product.yml" --cpe-items-dir "${CMAKE_CURRENT_BINARY_DIR}/cpe_items" ssg "${CMAKE_BINARY_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" "${CMAKE_CURRENT_BINARY_DIR}/cpe-oval-unlinked.xml"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/cpe_generate.py" --product-yaml "${CMAKE_CURRENT_BINARY_DIR}/product.yml" --cpe-items-dir "${CMAKE_CURRENT_BINARY_DIR}/cpe_items" "${CMAKE_BINARY_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" "${CMAKE_CURRENT_BINARY_DIR}/cpe-oval-unlinked.xml"
         COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml"
         COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml"
         DEPENDS generate-${PRODUCT}-xccdf-oval-ocil "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -165,6 +165,10 @@ class CPEList(object):
         tree = ET.ElementTree(root)
         tree.write(file_name, encoding="utf-8")
 
+    def translate_cpe_oval_def_ids(self):
+        for cpe_item in self.cpe_items:
+            cpe_item.set_cpe_oval_def_id()
+
 
 class CPEItem(XCCDFEntity, Templatable):
     """
@@ -179,6 +183,7 @@ class CPEItem(XCCDFEntity, Templatable):
         is_product_cpe=lambda: False,
         versioned=lambda: False,
         args=lambda: {},
+        content_id=lambda: "ssg",
         ** XCCDFEntity.KEYS
     )
     KEYS.update(**Templatable.KEYS)
@@ -196,10 +201,13 @@ class CPEItem(XCCDFEntity, Templatable):
 
     @property
     def cpe_oval_def_id(self):
-        translator = ssg.id_translate.IDTranslator("ssg")
+        translator = ssg.id_translate.IDTranslator(self.content_id)
         full_id = translator.generate_id(
             "{" + oval_namespace + "}definition", self.cpe_oval_short_def_id)
         return full_id
+
+    def set_cpe_oval_def_id(self):
+        self.check_id = self.cpe_oval_def_id
 
     def to_xml_element(self, cpe_oval_filename):
         cpe_item = ET.Element("{%s}cpe-item" % CPEItem.ns)


### PR DESCRIPTION
#### Description:
This PR reworks the `cpe_generate.py` script. It simplifies the code for future enhancements such as reducing CPE AL in the data stream. The script uses the OVAL object model to process OVAL.  And it separates the process of creating the CPE dictionary and the CPE OVAL.

#### Review Hints:
These changes shouldn't change the functionality of the script.
