### PR TITLE
Add bind package applicability to configure_bind_crypto_policy

### DIFF
--- a/components/bind.yml
+++ b/components/bind.yml
@@ -11,6 +11,7 @@ name: bind
 packages:
 - bind
 rules:
+- configure_bind_crypto_policy
 - dns_server_authenticate_zone_transfers
 - dns_server_disable_dynamic_updates
 - dns_server_disable_zone_transfers

--- a/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/rule.yml
@@ -51,3 +51,5 @@ fixtext: |-
     include "/etc/crypto-policies/back-ends/bind.config";
 
 srg_requirement: '{{{ full_name }}} BIND crypto policy must use approved ciphers.'
+
+platform: package[bind]

--- a/shared/applicability/package.yml
+++ b/shared/applicability/package.yml
@@ -30,6 +30,8 @@ args:
     {{% endif %}}
   bash:
     pkgname: bash
+  bind:
+    pkgname: bind
   chrony:
     pkgname: chrony
   dnf:


### PR DESCRIPTION
#### Description:

* Add bind package applicability to the project
* Use it on configure_bind_crypto_policy

#### Rationale:

Fixes #11688 


