### PR TITLE
Fix AIDE PATH Product Stability of OpenSUSE

### DIFF
--- a/tests/data/product_stability/opensuse.yml
+++ b/tests/data/product_stability/opensuse.yml
@@ -1,6 +1,6 @@
 aide_also_checks_audispd: 'yes'
 aide_also_checks_rsyslog: 'no'
-aide_bin_path: /usr/bin/aide
+aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
 audisp_conf_path: /etc/audit
 auid: 1000


### PR DESCRIPTION

#### Description:

This was causing issues for the nightly builds.


#### Rationale:

So the nightly builds pass.

