### PR TITLE
Add Ansible remediation to sssd_enable_pam_services

### DIFF
--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/ansible/shared.yml
@@ -33,7 +33,7 @@
   when: sssd_conf_file.stat.exists
 
 - name: {{{ rule_title }}} - Insert entry to /etc/sssd/sssd.conf
-  community.general.ini_file:
+  ini_file:
     path: /etc/sssd/sssd.conf
     section: sssd
     option: services

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/ansible/shared.yml
@@ -33,10 +33,10 @@
   when: sssd_conf_file.stat.exists
 
 - name: {{{ rule_title }}} - Find services key in /etc/sssd/sssd.conf
-  ansible.builtin.lineinfile:
+  ansible.builtin.replace:
     path: "/etc/sssd/sssd.conf"
-    regexp: '^\s*services\s*=.*$'
-    state: absent
+    regexp: '^\s*\[sssd\][^\[\]]*?(?:\n(?!\[)[^\n]*?services\s*=)+'
+    replace: ''
   changed_when: false
   check_mode: true
   register: sssd_conf_file_services
@@ -51,4 +51,4 @@
   when:
   - not modify_lines_sssd_conf_d_files.changed
   - not modify_lines_sssd_conf_file.changed
-  - (sssd_conf_file_services.found is defined and sssd_conf_file_services.found == 0) or not sssd_conf_file.stat.exists
+  - (sssd_conf_file_services.msg is defined and "replacements" not in sssd_conf_file_services.msg) or not sssd_conf_file.stat.exists

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/ansible/shared.yml
@@ -4,14 +4,14 @@
 # complexity = low
 # disruption = medium
 
-- name: Find all the conf files inside the /etc/sssd/conf.d/ directory
+- name: {{{ rule_title }}} - Find all the conf files inside the /etc/sssd/conf.d/ directory
   ansible.builtin.find:
     paths:
     - "/etc/sssd/conf.d/"
     patterns: "*.conf"
   register: sssd_conf_d_files
 
-- name: Modify lines in files in the /etc/sssd/conf.d/ directory
+- name: {{{ rule_title }}} - Modify lines in files in the /etc/sssd/conf.d/ directory
   ansible.builtin.replace:
     path: "{{ item }}"
     regexp: '^(services\s*=.*)'
@@ -19,12 +19,12 @@
   with_items: "{{ sssd_conf_d_files.files | map(attribute='path') }}"
   register: modify_lines_sssd_conf_d_files
 
-- name: Find /etc/sssd/sssd.conf
+- name: {{{ rule_title }}} - Find /etc/sssd/sssd.conf
   ansible.builtin.stat:
     path: /etc/sssd/sssd.conf
   register: sssd_conf_file
 
-- name: Modify lines in /etc/sssd/sssd.conf
+- name: {{{ rule_title }}} - Modify lines in /etc/sssd/sssd.conf
   ansible.builtin.replace:
     path: "/etc/sssd/sssd.conf"
     regexp: '^(services\s*=.*)'
@@ -32,7 +32,7 @@
   register: modify_lines_sssd_conf_file
   when: sssd_conf_file.stat.exists
 
-- name: Insert entry to /etc/sssd/sssd.conf
+- name: {{{ rule_title }}} - Insert entry to /etc/sssd/sssd.conf
   community.general.ini_file:
     path: /etc/sssd/sssd.conf
     section: sssd

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/ansible/shared.yml
@@ -32,10 +32,23 @@
   register: modify_lines_sssd_conf_file
   when: sssd_conf_file.stat.exists
 
+- name: {{{ rule_title }}} - Find services key in /etc/sssd/sssd.conf
+  ansible.builtin.lineinfile:
+    path: "/etc/sssd/sssd.conf"
+    regexp: '^\s*services\s*=.*$'
+    state: absent
+  changed_when: false
+  check_mode: true
+  register: sssd_conf_file_services
+  when: sssd_conf_file.stat.exists
+
 - name: {{{ rule_title }}} - Insert entry to /etc/sssd/sssd.conf
   ini_file:
     path: /etc/sssd/sssd.conf
     section: sssd
     option: services
     value: pam
-  when: not modify_lines_sssd_conf_d_files.changed and not modify_lines_sssd_conf_file.changed
+  when:
+  - not modify_lines_sssd_conf_d_files.changed
+  - not modify_lines_sssd_conf_file.changed
+  - (sssd_conf_file_services.found is defined and sssd_conf_file_services.found == 0) or not sssd_conf_file.stat.exists

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/ansible/shared.yml
@@ -14,7 +14,7 @@
 - name: {{{ rule_title }}} - Modify lines in files in the /etc/sssd/conf.d/ directory
   ansible.builtin.replace:
     path: "{{ item }}"
-    regexp: '^(services\s*=(?!.*\bpam\b).*)$'
+    regexp: '^(\s*\[sssd\].*(?:\n\s*[^[\s].*)*\n\s*services\s*=(?!.*\bpam\b).*)$'
     replace: '\1,pam'
   with_items: "{{ sssd_conf_d_files.files | map(attribute='path') }}"
   register: modify_lines_sssd_conf_d_files
@@ -27,7 +27,7 @@
 - name: {{{ rule_title }}} - Modify lines in /etc/sssd/sssd.conf
   ansible.builtin.replace:
     path: "/etc/sssd/sssd.conf"
-    regexp: '^(services\s*=(?!.*\bpam\b).*)$'
+    regexp: '^(\s*\[sssd\].*(?:\n\s*[^[\s].*)*\n\s*services\s*=(?!.*\bpam\b).*)$'
     replace: '\1,pam'
   register: modify_lines_sssd_conf_file
   when: sssd_conf_file.stat.exists

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/ansible/shared.yml
@@ -1,0 +1,41 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = medium
+
+- name: Find all the conf files inside the /etc/sssd/conf.d/ directory
+  ansible.builtin.find:
+    paths:
+    - "/etc/sssd/conf.d/"
+    patterns: "*.conf"
+  register: sssd_conf_d_files
+
+- name: Modify lines in files in the /etc/sssd/conf.d/ directory
+  ansible.builtin.replace:
+    path: "{{ item }}"
+    regexp: '^(services\s*=.*)'
+    replace: '\1,pam'
+  with_items: "{{ sssd_conf_d_files.files | map(attribute='path') }}"
+  register: modify_lines_sssd_conf_d_files
+
+- name: Find /etc/sssd/sssd.conf
+  ansible.builtin.stat:
+    path: /etc/sssd/sssd.conf
+  register: sssd_conf_file
+
+- name: Modify lines in /etc/sssd/sssd.conf
+  ansible.builtin.replace:
+    path: "/etc/sssd/sssd.conf"
+    regexp: '^(services\s*=.*)'
+    replace: '\1,pam'
+  register: modify_lines_sssd_conf_file
+  when: sssd_conf_file.stat.exists
+
+- name: Insert entry to /etc/sssd/sssd.conf
+  community.general.ini_file:
+    path: /etc/sssd/sssd.conf
+    section: sssd
+    option: services
+    value: pam
+  when: not modify_lines_sssd_conf_d_files.changed and not modify_lines_sssd_conf_file.changed

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/ansible/shared.yml
@@ -14,7 +14,7 @@
 - name: {{{ rule_title }}} - Modify lines in files in the /etc/sssd/conf.d/ directory
   ansible.builtin.replace:
     path: "{{ item }}"
-    regexp: '^(services\s*=.*)'
+    regexp: '^(services\s*=(?!.*\bpam\b).*)$'
     replace: '\1,pam'
   with_items: "{{ sssd_conf_d_files.files | map(attribute='path') }}"
   register: modify_lines_sssd_conf_d_files
@@ -27,7 +27,7 @@
 - name: {{{ rule_title }}} - Modify lines in /etc/sssd/sssd.conf
   ansible.builtin.replace:
     path: "/etc/sssd/sssd.conf"
-    regexp: '^(services\s*=.*)'
+    regexp: '^(services\s*=(?!.*\bpam\b).*)$'
     replace: '\1,pam'
   register: modify_lines_sssd_conf_file
   when: sssd_conf_file.stat.exists

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/services_pam_missing.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/services_pam_missing.fail.sh
@@ -2,11 +2,10 @@
 # packages = sssd
 #
 
-SSSD_SERVICES_REGEX_SHORT="^[[:space:]]*services.*$"
 SSSD_CONF="/etc/sssd/sssd.conf"
 
 rm -rf /etc/sssd/conf.d/
-rm -f SSSD_CONF
+rm -f $SSSD_CONF
 cat <<EOF > $SSSD_CONF
 [sssd]
 section1 = key

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/sssd_pam_services_conf_d.pass.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/sssd_pam_services_conf_d.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# packages = sssd
+
+rm -rf "/etc/sssd/conf.d/"
+rm -f "/etc/sssd/sssd.conf"
+mkdir -p "/etc/sssd/conf.d/"
+cat <<EOF > "/etc/sssd/conf.d/sssd.conf"
+[sssd]
+services = nss,pam
+[pam]
+example1 = abc
+EOF


### PR DESCRIPTION
This commit adds an Ansible remediation to rule sssd_enable_pam_services.

Fixes: #11753

