### PR TITLE
OCPBUGS-13589: Remove unecessary sysctl-file-exists rule

### DIFF
--- a/applications/openshift/kubelet/kubelet_enable_protect_kernel_sysctl_file_exist/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_protect_kernel_sysctl_file_exist/rule.yml
@@ -87,7 +87,6 @@ ocil: |-
 references:
   nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
   nist: CM-6,CM-6(1)
-  srg: SRG-APP-000516-CTR-001325
 
 template:
     name: file_existence

--- a/products/ocp4/profiles/stig-node-v1r1.profile
+++ b/products/ocp4/profiles/stig-node-v1r1.profile
@@ -121,7 +121,6 @@ selections:
     - kubelet_enable_iptables_util_chains
     - kubelet_enable_protect_kernel_defaults
     - kubelet_enable_protect_kernel_sysctl
-    - kubelet_enable_protect_kernel_sysctl_file_exist
     - kubelet_enable_protect_kernel_sysctl_kernel_keys_root_maxbytes
     - kubelet_enable_protect_kernel_sysctl_kernel_keys_root_maxkeys
     - kubelet_enable_protect_kernel_sysctl_kernel_panic


### PR DESCRIPTION

#### Description:

- Remove rule `kubelet_enable_protect_kernel_sysctl_file_exist` from OCP4 `stig-node` profie.

#### Rationale:

- This rule ensure that a sysctl file with a specific name exists. 
  The rules that create this file pass by default.
Furthermore, not sure why this rule is needed, since what should trigger the creation of the file is a sysctl configuration rule failing, not the absence of a file.

#### Review Hints:

- Scan OCP4 with `stig-node` profile.
```
$ oc get ccr | grep sysctl
ocp4-stig-node-master-kubelet-enable-protect-kernel-sysctl                             PASS     medium
ocp4-stig-node-master-kubelet-enable-protect-kernel-sysctl-file-exist                  FAIL     medium
ocp4-stig-node-master-kubelet-enable-protect-kernel-sysctl-kernel-keys-root-maxbytes   PASS     medium
ocp4-stig-node-master-kubelet-enable-protect-kernel-sysctl-kernel-keys-root-maxkeys    PASS     medium
ocp4-stig-node-master-kubelet-enable-protect-kernel-sysctl-kernel-panic                PASS     medium
ocp4-stig-node-master-kubelet-enable-protect-kernel-sysctl-kernel-panic-on-oops        PASS     medium
ocp4-stig-node-master-kubelet-enable-protect-kernel-sysctl-vm-overcommit-memory        PASS     medium
ocp4-stig-node-master-kubelet-enable-protect-kernel-sysctl-vm-panic-on-oom             PASS     medium
ocp4-stig-node-worker-kubelet-enable-protect-kernel-sysctl                             PASS     medium
ocp4-stig-node-worker-kubelet-enable-protect-kernel-sysctl-file-exist                  FAIL     medium
ocp4-stig-node-worker-kubelet-enable-protect-kernel-sysctl-kernel-keys-root-maxbytes   PASS     medium
ocp4-stig-node-worker-kubelet-enable-protect-kernel-sysctl-kernel-keys-root-maxkeys    PASS     medium
ocp4-stig-node-worker-kubelet-enable-protect-kernel-sysctl-kernel-panic                PASS     medium
ocp4-stig-node-worker-kubelet-enable-protect-kernel-sysctl-kernel-panic-on-oops        PASS     medium
ocp4-stig-node-worker-kubelet-enable-protect-kernel-sysctl-vm-overcommit-memory        PASS     medium
ocp4-stig-node-worker-kubelet-enable-protect-kernel-sysctl-vm-panic-on-oom             PASS 
``` 
-  Check that rule `kubelet-enable-protect-kernel-sysctl-file-exist` is always failing and is not needed since all other syctl rules PASS.
