### PR TITLE
Set the `requires` to `sshd_set_keepalive` on `sshd_set_idle_timeout`

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/rule.yml
@@ -64,11 +64,7 @@ references:
     stigid@ubuntu2004: UBTU-20-010037
 
 requires:
-  {{% if product in ['ubuntu2004', 'ubuntu2204'] %}}
     - sshd_set_keepalive
-  {{% else %}}
-    - sshd_set_keepalive_0
-  {{% endif %}}
 
 ocil_clause: 'it is commented out or not configured properly'
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/rule.yml
@@ -24,11 +24,6 @@ rationale: |-
 
 severity: medium
 
-{{% if "rhel" in product %}}
-platforms:
-    - os_linux[rhel]<=8.5
-{{% endif %}}
-
 identifiers:
     cce@rhcos4: CCE-82549-7
     cce@rhel7: CCE-27433-2


### PR DESCRIPTION


#### Description:

Clean up the `requires` for  sshd_set_keepalive.

#### Rationale:

Fixes #11803 

