### PR TITLE
Corrections in aide_periodic_cron_checking and aide_scan_notification…

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/ansible/shared.yml
@@ -16,7 +16,7 @@
         Description=Aide Check
         [Service]
         Type=simple
-        ExecStart=/usr/sbin/aide --check
+        ExecStart={{{ aide_bin_path }}} --check
         [Install]
         WantedBy=multi-user.target
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/bash/shared.sh
@@ -8,7 +8,7 @@ cat > /etc/systemd/system/aidecheck.service <<EOF
 Description=Aide Check
 [Service]
 Type=simple
-ExecStart=/usr/sbin/aide --check
+ExecStart={{{ aide_bin_path }}} --check
 [Install]
 WantedBy=multi-user.target
 EOF

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/tests/aide_timer_weekly.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/tests/aide_timer_weekly.pass.sh
@@ -7,7 +7,7 @@ cat > /etc/systemd/system/aidecheck.service <<EOF
 Description=Aide Check
 [Service]
 Type=simple
-ExecStart=/usr/sbin/aide --check
+ExecStart={{{ aide_bin_path }}} --check
 [Install]
 WantedBy=multi-user.target
 EOF

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/policy/stig/shared.yml
@@ -27,7 +27,7 @@ checktext: |-
     $ sudo more /etc/cron.daily/aide
 
     #!/bin/bash
-    /usr/sbin/aide --check | /bin/mail -s "$HOSTNAME - Daily aide integrity check run" root@sysname.mil
+    {{{ aide_bin_path }}} --check | /bin/mail -s "$HOSTNAME - Daily aide integrity check run" root@sysname.mil
 
     If the file integrity application does not exist, or a script file controlling the execution of the file integrity application does not exist, or the file integrity application does not notify designated personnel of changes, this is a finding.
 
@@ -39,4 +39,4 @@ fixtext: |-
     $ sudo more /etc/cron.daily/aide
 
     #!/bin/bash
-    /usr/sbin/aide --check | /bin/mail -s "$HOSTNAME - Daily aide integrity check run" root@sysname.mil
+    {{{ aide_bin_path }}} --check | /bin/mail -s "$HOSTNAME - Daily aide integrity check run" root@sysname.mil

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/aide_not_installed.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/aide_not_installed.fail.sh
@@ -3,4 +3,4 @@
 
 {{{ bash_package_remove("aide") }}}
 
-echo '21    21    *    *    *    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab
+echo '21    21    *    *    *    root    {{{ aide_bin_path }}} --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/cron_daily.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/cron_daily.pass.sh
@@ -2,4 +2,4 @@
 # packages = aide,crontabs
 
 mkdir -p /etc/cron.daily
-echo "/usr/sbin/aide --check" > /etc/cron.daily/aide
+echo "{{{ aide_bin_path }}} --check" > /etc/cron.daily/aide

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/cron_daily_complex.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/cron_daily_complex.pass.sh
@@ -6,7 +6,7 @@
 mkdir -p /etc/cron.daily
 cat > /etc/cron.daily/aide << EOF
 #!/bin/sh
-nice ionice /usr/sbin/aide --check
-nice ionice /usr/sbin/aide --init
+nice ionice {{{ aide_bin_path }}} --check
+nice ionice {{{ aide_bin_path }}} --init
 /bin/mv -f /var/lib/aide/aide.db.new.gz /var/lib/aide/aide.db.gz
 EOF

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_daily.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_daily.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # packages = aide,crontabs
 
-echo '21    21    *    *    *    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab
+echo '21    21    *    *    *    root    {{{ aide_bin_path }}} --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_daily_shortcut.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_daily_shortcut.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # packages = aide,crontabs
 
-echo '@daily    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab
+echo '@daily    root    {{{ aide_bin_path }}} --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_monthly.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_monthly.fail.sh
@@ -4,4 +4,4 @@
 # aide installs automatically a file that is periodically run on /etc/cron.daily/aide
 rm -f /etc/cron.daily/aide
 
-echo '21    21    1    *    *    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab
+echo '21    21    1    *    *    root    {{{ aide_bin_path }}} --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_two_days_week.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_two_days_week.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # packages = aide,crontabs
 
-echo '21    21    *    *    1-2    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab
+echo '21    21    *    *    1-2    root    {{{ aide_bin_path }}} --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_on_exact_day.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_on_exact_day.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # packages = aide,crontabs
 
-echo '21    21    *    *    3    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab
+echo '21    21    *    *    3    root    {{{ aide_bin_path }}} --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_shortcut.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_shortcut.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # packages = aide,crontabs
 
-echo '@weekly    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab
+echo '@weekly    root    {{{ aide_bin_path }}} --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_word.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_word.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # packages = aide,crontabs
 
-echo '21    21    *    *    mon    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab
+echo '21    21    *    *    mon    root    {{{ aide_bin_path }}} --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_yearly.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_yearly.fail.sh
@@ -4,4 +4,4 @@
 # aide installs automatically a file that is periodically run on /etc/cron.daily/aide
 rm -f /etc/cron.daily/aide
 
-echo '21    21    1    2    *    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab
+echo '21    21    1    2    *    root    {{{ aide_bin_path }}} --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/policy/stig/shared.yml
@@ -19,7 +19,7 @@ checktext: |-
     To determine that periodic AIDE execution has been scheduled, run the following command:
      $ grep aide /etc/crontab
     The output should return something similar to the following:
-     05 4 * * * root /usr/sbin/aide --check | /bin/mail -s "$(hostname) - AIDE Integrity Check" root@localhost
+     05 4 * * * root {{{ aide_bin_path }}} --check | /bin/mail -s "$(hostname) - AIDE Integrity Check" root@localhost
     The email address that the notifications are sent to can be changed by overriding
      root@localhost .
 
@@ -33,4 +33,4 @@ fixtext: |-
     $ sudo more /etc/cron.daily/aide
 
     #!/bin/bash
-    /usr/sbin/aide --check | /bin/mail -s "$HOSTNAME - Daily aide integrity check run" root@sysname.mil
+    {{{ aide_bin_path }}} --check | /bin/mail -s "$HOSTNAME - Daily aide integrity check run" root@sysname.mil

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/rule.yml
@@ -9,7 +9,7 @@ description: |-
     following line to the existing AIDE line:
     <pre> | /bin/mail -s "$(hostname) - AIDE Integrity Check" root@localhost</pre>
     Otherwise, add the following line to <tt>/etc/crontab</tt>:
-    <pre>05 4 * * * root /usr/sbin/aide --check | /bin/mail -s "$(hostname) - AIDE Integrity Check" root@localhost</pre>
+    <pre>05 4 * * * root {{{ aide_bin_path }}} --check | /bin/mail -s "$(hostname) - AIDE Integrity Check" root@localhost</pre>
     AIDE can be executed periodically through other means; this is merely one example.
 
 rationale: |-
@@ -64,7 +64,7 @@ ocil: |-
 {{% else %}}
     <pre>$ grep aide /etc/crontab</pre>
     The output should return something similar to the following:
-    <pre>05 4 * * * root /usr/sbin/aide --check | /bin/mail -s "$(hostname) - AIDE Integrity Check" root@localhost</pre>
+    <pre>05 4 * * * root {{{ aide_bin_path }}} --check | /bin/mail -s "$(hostname) - AIDE Integrity Check" root@localhost</pre>
     The email address that the notifications are sent to can be changed by overriding
     <pre><sub idref="var_aide_scan_notification_email" /></pre>.
 {{% endif %}}
@@ -88,7 +88,7 @@ fixtext: |-
 
     #!/bin/bash
 
-    /usr/sbin/aide --check | /bin/mail -s "$HOSTNAME - Daily aide integrity check run" root@sysname.mil
+    {{{ aide_bin_path }}} --check | /bin/mail -s "$HOSTNAME - Daily aide integrity check run" root@sysname.mil
 {{% endif %}}
 
 srg_requirement: |-

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/cron_weekly_configured.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/cron_weekly_configured.pass.sh
@@ -2,4 +2,4 @@
 # packages = aide,crontabs
 
 # configured in crontab
-echo '0 5 * * * root /usr/sbin/aide  --check | /bin/mail -s "Automatus - AIDE Integrity Check" admin@automatus' > /etc/cron.weekly/aidescan
+echo '0 5 * * * root {{{ aide_bin_path }}}  --check | /bin/mail -s "Automatus - AIDE Integrity Check" admin@automatus' > /etc/cron.weekly/aidescan

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/crontab_configured.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/crontab_configured.pass.sh
@@ -2,4 +2,4 @@
 # packages = aide,crontabs
 
 # configured in crontab
-echo '0 5 * * * root /usr/sbin/aide  --check | /bin/mail -s "Automatus - AIDE Integrity Check" admin@automatus' >> /etc/crontab
+echo '0 5 * * * root {{{ aide_bin_path }}}  --check | /bin/mail -s "Automatus - AIDE Integrity Check" admin@automatus' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/crontab_just_periodic_checking.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/crontab_just_periodic_checking.fail.sh
@@ -2,4 +2,4 @@
 # packages = aide,crontabs
 
 # configured in crontab
-echo '0 5 * * * root /usr/sbin/aide  --check' >> /etc/crontab
+echo '0 5 * * * root {{{ aide_bin_path }}}  --check' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/var_cron_configured.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/var_cron_configured.pass.sh
@@ -2,4 +2,4 @@
 # packages = aide,cronie
 
 # configured in crontab
-echo '0 5 * * * root /usr/sbin/aide  --check | /bin/mail -s "Automatus - AIDE Integrity Check" admin@automatus' >> /var/spool/cron/root
+echo '0 5 * * * root {{{ aide_bin_path }}}  --check | /bin/mail -s "Automatus - AIDE Integrity Check" admin@automatus' >> /var/spool/cron/root

--- a/products/sle15/profiles/stig.profile
+++ b/products/sle15/profiles/stig.profile
@@ -71,6 +71,7 @@ selections:
     - agent_mfetpd_running
     - aide_build_database
     - aide_check_audit_tools
+    - aide_periodic_cron_checking
     - aide_scan_notification
     - aide_verify_acls
     - aide_verify_ext_attributes

--- a/shared/references/disa-stig-sle12-v2r13-xccdf-manual.xml
+++ b/shared/references/disa-stig-sle12-v2r13-xccdf-manual.xml
@@ -864,7 +864,7 @@ The following example output is generic. It will set cron to run AIDE weekly, bu
 
      # sudo crontab -l
 
-     0 0 * * 6 /usr/sbin/aide --check | /bin/mail -s "$HOSTNAME - Daily AIDE integrity check run" root@example_server_name.mil
+     0 0 * * 6 /usr/bin/aide --check | /bin/mail -s "$HOSTNAME - Daily AIDE integrity check run" root@example_server_name.mil
 
 Note: Per requirement SLES-12-010498, the "mailx" package must be installed on the system to enable email functionality.</fixtext><fix id="F-18374r902839_fix" /><check system="C-18376r902838_chk"><check-content-ref href="SUSE_Linux_Enterprise_Server_12_STIG.xml" name="M" /><check-content>Verify the SUSE operating system checks the baseline configuration for unauthorized changes at least once weekly.
 
@@ -891,14 +891,14 @@ This capability must take into account operational requirements for availability
 
 Add following command to a cron job replacing the "[E-MAIL]" parameter with a proper email address for the SA:
 
-     /usr/sbin/aide --check | /bin/mail -s "$HOSTNAME - Daily AIDE integrity check run" root@example_server_name.mil
+     /usr/bin/aide --check | /bin/mail -s "$HOSTNAME - Daily AIDE integrity check run" root@example_server_name.mil
 
 Note: Per requirement SLES-12-010498, the "mailx" package must be installed on the system to enable email functionality.</fixtext><fix id="F-18375r902842_fix" /><check system="C-18377r902841_chk"><check-content-ref href="SUSE_Linux_Enterprise_Server_12_STIG.xml" name="M" /><check-content>Verify the SUSE operating system notifies the SA when AIDE discovers anomalies in the operation of any security functions.
 
 Check to see if the aide cron job sends an email when executed with the following command:
 
      # sudo crontab -l 
-     0 0 * * 6 /usr/sbin/aide --check | /bin/mail -s "$HOSTNAME - Daily AIDE integrity check run" root@example_server_name.mil
+     0 0 * * 6 /usr/bin/aide --check | /bin/mail -s "$HOSTNAME - Daily AIDE integrity check run" root@example_server_name.mil
 
 If a "crontab" entry does not exist, check the cron directories for a script that runs the file integrity application and is configured to execute a binary to send an email:
 

--- a/shared/references/disa-stig-sle15-v1r12-xccdf-manual.xml
+++ b/shared/references/disa-stig-sle15-v1r12-xccdf-manual.xml
@@ -1216,7 +1216,7 @@ If the "aide" package is not installed, install it with the following command:
 Configure the file integrity tool to automatically run on the system at least weekly. The following example output is generic. It will set cron to run AIDE weekly, but other file integrity tools may be used:
 
      &gt; cat /etc/cron.weekly/aide 
-     0 0 * * * /usr/sbin/aide --check | /bin/mail -s "$HOSTNAME - Daily AIDE integrity check run" root@example_server_name.mil
+     0 0 * * * /usr/bin/aide --check | /bin/mail -s "$HOSTNAME - Daily AIDE integrity check run" root@example_server_name.mil
 
 Note: Per requirement SLES-15-010418, the "mailx" package must be installed on the system to enable email functionality.</fixtext><fix id="F-38002r902850_fix" /><check system="C-38039r880946_chk"><check-content-ref href="SUSE_Linux_Enterprise_Server_15_STIG.xml" name="M" /><check-content>Verify the SUSE operating system checks the baseline configuration for unauthorized changes at least once weekly.
 
@@ -1468,14 +1468,14 @@ This capability must take into account operational requirements for availability
 
 Create the aide crontab file in "/etc/cron.daily" and add following command replacing the "[E-MAIL]" parameter with a proper email address for the SA:
 
-     0 0 * * * /usr/sbin/aide --check | /bin/mail -s "$HOSTNAME - Daily AIDE integrity check run" root@example_server_name.mil
+     0 0 * * * /usr/bin/aide --check | /bin/mail -s "$HOSTNAME - Daily AIDE integrity check run" root@example_server_name.mil
 
 Note: Per requirement SLES-15-010418, the "mailx" package must be installed on the system to enable email functionality.</fixtext><fix id="F-38015r902853_fix" /><check system="C-38052r902852_chk"><check-content-ref href="SUSE_Linux_Enterprise_Server_15_STIG.xml" name="M" /><check-content>Verify the SUSE operating system notifies the SA when AIDE discovers anomalies in the operation of any security functions.
 
 Check to see if the aide cron job sends an email when executed with the following command:
 
      &gt; grep -i "aide" /etc/cron.*/aide 
-     0 0 * * * /usr/sbin/aide --check | /bin/mail -s "$HOSTNAME - Daily AIDE integrity check run" root@example_server_name.mil
+     0 0 * * * /usr/bin/aide --check | /bin/mail -s "$HOSTNAME - Daily AIDE integrity check run" root@example_server_name.mil
 
 If the "aide" file does not exist under the "/etc/cron" directory structure or the cron job is not configured to execute a binary to send an email (such as "/bin/mail"), this is a finding.</check-content></check></Rule></Group><Group id="V-234865"><title>SRG-OS-000479-GPOS-00224</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-234865r854211_rule" weight="10.0" severity="medium"><version>SLES-15-010580</version><title>The SUSE operating system must off-load rsyslog messages for networked systems in real time and off-load standalone systems at least weekly.</title><description>&lt;VulnDiscussion&gt;Information stored in one location is vulnerable to accidental or incidental deletion or alteration.
 

--- a/tests/data/product_stability/opensuse.yml
+++ b/tests/data/product_stability/opensuse.yml
@@ -1,6 +1,6 @@
 aide_also_checks_audispd: 'yes'
 aide_also_checks_rsyslog: 'no'
-aide_bin_path: /usr/sbin/aide
+aide_bin_path: /usr/bin/aide
 aide_conf_path: /etc/aide.conf
 audisp_conf_path: /etc/audit
 auid: 1000


### PR DESCRIPTION
… - SUSE products

#### Description:

- _The proposed correction corrects 2 rules aide_periodic_cron_checking  and aide_scan_notification _

#### Rationale:
SUSE SLE 12 and SLE 15 install aide in /usr/bin/aide, but both rules consider that the location is /usr/sbin/aide, following recommendations of DISA. This issue was addressed to DISA by SUSE.
Also there is an open discussion https://github.com/ComplianceAsCode/content/discussions/11661. The proposed correction covers only SUSE products. 




