### PR TITLE
update links and unify documentation in kickstart files

### DIFF
--- a/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_enhanced-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_enhanced-ks.cfg
@@ -5,6 +5,8 @@
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -126,20 +128,8 @@ logvol swap --name=swap --vgname=VolGroup --size=2016
 #   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
 #   Values can be optionally enclosed in single quotes (') or double quotes (").
 #   
-#  The following keys are recognized by the add-on:
-#    content-type - Type of the security content. Possible values are datastream, archive, rpm, and scap-security-guide.
-#      - If the content-type is scap-security-guide, the add-on will use content provided by the
-#        scap-security-guide package, which is present on the boot media. This means that all other keys except profile will have no effect.
-#    content-url - Location of the security content. The content must be accessible using HTTP, HTTPS, or FTP; local storage is currently not supported. A network connection must be available to reach content definitions in a remote location.
-#    datastream-id - ID of the data stream referenced in the content-url value. Used only if content-type is datastream.
-#    xccdf-id - ID of the benchmark you want to use.
-#    xccdf-path - Path to the XCCDF file which should be used; given as a relative path in the archive.
-#    profile - ID of the profile to be applied. Use default to apply the default profile.
-#    fingerprint - A MD5, SHA1 or SHA2 checksum of the content referenced by content-url.
-#    tailoring-path - Path to a tailoring file which should be used, given as a relative path in the archive.
-#
-#  The following is an example %addon org_fedora_oscap section which uses content from the
-#  scap-security-guide on the installation media: 
+# For more details and configuration options see
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_an_advanced_rhel_8_installation/kickstart-commands-and-options-reference_installing-rhel-as-an-experienced-user#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon org_fedora_oscap
 	content-type = scap-security-guide
 	profile = xccdf_org.ssgproject.content_profile_anssi_bp28_enhanced

--- a/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_high-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_high-ks.cfg
@@ -5,6 +5,8 @@
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -117,6 +119,7 @@ logvol /var/log --fstype=xfs --name=varlog --vgname=VolGroup --size=1024 --fsopt
 logvol /var/log/audit --fstype=xfs --name=varlogaudit --vgname=VolGroup --size=512 --fsoptions="nodev,nosuid,noexec"
 logvol swap --name=swap --vgname=VolGroup --size=2016
 
+
 # The OpenSCAP installer add-on is used to apply SCAP (Security Content Automation Protocol)
 # content - security policies - on the installed system.This add-on has been enabled by default
 # since Red Hat Enterprise Linux 7.2. When enabled, the packages necessary to provide this 
@@ -130,20 +133,8 @@ logvol swap --name=swap --vgname=VolGroup --size=2016
 #   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
 #   Values can be optionally enclosed in single quotes (') or double quotes (").
 #   
-#  The following keys are recognized by the add-on:
-#    content-type - Type of the security content. Possible values are datastream, archive, rpm, and scap-security-guide.
-#      - If the content-type is scap-security-guide, the add-on will use content provided by the
-#        scap-security-guide package, which is present on the boot media. This means that all other keys except profile will have no effect.
-#    content-url - Location of the security content. The content must be accessible using HTTP, HTTPS, or FTP; local storage is currently not supported. A network connection must be available to reach content definitions in a remote location.
-#    datastream-id - ID of the data stream referenced in the content-url value. Used only if content-type is datastream.
-#    xccdf-id - ID of the benchmark you want to use.
-#    xccdf-path - Path to the XCCDF file which should be used; given as a relative path in the archive.
-#    profile - ID of the profile to be applied. Use default to apply the default profile.
-#    fingerprint - A MD5, SHA1 or SHA2 checksum of the content referenced by content-url.
-#    tailoring-path - Path to a tailoring file which should be used, given as a relative path in the archive.
-#
-#  The following is an example %addon org_fedora_oscap section which uses content from the
-#  scap-security-guide on the installation media: 
+# For more details and configuration options see
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_an_advanced_rhel_8_installation/kickstart-commands-and-options-reference_installing-rhel-as-an-experienced-user#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon org_fedora_oscap
 	content-type = scap-security-guide
 	profile = xccdf_org.ssgproject.content_profile_anssi_bp28_high

--- a/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_intermediary-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_intermediary-ks.cfg
@@ -5,6 +5,9 @@
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
+
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -126,20 +129,8 @@ logvol swap --name=swap --vgname=VolGroup --size=2016
 #   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
 #   Values can be optionally enclosed in single quotes (') or double quotes (").
 #   
-#  The following keys are recognized by the add-on:
-#    content-type - Type of the security content. Possible values are datastream, archive, rpm, and scap-security-guide.
-#      - If the content-type is scap-security-guide, the add-on will use content provided by the
-#        scap-security-guide package, which is present on the boot media. This means that all other keys except profile will have no effect.
-#    content-url - Location of the security content. The content must be accessible using HTTP, HTTPS, or FTP; local storage is currently not supported. A network connection must be available to reach content definitions in a remote location.
-#    datastream-id - ID of the data stream referenced in the content-url value. Used only if content-type is datastream.
-#    xccdf-id - ID of the benchmark you want to use.
-#    xccdf-path - Path to the XCCDF file which should be used; given as a relative path in the archive.
-#    profile - ID of the profile to be applied. Use default to apply the default profile.
-#    fingerprint - A MD5, SHA1 or SHA2 checksum of the content referenced by content-url.
-#    tailoring-path - Path to a tailoring file which should be used, given as a relative path in the archive.
-#
-#  The following is an example %addon org_fedora_oscap section which uses content from the
-#  scap-security-guide on the installation media: 
+# For more details and configuration options see
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_an_advanced_rhel_8_installation/kickstart-commands-and-options-reference_installing-rhel-as-an-experienced-user#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon org_fedora_oscap
 	content-type = scap-security-guide
 	profile = xccdf_org.ssgproject.content_profile_anssi_bp28_intermediary

--- a/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_minimal-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_minimal-ks.cfg
@@ -5,6 +5,8 @@
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -90,20 +92,8 @@ autopart
 #   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
 #   Values can be optionally enclosed in single quotes (') or double quotes (").
 #   
-#  The following keys are recognized by the add-on:
-#    content-type - Type of the security content. Possible values are datastream, archive, rpm, and scap-security-guide.
-#      - If the content-type is scap-security-guide, the add-on will use content provided by the
-#        scap-security-guide package, which is present on the boot media. This means that all other keys except profile will have no effect.
-#    content-url - Location of the security content. The content must be accessible using HTTP, HTTPS, or FTP; local storage is currently not supported. A network connection must be available to reach content definitions in a remote location.
-#    datastream-id - ID of the data stream referenced in the content-url value. Used only if content-type is datastream.
-#    xccdf-id - ID of the benchmark you want to use.
-#    xccdf-path - Path to the XCCDF file which should be used; given as a relative path in the archive.
-#    profile - ID of the profile to be applied. Use default to apply the default profile.
-#    fingerprint - A MD5, SHA1 or SHA2 checksum of the content referenced by content-url.
-#    tailoring-path - Path to a tailoring file which should be used, given as a relative path in the archive.
-#
-#  The following is an example %addon org_fedora_oscap section which uses content from the
-#  scap-security-guide on the installation media: 
+# For more details and configuration options see
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_an_advanced_rhel_8_installation/kickstart-commands-and-options-reference_installing-rhel-as-an-experienced-user#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon org_fedora_oscap
 	content-type = scap-security-guide
 	profile = xccdf_org.ssgproject.content_profile_anssi_bp28_minimal

--- a/products/rhel8/kickstart/ssg-rhel8-cis-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-cis-ks.cfg
@@ -4,7 +4,8 @@
 #
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#performing_an_automated_installation_using_kickstart
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -111,9 +112,21 @@ logvol /var/log/audit --fstype=xfs --name=varlogaudit --vgname=VolGroup --size=5
 logvol swap --name=swap --vgname=VolGroup --size=2016
 
 
-# Harden installation with CIS profile
+# The OpenSCAP installer add-on is used to apply SCAP (Security Content Automation Protocol)
+# content - security policies - on the installed system.This add-on has been enabled by default
+# since Red Hat Enterprise Linux 7.2. When enabled, the packages necessary to provide this 
+# functionality will automatically be installed. However, by default, no policies are enforced,
+# meaning that no checks are performed during or after installation unless specifically configured.
+#  
+#  Important
+#   Applying a security policy is not necessary on all systems. This screen should only be used
+#   when a specific policy is mandated by your organization rules or government regulations.
+#   Unlike most other commands, this add-on does not accept regular options, but uses key-value
+#   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
+#   Values can be optionally enclosed in single quotes (') or double quotes (").
+#   
 # For more details and configuration options see
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_an_advanced_rhel_8_installation/kickstart-commands-and-options-reference_installing-rhel-as-an-experienced-user#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon org_fedora_oscap
         content-type = scap-security-guide
         profile = xccdf_org.ssgproject.content_profile_cis

--- a/products/rhel8/kickstart/ssg-rhel8-cis_server_l1-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-cis_server_l1-ks.cfg
@@ -4,7 +4,8 @@
 #
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#performing_an_automated_installation_using_kickstart
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -111,9 +112,21 @@ logvol /var/log/audit --fstype=xfs --name=varlogaudit --vgname=VolGroup --size=5
 logvol swap --name=swap --vgname=VolGroup --size=2016
 
 
-# Harden installation with CIS profile
+# The OpenSCAP installer add-on is used to apply SCAP (Security Content Automation Protocol)
+# content - security policies - on the installed system.This add-on has been enabled by default
+# since Red Hat Enterprise Linux 7.2. When enabled, the packages necessary to provide this 
+# functionality will automatically be installed. However, by default, no policies are enforced,
+# meaning that no checks are performed during or after installation unless specifically configured.
+#  
+#  Important
+#   Applying a security policy is not necessary on all systems. This screen should only be used
+#   when a specific policy is mandated by your organization rules or government regulations.
+#   Unlike most other commands, this add-on does not accept regular options, but uses key-value
+#   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
+#   Values can be optionally enclosed in single quotes (') or double quotes (").
+#   
 # For more details and configuration options see
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_an_advanced_rhel_8_installation/kickstart-commands-and-options-reference_installing-rhel-as-an-experienced-user#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon org_fedora_oscap
         content-type = scap-security-guide
         profile = xccdf_org.ssgproject.content_profile_cis_server_l1

--- a/products/rhel8/kickstart/ssg-rhel8-cis_workstation_l1-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-cis_workstation_l1-ks.cfg
@@ -4,7 +4,8 @@
 #
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#performing_an_automated_installation_using_kickstart
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -111,9 +112,21 @@ logvol /var/log/audit --fstype=xfs --name=varlogaudit --vgname=VolGroup --size=5
 logvol swap --name=swap --vgname=VolGroup --size=2016
 
 
-# Harden installation with CIS profile
+# The OpenSCAP installer add-on is used to apply SCAP (Security Content Automation Protocol)
+# content - security policies - on the installed system.This add-on has been enabled by default
+# since Red Hat Enterprise Linux 7.2. When enabled, the packages necessary to provide this 
+# functionality will automatically be installed. However, by default, no policies are enforced,
+# meaning that no checks are performed during or after installation unless specifically configured.
+#  
+#  Important
+#   Applying a security policy is not necessary on all systems. This screen should only be used
+#   when a specific policy is mandated by your organization rules or government regulations.
+#   Unlike most other commands, this add-on does not accept regular options, but uses key-value
+#   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
+#   Values can be optionally enclosed in single quotes (') or double quotes (").
+#   
 # For more details and configuration options see
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_an_advanced_rhel_8_installation/kickstart-commands-and-options-reference_installing-rhel-as-an-experienced-user#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon org_fedora_oscap
         content-type = scap-security-guide
         profile = xccdf_org.ssgproject.content_profile_cis_workstation_l1

--- a/products/rhel8/kickstart/ssg-rhel8-cis_workstation_l2-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-cis_workstation_l2-ks.cfg
@@ -4,7 +4,8 @@
 #
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#performing_an_automated_installation_using_kickstart
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -111,9 +112,21 @@ logvol /var/log/audit --fstype=xfs --name=varlogaudit --vgname=VolGroup --size=5
 logvol swap --name=swap --vgname=VolGroup --size=2016
 
 
-# Harden installation with CIS profile
+# The OpenSCAP installer add-on is used to apply SCAP (Security Content Automation Protocol)
+# content - security policies - on the installed system.This add-on has been enabled by default
+# since Red Hat Enterprise Linux 7.2. When enabled, the packages necessary to provide this 
+# functionality will automatically be installed. However, by default, no policies are enforced,
+# meaning that no checks are performed during or after installation unless specifically configured.
+#  
+#  Important
+#   Applying a security policy is not necessary on all systems. This screen should only be used
+#   when a specific policy is mandated by your organization rules or government regulations.
+#   Unlike most other commands, this add-on does not accept regular options, but uses key-value
+#   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
+#   Values can be optionally enclosed in single quotes (') or double quotes (").
+#   
 # For more details and configuration options see
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_an_advanced_rhel_8_installation/kickstart-commands-and-options-reference_installing-rhel-as-an-experienced-user#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon org_fedora_oscap
         content-type = scap-security-guide
         profile = xccdf_org.ssgproject.content_profile_cis_workstation_l2

--- a/products/rhel8/kickstart/ssg-rhel8-cui-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-cui-ks.cfg
@@ -3,6 +3,8 @@
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -121,20 +123,8 @@ logvol swap --name=swap --vgname=VolGroup --size=2016
 #   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
 #   Values can be optionally enclosed in single quotes (') or double quotes (").
 #   
-#  The following keys are recognized by the add-on:
-#    content-type - Type of the security content. Possible values are datastream, archive, rpm, and scap-security-guide.
-#      - If the content-type is scap-security-guide, the add-on will use content provided by the
-#        scap-security-guide package, which is present on the boot media. This means that all other keys except profile will have no effect.
-#    content-url - Location of the security content. The content must be accessible using HTTP, HTTPS, or FTP; local storage is currently not supported. A network connection must be available to reach content definitions in a remote location.
-#    datastream-id - ID of the data stream referenced in the content-url value. Used only if content-type is datastream.
-#    xccdf-id - ID of the benchmark you want to use.
-#    xccdf-path - Path to the XCCDF file which should be used; given as a relative path in the archive.
-#    profile - ID of the profile to be applied. Use default to apply the default profile.
-#    fingerprint - A MD5, SHA1 or SHA2 checksum of the content referenced by content-url.
-#    tailoring-path - Path to a tailoring file which should be used, given as a relative path in the archive.
-#
-#  The following is an example %addon org_fedora_oscap section which uses content from the
-#  scap-security-guide on the installation media: 
+# For more details and configuration options see
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_an_advanced_rhel_8_installation/kickstart-commands-and-options-reference_installing-rhel-as-an-experienced-user#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon org_fedora_oscap
 	content-type = scap-security-guide
 	profile = xccdf_org.ssgproject.content_profile_cui

--- a/products/rhel8/kickstart/ssg-rhel8-e8-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-e8-ks.cfg
@@ -4,7 +4,8 @@
 #
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#performing_an_automated_installation_using_kickstart
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -90,9 +91,21 @@ clearpart --linux --initlabel
 # Create primary system partitions (required for installs)
 autopart
 
-# Harden installation with Essential Eight profile
+# The OpenSCAP installer add-on is used to apply SCAP (Security Content Automation Protocol)
+# content - security policies - on the installed system.This add-on has been enabled by default
+# since Red Hat Enterprise Linux 7.2. When enabled, the packages necessary to provide this 
+# functionality will automatically be installed. However, by default, no policies are enforced,
+# meaning that no checks are performed during or after installation unless specifically configured.
+#  
+#  Important
+#   Applying a security policy is not necessary on all systems. This screen should only be used
+#   when a specific policy is mandated by your organization rules or government regulations.
+#   Unlike most other commands, this add-on does not accept regular options, but uses key-value
+#   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
+#   Values can be optionally enclosed in single quotes (') or double quotes (").
+#   
 # For more details and configuration options see
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_an_advanced_rhel_8_installation/kickstart-commands-and-options-reference_installing-rhel-as-an-experienced-user#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon org_fedora_oscap
         content-type = scap-security-guide
         profile = xccdf_org.ssgproject.content_profile_e8

--- a/products/rhel8/kickstart/ssg-rhel8-hipaa-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-hipaa-ks.cfg
@@ -4,7 +4,8 @@
 #
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#performing_an_automated_installation_using_kickstart
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -90,9 +91,21 @@ clearpart --linux --initlabel
 # Create primary system partitions (required for installs)
 autopart
 
-# Harden installation with HIPAA profile
+# The OpenSCAP installer add-on is used to apply SCAP (Security Content Automation Protocol)
+# content - security policies - on the installed system.This add-on has been enabled by default
+# since Red Hat Enterprise Linux 7.2. When enabled, the packages necessary to provide this 
+# functionality will automatically be installed. However, by default, no policies are enforced,
+# meaning that no checks are performed during or after installation unless specifically configured.
+#  
+#  Important
+#   Applying a security policy is not necessary on all systems. This screen should only be used
+#   when a specific policy is mandated by your organization rules or government regulations.
+#   Unlike most other commands, this add-on does not accept regular options, but uses key-value
+#   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
+#   Values can be optionally enclosed in single quotes (') or double quotes (").
+#   
 # For more details and configuration options see
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_an_advanced_rhel_8_installation/kickstart-commands-and-options-reference_installing-rhel-as-an-experienced-user#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon org_fedora_oscap
         content-type = scap-security-guide
         profile = xccdf_org.ssgproject.content_profile_hipaa

--- a/products/rhel8/kickstart/ssg-rhel8-ism_o-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-ism_o-ks.cfg
@@ -4,7 +4,8 @@
 #
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#performing_an_automated_installation_using_kickstart
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -89,9 +90,21 @@ clearpart --linux --initlabel
 # Create primary system partitions (required for installs)
 autopart
 
-# Harden installation with Essential Eight profile
+# The OpenSCAP installer add-on is used to apply SCAP (Security Content Automation Protocol)
+# content - security policies - on the installed system.This add-on has been enabled by default
+# since Red Hat Enterprise Linux 7.2. When enabled, the packages necessary to provide this 
+# functionality will automatically be installed. However, by default, no policies are enforced,
+# meaning that no checks are performed during or after installation unless specifically configured.
+#  
+#  Important
+#   Applying a security policy is not necessary on all systems. This screen should only be used
+#   when a specific policy is mandated by your organization rules or government regulations.
+#   Unlike most other commands, this add-on does not accept regular options, but uses key-value
+#   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
+#   Values can be optionally enclosed in single quotes (') or double quotes (").
+#   
 # For more details and configuration options see
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_an_advanced_rhel_8_installation/kickstart-commands-and-options-reference_installing-rhel-as-an-experienced-user#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon org_fedora_oscap
         content-type = scap-security-guide
         profile = xccdf_org.ssgproject.content_profile_ism_o

--- a/products/rhel8/kickstart/ssg-rhel8-ospp-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-ospp-ks.cfg
@@ -3,6 +3,8 @@
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -121,20 +123,8 @@ logvol swap --name=swap --vgname=VolGroup --size=2016
 #   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
 #   Values can be optionally enclosed in single quotes (') or double quotes (").
 #   
-#  The following keys are recognized by the add-on:
-#    content-type - Type of the security content. Possible values are datastream, archive, rpm, and scap-security-guide.
-#      - If the content-type is scap-security-guide, the add-on will use content provided by the
-#        scap-security-guide package, which is present on the boot media. This means that all other keys except profile will have no effect.
-#    content-url - Location of the security content. The content must be accessible using HTTP, HTTPS, or FTP; local storage is currently not supported. A network connection must be available to reach content definitions in a remote location.
-#    datastream-id - ID of the data stream referenced in the content-url value. Used only if content-type is datastream.
-#    xccdf-id - ID of the benchmark you want to use.
-#    xccdf-path - Path to the XCCDF file which should be used; given as a relative path in the archive.
-#    profile - ID of the profile to be applied. Use default to apply the default profile.
-#    fingerprint - A MD5, SHA1 or SHA2 checksum of the content referenced by content-url.
-#    tailoring-path - Path to a tailoring file which should be used, given as a relative path in the archive.
-#
-#  The following is an example %addon org_fedora_oscap section which uses content from the
-#  scap-security-guide on the installation media: 
+# For more details and configuration options see
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_an_advanced_rhel_8_installation/kickstart-commands-and-options-reference_installing-rhel-as-an-experienced-user#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon org_fedora_oscap
 	content-type = scap-security-guide
 	profile = xccdf_org.ssgproject.content_profile_ospp

--- a/products/rhel8/kickstart/ssg-rhel8-pci-dss-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-pci-dss-ks.cfg
@@ -3,6 +3,8 @@
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -116,20 +118,8 @@ logvol swap --name=swap --vgname=VolGroup --size=2016
 #   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
 #   Values can be optionally enclosed in single quotes (') or double quotes (").
 #   
-#  The following keys are recognized by the add-on:
-#    content-type - Type of the security content. Possible values are datastream, archive, rpm, and scap-security-guide.
-#      - If the content-type is scap-security-guide, the add-on will use content provided by the
-#        scap-security-guide package, which is present on the boot media. This means that all other keys except profile will have no effect.
-#    content-url - Location of the security content. The content must be accessible using HTTP, HTTPS, or FTP; local storage is currently not supported. A network connection must be available to reach content definitions in a remote location.
-#    datastream-id - ID of the data stream referenced in the content-url value. Used only if content-type is datastream.
-#    xccdf-id - ID of the benchmark you want to use.
-#    xccdf-path - Path to the XCCDF file which should be used; given as a relative path in the archive.
-#    profile - ID of the profile to be applied. Use default to apply the default profile.
-#    fingerprint - A MD5, SHA1 or SHA2 checksum of the content referenced by content-url.
-#    tailoring-path - Path to a tailoring file which should be used, given as a relative path in the archive.
-#
-#  The following is an example %addon org_fedora_oscap section which uses content from the
-#  scap-security-guide on the installation media: 
+# For more details and configuration options see
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_an_advanced_rhel_8_installation/kickstart-commands-and-options-reference_installing-rhel-as-an-experienced-user#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon org_fedora_oscap
         content-type = scap-security-guide
         profile = xccdf_org.ssgproject.content_profile_pci-dss

--- a/products/rhel8/kickstart/ssg-rhel8-stig-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-stig-ks.cfg
@@ -3,6 +3,8 @@
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -123,20 +125,8 @@ logvol swap --name=swap --vgname=VolGroup --size=2016
 #   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
 #   Values can be optionally enclosed in single quotes (') or double quotes (").
 #   
-#  The following keys are recognized by the add-on:
-#    content-type - Type of the security content. Possible values are datastream, archive, rpm, and scap-security-guide.
-#      - If the content-type is scap-security-guide, the add-on will use content provided by the
-#        scap-security-guide package, which is present on the boot media. This means that all other keys except profile will have no effect.
-#    content-url - Location of the security content. The content must be accessible using HTTP, HTTPS, or FTP; local storage is currently not supported. A network connection must be available to reach content definitions in a remote location.
-#    datastream-id - ID of the data stream referenced in the content-url value. Used only if content-type is datastream.
-#    xccdf-id - ID of the benchmark you want to use.
-#    xccdf-path - Path to the XCCDF file which should be used; given as a relative path in the archive.
-#    profile - ID of the profile to be applied. Use default to apply the default profile.
-#    fingerprint - A MD5, SHA1 or SHA2 checksum of the content referenced by content-url.
-#    tailoring-path - Path to a tailoring file which should be used, given as a relative path in the archive.
-#
-#  The following is an example %addon org_fedora_oscap section which uses content from the
-#  scap-security-guide on the installation media: 
+# For more details and configuration options see
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_an_advanced_rhel_8_installation/kickstart-commands-and-options-reference_installing-rhel-as-an-experienced-user#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon org_fedora_oscap
 	content-type = scap-security-guide
 	profile = xccdf_org.ssgproject.content_profile_stig

--- a/products/rhel8/kickstart/ssg-rhel8-stig_gui-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-stig_gui-ks.cfg
@@ -3,6 +3,8 @@
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -122,20 +124,8 @@ logvol swap --name=swap --vgname=VolGroup --size=2016
 #   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
 #   Values can be optionally enclosed in single quotes (') or double quotes (").
 #   
-#  The following keys are recognized by the add-on:
-#    content-type - Type of the security content. Possible values are datastream, archive, rpm, and scap-security-guide.
-#      - If the content-type is scap-security-guide, the add-on will use content provided by the
-#        scap-security-guide package, which is present on the boot media. This means that all other keys except profile will have no effect.
-#    content-url - Location of the security content. The content must be accessible using HTTP, HTTPS, or FTP; local storage is currently not supported. A network connection must be available to reach content definitions in a remote location.
-#    datastream-id - ID of the data stream referenced in the content-url value. Used only if content-type is datastream.
-#    xccdf-id - ID of the benchmark you want to use.
-#    xccdf-path - Path to the XCCDF file which should be used; given as a relative path in the archive.
-#    profile - ID of the profile to be applied. Use default to apply the default profile.
-#    fingerprint - A MD5, SHA1 or SHA2 checksum of the content referenced by content-url.
-#    tailoring-path - Path to a tailoring file which should be used, given as a relative path in the archive.
-#
-#  The following is an example %addon org_fedora_oscap section which uses content from the
-#  scap-security-guide on the installation media: 
+# For more details and configuration options see
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_an_advanced_rhel_8_installation/kickstart-commands-and-options-reference_installing-rhel-as-an-experienced-user#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon org_fedora_oscap
 	content-type = scap-security-guide
 	profile = xccdf_org.ssgproject.content_profile_stig_gui

--- a/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_enhanced-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_enhanced-ks.cfg
@@ -5,6 +5,8 @@
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -126,20 +128,8 @@ logvol swap --name=swap --vgname=VolGroup --size=2016
 #   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
 #   Values can be optionally enclosed in single quotes (') or double quotes (").
 #   
-#  The following keys are recognized by the add-on:
-#    content-type - Type of the security content. Possible values are datastream, archive, rpm, and scap-security-guide.
-#      - If the content-type is scap-security-guide, the add-on will use content provided by the
-#        scap-security-guide package, which is present on the boot media. This means that all other keys except profile will have no effect.
-#    content-url - Location of the security content. The content must be accessible using HTTP, HTTPS, or FTP; local storage is currently not supported. A network connection must be available to reach content definitions in a remote location.
-#    datastream-id - ID of the data stream referenced in the content-url value. Used only if content-type is datastream.
-#    xccdf-id - ID of the benchmark you want to use.
-#    xccdf-path - Path to the XCCDF file which should be used; given as a relative path in the archive.
-#    profile - ID of the profile to be applied. Use default to apply the default profile.
-#    fingerprint - A MD5, SHA1 or SHA2 checksum of the content referenced by content-url.
-#    tailoring-path - Path to a tailoring file which should be used, given as a relative path in the archive.
-#
-#  The following is an example %addon com_redhat_oscap section which uses content from the
-#  scap-security-guide on the installation media: 
+# For more details and configuration options see
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/performing_an_advanced_rhel_9_installation/index#addon-com_redhat_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon com_redhat_oscap
 	content-type = scap-security-guide
 	profile = xccdf_org.ssgproject.content_profile_anssi_bp28_enhanced

--- a/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_high-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_high-ks.cfg
@@ -5,6 +5,8 @@
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -130,20 +132,8 @@ logvol swap --name=swap --vgname=VolGroup --size=2016
 #   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
 #   Values can be optionally enclosed in single quotes (') or double quotes (").
 #   
-#  The following keys are recognized by the add-on:
-#    content-type - Type of the security content. Possible values are datastream, archive, rpm, and scap-security-guide.
-#      - If the content-type is scap-security-guide, the add-on will use content provided by the
-#        scap-security-guide package, which is present on the boot media. This means that all other keys except profile will have no effect.
-#    content-url - Location of the security content. The content must be accessible using HTTP, HTTPS, or FTP; local storage is currently not supported. A network connection must be available to reach content definitions in a remote location.
-#    datastream-id - ID of the data stream referenced in the content-url value. Used only if content-type is datastream.
-#    xccdf-id - ID of the benchmark you want to use.
-#    xccdf-path - Path to the XCCDF file which should be used; given as a relative path in the archive.
-#    profile - ID of the profile to be applied. Use default to apply the default profile.
-#    fingerprint - A MD5, SHA1 or SHA2 checksum of the content referenced by content-url.
-#    tailoring-path - Path to a tailoring file which should be used, given as a relative path in the archive.
-#
-#  The following is an example %addon com_redhat_oscap section which uses content from the
-#  scap-security-guide on the installation media: 
+# For more details and configuration options see
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/performing_an_advanced_rhel_9_installation/index#addon-com_redhat_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon com_redhat_oscap
 	content-type = scap-security-guide
 	profile = xccdf_org.ssgproject.content_profile_anssi_bp28_high

--- a/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_intermediary-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_intermediary-ks.cfg
@@ -5,6 +5,8 @@
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -126,20 +128,8 @@ logvol swap --name=swap --vgname=VolGroup --size=2016
 #   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
 #   Values can be optionally enclosed in single quotes (') or double quotes (").
 #   
-#  The following keys are recognized by the add-on:
-#    content-type - Type of the security content. Possible values are datastream, archive, rpm, and scap-security-guide.
-#      - If the content-type is scap-security-guide, the add-on will use content provided by the
-#        scap-security-guide package, which is present on the boot media. This means that all other keys except profile will have no effect.
-#    content-url - Location of the security content. The content must be accessible using HTTP, HTTPS, or FTP; local storage is currently not supported. A network connection must be available to reach content definitions in a remote location.
-#    datastream-id - ID of the data stream referenced in the content-url value. Used only if content-type is datastream.
-#    xccdf-id - ID of the benchmark you want to use.
-#    xccdf-path - Path to the XCCDF file which should be used; given as a relative path in the archive.
-#    profile - ID of the profile to be applied. Use default to apply the default profile.
-#    fingerprint - A MD5, SHA1 or SHA2 checksum of the content referenced by content-url.
-#    tailoring-path - Path to a tailoring file which should be used, given as a relative path in the archive.
-#
-#  The following is an example %addon com_redhat_oscap section which uses content from the
-#  scap-security-guide on the installation media: 
+# For more details and configuration options see
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/performing_an_advanced_rhel_9_installation/index#addon-com_redhat_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon com_redhat_oscap
 	content-type = scap-security-guide
 	profile = xccdf_org.ssgproject.content_profile_anssi_bp28_intermediary

--- a/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_minimal-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_minimal-ks.cfg
@@ -5,6 +5,8 @@
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -90,20 +92,8 @@ autopart
 #   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
 #   Values can be optionally enclosed in single quotes (') or double quotes (").
 #   
-#  The following keys are recognized by the add-on:
-#    content-type - Type of the security content. Possible values are datastream, archive, rpm, and scap-security-guide.
-#      - If the content-type is scap-security-guide, the add-on will use content provided by the
-#        scap-security-guide package, which is present on the boot media. This means that all other keys except profile will have no effect.
-#    content-url - Location of the security content. The content must be accessible using HTTP, HTTPS, or FTP; local storage is currently not supported. A network connection must be available to reach content definitions in a remote location.
-#    datastream-id - ID of the data stream referenced in the content-url value. Used only if content-type is datastream.
-#    xccdf-id - ID of the benchmark you want to use.
-#    xccdf-path - Path to the XCCDF file which should be used; given as a relative path in the archive.
-#    profile - ID of the profile to be applied. Use default to apply the default profile.
-#    fingerprint - A MD5, SHA1 or SHA2 checksum of the content referenced by content-url.
-#    tailoring-path - Path to a tailoring file which should be used, given as a relative path in the archive.
-#
-#  The following is an example %addon com_redhat_oscap section which uses content from the
-#  scap-security-guide on the installation media: 
+# For more details and configuration options see
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/performing_an_advanced_rhel_9_installation/index#addon-com_redhat_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon com_redhat_oscap
 	content-type = scap-security-guide
 	profile = xccdf_org.ssgproject.content_profile_anssi_bp28_minimal

--- a/products/rhel9/kickstart/ssg-rhel9-ccn_advanced-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-ccn_advanced-ks.cfg
@@ -4,7 +4,8 @@
 #
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/performing_an_advanced_rhel_9_installation/starting-kickstart-installations_installing-rhel-as-an-experienced-user
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation. To use a different one comment out
 # the 'url' one below, update the selected choice with proper options & un-comment it.
@@ -107,9 +108,21 @@ logvol /var/log --fstype=xfs --name=varlog --vgname=VolGroup --size=1024
 logvol /var/log/audit --fstype=xfs --name=varlogaudit --vgname=VolGroup --size=512
 logvol swap --name=swap --vgname=VolGroup --size=2016
 
-# Harden installation with CCN profile (Advanced)
+# The OpenSCAP installer add-on is used to apply SCAP (Security Content Automation Protocol)
+# content - security policies - on the installed system.This add-on has been enabled by default
+# since Red Hat Enterprise Linux 7.2. When enabled, the packages necessary to provide this 
+# functionality will automatically be installed. However, by default, no policies are enforced,
+# meaning that no checks are performed during or after installation unless specifically configured.
+#  
+#  Important
+#   Applying a security policy is not necessary on all systems. This screen should only be used
+#   when a specific policy is mandated by your organization rules or government regulations.
+#   Unlike most other commands, this add-on does not accept regular options, but uses key-value
+#   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
+#   Values can be optionally enclosed in single quotes (') or double quotes (").
+#   
 # For more details and configuration options see
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/performing_an_advanced_rhel_9_installation/index#addon-com_redhat_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon com_redhat_oscap
         content-type = scap-security-guide
         profile = xccdf_org.ssgproject.content_profile_ccn_advanced

--- a/products/rhel9/kickstart/ssg-rhel9-ccn_basic-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-ccn_basic-ks.cfg
@@ -4,7 +4,8 @@
 #
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/performing_an_advanced_rhel_9_installation/starting-kickstart-installations_installing-rhel-as-an-experienced-user
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation. To use a different one comment out
 # the 'url' one below, update the selected choice with proper options & un-comment it.
@@ -107,9 +108,21 @@ logvol /var/log --fstype=xfs --name=varlog --vgname=VolGroup --size=1024
 logvol /var/log/audit --fstype=xfs --name=varlogaudit --vgname=VolGroup --size=512
 logvol swap --name=swap --vgname=VolGroup --size=2016
 
-# Harden installation with CCN profile (Basic)
+# The OpenSCAP installer add-on is used to apply SCAP (Security Content Automation Protocol)
+# content - security policies - on the installed system.This add-on has been enabled by default
+# since Red Hat Enterprise Linux 7.2. When enabled, the packages necessary to provide this 
+# functionality will automatically be installed. However, by default, no policies are enforced,
+# meaning that no checks are performed during or after installation unless specifically configured.
+#  
+#  Important
+#   Applying a security policy is not necessary on all systems. This screen should only be used
+#   when a specific policy is mandated by your organization rules or government regulations.
+#   Unlike most other commands, this add-on does not accept regular options, but uses key-value
+#   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
+#   Values can be optionally enclosed in single quotes (') or double quotes (").
+#   
 # For more details and configuration options see
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/performing_an_advanced_rhel_9_installation/index#addon-com_redhat_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon com_redhat_oscap
         content-type = scap-security-guide
         profile = xccdf_org.ssgproject.content_profile_ccn_basic

--- a/products/rhel9/kickstart/ssg-rhel9-ccn_intermediate-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-ccn_intermediate-ks.cfg
@@ -4,7 +4,8 @@
 #
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/performing_an_advanced_rhel_9_installation/starting-kickstart-installations_installing-rhel-as-an-experienced-user
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation. To use a different one comment out
 # the 'url' one below, update the selected choice with proper options & un-comment it.
@@ -107,9 +108,21 @@ logvol /var/log --fstype=xfs --name=varlog --vgname=VolGroup --size=1024
 logvol /var/log/audit --fstype=xfs --name=varlogaudit --vgname=VolGroup --size=512
 logvol swap --name=swap --vgname=VolGroup --size=2016
 
-# Harden installation with CCN profile (Intermediate)
+# The OpenSCAP installer add-on is used to apply SCAP (Security Content Automation Protocol)
+# content - security policies - on the installed system.This add-on has been enabled by default
+# since Red Hat Enterprise Linux 7.2. When enabled, the packages necessary to provide this 
+# functionality will automatically be installed. However, by default, no policies are enforced,
+# meaning that no checks are performed during or after installation unless specifically configured.
+#  
+#  Important
+#   Applying a security policy is not necessary on all systems. This screen should only be used
+#   when a specific policy is mandated by your organization rules or government regulations.
+#   Unlike most other commands, this add-on does not accept regular options, but uses key-value
+#   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
+#   Values can be optionally enclosed in single quotes (') or double quotes (").
+#   
 # For more details and configuration options see
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/performing_an_advanced_rhel_9_installation/index#addon-com_redhat_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon com_redhat_oscap
         content-type = scap-security-guide
         profile = xccdf_org.ssgproject.content_profile_ccn_intermediate

--- a/products/rhel9/kickstart/ssg-rhel9-cis-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-cis-ks.cfg
@@ -4,7 +4,8 @@
 #
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#performing_an_automated_installation_using_kickstart
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -111,9 +112,21 @@ logvol /var/log/audit --fstype=xfs --name=varlogaudit --vgname=VolGroup --size=5
 logvol swap --name=swap --vgname=VolGroup --size=2016
 
 
-# Harden installation with CIS profile
+# The OpenSCAP installer add-on is used to apply SCAP (Security Content Automation Protocol)
+# content - security policies - on the installed system.This add-on has been enabled by default
+# since Red Hat Enterprise Linux 7.2. When enabled, the packages necessary to provide this 
+# functionality will automatically be installed. However, by default, no policies are enforced,
+# meaning that no checks are performed during or after installation unless specifically configured.
+#  
+#  Important
+#   Applying a security policy is not necessary on all systems. This screen should only be used
+#   when a specific policy is mandated by your organization rules or government regulations.
+#   Unlike most other commands, this add-on does not accept regular options, but uses key-value
+#   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
+#   Values can be optionally enclosed in single quotes (') or double quotes (").
+#   
 # For more details and configuration options see
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/performing_an_advanced_rhel_9_installation/index#addon-com_redhat_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon com_redhat_oscap
         content-type = scap-security-guide
         profile = xccdf_org.ssgproject.content_profile_cis

--- a/products/rhel9/kickstart/ssg-rhel9-cis_server_l1-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-cis_server_l1-ks.cfg
@@ -4,7 +4,8 @@
 #
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#performing_an_automated_installation_using_kickstart
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -111,9 +112,21 @@ logvol /var/log/audit --fstype=xfs --name=varlogaudit --vgname=VolGroup --size=5
 logvol swap --name=swap --vgname=VolGroup --size=2016
 
 
-# Harden installation with CIS profile
+# The OpenSCAP installer add-on is used to apply SCAP (Security Content Automation Protocol)
+# content - security policies - on the installed system.This add-on has been enabled by default
+# since Red Hat Enterprise Linux 7.2. When enabled, the packages necessary to provide this 
+# functionality will automatically be installed. However, by default, no policies are enforced,
+# meaning that no checks are performed during or after installation unless specifically configured.
+#  
+#  Important
+#   Applying a security policy is not necessary on all systems. This screen should only be used
+#   when a specific policy is mandated by your organization rules or government regulations.
+#   Unlike most other commands, this add-on does not accept regular options, but uses key-value
+#   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
+#   Values can be optionally enclosed in single quotes (') or double quotes (").
+#   
 # For more details and configuration options see
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/performing_an_advanced_rhel_9_installation/index#addon-com_redhat_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon com_redhat_oscap
         content-type = scap-security-guide
         profile = xccdf_org.ssgproject.content_profile_cis_server_l1

--- a/products/rhel9/kickstart/ssg-rhel9-cis_workstation_l1-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-cis_workstation_l1-ks.cfg
@@ -4,7 +4,8 @@
 #
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#performing_an_automated_installation_using_kickstart
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -111,9 +112,21 @@ logvol /var/log/audit --fstype=xfs --name=varlogaudit --vgname=VolGroup --size=5
 logvol swap --name=swap --vgname=VolGroup --size=2016
 
 
-# Harden installation with CIS profile
+# The OpenSCAP installer add-on is used to apply SCAP (Security Content Automation Protocol)
+# content - security policies - on the installed system.This add-on has been enabled by default
+# since Red Hat Enterprise Linux 7.2. When enabled, the packages necessary to provide this 
+# functionality will automatically be installed. However, by default, no policies are enforced,
+# meaning that no checks are performed during or after installation unless specifically configured.
+#  
+#  Important
+#   Applying a security policy is not necessary on all systems. This screen should only be used
+#   when a specific policy is mandated by your organization rules or government regulations.
+#   Unlike most other commands, this add-on does not accept regular options, but uses key-value
+#   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
+#   Values can be optionally enclosed in single quotes (') or double quotes (").
+#   
 # For more details and configuration options see
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/performing_an_advanced_rhel_9_installation/index#addon-com_redhat_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon com_redhat_oscap
         content-type = scap-security-guide
         profile = xccdf_org.ssgproject.content_profile_cis_workstation_l1

--- a/products/rhel9/kickstart/ssg-rhel9-cis_workstation_l2-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-cis_workstation_l2-ks.cfg
@@ -4,7 +4,8 @@
 #
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#performing_an_automated_installation_using_kickstart
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -111,9 +112,21 @@ logvol /var/log/audit --fstype=xfs --name=varlogaudit --vgname=VolGroup --size=5
 logvol swap --name=swap --vgname=VolGroup --size=2016
 
 
-# Harden installation with CIS profile
+# The OpenSCAP installer add-on is used to apply SCAP (Security Content Automation Protocol)
+# content - security policies - on the installed system.This add-on has been enabled by default
+# since Red Hat Enterprise Linux 7.2. When enabled, the packages necessary to provide this 
+# functionality will automatically be installed. However, by default, no policies are enforced,
+# meaning that no checks are performed during or after installation unless specifically configured.
+#  
+#  Important
+#   Applying a security policy is not necessary on all systems. This screen should only be used
+#   when a specific policy is mandated by your organization rules or government regulations.
+#   Unlike most other commands, this add-on does not accept regular options, but uses key-value
+#   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
+#   Values can be optionally enclosed in single quotes (') or double quotes (").
+#   
 # For more details and configuration options see
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/performing_an_advanced_rhel_9_installation/index#addon-com_redhat_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon com_redhat_oscap
         content-type = scap-security-guide
         profile = xccdf_org.ssgproject.content_profile_cis_workstation_l2

--- a/products/rhel9/kickstart/ssg-rhel9-cui-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-cui-ks.cfg
@@ -3,6 +3,8 @@
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -121,20 +123,8 @@ logvol swap --name=swap --vgname=VolGroup --size=2016
 #   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
 #   Values can be optionally enclosed in single quotes (') or double quotes (").
 #   
-#  The following keys are recognized by the add-on:
-#    content-type - Type of the security content. Possible values are datastream, archive, rpm, and scap-security-guide.
-#      - If the content-type is scap-security-guide, the add-on will use content provided by the
-#        scap-security-guide package, which is present on the boot media. This means that all other keys except profile will have no effect.
-#    content-url - Location of the security content. The content must be accessible using HTTP, HTTPS, or FTP; local storage is currently not supported. A network connection must be available to reach content definitions in a remote location.
-#    datastream-id - ID of the data stream referenced in the content-url value. Used only if content-type is datastream.
-#    xccdf-id - ID of the benchmark you want to use.
-#    xccdf-path - Path to the XCCDF file which should be used; given as a relative path in the archive.
-#    profile - ID of the profile to be applied. Use default to apply the default profile.
-#    fingerprint - A MD5, SHA1 or SHA2 checksum of the content referenced by content-url.
-#    tailoring-path - Path to a tailoring file which should be used, given as a relative path in the archive.
-#
-#  The following is an example %addon com_redhat_oscap section which uses content from the
-#  scap-security-guide on the installation media: 
+# For more details and configuration options see
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/performing_an_advanced_rhel_9_installation/index#addon-com_redhat_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon com_redhat_oscap
 	content-type = scap-security-guide
 	profile = xccdf_org.ssgproject.content_profile_cui

--- a/products/rhel9/kickstart/ssg-rhel9-e8-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-e8-ks.cfg
@@ -4,7 +4,8 @@
 #
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#performing_an_automated_installation_using_kickstart
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -90,9 +91,21 @@ clearpart --linux --initlabel
 # Create primary system partitions (required for installs)
 autopart
 
-# Harden installation with Essential Eight profile
+# The OpenSCAP installer add-on is used to apply SCAP (Security Content Automation Protocol)
+# content - security policies - on the installed system.This add-on has been enabled by default
+# since Red Hat Enterprise Linux 7.2. When enabled, the packages necessary to provide this 
+# functionality will automatically be installed. However, by default, no policies are enforced,
+# meaning that no checks are performed during or after installation unless specifically configured.
+#  
+#  Important
+#   Applying a security policy is not necessary on all systems. This screen should only be used
+#   when a specific policy is mandated by your organization rules or government regulations.
+#   Unlike most other commands, this add-on does not accept regular options, but uses key-value
+#   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
+#   Values can be optionally enclosed in single quotes (') or double quotes (").
+#   
 # For more details and configuration options see
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#addon-com_redhat_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/performing_an_advanced_rhel_9_installation/index#addon-com_redhat_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon com_redhat_oscap
         content-type = scap-security-guide
         profile = xccdf_org.ssgproject.content_profile_e8

--- a/products/rhel9/kickstart/ssg-rhel9-hipaa-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-hipaa-ks.cfg
@@ -4,7 +4,8 @@
 #
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#performing_an_automated_installation_using_kickstart
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -90,9 +91,21 @@ clearpart --linux --initlabel
 # Create primary system partitions (required for installs)
 autopart
 
-# Harden installation with HIPAA profile
+# The OpenSCAP installer add-on is used to apply SCAP (Security Content Automation Protocol)
+# content - security policies - on the installed system.This add-on has been enabled by default
+# since Red Hat Enterprise Linux 7.2. When enabled, the packages necessary to provide this 
+# functionality will automatically be installed. However, by default, no policies are enforced,
+# meaning that no checks are performed during or after installation unless specifically configured.
+#  
+#  Important
+#   Applying a security policy is not necessary on all systems. This screen should only be used
+#   when a specific policy is mandated by your organization rules or government regulations.
+#   Unlike most other commands, this add-on does not accept regular options, but uses key-value
+#   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
+#   Values can be optionally enclosed in single quotes (') or double quotes (").
+#   
 # For more details and configuration options see
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#addon-com_redhat_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/performing_an_advanced_rhel_9_installation/index#addon-com_redhat_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon com_redhat_oscap
         content-type = scap-security-guide
         profile = xccdf_org.ssgproject.content_profile_hipaa

--- a/products/rhel9/kickstart/ssg-rhel9-ism_o-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-ism_o-ks.cfg
@@ -4,7 +4,8 @@
 #
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#performing_an_automated_installation_using_kickstart
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -89,9 +90,21 @@ clearpart --linux --initlabel
 # Create primary system partitions (required for installs)
 autopart
 
-# Harden installation with Essential Eight profile
+# The OpenSCAP installer add-on is used to apply SCAP (Security Content Automation Protocol)
+# content - security policies - on the installed system.This add-on has been enabled by default
+# since Red Hat Enterprise Linux 7.2. When enabled, the packages necessary to provide this 
+# functionality will automatically be installed. However, by default, no policies are enforced,
+# meaning that no checks are performed during or after installation unless specifically configured.
+#  
+#  Important
+#   Applying a security policy is not necessary on all systems. This screen should only be used
+#   when a specific policy is mandated by your organization rules or government regulations.
+#   Unlike most other commands, this add-on does not accept regular options, but uses key-value
+#   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
+#   Values can be optionally enclosed in single quotes (') or double quotes (").
+#   
 # For more details and configuration options see
-# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/performing_an_advanced_rhel_9_installation/index#addon-com_redhat_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon com_redhat_oscap
         content-type = scap-security-guide
         profile = xccdf_org.ssgproject.content_profile_ism_o

--- a/products/rhel9/kickstart/ssg-rhel9-ospp-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-ospp-ks.cfg
@@ -3,6 +3,8 @@
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -121,20 +123,8 @@ logvol swap --name=swap --vgname=VolGroup --size=2016
 #   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
 #   Values can be optionally enclosed in single quotes (') or double quotes (").
 #   
-#  The following keys are recognized by the add-on:
-#    content-type - Type of the security content. Possible values are datastream, archive, rpm, and scap-security-guide.
-#      - If the content-type is scap-security-guide, the add-on will use content provided by the
-#        scap-security-guide package, which is present on the boot media. This means that all other keys except profile will have no effect.
-#    content-url - Location of the security content. The content must be accessible using HTTP, HTTPS, or FTP; local storage is currently not supported. A network connection must be available to reach content definitions in a remote location.
-#    datastream-id - ID of the data stream referenced in the content-url value. Used only if content-type is datastream.
-#    xccdf-id - ID of the benchmark you want to use.
-#    xccdf-path - Path to the XCCDF file which should be used; given as a relative path in the archive.
-#    profile - ID of the profile to be applied. Use default to apply the default profile.
-#    fingerprint - A MD5, SHA1 or SHA2 checksum of the content referenced by content-url.
-#    tailoring-path - Path to a tailoring file which should be used, given as a relative path in the archive.
-#
-#  The following is an example %addon com_redhat_oscap section which uses content from the
-#  scap-security-guide on the installation media: 
+# For more details and configuration options see
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/performing_an_advanced_rhel_9_installation/index#addon-com_redhat_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon com_redhat_oscap
 	content-type = scap-security-guide
 	profile = xccdf_org.ssgproject.content_profile_ospp

--- a/products/rhel9/kickstart/ssg-rhel9-pci-dss-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-pci-dss-ks.cfg
@@ -3,6 +3,8 @@
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -116,20 +118,8 @@ logvol swap --name=swap --vgname=VolGroup --size=2016
 #   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
 #   Values can be optionally enclosed in single quotes (') or double quotes (").
 #   
-#  The following keys are recognized by the add-on:
-#    content-type - Type of the security content. Possible values are datastream, archive, rpm, and scap-security-guide.
-#      - If the content-type is scap-security-guide, the add-on will use content provided by the
-#        scap-security-guide package, which is present on the boot media. This means that all other keys except profile will have no effect.
-#    content-url - Location of the security content. The content must be accessible using HTTP, HTTPS, or FTP; local storage is currently not supported. A network connection must be available to reach content definitions in a remote location.
-#    datastream-id - ID of the data stream referenced in the content-url value. Used only if content-type is datastream.
-#    xccdf-id - ID of the benchmark you want to use.
-#    xccdf-path - Path to the XCCDF file which should be used; given as a relative path in the archive.
-#    profile - ID of the profile to be applied. Use default to apply the default profile.
-#    fingerprint - A MD5, SHA1 or SHA2 checksum of the content referenced by content-url.
-#    tailoring-path - Path to a tailoring file which should be used, given as a relative path in the archive.
-#
-#  The following is an example %addon com_redhat_oscap section which uses content from the
-#  scap-security-guide on the installation media: 
+# For more details and configuration options see
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/performing_an_advanced_rhel_9_installation/index#addon-com_redhat_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon com_redhat_oscap
         content-type = scap-security-guide
         profile = xccdf_org.ssgproject.content_profile_pci-dss

--- a/products/rhel9/kickstart/ssg-rhel9-stig-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-stig-ks.cfg
@@ -3,6 +3,8 @@
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -122,20 +124,8 @@ logvol swap --name=swap --vgname=VolGroup --size=2016
 #   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
 #   Values can be optionally enclosed in single quotes (') or double quotes (").
 #   
-#  The following keys are recognized by the add-on:
-#    content-type - Type of the security content. Possible values are datastream, archive, rpm, and scap-security-guide.
-#      - If the content-type is scap-security-guide, the add-on will use content provided by the
-#        scap-security-guide package, which is present on the boot media. This means that all other keys except profile will have no effect.
-#    content-url - Location of the security content. The content must be accessible using HTTP, HTTPS, or FTP; local storage is currently not supported. A network connection must be available to reach content definitions in a remote location.
-#    datastream-id - ID of the data stream referenced in the content-url value. Used only if content-type is datastream.
-#    xccdf-id - ID of the benchmark you want to use.
-#    xccdf-path - Path to the XCCDF file which should be used; given as a relative path in the archive.
-#    profile - ID of the profile to be applied. Use default to apply the default profile.
-#    fingerprint - A MD5, SHA1 or SHA2 checksum of the content referenced by content-url.
-#    tailoring-path - Path to a tailoring file which should be used, given as a relative path in the archive.
-#
-#  The following is an example %addon com_redhat_oscap section which uses content from the
-#  scap-security-guide on the installation media: 
+# For more details and configuration options see
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/performing_an_advanced_rhel_9_installation/index#addon-com_redhat_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon com_redhat_oscap
 	content-type = scap-security-guide
 	profile = xccdf_org.ssgproject.content_profile_stig

--- a/products/rhel9/kickstart/ssg-rhel9-stig_gui-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-stig_gui-ks.cfg
@@ -3,6 +3,8 @@
 # Based on:
 # https://pykickstart.readthedocs.io/en/latest/
 # http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
 
 # Specify installation method to use for installation
 # To use a different one comment out the 'url' one below, update
@@ -123,20 +125,8 @@ logvol swap --name=swap --vgname=VolGroup --size=2016
 #   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
 #   Values can be optionally enclosed in single quotes (') or double quotes (").
 #   
-#  The following keys are recognized by the add-on:
-#    content-type - Type of the security content. Possible values are datastream, archive, rpm, and scap-security-guide.
-#      - If the content-type is scap-security-guide, the add-on will use content provided by the
-#        scap-security-guide package, which is present on the boot media. This means that all other keys except profile will have no effect.
-#    content-url - Location of the security content. The content must be accessible using HTTP, HTTPS, or FTP; local storage is currently not supported. A network connection must be available to reach content definitions in a remote location.
-#    datastream-id - ID of the data stream referenced in the content-url value. Used only if content-type is datastream.
-#    xccdf-id - ID of the benchmark you want to use.
-#    xccdf-path - Path to the XCCDF file which should be used; given as a relative path in the archive.
-#    profile - ID of the profile to be applied. Use default to apply the default profile.
-#    fingerprint - A MD5, SHA1 or SHA2 checksum of the content referenced by content-url.
-#    tailoring-path - Path to a tailoring file which should be used, given as a relative path in the archive.
-#
-#  The following is an example %addon com_redhat_oscap section which uses content from the
-#  scap-security-guide on the installation media: 
+# For more details and configuration options see
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/performing_an_advanced_rhel_9_installation/index#addon-com_redhat_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
 %addon com_redhat_oscap
 	content-type = scap-security-guide
 	profile = xccdf_org.ssgproject.content_profile_stig_gui


### PR DESCRIPTION
#### Description:

- unify documentation and updater links in kickstart files for rhel8 and rhel9 products

#### Rationale:

- https://issues.redhat.com/browse/RHEL-30735

#### Review Hints:

- review changes and especially validate that URLs are correct