### PR TITLE
Add RHEL 10 Install Command to Automatus

### DIFF
--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -573,6 +573,7 @@ INSTALL_COMMANDS = dict(
     rhel7=("yum", "install", "-y"),
     rhel8=("yum", "install", "-y"),
     rhel9=("yum", "install", "-y"),
+    rhel10=("dnf", "install", "-y"),
     sles=("zypper", "install", "-y"),
     ubuntu=("DEBIAN_FRONTEND=noninteractive", "apt", "install", "-y"),
 )


### PR DESCRIPTION
#### Description:
Add RHEL 10 install command to Automatus.

#### Rationale:

So that the tests can run for RHEL 10.