### PR TITLE
Reduction of CPE content in DS

### DIFF
--- a/build-scripts/build_xccdf.py
+++ b/build-scripts/build_xccdf.py
@@ -136,7 +136,7 @@ def main():
     ssg.xml.ElementTree.ElementTree(xccdftree).write(
         args.xccdf, xml_declaration=True, encoding="utf-8")
 
-    if args.thin_ds_components_dir != "off":
+    if args.thin_ds_components_dir is not None and args.thin_ds_components_dir != "off":
         if not os.path.exists(args.thin_ds_components_dir):
             os.makedirs(args.thin_ds_components_dir)
         store_xccdf_per_profile(loader, oval_linker, args.thin_ds_components_dir)

--- a/build-scripts/compose_ds.py
+++ b/build-scripts/compose_ds.py
@@ -311,8 +311,11 @@ def _compose_multiple_ds(args):
     for xccdf in glob.glob("{}/xccdf*.xml".format(args.multiple_ds)):
         oval = xccdf.replace("xccdf", "oval")
         ocil = xccdf.replace("xccdf", "ocil")
+        cpe_dict = xccdf.replace("xccdf", "cpe_dict")
+        cpe_oval = xccdf.replace("xccdf", "cpe_oval")
+
         ds = compose_ds(
-            xccdf, oval, ocil, args.cpe_dict, args.cpe_oval, args.enable_sce
+            xccdf, oval, ocil, cpe_dict, cpe_oval, args.enable_sce
         )
         output_13 = _get_thin_ds_output_path(args.output_13, xccdf.replace("xccdf_", ""))
         output_12 = None

--- a/build-scripts/cpe_generate.py
+++ b/build-scripts/cpe_generate.py
@@ -62,26 +62,6 @@ def parse_args():
     return p.parse_args()
 
 
-def process_cpe_oval(oval_file_path):
-    oval_document = ssg.oval_object_model.load_oval_document(ssg.xml.parse_file(oval_file_path))
-    oval_document.product_name = os.path.basename(__file__)
-
-    references_to_keep = ssg.oval_object_model.OVALDefinitionReference()
-    for oval_def in oval_document.definitions.values():
-        if oval_def.class_ != "inventory":
-            continue
-        references_to_keep += oval_document.get_all_references_of_definition(
-            oval_def.id_
-        )
-
-    oval_document.keep_referenced_components(references_to_keep)
-
-    translator = ssg.id_translate.IDTranslator("ssg")
-    oval_document = translator.translate_oval_document(oval_document)
-
-    return oval_document
-
-
 def get_benchmark_cpe_names(xccdf_el_root_xml):
     benchmark_cpe_names = set()
 
@@ -177,7 +157,7 @@ def main():
     used_cpe_oval_def_ids = get_all_cpe_oval_def_ids(
         xccdf_el_root_xml, cpe_dict, benchmark_cpe_names
     )
-    oval_document = process_cpe_oval(args.ovalfile)
+    oval_document = ssg.build_cpe.get_linked_cpe_oval_document(args.ovalfile)
     _save_minimal_cpe_oval(oval_document, oval_file_path, used_cpe_oval_def_ids)
 
     if args.thin_ds_components_dir is not None and args.thin_ds_components_dir != "off":

--- a/build-scripts/cpe_generate.py
+++ b/build-scripts/cpe_generate.py
@@ -81,7 +81,7 @@ def process_cpe_oval(oval_file_path):
     oval_document.keep_referenced_components(references_to_keep)
 
     translator = ssg.id_translate.IDTranslator("ssg")
-    oval_document = translator.translate_oval_document(oval_document, store_defname=True)
+    oval_document = translator.translate_oval_document(oval_document)
 
     return oval_document
 

--- a/build-scripts/cpe_generate.py
+++ b/build-scripts/cpe_generate.py
@@ -14,16 +14,12 @@ import ssg.products
 import ssg.xml
 import ssg.yaml
 import ssg.oval_object_model
-from ssg.constants import XCCDF12_NS
+from ssg.constants import XCCDF12_NS, cpe_language_namespace
 
 # This script requires two arguments: an OVAL file and a CPE dictionary file.
 # It is designed to extract any inventory definitions and the tests, states,
 # objects and variables it references and then write them into a standalone
 # OVAL CPE file, along with a synchronized CPE dictionary file.
-
-oval_ns = "http://oval.mitre.org/XMLSchema/oval-definitions-5"
-cpe_ns = "http://cpe.mitre.org/dictionary/2.0"
-cpe_lang_ns = ssg.constants.PREFIX_TO_NS["cpe-lang"]
 
 
 def parse_args():
@@ -97,7 +93,7 @@ def get_benchmark_cpe_names(xccdf_el_root_xml):
             continue
         benchmark_cpe_names.add(cpe_name)
 
-    for fact_ref in xccdf_el_root_xml.findall(".//{%s}fact-ref" % cpe_lang_ns):
+    for fact_ref in xccdf_el_root_xml.findall(".//{%s}fact-ref" % cpe_language_namespace):
         cpe_fact_ref_name = fact_ref.get("name")
         benchmark_cpe_names.add(cpe_fact_ref_name)
     return benchmark_cpe_names
@@ -114,7 +110,7 @@ def load_cpe_dictionary(benchmark_cpe_names, product_yaml, cpe_items_dir):
 
 
 def _get_all_check_fact_ref(xccdf_el_root_xml):
-    return xccdf_el_root_xml.findall(".//{%s}check-fact-ref" % cpe_lang_ns)
+    return xccdf_el_root_xml.findall(".//{%s}check-fact-ref" % cpe_language_namespace)
 
 
 def get_all_cpe_oval_def_ids(xccdf_el_root_xml, cpe_dict, benchmark_cpe_names):

--- a/build-scripts/cpe_generate.py
+++ b/build-scripts/cpe_generate.py
@@ -136,6 +136,13 @@ def _save_minimal_cpe_oval(oval_document, path, oval_def_ids):
     oval_document.save_as_xml(path, references_to_keep)
 
 
+def _update_oval_href_in_xccdf(xccdf_el_root_xml, file_name):
+    for check_fact_ref in xccdf_el_root_xml.findall(
+        ".//{%s}check-fact-ref" % ssg.constants.PREFIX_TO_NS["cpe-lang"]
+    ):
+        check_fact_ref.set("href", file_name)
+
+
 def _generate_cpe_for_thin_xccdf(thin_ds_components_dir, oval_document, cpe_dict):
     for xccdf_path in glob.glob("{}/xccdf*.xml".format(thin_ds_components_dir)):
         cpe_oval_path = xccdf_path.replace("xccdf_", "cpe_oval_")
@@ -146,8 +153,10 @@ def _generate_cpe_for_thin_xccdf(thin_ds_components_dir, oval_document, cpe_dict
         used_cpe_oval_def_ids = get_all_cpe_oval_def_ids(
             xccdf_el_root_xml, cpe_dict, benchmark_cpe_names
         )
-        cpe_dict.to_file(cpe_dict_path, cpe_oval_path, benchmark_cpe_names)
+        cpe_dict.to_file(cpe_dict_path, os.path.basename(cpe_oval_path), benchmark_cpe_names)
         _save_minimal_cpe_oval(oval_document, cpe_oval_path, used_cpe_oval_def_ids)
+        _update_oval_href_in_xccdf(xccdf_el_root_xml, os.path.basename(cpe_oval_path))
+        ssg.xml.ElementTree.ElementTree(xccdf_el_root_xml).write(xccdf_path, encoding="utf-8")
 
 
 def main():

--- a/build-scripts/cpe_generate.py
+++ b/build-scripts/cpe_generate.py
@@ -23,6 +23,7 @@ from ssg.constants import XCCDF12_NS
 
 oval_ns = "http://oval.mitre.org/XMLSchema/oval-definitions-5"
 cpe_ns = "http://cpe.mitre.org/dictionary/2.0"
+cpe_lang_ns = ssg.constants.PREFIX_TO_NS["cpe-lang"]
 
 
 def parse_args():
@@ -96,9 +97,7 @@ def get_benchmark_cpe_names(xccdf_el_root_xml):
             continue
         benchmark_cpe_names.add(cpe_name)
 
-    for fact_ref in xccdf_el_root_xml.findall(
-        ".//{%s}fact-ref" % ssg.constants.PREFIX_TO_NS["cpe-lang"]
-    ):
+    for fact_ref in xccdf_el_root_xml.findall(".//{%s}fact-ref" % cpe_lang_ns):
         cpe_fact_ref_name = fact_ref.get("name")
         benchmark_cpe_names.add(cpe_fact_ref_name)
     return benchmark_cpe_names
@@ -114,6 +113,10 @@ def load_cpe_dictionary(benchmark_cpe_names, product_yaml, cpe_items_dir):
     return cpe_list
 
 
+def _get_all_check_fact_ref(xccdf_el_root_xml):
+    return xccdf_el_root_xml.findall(".//{%s}check-fact-ref" % cpe_lang_ns)
+
+
 def get_all_cpe_oval_def_ids(xccdf_el_root_xml, cpe_dict, benchmark_cpe_names):
     out = set()
 
@@ -121,9 +124,7 @@ def get_all_cpe_oval_def_ids(xccdf_el_root_xml, cpe_dict, benchmark_cpe_names):
         if cpe_item.name in benchmark_cpe_names:
             out.add(cpe_item.check_id)
 
-    for check_fact_ref in xccdf_el_root_xml.findall(
-        ".//{%s}check-fact-ref" % ssg.constants.PREFIX_TO_NS["cpe-lang"]
-    ):
+    for check_fact_ref in _get_all_check_fact_ref(xccdf_el_root_xml):
         out.add(check_fact_ref.get("id-ref"))
     return out
 
@@ -137,9 +138,7 @@ def _save_minimal_cpe_oval(oval_document, path, oval_def_ids):
 
 
 def _update_oval_href_in_xccdf(xccdf_el_root_xml, file_name):
-    for check_fact_ref in xccdf_el_root_xml.findall(
-        ".//{%s}check-fact-ref" % ssg.constants.PREFIX_TO_NS["cpe-lang"]
-    ):
+    for check_fact_ref in _get_all_check_fact_ref(xccdf_el_root_xml):
         check_fact_ref.set("href", file_name)
 
 

--- a/build-scripts/enable_derivatives.py
+++ b/build-scripts/enable_derivatives.py
@@ -69,6 +69,12 @@ def parse_args():
     return options, args
 
 
+def store_xml(tree, path):
+    if hasattr(ssg.xml.ElementTree, "indent"):
+        ssg.xml.ElementTree.indent(tree, space="  ", level=0)
+    tree.write(path, encoding="utf-8", xml_declaration=True)
+
+
 def main():
     options, args = parse_args()
 
@@ -125,7 +131,8 @@ def main():
         ssg.build_derivatives.add_oval_definition_to_cpe_oval(
             root, options.unlinked_oval_file_path, oval_def_id
         )
-    tree.write(options.output)
+
+    store_xml(tree, options.output)
 
 
 if __name__ == "__main__":

--- a/build-scripts/enable_derivatives.py
+++ b/build-scripts/enable_derivatives.py
@@ -16,8 +16,8 @@ Author: Martin Preisler <mpreisle@redhat.com>
 import sys
 from optparse import OptionParser
 
-import ssg.constants
 import ssg.build_derivatives
+import ssg.constants
 import ssg.xccdf
 import ssg.xml
 
@@ -48,6 +48,12 @@ def parse_args():
     parser.add_option(
         "--cpe-items-dir",
         dest="cpe_items_dir", help="path to the directory where compiled cpe items are stored")
+    parser.add_option(
+        "--unlinked-cpe-oval-path",
+        dest="unlinked_oval_file_path",
+        help="path to the unlinked cpe oval"
+    )
+
     (options, args) = parser.parse_args()
 
     if options.centos and options.sl:
@@ -112,9 +118,13 @@ def main():
             )
 
     ssg.build_derivatives.replace_platform(root, oval_ns, derivative)
-    ssg.build_derivatives.add_cpe_item_to_dictionary(
-        root, args[0], args[1], options.id_name, options.cpe_items_dir)
-
+    oval_def_id = ssg.build_derivatives.add_cpe_item_to_dictionary(
+        root, args[0], args[1], options.id_name, options.cpe_items_dir
+    )
+    if oval_def_id is not None:
+        ssg.build_derivatives.add_oval_definition_to_cpe_oval(
+            root, options.unlinked_oval_file_path, oval_def_id
+        )
     tree.write(options.output)
 
 

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -383,7 +383,7 @@ macro(ssg_build_cpe_dictionary PRODUCT)
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml"
         OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/cpe_generate.py" --product-yaml "${CMAKE_CURRENT_BINARY_DIR}/product.yml" --cpe-items-dir "${CMAKE_CURRENT_BINARY_DIR}/cpe_items" "${CMAKE_BINARY_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" "${CMAKE_CURRENT_BINARY_DIR}/cpe-oval-unlinked.xml"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/cpe_generate.py" --product-yaml "${CMAKE_CURRENT_BINARY_DIR}/product.yml" --cpe-items-dir "${CMAKE_CURRENT_BINARY_DIR}/cpe_items" "${CMAKE_BINARY_DIR}" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" "${CMAKE_CURRENT_BINARY_DIR}/cpe-oval-unlinked.xml" --thin-ds-components-dir "${SSG_THIN_DS_COMPONENTS_DIR}"
         COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml"
         COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml"
         DEPENDS generate-${PRODUCT}-xccdf-oval-ocil "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -932,7 +932,7 @@ macro(ssg_build_derivative_product ORIGINAL SHORTNAME DERIVATIVE)
 
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-xccdf.xml"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/enable_derivatives.py" --enable-${SHORTNAME} -i "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-xccdf.xml" -o "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-xccdf.xml" "${CMAKE_CURRENT_BINARY_DIR}/product.yml" ${DERIVATIVE} --id-name ssg --cpe-items-dir "${CMAKE_CURRENT_BINARY_DIR}/cpe_items"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/enable_derivatives.py" --enable-${SHORTNAME} -i "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-xccdf.xml" -o "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-xccdf.xml" "${CMAKE_CURRENT_BINARY_DIR}/product.yml" ${DERIVATIVE} --id-name ssg --cpe-items-dir "${CMAKE_CURRENT_BINARY_DIR}/cpe_items" --unlinked-cpe-oval-path "${CMAKE_CURRENT_BINARY_DIR}/cpe-oval-unlinked.xml"
         DEPENDS generate-ssg-${ORIGINAL}-xccdf.xml "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-xccdf.xml"
         DEPENDS ${PRODUCT}-compile-all "${CMAKE_CURRENT_BINARY_DIR}/ssg_build_compile_all-${PRODUCT}"
         COMMENT "[${DERIVATIVE}-content] generating ssg-${DERIVATIVE}-xccdf.xml"
@@ -944,7 +944,7 @@ macro(ssg_build_derivative_product ORIGINAL SHORTNAME DERIVATIVE)
 
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds.xml"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/enable_derivatives.py" --enable-${SHORTNAME} -i "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-ds.xml" -o "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds.xml" "${CMAKE_CURRENT_BINARY_DIR}/product.yml" ${DERIVATIVE} --id-name ssg --cpe-items-dir "${CMAKE_CURRENT_BINARY_DIR}/cpe_items"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/enable_derivatives.py" --enable-${SHORTNAME} -i "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-ds.xml" -o "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds.xml" "${CMAKE_CURRENT_BINARY_DIR}/product.yml" ${DERIVATIVE} --id-name ssg --cpe-items-dir "${CMAKE_CURRENT_BINARY_DIR}/cpe_items" --unlinked-cpe-oval-path "${CMAKE_CURRENT_BINARY_DIR}/cpe-oval-unlinked.xml"
         COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds.xml" "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds.xml"
         DEPENDS generate-ssg-${ORIGINAL}-ds.xml "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-ds.xml"
         DEPENDS ${PRODUCT}-compile-all "${CMAKE_CURRENT_BINARY_DIR}/ssg_build_compile_all-${PRODUCT}"
@@ -958,7 +958,7 @@ macro(ssg_build_derivative_product ORIGINAL SHORTNAME DERIVATIVE)
     if(SSG_BUILD_SCAP_12_DS)
         add_custom_command(
             OUTPUT "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds-1.2.xml"
-            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/enable_derivatives.py" --enable-${SHORTNAME} -i "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-ds-1.2.xml" -o "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds-1.2.xml" "${CMAKE_CURRENT_BINARY_DIR}/product.yml" ${DERIVATIVE} --id-name ssg --cpe-items-dir "${CMAKE_CURRENT_BINARY_DIR}/cpe_items"
+            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/enable_derivatives.py" --enable-${SHORTNAME} -i "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-ds-1.2.xml" -o "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds-1.2.xml" "${CMAKE_CURRENT_BINARY_DIR}/product.yml" ${DERIVATIVE} --id-name ssg --cpe-items-dir "${CMAKE_CURRENT_BINARY_DIR}/cpe_items" --unlinked-cpe-oval-path "${CMAKE_CURRENT_BINARY_DIR}/cpe-oval-unlinked.xml"
             COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds-1.2.xml" "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds-1.2.xml"
             DEPENDS generate-ssg-${ORIGINAL}-ds.xml "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-ds.xml" "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-ds-1.2.xml"
             DEPENDS ${PRODUCT}-compile-all "${CMAKE_CURRENT_BINARY_DIR}/ssg_build_compile_all-${PRODUCT}"

--- a/ssg/build_derivatives.py
+++ b/ssg/build_derivatives.py
@@ -7,9 +7,14 @@ from __future__ import print_function
 
 import re
 from .xml import ElementTree
-from .constants import standard_profiles, OSCAP_VENDOR, PREFIX_TO_NS, oval_namespace
-from .build_cpe import ProductCPEs
-from .id_translate import IDTranslator
+from .constants import (
+    standard_profiles,
+    OSCAP_VENDOR,
+    cpe_dictionary_namespace,
+    oval_namespace,
+    datastream_namespace,
+)
+from .build_cpe import ProductCPEs, get_linked_cpe_oval_document
 from .products import load_product_yaml
 
 
@@ -44,16 +49,65 @@ def add_cpes(elem, namespace, mapping):
     return affected
 
 
-def add_cpe_item_to_dictionary(tree_root, product_yaml_path, cpe_ref, id_name, cpe_items_dir):
-    cpe_list = tree_root.find(".//{%s}cpe-list" % (PREFIX_TO_NS["cpe-dict"]))
+def get_cpe_item(product_yaml, cpe_ref, cpe_items_dir):
+    product_cpes = ProductCPEs()
+    product_cpes.load_cpes_from_directory_tree(cpe_items_dir, product_yaml)
+    return product_cpes.get_cpe(cpe_ref)
+
+
+def add_cpe_item_to_dictionary(
+    tree_root, product_yaml_path, cpe_ref, id_name, cpe_items_dir
+):
+    cpe_list = tree_root.find(".//{%s}cpe-list" % cpe_dictionary_namespace)
     if cpe_list is not None:
         product_yaml = load_product_yaml(product_yaml_path)
-        product_cpes = ProductCPEs()
-        product_cpes.load_cpes_from_directory_tree(cpe_items_dir, product_yaml)
-        cpe_item = product_cpes.get_cpe(cpe_ref)
-        translator = IDTranslator(id_name)
-        cpe_item.check_id = translator.generate_id("{" + oval_namespace + "}definition", cpe_item.check_id)
-        cpe_list.append(cpe_item.to_xml_element("ssg-%s-cpe-oval.xml" % product_yaml.get("product")))
+        cpe_item = get_cpe_item(product_yaml, cpe_ref, cpe_items_dir)
+        cpe_item.content_id = id_name
+        cpe_item.set_cpe_oval_def_id()
+        cpe_list.append(
+            cpe_item.to_xml_element("ssg-%s-cpe-oval.xml" % product_yaml.get("product"))
+        )
+        return cpe_item.cpe_oval_short_def_id
+    return None
+
+
+def add_element_to(oval_root, tag_name, component_element):
+    xml_el = oval_root.find(".//{%s}%s" % (oval_namespace, tag_name))
+    if xml_el is None:
+        xml_el = ElementTree.Element("{%s}%s" % (oval_namespace, tag_name))
+        oval_root.append(xml_el)
+    xml_el.append(component_element)
+
+
+def add_oval_components_to_oval_xml(oval_root, tag_name, component_dict):
+    for component in component_dict.values():
+        add_element_to(oval_root, tag_name, component.get_xml_element())
+
+
+def get_cpe_oval_root(root):
+    for component_el in root.findall("./{%s}component" % datastream_namespace):
+        if "cpe-oval" in component_el.get("id", ""):
+            return component_el
+    return None
+
+
+def add_oval_definition_to_cpe_oval(root, unlinked_oval_file_path, oval_def_id):
+    oval_cpe_root = get_cpe_oval_root(root)
+    if oval_cpe_root is None:
+        raise Exception("CPE OVAL is missing in base DS!")
+
+    oval_document = get_linked_cpe_oval_document(unlinked_oval_file_path)
+
+    references_to_keep = oval_document.get_all_references_of_definition(oval_def_id)
+    oval_document.keep_referenced_components(references_to_keep)
+
+    add_oval_components_to_oval_xml(
+        oval_cpe_root, "definitions", oval_document.definitions
+    )
+    add_oval_components_to_oval_xml(oval_cpe_root, "tests", oval_document.tests)
+    add_oval_components_to_oval_xml(oval_cpe_root, "objects", oval_document.objects)
+    add_oval_components_to_oval_xml(oval_cpe_root, "states", oval_document.states)
+    add_oval_components_to_oval_xml(oval_cpe_root, "variables", oval_document.variables)
 
 
 def add_notice(benchmark, namespace, notice, warning):

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -72,6 +72,7 @@ datastream_namespace = "http://scap.nist.gov/schema/scap/source/1.2"
 dc_namespace = "http://purl.org/dc/elements/1.1/"
 ocil_namespace = "http://scap.nist.gov/schema/ocil/2.0"
 cpe_language_namespace = "http://cpe.mitre.org/language/2.0"
+cpe_dictionary_namespace = "http://cpe.mitre.org/dictionary/2.0"
 oval_footer = "</oval_definitions>"
 oval_namespace = "http://oval.mitre.org/XMLSchema/oval-definitions-5"
 xlink_namespace = "http://www.w3.org/1999/xlink"
@@ -139,9 +140,9 @@ PREFIX_TO_NS = {
     "xccdf-1.2": XCCDF12_NS,
     "html": xhtml_namespace,
     "xlink": xlink_namespace,
-    "cpe-dict": "http://cpe.mitre.org/dictionary/2.0",
+    "cpe-dict": cpe_dictionary_namespace,
     "cat": cat_namespace,
-    "cpe-lang": "http://cpe.mitre.org/language/2.0",
+    "cpe-lang": cpe_language_namespace,
     "sce": sce_namespace,
 }
 


### PR DESCRIPTION
#### Description:
This PR reduces the CPE OVAL, CPE AL and CPE dictionary in the data stream. This PR also includes the integration of minimal CPE components into thin DS.  For example, the data stream size reduction generated by `./build_product fedora --rule-id audit_rules_privileged_commands_fusermount3` is 249K. 

This PR also deals with the problem of adding new CPE platforms to the derivative. In connection with this, an automatically formatted derivative is generated. 

#### Review Hints:

To test one rule you can run this command:
```bash
./build_product fedora --rule-id audit_rules_privileged_commands_fusermount3
```

To test changes you can run this script:
```bash
#!/bin/bash

./build_product fedora --thin

for filename in ./build/thin_ds/*.xml; do
    echo "$filename"
    oscap xccdf eval  --profile "(all)" --results-arf "arf_results/arf_$(basename -- $filename)" "$filename"
done
```
_The script generates a thin Datastream for each rule and then performs a scan using `oscap`.
This test takes more than an hour to run because there are approximately 1830 rules to process and some are memory intensive._

Depends on:
- #11644