### PR TITLE
update cryptopolicy used in CUI profile to fips

### DIFF
--- a/products/rhel8/profiles/cui.profile
+++ b/products/rhel8/profiles/cui.profile
@@ -30,3 +30,4 @@ extends: ospp
 
 selections:
     - inactivity_timeout_value=10_minutes
+    - var_system_crypto_policy=fips

--- a/products/rhel9/profiles/cui.profile
+++ b/products/rhel9/profiles/cui.profile
@@ -30,3 +30,4 @@ extends: ospp
 
 selections:
     - inactivity_timeout_value=10_minutes
+    - var_system_crypto_policy=fips


### PR DESCRIPTION
#### Description:

- change the cryptopolicy from FIPS:OSPP to FIPS

#### Rationale:

- the CUI profile is NIST based and FIPS policy is enough for the compliance. The FiPS:OSPP subpolicy is too strict.

#### Review Hints:

- _Review hints here. Replace this text. Don't use the italics format!_

- _Use this optional section to give any relevant information which could help the reviewer to more quickly and assertively understand and test the changes._

- _Good examples are useful commands, if it is better to review all commits together or in a suggested sequence, any relevant discussion in other PRs or issues, etc._
