### PR TITLE
Reduce XCCDF

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -537,11 +537,12 @@ class Benchmark(XCCDFEntity):
     def __str__(self):
         return self.id_
 
-    def get_benchmark_xml_for_profile(self, env_yaml, profile):
-        rules, groups = self.get_components_not_included_in_a_profiles([profile])
-        cpe_platforms = self.get_not_used_cpe_platforms([profile])
+    def get_benchmark_xml_for_profiles(self, env_yaml, profiles):
+        rules, groups = self.get_components_not_included_in_a_profiles(profiles)
+        cpe_platforms = self.get_not_used_cpe_platforms(profiles)
+        profiles_ids = [profile.id_ for profile in profiles]
         profiles = set(filter(
-            lambda id_, profile_id=profile.id_: id_ != profile_id,
+            lambda id_, profiles_ids=profiles_ids: id_ not in profiles_ids,
             [profile.id_ for profile in self.profiles]
         ))
         components_to_not_include = {
@@ -550,7 +551,7 @@ class Benchmark(XCCDFEntity):
                 "profiles": profiles,
                 "cpe_platforms": cpe_platforms
             }
-        return profile.id_, self.to_xml_element(
+        return profiles_ids, self.to_xml_element(
             env_yaml,
             components_to_not_include=components_to_not_include
         )

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1657,10 +1657,10 @@ class LinearLoader(object):
             )
 
         for profile in self.benchmark.profiles:
-            profile_id, benchmark = self.benchmark.get_benchmark_xml_for_profile(
-                self.env_yaml, profile
+            profiles_ids, benchmark = self.benchmark.get_benchmark_xml_for_profiles(
+                self.env_yaml, [profile]
             )
-            yield profile_id, benchmark
+            yield profiles_ids.pop(), benchmark
 
     def load_compiled_content(self):
         self.product_cpes.load_cpes_from_directory_tree(self.resolved_cpe_items_dir, self.env_yaml)
@@ -1684,7 +1684,10 @@ class LinearLoader(object):
             g.load_entities(self.rules, self.values, self.groups)
 
     def export_benchmark_to_xml(self):
-        return self.benchmark.to_xml_element(self.env_yaml)
+        _, benchmark = self.benchmark.get_benchmark_xml_for_profiles(
+            self.env_yaml, self.benchmark.profiles
+        )
+        return benchmark
 
     def export_benchmark_to_file(self, filename):
         register_namespaces()


### PR DESCRIPTION
#### Description:
This PR allows you to reduce the size of XCCDF to normal Datastreams and Thin Datastreams with the specified rule ID. Thin DSs generated by `--thin` have this feature enabled previously.

The process removes unused CPE platforms, rules, groups, and profiles (In the case of normal Datastream, selects all profiles for the product and uses only the profile with one rule for thin DS.)

When a group is deleted, its children, such as variables, rules, and other subgroups, are also deleted.

Thin DS:
- Before: `679K`
- After: `114K`

Normal Datastream (Product: Fedora):
- Before: `18,7 MB`
- After: `18,4 MB`
