### PR TITLE
Ensure that components not in datastream are not mentioned by profiles

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -443,10 +443,12 @@ class Benchmark(XCCDFEntity):
             plat = ET.SubElement(root, "{%s}platform" % XCCDF12_NS)
             plat.set("idref", cpe_name)
 
-    def _add_profiles_xml(self, root, profiles_to_not_include):
+    def _add_profiles_xml(self, root, components_to_not_include):
+        profiles_to_not_include = components_to_not_include.get("profiles", set())
         for profile in self.profiles:
             if profile.id_ in profiles_to_not_include:
                 continue
+            profile.remove_components_not_included(components_to_not_include)
             root.append(profile.to_xml_element())
 
     def _add_values_xml(self, root):
@@ -497,7 +499,7 @@ class Benchmark(XCCDFEntity):
         contributors_file = os.path.join(os.path.dirname(__file__), "../Contributors.xml")
         add_benchmark_metadata(root, contributors_file)
 
-        self._add_profiles_xml(root, components_to_not_include.get("profiles", set()))
+        self._add_profiles_xml(root, components_to_not_include)
         self._add_values_xml(root)
         self._add_groups_xml(root, components_to_not_include, env_yaml)
         self._add_rules_xml(root, components_to_not_include.get("rules", set()),  env_yaml,)

--- a/ssg/entities/profile_base.py
+++ b/ssg/entities/profile_base.py
@@ -259,6 +259,13 @@ class Profile(XCCDFEntity, SelectionHandler):
             raise ValueError(msg)
         self.unselected_groups.extend(sorted(empty_groups))
 
+    def remove_components_not_included(self, components_to_not_include):
+        rules_to_not_include = components_to_not_include.get("rules", set())
+        groups_to_not_include = components_to_not_include.get("groups", set())
+        self.selected = list(set(self.selected) - rules_to_not_include)
+        self.unselected = list(set(self.unselected) - rules_to_not_include)
+        self.unselected_groups = list(set(self.unselected_groups) - groups_to_not_include)
+
     def __sub__(self, other):
         profile = Profile(self.id_)
         profile.title = self.title

--- a/ssg/entities/profile_base.py
+++ b/ssg/entities/profile_base.py
@@ -262,9 +262,9 @@ class Profile(XCCDFEntity, SelectionHandler):
     def remove_components_not_included(self, components_to_not_include):
         rules_to_not_include = components_to_not_include.get("rules", set())
         groups_to_not_include = components_to_not_include.get("groups", set())
-        self.selected = list(set(self.selected) - rules_to_not_include)
-        self.unselected = list(set(self.unselected) - rules_to_not_include)
-        self.unselected_groups = list(set(self.unselected_groups) - groups_to_not_include)
+        self.selected = sorted(set(self.selected) - rules_to_not_include)
+        self.unselected = sorted(set(self.unselected) - rules_to_not_include)
+        self.unselected_groups = sorted(set(self.unselected_groups) - groups_to_not_include)
 
     def __sub__(self, other):
         profile = Profile(self.id_)


### PR DESCRIPTION
#### Description:

- see #11800 for context
- Add function which will ensure that rules / groups which are removed from the datastream are not mentioned in profile definitions

#### Rationale:

- the mentioned PR removes unused rules / groups from the datastream, but those rules and groups  are still selected (or unselected) by profiles. This breaks the SCAP standard and it produces invalid datastream.

- Fixes #11810 

#### Review Hints:

- run the test according to the linked issue
