### PR TITLE
use `failed_when:false` for Ansible `register:` checks

### DIFF
--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
@@ -6,7 +6,7 @@
 - name: "Test for domain group"
   command: grep '^\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
   register: test_grep_domain
-  ignore_errors: yes
+  failed_when: false
   changed_when: False
   check_mode: no
 

--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/ansible/shared.yml
@@ -8,7 +8,7 @@
 - name: "Test for domain group"
   command: grep '\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
   register: test_grep_domain
-  ignore_errors: yes
+  failed_when: false
   changed_when: False
   check_mode: no
 

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/ansible/shared.yml
@@ -6,7 +6,7 @@
 - name: "Test for domain group"
   command: grep '\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
   register: test_grep_domain
-  ignore_errors: yes
+  failed_when: false
   changed_when: False
   check_mode: no
 

--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/ansible/shared.yml
@@ -8,7 +8,7 @@
 - name: "Test for domain group"
   command: grep '\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
   register: test_grep_domain
-  ignore_errors: yes
+  failed_when: false
   changed_when: False
   check_mode: no
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/ansible/shared.yml
@@ -26,7 +26,7 @@
   ansible.builtin.command:
     cmd: semanage fcontext -a -t faillog_t "{{ var_accounts_passwords_pam_faillock_dir }}(/.*)?"
   register: result_accounts_passwords_pam_faillock_dir_semanage
-  ignore_errors: yes
+  failed_when: false
   changed_when:
     - result_accounts_passwords_pam_faillock_dir_semanage.rc == 0
 

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/ansible/shared.yml
@@ -8,7 +8,7 @@
 - name: "{{{ rule_title }}} - Check to See the Current Status of FIPS Mode"
   ansible.builtin.command: /usr/bin/fips-mode-setup --check
   register: is_fips_enabled
-  ignore_errors: yes
+  failed_when: false
   changed_when: false
 
 - name: "{{{ rule_title }}} - Enable FIPS Mode"


### PR DESCRIPTION
#### Description:

Using `ignore_errors` leads to user-visible fatal errors produced by ansible-playbook:

```
TASK [Enable FIPS Mode - Check to See the Current Status of FIPS Mode] *********
fatal: [192.168.122.178]: FAILED! => {"changed": false, "cmd": ["/usr/bin/fips-mode-setup", "--check"] ...
```
These are indistinguishable from actually terminating fatal errors (to a log-reading script) that need to be investigated.

Using `failed_when` avoids those, while still registering the output for use by other checks, as done by many other checks:
```
$ grep -i 'failed_when: false' -r linux_os/ | wc -l
25

$ grep -i 'failed_when: false' -r linux_os/ 
linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml:  failed_when: false
linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/ansible/shared.yml:  failed_when: false
linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/ansible/shared.yml:  failed_when: false
linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/ansible/shared.yml:  failed_when: false
linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/ansible/shared.yml:  failed_when: false
linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/ansible/shared.yml:  failed_when: false
linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/ansible/shared.yml:  failed_when: false
linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/ansible/shared.yml:  failed_when: false
linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/ansible/shared.yml:  failed_when: false
linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_auid_privilege_function/ansible/shared.yml:  failed_when: false
linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/ansible/shared.yml:  failed_when: False
linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/ansible/shared.yml:  failed_when: False
linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/ansible/shared.yml:  failed_when: Fals
linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/ansible/shared.yml:  failed_when: False
linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_system_commands_dirs/ansible/shared.yml:  failed_when: False
linux_os/guide/system/permissions/files/dir_system_commands_group_root_owned/ansible/shared.yml:  failed_when: False
linux_os/guide/system/accounts/accounts-session/root_paths/accounts_root_path_dirs_no_write/ansible/shared.yml:  failed_when: False
linux_os/guide/system/accounts/enable_authselect/ansible/shared.yml:  failed_when: false
linux_os/guide/system/accounts/enable_authselect/ansible/shared.yml:  failed_when: false
linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/ansible/shared.yml:  failed_when: False
linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/ansible/shared.yml:  failed_when: False
linux_os/guide/system/network/network-nftables/set_nftables_base_chain/ansible/shared.yml:  failed_when: false
linux_os/guide/services/ssh/file_permissions_sshd_private_key/ansible/shared.yml:  failed_when: False
linux_os/guide/services/ssh/file_permissions_sshd_private_key/ansible/shared.yml:  failed_when: False
```

#### Review Hints:

Double-check that this is sane, please. I'm not an Ansible expert, so I don't know if this may have side-effects, but I did some preliminary testing and it seems to be working as intended.