### PR TITLE
Simplify output of ip link show command

### DIFF
--- a/linux_os/guide/system/network/network_sniffer_disabled/ansible/shared.yml
+++ b/linux_os/guide/system/network/network_sniffer_disabled/ansible/shared.yml
@@ -6,11 +6,11 @@
 
 - name: "{{{ rule_title }}} - Gather network interfaces"
   ansible.builtin.command:
-    cmd: ip link show
+    cmd: ip -o link show
   register: network_interfaces
 
 - name: "{{{ rule_title }}} - Disable promiscuous mode"
   ansible.builtin.command:
     cmd: ip link set dev {{ item.split(':')[1] }} multicast off promisc off
   loop: "{{ network_interfaces.stdout_lines }}"
-  when: "item.split(':') | length == 3"
+  when: "item.split(':')"

--- a/linux_os/guide/system/network/network_sniffer_disabled/bash/shared.sh
+++ b/linux_os/guide/system/network/network_sniffer_disabled/bash/shared.sh
@@ -4,6 +4,6 @@
 # complexity = low
 # disruption = low
 
-for interface in $(ip link show | grep -E '^[0-9]' | cut -d ":" -f 2); do
+for interface in $(ip -o link show | cut -d ":" -f 2); do
     ip link set dev $interface multicast off promisc off
 done

--- a/linux_os/guide/system/network/network_sniffer_disabled/tests/no_promisc_interfaces.pass.sh
+++ b/linux_os/guide/system/network/network_sniffer_disabled/tests/no_promisc_interfaces.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-for interface in $(ip link show | grep -i promisc | sed 's/^.*: \(.*\):.*$/\1/'); do
+for interface in $(ip -o link show | grep -i promisc | sed 's/^.*: \(.*\):.*$/\1/'); do
   ip link set dev $interface promisc off
 done


### PR DESCRIPTION
#### Description:

In `network_sniffer_disabled` rule this command is used to collect the interface names.
This can be simplified using the -o (oneline) option from `ip` command instead of filtering the output with other commands.

This was noticed when investigating failures in CI tests for https://github.com/ComplianceAsCode/content/pull/11248 

#### Rationale:

Simplify command output so Bash and Ansible remediation are more robust.
Less is more. : )