### PR TITLE
Firewall technology related rules per service and package change logic according to interactive profile variable

### DIFF
--- a/linux_os/guide/system/network/network-firewalld/firewalld_activation/package_firewalld_installed/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_activation/package_firewalld_installed/rule.yml
@@ -49,10 +49,20 @@ fixtext: |-
 
     {{{ package_install("firewalld") }}}
 
+{{%- if product in [ "sle12", "sle15" ] %}}
+template:
+    name: package_installed_guard_var
+    vars:
+        pkgname: firewalld
+        variable: var_network_filtering_service
+        value: firewalld
+{{%- else %}}
 template:
     name: package_installed
     vars:
         pkgname: firewalld
+{{%- endif %}}
+
 
 srg_requirement:
     {{{ full_name }}} must have the firewalld package installed.

--- a/linux_os/guide/system/network/network-firewalld/firewalld_activation/service_firewalld_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_activation/service_firewalld_enabled/rule.yml
@@ -55,7 +55,17 @@ fixtext: |-
 
 srg_requirement: '{{{ srg_requirement_service_enabled("firewalld") }}}'
 
+{{%- if product in [ "sle12", "sle15" ] %}}
+template:
+    name: service_enabled_guard_var
+    vars:
+        packagename: firewalld
+        servicename: firewalld
+        variable: var_network_filtering_service
+        value: firewalld
+{{%- else %}}
 template:
     name: service_enabled
     vars:
         servicename: firewalld
+{{%- endif %}}

--- a/linux_os/guide/system/network/network-firewalld/firewalld_deactivation/package_firewalld_removed/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_deactivation/package_firewalld_removed/rule.yml
@@ -29,7 +29,17 @@ references:
 
 fixtext: '{{{ fixtext_package_removed("firewalld") }}}'
 
+{{%- if product in [ "sle12", "sle15" ] %}}
+template:
+    name: package_removed_guard_var
+    vars:
+        pkgname: firewalld
+        variable: var_network_filtering_service
+        value: nftables|iptables
+        operation: pattern match
+{{%- else %}}
 template:
     name: package_removed
     vars:
         pkgname: firewalld
+{{%- endif %}}

--- a/linux_os/guide/system/network/network-firewalld/firewalld_deactivation/package_firewalld_removed/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_deactivation/package_firewalld_removed/rule.yml
@@ -35,8 +35,7 @@ template:
     vars:
         pkgname: firewalld
         variable: var_network_filtering_service
-        value: nftables|iptables
-        operation: pattern match
+        value: firewalld
 {{%- else %}}
 template:
     name: package_removed

--- a/linux_os/guide/system/network/network-firewalld/firewalld_deactivation/service_firewalld_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_deactivation/service_firewalld_disabled/rule.yml
@@ -37,8 +37,19 @@ fixtext: '{{{ fixtext_service_disabled("firewalld") }}}'
 
 srg_requirement: '{{{ srg_requirement_service_disabled("firewalld") }}}'
 
+{{%- if product in [ "sle12", "sle15" ] %}}
+template:
+    name: service_disabled_guard_var
+    vars:
+        packagename: firewalld
+        servicename: firewalld
+        variable: var_network_filtering_service
+        value: nftables|iptables
+        operation: pattern match
+{{%- else %}}
 template:
     name: service_disabled
     vars:
         servicename: firewalld
         packagename: firewalld
+{{%- endif %}}

--- a/linux_os/guide/system/network/network-firewalld/firewalld_deactivation/service_firewalld_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_deactivation/service_firewalld_disabled/rule.yml
@@ -44,8 +44,7 @@ template:
         packagename: firewalld
         servicename: firewalld
         variable: var_network_filtering_service
-        value: nftables|iptables
-        operation: pattern match
+        value: firewalld
 {{%- else %}}
 template:
     name: service_disabled

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/service_ip6tables_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/service_ip6tables_enabled/rule.yml
@@ -34,8 +34,18 @@ ocil: |-
     <br /><br />
     {{{ ocil_service_enabled(service="ip6tables") }}}
 
+{{%- if product in [ "sle12", "sle15" ] %}}
+template:
+    name: service_enabled_guard_var
+    vars:
+        packagename: iptables
+        servicename: iptables
+        variable: var_network_filtering_service
+        value: iptables
+{{%- else %}}
 template:
     name: service_enabled
     vars:
         servicename: ip6tables
         packagename: iptables-ipv6
+{{%- endif %}}

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/service_iptables_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/service_iptables_enabled/rule.yml
@@ -31,7 +31,7 @@ references:
     nist: AC-4,CM-7(b),CA-3(5),SC-7(21),CM-6(a)
     nist-csf: DE.AE-1,ID.AM-3,PR.AC-5,PR.DS-5,PR.IP-1,PR.PT-3,PR.PT-4
 
-platform: machine and package[iptables] and service_disabled[firewalld]
+platform: system_with_kernel and package[iptables] and service_disabled[firewalld]
 
 ocil: |-
     {{{ ocil_service_enabled(service="iptables") }}}

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/service_iptables_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/service_iptables_enabled/rule.yml
@@ -40,8 +40,8 @@ ocil: |-
 template:
     name: service_enabled_guard_var
     vars:
-        packagename: iptables
-        servicename: iptables
+        packagename: ip6tables
+        servicename: iptables-ipv6
         variable: var_network_filtering_service
         value: iptables
 {{%- else %}}

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/service_iptables_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/service_iptables_enabled/rule.yml
@@ -31,12 +31,22 @@ references:
     nist: AC-4,CM-7(b),CA-3(5),SC-7(21),CM-6(a)
     nist-csf: DE.AE-1,ID.AM-3,PR.AC-5,PR.DS-5,PR.IP-1,PR.PT-3,PR.PT-4
 
-platform: system_with_kernel and package[iptables] and service_disabled[firewalld]
+platform: machine and package[iptables] and service_disabled[firewalld]
 
 ocil: |-
     {{{ ocil_service_enabled(service="iptables") }}}
 
+{{%- if product in [ "sle12", "sle15" ] %}}
+template:
+    name: service_enabled_guard_var
+    vars:
+        packagename: iptables
+        servicename: iptables
+        variable: var_network_filtering_service
+        value: iptables
+{{%- else %}}
 template:
     name: service_enabled
     vars:
         servicename: iptables
+{{%- endif %}}

--- a/linux_os/guide/system/network/network-iptables/package_iptables_installed/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/package_iptables_installed/rule.yml
@@ -36,7 +36,16 @@ ocil_clause: 'the package is not installed'
 
 ocil: '{{{ ocil_package(package="iptables") }}}'
 
+{{%- if product in [ "sle12", "sle15" ] %}}
+template:
+    name: package_installed_guard_var
+    vars:
+        pkgname: iptables
+        variable: var_network_filtering_service
+        value: iptables
+{{%- else %}}
 template:
     name: package_installed
     vars:
         pkgname: iptables
+{{%- endif %}}

--- a/linux_os/guide/system/network/network-nftables/package_nftables_removed/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/package_nftables_removed/rule.yml
@@ -27,7 +27,17 @@ references:
 
 fixtext: '{{{ fixtext_package_removed("nftables") }}}'
 
+{{%- if product in [ "sle12", "sle15" ] %}}
+template:
+    name: package_removed_guard_var
+    vars:
+        pkgname: nftables
+        variable: var_network_filtering_service
+        value: firewalld|iptables
+        operation: pattern match
+{{%- else %}}
 template:
     name: package_removed
     vars:
         pkgname: nftables
+{{%- endif %}}

--- a/linux_os/guide/system/network/network-nftables/package_nftables_removed/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/package_nftables_removed/rule.yml
@@ -33,7 +33,7 @@ template:
     vars:
         pkgname: nftables
         variable: var_network_filtering_service
-        value: firewalld|iptables
+        value: firewalld|nftables
         operation: pattern match
 {{%- else %}}
 template:

--- a/linux_os/guide/system/network/network-nftables/service_nftables_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/service_nftables_disabled/rule.yml
@@ -38,8 +38,19 @@ fixtext: '{{{ fixtext_service_disabled("nftables") }}}'
 
 platform: system_with_kernel and package[nftables] and package[firewalld]
 
+{{%- if product in [ "sle12", "sle15" ] %}}
+template:
+    name: service_disabled_guard_var
+    vars:
+        packagename: nftables
+        servicename: nftables
+        variable: var_network_filtering_service
+        value: firewalld|iptables
+        operation: pattern match
+{{%- else %}}
 template:
     name: service_disabled
     vars:
         servicename: nftables
         packagename: nftables
+{{%- endif %}}

--- a/linux_os/guide/system/network/network-nftables/service_nftables_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/service_nftables_disabled/rule.yml
@@ -45,8 +45,7 @@ template:
         packagename: nftables
         servicename: nftables
         variable: var_network_filtering_service
-        value: firewalld|iptables
-        operation: pattern match
+        value: nftables
 {{%- else %}}
 template:
     name: service_disabled

--- a/linux_os/guide/system/network/network-nftables/service_nftables_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/service_nftables_enabled/rule.yml
@@ -35,7 +35,7 @@ fixtext: |-
     {{{ fixtext_service_enabled("nftables") }}}
 
 
-platform: machine and package[nftables] and service_disabled[firewalld]
+platform: system_with_kernel and package[nftables] and service_disabled[firewalld]
 
 
 {{%- if product in [ "sle12", "sle15" ] %}}

--- a/linux_os/guide/system/network/network-nftables/service_nftables_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/service_nftables_enabled/rule.yml
@@ -34,9 +34,21 @@ ocil: |-
 fixtext: |-
     {{{ fixtext_service_enabled("nftables") }}}
 
-platform: system_with_kernel and package[nftables] and service_disabled[firewalld]
 
+platform: machine and package[nftables] and service_disabled[firewalld]
+
+
+{{%- if product in [ "sle12", "sle15" ] %}}
+template:
+    name: service_enabled_guard_var
+    vars:
+        packagename: nftables
+        servicename: nftables
+        variable: var_network_filtering_service
+        value: nftables
+{{%- else %}}
 template:
     name: service_enabled
     vars:
         servicename: nftables
+{{%- endif %}}

--- a/linux_os/guide/system/network/var_network_filtering_service.var
+++ b/linux_os/guide/system/network/var_network_filtering_service.var
@@ -1,0 +1,19 @@
+documentation_complete: true
+
+title: 'Network filtering service'
+
+description: |-
+   Network filtering service: iptables, nftables, firewalld or ufw
+
+type: string
+
+operator: equals
+
+interactive: true
+
+options:
+    iptables: iptables
+    nftables: nftables
+    firewalld: firewalld
+    ufw: ufw
+    default: firewalld

--- a/products/sle12/profiles/default.profile
+++ b/products/sle12/profiles/default.profile
@@ -12,6 +12,7 @@ description: |-
     is to keep a rule in the product's XCCDF Benchmark.
 
 selections:
+    - var_network_filtering_service=iptables
     - accounts_user_dot_user_ownership
     - service_timesyncd_enabled
     - gnome_gdm_disable_xdmcp

--- a/products/sle15/profiles/cis.profile
+++ b/products/sle15/profiles/cis.profile
@@ -21,6 +21,7 @@ description: |-
 
 selections:
     - cis_sle15:all:l2_server
+    - var_network_filtering_service=firewalld
 # Exclude from CIS profile all rules related to ntp and timesyncd and keep only
 # rules related to chrony
     - '!ntpd_configure_restrictions'

--- a/products/sle15/profiles/default.profile
+++ b/products/sle15/profiles/default.profile
@@ -12,6 +12,7 @@ description: |-
     is to keep a rule in the product's XCCDF Benchmark.
 
 selections:
+    - var_network_filtering_service=firewalld
     - accounts_user_dot_user_ownership
     - service_timesyncd_enabled
     - gnome_gdm_disable_xdmcp

--- a/shared/macros/10-oval.jinja
+++ b/shared/macros/10-oval.jinja
@@ -1760,3 +1760,31 @@ The macros generates the OVAL test including the dependent OVAL object and OVAL 
 
 </def-group>
 {{%- endmacro -%}}
+
+{{#
+Macro to check if external variable is set to value
+  :param variable: Name of the external variable to check
+  :type variable: str
+  :param value: Value of the external variable
+  :type value: str
+  :param test_id: Suffix of the Ids in test, obj, and state elements
+  :type test_id: str
+  :param operation: Value operation
+  :type operation: str
+#}}
+{{%- macro oval_test_external_variable_value(variable,value,test_id='',operation='equals') -%}}
+  <ind:variable_test id="{{{ test_id }}}"
+  comment="Check external {{{ variable }}} is set to {{{ value }}}" check="all" version="1">
+    <ind:object object_ref="obj_{{{ test_id }}}"/>
+    <ind:state state_ref="ste_{{{ test_id }}}" />
+  </ind:variable_test>
+
+  <ind:variable_object id="obj_{{{ test_id }}}" version="1">
+    <ind:var_ref>{{{ variable }}}</ind:var_ref>
+  </ind:variable_object>
+  <ind:variable_state id="ste_{{{ test_id }}}" version="1">
+    <ind:value operation="{{{ operation }}}" datatype="string">{{{ value }}}</ind:value>
+  </ind:variable_state>
+
+  <external_variable comment="External variable {{{ variable }}}" datatype="string" id="{{{ variable }}}" version="1" />
+{{%- endmacro -%}}

--- a/shared/templates/package_installed_guard_var/ansible.template
+++ b/shared/templates/package_installed_guard_var/ansible.template
@@ -1,0 +1,17 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = enable
+# complexity = low
+# disruption = low
+
+{{{ ansible_instantiate_variables(VARIABLE) }}}
+
+- name: Ensure {{{ PKGNAME }}} is installed
+  package:
+    name: "{{{ PKGNAME }}}"
+    state: present
+{{% if OPERATION == "pattern match" %}}
+  when: {{{ VARIABLE }}} is regex("{{{ VALUE }}}")
+{{% else %}}
+  when: {{{ VARIABLE }}} == "{{{ VALUE }}}"
+{{% endif %}}

--- a/shared/templates/package_installed_guard_var/ansible.template
+++ b/shared/templates/package_installed_guard_var/ansible.template
@@ -7,7 +7,7 @@
 {{{ ansible_instantiate_variables(VARIABLE) }}}
 
 - name: Ensure {{{ PKGNAME }}} is installed
-  package:
+  ansible.builtin.package:
     name: "{{{ PKGNAME }}}"
     state: present
 {{% if OPERATION == "pattern match" %}}

--- a/shared/templates/package_installed_guard_var/bash.template
+++ b/shared/templates/package_installed_guard_var/bash.template
@@ -1,0 +1,17 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = enable
+# complexity = low
+# disruption = low
+
+{{{ bash_instantiate_variables(VARIABLE) }}}
+
+{{% if OPERATION == "pattern match" %}}
+  if [[ "{{{ VALUE }}}" =~ "${{{ VARIABLE }}}" ]]; then
+    {{{ bash_package_install(package=PKGNAME) }}}
+  fi
+{{% else %}}
+  if [ ${{{ VARIABLE }}} == {{{ VALUE }}} ]; then
+    {{{ bash_package_install(package=PKGNAME) }}}
+  fi
+{{% endif %}}

--- a/shared/templates/package_installed_guard_var/bash.template
+++ b/shared/templates/package_installed_guard_var/bash.template
@@ -7,7 +7,7 @@
 {{{ bash_instantiate_variables(VARIABLE) }}}
 
 {{% if OPERATION == "pattern match" %}}
-  if [[ "{{{ VALUE }}}" =~ "${{{ VARIABLE }}}" ]]; then
+  if [[ "{{{ VALUE }}}" =~ ${{{ VARIABLE }}} ]]; then
     {{{ bash_package_install(package=PKGNAME) }}}
   fi
 {{% else %}}

--- a/shared/templates/package_installed_guard_var/oval.template
+++ b/shared/templates/package_installed_guard_var/oval.template
@@ -1,0 +1,26 @@
+<def-group>
+  {{%- set variable_value_test_id = _RULE_ID + "_test_variable_" + VARIABLE -%}}
+  {{% if OPERATION is defined %}}
+    {{%- set variable_value_op = OPERATION -%}}
+  {{% else %}}
+    {{%- set variable_value_op = "equals" -%}}
+  {{% endif %}}
+  <definition class="compliance" id="{{{ _RULE_ID }}}"
+  version="1">
+    {{{ oval_metadata("The " + pkg_system|upper + " package " + PKGNAME + " should be installed.", affected_platforms=["multi_platform_sle"]) }}}
+    <criteria operator="OR" comment="package {{{ PKGNAME }}} is installed or not needed">
+      <criteria comment="{{{ PKGNAME }}} is not needed" operator="AND">
+        <criterion comment="variable {{{ VARIABLE }}} is set to {{{ VALUE }}}"
+        test_ref="{{{ variable_value_test_id }}}" negate="true"/>
+      </criteria>
+      <criteria comment="package {{{ PKGNAME }}} is installed and needed" operator="AND">
+        <criterion comment="package {{{ PKGNAME }}} is installed"
+        test_ref="test_package_{{{ PKGNAME }}}_installed" />
+        <criterion comment="variable {{{ VARIABLE }}} is set to {{{ VALUE }}}"
+        test_ref="{{{ variable_value_test_id }}}" />
+      </criteria>
+    </criteria>
+  </definition>
+{{{ oval_test_external_variable_value(variable=VARIABLE, value=VALUE, test_id=variable_value_test_id, operation=variable_value_op) }}}
+{{{ oval_test_package_installed(package=PKGNAME, evr=EVR, test_id="test_package_"+PKGNAME+"_installed") }}}
+</def-group>

--- a/shared/templates/package_installed_guard_var/template.py
+++ b/shared/templates/package_installed_guard_var/template.py
@@ -1,0 +1,12 @@
+import re
+
+
+def preprocess(data, lang):
+    if "evr" in data:
+        evr = data["evr"]
+        if evr and not re.match(r'\d:\d[\d\w+.]*-\d[\d\w+.]*', evr, 0):
+            raise RuntimeError(
+                "ERROR: input violation: evr key should be in "
+                "epoch:version-release format, but package {0} has set "
+                "evr to {1}".format(data["pkgname"], evr))
+    return data

--- a/shared/templates/package_installed_guard_var/template.yml
+++ b/shared/templates/package_installed_guard_var/template.yml
@@ -1,0 +1,4 @@
+supported_languages:
+  - ansible
+  - bash
+  - oval

--- a/shared/templates/package_removed_guard_var/ansible.template
+++ b/shared/templates/package_removed_guard_var/ansible.template
@@ -7,7 +7,7 @@
 {{{ ansible_instantiate_variables(VARIABLE) }}}
 
 - name: Ensure {{{ PKGNAME }}} is removed
-  package:
+  ansible.builtin.package:
     name: "{{{ PKGNAME }}}"
     state: absent
   when: {{{ VARIABLE }}} != "{{{ VALUE }}}"

--- a/shared/templates/package_removed_guard_var/ansible.template
+++ b/shared/templates/package_removed_guard_var/ansible.template
@@ -1,0 +1,18 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = disable
+# complexity = low
+# disruption = low
+
+{{{ ansible_instantiate_variables(VARIABLE) }}}
+
+- name: Ensure {{{ PKGNAME }}} is removed
+  package:
+    name: "{{{ PKGNAME }}}"
+    state: absent
+  when: {{{ VARIABLE }}} != "{{{ VALUE }}}"
+{{% if OPERATION == "pattern match" %}}
+  when: {{{ VARIABLE }}} is not regex("{{{ VALUE }}}")
+{{% else %}}
+  when: {{{ VARIABLE }}} != "{{{ VALUE }}}"
+{{% endif %}}

--- a/shared/templates/package_removed_guard_var/bash.template
+++ b/shared/templates/package_removed_guard_var/bash.template
@@ -13,7 +13,7 @@
 {{{ bash_instantiate_variables(VARIABLE) }}}
 
 {{% if OPERATION == "pattern match" %}}
-  if ! [[ "{{{ VALUE }}}" =~ "${{{ VARIABLE }}}" ]]; then
+  if ! [[ "{{{ VALUE }}}" =~ ${{{ VARIABLE }}} ]]; then
     {{{ bash_package_remove(package=PKGNAME) }}}
   fi
 {{% else %}}

--- a/shared/templates/package_removed_guard_var/bash.template
+++ b/shared/templates/package_removed_guard_var/bash.template
@@ -1,0 +1,23 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = disable
+# complexity = low
+# disruption = low
+
+# CAUTION: This remediation script will remove {{{ PKGNAME }}}
+#	   from the system, and may remove any packages
+#	   that depend on {{{ PKGNAME }}}. Execute this
+#	   remediation AFTER testing on a non-production
+#	   system!
+
+{{{ bash_instantiate_variables(VARIABLE) }}}
+
+{{% if OPERATION == "pattern match" %}}
+  if ! [[ "{{{ VALUE }}}" =~ "${{{ VARIABLE }}}" ]]; then
+    {{{ bash_package_remove(package=PKGNAME) }}}
+  fi
+{{% else %}}
+  if [ ${{{ VARIABLE }}} != {{{ VALUE }}} ]; then
+    {{{ bash_package_remove(package=PKGNAME) }}}
+  fi
+{{% endif %}}

--- a/shared/templates/package_removed_guard_var/oval.template
+++ b/shared/templates/package_removed_guard_var/oval.template
@@ -1,0 +1,26 @@
+<def-group>
+  {{%- set variable_value_test_id = _RULE_ID + "_test_variable_" + VARIABLE -%}}
+  {{% if OPERATION is defined %}}
+    {{%- set variable_value_op = OPERATION -%}}
+  {{% else %}}
+    {{%- set variable_value_op = "equals" -%}}
+  {{% endif %}}
+  <definition class="compliance" id="{{{ _RULE_ID }}}"
+  version="1">
+    {{{ oval_metadata("The " + pkg_system|upper + " package " + PKGNAME + " should be removed.", affected_platforms=["multi_platform_sle"]) }}}
+    <criteria operator="OR" comment="package {{{ PKGNAME }}} is removed or not needed">
+      <criteria comment="{{{ PKGNAME }}} is needed" operator="AND">
+        <criterion comment="variable {{{ VARIABLE }}} is set to {{{ VALUE }}}"
+        test_ref="{{{ variable_value_test_id }}}"/>
+      </criteria>
+      <criteria>
+        <criterion comment="package {{{ PKGNAME }}} is removed"
+        test_ref="test_package_{{{ PKGNAME }}}_removed" />
+        <criterion comment="variable {{{ VARIABLE }}} is not set to {{{ VALUE }}}"
+        test_ref="{{{ variable_value_test_id }}}" negate="true"/>
+      </criteria>
+    </criteria>
+  </definition>
+{{{ oval_test_external_variable_value(variable=VARIABLE, value=VALUE, test_id=variable_value_test_id, operation=variable_value_op) }}}
+{{{ oval_test_package_removed(package=PKGNAME, test_id="test_package_"+PKGNAME+"_removed") }}}
+</def-group>

--- a/shared/templates/package_removed_guard_var/template.yml
+++ b/shared/templates/package_removed_guard_var/template.yml
@@ -1,0 +1,4 @@
+supported_languages:
+  - ansible
+  - bash
+  - oval

--- a/shared/templates/service_disabled_guard_var/ansible.template
+++ b/shared/templates/service_disabled_guard_var/ansible.template
@@ -1,0 +1,54 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = disable
+# complexity = low
+# disruption = low
+
+{{{ ansible_instantiate_variables(VARIABLE) }}}
+
+{{%- if init_system == "systemd" %}}
+
+- name: "{{{ rule_title }}} - Collect systemd Services Present in the System"
+  ansible.builtin.command: systemctl -q list-unit-files --type service
+  register: service_exists
+  changed_when: false
+  failed_when: service_exists.rc not in [0, 1]
+  check_mode: false
+
+- name: '{{{ rule_title }}} - Ensure "{{{ DAEMONNAME }}}.service" is Masked'
+  ansible.builtin.systemd:
+    name: "{{{ DAEMONNAME }}}.service"
+    state: "stopped"
+    enabled: false
+    masked: true
+  when:
+    - 'service_exists.stdout_lines is search("{{{ SERVICENAME }}}.service",multiline=True)'
+{{% if OPERATION == "pattern match" %}}
+    - {{{ VARIABLE }}} is not regex("{{{ VALUE }}}")
+{{% else %}}
+    - {{{ VARIABLE }}} != "{{{ VALUE }}}"
+{{% endif %}}
+
+- name: "Unit Socket Exists - {{{ DAEMONNAME }}}.socket"
+  ansible.builtin.command: systemctl -q list-unit-files {{{ DAEMONNAME }}}.socket
+  register: socket_file_exists
+  changed_when: false
+  failed_when: socket_file_exists.rc not in [0, 1]
+  check_mode: false
+
+- name: Disable socket {{{ SERVICENAME }}}
+  ansible.builtin.systemd:
+    name: "{{{ DAEMONNAME }}}.socket"
+    enabled: "no"
+    state: "stopped"
+    masked: "yes"
+  when:
+    - 'socket_file_exists.stdout_lines is search("{{{ DAEMONNAME }}}.socket",multiline=True)'
+{{% if OPERATION == "pattern match" %}}
+    - {{{ VARIABLE }}} is not regex("{{{ VALUE }}}")
+{{% else %}}
+    - {{{ VARIABLE }}} != "{{{ VALUE }}}"
+{{% endif %}}
+{{%- else %}}
+JINJA TEMPLATE ERROR: Unknown init system '{{{ init_system }}}'
+{{%- endif %}}

--- a/shared/templates/service_disabled_guard_var/bash.template
+++ b/shared/templates/service_disabled_guard_var/bash.template
@@ -8,7 +8,7 @@
 {{{ bash_instantiate_variables(VARIABLE) }}}
 
 {{% if OPERATION == "pattern match" %}}
-if ! [[ "{{{ VALUE }}}" =~ "${{{ VARIABLE }}}" ]];
+if ! [[ "{{{ VALUE }}}" =~ ${{{ VARIABLE }}} ]]; then
 {{% else %}}
 if [ ${{{ VARIABLE }}} != {{{ VALUE }}} ]; then
 {{%- endif %}}

--- a/shared/templates/service_disabled_guard_var/bash.template
+++ b/shared/templates/service_disabled_guard_var/bash.template
@@ -1,0 +1,32 @@
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle,multi_platform_ubuntu
+# reboot = false
+# strategy = disable
+# complexity = low
+# disruption = low
+{{%- if init_system == "systemd" %}}
+
+{{{ bash_instantiate_variables(VARIABLE) }}}
+
+{{% if OPERATION == "pattern match" %}}
+if ! [[ "{{{ VALUE }}}" =~ "${{{ VARIABLE }}}" ]];
+{{% else %}}
+if [ ${{{ VARIABLE }}} != {{{ VALUE }}} ]; then
+{{%- endif %}}
+  SYSTEMCTL_EXEC='/usr/bin/systemctl'
+  "$SYSTEMCTL_EXEC" stop '{{{ DAEMONNAME }}}.service'
+  "$SYSTEMCTL_EXEC" disable '{{{ DAEMONNAME }}}.service'
+  "$SYSTEMCTL_EXEC" mask '{{{ DAEMONNAME }}}.service'
+  # Disable socket activation if we have a unit file for it
+  if "$SYSTEMCTL_EXEC" -q list-unit-files {{{ DAEMONNAME }}}.socket; then
+      "$SYSTEMCTL_EXEC" stop '{{{ DAEMONNAME }}}.socket'
+      "$SYSTEMCTL_EXEC" mask '{{{ DAEMONNAME }}}.socket'
+  fi
+  # The service may not be running because it has been started and failed,
+  # so let's reset the state so OVAL checks pass.
+  # Service should be 'inactive', not 'failed' after reboot though.
+  "$SYSTEMCTL_EXEC" reset-failed '{{{ DAEMONNAME }}}.service' || true
+fi
+{{%- else %}}
+
+JINJA TEMPLATE ERROR: Unknown init system '{{{ init_system }}}'
+{{%- endif %}}

--- a/shared/templates/service_disabled_guard_var/oval.template
+++ b/shared/templates/service_disabled_guard_var/oval.template
@@ -1,0 +1,37 @@
+<def-group>
+
+{{%- set package_removed_test_id = _RULE_ID + "_test_service_" + SERVICENAME + "_package_" + PACKAGENAME + "_removed" -%}}
+{{%- set variable_value_test_id = _RULE_ID + "_test_variable_" + VARIABLE -%}}
+{{% if OPERATION is defined %}}
+  {{%- set variable_value_op = OPERATION -%}}
+{{% else %}}
+  {{%- set variable_value_op = "equals" -%}}
+{{% endif %}}
+
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
+    {{{ oval_metadata("The " + SERVICENAME + " service should be disabled.", affected_platforms=["multi_platform_sle"]) }}}
+    <criteria operator="OR" comment="package {{{ PACKAGENAME }}} removed or service {{{ SERVICENAME }}} is not configured to start">
+      <criteria comment="{{{ PKGNAME }}} and service {{{ SERVICENAME }}} are needed" operator="AND">
+        <criterion comment="variable {{{ VARIABLE }}} is set to {{{ VALUE }}}"
+        test_ref="{{{ variable_value_test_id }}}"/>
+      </criteria>
+      <criteria operator="AND">
+        <criteria comment="variable {{{ VARIABLE }}} is set to {{{ VALUE }}}" operator="AND">
+          <criterion comment="variable {{{ VARIABLE }}} is set to {{{ VALUE }}}"
+          test_ref="{{{ variable_value_test_id }}}" negate="true"/>
+        </criteria>
+        <criteria comment="package {{{ PACKAGENAME }}} removed or service {{{ SERVICENAME }}} is not configured to start" operator="OR">
+          <criterion comment="{{{ PACKAGENAME }}} removed" test_ref="{{{ package_removed_test_id }}}" />
+          {{{ oval_test_service_disabled_criteria(SERVICENAME) }}}
+        </criteria>
+      </criteria>
+    </criteria>
+  </definition>
+
+  {{{ oval_test_external_variable_value(variable=VARIABLE, value=VALUE, test_id=variable_value_test_id, operation=variable_value_op) }}}
+
+  {{{ oval_test_service_disabled_tests(SERVICENAME) }}}
+
+  {{{ oval_test_package_removed(package=PACKAGENAME, test_id=package_removed_test_id) }}}
+
+</def-group>

--- a/shared/templates/service_disabled_guard_var/template.py
+++ b/shared/templates/service_disabled_guard_var/template.py
@@ -1,0 +1,8 @@
+def preprocess(data, lang):
+    if "packagename" not in data:
+        data["packagename"] = data["servicename"]
+    if "daemonname" not in data:
+        data["daemonname"] = data["servicename"]
+    if "mask_service" not in data:
+        data["mask_service"] = "true"
+    return data

--- a/shared/templates/service_disabled_guard_var/template.yml
+++ b/shared/templates/service_disabled_guard_var/template.yml
@@ -1,0 +1,4 @@
+supported_languages:
+  - ansible
+  - bash
+  - oval

--- a/shared/templates/service_enabled_guard_var/ansible.template
+++ b/shared/templates/service_enabled_guard_var/ansible.template
@@ -1,0 +1,32 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = enable
+# complexity = low
+# disruption = low
+
+{{{ ansible_instantiate_variables(VARIABLE) }}}
+
+- name: Enable service {{{ SERVICENAME }}}
+  block:
+  - name: Gather the package facts
+    package_facts:
+      manager: auto
+
+{{%- if init_system == "systemd" %}}
+  - name: Enable service {{{ SERVICENAME }}}
+    systemd:
+      name: "{{{ DAEMONNAME }}}"
+      enabled: "yes"
+      state: "started"
+      masked: "no"
+    when:
+    - '"{{{ PACKAGENAME }}}" in ansible_facts.packages'
+    - {{{ VARIABLE }}} == "{{{ VALUE }}}"
+{{% if OPERATION == "pattern match" %}}
+    - {{{ VARIABLE }}} is regex("{{{ VALUE }}}")
+{{% else %}}
+    - {{{ VARIABLE }}} == "{{{ VALUE }}}"
+{{% endif %}}
+{{%- else %}}
+JINJA TEMPLATE ERROR: Unknown init system '{{{ init_system }}}'
+{{%- endif %}}

--- a/shared/templates/service_enabled_guard_var/ansible.template
+++ b/shared/templates/service_enabled_guard_var/ansible.template
@@ -14,7 +14,7 @@
 
 {{%- if init_system == "systemd" %}}
   - name: Enable service {{{ SERVICENAME }}}
-    systemd:
+    ansible.builtin.systemd_service:
       name: "{{{ DAEMONNAME }}}"
       enabled: "yes"
       state: "started"

--- a/shared/templates/service_enabled_guard_var/bash.template
+++ b/shared/templates/service_enabled_guard_var/bash.template
@@ -1,0 +1,22 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = enable
+# complexity = low
+# disruption = low
+{{%- if init_system == "systemd" %}}
+
+{{{ bash_instantiate_variables(VARIABLE) }}}
+
+SYSTEMCTL_EXEC='/usr/bin/systemctl'
+{{% if OPERATION == "pattern match" %}}
+if [[ "{{{ VALUE }}}" =~ "${{{ VARIABLE }}}" ]];
+{{% else %}}
+if [ ${{{ VARIABLE }}} == {{{ VALUE }}} ]; then
+{{%- endif %}}
+  "$SYSTEMCTL_EXEC" unmask '{{{ DAEMONNAME }}}.service'
+  "$SYSTEMCTL_EXEC" start '{{{ DAEMONNAME }}}.service'
+  "$SYSTEMCTL_EXEC" enable '{{{ DAEMONNAME }}}.service'
+fi
+{{% else %}}
+JINJA TEMPLATE ERROR: Unknown init system '{{{ init_system }}}'
+{{%- endif %}}

--- a/shared/templates/service_enabled_guard_var/bash.template
+++ b/shared/templates/service_enabled_guard_var/bash.template
@@ -9,7 +9,7 @@
 
 SYSTEMCTL_EXEC='/usr/bin/systemctl'
 {{% if OPERATION == "pattern match" %}}
-if [[ "{{{ VALUE }}}" =~ "${{{ VARIABLE }}}" ]];
+if [[ "{{{ VALUE }}}" =~ ${{{ VARIABLE }}} ]]; then
 {{% else %}}
 if [ ${{{ VARIABLE }}} == {{{ VALUE }}} ]; then
 {{%- endif %}}

--- a/shared/templates/service_enabled_guard_var/oval.template
+++ b/shared/templates/service_enabled_guard_var/oval.template
@@ -7,8 +7,6 @@
 {{% else %}}
   {{%- set variable_value_op = "equals" -%}}
 {{% endif %}}
-{{% if target_oval_version >= [5, 11] %}}
-
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
     {{{ oval_metadata("The " + SERVICENAME + " service should be enabled if possible.") }}}
     <criteria operator="OR" comment="package {{{ PACKAGENAME }}} installed and service {{{ SERVICENAME }}} is configured to start or not needed">
@@ -64,107 +62,6 @@
   <linux:systemdunitproperty_state id="state_service_running_{{{ SERVICENAME }}}" version="1" comment="{{{ SERVICENAME }}} is running">
       <linux:value>active</linux:value>
   </linux:systemdunitproperty_state>
-
-{{% else %}}
-
-  <definition class="compliance" id="{{{ _RULE_ID }}}"
-  version="1">
-    {{{ oval_metadata("The " + SERVICENAME + " service should be enabled if possible.") }}}
-    <criteria operator="OR" comment="package {{{ PACKAGENAME }}} installed and service {{{ SERVICENAME }}} is configured to start or not needed">
-      <criteria comment="service {{{ SERVICENAME }}} is not needed" operator="AND">
-        <criterion comment="variable {{{ VARIABLE }}} is set to {{{ VALUE }}}"
-        test_ref="test_variable_{{{ VARIABLE }}}_set_to_{{{ VALUE }}}" negate="true"/>
-      </criteria>
-      <criteria comment="package {{{ PACKAGENAME }}} installed and service {{{ SERVICENAME }}} is configured to start" operator="AND">
-      <criterion comment="{{{ PACKAGENAME }}} installed" test_ref="{{{ package_installed_test_id }}}" />
-      <criteria operator="OR" comment="service {{{ SERVICENAME }}} is configured to start">
-        <criterion comment="{{{ SERVICENAME }}} runlevel 0" test_ref="test_runlevel0_{{{ SERVICENAME }}}_on" />
-        <criterion comment="{{{ SERVICENAME }}} runlevel 1" test_ref="test_runlevel1_{{{ SERVICENAME }}}_on" />
-        <criterion comment="{{{ SERVICENAME }}} runlevel 2" test_ref="test_runlevel2_{{{ SERVICENAME }}}_on" />
-        <criterion comment="{{{ SERVICENAME }}} runlevel 3" test_ref="test_runlevel3_{{{ SERVICENAME }}}_on" />
-        <criterion comment="{{{ SERVICENAME }}} runlevel 4" test_ref="test_runlevel4_{{{ SERVICENAME }}}_on" />
-        <criterion comment="{{{ SERVICENAME }}} runlevel 5" test_ref="test_runlevel5_{{{ SERVICENAME }}}_on" />
-        <criterion comment="{{{ SERVICENAME }}} runlevel 6" test_ref="test_runlevel6_{{{ SERVICENAME }}}_on" />
-      </criteria>
-      </criteria>
-    </criteria>
-  </definition>
-  <unix:runlevel_test check="all" check_existence="any_exist"
-  comment="Runlevel test" id="test_runlevel0_{{{ SERVICENAME }}}_on"
-  version="2">
-    <unix:object object_ref="obj_runlevel0_{{{ SERVICENAME }}}_on" />
-    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_on" />
-  </unix:runlevel_test>
-  <unix:runlevel_test check="all" check_existence="any_exist"
-  comment="Runlevel test" id="test_runlevel1_{{{ SERVICENAME }}}_on"
-  version="2">
-    <unix:object object_ref="obj_runlevel1_{{{ SERVICENAME }}}_on" />
-    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_on" />
-  </unix:runlevel_test>
-  <unix:runlevel_test check="all" check_existence="any_exist"
-  comment="Runlevel test" id="test_runlevel2_{{{ SERVICENAME }}}_on"
-  version="2">
-    <unix:object object_ref="obj_runlevel2_{{{ SERVICENAME }}}_on" />
-    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_on" />
-  </unix:runlevel_test>
-  <unix:runlevel_test check="all" check_existence="any_exist"
-  comment="Runlevel test" id="test_runlevel3_{{{ SERVICENAME }}}_on"
-  version="2">
-    <unix:object object_ref="obj_runlevel3_{{{ SERVICENAME }}}_on" />
-    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_on" />
-  </unix:runlevel_test>
-  <unix:runlevel_test check="all" check_existence="any_exist"
-  comment="Runlevel test" id="test_runlevel4_{{{ SERVICENAME }}}_on"
-  version="2">
-    <unix:object object_ref="obj_runlevel4_{{{ SERVICENAME }}}_on" />
-    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_on" />
-  </unix:runlevel_test>
-  <unix:runlevel_test check="all" check_existence="any_exist"
-  comment="Runlevel test" id="test_runlevel5_{{{ SERVICENAME }}}_on"
-  version="2">
-    <unix:object object_ref="obj_runlevel5_{{{ SERVICENAME }}}_on" />
-    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_on" />
-  </unix:runlevel_test>
-  <unix:runlevel_test check="all" check_existence="any_exist"
-  comment="Runlevel test" id="test_runlevel6_{{{ SERVICENAME }}}_on"
-  version="2">
-    <unix:object object_ref="obj_runlevel6_{{{ SERVICENAME }}}_on" />
-    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_on" />
-  </unix:runlevel_test>
-  <unix:runlevel_object id="obj_runlevel0_{{{ SERVICENAME }}}_on" version="1">
-    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
-    <unix:runlevel operation="equals">0</unix:runlevel>
-  </unix:runlevel_object>
-  <unix:runlevel_object id="obj_runlevel1_{{{ SERVICENAME }}}_on" version="1">
-    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
-    <unix:runlevel operation="equals">1</unix:runlevel>
-  </unix:runlevel_object>
-  <unix:runlevel_object id="obj_runlevel2_{{{ SERVICENAME }}}_on" version="1">
-    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
-    <unix:runlevel operation="equals">2</unix:runlevel>
-  </unix:runlevel_object>
-  <unix:runlevel_object id="obj_runlevel3_{{{ SERVICENAME }}}_on" version="1">
-    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
-    <unix:runlevel operation="equals">3</unix:runlevel>
-  </unix:runlevel_object>
-  <unix:runlevel_object id="obj_runlevel4_{{{ SERVICENAME }}}_on" version="1">
-    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
-    <unix:runlevel operation="equals">4</unix:runlevel>
-  </unix:runlevel_object>
-  <unix:runlevel_object id="obj_runlevel5_{{{ SERVICENAME }}}_on" version="1">
-    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
-    <unix:runlevel operation="equals">5</unix:runlevel>
-  </unix:runlevel_object>
-  <unix:runlevel_object id="obj_runlevel6_{{{ SERVICENAME }}}_on" version="1">
-    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
-    <unix:runlevel operation="equals">6</unix:runlevel>
-  </unix:runlevel_object>
-  <unix:runlevel_state comment="configured to start" id="state_service_{{{ SERVICENAME }}}_on" version="1">
-    <unix:start datatype="boolean">true</unix:start>
-    <unix:kill datatype="boolean">false</unix:kill>
-  </unix:runlevel_state>
-
-{{% endif %}}
 {{{ oval_test_external_variable_value(variable=VARIABLE, value=VALUE, test_id=variable_value_test_id, operation=variable_value_op) }}}
 {{{ oval_test_package_installed(package=PACKAGENAME, evr="", test_id=package_installed_test_id) }}}
 </def-group>

--- a/shared/templates/service_enabled_guard_var/oval.template
+++ b/shared/templates/service_enabled_guard_var/oval.template
@@ -1,0 +1,170 @@
+<def-group>
+
+{{%- set package_installed_test_id = "test_service_" + SERVICENAME + "_package_" + PACKAGENAME + "_installed" -%}}
+{{%- set variable_value_test_id = _RULE_ID + "_test_variable_" + VARIABLE -%}}
+{{% if OPERATION is defined %}}
+  {{%- set variable_value_op = OPERATION -%}}
+{{% else %}}
+  {{%- set variable_value_op = "equals" -%}}
+{{% endif %}}
+{{% if target_oval_version >= [5, 11] %}}
+
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
+    {{{ oval_metadata("The " + SERVICENAME + " service should be enabled if possible.") }}}
+    <criteria operator="OR" comment="package {{{ PACKAGENAME }}} installed and service {{{ SERVICENAME }}} is configured to start or not needed">
+      <criteria comment="service {{{ SERVICENAME }}} is not needed" operator="AND">
+        <criterion comment="variable {{{ VARIABLE }}} is set to {{{ VALUE }}}"
+        test_ref="{{{ variable_value_test_id }}}" negate="true"/>
+      </criteria>
+      <criteria comment="package {{{ PACKAGENAME }}} installed and service {{{ SERVICENAME }}} is configured to start" operator="AND">
+      <criterion comment="variable {{{ VARIABLE }}} is set to {{{ VALUE }}}"
+      test_ref="{{{ variable_value_test_id }}}" />
+      <criterion comment="{{{ PACKAGENAME }}} installed" test_ref="{{{ package_installed_test_id }}}" />
+        <criteria comment="service {{{ SERVICENAME }}} is configured to start and is running" operator="AND">
+          <criterion comment="{{{ SERVICENAME }}} is running" test_ref="test_service_running_{{{ SERVICENAME }}}" />
+          <criteria operator="OR" comment="service {{{ SERVICENAME }}} is configured to start">
+            <criterion comment="multi-user.target wants {{{ SERVICENAME }}}" test_ref="test_multi_user_wants_{{{ SERVICENAME }}}" />
+            <criterion comment="multi-user.target wants {{{ SERVICENAME }}} socket" test_ref="test_multi_user_wants_{{{ SERVICENAME }}}_socket" />
+          </criteria>
+        </criteria>
+      </criteria>
+    </criteria>
+  </definition>
+
+  <linux:systemdunitdependency_test check="all" check_existence="any_exist" comment="systemd test" id="test_multi_user_wants_{{{ SERVICENAME }}}" version="1">
+    <linux:object object_ref="object_multi_user_target_for_{{{ SERVICENAME }}}_enabled" />
+    <linux:state state_ref="state_systemd_{{{ SERVICENAME }}}_on"/>
+  </linux:systemdunitdependency_test>
+  <linux:systemdunitdependency_object id="object_multi_user_target_for_{{{ SERVICENAME }}}_enabled" comment="list of dependencies of multi-user.target" version="1">
+    <linux:unit>multi-user.target</linux:unit>
+  </linux:systemdunitdependency_object>
+  <linux:systemdunitdependency_state id="state_systemd_{{{ SERVICENAME }}}_on" comment="{{{ SERVICENAME }}} listed at least once in the dependencies" version="1">
+    <linux:dependency entity_check="at least one">{{{ SERVICENAME }}}.service</linux:dependency>
+  </linux:systemdunitdependency_state>
+
+  <linux:systemdunitdependency_test check="all" check_existence="any_exist" comment="systemd test" id="test_multi_user_wants_{{{ SERVICENAME }}}_socket" version="1">
+    <linux:object object_ref="object_multi_user_target_for_{{{ SERVICENAME }}}_socket_enabled" />
+    <linux:state state_ref="state_systemd_{{{ SERVICENAME }}}_socket_on"/>
+  </linux:systemdunitdependency_test>
+  <linux:systemdunitdependency_object id="object_multi_user_target_for_{{{ SERVICENAME }}}_socket_enabled" comment="list of dependencies of multi-user.target" version="1">
+    <linux:unit>multi-user.target</linux:unit>
+  </linux:systemdunitdependency_object>
+  <linux:systemdunitdependency_state id="state_systemd_{{{ SERVICENAME }}}_socket_on" comment="{{{ SERVICENAME }}} listed at least once in the dependencies" version="1">
+    <linux:dependency entity_check="at least one">{{{ SERVICENAME }}}.socket</linux:dependency>
+  </linux:systemdunitdependency_state>
+
+  <linux:systemdunitproperty_test id="test_service_running_{{{ SERVICENAME }}}" check="at least one" check_existence="at_least_one_exists" comment="Test that the {{{ SERVICENAME }}} service is running" version="1">
+    <linux:object object_ref="obj_service_running_{{{ SERVICENAME }}}"/>
+    <linux:state state_ref="state_service_running_{{{ SERVICENAME }}}"/>
+  </linux:systemdunitproperty_test>
+  <linux:systemdunitproperty_object id="obj_service_running_{{{ SERVICENAME }}}" comment="Retrieve the ActiveState property of {{{ SERVICENAME }}}" version="1">
+    <linux:unit operation="pattern match">^{{{ SERVICENAME }}}\.(socket|service)$</linux:unit>
+    <linux:property>ActiveState</linux:property>
+  </linux:systemdunitproperty_object>
+  <linux:systemdunitproperty_state id="state_service_running_{{{ SERVICENAME }}}" version="1" comment="{{{ SERVICENAME }}} is running">
+      <linux:value>active</linux:value>
+  </linux:systemdunitproperty_state>
+
+{{% else %}}
+
+  <definition class="compliance" id="{{{ _RULE_ID }}}"
+  version="1">
+    {{{ oval_metadata("The " + SERVICENAME + " service should be enabled if possible.") }}}
+    <criteria operator="OR" comment="package {{{ PACKAGENAME }}} installed and service {{{ SERVICENAME }}} is configured to start or not needed">
+      <criteria comment="service {{{ SERVICENAME }}} is not needed" operator="AND">
+        <criterion comment="variable {{{ VARIABLE }}} is set to {{{ VALUE }}}"
+        test_ref="test_variable_{{{ VARIABLE }}}_set_to_{{{ VALUE }}}" negate="true"/>
+      </criteria>
+      <criteria comment="package {{{ PACKAGENAME }}} installed and service {{{ SERVICENAME }}} is configured to start" operator="AND">
+      <criterion comment="{{{ PACKAGENAME }}} installed" test_ref="{{{ package_installed_test_id }}}" />
+      <criteria operator="OR" comment="service {{{ SERVICENAME }}} is configured to start">
+        <criterion comment="{{{ SERVICENAME }}} runlevel 0" test_ref="test_runlevel0_{{{ SERVICENAME }}}_on" />
+        <criterion comment="{{{ SERVICENAME }}} runlevel 1" test_ref="test_runlevel1_{{{ SERVICENAME }}}_on" />
+        <criterion comment="{{{ SERVICENAME }}} runlevel 2" test_ref="test_runlevel2_{{{ SERVICENAME }}}_on" />
+        <criterion comment="{{{ SERVICENAME }}} runlevel 3" test_ref="test_runlevel3_{{{ SERVICENAME }}}_on" />
+        <criterion comment="{{{ SERVICENAME }}} runlevel 4" test_ref="test_runlevel4_{{{ SERVICENAME }}}_on" />
+        <criterion comment="{{{ SERVICENAME }}} runlevel 5" test_ref="test_runlevel5_{{{ SERVICENAME }}}_on" />
+        <criterion comment="{{{ SERVICENAME }}} runlevel 6" test_ref="test_runlevel6_{{{ SERVICENAME }}}_on" />
+      </criteria>
+      </criteria>
+    </criteria>
+  </definition>
+  <unix:runlevel_test check="all" check_existence="any_exist"
+  comment="Runlevel test" id="test_runlevel0_{{{ SERVICENAME }}}_on"
+  version="2">
+    <unix:object object_ref="obj_runlevel0_{{{ SERVICENAME }}}_on" />
+    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_on" />
+  </unix:runlevel_test>
+  <unix:runlevel_test check="all" check_existence="any_exist"
+  comment="Runlevel test" id="test_runlevel1_{{{ SERVICENAME }}}_on"
+  version="2">
+    <unix:object object_ref="obj_runlevel1_{{{ SERVICENAME }}}_on" />
+    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_on" />
+  </unix:runlevel_test>
+  <unix:runlevel_test check="all" check_existence="any_exist"
+  comment="Runlevel test" id="test_runlevel2_{{{ SERVICENAME }}}_on"
+  version="2">
+    <unix:object object_ref="obj_runlevel2_{{{ SERVICENAME }}}_on" />
+    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_on" />
+  </unix:runlevel_test>
+  <unix:runlevel_test check="all" check_existence="any_exist"
+  comment="Runlevel test" id="test_runlevel3_{{{ SERVICENAME }}}_on"
+  version="2">
+    <unix:object object_ref="obj_runlevel3_{{{ SERVICENAME }}}_on" />
+    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_on" />
+  </unix:runlevel_test>
+  <unix:runlevel_test check="all" check_existence="any_exist"
+  comment="Runlevel test" id="test_runlevel4_{{{ SERVICENAME }}}_on"
+  version="2">
+    <unix:object object_ref="obj_runlevel4_{{{ SERVICENAME }}}_on" />
+    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_on" />
+  </unix:runlevel_test>
+  <unix:runlevel_test check="all" check_existence="any_exist"
+  comment="Runlevel test" id="test_runlevel5_{{{ SERVICENAME }}}_on"
+  version="2">
+    <unix:object object_ref="obj_runlevel5_{{{ SERVICENAME }}}_on" />
+    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_on" />
+  </unix:runlevel_test>
+  <unix:runlevel_test check="all" check_existence="any_exist"
+  comment="Runlevel test" id="test_runlevel6_{{{ SERVICENAME }}}_on"
+  version="2">
+    <unix:object object_ref="obj_runlevel6_{{{ SERVICENAME }}}_on" />
+    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_on" />
+  </unix:runlevel_test>
+  <unix:runlevel_object id="obj_runlevel0_{{{ SERVICENAME }}}_on" version="1">
+    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
+    <unix:runlevel operation="equals">0</unix:runlevel>
+  </unix:runlevel_object>
+  <unix:runlevel_object id="obj_runlevel1_{{{ SERVICENAME }}}_on" version="1">
+    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
+    <unix:runlevel operation="equals">1</unix:runlevel>
+  </unix:runlevel_object>
+  <unix:runlevel_object id="obj_runlevel2_{{{ SERVICENAME }}}_on" version="1">
+    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
+    <unix:runlevel operation="equals">2</unix:runlevel>
+  </unix:runlevel_object>
+  <unix:runlevel_object id="obj_runlevel3_{{{ SERVICENAME }}}_on" version="1">
+    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
+    <unix:runlevel operation="equals">3</unix:runlevel>
+  </unix:runlevel_object>
+  <unix:runlevel_object id="obj_runlevel4_{{{ SERVICENAME }}}_on" version="1">
+    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
+    <unix:runlevel operation="equals">4</unix:runlevel>
+  </unix:runlevel_object>
+  <unix:runlevel_object id="obj_runlevel5_{{{ SERVICENAME }}}_on" version="1">
+    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
+    <unix:runlevel operation="equals">5</unix:runlevel>
+  </unix:runlevel_object>
+  <unix:runlevel_object id="obj_runlevel6_{{{ SERVICENAME }}}_on" version="1">
+    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
+    <unix:runlevel operation="equals">6</unix:runlevel>
+  </unix:runlevel_object>
+  <unix:runlevel_state comment="configured to start" id="state_service_{{{ SERVICENAME }}}_on" version="1">
+    <unix:start datatype="boolean">true</unix:start>
+    <unix:kill datatype="boolean">false</unix:kill>
+  </unix:runlevel_state>
+
+{{% endif %}}
+{{{ oval_test_external_variable_value(variable=VARIABLE, value=VALUE, test_id=variable_value_test_id, operation=variable_value_op) }}}
+{{{ oval_test_package_installed(package=PACKAGENAME, evr="", test_id=package_installed_test_id) }}}
+</def-group>

--- a/shared/templates/service_enabled_guard_var/template.py
+++ b/shared/templates/service_enabled_guard_var/template.py
@@ -1,0 +1,6 @@
+def preprocess(data, lang):
+    if "packagename" not in data:
+        data["packagename"] = data["servicename"]
+    if "daemonname" not in data:
+        data["daemonname"] = data["servicename"]
+    return data

--- a/shared/templates/service_enabled_guard_var/template.yml
+++ b/shared/templates/service_enabled_guard_var/template.yml
@@ -1,0 +1,4 @@
+supported_languages:
+  - ansible
+  - bash
+  - oval


### PR DESCRIPTION
#### Description:

- Make sure that behaviour of rules about nftables,iptables and firewalld are mutually exclusive and the default behaviour of the checks and remediations is based on external interactive variable, that is part of the profile definition

#### Rationale:
- Add oval macro to check external variable vs expected value
- Add variable to set default firewall technology used
- Set relevant values for SLE platforms
- Templates for pkg installed/removed and svc enabled/disabled, guarded by ext varaiable
- The idea is the oval checks and remediation to check provided external variable, and thus honour if really to check/install/remove certain package or service
- Enable nftable service on SLE only if active firewall technology is set to be nftables
- Disable nftable service on SLE only if active firewall technology is set to be firewalld or iptables
- Removing nftable package on SLE makes sense only if active firewall technology is set to be firewalld or iptables
- Installing iptables package on SLE only if active firewall technology is set to be iptables
- Enable iptables service on SLE only if active firewall technology is set to be iptables
- Disable firewalld service on SLE only if active firewall technology is set to be nftables or iptables
- Removing  package on SLE makes sense only if active firewall technology is set to be nftables or iptables
- Enable firewalld service on SLE only if active firewall technology is set to be firewalld
- Installing firewalld package on SLE only if active firewall technology is set to be firewalld

#### Review Hints:
- For now the proposed change is applied to SLE platforms only, and if proves to be a good approach can distribute to other platforms also
- The use case would be that the user will have in its profile defined default firewall technology, one of iptables,nftables,ufw, firewalld ,and if the system has been modified a non-default option for that, one can use `scap-workbench` or similar tool, or  define a new alternative profile to the original one (CIS is currently the one having conflicting rules ) , or via command line arguments of the `oscap ` tool, if that is the weapon of choice to run checks and remediations.
