### PR TITLE
Fix ansible_ini_file_set

### DIFF
--- a/linux_os/guide/system/network/networkmanager/networkmanager_dns_mode/ansible/shared.yml
+++ b/linux_os/guide/system/network/networkmanager/networkmanager_dns_mode/ansible/shared.yml
@@ -6,7 +6,7 @@
 
 {{{ ansible_instantiate_variables("var_networkmanager_dns_mode") }}}
 
-{{{ ansible_ini_file_set("/etc/NetworkManager/NetworkManager.conf", "main", "dns", "{{ var_networkmanager_dns_mode }}", description="", ignore_spaces=true) }}}
+{{{ ansible_ini_file_set("/etc/NetworkManager/NetworkManager.conf", "main", "dns", "{{ var_networkmanager_dns_mode }}", description="", no_extra_spaces=true) }}}
 
 - name: "{{{ rule_title }}} - Ensure Network Manager"
   ansible.builtin.systemd:

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -724,7 +724,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
 {{%- endmacro %}}
 
 
-{{% macro ansible_ini_file_set(filename, section, key, value, description="", ignore_spaces=false) -%}}
+{{% macro ansible_ini_file_set(filename, section, key, value, description="", no_extra_spaces=False) -%}}
 - name: "{{{ description if description else ("Set '" + key + "' to '" + value + "' in the [" + section + "] section of '" + filename + "'") }}}"
   ini_file:
     path: "{{{ filename }}}"
@@ -733,8 +733,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
     value: "{{{ value }}}"
     create: yes
     mode: 0644
-    {{% if ignore_spaces %}}
-    ignore_spaces: false
+    {{% if no_extra_spaces %}}
     no_extra_spaces: true
     {{% endif %}}
 


### PR DESCRIPTION


#### Description:

Remove `ignore_spaces` from `ansible_ini_file_set`

#### Rationale:
Since `ignore_spaces` is not valid on older installs, remove it.
Fixes #11771

#### Review Hints:

- _Review hints here. Replace this text. Don't use the italics format!_

- _Use this optional section to give any relevant information which could help the reviewer to more quickly and assertively understand and test the changes._

- _Good examples are useful commands, if it is better to review all commits together or in a suggested sequence, any relevant discussion in other PRs or issues, etc._
