### PR TITLE
ubuntu2204: cis_level1_workstation: Add missing !package_cups_removed

### DIFF
--- a/products/ubuntu2204/profiles/cis_level1_workstation.profile
+++ b/products/ubuntu2204/profiles/cis_level1_workstation.profile
@@ -33,7 +33,7 @@ selections:
     ### 2.2.3 Ensure CUPS is not installed (Automated)
     # Skip due to being Level 1 Server and Level 2 Workstation.
     - '!service_cups_disabled'
-    # - '!package_cups_removed'
+    - '!package_cups_removed'
 
     ### 3.1.2 Ensure wireless interfaces are disabled (Automated)
     # Skip due to being Level 1 Server and Level 2 Workstation.


### PR DESCRIPTION
#### Description:

- package_cups_removed is a CIS level 1 server and level 2 workstation rule, therefore for level 1 workstation it must not be selected.

#### Rationale:

- Ubuntu 22.04 CIS benchmark