### PR TITLE
add the "components" test among quick tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -324,6 +324,7 @@ add_test(
     NAME "components"
     COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/test_components.py" --build-dir "${CMAKE_BINARY_DIR}" --source-dir "${CMAKE_SOURCE_DIR}" --product "rhel9"
 )
+set_tests_properties("components" PROPERTIES LABELS quick)
 endif()
 
 macro(cce_avail_check TEST_NAME_SUFFIX PRODUCTS CCE_LIST_PATH)


### PR DESCRIPTION
#### Description:

- add the quick label to components test

#### Rationale:

- the test is quick
- a developer (like me) may run quick tests before submitting a PR to catch mistakes

