### PR TITLE
Re-enable runtime check on network related sysctls

### DIFF
--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra/rule.yml
@@ -49,4 +49,3 @@ template:
     vars:
         sysctlvar: net.ipv6.conf.all.accept_ra
         datatype: int
-        check_runtime@rhcos4: "false"

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_redirects/rule.yml
@@ -51,4 +51,3 @@ template:
     vars:
         sysctlvar: net.ipv6.conf.all.accept_redirects
         datatype: int
-        check_runtime@rhcos4: "false"

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra/rule.yml
@@ -49,4 +49,3 @@ template:
     vars:
         sysctlvar: net.ipv6.conf.default.accept_ra
         datatype: int
-        check_runtime@rhcos4: "false"

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_redirects/rule.yml
@@ -53,4 +53,3 @@ template:
     vars:
         sysctlvar: net.ipv6.conf.default.accept_redirects
         datatype: int
-        check_runtime@rhcos4: "false"

--- a/linux_os/guide/system/permissions/restrictions/sysctl_net_core_bpf_jit_harden/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_net_core_bpf_jit_harden/rule.yml
@@ -41,4 +41,3 @@ template:
         sysctlvar: net.core.bpf_jit_harden
         sysctlval: '2'
         datatype: int
-        check_runtime@rhcos4: "false"


### PR DESCRIPTION


#### Description:

- Re-add the syctl runtime checks to test https://github.com/ComplianceAsCode/compliance-operator/pull/497

#### Rationale:

- It seems taht when CO's "scanner" pod has "HostNetwork" option set to true, these sysctls are visible with values matching Host syctls.

- Fixes  https://issues.redhat.com/browse/OCPBUGS-19690
