### PR TITLE
utils/gen_rendered_policies_index.py: read compiled control files

### DIFF
--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -222,6 +222,7 @@ class Policy(ssg.entities.common.XCCDFEntity):
     def represent_as_dict(self):
         data = dict()
         data["id"] = self.id
+        data["policy"] = self.policy
         data["title"] = self.title
         data["source"] = self.source
         data["definition_location"] = self.filepath
@@ -337,6 +338,7 @@ class Policy(ssg.entities.common.XCCDFEntity):
         if controls_dir:
             self.controls_dir = os.path.join(os.path.dirname(self.filepath), controls_dir)
         self.id = ssg.utils.required_key(yaml_contents, "id")
+        self.policy = ssg.utils.required_key(yaml_contents, "policy")
         self.title = ssg.utils.required_key(yaml_contents, "title")
         self.source = yaml_contents.get("source", "")
         self.reference_type = yaml_contents.get("reference_type", None)

--- a/utils/gen_rendered_policies_index.py
+++ b/utils/gen_rendered_policies_index.py
@@ -23,18 +23,17 @@ def get_rendered_policies_ids(rendered_policies_dir):
     return policy_ids
 
 
-def get_policy_names(ssg_root):
+def get_policy_names(ssg_root, products):
     policy_names = dict()
-    p = pathlib.Path(ssg_root)
-    for control_file in p.glob("controls/*.yml"):
-        # only process files, ignore controls directories
-        if not os.path.isfile(control_file):
-            continue
-        policy_id = pathlib.Path(control_file).stem
-        with open(control_file, "r") as f:
-            policy_yaml = yaml.full_load(f)
-        policy_name = policy_yaml["policy"]
-        policy_names[policy_id] = policy_name
+    for product in products:
+        p = pathlib.Path(ssg_root, "build", product.id)
+        for control_file in p.glob("controls/*.yml"):
+            policy_id = pathlib.Path(control_file).stem
+            if policy_id not in policy_names:
+                with open(control_file, "r") as f:
+                    policy_yaml = yaml.full_load(f)
+                policy_name = policy_yaml["policy"]
+                policy_names[policy_id] = policy_name
     return policy_names
 
 
@@ -62,7 +61,7 @@ def get_products(ssg_root):
 
 def get_data(ssg_root):
     products = get_products(ssg_root)
-    policy_names = get_policy_names(ssg_root)
+    policy_names = get_policy_names(ssg_root, products)
     data = {"products": products, "policy_names": policy_names}
     return data
 


### PR DESCRIPTION
#### Description:

- include the "policy" key in compiled control files
- the script for generating of  HTML index for rendered policies now reads compiled control files

#### Rationale:

Control files in the "controls" directory can contain Jinja macros. If a script wants to parse our content with Jinja macros, it requires non-trivial steps to get this working.
The script gen_rendered_policies_index.py is very simple and it reads literarily one key (policy) from the control file. Therefore, it does not care about Jinja at all.
Therefore, it is now reading compiled contro files in the build/<product>/controls directory.

This problem was discovered in this PR which added Jinja statements into ANSSI file: https://github.com/ComplianceAsCode/content/pull/11663


#### Review Hints:

I think you can review the Github action which builds the web content and compare it with the one present at https://complianceascode.github.io/content-pages/

Or you can do following steps for master and the PR and compare results:

1. cd build
2. rm -r *
3. cmake ../
4. make -j8 
5. make -j8 render-policies
6. cd ..
7. source .pyenv.sh
8. ./utils/gen_rendered_policies_index.py /tmp/sites
9. inspect /tmp/sites directory