### PR TITLE
Changes in template service_disabled - ansible part

### DIFF
--- a/shared/templates/service_disabled/ansible.template
+++ b/shared/templates/service_disabled/ansible.template
@@ -11,9 +11,10 @@
         - name: Disable service {{{ SERVICENAME }}}
           systemd:
             name: "{{{ DAEMONNAME }}}.service"
-            enabled: "no"
+            enabled: false
             state: "stopped"
-            masked: "yes"
+            masked: true
+          when: ansible_facts.services["{{{ DAEMONNAME }}}.service"] is defined 
       rescue:
         - name: "Intentionally ignored previous 'Disable service {{{ SERVICENAME }}}' failure, service was already disabled"
           meta: noop
@@ -28,9 +29,9 @@
 - name: Disable socket {{{ SERVICENAME }}}
   systemd:
     name: "{{{ DAEMONNAME }}}.socket"
-    enabled: "no"
+    enabled: false
     state: "stopped"
-    masked: "yes"
+    masked: true
   when: 'socket_file_exists.stdout_lines is search("{{{ DAEMONNAME }}}.socket",multiline=True)' 
 {{%- else %}}
 JINJA TEMPLATE ERROR: Unknown init system '{{{ init_system }}}'

--- a/shared/templates/service_disabled/ansible.template
+++ b/shared/templates/service_disabled/ansible.template
@@ -7,7 +7,7 @@
 {{%- if init_system == "systemd" %}}
 
 - name: "{{{ rule_title }}} - Collect systemd Services Present in the System"
-  command: systemctl -q list-unit-files --type service
+  ansible.builtin.command: systemctl -q list-unit-files --type service
   register: service_exists
   changed_when: false
   failed_when: service_exists.rc not in [0, 1]
@@ -22,14 +22,14 @@
   when: 'service_exists.stdout_lines is search("{{{ SERVICENAME }}}.service",multiline=True)'
 
 - name: "Unit Socket Exists - {{{ DAEMONNAME }}}.socket"
-  command: systemctl -q list-unit-files {{{ DAEMONNAME }}}.socket
+  ansible.builtin.command: systemctl -q list-unit-files {{{ DAEMONNAME }}}.socket
   register: socket_file_exists
   changed_when: false
   failed_when: socket_file_exists.rc not in [0, 1]
   check_mode: false
 
 - name: Disable socket {{{ SERVICENAME }}}
-  systemd:
+  ansible.builtin.systemd:
     name: "{{{ DAEMONNAME }}}.socket"
     enabled: "no"
     state: "stopped"

--- a/shared/templates/service_disabled/ansible.template
+++ b/shared/templates/service_disabled/ansible.template
@@ -3,35 +3,37 @@
 # strategy = disable
 # complexity = low
 # disruption = low
+
 {{%- if init_system == "systemd" %}}
-- name: Block Disable service {{{ SERVICENAME }}}
-  block:
-    - name: Disable service {{{ SERVICENAME }}}
-      block:
-        - name: Disable service {{{ SERVICENAME }}}
-          systemd:
-            name: "{{{ DAEMONNAME }}}.service"
-            enabled: false
-            state: "stopped"
-            masked: true
-          when: ansible_facts.services["{{{ DAEMONNAME }}}.service"] is defined 
-      rescue:
-        - name: "Intentionally ignored previous 'Disable service {{{ SERVICENAME }}}' failure, service was already disabled"
-          meta: noop
+
+- name: "{{{ rule_title }}} - Collect systemd Services Present in the System"
+  command: systemctl -q list-unit-files --type service
+  register: service_exists
+  changed_when: false
+  failed_when: service_exists.rc not in [0, 1]
+  check_mode: false
+
+- name: '{{{ rule_title }}} - Ensure "{{{ DAEMONNAME }}}.service" is Masked'
+  ansible.builtin.systemd:
+    name: "{{{ DAEMONNAME }}}.service"
+    state: "stopped"
+    enabled: false
+    masked: true
+  when: 'service_exists.stdout_lines is search("{{{ SERVICENAME }}}.service",multiline=True)'
 
 - name: "Unit Socket Exists - {{{ DAEMONNAME }}}.socket"
   command: systemctl -q list-unit-files {{{ DAEMONNAME }}}.socket
   register: socket_file_exists
-  changed_when: False
+  changed_when: false
   failed_when: socket_file_exists.rc not in [0, 1]
-  check_mode: False
+  check_mode: false
 
 - name: Disable socket {{{ SERVICENAME }}}
   systemd:
     name: "{{{ DAEMONNAME }}}.socket"
-    enabled: false
+    enabled: "no"
     state: "stopped"
-    masked: true
+    masked: "yes"
   when: 'socket_file_exists.stdout_lines is search("{{{ DAEMONNAME }}}.socket",multiline=True)' 
 {{%- else %}}
 JINJA TEMPLATE ERROR: Unknown init system '{{{ init_system }}}'


### PR DESCRIPTION
#### Description:

- _Changes in ansible template which is a part of service_disabled_

#### Rationale:

- At the moment the current ansible template: 

- does not check if the service exists and there are cases when it tries to disable services which are not exists. Because of that we have a fatal error like this - when we want to disable for example the service zebra via the rule "service_zebra_disabled"
TASK [Disable service zebra] ********************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Could not find the requested service zebra.service: host"}
[WARNING]: noop task does not support when conditional

- uses values "yes" and "no" for attributes which according the official ansible documentation are boolean and they have to be true or false
