### PR TITLE
grub2_spectre_v2_argument: fix wrong description

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/grub2_spectre_v2_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_spectre_v2_argument/rule.yml
@@ -14,7 +14,7 @@ description: |-
     Enforce the Spectre V2 mitigation by adding the argument
     <tt>spectre_v2=on</tt> to the default
     GRUB 2 command line for the Linux operating system.
-    {{{ describe_grub2_argument("spectre_v2=on)") | indent(4) }}}
+    {{{ describe_grub2_argument("spectre_v2=on") | indent(4) }}}
 
 rationale: |-
     The Spectre V2 vulnerability allows an attacker to read memory that he should not have


### PR DESCRIPTION
#### Description:

- remove incorrect ")" character from the argument

#### Rationale:

- it caused confusion


#### Review Hints:

Try to run the grubby command as shown in the description and scan the system for the rule