### PR TITLE
mount_option_remote_systems: make rule not applicable if mounts not found

### DIFF
--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/rule.yml
@@ -44,3 +44,5 @@ template:
         mount_has_to_exist: 'yes'
         mountoption: sec=krb5:krb5i:krb5p
         mountpoint: remote_filesystems
+
+platform: nfs_mount_defined

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/tests/no_nfs.pass.sh
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/tests/no_nfs.pass.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-cp $SHARED/fstab /etc/
-sed -i '/nfs/d' /etc/fstab

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_nodev_remote_filesystems/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_nodev_remote_filesystems/rule.yml
@@ -48,3 +48,5 @@ template:
         mount_has_to_exist: 'yes'
         mountoption: nodev
         mountpoint: remote_filesystems
+
+platform: nfs_mount_defined

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_noexec_remote_filesystems/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_noexec_remote_filesystems/rule.yml
@@ -56,3 +56,5 @@ template:
         mount_has_to_exist: 'yes'
         mountoption: noexec
         mountpoint: remote_filesystems
+
+platform: nfs_mount_defined

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_noexec_remote_filesystems/tests/no_nfs.pass.sh
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_noexec_remote_filesystems/tests/no_nfs.pass.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-cp $SHARED/fstab /etc/
-sed -i '/nfs/d' /etc/fstab

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_nosuid_remote_filesystems/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_nosuid_remote_filesystems/rule.yml
@@ -54,3 +54,5 @@ template:
         mount_has_to_exist: 'yes'
         mountoption: nosuid
         mountpoint: remote_filesystems
+
+platform: nfs_mount_defined

--- a/shared/applicability/nfs_mount_defined.yml
+++ b/shared/applicability/nfs_mount_defined.yml
@@ -1,0 +1,5 @@
+name: "cpe:/a:nfs_mount_defined"
+title: "Remote NFS file system mount is defined"
+check_id: nfs_mount_defined
+bash_conditional: 'grep -E "[[:space:]](nfs|nfs4)[[:space:]]" /etc/fstab'
+ansible_conditional: 'ansible_mounts|selectattr("fstype", "in", ["nfs", "nfs4"])|list|length > 0'

--- a/shared/applicability/oval/nfs_mount_defined.xml
+++ b/shared/applicability/oval/nfs_mount_defined.xml
@@ -1,0 +1,24 @@
+<def-group>
+  <definition class="inventory" id="nfs_mount_defined" version="1">
+    <metadata>
+      <title>Remote NFS file system mount is defined</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>At least one remote NFS file system mount is defined in  /etc/fstab</description>
+      <reference ref_id="cpe:/a:nfs_mount_defined" source="CPE" />
+    </metadata>
+    <criteria>
+      <criterion comment="remote nfs filesystem exist" test_ref="test_nfs_mount_exists" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="at least one nfs is defined" id="test_nfs_mount_exists" version="1">
+    <ind:object object_ref="object_nfs_mount_defined" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_nfs_mount_defined" version="1">
+    <ind:filepath>/etc/fstab</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*\[?[\.\w:-]+\]?[:=][/\w-]+\s+[/\w\\-]+\s+nfs[4]?\s+(.*)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/shared/templates/mount_option_remote_filesystems/oval.template
+++ b/shared/templates/mount_option_remote_filesystems/oval.template
@@ -1,10 +1,7 @@
 <def-group>
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
     {{{ oval_metadata("The " + MOUNTOPTIONID + " option should be enabled for all NFS mounts in /etc/fstab.") }}}
-    <criteria operator="XOR">
-      <!-- these tests are designed to be mutually exclusive; either no nfs mounts exist in /etc/fstab -->
-      <!-- or all of the nfs mounts defined in /etc/fstab have the {{{ MOUNTOPTIONID }}} mount option specified -->
-      <criterion comment="remote nfs filesystems" test_ref="test_no_nfs_defined_etc_fstab_{{{ MOUNTOPTIONID }}}" />
+    <criteria operator="OR">
       <criterion comment="remote nfs filesystems" test_ref="test_nfs_{{{ MOUNTOPTIONID }}}_etc_fstab" />
     </criteria>
   </definition>
@@ -21,14 +18,4 @@
   <ind:textfilecontent54_state id="state_remote_filesystem_{{{ MOUNTOPTIONID }}}" version="1">
     <ind:subexpression operation="pattern match">^.*{{{ MOUNTOPTION }}}.*$</ind:subexpression>
   </ind:textfilecontent54_state>
-  <ind:textfilecontent54_test check="all" check_existence="none_exist" comment="no nfs" id="test_no_nfs_defined_etc_fstab_{{{ MOUNTOPTIONID }}}" version="1">
-    <!-- this test returns 'true' if /etc/fstab does not contain nfs/nfs4 mounts -->
-    <ind:object object_ref="object_no_nfs_defined_etc_fstab_{{{ MOUNTOPTIONID }}}" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_no_nfs_defined_etc_fstab_{{{ MOUNTOPTIONID }}}" version="1">
-    <ind:filepath>/etc/fstab</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*\[?[\.\w:-]+\]?[:=][/\w-]+\s+[/\w\\-]+\s+nfs[4]?\s+(.*)$</ind:pattern>
-    <!-- the "not equal" operation below essentially means all instances of the regexp -->
-    <ind:instance datatype="int" operation="not equal">0</ind:instance>
-  </ind:textfilecontent54_object>
 </def-group>


### PR DESCRIPTION
#### Description:

- new platform nfs_mount_defined added
- change the OVAL check of the mount_option_remote_filesystems template so that it only checks for mount options. Previously, it also checked if any mount points of nfs or nfs4 are defined. If there were not any, the check resulted in "pass".
- now the approach is a bit different; the check for presence of nfs / nfs4 mount points is performed by CPE platform. Therefore, in case there is no such a mount point, the rule is marked as not applicable
- This also led me to removing of test scenarios which were testing for the case when there is no nfs / nfs4 mount point.

#### Rationale:

- This is aligning the content with DISA and at the some time I think it makes more sense.

Fixes: #11705  #11707 

#### Review Hints:

- test the rule with automatus
- ensure that the applicability check works by evaluating some templated rule against the system without nfs / nfs4 mounts

