### PR TITLE
align RHEL09-255065 with official DISA requirement

### DIFF
--- a/controls/stig_rhel9.yml
+++ b/controls/stig_rhel9.yml
@@ -1866,7 +1866,7 @@ controls:
             of SSH client connections.
         rules:
             - harden_sshd_ciphers_openssh_conf_crypto_policy
-            - sshd_approved_ciphers=stig_extended
+            - sshd_approved_ciphers=stig_rhel9
         status: automated
 
     -   id: RHEL-09-255065

--- a/linux_os/guide/services/ssh/sshd_approved_ciphers.var
+++ b/linux_os/guide/services/ssh/sshd_approved_ciphers.var
@@ -13,6 +13,7 @@ interactive: false
 options:
     stig: aes256-ctr,aes192-ctr,aes128-ctr
     stig_extended: aes256-ctr,aes192-ctr,aes128-ctr,aes256-gcm@openssh.com,aes128-gcm@openssh.com
+    stig_rhel9: aes256-gcm@openssh.com,chacha20-poly1305@openssh.com,aes256-ctr,aes128-gcm@openssh.com,aes128-ctr
     default: aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc,rijndael-cbc@lysator.liu.se
     cis_rhel7: chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
     cis_rhel8: -3des-cbc,aes128-cbc,aes192-cbc,aes256-cbc,rijndael-cbc@lysator.liu.se

--- a/tests/data/profile_stability/rhel9/stig.profile
+++ b/tests/data/profile_stability/rhel9/stig.profile
@@ -570,7 +570,7 @@ selections:
 - var_sshd_set_keepalive=1
 - var_rekey_limit_size=1G
 - var_rekey_limit_time=1hour
-- sshd_approved_ciphers=stig_extended
+- sshd_approved_ciphers=stig_rhel9
 - var_networkmanager_dns_mode=none
 - var_multiple_time_servers=stig
 - var_time_service_set_maxpoll=18_hours

--- a/tests/data/profile_stability/rhel9/stig_gui.profile
+++ b/tests/data/profile_stability/rhel9/stig_gui.profile
@@ -578,7 +578,7 @@ selections:
 - var_sshd_set_keepalive=1
 - var_rekey_limit_size=1G
 - var_rekey_limit_time=1hour
-- sshd_approved_ciphers=stig_extended
+- sshd_approved_ciphers=stig_rhel9
 - var_networkmanager_dns_mode=none
 - var_multiple_time_servers=stig
 - var_time_service_set_maxpoll=18_hours


### PR DESCRIPTION
#### Description:

- create a new variable value which contains list of ciphers required by RHEL 9 STIG
- use the new value in RHEL 9 STIG profiles

#### Rationale:

- partially fixes https://issues.redhat.com/browse/RHEL-29684?filter=12420681

#### Review Hints:

- Remediate the rule harden_sshd_ciphers_openssh_conf_crypto_policy
- then check with the rule xccdf_mil.disa.stig_rule_SV-257989r943014_rule from the official DISA SCAP datastream