### PR TITLE
Fix a case where the motd check would consider an empty file valid.

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/oval/shared.xml
@@ -1,12 +1,21 @@
 <def-group>
   <definition class="compliance" id="banner_etc_motd" version="2">
     {{{ oval_metadata("The system motd banner text should be set correctly.") }}}
-    <criteria>
+    <criteria operator="OR">
+      <criterion comment="/etc/motd is absent" test_ref="test_banner_etc_motd_exists" negate="true"/>
       <criterion comment="/etc/motd is set appropriately" test_ref="test_banner_etc_motd" />
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" check_existence="any_exist" comment="correct banner in /etc/motd" id="test_banner_etc_motd" version="1">
+  <unix:file_test version="1" id="test_banner_etc_motd_exists" check="all" check_existence="all_exist" comment="/etc/motd exists">
+      <unix:object object_ref="object_banner_etc_motd_exists" />
+  </unix:file_test>
+
+  <unix:file_object version="1" id="object_banner_etc_motd_exists">
+      <unix:filepath>/etc/motd</unix:filepath>
+  </unix:file_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="correct banner in /etc/motd" id="test_banner_etc_motd" version="1">
     <ind:object object_ref="object_banner_etc_motd" />
     <ind:state state_ref="state_banner_etc_motd" />
   </ind:textfilecontent54_test>

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/tests/banner_etc_motd_empty.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/tests/banner_etc_motd_empty.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+rm -f /etc/motd
+touch /etc/motd


### PR DESCRIPTION
#### Description:

- Fix a case where the motd check would consider an empty file valid.

#### Rationale:

- Empty files should be treated as a fail.
