### PR TITLE
Align `securetty_root_login_console_only` remediations with OVAL/rule description

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/securetty_root_login_console_only/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/securetty_root_login_console_only/ansible/shared.yml
@@ -6,5 +6,5 @@
 - name: "Restrict Virtual Console Root Logins"
   lineinfile:
     dest: /etc/securetty
-    regexp: '^vc'
+    regexp: '^vc/[0-9]'
     state: absent

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/securetty_root_login_console_only/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/securetty_root_login_console_only/bash/shared.sh
@@ -1,2 +1,2 @@
 # platform = multi_platform_all
-sed -i '/^vc\//d' /etc/securetty
+sed -i '/^vc\/[0-9]/d' /etc/securetty


### PR DESCRIPTION
#### Description:
The rule had wrong `regex` according to rule description. 
See also one of older STIG requiremets - https://www.stigviewer.com/stig/red_hat_enterprise_linux_6/2020-09-03/finding/V-217865 where for such requirement is `grep '^vc/[0-9]' /etc/securetty`

#### Rationale:
Seems as it causes problem in Testing Farm hardening tests.

#### Review Hints:
See rule description/oval regex.
