### PR TITLE
update meaning of the "automated" status in control files

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -696,7 +696,7 @@ controls:
       The /boot partition mounted is essential to perform certain administrative actions, for
       example updating the kernel. Therefore, for better stability, in this requirement only rules
       to restrict the access to /boot are selected. It is not changed how the /boot is mounted.
-    status: partial
+    status: automated
     rules:
       - file_groupowner_efi_grub2_cfg
       - file_groupowner_grub2_cfg

--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -866,7 +866,7 @@ controls:
       would be configured to 0027 for all services. One such example is the
       Cups service which needs to create sockets which need to be available for
       all users. Therefore, this part of the requirement can't be automated.
-    status: partial
+    status: automated
     rules:
       - accounts_umask_etc_bashrc
       - accounts_umask_etc_login_defs

--- a/docs/manual/developer/03_creating_content.md
+++ b/docs/manual/developer/03_creating_content.md
@@ -922,7 +922,9 @@ The `status` key may hold the following values:
                 automation).
 
 * `automated`: The control is addressed by the product and can be automatically
-               checked for.
+               checked for. In case a part of a requirement cannot be
+               reasonably automated but the rest is fully automated, this
+               status is appropriate as well.
 
 * `manual`: The control cannot or should not be automated, and should be addressed manually.
 


### PR DESCRIPTION
#### Description:

- extend the definition of that status
- update two related cases in ANSSI control file

#### Rationale:

- sometimes a requirement can be reasonably automated only partially... but that does not mean it should have the "partial" status. The "partial" status suggests that something can be automated but it is not implemented yet.
