### PR TITLE
Make Blueprint for service_disabled template to mask services

### DIFF
--- a/shared/templates/service_disabled/blueprint.template
+++ b/shared/templates/service_disabled/blueprint.template
@@ -1,4 +1,4 @@
 # platform = multi_platform_all
 
 [customizations.services]
-disabled = ["{{{ DAEMONNAME }}}"]
+masked = ["{{{ DAEMONNAME }}}"]


### PR DESCRIPTION
#### Description:

- It is now aligned with other remediations.

#### Rationale:

- We mask services in Bash and Ansible to take the service down and keep it down.
- IB handles it better.
- Fixes #11587.

#### Review Hints:

- OpenSCAP: https://github.com/OpenSCAP/openscap/pull/2091
- IB: https://github.com/osbuild/osbuild-composer/pull/3972