### PR TITLE
Remove OVAL version restrictions from auditd_audispd_configure_sufficiently_large_partition

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_sufficiently_large_partition/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_sufficiently_large_partition/oval/shared.xml
@@ -1,5 +1,4 @@
-{{% if target_oval_version >= [5, 11.2] %}}
-<def-group oval_version="5.11.2">
+<def-group>
   <definition class="compliance" id="auditd_audispd_configure_sufficiently_large_partition" version="1">
     {{{ oval_metadata("Configure a sufficiently large partition for audit logs.") }}}
     <criteria>
@@ -29,6 +28,4 @@
   <ind:variable_state id="state_aacsflp_partition_sufficiently_large" version="1">
       <ind:value operation="greater than or equal" datatype="int">10000000000</ind:value>
   </ind:variable_state>
-
 </def-group>
-{{% endif %}}


### PR DESCRIPTION


#### Description:

Remove OVAL version restrictions from auditd_audispd_configure_sufficiently_large_partition

#### Rationale:
Fixes #11802

