### PR TITLE
Add more precise URI for SRG CTR

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -107,6 +107,9 @@ def add_reference_elements(element, references, ref_uri_dict):
             if ref_type == 'srg':
                 if ref_val.startswith('SRG-OS-'):
                     ref_href = ref_uri_dict['os-srg']
+                elif re.match(r'SRG-APP-\d{5,}-CTR-\d{5,}', ref_val):
+                    # The more specific case needs to come first, otherwise the generic SRG-APP will catch everything
+                    ref_href = ref_uri_dict['app-srg-ctr']
                 elif ref_val.startswith('SRG-APP-'):
                     ref_href = ref_uri_dict['app-srg']
                 else:

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -34,6 +34,7 @@ SSG_REF_URIS = {
     'stigid': 'https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux',
     'os-srg': 'https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cgeneral-purpose-os',
     'app-srg': 'https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers',
+    'app-srg-ctr': 'https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform',
     'stigref': 'https://public.cyber.mil/stigs/srg-stig-tools/',
 }
 

--- a/tests/data/product_stability/alinux2.yml
+++ b/tests/data/product_stability/alinux2.yml
@@ -9,8 +9,10 @@ benchmark_id: ALINUX-2
 benchmark_root: ../../linux_os/guide
 chrony_conf_path: /etc/chrony.conf
 cpes:
-- alinux2: {check_id: installed_OS_is_alinux2, name: 'cpe:/o:alinux:alibaba_cloud_linux:2',
-    title: Alibaba Cloud Linux 2}
+- alinux2:
+    check_id: installed_OS_is_alinux2
+    name: cpe:/o:alinux:alibaba_cloud_linux:2
+    title: Alibaba Cloud Linux 2
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
 faillock_path: /var/run/faillock
@@ -26,28 +28,48 @@ nobody_uid: 65534
 pkg_manager: yum
 pkg_manager_config_file: /etc/yum.conf
 pkg_system: rpm
-platform_package_overrides: {aarch64_arch: null, grub2: grub2-common, login_defs: shadow-utils,
-  no_ovirt: null, non-uefi: null, not_aarch64_arch: null, not_s390x_arch: null, ovirt: null,
-  s390x_arch: null, sssd: sssd-common, sssd-ldap: null, uefi: null, zipl: s390utils-base}
+platform_package_overrides:
+  aarch64_arch: null
+  grub2: grub2-common
+  login_defs: shadow-utils
+  no_ovirt: null
+  non-uefi: null
+  not_aarch64_arch: null
+  not_s390x_arch: null
+  ovirt: null
+  s390x_arch: null
+  sssd: sssd-common
+  sssd-ldap: null
+  uefi: null
+  zipl: s390utils-base
 product: alinux2
 profiles_root: ./profiles
-reference_uris: {anssi: 'https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf',
-  app-srg: 'https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers',
-  bsi: 'https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf',
-  cis-csc: 'https://www.cisecurity.org/controls/', cjis: 'https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf',
-  cnss: 'http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf', cobit5: 'https://www.isaca.org/resources/cobit',
-  cui: 'http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf',
-  dcid: not_officially_available, disa: 'https://public.cyber.mil/stigs/cci/', hipaa: 'https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf',
-  isa-62443-2009: 'https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat',
-  isa-62443-2013: 'https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu',
-  ism: 'https://www.cyber.gov.au/acsc/view-all-content/ism', iso27001-2013: 'https://www.iso.org/contents/data/standard/05/45/54534.html',
-  nerc-cip: 'https://www.nerc.com/pa/Stand/Standard%20Purpose%20Statement%20DL/US_Standard_One-Stop-Shop.xlsx',
-  nist: 'http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf',
-  nist-csf: 'https://nvlpubs.nist.gov/nistpubs/CSWP/NIST.CSWP.04162018.pdf', os-srg: 'https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cgeneral-purpose-os',
-  ospp: 'https://www.niap-ccevs.org/Profile/PP.cfm', pcidss: 'https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-2-1.pdf',
-  pcidss4: 'https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf',
-  stigid: 'https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux',
-  stigref: 'https://public.cyber.mil/stigs/srg-stig-tools/'}
+reference_uris:
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
+  app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
+  bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
+  cis-csc: https://www.cisecurity.org/controls/
+  cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
+  cnss: http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf
+  cobit5: https://www.isaca.org/resources/cobit
+  cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
+  dcid: not_officially_available
+  disa: https://public.cyber.mil/stigs/cci/
+  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
+  isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
+  ism: https://www.cyber.gov.au/acsc/view-all-content/ism
+  iso27001-2013: https://www.iso.org/contents/data/standard/05/45/54534.html
+  nerc-cip: https://www.nerc.com/pa/Stand/Standard%20Purpose%20Statement%20DL/US_Standard_One-Stop-Shop.xlsx
+  nist: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf
+  nist-csf: https://nvlpubs.nist.gov/nistpubs/CSWP/NIST.CSWP.04162018.pdf
+  os-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cgeneral-purpose-os
+  ospp: https://www.niap-ccevs.org/Profile/PP.cfm
+  pcidss: https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-2-1.pdf
+  pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
+  stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
+  stigref: https://public.cyber.mil/stigs/srg-stig-tools/
 sshd_distributed_config: 'false'
 sysctl_remediate_drop_in_file: 'false'
 type: platform

--- a/tests/data/product_stability/alinux3.yml
+++ b/tests/data/product_stability/alinux3.yml
@@ -9,8 +9,10 @@ benchmark_id: ALINUX-3
 benchmark_root: ../../linux_os/guide
 chrony_conf_path: /etc/chrony.conf
 cpes:
-- alinux3: {check_id: installed_OS_is_alinux3, name: 'cpe:/o:alinux:alibaba_cloud_linux:3',
-    title: Alibaba Cloud Linux 3}
+- alinux3:
+    check_id: installed_OS_is_alinux3
+    name: cpe:/o:alinux:alibaba_cloud_linux:3
+    title: Alibaba Cloud Linux 3
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
 faillock_path: /var/run/faillock
@@ -26,28 +28,48 @@ nobody_uid: 65534
 pkg_manager: yum
 pkg_manager_config_file: /etc/yum.conf
 pkg_system: rpm
-platform_package_overrides: {aarch64_arch: null, grub2: grub2-common, login_defs: shadow-utils,
-  no_ovirt: null, non-uefi: null, not_aarch64_arch: null, not_s390x_arch: null, ovirt: null,
-  s390x_arch: null, sssd: sssd-common, sssd-ldap: null, uefi: null, zipl: s390utils-base}
+platform_package_overrides:
+  aarch64_arch: null
+  grub2: grub2-common
+  login_defs: shadow-utils
+  no_ovirt: null
+  non-uefi: null
+  not_aarch64_arch: null
+  not_s390x_arch: null
+  ovirt: null
+  s390x_arch: null
+  sssd: sssd-common
+  sssd-ldap: null
+  uefi: null
+  zipl: s390utils-base
 product: alinux3
 profiles_root: ./profiles
-reference_uris: {anssi: 'https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf',
-  app-srg: 'https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers',
-  bsi: 'https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf',
-  cis-csc: 'https://www.cisecurity.org/controls/', cjis: 'https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf',
-  cnss: 'http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf', cobit5: 'https://www.isaca.org/resources/cobit',
-  cui: 'http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf',
-  dcid: not_officially_available, disa: 'https://public.cyber.mil/stigs/cci/', hipaa: 'https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf',
-  isa-62443-2009: 'https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat',
-  isa-62443-2013: 'https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu',
-  ism: 'https://www.cyber.gov.au/acsc/view-all-content/ism', iso27001-2013: 'https://www.iso.org/contents/data/standard/05/45/54534.html',
-  nerc-cip: 'https://www.nerc.com/pa/Stand/Standard%20Purpose%20Statement%20DL/US_Standard_One-Stop-Shop.xlsx',
-  nist: 'http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf',
-  nist-csf: 'https://nvlpubs.nist.gov/nistpubs/CSWP/NIST.CSWP.04162018.pdf', os-srg: 'https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cgeneral-purpose-os',
-  ospp: 'https://www.niap-ccevs.org/Profile/PP.cfm', pcidss: 'https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-2-1.pdf',
-  pcidss4: 'https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf',
-  stigid: 'https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux',
-  stigref: 'https://public.cyber.mil/stigs/srg-stig-tools/'}
+reference_uris:
+  anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
+  app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
+  bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
+  cis-csc: https://www.cisecurity.org/controls/
+  cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
+  cnss: http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf
+  cobit5: https://www.isaca.org/resources/cobit
+  cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
+  dcid: not_officially_available
+  disa: https://public.cyber.mil/stigs/cci/
+  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
+  isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
+  ism: https://www.cyber.gov.au/acsc/view-all-content/ism
+  iso27001-2013: https://www.iso.org/contents/data/standard/05/45/54534.html
+  nerc-cip: https://www.nerc.com/pa/Stand/Standard%20Purpose%20Statement%20DL/US_Standard_One-Stop-Shop.xlsx
+  nist: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf
+  nist-csf: https://nvlpubs.nist.gov/nistpubs/CSWP/NIST.CSWP.04162018.pdf
+  os-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cgeneral-purpose-os
+  ospp: https://www.niap-ccevs.org/Profile/PP.cfm
+  pcidss: https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-2-1.pdf
+  pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
+  stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
+  stigref: https://public.cyber.mil/stigs/srg-stig-tools/
 sshd_distributed_config: 'false'
 sysctl_remediate_drop_in_file: 'false'
 type: platform

--- a/tests/data/product_stability/anolis23.yml
+++ b/tests/data/product_stability/anolis23.yml
@@ -47,6 +47,7 @@ profiles_root: ./profiles
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis-csc: https://www.cisecurity.org/controls/
   cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf

--- a/tests/data/product_stability/anolis8.yml
+++ b/tests/data/product_stability/anolis8.yml
@@ -47,6 +47,7 @@ profiles_root: ./profiles
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis-csc: https://www.cisecurity.org/controls/
   cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf

--- a/tests/data/product_stability/chromium.yml
+++ b/tests/data/product_stability/chromium.yml
@@ -43,6 +43,7 @@ profiles_root: ./profiles
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis-csc: https://www.cisecurity.org/controls/
   cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf

--- a/tests/data/product_stability/debian10.yml
+++ b/tests/data/product_stability/debian10.yml
@@ -55,6 +55,7 @@ profiles_root: ./profiles
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: https://benchmarks.cisecurity.org/tools2/linux/CIS_Debian_Benchmark_v1.0.pdf
   cis-csc: https://www.cisecurity.org/controls/

--- a/tests/data/product_stability/debian11.yml
+++ b/tests/data/product_stability/debian11.yml
@@ -55,6 +55,7 @@ profiles_root: ./profiles
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: https://benchmarks.cisecurity.org/tools2/linux/CIS_Debian_Benchmark_v1.0.pdf
   cis-csc: https://www.cisecurity.org/controls/

--- a/tests/data/product_stability/debian12.yml
+++ b/tests/data/product_stability/debian12.yml
@@ -55,6 +55,7 @@ profiles_root: ./profiles
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis-csc: https://www.cisecurity.org/controls/
   cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf

--- a/tests/data/product_stability/eks.yml
+++ b/tests/data/product_stability/eks.yml
@@ -53,6 +53,7 @@ profiles_root: ./profiles
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: https://www.cisecurity.org/benchmark/kubernetes/
   cis-csc: https://www.cisecurity.org/controls/

--- a/tests/data/product_stability/example.yml
+++ b/tests/data/product_stability/example.yml
@@ -48,6 +48,7 @@ profiles_root: ./profiles
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis-csc: https://www.cisecurity.org/controls/
   cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf

--- a/tests/data/product_stability/fedora.yml
+++ b/tests/data/product_stability/fedora.yml
@@ -83,6 +83,7 @@ rawhide_version: 40
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis-csc: https://www.cisecurity.org/controls/
   cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf

--- a/tests/data/product_stability/firefox.yml
+++ b/tests/data/product_stability/firefox.yml
@@ -43,6 +43,7 @@ profiles_root: ./profiles
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis-csc: https://www.cisecurity.org/controls/
   cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf

--- a/tests/data/product_stability/macos1015.yml
+++ b/tests/data/product_stability/macos1015.yml
@@ -43,6 +43,7 @@ profiles_root: ./profiles
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis-csc: https://www.cisecurity.org/controls/
   cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf

--- a/tests/data/product_stability/ocp4.yml
+++ b/tests/data/product_stability/ocp4.yml
@@ -129,6 +129,7 @@ profiles_root: ./profiles
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: https://www.cisecurity.org/benchmark/kubernetes/
   cis-csc: https://www.cisecurity.org/controls/

--- a/tests/data/product_stability/ol7.yml
+++ b/tests/data/product_stability/ol7.yml
@@ -57,6 +57,7 @@ profiles_root: ./profiles
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: https://www.cisecurity.org/benchmark/oracle_linux/
   cis-csc: https://www.cisecurity.org/controls/

--- a/tests/data/product_stability/ol8.yml
+++ b/tests/data/product_stability/ol8.yml
@@ -56,6 +56,7 @@ profiles_root: ./profiles
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: https://www.cisecurity.org/benchmark/oracle_linux/
   cis-csc: https://www.cisecurity.org/controls/

--- a/tests/data/product_stability/ol9.yml
+++ b/tests/data/product_stability/ol9.yml
@@ -59,6 +59,7 @@ profiles_root: ./profiles
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: ''
   cis-csc: https://www.cisecurity.org/controls/

--- a/tests/data/product_stability/openembedded.yml
+++ b/tests/data/product_stability/openembedded.yml
@@ -51,6 +51,7 @@ profiles_root: ./profiles
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis-csc: https://www.cisecurity.org/controls/
   cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf

--- a/tests/data/product_stability/opensuse.yml
+++ b/tests/data/product_stability/opensuse.yml
@@ -59,6 +59,7 @@ profiles_root: ./profiles
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis-csc: https://www.cisecurity.org/controls/
   cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf

--- a/tests/data/product_stability/rhcos4.yml
+++ b/tests/data/product_stability/rhcos4.yml
@@ -51,6 +51,7 @@ profiles_root: ./profiles
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis-csc: https://www.cisecurity.org/controls/
   cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf

--- a/tests/data/product_stability/rhel7.yml
+++ b/tests/data/product_stability/rhel7.yml
@@ -79,6 +79,7 @@ profiles_root: ./profiles
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: https://www.cisecurity.org/benchmark/red_hat_linux/
   cis-csc: https://www.cisecurity.org/controls/

--- a/tests/data/product_stability/rhel8.yml
+++ b/tests/data/product_stability/rhel8.yml
@@ -107,6 +107,7 @@ profiles_root: ./profiles
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: https://www.cisecurity.org/benchmark/red_hat_linux/
   cis-csc: https://www.cisecurity.org/controls/

--- a/tests/data/product_stability/rhel9.yml
+++ b/tests/data/product_stability/rhel9.yml
@@ -63,6 +63,7 @@ profiles_root: ./profiles
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   ccn: https://www.ccn-cert.cni.es/pdf/guias/series-ccn-stic/guias-de-acceso-publico-ccn-stic/6768-ccn-stic-610a22-perfilado-de-seguridad-red-hat-enterprise-linux-9-0/file.html
   cis: https://www.cisecurity.org/benchmark/red_hat_linux/

--- a/tests/data/product_stability/rhv4.yml
+++ b/tests/data/product_stability/rhv4.yml
@@ -56,6 +56,7 @@ profiles_root: ./profiles
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis-csc: https://www.cisecurity.org/controls/
   cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf

--- a/tests/data/product_stability/sle12.yml
+++ b/tests/data/product_stability/sle12.yml
@@ -55,6 +55,7 @@ profiles_root: ./profiles
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: https://www.cisecurity.org/benchmark/suse_linux/
   cis-csc: https://www.cisecurity.org/controls/

--- a/tests/data/product_stability/sle15.yml
+++ b/tests/data/product_stability/sle15.yml
@@ -59,6 +59,7 @@ profiles_root: ./profiles
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: https://www.cisecurity.org/benchmark/suse_linux/
   cis-csc: https://www.cisecurity.org/controls/

--- a/tests/data/product_stability/ubuntu1604.yml
+++ b/tests/data/product_stability/ubuntu1604.yml
@@ -59,6 +59,7 @@ profiles_root: ./profiles
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: https://www.cisecurity.org/benchmark/ubuntu_linux/
   cis-csc: https://www.cisecurity.org/controls/

--- a/tests/data/product_stability/ubuntu1804.yml
+++ b/tests/data/product_stability/ubuntu1804.yml
@@ -58,6 +58,7 @@ profiles_root: ./profiles
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: https://www.cisecurity.org/benchmark/ubuntu_linux/
   cis-csc: https://www.cisecurity.org/controls/

--- a/tests/data/product_stability/ubuntu2004.yml
+++ b/tests/data/product_stability/ubuntu2004.yml
@@ -60,6 +60,7 @@ profiles_root: ./profiles
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: https://www.cisecurity.org/benchmark/ubuntu_linux/
   cis-csc: https://www.cisecurity.org/controls/

--- a/tests/data/product_stability/ubuntu2204.yml
+++ b/tests/data/product_stability/ubuntu2204.yml
@@ -61,6 +61,7 @@ profiles_root: ./profiles
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis: https://www.cisecurity.org/benchmark/ubuntu_linux/
   cis-csc: https://www.cisecurity.org/controls/

--- a/tests/data/product_stability/uos20.yml
+++ b/tests/data/product_stability/uos20.yml
@@ -47,6 +47,7 @@ profiles_root: ./profiles
 reference_uris:
   anssi: https://cyber.gouv.fr/sites/default/files/document/linux_configuration-en-v2.pdf
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  app-srg-ctr: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   bsi: https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf
   cis-csc: https://www.cisecurity.org/controls/
   cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf


### PR DESCRIPTION
#### Description:

- Add more specific URI for  `SRG-APP-XXXXXX-CTR-XXXXXX` references: `container-platform`
  - https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
- Update product stability data to include new `app-srg-ctr` reference URI.
  - `test_product_stability.py --update-reference-data`

#### Rationale:

- The `container-platform` URI more accurately points to the source of SRG CTR.
- These SRGs are not yet parsed by CO, so this change should not have any impact there.

#### Review Hints:

- Build `ocp4` and `rhcos4` and check that the `SRG-APP-XXXXXX-CTR-XXXXX` references have `href` pointing to `   https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform`

