### PR TITLE
Disallow spaces in SSSD certificate_verification option

### DIFF
--- a/linux_os/guide/services/sssd/sssd_certificate_verification/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_certificate_verification/ansible/shared.yml
@@ -26,6 +26,6 @@
       path: /etc/sssd/conf.d/certificate_verification.conf
       section: sssd
       option: certificate_verification
-      value: "ocsp_dgst = {{ var_sssd_certificate_verification_digest_function }}"
+      value: "ocsp_dgst={{ var_sssd_certificate_verification_digest_function }}"
       state: present
       mode: 0600

--- a/linux_os/guide/services/sssd/sssd_certificate_verification/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_certificate_verification/bash/shared.sh
@@ -13,6 +13,6 @@ umask u=rw,go=
 
 MAIN_CONF="/etc/sssd/conf.d/certificate_verification.conf"
 
-{{{ bash_ensure_ini_config("$MAIN_CONF /etc/sssd/sssd.conf /etc/sssd/conf.d/*.conf", "sssd", "certificate_verification", "ocsp_dgst = $var_sssd_certificate_verification_digest_function") }}}
+{{{ bash_ensure_ini_config("$MAIN_CONF /etc/sssd/sssd.conf /etc/sssd/conf.d/*.conf", "sssd", "certificate_verification", "ocsp_dgst=$var_sssd_certificate_verification_digest_function") }}}
 
 umask $OLD_UMASK

--- a/linux_os/guide/services/sssd/sssd_certificate_verification/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_certificate_verification/oval/shared.xml
@@ -16,7 +16,7 @@
 
     <ind:textfilecontent54_object id="obj_{{{rule_id}}}" version="1">
         <ind:filepath operation="pattern match">^/etc/sssd/(sssd|conf\.d/.*)\.conf$</ind:filepath>
-        <ind:pattern operation="pattern match">^[\s]*\[sssd](?:[^\n\[]*\n+)+?[\s]*certificate_verification\s*=\s*ocsp_dgst\s*=\s*(\w+)$</ind:pattern>
+        <ind:pattern operation="pattern match">^[\s]*\[sssd](?:[^\n\[]*\n+)+?[\s]*certificate_verification\s*=\s*ocsp_dgst=(\w+)$</ind:pattern>
         <ind:instance datatype="int">1</ind:instance>
     </ind:textfilecontent54_object>
 

--- a/linux_os/guide/services/sssd/sssd_certificate_verification/tests/spaces.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_certificate_verification/tests/spaces.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# packages = sssd-common
+
+mkdir -p /etc/sssd/conf.d
+touch /etc/sssd/sssd.conf
+echo -e "[sssd]\ncertificate_verification = ocsp_dgst = sha1" >> /etc/sssd/sssd.conf


### PR DESCRIPTION
We will not allow spaces around the equal sign in the value of the certificate_verification option in SSSD configuration. This will align our content with RHEL 9 STIG requirements.

Fixes: #11708

