### PR TITLE
Enforce explicit setting in system-auth

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/oval/shared.xml
@@ -2,11 +2,7 @@
     <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("The number of rounds for password hashing should be set correctly.") }}}
     <criteria comment="Check if rounds option of pam_unix is as expected" operator="OR">
-        <criterion comment="The value of rounds is set correctly in pam_unix.so" test_ref="test_system_auth_pam_unix_rounds_is_set" />
-        <criteria comment="The value of rounds is no set, in this case the system default is used" operator="AND">
-            <criterion comment="The default value of rounds is used in pam_unix.so" test_ref="test_system_auth_pam_unix_rounds_is_default" />
-            <criterion comment="The target value of rounds is the default" test_ref="test_system_auth_default_pam_unix_rounds_var" />
-        </criteria>
+      <criterion comment="The value of rounds is set correctly in pam_unix.so" test_ref="test_system_auth_pam_unix_rounds_is_set" />
     </criteria>
   </definition>
 
@@ -14,11 +10,6 @@
   comment="Test if rounds attribute of pam_unix.so is set correctly in /etc/pam.d/system-auth" version="1">
     <ind:object object_ref="object_system_auth_pam_unix_rounds" />
     <ind:state state_ref="state_system_auth_pam_unix_rounds" />
-  </ind:textfilecontent54_test>
-
-  <ind:textfilecontent54_test id="test_system_auth_pam_unix_rounds_is_default" check="all" check_existence="none_exist"
-  comment="Test if rounds attribute of pam_unix.so is not set in /etc/pam.d/system-auth" version="1">
-    <ind:object object_ref="object_system_auth_pam_unix_rounds" />
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_system_auth_pam_unix_rounds" version="1">
@@ -30,24 +21,6 @@
   <ind:textfilecontent54_state id="state_system_auth_pam_unix_rounds" version="1">
     <ind:subexpression datatype="int" operation="greater than or equal" var_ref="var_password_pam_unix_rounds" />
   </ind:textfilecontent54_state>
-
-  <ind:variable_test check="all" check_existence="all_exist" id="test_system_auth_default_pam_unix_rounds_var" version="1"
-      comment="Check if value of var_password_pam_unix_rounds is the system's default">
-    <ind:object object_ref="object_system_auth_default_pam_unix_rounds_var" />
-    <ind:state state_ref="state_system_auth_default_pam_unix_rounds_var" />
-  </ind:variable_test>
-
-  <ind:variable_object comment="All modified times of all keyfiles" id="object_system_auth_default_pam_unix_rounds_var" version="1">
-     <ind:var_ref>var_password_pam_unix_rounds</ind:var_ref>
-   </ind:variable_object>
-
-  <ind:variable_state id="state_system_auth_default_pam_unix_rounds_var" version="1">
-    <ind:value datatype="int" operation="equals" var_check="all" var_ref="var_system_auth_default_hashing_rounds" />
-  </ind:variable_state>
-
-  <local_variable id="var_system_auth_default_hashing_rounds" datatype="int" version="1" comment="Default number of password hashing rounds">
-      <literal_component>5000</literal_component>
-  </local_variable>
 
   <external_variable comment="number of passwords hashing rounds" datatype="int" id="var_password_pam_unix_rounds" version="1" />
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/authselect_default_rounds.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/authselect_default_rounds.fail.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# packages = authselect
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# variables = var_password_pam_unix_rounds=5000
+
+authselect create-profile hardening -b sssd
+CUSTOM_PROFILE="custom/hardening"
+authselect select $CUSTOM_PROFILE --force
+CUSTOM_SYSTEM_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
+# Remove rounds parameter from line if present
+if $(grep -q "^\s*password.*pam_unix\.so.*rounds=" $CUSTOM_SYSTEM_AUTH); then
+	sed -r -i --follow-symlinks "s/(^\s*password.*pam_unix\.so.*)(rounds=[[:digit:]]+)(.*)/\1 \3/g" $CUSTOM_SYSTEM_AUTH
+fi
+authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/default_rounds.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/default_rounds.fail.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 # packages = pam
+# variables = var_password_pam_unix_rounds=5000
 
 pamFile="/etc/pam.d/system-auth"
 


### PR DESCRIPTION
The rule passes if the `rounds` option isn't set but the profile uses a value that equals to system default value. This will no longer be possible. We will always require `rounds` to be set explicitly. The reason is to align the rule with DISA STIG.

The commit also updates the test scenarios to fail if the `rounds` isn't set and system default is used.

Fixes: #11697