### PR TITLE
Update links for Ansible role

### DIFF
--- a/docs/manual/developer/02_building_complianceascode.md
+++ b/docs/manual/developer/02_building_complianceascode.md
@@ -1,7 +1,7 @@
 # Building ComplianceAsCode
 
 ## Fast Track
-Ok, if you are eager to start contributing, seeing the things happening faster and are passionate about automation, this is what you need for now. Every technical procedure described in the next sessions of this guide is covered by the [ansible-role-openscap](https://galaxy.ansible.com/marcusburghardt/ansible_role_openscap) role.
+Ok, if you are eager to start contributing, seeing the things happening faster and are passionate about automation, this is what you need for now. Every technical procedure described in the next sessions of this guide is covered by the [openscap](https://galaxy.ansible.com/ui/standalone/roles/marcusburghardt/openscap/) role.
 
 Do you prefer to see it working before starting to use it? Please, take a look in this demo:
 [![ansible-role-openscap demo](https://img.youtube.com/vi/YI5lo1P0gw0/3.jpg)](http://www.youtube.com/watch?v=YI5lo1P0gw0 "watch an ansible-role-openscap demo")
@@ -13,11 +13,11 @@ dnf install -y ansible python3
 ```
 Then you can download the ansible role:
 ```bash
-ansible-galaxy install marcusburghardt.ansible_role_openscap
+ansible-galaxy install marcusburghardt.openscap
 ```
 Now it is time to run it. To help with this, the function also comes with a pre-configured Ansible environment for this. It is recommended to use this environment in order to ensure that it is only applicable to this context, not impacting any other possible Ansible settings you may have on your computer:
 ```bash
-cp -r ~/.ansible/roles/marcusburghardt.ansible_role_openscap/files/Ansible_Samples/ ~/Ansible
+cp -r ~/.ansible/roles/marcusburghardt.openscap/files/Ansible_Samples/ ~/Ansible
 cd ~/Ansible/
 ansible-playbook -K ansible_openscap.yml
 ```


### PR DESCRIPTION
#### Description:

The ansible-role-openscap was updated and it was noticed a change with role names in Ansible Galaxy.
The links were properly updated.

#### Rationale:

Documentation updated.