### PR TITLE
Fix rule mount_option_nodev_nonroot_local_partitions Bash remediation

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/bash/shared.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/bash/shared.sh
@@ -2,7 +2,7 @@
 
 MOUNT_OPTION="nodev"
 # Create array of local non-root partitions
-readarray -t partitions_records < <(findmnt --mtab --raw --evaluate | grep "^/\w" | grep "\s/dev/\w")
+readarray -t partitions_records < <(findmnt --mtab --raw --evaluate | grep "^/\w" | grep -v "^/proc" | grep "\s/dev/\w")
 
 # Create array of polyinstantiated directories, in case one of them is found in mtab
 readarray -t polyinstantiated_dirs < \


### PR DESCRIPTION
#### Description:

- Don't try to create an **fstab** entry for `/proc/*` **mtab** items.

#### Rationale:

- It is a problem because **mtab** could contain a line like `/proc/cmdline /dev/mapper/rhel_rhel91-root[/var/cache/osbuild-worker/osbuild-store/tmp/osbuild-tmp-ahbt5omy/proc/cmdline] xfs ro,nosuid,nodev,relatime,seclabel,attr2,inode64,logbufs=8,logbsize=32k,noquota` which would end as a bogus **fstab** entry.

- Fixes #11795 