### PR TITLE
accounts_passwords_pam_tally2_deny_root fix

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_deny_root/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_deny_root/ansible/shared.yml
@@ -3,7 +3,9 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+{{{ ansible_instantiate_variables("var_password_pam_tally2")  }}}
 
 {{{ ansible_remove_pam_module_option('/etc/pam.d/login', 'auth', 'required', 'pam_tally2.so', 'onerr=fail') }}}
+{{{ ansible_ensure_pam_module_option('/etc/pam.d/login', 'auth', 'required', 'pam_tally2.so', 'deny', "{{ var_password_pam_tally2 }}", '') }}}
 {{{ ansible_ensure_pam_module_option('/etc/pam.d/login', 'auth', 'required', 'pam_tally2.so', 'even_deny_root', '', '') }}}
 {{{ ansible_ensure_pam_module_option('/etc/pam.d/common-account', 'account', 'required', 'pam_tally2.so', '', '', '') }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_deny_root/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_deny_root/bash/shared.sh
@@ -3,7 +3,9 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+{{{ bash_instantiate_variables("var_password_pam_tally2") }}}
 
 {{{ bash_remove_pam_module_option('/etc/pam.d/login', 'auth', 'required', 'pam_tally2.so', 'onerr=fail') }}}
+{{{ bash_ensure_pam_module_option('/etc/pam.d/login', 'auth', 'required', 'pam_tally2.so', 'deny', "${var_password_pam_tally2}", '') }}}
 {{{ bash_ensure_pam_module_option('/etc/pam.d/login', 'auth', 'required', 'pam_tally2.so', 'even_deny_root', '', '') }}}
 {{{ bash_ensure_pam_module_option('/etc/pam.d/common-account', 'account', 'required', 'pam_tally2.so', '', '', '') }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_deny_root/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_deny_root/oval/shared.xml
@@ -18,8 +18,8 @@
 
   <ind:textfilecontent54_object id="object_accounts_passwords_pam_tally2_even_deny_root" comment="Check even deny root configuration of pam_tally2" version="1">
     <ind:filepath>/etc/pam.d/login</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*auth(?:(?!\n)\s)+required(?:(?!\n)\s)+pam_tally2.so(?:(?!\n)\s)+(?:(?:(?:(?!\n)\s)?[^\n]+)?onerr=fail(?:(?:(?!\n)\s)+[^\n]+)?(?:(?!\n)\s)+deny=(\d+)(?:(?:\s+\S+)*\s*$))|(?:(?:(?:(?!\n)\s)?[^\n]+)?deny=(\d+)(?:(?:(?!\n)\s)+[^\n]+)?(?:(?!\n)\s)+even_deny_root(?:(?:\s+\S+)*\s*$))</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>    
+    <ind:pattern operation="pattern match">^\s*auth(?:(?!\n)\s)+required(?:(?!\n)\s)+pam_tally2.so(?:(?!\n)\s)+(?:(?:(?:(?!\n)\s)?[^\n]+)?even_deny_root(?:(?:\s+\S+)*\s*$))</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_test id="test_accounts_passwords_pam_tally2_even_deny_root_account"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_deny_root/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_deny_root/oval/shared.xml
@@ -5,6 +5,8 @@
     <criteria operator="AND" comment="Checks common to both scenarios">
       <criterion test_ref="test_accounts_passwords_pam_tally2_even_deny_root"
       comment="Verify deny root configuation of pam_tally2 in common-auth" />
+      <criterion test_ref="test_accounts_passwords_pam_tally2_deny_number"
+      comment="Verify deny number configuation of pam_tally2 in common-auth" />
       <criterion test_ref="test_accounts_passwords_pam_tally2_even_deny_root_account"
       comment="Verify deny configuation of pam_tally2 in common-account" />
     </criteria>
@@ -19,6 +21,18 @@
   <ind:textfilecontent54_object id="object_accounts_passwords_pam_tally2_even_deny_root" comment="Check even deny root configuration of pam_tally2" version="1">
     <ind:filepath>/etc/pam.d/login</ind:filepath>
     <ind:pattern operation="pattern match">^\s*auth(?:(?!\n)\s)+required(?:(?!\n)\s)+pam_tally2.so(?:(?!\n)\s)+(?:(?:(?:(?!\n)\s)?[^\n]+)?even_deny_root(?:(?:\s+\S+)*\s*$))</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="test_accounts_passwords_pam_tally2_deny_number"
+  check="all" check_existence="all_exist"
+  comment="Verify deny number configuation of pam_tally2" version="1">
+    <ind:object object_ref="object_accounts_passwords_pam_tally2_deny_number" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_accounts_passwords_pam_tally2_deny_number" comment="Check deny number configuration of pam_tally2" version="1">
+    <ind:filepath>/etc/pam.d/login</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*auth(?:(?!\n)\s)+required(?:(?!\n)\s)+pam_tally2.so(?:(?!\n)\s)+(?:(?:(?:(?!\n)\s)?[^\n]+)?deny=(\d+)(?:(?:\s+\S+)*\s*$))</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 


### PR DESCRIPTION
#### Description:

- The rule accounts_passwords_pam_tally2_deny_root was failing oval check eventhough remediation was applied correctly

#### Rationale:

- The regex in the OVAL needed simplification