### PR TITLE
Clean up check_eof

### DIFF
--- a/utils/check_eof.py
+++ b/utils/check_eof.py
@@ -14,9 +14,9 @@ EXCLUSIONS = ['/shared/references/', '/logs/', '/tests/data/utils/', '/tests/.my
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Print and fix files that don't end "
                                                  "in a new line")
-    parser.add_argument("paths", type=str, nargs="+")
+    parser.add_argument("paths", type=str, nargs="+", help="Paths to check")
     parser.add_argument("--fix", action="store_true",
-                        help='If set the program will add a new file to end of files that are '
+                        help='If set the program will add a new line to end of files that are '
                              'missing it.')
     return parser.parse_args()
 
@@ -46,7 +46,7 @@ def should_skip_file(file: pathlib.Path) -> bool:
     return False
 
 
-def is_file_readable(file: pathlib.Path, f: typing.BinaryIO) -> bool:
+def is_file_not_readable(file: pathlib.Path, f: typing.BinaryIO) -> bool:
     return not f.seekable() or file.stat().st_size < 2
 
 
@@ -56,7 +56,7 @@ def get_files_with_no_newline(files: list) -> list:
         if should_skip_file(file):
             continue
         with open(file.absolute(), 'rb') as f:
-            if is_file_readable(file, f):
+            if is_file_not_readable(file, f):
                 continue
             f.seek(-1, os.SEEK_END)
             data = f.read(1)
@@ -70,7 +70,7 @@ def fix_file(file: pathlib.Path) -> None:
         f.write('\n')
 
 
-def main():
+def main() -> int:
     args = parse_args()
     files = get_all_files(args.paths)
     bad_files = get_files_with_no_newline(files)
@@ -82,8 +82,9 @@ def main():
 
     print(f"{count} of {len(files)} files do not have the correct ending.")
     if count != 0:
-        exit(1)
+        return 1
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())


### PR DESCRIPTION


#### Description:

1. Use raise SystemExit
2. Clean up file names
3. Clean up help text

#### Rationale:

Clean up the help text
