### PR TITLE
OCPBUGS-31510: change the analysis to not include ImageStreamTag

### DIFF
--- a/applications/openshift/registry/imagestream_sets_schedule/policy/stig/shared.yml
+++ b/applications/openshift/registry/imagestream_sets_schedule/policy/stig/shared.yml
@@ -11,9 +11,9 @@ vuldiscussion: |-
     The OpenShift platform can be configured to limit and control which image source repositories may be used by the platform and the users of the platform. By configuring this to only allow users to deploy images from trusted sources, lowers the risk for a user to deploy unsafe, or untested images that would be detrimental to the security and stability of the platform.
 
 checktext: |-
-    To list all the imagestreams and identify which imagestream tags are configured to periodically check for updates (imagePolicy = { scheduled: true }) run the following command
+    To list all the imagestreams and identify which imagestream tags are configured to periodically check for updates (imagePolicy = { scheduled: true }) and (kind = DockerImage) run the following command:
 
-    > oc get imagestream  --all-namespaces -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{range .spec.tags[*]}{"\t"}{.name}{": "}{.importPolicy}{"\n"}'
+    > oc get imagestream --all-namespaces -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{range .spec.tags[*]}{"\t"}{.name}{": "}{.importPolicy}{"\t"}{.from}{"\n"}
 
     You will see an ouput similar to:
 

--- a/applications/openshift/registry/imagestream_sets_schedule/rule.yml
+++ b/applications/openshift/registry/imagestream_sets_schedule/rule.yml
@@ -32,7 +32,7 @@ references:
     srg: SRG-APP-000456-CTR-001125
 
 {{% set api_path = '/apis/image.openshift.io/v1/imagestreams' %}}
-{{% set jqfilter = '[.items[]] | map(.spec.tags[]?.importPolicy.scheduled != true) | any' %}}
+{{% set jqfilter = '[.items[] | map(.spec.tags[]? | select(.from.kind != "ImageStreamTag").importPolicy.scheduled != true) | all ]' %}}
 
 ocil_clause: 'imagestream is not configured to perform periodical updates'
 
@@ -42,22 +42,21 @@ ocil: |-
   <pre>oc get imagestream  --all-namespaces -o jsonpath='{{{ jqfilter }}}'</pre>
   Alternatively, to view a list of ImageStreams that do not schedule updates,
   run:
-  <pre>oc get imagestreams -A -ojson | jq '.items[] | select(.spec.tags[]?.importPolicy.scheduled != true) | .metadata.name' | sort | uniq</pre>
+  <pre>oc get imagestreams -A -ojson | jq -r '.items[] | select(.spec.tags[]? | .from.kind == "DockerImage" and .importPolicy.scheduled != true) | .metadata.name' | sort | uniq</pre>
 
 warnings:
 - general: |-
     {{{ openshift_filtered_cluster_setting({api_path: jqfilter}) | indent(4) }}}
 
 template:
-    name: yamlfile_value
-    vars:
-        ocp_data: 'true'
-        filepath: |-
-          {{{ openshift_filtered_path(api_path, jqfilter) }}}
-        yamlpath: "[:]"
-        check_existence: "all_exist"
-        entity_check: "all"
-        values:
-        - value: "true"
-          operation: "equals"
-
+  name: yamlfile_value
+  vars:
+    ocp_data: 'true'
+    filepath: |-
+      {{{ openshift_filtered_path(api_path, jqfilter) }}}
+    yamlpath: "[:]"
+    check_existence: "all_exist"
+    entity_check: "all"
+    values:
+      - value: "true"
+        operation: "equals"


### PR DESCRIPTION
#### Description:

ImageStreamTag is improperly considered with the rule.yaml

#### Rationale:

https://issues.redhat.com/browse/OCPBUGS-31510

#### Review Hints:

The logic changes are for rhcos4-disa-stig.