### PR TITLE
OCP4: Add container_security_operator_exists to PCIDSS profile

### DIFF
--- a/controls/pcidss_4_ocp4.yml
+++ b/controls/pcidss_4_ocp4.yml
@@ -1452,6 +1452,7 @@ controls:
         and must be fully considered during a PCI DSS assessment.
       rules:
         - acs_sensor_exists
+        - container_security_operator_exists
 
     - id: 6.3.3
       title: All system components are protected from known vulnerabilities by installing


### PR DESCRIPTION
This pr adds `container_security_operator_exists` rule to PCI-DSS 4.0 6.3.2
