### PR TITLE
Add Ansible Remediations

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/force_opensc_card_drivers/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/force_opensc_card_drivers/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_rhv,multi_platform_ol,multi_platform_sle
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhv,multi_platform_ol,multi_platform_sle
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/system/software/updating/dnf-automatic_apply_updates/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/dnf-automatic_apply_updates/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_fedora,multi_platform_sle,Red Hat Enterprise Linux 8,Oracle Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,multi_platform_sle,Oracle Linux 8
 # reboot = false
 # strategy = unknown
 # complexity = low

--- a/linux_os/guide/system/software/updating/dnf-automatic_security_updates_only/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/dnf-automatic_security_updates_only/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_fedora,multi_platform_sle,Red Hat Enterprise Linux 8,Oracle Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,multi_platform_sle,Oracle Linux 8
 # reboot = false
 # strategy = unknown
 # complexity = low


### PR DESCRIPTION
This patch extends the Ansible remediations to RHEL 9:
- force_opensc_card_drivers
- dnf-automatic_apply_updates
- dnf-automatic_security_updates_only

More context:
https://github.com/RHSecurityCompliance/contest/pull/129#issuecomment-2019515006

