### PR TITLE
OCP4: deprecating two api_server rules

### DIFF
--- a/applications/openshift/api-server/api_server_api_priority_gate_enabled/rule.yml
+++ b/applications/openshift/api-server/api_server_api_priority_gate_enabled/rule.yml
@@ -32,12 +32,6 @@ identifiers:
 
 severity: medium
 
-references:
-  cis@ocp4: 1.2.9
-  nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
-  nist: CM-6,CM-6(1)
-  pcidss: Req-2.2
-  srg: SRG-APP-000516-CTR-001325
 
 platform: not ocp4-on-hypershift-hosted and ocp4.6
 

--- a/applications/openshift/api-server/api_server_insecure_port/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_port/rule.yml
@@ -42,12 +42,6 @@ platforms:
 
 severity: medium
 
-references:
-    cis@ocp4: 1.2.17
-    nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
-    nist: CM-6,CM-6(1)
-    pcidss: Req-2.2,Req-2.3
-    srg: SRG-APP-000516-CTR-001325
 
 ocil_clause: '<tt>insecure-port</tt> setting exists'
 

--- a/controls/cis_ocp_1_4_0/section-1.yml
+++ b/controls/cis_ocp_1_4_0/section-1.yml
@@ -246,9 +246,8 @@ controls:
       levels: [ level_1, ]
     - id: 1.2.9
       title: Ensure that the APIPriorityAndFairness feature gate is enabled
-      status: automated
-      rules:
-        - api_server_api_priority_gate_enabled
+      status: inherently met
+      rules: []
       levels: [ level_1, ]
     - id: 1.2.10
       title: Ensure that the admission control plugin AlwaysAdmit is not set
@@ -294,9 +293,8 @@ controls:
       levels: [ level_1, ]
     - id: 1.2.17
       title: Ensure that the --insecure-port argument is set to 0
-      status: automated
-      rules:
-        - api_server_insecure_port
+      status: inherently met
+      rules: []
       levels: [ level_1, ]
     - id: 1.2.18
       title: Ensure that the --secure-port argument is not set to 0

--- a/controls/nist_ocp4.yml
+++ b/controls/nist_ocp4.yml
@@ -4815,7 +4815,6 @@ controls:
   - file_permissions_openshift_pki_key_files
   - file_owner_cni_conf
   - ocp_api_server_audit_log_maxsize
-  - api_server_api_priority_gate_enabled
   - file_owner_master_admin_kubeconfigs
   - file_permissions_ovsdb_server_pid
   - file_groupowner_kube_scheduler
@@ -4994,7 +4993,6 @@ controls:
   - controller_use_service_account
   - file_groupowner_ovs_sys_id_conf
   - file_groupowner_cni_conf
-  - api_server_insecure_port
   - rbac_debug_role_protects_pprof
   - rbac_limit_cluster_admin
   - file_groupowner_ovs_pid
@@ -5044,7 +5042,6 @@ controls:
   - file_permissions_openshift_pki_key_files
   - file_owner_cni_conf
   - ocp_api_server_audit_log_maxsize
-  - api_server_api_priority_gate_enabled
   - file_owner_master_admin_kubeconfigs
   - file_permissions_ovsdb_server_pid
   - file_groupowner_kube_scheduler
@@ -5211,7 +5208,6 @@ controls:
   - controller_use_service_account
   - file_groupowner_ovs_sys_id_conf
   - file_groupowner_cni_conf
-  - api_server_insecure_port
   - rbac_debug_role_protects_pprof
   - rbac_limit_cluster_admin
   - file_groupowner_ovs_pid

--- a/controls/pcidss_4_ocp4.yml
+++ b/controls/pcidss_4_ocp4.yml
@@ -522,7 +522,6 @@ controls:
         - api_server_etcd_cert
         - api_server_etcd_key
         - api_server_https_for_kubelet_conn
-        - api_server_insecure_port
         - api_server_kubelet_certificate_authority
         - api_server_oauth_https_serving_cert
         - api_server_openshift_https_serving_cert

--- a/controls/pcidss_ocp4.yml
+++ b/controls/pcidss_ocp4.yml
@@ -519,7 +519,6 @@ controls:
     - api_server_etcd_cert
     - api_server_etcd_key
     - api_server_https_for_kubelet_conn
-    - api_server_insecure_port
     - api_server_kubelet_certificate_authority
     - api_server_oauth_https_serving_cert
     - api_server_openshift_https_serving_cert


### PR DESCRIPTION
This pr removes `api_server_insecure_port` and `api_server_api_priority_gate_enabled` from any of the OCP profiles because we no longer support those applicable OCP versions.
