### PR TITLE
Fix SCE finding XPath to allow nesting with OCILs

### DIFF
--- a/ssg/build_sce.py
+++ b/ssg/build_sce.py
@@ -241,7 +241,7 @@ def collect_sce_checks(datastreamtree):
     checks_xpath = str.format(
         ".//{{{ds_ns}}}component[@id='{cid}']/"
         "{{{xccdf_ns}}}Benchmark//"
-        "{{{xccdf_ns}}}Rule/"
+        "{{{xccdf_ns}}}Rule//"
         "{{{xccdf_ns}}}check[@system='{sce_sys}']/"
         "{{{xccdf_ns}}}check-content-ref",
         ds_ns=datastream_namespace,


### PR DESCRIPTION
#### Description:

When building data streams with complex checks (SCE combined with OVAL) that also have OCIL checks, we build a nested check system like:

    <complex-check operator="OR">
        <complex-check operator="<SCE-CROSS-OVAL>">
            <OVAL />
            <SCE />
        </complex-check>
        <OCIL />
    </complex-check>

However, the XPath for finding such checks (to include the SCE in the data stream) required the SCE check to be a direct descendant of the rule. Modify the XPath to allow arbitrary nesting on the inner SCE.

#### Rationale:

Fix is broken :-) 

Resolves: #11681

#### Review Hints:

Pull this commit on top of the branch described in #11681 and run:

```
ADDITIONAL_CMAKE_OPTIONS="-DSSG_SCE_ENABLED:BOOL=ON" ./build_product debian12
```