### PR TITLE
Add `aide_build_database` to the RHEL 9 STIG

### DIFF
--- a/controls/stig_rhel9.yml
+++ b/controls/stig_rhel9.yml
@@ -3230,6 +3230,7 @@ controls:
         title: RHEL 9 must have the AIDE package installed.
         rules:
             - package_aide_installed
+            - aide_build_database
         status: automated
 
     -   id: RHEL-09-651015

--- a/tests/data/profile_stability/rhel9/stig.profile
+++ b/tests/data/profile_stability/rhel9/stig.profile
@@ -29,6 +29,7 @@ metadata:
     - ggbecker
 reference: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
 selections:
+- aide_build_database
 - configure_bashrc_tmux
 - package_crypto-policies_installed
 - sysctl_net_ipv4_conf_all_accept_redirects

--- a/tests/data/profile_stability/rhel9/stig_gui.profile
+++ b/tests/data/profile_stability/rhel9/stig_gui.profile
@@ -41,6 +41,7 @@ metadata:
     - ggbecker
 reference: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
 selections:
+- aide_build_database
 - auditd_data_retention_admin_space_left_action
 - postfix_client_configure_mail_alias
 - accounts_password_pam_ocredit


### PR DESCRIPTION
#### Description:

Add `aide_build_database` to the RHEL 9 STIG.
#### Rationale:

Fixes #11687 
