### PR TITLE
accounts_umask_etc_bashrc: extend handled cases of umask

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/ansible/shared.yml
@@ -14,7 +14,7 @@
 - name: Check if umask in {{{ etc_bash_rc }}} is already set
   ansible.builtin.lineinfile:
     path: {{{ etc_bash_rc }}}
-    regexp: ^[^#]*\s*umask\s*
+    regexp: ^[^#]*\bumask\s+
     state: absent
   check_mode: true
   changed_when: false
@@ -23,7 +23,7 @@
 - name: Replace user umask in {{{ etc_bash_rc }}}
   ansible.builtin.replace:
     path: {{{ etc_bash_rc }}}
-    regexp: ^([^#]*\s*)umask(\s*)
+    regexp: ^([^#]*\b)umask(\s*)
     replace: \g<1>umask\g<2>{{ var_accounts_user_umask }}
   when:
   - umask_replace.found > 0

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/ansible/shared.yml
@@ -14,7 +14,7 @@
 - name: Check if umask in {{{ etc_bash_rc }}} is already set
   ansible.builtin.lineinfile:
     path: {{{ etc_bash_rc }}}
-    regexp: ^(\s*)umask\s+.*
+    regexp: ^[^#]*\s*umask\s*
     state: absent
   check_mode: true
   changed_when: false
@@ -23,7 +23,7 @@
 - name: Replace user umask in {{{ etc_bash_rc }}}
   ansible.builtin.replace:
     path: {{{ etc_bash_rc }}}
-    regexp: ^(\s*)umask(\s+).*
+    regexp: ^([^#]*\s*)umask(\s*)
     replace: \g<1>umask\g<2>{{ var_accounts_user_umask }}
   when:
   - umask_replace.found > 0

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/bash/shared.sh
@@ -8,8 +8,8 @@
 {{% set etc_bash_rc = "/etc/bashrc" %}}
 {{% endif %}}
 
-grep -q "[^#]*\s*umask" {{{ etc_bash_rc }}} && \
-  sed -i -E -e "s/^([^#]*\s*umask).*/\1 $var_accounts_user_umask/g" {{{ etc_bash_rc }}}
+grep -q "^[^#]*\bumask" {{{ etc_bash_rc }}} && \
+  sed -i -E -e "s/^([^#]*\bumask).*/\1 $var_accounts_user_umask/g" {{{ etc_bash_rc }}}
 if ! [ $? -eq 0 ]; then
     echo "umask $var_accounts_user_umask" >> {{{ etc_bash_rc }}}
 fi

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/bash/shared.sh
@@ -8,8 +8,8 @@
 {{% set etc_bash_rc = "/etc/bashrc" %}}
 {{% endif %}}
 
-grep -q "^\s*umask" {{{ etc_bash_rc }}} && \
-  sed -i -E -e "s/^(\s*umask).*/\1 $var_accounts_user_umask/g" {{{ etc_bash_rc }}}
+grep -q "[^#]*\s*umask" {{{ etc_bash_rc }}} && \
+  sed -i -E -e "s/^([^#]*\s*umask).*/\1 $var_accounts_user_umask/g" {{{ etc_bash_rc }}}
 if ! [ $? -eq 0 ]; then
     echo "umask $var_accounts_user_umask" >> {{{ etc_bash_rc }}}
 fi

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/oval/shared.xml
@@ -16,7 +16,7 @@
   <ind:textfilecontent54_object id="obj_umask_from_etc_bashrc"
   comment="Umask value from {{{ etc_bash_rc }}}" version="1">
     <ind:filepath>{{{ etc_bash_rc }}}</ind:filepath>
-    <ind:pattern operation="pattern match">[^#]*\s*umask\s*([^#\s]*)</ind:pattern>
+    <ind:pattern operation="pattern match">^[^#]*\bumask\s+([^#\s]*)</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/oval/shared.xml
@@ -16,7 +16,7 @@
   <ind:textfilecontent54_object id="obj_umask_from_etc_bashrc"
   comment="Umask value from {{{ etc_bash_rc }}}" version="1">
     <ind:filepath>{{{ etc_bash_rc }}}</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*umask[\s]+([^#\s]*)</ind:pattern>
+    <ind:pattern operation="pattern match">[^#]*\s*umask\s*([^#\s]*)</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/wrong_and_not_at_the_begining_of_line.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/wrong_and_not_at_the_begining_of_line.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# packages = bash
+
+sed -i '/umask/d' /etc/bashrc
+echo "    [ `umask` -eq 0 ] && umask 022" >> /etc/bashrc
+umask 000


### PR DESCRIPTION
#### Description:

- extend regex in OVAL, Bash and Ansible to capture also cases of umask definition which are preceded by some other alphanumeric strings


#### Rationale:

- sometimes the umask definition might be for example part of a one line conditional. This modification covers these cases as well.

- Fixes #11700 

#### Review Hints:

- _Review hints here. Replace this text. Don't use the italics format!_

- _Use this optional section to give any relevant information which could help the reviewer to more quickly and assertively understand and test the changes._

- _Good examples are useful commands, if it is better to review all commits together or in a suggested sequence, any relevant discussion in other PRs or issues, etc._
