### PR TITLE
Add configure_tmux_lock_keybinding to the RHEL 9 STIG

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/tests/alternative_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/tests/alternative_value.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Oracle Linux 8,multi_platform_rhel,multi_platform_fedora
 
 echo 'bind W lock-session' >> '/etc/tmux.conf'
 chmod 0644 "/etc/tmux.conf"

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/tests/correct.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Oracle Linux 8,multi_platform_rhel,multi_platform_fedora
+# packages = tmux
 
 echo 'bind X lock-session' >> '/etc/tmux.conf'
 chmod 0644 "/etc/tmux.conf"

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/tests/file_empty.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/tests/file_empty.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Oracle Linux 8,multi_platform_rhel,multi_platform_fedora
+# packages = tmux
 
 echo > '/etc/tmux.conf'

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/tests/line_commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/tests/line_commented.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Oracle Linux 8,multi_platform_rhel,multi_platform_fedora
+# packages = tmux
 
 echo '# bind X lock-session' >> '/etc/tmux.conf'

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/tests/wrong_permissions.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/tests/wrong_permissions.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Oracle Linux 8,multi_platform_rhel,multi_platform_fedora
+# packages = tmux
 
 echo 'bind X lock-session' >> '/etc/tmux.conf'
 chmod 0600 "/etc/tmux.conf"

--- a/products/rhel9/profiles/stig.profile
+++ b/products/rhel9/profiles/stig.profile
@@ -28,4 +28,3 @@ selections:
   - stig_rhel9:all
   # Following rules once had a prodtype incompatible with the rhel9 product
   - '!audit_rules_immutable_login_uids'
-  - '!configure_tmux_lock_keybinding'


### PR DESCRIPTION
#### Description:
Adds back configure_tmux_lock_keybinding to the RHEL 9 STIG

#### Rationale:
  
 Fixes #11694


#### Review Hints:

Apply `configure_tmux_lock_command` and `configure_tmux_lock_keybinding` to a  RHEL 9 box. Then open tmux and lock with `Ctrl-b X`.
