### PR TITLE
CMP-2471: Disable rules on s390x

### DIFF
--- a/applications/openshift/master/file_groupowner_ovs_conf_db_lock/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_lock/rule.yml
@@ -1,7 +1,7 @@
 documentation_complete: true
 
 
-platform: ocp4-node
+platform: ocp4-node and not_s390x_arch
 
 title: 'Verify Group Who Owns The Open vSwitch Configuration Database Lock'
 

--- a/applications/openshift/master/file_groupowner_ovs_sys_id_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_sys_id_conf/rule.yml
@@ -1,7 +1,7 @@
 documentation_complete: true
 
 
-platform: ocp4-node
+platform: ocp4-node and not_s390x_arch
 
 title: 'Verify Group Who Owns The Open vSwitch Persistent System ID'
 

--- a/applications/openshift/master/file_permissions_cni_conf/rule.yml
+++ b/applications/openshift/master/file_permissions_cni_conf/rule.yml
@@ -1,7 +1,7 @@
 documentation_complete: true
 
 
-platform: ocp4-node
+platform: ocp4-node and not_s390x_arch
 
 title: 'Verify Permissions on the OpenShift Container Network Interface Files'
 


### PR DESCRIPTION
There are some ocp rules are not applicable to s390x cluster, this commit disable those rules on s390x arch.

```
* file_groupowner_ovs_conf_db_lock
* file_groupowner_ovs_sys_id_conf
* file_permissions_cni_conf
```