### PR TITLE
Align networkmanager_dns_mode to the RHEL 9 STIG

### DIFF
--- a/linux_os/guide/system/network/networkmanager/networkmanager_dns_mode/ansible/shared.yml
+++ b/linux_os/guide/system/network/networkmanager/networkmanager_dns_mode/ansible/shared.yml
@@ -6,7 +6,7 @@
 
 {{{ ansible_instantiate_variables("var_networkmanager_dns_mode") }}}
 
-{{{ ansible_ini_file_set("/etc/NetworkManager/NetworkManager.conf", "main", "dns", "{{ var_networkmanager_dns_mode }}") }}}
+{{{ ansible_ini_file_set("/etc/NetworkManager/NetworkManager.conf", "main", "dns", "{{ var_networkmanager_dns_mode }}", description="", ignore_spaces=true) }}}
 
 - name: "{{{ rule_title }}} - Ensure Network Manager"
   ansible.builtin.systemd:

--- a/linux_os/guide/system/network/networkmanager/networkmanager_dns_mode/oval/shared.xml
+++ b/linux_os/guide/system/network/networkmanager/networkmanager_dns_mode/oval/shared.xml
@@ -1,12 +1,12 @@
-{{{
-oval_check_ini_file(
+{{{ oval_check_config_file(
     path="/etc/NetworkManager/NetworkManager.conf",
-    section="main",
+    prefix_regex="",
     parameter="dns",
     value="default|none",
-    missing_parameter_pass=false,
+    separator_regex="=",
+    missing_parameter_pass=False,
     application="NetworkManager",
-    multi_value=false,
-    missing_config_file_fail=true
-)
+    multi_value=true,
+    missing_config_file_fail=true,
+    section="main")
 }}}

--- a/linux_os/guide/system/network/networkmanager/networkmanager_dns_mode/tests/space.fail.sh
+++ b/linux_os/guide/system/network/networkmanager/networkmanager_dns_mode/tests/space.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# variables = var_networkmanager_dns_mode = default
+# packages = NetworkManager
+
+cat > /etc/NetworkManager/NetworkManager.conf << EOM
+[main]
+dns = none
+EOM

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -724,7 +724,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
 {{%- endmacro %}}
 
 
-{{% macro ansible_ini_file_set(filename, section, key, value, description="") -%}}
+{{% macro ansible_ini_file_set(filename, section, key, value, description="", ignore_spaces=false) -%}}
 - name: "{{{ description if description else ("Set '" + key + "' to '" + value + "' in the [" + section + "] section of '" + filename + "'") }}}"
   ini_file:
     path: "{{{ filename }}}"
@@ -733,6 +733,11 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
     value: "{{{ value }}}"
     create: yes
     mode: 0644
+    {{% if ignore_spaces %}}
+    ignore_spaces: false
+    no_extra_spaces: true
+    {{% endif %}}
+
 {{%- endmacro %}}
 
 {{#


### PR DESCRIPTION


#### Description:

Removes the ability to add space around the `dns=none` per the STIG SCAP content.

#### Rationale:

Fixes #11702

