### PR TITLE
Extension of the `most-used-rules` and `most-used-components` subcommands of the `profile_tool.py` script to specify a list of products to be considered

### DIFF
--- a/build-scripts/profile_tool.py
+++ b/build-scripts/profile_tool.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 import argparse
 
 try:
-    from utils.controleval import get_available_products
+    from utils.controleval import get_available_products, load_product_yaml
     from utils.profile_tool import (
         command_stats,
         command_sub,
@@ -304,6 +304,26 @@ def parse_most_used_components(subparsers):
         choices=["plain", "json", "csv"],
         help="Which format to use for output.",
     )
+    parser_most_used_components.add_argument(
+        "--products",
+        help=(
+            "List of products to be considered. "
+            "If not specified will by used all products with components_root."
+        ),
+        nargs="+",
+        choices=get_available_products_with_components_root(),
+        default=get_available_products_with_components_root(),
+    )
+
+
+def get_available_products_with_components_root():
+    out = set()
+    for product in get_available_products():
+        product_yaml = load_product_yaml(product)
+        components_root = product_yaml.get("components_root")
+        if components_root is not None:
+            out.add(product)
+    return out
 
 
 def parse_args():

--- a/build-scripts/profile_tool.py
+++ b/build-scripts/profile_tool.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import argparse
 
 try:
+    from utils.controleval import get_available_products
     from utils.profile_tool import (
         command_stats,
         command_sub,
@@ -278,6 +279,13 @@ def parse_most_used_rules_subcommand(subparsers):
         default="plain",
         choices=["plain", "json", "csv"],
         help="Which format to use for output.",
+    )
+    parser_most_used_rules.add_argument(
+        "--products",
+        help="List of products to be considered. If not specified will by used all products.",
+        nargs="+",
+        choices=get_available_products(),
+        default=get_available_products(),
     )
 
 

--- a/build-scripts/profile_tool.py
+++ b/build-scripts/profile_tool.py
@@ -5,7 +5,12 @@ from __future__ import print_function
 import argparse
 
 try:
-    from utils.profile_tool import command_stats, command_sub, command_most_used_rules
+    from utils.profile_tool import (
+        command_stats,
+        command_sub,
+        command_most_used_rules,
+        command_most_used_components,
+    )
 except ImportError:
     print("The ssg module could not be found.")
     print(
@@ -276,6 +281,23 @@ def parse_most_used_rules_subcommand(subparsers):
     )
 
 
+def parse_most_used_components(subparsers):
+    parser_most_used_components = subparsers.add_parser(
+        "most-used-components",
+        description=(
+            "Generates list of all components used by the rules in existing profiles."
+            " In various formats."
+        ),
+        help="Generates list of all components used by the rules in existing profiles.",
+    )
+    parser_most_used_components.add_argument(
+        "--format",
+        default="plain",
+        choices=["plain", "json", "csv"],
+        help="Which format to use for output.",
+    )
+
+
 def parse_args():
     parser = argparse.ArgumentParser(description="Profile statistics and utilities tool")
     subparsers = parser.add_subparsers(title="subcommands", dest="subcommand", required=True)
@@ -283,6 +305,7 @@ def parse_args():
     parse_stats_subcommand(subparsers)
     parse_sub_subcommand(subparsers)
     parse_most_used_rules_subcommand(subparsers)
+    parse_most_used_components(subparsers)
 
     args = parser.parse_args()
 
@@ -319,6 +342,7 @@ SUBCMDS = {
     "stats": command_stats,
     "sub": command_sub,
     "most-used-rules": command_most_used_rules,
+    "most-used-components": command_most_used_components,
 }
 
 

--- a/docs/manual/developer/05_tools_and_utilities.md
+++ b/docs/manual/developer/05_tools_and_utilities.md
@@ -61,6 +61,16 @@ The result will be a list of rules with the number of uses in the profiles.
 The list can be generated as plain text, JSON or CVS.
 Via the `--format FORMAT` parameter.
 
+The tool can also generate a list of the most used component based on rules contained in profiles from the entire project:
+
+```bash
+    $ ./build-scripts/profile_tool.py most-used-components
+```
+
+The result will be a list of rules with the number of uses in the profiles.
+The list can be generated as plain text, JSON or CVS.
+Via the `--format FORMAT` parameter.
+
 ## Generating Controls from DISA's XCCDF Files
 
 If you want a control file for product from DISA's XCCDF files you can run the following command:

--- a/docs/manual/developer/05_tools_and_utilities.md
+++ b/docs/manual/developer/05_tools_and_utilities.md
@@ -57,6 +57,12 @@ Or you can also run this command to get a list of the most used rules in the ent
     $ ./build-scripts/profile_tool.py most-used-rules
 ```
 
+Optionally, you can use this command to limit the statistics for a specific product:
+
+```bash
+    $ ./build-scripts/profile_tool.py most-used-rules --products rhel9
+```
+
 The result will be a list of rules with the number of uses in the profiles.
 The list can be generated as plain text, JSON or CVS.
 Via the `--format FORMAT` parameter.
@@ -65,6 +71,12 @@ The tool can also generate a list of the most used component based on rules cont
 
 ```bash
     $ ./build-scripts/profile_tool.py most-used-components
+```
+
+Optionally, you can use this command to limit the statistics for a specific product:
+
+```bash
+    $ ./build-scripts/profile_tool.py most-used-components --products rhel9
 ```
 
 The result will be a list of rules with the number of uses in the profiles.

--- a/utils/profile_tool/__init__.py
+++ b/utils/profile_tool/__init__.py
@@ -1,3 +1,4 @@
 from .sub import command_sub
 from .stats import command_stats
 from .most_used_rules import command_most_used_rules
+from .most_used_components import command_most_used_components

--- a/utils/profile_tool/__init__.py
+++ b/utils/profile_tool/__init__.py
@@ -2,3 +2,4 @@ from .sub import command_sub
 from .stats import command_stats
 from .most_used_rules import command_most_used_rules
 from .most_used_components import command_most_used_components
+from .common import generate_output

--- a/utils/profile_tool/common.py
+++ b/utils/profile_tool/common.py
@@ -1,0 +1,15 @@
+import json
+
+
+def generate_output(dict_, format, csv_header):
+    f_string = "{}: {}"
+
+    if format == "json":
+        print(json.dumps(dict_, indent=4))
+        return
+    elif format == "csv":
+        print(csv_header)
+        f_string = "{},{}"
+
+    for rule_id, rule_count in dict_.items():
+        print(f_string.format(rule_id, rule_count))

--- a/utils/profile_tool/most_used_components.py
+++ b/utils/profile_tool/most_used_components.py
@@ -1,0 +1,3 @@
+
+def command_most_used_components(args):
+    pass

--- a/utils/profile_tool/most_used_components.py
+++ b/utils/profile_tool/most_used_components.py
@@ -13,7 +13,6 @@ if not PYTHON_2:
     from .most_used_rules import _get_profiles_for_product
     from ..controleval import (
         load_controls_manager,
-        get_available_products,
         load_product_yaml,
     )
 
@@ -41,11 +40,11 @@ def load_components(product):
     return ssg.components.load(components_dir)
 
 
-def _process_all_products_from_controls(components_out):
+def _process_all_products_from_controls(components_out, products):
     if PYTHON_2:
         raise Exception("This feature is not supported for python2.")
 
-    for product in get_available_products():
+    for product in products:
         components = load_components(product)
         if components is None:
             continue
@@ -57,7 +56,7 @@ def _process_all_products_from_controls(components_out):
 def command_most_used_components(args):
     components = defaultdict(int)
 
-    _process_all_products_from_controls(components)
+    _process_all_products_from_controls(components, args.products)
 
     sorted_components = _sorted_dict_by_num_value(components)
     csv_header = "component_name,count_of_rules"

--- a/utils/profile_tool/most_used_components.py
+++ b/utils/profile_tool/most_used_components.py
@@ -1,8 +1,8 @@
-import json
 import sys
 import os
 import ssg.components
 from .most_used_rules import _sorted_dict_by_num_value
+from .common import generate_output
 
 PYTHON_2 = sys.version_info[0] < 3
 
@@ -60,15 +60,5 @@ def command_most_used_components(args):
     _process_all_products_from_controls(components)
 
     sorted_components = _sorted_dict_by_num_value(components)
-
-    f_string = "{}: {}"
-
-    if args.format == "json":
-        print(json.dumps(sorted_components, indent=4))
-        return
-    elif args.format == "csv":
-        print("component_name,count_of_rules")
-        f_string = "{},{}"
-
-    for rule_id, rule_count in sorted_components.items():
-        print(f_string.format(rule_id, rule_count))
+    csv_header = "component_name,count_of_rules"
+    generate_output(sorted_components, args.format, csv_header)

--- a/utils/profile_tool/most_used_components.py
+++ b/utils/profile_tool/most_used_components.py
@@ -1,3 +1,70 @@
+import json
+import sys
+import os
+from ssg.components import Component
+from .most_used_rules import _sorted_dict_by_num_value
+
+PYTHON_2 = sys.version_info[0] < 3
+
+if not PYTHON_2:
+    from .most_used_rules import _get_profiles_for_product
+    from ..controleval import (
+        load_controls_manager,
+        get_available_products,
+    )
+
+
+def _count_components(components, rules_list, components_out):
+    for rule in rules_list:
+        component = get_component_name_by_rule_id(rule, components)
+        if component in components_out:
+            components_out[component] += 1
+        else:
+            components_out[component] = 1
+
+
+def get_component_name_by_rule_id(rule_id, components):
+    for component in components.values():
+        if rule_id in component.rules:
+            return component.name
+    return "without_component"
+
+
+def load_components(components_dir):
+    components = {}
+    for component_file in os.listdir(os.path.abspath(components_dir)):
+        component_path = os.path.join(components_dir, component_file)
+        component = Component(component_path)
+        components[component.name] = component
+    return components
+
+
+def _process_all_products_from_controls(components_out):
+    components = load_components("./components/")
+    if PYTHON_2:
+        raise Exception("This feature is not supported for python2.")
+
+    for product in get_available_products():
+        controls_manager = load_controls_manager("./controls/", product)
+        for profile in _get_profiles_for_product(controls_manager, product):
+            _count_components(components, profile.rules, components_out)
+
 
 def command_most_used_components(args):
-    pass
+    components = {}
+
+    _process_all_products_from_controls(components)
+
+    sorted_components = _sorted_dict_by_num_value(components)
+
+    f_string = "{}: {}"
+
+    if args.format == "json":
+        print(json.dumps(sorted_components, indent=4))
+        return
+    elif args.format == "csv":
+        print("component_name,count_of_rules")
+        f_string = "{},{}"
+
+    for rule_id, rule_count in sorted_components.items():
+        print(f_string.format(rule_id, rule_count))

--- a/utils/profile_tool/most_used_components.py
+++ b/utils/profile_tool/most_used_components.py
@@ -1,6 +1,9 @@
 import sys
 import os
+from collections import defaultdict
+
 import ssg.components
+
 from .most_used_rules import _sorted_dict_by_num_value
 from .common import generate_output
 
@@ -18,10 +21,7 @@ if not PYTHON_2:
 def _count_components(components, rules_list, components_out):
     for rule in rules_list:
         component = get_component_name_by_rule_id(rule, components)
-        if component in components_out:
-            components_out[component] += 1
-        else:
-            components_out[component] = 1
+        components_out[component] += 1
 
 
 def get_component_name_by_rule_id(rule_id, components):
@@ -55,7 +55,7 @@ def _process_all_products_from_controls(components_out):
 
 
 def command_most_used_components(args):
-    components = {}
+    components = defaultdict(int)
 
     _process_all_products_from_controls(components)
 

--- a/utils/profile_tool/most_used_rules.py
+++ b/utils/profile_tool/most_used_rules.py
@@ -12,7 +12,6 @@ if not PYTHON_2:
     from .profile import get_profile
     from ..controleval import (
         load_controls_manager,
-        get_available_products,
         get_product_profiles_files,
     )
 
@@ -37,11 +36,11 @@ def _get_profiles_for_product(ctrls_mgr, product):
     return profiles
 
 
-def _process_all_products_from_controls(rules):
+def _process_all_products_from_controls(rules, products):
     if PYTHON_2:
         raise Exception("This feature is not supported for python2.")
 
-    for product in get_available_products():
+    for product in products:
         controls_manager = load_controls_manager("./controls/", product)
         for profile in _get_profiles_for_product(controls_manager, product):
             _count_rules_per_rules_list(profile.rules, rules)
@@ -56,7 +55,7 @@ def command_most_used_rules(args):
     rules = defaultdict(int)
 
     if not args.BENCHMARKS:
-        _process_all_products_from_controls(rules)
+        _process_all_products_from_controls(rules, args.products)
     else:
         for benchmark in args.BENCHMARKS:
             _count_rules_per_benchmark(benchmark, rules)

--- a/utils/profile_tool/most_used_rules.py
+++ b/utils/profile_tool/most_used_rules.py
@@ -48,12 +48,9 @@ def _process_all_products_from_controls(rules):
             _count_rules_per_rules_list(profile.rules, rules)
 
 
-def _sorted_rules(rules):
-    sorted_rules = {
-        k: v
-        for k, v in sorted(rules.items(), key=lambda x: x[1], reverse=True)
-    }
-    return sorted_rules
+def _sorted_dict_by_num_value(dict_):
+    sorted_ = {k: v for k, v in sorted(dict_.items(), key=lambda x: x[1], reverse=True)}
+    return sorted_
 
 
 def command_most_used_rules(args):
@@ -65,7 +62,7 @@ def command_most_used_rules(args):
         for benchmark in args.BENCHMARKS:
             _count_rules_per_benchmark(benchmark, rules)
 
-    sorted_rules = _sorted_rules(rules)
+    sorted_rules = _sorted_dict_by_num_value(rules)
 
     f_string = "{}: {}"
 

--- a/utils/profile_tool/most_used_rules.py
+++ b/utils/profile_tool/most_used_rules.py
@@ -1,4 +1,5 @@
 import sys
+from collections import defaultdict
 
 from ssg.build_profile import XCCDFBenchmark
 
@@ -18,10 +19,7 @@ if not PYTHON_2:
 
 def _count_rules_per_rules_list(rules_list, rules):
     for rule in rules_list:
-        if rule in rules:
-            rules[rule] += 1
-        else:
-            rules[rule] = 1
+        rules[rule] += 1
 
 
 def _count_rules_per_benchmark(benchmark, rules):
@@ -55,7 +53,7 @@ def _sorted_dict_by_num_value(dict_):
 
 
 def command_most_used_rules(args):
-    rules = {}
+    rules = defaultdict(int)
 
     if not args.BENCHMARKS:
         _process_all_products_from_controls(rules)

--- a/utils/profile_tool/most_used_rules.py
+++ b/utils/profile_tool/most_used_rules.py
@@ -1,7 +1,8 @@
 import sys
-import json
 
 from ssg.build_profile import XCCDFBenchmark
+
+from .common import generate_output
 
 
 PYTHON_2 = sys.version_info[0] < 3
@@ -63,15 +64,5 @@ def command_most_used_rules(args):
             _count_rules_per_benchmark(benchmark, rules)
 
     sorted_rules = _sorted_dict_by_num_value(rules)
-
-    f_string = "{}: {}"
-
-    if args.format == "json":
-        print(json.dumps(sorted_rules, indent=4))
-        return
-    elif args.format == "csv":
-        print("rule_id,count_of_profiles")
-        f_string = "{},{}"
-
-    for rule_id, rule_count in sorted_rules.items():
-        print(f_string.format(rule_id, rule_count))
+    csv_header = "rule_id,count_of_profiles"
+    generate_output(sorted_rules, args.format, csv_header)


### PR DESCRIPTION
#### Description:
This PR extends the `most-used-rules` and `most-used-components` subcommands of the `profile_tool.py` script to specify a list of products to be considered.

The new `--products` flag allows users to get a list of the most used rules or components for Red Hat products only or other available products. 


Depends on:
- #11730 

#### Review Hints:
To test new flag for `most-used-rules`  you can use this command:
```bash 
    $  ./build-scripts/profile_tool.py most-used-rules --products rhel9
```

To test new flag for `most-used-components`  you can use this command:
```bash 
    $  ./build-scripts/profile_tool.py most-used-components --products rhel9
```