### PR TITLE
all_apparmor_profiles_in_enforce_complain_mode: Fix OVAL logic

### DIFF
--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/oval/shared.xml
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/oval/shared.xml
@@ -8,23 +8,17 @@
   </definition>
   <ind:textfilecontent54_object id="{{{ rule_id }}}_obj_apparmor_profiles" version="1">
     <ind:filepath datatype="string">/sys/kernel/security/apparmor/profiles</ind:filepath>
-    <ind:pattern operation="pattern match">^.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^(.*)$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_object id="{{{ rule_id }}}_obj_apparmor_enforced_profiles" version="1">
     <ind:filepath datatype="string">/sys/kernel/security/apparmor/profiles</ind:filepath>
-    <ind:pattern operation="pattern match" datatype="string">^.*\(enforce\)$</ind:pattern>
+    <ind:pattern operation="pattern match" datatype="string">^.*(\(enforce\))$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_object id="{{{ rule_id }}}_obj_apparmor_complaining_profiles" version="1">
     <ind:filepath datatype="string">/sys/kernel/security/apparmor/profiles</ind:filepath>
-    <ind:pattern operation="pattern match" datatype="string">^.*\(complain\)$</ind:pattern>
-    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-  <ind:textfilecontent54_object id="{{{ rule_id }}}_obj_apparmor_unconfined_profiles" version="1">
-    <ind:filepath datatype="string">/sys/kernel/security/apparmor/profiles</ind:filepath>
-    <ind:pattern operation="pattern match"
-      datatype="string">^\.*processes are unconfined.*$</ind:pattern>
+    <ind:pattern operation="pattern match" datatype="string">^.*(\(complain\))$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <local_variable datatype="int" id="{{{ rule_id }}}_var_num_apparmor_profiles" version="1"
@@ -46,11 +40,6 @@
         object_ref="{{{ rule_id }}}_obj_apparmor_complaining_profiles" />
       </count>
     </arithmetic>
-  </local_variable>
-  <local_variable datatype="int" id="{{{ rule_id }}}_var_num_apparmor_unconfined_profiles"
-    version="1" comment="apparmor profiles with unconfined processes">
-    <object_component item_field="subexpression"
-     object_ref="{{{ rule_id }}}_obj_apparmor_unconfined_profiles" />
   </local_variable>
 
   <ind:variable_object id="{{{ rule_id }}}_obj_all_apparmor_profiles" version="1">

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/correct_all_apparmor_profiles_in_complain.pass.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/correct_all_apparmor_profiles_in_complain.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = apparmor
+# packages = apparmor-utils
 
 #Replace apparmor definitions
 apparmor_parser -q -r /etc/apparmor.d/

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/correct_all_apparmor_profiles_in_enforce.pass.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/correct_all_apparmor_profiles_in_enforce.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = apparmor
+# packages = apparmor-utils
 
 #Replace apparmor definitions
 apparmor_parser -q -r /etc/apparmor.d/

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/incorrect_all_apparmor_profiles.fail.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/incorrect_all_apparmor_profiles.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = apparmor
+# packages = apparmor-utils
 
 #Configure the OS to unload all AppArmor profiles
 aa-teardown


### PR DESCRIPTION
#### Description:

- Current OVAL fails with `unknown` result because the variables are looking for a `subexpression` field of the object when there's none. Instead use `text` part of the object. Also change how you seek for unconfined.
- Also fixes test not working on sle15.

#### Rationale:

- To have a `subexpression` field from the object you would need to select some specific text with parenthesis, but that's not being done. Since we don't care about the actual pattern being matched but instead the number of matches, using the `text` field instead is enough.

#### Review Hints:

- OVAL passes.