### PR TITLE
Enable ansible  in SLE for dconf_gnome_session_idle_user_locks

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle
 # reboot = false
 # strategy = unknown
 # complexity = low


### PR DESCRIPTION
#### Description:

- Make sure ansible remediation for dconf_gnome_session_idle_user_locks rule is valid also for the SLE platforms

#### Rationale:

- Remediation is relevant for SLE so enable it via multi_platform_sle