### PR TITLE
add namespace parameter for cluster-test

### DIFF
--- a/utils/add_kubernetes_rule.py
+++ b/utils/add_kubernetes_rule.py
@@ -501,7 +501,7 @@ def main():
         default="Platform",
         choices=["Node", "Platform"])
     cluster_test_parser.add_argument(
-        '--namespace', help='Namespace where compliance operator is installed', dest="namespace", default="openshift-compliance"
+        '--namespace', help='Namespace where compliance operator is installed. Default is "openshift-compliance".', dest="namespace", default="openshift-compliance"
     )
     cluster_test_parser.set_defaults(func=clusterTestFunc)
 


### PR DESCRIPTION
#### Description:

this pr adds the ability to define a --namespace parameter for cluster-test in add_kubernetes_rule.py and defines "openshift-compliance" as default

#### Rationale:

while running `./utils/add_kubernetes_rule.py cluster-test --rule kubelet_anonymous_auth` there were sometimes empty results.
```
* Running scan with rule 'kube_descheduler_operator_exists'
> Output from last phase check: <no value> <no value>
[ ... ]
> Output from last phase check: <no value> <no value>
> Output from last phase check: <no value> <no value>
ERROR: Timeout waiting for scan to finish
```

this was caused by not switching to `openshift-compliance` namespace before running the command. To fix this I added a `--namespace` with `openshift-compliance` as default.


#### Review Hints:

deployments with non default namespace (not `openshift-compliance`) have a workflow impact.
before:
`oc project $namespace`
`./utils/add_kubernetes_rule.py cluster-test --rule kubelet_anonymous_auth`

after:
`./utils/add_kubernetes_rule.py cluster-test --rule kubelet_anonymous_auth --namespace $namespace`
