### PR TITLE
remove Bash and Ansible conditionals from the nfs_mount_defined  CPE

### DIFF
--- a/shared/applicability/nfs_mount_defined.yml
+++ b/shared/applicability/nfs_mount_defined.yml
@@ -1,5 +1,3 @@
 name: "cpe:/a:nfs_mount_defined"
 title: "Remote NFS file system mount is defined"
 check_id: nfs_mount_defined
-bash_conditional: 'grep -E "[[:space:]](nfs|nfs4)[[:space:]]" /etc/fstab'
-ansible_conditional: 'ansible_mounts|selectattr("fstype", "in", ["nfs", "nfs4"])|list|length > 0'


### PR DESCRIPTION
#### Description:

- remove conditionals for this CjPE

#### Rationale:

- the initial problem was that the Ansible conditional was not working on RHEL 7
- after some time, I discovered that the template `mount_option_remote_filesystems` has its own limiting conditions within the bash.template and ansible.template and that these limitations are more practical than trying to come up with some complicated Ansible conditional

- Fixes: #11774 

#### Review Hints:

- I recommend running Automatus on all RHEL versions testing both Bash and Ansible