### PR TITLE
Improve Rsyslog Rainer regex to find log files

### DIFF
--- a/shared/templates/rsyslog_logfiles_attributes_modify/ansible.template
+++ b/shared/templates/rsyslog_logfiles_attributes_modify/ansible.template
@@ -63,7 +63,7 @@
     {{%- if not 'debian' in product %}}
     set -o pipefail{{% endif %}}
     grep -ozP "action\s*\(\s*type\s*=\s*\"omfile\"[^\)]*\)" {{ item.1.path }} | \
-    grep -aoP "File\s*=\s*\"([/[:alnum:][:punct:]]*)\"\s*\)" | \
+    grep -aoP "\bFile\s*=\s*\"([/[:alnum:][:punct:]]*)\"\s*\)" | \
     grep -oE "\"([/[:alnum:][:punct:]]*)\"" | \
     tr -d "\""|| true
   loop: "{{ rsyslog_config_files.results | default([]) | subelements('files') }}"

--- a/shared/templates/rsyslog_logfiles_attributes_modify/bash.template
+++ b/shared/templates/rsyslog_logfiles_attributes_modify/bash.template
@@ -80,7 +80,7 @@ done
 for LOG_FILE in "${RSYSLOG_CONFIG_FILES[@]}"
 do
 	ACTION_OMFILE_LINES=$(grep -iozP "action\s*\(\s*type\s*=\s*\"omfile\"[^\)]*\)" "${LOG_FILE}")
-	OMFILE_LINES=$(echo "${ACTION_OMFILE_LINES}"| grep -iaoP "File\s*=\s*\"([/[:alnum:][:punct:]]*)\"\s*\)")
+	OMFILE_LINES=$(echo "${ACTION_OMFILE_LINES}"| grep -iaoP "\bFile\s*=\s*\"([/[:alnum:][:punct:]]*)\"\s*\)")
 	LOG_FILE_PATHS+=("$(echo "${OMFILE_LINES}"| grep -oE "\"([/[:alnum:][:punct:]]*)\""|tr -d "\"")")
 done
 

--- a/shared/templates/rsyslog_logfiles_attributes_modify/oval.template
+++ b/shared/templates/rsyslog_logfiles_attributes_modify/oval.template
@@ -84,7 +84,7 @@
             * the chunk was retrieved from a row not starting with space, '#', or '$' characters
       -->
     <ind:pattern
-      operation="pattern match">^\s*[^(\s|#|\$)]+\s+.*\s+-?[\w\(="\s]*(\/[^:;\s"]+)+.*$</ind:pattern>
+      operation="pattern match">^\s*[^(\s|#|\$)]+\s+.*(?:\bFile="|\s|\/|-)(\/[^:;\s"]+).*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
     <filter action="exclude">state_{{{ _RULE_ID }}}_ignore_include_paths</filter>
   </ind:textfilecontent54_object>

--- a/shared/templates/rsyslog_logfiles_attributes_modify/tests/rainer_correct_attr_exceptions.pass.sh
+++ b/shared/templates/rsyslog_logfiles_attributes_modify/tests/rainer_correct_attr_exceptions.pass.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle
+
+# Declare variables used for the tests and define the create_rsyslog_test_logs function
+source $SHARED/rsyslog_log_utils.sh
+
+{{% if ATTRIBUTE == "owner" %}}
+CHATTR="chown"
+ATTR_VALUE="root"
+ATTR_INCORRECT_VALUE="cac_testuser"
+useradd $ATTR_INCORRECT_VALUE
+{{% elif ATTRIBUTE == "groupowner" %}}
+CHATTR="chgrp"
+ATTR_VALUE="root"
+ATTR_INCORRECT_VALUE="cac_testgroup"
+groupadd $ATTR_INCORRECT_VALUE
+{{% else %}}
+CHATTR="chmod"
+ATTR_VALUE="0640"
+ATTR_INCORRECT_VALUE="0666"
+{{% endif %}}
+
+# create one test log file
+create_rsyslog_test_logs 1
+
+# setup test log file property
+$CHATTR $ATTR_VALUE ${RSYSLOG_TEST_LOGS[0]}
+
+# ignore check and remediation for files which are not used for logs
+NO_LOG_FILE="/etc/pki/tls/certs/ca-bundle.crt"
+touch $NO_LOG_FILE
+$CHATTR $ATTR_INCORRECT_VALUE $NO_LOG_FILE
+
+# example of configuration file including three filepaths but only one specifies
+# a log file, in the last rule.
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+global(workDirectory="/var/spool/rsyslog" net.ipprotocol="ipv4-only" DefaultNetstreamDriver="gtls" DefaultNetstreamDriverCAFile="${NO_LOG_FILE}")
+
+#### RULES ####
+# Should only check value of "File" and not other variations such as "DefaultNetstreamDriverCAFile".
+*.*     action(type="omfile" FileCreateMode="0640" fileOwner="root" fileGroup="hoiadm" DefaultNetstreamDriverCAFile="${NO_LOG_FILE}")
+
+# Here is a valid entry defining a log file.
+*.*     action(type="omfile" FileCreateMode="0640" fileOwner="root" fileGroup="hoiadm" File="${RSYSLOG_TEST_LOGS[0]}")
+
+EOF


### PR DESCRIPTION
#### Description:

There are other entries in RainerScript syntax used to specify filepaths, but the files are not used for logs.
It was included a test scenario to test these exceptions.
The regex was also improved in OVAL, Bash and Ansible.

#### Rationale:

- Fixes https://issues.redhat.com/browse/RHEL-17202

#### Review Hints:

```
./build_product rhel9
./tests/automatus.py rule --libvirt qemu:///session rhel9 --datastream build/ssg-rhel9-ds.xml --dontclean --remediate-using bash rsyslog_files_permissions
./tests/automatus.py rule --libvirt qemu:///session rhel9 --datastream build/ssg-rhel9-ds.xml --dontclean --remediate-using ansible rsyslog_files_ownership
./tests/automatus.py rule --libvirt qemu:///session rhel9 --datastream build/ssg-rhel9-ds.xml --dontclean --remediate-using ansible rsyslog_files_groupownership
```