### PR TITLE
set correct package name for service_sssd_enabled rule

### DIFF
--- a/components/sssd.yml
+++ b/components/sssd.yml
@@ -4,6 +4,7 @@ groups:
 name: sssd
 packages:
 - sssd
+- sssd-common
 - sssd-ipa
 rules:
 - package_sssd-ipa_installed

--- a/linux_os/guide/services/sssd/service_sssd_enabled/rule.yml
+++ b/linux_os/guide/services/sssd/service_sssd_enabled/rule.yml
@@ -36,6 +36,7 @@ template:
     name: service_enabled
     vars:
         servicename: sssd
+        packagename: sssd-common
 
 warnings:
     - general:


### PR DESCRIPTION
#### Description:

- use the sssd-common package in the template configuration of service_sssd_enabled
- add sssd-common to the sssd component

#### Rationale:

- the /usr/sbin/sssd which is launched by the sssd.service is provided by sssd-common package
- before this fix, the rule was always failing although the service was running and the configuration of sssd was correct

#### Review Hints:

use automatus to test the rule service_sssd_enabled before and after the fix