### PR TITLE
Issue when using set -e with grep commands

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/bash/shared.sh
@@ -11,7 +11,7 @@ test -f ${CONF_FILE} || touch ${CONF_FILE}
 # Ensure CRYPTO_POLICY is not commented out
 sed -i 's/#CRYPTO_POLICY=/CRYPTO_POLICY=/' ${CONF_FILE}
 
-if ! grep -q -- "$correct_value" "$CONF_FILE"; then
+if ! grep -q "$correct_value" "$CONF_FILE"; then
     # We need to get the existing value, using PCRE to maintain same regex
     existing_value=$(grep -Po '(-oCiphers=\S+)' ${CONF_FILE})
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/bash/shared.sh
@@ -11,9 +11,7 @@ test -f ${CONF_FILE} || touch ${CONF_FILE}
 # Ensure CRYPTO_POLICY is not commented out
 sed -i 's/#CRYPTO_POLICY=/CRYPTO_POLICY=/' ${CONF_FILE}
 
-grep -q "'${correct_value}'" ${CONF_FILE}
-
-if [[ $? -ne 0 ]]; then
+if ! grep -q "$correct_value" "$CONF_FILE"; then
     # We need to get the existing value, using PCRE to maintain same regex
     existing_value=$(grep -Po '(-oCiphers=\S+)' ${CONF_FILE})
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/bash/shared.sh
@@ -11,7 +11,7 @@ test -f ${CONF_FILE} || touch ${CONF_FILE}
 # Ensure CRYPTO_POLICY is not commented out
 sed -i 's/#CRYPTO_POLICY=/CRYPTO_POLICY=/' ${CONF_FILE}
 
-if ! grep -q "$correct_value" "$CONF_FILE"; then
+if ! grep -q -- "$correct_value" "$CONF_FILE"; then
     # We need to get the existing value, using PCRE to maintain same regex
     existing_value=$(grep -Po '(-oCiphers=\S+)' ${CONF_FILE})
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/bash/shared.sh
@@ -11,7 +11,7 @@ test -f ${CONF_FILE} || touch ${CONF_FILE}
 # Ensure CRYPTO_POLICY is not commented out
 sed -i 's/#CRYPTO_POLICY=/CRYPTO_POLICY=/' ${CONF_FILE}
 
-if ! grep -q -- "$correct_value" "$CONF_FILE"; then
+if ! grep -q "$correct_value" "$CONF_FILE"; then
     # We need to get the existing value, using PCRE to maintain same regex
     existing_value=$(grep -Po '(-oMACs=\S+)' ${CONF_FILE})
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/bash/shared.sh
@@ -11,7 +11,7 @@ test -f ${CONF_FILE} || touch ${CONF_FILE}
 # Ensure CRYPTO_POLICY is not commented out
 sed -i 's/#CRYPTO_POLICY=/CRYPTO_POLICY=/' ${CONF_FILE}
 
-if ! grep -q "$correct_value" "$CONF_FILE"; then
+if ! grep -q -- "$correct_value" "$CONF_FILE"; then
     # We need to get the existing value, using PCRE to maintain same regex
     existing_value=$(grep -Po '(-oMACs=\S+)' ${CONF_FILE})
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/bash/shared.sh
@@ -11,9 +11,7 @@ test -f ${CONF_FILE} || touch ${CONF_FILE}
 # Ensure CRYPTO_POLICY is not commented out
 sed -i 's/#CRYPTO_POLICY=/CRYPTO_POLICY=/' ${CONF_FILE}
 
-grep -q "'${correct_value}'" ${CONF_FILE}
-
-if [[ $? -ne 0 ]]; then
+if ! grep -q "$correct_value" "$CONF_FILE"; then
     # We need to get the existing value, using PCRE to maintain same regex
     existing_value=$(grep -Po '(-oMACs=\S+)' ${CONF_FILE})
 


### PR DESCRIPTION
#### Description:

Changed two crypto policy remediation scripts to use the grep command in the if statement

#### Rationale:

grep -q will exit with code 0 if any match is found and returns 1 otherwise. This causes the script to exit if set -e is set. Having the grep command within the if statement fixes this issue.
