### PR TITLE
Update ol8 stig

### DIFF
--- a/linux_os/guide/services/ssh/ssh_client/ssh_keys_passphrase_protected/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_client/ssh_keys_passphrase_protected/rule.yml
@@ -23,6 +23,7 @@ identifiers:
 
 references:
     srg: SRG-OS-000067-GPOS-00035
+    stigid@ol8: OL08-00-010100
     stigid@rhel8: RHEL-08-010100
 
 ocil_clause: 'no ssh private key is accessible without a passcode'

--- a/linux_os/guide/services/ssh/ssh_private_keys_have_passcode/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_private_keys_have_passcode/rule.yml
@@ -24,7 +24,6 @@ references:
     disa: CCI-000186
     nist: IA-5(2),IA-5(2).1
     srg: SRG-OS-000067-GPOS-00035
-    stigid@ol8: OL08-00-010100
 
 ocil_clause: Any contents were displayed without asking a passphrase
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/rule.yml
@@ -50,6 +50,7 @@ references:
     nist-csf: DE.CM-1,DE.CM-3,PR.AC-1,PR.AC-4,PR.AC-6,PR.AC-7,PR.IP-2
     pcidss: Req-8.1.8
     srg: SRG-OS-000163-GPOS-00072,SRG-OS-000279-GPOS-00109
+    stigid@ol8: OL08-00-010200
     stigid@rhel8: RHEL-08-010200
     stigid@sle12: SLES-12-030191
     stigid@sle15: SLES-15-010320

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive_0/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive_0/rule.yml
@@ -47,7 +47,6 @@ references:
     pcidss: Req-8.1.8
     srg: SRG-OS-000126-GPOS-00066,SRG-OS-000163-GPOS-00072,SRG-OS-000279-GPOS-00109
     stigid@ol7: OL07-00-040340
-    stigid@ol8: OL08-00-010200
     stigid@rhel7: RHEL-07-040340
     stigid@sle12: SLES-12-030191
     stigid@sle15: SLES-15-010320

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_emergency_expire_date/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_emergency_expire_date/rule.yml
@@ -41,7 +41,6 @@ references:
     nist: AC-2(2),AC-2(3),CM-6(a)
     nist-csf: DE.CM-1,DE.CM-3,PR.AC-1,PR.AC-4,PR.AC-6
     srg: SRG-OS-000123-GPOS-00064,SRG-OS-000002-GPOS-00002
-    stigid@ol8: OL08-00-020270
     stigid@rhel7: RHEL-07-010271
 
 ocil_clause: 'any emergency accounts have no expiration date set or do not expire within 72 hours'

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_temp_expire_date/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_temp_expire_date/rule.yml
@@ -43,7 +43,7 @@ references:
     nist-csf: DE.CM-1,DE.CM-3,PR.AC-1,PR.AC-4,PR.AC-6
     srg: SRG-OS-000123-GPOS-00064,SRG-OS-000002-GPOS-00002
     stigid@ol7: OL07-00-010271
-    stigid@ol8: OL08-00-020000
+    stigid@ol8: OL08-00-020000,OL08-00-020270
     stigid@rhel7: RHEL-07-010271
     stigid@rhel8: RHEL-08-020000,RHEL-08-020270
     stigid@sle12: SLES-12-010331

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable_login_uids/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable_login_uids/rule.yml
@@ -31,6 +31,7 @@ identifiers:
 references:
     disa: CCI-000162,CCI-000163,CCI-000164
     srg: SRG-OS-000462-GPOS-00206,SRG-OS-000475-GPOS-00220,SRG-OS-000057-GPOS-00027,SRG-OS-000058-GPOS-00028,SRG-OS-000059-GPOS-00029
+    stigid@ol8: OL08-00-030122
     stigid@rhel8: RHEL-08-030122
 
 ocil_clause: 'the system is not configured to make login UIDs immutable'

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/tests/commented_out.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/tests/commented_out.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # packages = audit
+# variables = var_auditd_name_format=hostname|fqd|numeric
 # Ensure test system has proper directories/files for test scenario
 bash -x setup.sh
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/tests/correct_value.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # packages = audit
+# variables = var_auditd_name_format=hostname|fqd|numeric
 # Ensure test system has proper directories/files for test scenario
 bash -x setup.sh
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/tests/correct_value_2.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/tests/correct_value_2.pass.sh
@@ -2,7 +2,6 @@
 # packages = audit
 # variables = var_auditd_name_format=hostname|fqd|numeric
 # Ensure test system has proper directories/files for test scenario
-
 bash -x setup.sh
 
 {{%- if product in ["rhel7", "ol7"] %}}
@@ -11,6 +10,6 @@ config_file="/etc/audisp/audispd.conf"
 config_file="/etc/audit/auditd.conf"
 {{%- endif %}}
 
-if [[ -f $config_file ]]; then
-    echo '' > ${config_file}
-fi
+# remove any occurrence
+sed -i "s/^.*name_format.*$//" $config_file
+echo "name_format = fqd" >> $config_file

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/tests/file_not_present.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/tests/file_not_present.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # packages = audit
+# variables = var_auditd_name_format=hostname|fqd|numeric
 
 {{%- if product in ["rhel7", "ol7"] %}}
 config_file="/etc/audisp/audispd.conf"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/tests/not_present.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/tests/not_present.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # packages = audit
+# variables = var_auditd_name_format=hostname|fqd|numeric
 # Ensure test system has proper directories/files for test scenario
 bash -x setup.sh
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/tests/wrong_value.fail.sh
@@ -2,7 +2,6 @@
 # packages = audit
 # variables = var_auditd_name_format=hostname|fqd|numeric
 # Ensure test system has proper directories/files for test scenario
-
 bash -x setup.sh
 
 {{%- if product in ["rhel7", "ol7"] %}}
@@ -11,6 +10,6 @@ config_file="/etc/audisp/audispd.conf"
 config_file="/etc/audit/auditd.conf"
 {{%- endif %}}
 
-if [[ -f $config_file ]]; then
-    echo '' > ${config_file}
-fi
+# remove any occurrence
+sed -i "s/^.*name_format.*$//" $config_file
+echo "name_format = none" >> $config_file

--- a/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/rule.yml
@@ -33,7 +33,6 @@ references:
     nist: AU-2(a)
     ospp: FAU_GEN.1.2
     srg: SRG-OS-000462-GPOS-00206,SRG-OS-000475-GPOS-00220,SRG-OS-000057-GPOS-00027,SRG-OS-000058-GPOS-00028,SRG-OS-000059-GPOS-00029,SRG-APP-000121-CTR-000255,SRG-APP-000495-CTR-001235
-    stigid@ol8: OL08-00-030122
 
 ocil_clause: 'the file does not exist or the content differs'
 

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -112,7 +112,7 @@ selections:
     - sssd_has_trust_anchor
 
     # OL08-00-010100
-    - ssh_private_keys_have_passcode
+    - ssh_keys_passphrase_protected
 
     # OL08-00-010110
     - set_password_hashing_algorithm_logindefs

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -37,7 +37,6 @@ selections:
     - var_password_pam_lcredit=1
     - var_password_pam_retry=3
     - var_password_pam_minlen=15
-    - var_sshd_set_keepalive=0
     - sshd_approved_macs=stig_extended
     - sshd_approved_ciphers=stig_extended
     - sshd_idle_timeout_value=10_minutes
@@ -167,7 +166,8 @@ selections:
     - dir_perms_world_writable_sticky_bits
 
     # OL08-00-010200
-    - sshd_set_keepalive_0
+    - sshd_set_keepalive
+    - var_sshd_set_keepalive=1
 
     # OL08-00-010201
     - sshd_set_idle_timeout

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -741,7 +741,7 @@ selections:
     - audit_rules_immutable
 
     # OL08-00-030122
-    - audit_immutable_login_uids
+    - audit_rules_immutable_login_uids
 
     # OL08-00-030130
     - audit_rules_usergroup_modification_shadow

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -60,6 +60,7 @@ selections:
     - var_auditd_disk_full_action=ol8
     - var_sssd_certificate_verification_digest_function=sha1
     - login_banner_text=dod_banners
+    - var_authselect_profile=sssd
 
     ### Enable / Configure FIPS
     - enable_fips_mode
@@ -69,6 +70,9 @@ selections:
     - configure_libreswan_crypto_policy
     - configure_kerberos_crypto_policy
     - enable_dracut_fips_module
+
+    # Other needed rules
+    - enable_authselect
 
     ### Rules:
     # OL08-00-010000

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -719,6 +719,7 @@ selections:
 
     # OL08-00-030062
     - auditd_name_format
+    - var_auditd_name_format=stig
 
     # OL08-00-030063
     - auditd_log_format

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -486,7 +486,7 @@ selections:
     - sshd_do_not_permit_user_env
     - sshd_do_not_permit_user_env.severity=high
 
-    # OL08-00-020000
+    # OL08-00-020000, OL08-00-020270
     - account_temp_expire_date
 
     # OL08-00-020010, OL08-00-020011
@@ -652,9 +652,6 @@ selections:
 
     # OL08-00-020264
     - file_groupownership_lastlog
-
-    # OL08-00-020270
-    - account_emergency_expire_date
 
     # OL08-00-020280
     - accounts_password_pam_ocredit


### PR DESCRIPTION
#### Description:

* Remove rule `account_emergency_expire_date` since `account_temp_expire_date` already covers the same requirement
* Replace `audit_immutable_login_uids` rule with `audit_rules_immutable_login_uids`. This other rule is better aligned with requirement `OL08-00-030122`
* Replace rule `sshd_set_keepalive_0` with `sshd_set_keepalive` to better cover requirement `OL08-00-010200`
* Replace `ssh_private_keys_have_passcode` rule with `ssh_keys_passphrase_protected`, both rules are manual, but the new one includes the 'policy' directory
* Add `enable_authselect` to ol8 stig (This helps rules related to authselect)
* Update `var_auditd_name_format`. STIG OL08-00-030062 allows 'hostname', 'fqd', or 'numeric' as the stig selector for this variable
* Update tests in `auditd_name_format`. Cover some extra scenarios and set explicitly the `var_auditd_name_format` variable

#### Rationale:

- Update OL8 STIG to be better aligned with DISA STIG, or use more convenient rules

#### Review Hints:

- No new rules introduced, only new tests in  `auditd_name_format` need more careful check.

**Note:** the rule  `ssh_private_keys_have_passcode` is no longer in use, let me know if it is reasonable to delete it, as it is basically the same as `ssh_keys_passphrase_protected`
