### PR TITLE
Fix regression in grub2_bootloader_argument

### DIFF
--- a/shared/templates/grub2_bootloader_argument/oval.template
+++ b/shared/templates/grub2_bootloader_argument/oval.template
@@ -128,7 +128,7 @@
 {{% if system_with_kernel_options_in_etc_default_grub_d -%}}
   <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_configdir"
   comment="check for {{{ ARG_NAME_VALUE }}} in /etc/default/grub.d/*cfg via GRUB_CMDLINE_LINUX"
-  check="all" check_existence="any_exist" version="1">
+  check="at least one" check_existence="all_exist" version="1">
     <ind:object object_ref="object_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_configdir" />
     <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
   </ind:textfilecontent54_test>
@@ -141,7 +141,7 @@
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_configdir" version="1">
-    <ind:filepath>/etc/default/grub.d/*.cfg</ind:filepath>
+    <ind:filepath operation="pattern match">/etc/default/grub.d/[^/]+\.cfg</ind:filepath>
     <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX="(.*)"$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_etcdefault_dir.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_etcdefault_dir.pass.sh
@@ -3,17 +3,12 @@
 # platform = multi_platform_ubuntu
 # packages = grub2
 
-{{%- if ARG_VARIABLE %}}
-# variables = {{{ ARG_VARIABLE }}}=correct_value
-{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
-{{%- endif %}}
-
-source common.sh
-
-echo "GRUB_CMDLINE_LINUX=\"\"" > /etc/default/grub
+# Clean up
 rm -f /etc/default/grub.d/*
+echo "GRUB_CMDLINE_LINUX=\"\"" > /etc/default/grub
 
+# Set the correct argument and update grub
 echo "GRUB_CMDLINE_LINUX=\"\$GRUB_CMDLINE_LINUX {{{ ARG_NAME_VALUE }}}\"" > /etc/default/grub.d/custom.cfg
-
+echo "GRUB_CMDLINE_LINUX=\"\$GRUB_CMDLINE_LINUX some_random_arg\"" > /etc/default/grub.d/custom2.cfg
 {{{ grub_command("update") }}}
 

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_etcdefault_dir_noupdate.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_etcdefault_dir_noupdate.fail.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# platform = multi_platform_ubuntu
+# packages = grub2
+
+{{%- if ARG_VARIABLE %}}
+# variables = {{{ ARG_VARIABLE }}}=correct_value
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+{{%- endif %}}
+
+# Clean up
+rm -f /etc/default/grub.d/*
+echo "GRUB_CMDLINE_LINUX=\"\"" > /etc/default/grub
+{{{ grub_command("update") }}}
+
+# Set the correct argument without updating the grub.cfg
+echo "GRUB_CMDLINE_LINUX=\"\$GRUB_CMDLINE_LINUX {{{ ARG_NAME_VALUE }}}\"" > /etc/default/grub.d/custom.cfg
+

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_noupdate.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_noupdate.fail.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# platform = multi_platform_ubuntu
+# packages = grub2
+
+{{%- if ARG_VARIABLE %}}
+# variables = {{{ ARG_VARIABLE }}}=correct_value
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+{{%- endif %}}
+
+# Clean up
+rm -f /etc/default/grub.d/*
+echo "GRUB_CMDLINE_LINUX=\"\"" > /etc/default/grub
+{{{ grub_command("update") }}}
+
+# Set the correct argument without updating the grub.cfg
+echo "GRUB_CMDLINE_LINUX=\"{{{ ARG_NAME_VALUE }}}\"" > /etc/default/grub
+

--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value_etcdefault.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value_etcdefault.fail.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# platform = multi_platform_ubuntu
+# packages = grub2
+
+{{%- if ARG_VARIABLE %}}
+# variables = {{{ ARG_VARIABLE }}}=correct_value
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+{{%- set ARG_NAME_VALUE_WRONG= ARG_NAME ~ "=correct_value" %}}
+{{%- else %}}
+{{%- set ARG_NAME_VALUE= ARG_NAME %}}
+{{%- set ARG_NAME_VALUE_WRONG= "wrong_variable" %}}
+{{%- endif %}}
+
+# Clean up and make sure we are at a passing state
+rm -f /etc/default/grub.d/*
+echo "GRUB_CMDLINE_LINUX=\"{{{ ARG_NAME_VALUE }}}\"" > /etc/default/grub
+{{{ grub_command("update") }}}
+
+# Set to wrong var/value
+echo "GRUB_CMDLINE_LINUX=\"{{{ ARG_NAME }}}=wrong_value\"" > /etc/default/grub

--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value_etcdefault_dir.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value_etcdefault_dir.fail.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# platform = multi_platform_ubuntu
+# packages = grub2
+
+{{%- if ARG_VARIABLE %}}
+# variables = {{{ ARG_VARIABLE }}}=correct_value
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+{{%- endif %}}
+
+# Clean up and make sure we are at a passing state
+rm -f /etc/default/grub.d/*
+echo "GRUB_CMDLINE_LINUX=\"\"" > /etc/default/grub
+echo "GRUB_CMDLINE_LINUX=\"{{{ ARG_NAME_VALUE }}}\"" > /etc/default/grub.d/custom.cfg
+{{{ grub_command("update") }}}
+
+# Set to wrong var/value
+echo "GRUB_CMDLINE_LINUX=\"\$GRUB_CMDLINE_LINUX {{{ ARG_NAME }}}=wrong_value\"" > /etc/default/grub.d/custom.cfg
+


### PR DESCRIPTION
#### Description:

- Fixed issue in `grub2_bootloader_argument` on Ubuntu which was introduced in #11726 
- Added additional tests for Ubuntu

#### Rationale:

- The OVAL passed even if the grub2 argument was not defined in /etc/default/grub nor in /etc/default/grub.d/*cfg. 
- The fixed and correct behavior is to pass if it is defined in "at least one" configuration file.
