### PR TITLE
Add new rules package_ntp_removed, package_timesyncd_removed

### DIFF
--- a/components/ntp.yml
+++ b/components/ntp.yml
@@ -23,7 +23,9 @@ rules:
 - ntpd_specify_remote_server
 - package_chrony_installed
 - package_ntp_installed
+- package_ntp_removed
 - package_timesyncd_installed
+- package_timesyncd_removed
 - service_chronyd_enabled
 - service_chronyd_or_ntpd_enabled
 - service_ntp_enabled

--- a/components/systemd.yml
+++ b/components/systemd.yml
@@ -20,6 +20,7 @@ rules:
 - journald_storage
 - package_systemd-journal-remote_installed
 - package_timesyncd_installed
+- package_timesyncd_removed
 - service_debug-shell_disabled
 - service_systemd-coredump_disabled
 - service_systemd-journald_enabled

--- a/linux_os/guide/services/ntp/package_ntp_removed/rule.yml
+++ b/linux_os/guide/services/ntp/package_ntp_removed/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+title: 'Remove the ntp service'
+
+description: 'The ntpd service should not be installed.'
+
+rationale: |
+   Inaccurate time stamps make it more difficult to correlate events
+   and can lead to an inaccurate analysis. Determining the correct
+   time a particular event occurred on a system is critical when
+   conducting forensic analysis and investigating system events.
+   Sources outside the configured acceptable allowance (drift)
+   may be inaccurate.
+
+severity: low
+
+references:
+    disa: CCI-001891
+    stigid@ubuntu2204: UBTU-22-215025
+
+template:
+    name: package_removed
+    vars:
+        pkgname: ntp

--- a/linux_os/guide/services/ntp/package_timesyncd_removed/rule.yml
+++ b/linux_os/guide/services/ntp/package_timesyncd_removed/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+title: 'Remove the systemd_timesyncd Service'
+
+description: 'The systemd_timesyncd service should not be installed.'
+
+rationale: |
+   Inaccurate time stamps make it more difficult to correlate events
+   and can lead to an inaccurate analysis. Determining the correct
+   time a particular event occurred on a system is critical when
+   conducting forensic analysis and investigating system events.
+   Sources outside the configured acceptable allowance (drift)
+   may be inaccurate.
+
+severity: low
+
+references:
+    disa: CCI-000366
+    stigid@ubuntu2204: UBTU-22-215020
+
+template:
+    name: package_removed
+    vars:
+        pkgname: systemd-timesyncd

--- a/products/ubuntu2204/profiles/stig.profile
+++ b/products/ubuntu2204/profiles/stig.profile
@@ -628,13 +628,11 @@ selections:
     # Analogous to audit_rules_login_events_lastlog
     # UBTU-22-654190 The Ubuntu operating system must generate audit records for all events that affect the systemd journal files
 
-    ### TODO (rule needed)
-    # Analogous to package_telnetd_removed
-    # UBTU-22-215025 The Ubuntu operating system must not have the "ntp" package installed
-
-    ### TODO (rule needed)
-    # Analogous to package_telnetd_removed
     # UBTU-22-215020 The Ubuntu operating system must not have the "systemd-timesyncd" package installed
+    - package_timesyncd_removed
+
+    # UBTU-22-215025 The Ubuntu operating system must not have the "ntp" package installed
+    - package_ntp_removed
 
     ### TODO (rule needed; reevaluate permissions)
     # Similar to file_permissions_library_dirs and dir_permissions_library_dirs
@@ -667,4 +665,3 @@ selections:
     ### TODO (rule needed)
     # Similar to file_permissions_var_log_audit
     # UBTU-22-232140 The Ubuntu operating system must be configured so that the "journalctl" command is not accessible by unauthorized users
-


### PR DESCRIPTION
#### Description:

- Added new rules for removing packages ntp and systemd-timesyncd
- Satisfies Ubuntu 22.04 STIGs: UBTU-22-215025 UBTU-220-215020
- Based on package_ntp_installed / package_timesyncd_installed