### PR TITLE
Fix dconf package name for Ubuntu

### DIFF
--- a/shared/templates/extra_ovals.yml
+++ b/shared/templates/extra_ovals.yml
@@ -21,6 +21,8 @@ package_dconf_installed:
   name: package_installed
   vars:
     pkgname: dconf
+    pkgname@ubuntu2004: dconf-service
+    pkgname@ubuntu2204: dconf-service
 
 package_gdm_installed:
   name: package_installed


### PR DESCRIPTION
#### Description:

In several rules, the OVAL check automatically passes if the `dconf` package is not present on the system.
On Ubuntu, the rules always pass and give false positives because `dconf` does not exist.

Fixed by changing the package name to `dconf-service`.

