### PR TITLE
extend misleading Automatus error message

### DIFF
--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -568,9 +568,9 @@ class RuleRunner(GenericRunner):
                 msg = (
                     'Rule {0} has not been evaluated! '
                     'Wrong profile selected in test scenario or '
-                    'there has been problem starting the evaluation. Attaching output:\n'
-                    '{1}'
-                    .format(self.rule_id, self._oscap_output))
+                    'there has been problem starting the evaluation. '
+                    'Please inspect the log file {1} for details.'
+                    .format(self.rule_id, self.verbose_path))
             else:
                 msg = (
                     'Rule evaluation resulted in {0}, '

--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -567,8 +567,10 @@ class RuleRunner(GenericRunner):
             if rule_result == 'notselected':
                 msg = (
                     'Rule {0} has not been evaluated! '
-                    'Wrong profile selected in test scenario?'
-                    .format(self.rule_id))
+                    'Wrong profile selected in test scenario or '
+                    'there has been problem starting the evaluation. Attaching output:\n'
+                    '{1}'
+                    .format(self.rule_id, self._oscap_output))
             else:
                 msg = (
                     'Rule evaluation resulted in {0}, '


### PR DESCRIPTION
### Description:

- The error message is extended and the oscap output is appended

#### Rationale:

- The condition checks that the output does not contain the rule id. This can mean that the rule has not been selected. But it can mean also other errors, e.g. there has been problem starting evaluation.

I think this manifests also here: https://github.com/ComplianceAsCode/content/issues/10895

#### Review Hints:

I managed to reproduce it by editing /etc/nsswitch.conf, removing all lines starting with "passwd" and replacing them with:

```
passwd nis
```

This is invalid on RHEL 9 and mostly on RHEL 8. It seems this prevents oscap-ssh from logging in and the error message is encountered.