### PR TITLE
Adjust action for RHEL-09-653050

### DIFF
--- a/controls/stig_rhel9.yml
+++ b/controls/stig_rhel9.yml
@@ -3476,7 +3476,7 @@ controls:
             95 percent of the repository maximum audit record storage capacity.
         rules:
             - auditd_data_retention_admin_space_left_action
-            - var_auditd_admin_space_left_action=halt
+            - var_auditd_admin_space_left_action=single
         status: automated
 
     -   id: RHEL-09-653055

--- a/tests/data/profile_stability/rhel9/stig.profile
+++ b/tests/data/profile_stability/rhel9/stig.profile
@@ -528,7 +528,7 @@ selections:
 - var_auditd_action_mail_acct=root
 - var_auditd_name_format=stig
 - var_auditd_max_log_file_action=rotate
-- var_auditd_admin_space_left_action=halt
+- var_auditd_admin_space_left_action=single
 - var_auditd_admin_space_left_percentage=5pc
 - var_auditd_space_left_action=email
 - var_auditd_space_left_percentage=25pc

--- a/tests/data/profile_stability/rhel9/stig_gui.profile
+++ b/tests/data/profile_stability/rhel9/stig_gui.profile
@@ -537,7 +537,7 @@ selections:
 - var_auditd_action_mail_acct=root
 - var_auditd_name_format=stig
 - var_auditd_max_log_file_action=rotate
-- var_auditd_admin_space_left_action=halt
+- var_auditd_admin_space_left_action=single
 - var_auditd_admin_space_left_percentage=5pc
 - var_auditd_space_left_action=email
 - var_auditd_space_left_percentage=25pc


### PR DESCRIPTION




#### Description:

Adjust action for var_auditd_admin_space_left_action to `single`

#### Rationale:
The RHEL 9 STIG requires single not halt.

Fixes #11701
#### Review Hints:

- _Review hints here. Replace this text. Don't use the italics format!_

- _Use this optional section to give any relevant information which could help the reviewer to more quickly and assertively understand and test the changes._

- _Good examples are useful commands, if it is better to review all commits together or in a suggested sequence, any relevant discussion in other PRs or issues, etc._
