### PR TITLE
Fix test for template file_permissions

### DIFF
--- a/shared/templates/file_permissions/tests/lenient_permissions.fail.sh
+++ b/shared/templates/file_permissions/tests/lenient_permissions.fail.sh
@@ -1,14 +1,26 @@
 #!/bin/bash
 
+{{%- if RECURSIVE %}}
+{{% set FIND_RECURSE_ARGS="" %}}
+{{%- else %}}
+{{% set FIND_RECURSE_ARGS="-maxdepth 1" %}}
+{{%- endif %}}
+
+{{%- if EXCLUDED_FILES %}}
+{{% set EXCLUDED_FILES_ARGS="! -name '" + EXCLUDED_FILES|join("' ! -name '") + "'" %}}
+{{%- else %}}
+{{% set EXCLUDED_FILES_ARGS="" %}}
+{{%- endif %}}
+
 {{% for path in FILEPATH %}}
 {{% if path.endswith("/") %}}
 if [ ! -d {{{ path }}} ]; then
     mkdir -p {{{ path }}}
 fi
 {{% if FILE_REGEX %}}
-echo "Create specific tests for this rule because of regex"
+find -H {{{ path }}} {{{ FIND_RECURSE_ARGS }}} {{{ EXCLUDED_FILES_ARGS }}} -type f -regex '{{{ FILE_REGEX[loop.index0] }}}' -exec chmod 777 {} \;
 {{% elif RECURSIVE %}}
-find -L {{{ path }}} -type d -maxdepth 1 -exec chmod 777 {} \;
+find -H {{{ path }}} -type d -maxdepth 1 -exec chmod 777 {} \;
 {{% else %}}
 chmod 777 {{{ path }}}
 {{% endif %}}


### PR DESCRIPTION
#### Description:

- Fixed test for `file_permissions` template

#### Rationale:

- `lenient_permissions.fail.sh` test did not fail when run on a compliant system because the permissions were not modified

