### PR TITLE
Stabilize resolved profiles

### DIFF
--- a/ssg/entities/profile.py
+++ b/ssg/entities/profile.py
@@ -19,13 +19,13 @@ class ResolvableProfile(Profile):
         self.update_with(extended_profile)
 
     def apply_filter(self, rules_by_id):
-        selections = set()
+        selections = []
         for rid in self.selected:
             rule = rules_by_id[rid]
             if not self.rule_filter(rule):
                 continue
-            selections.add(rid)
-        self.selected = list(selections)
+            selections.append(rid)
+        self.selected = selections
 
     def resolve(self, all_profiles, rules_by_id, controls_manager=None):
         if self.resolved:


### PR DESCRIPTION
Currently, the resolved profiles have random order of items in the selections list. This makes it less convenient to update the profile stability test data, because copying a resolved profile causes shuffling the git diff. This problem is a recent regression. Git bisect shows that it has been broken by 890ce49010529494bea0dabeedec0326fa885795. The proposed fix is to use a list instead of set so that the original order of elements is preserved.

Related to conversation in #11719.
