### PR TITLE
Fix rule dconf_gnome_banner_enabled on Ubuntu

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/oval/shared.xml
@@ -8,6 +8,9 @@
         <criterion comment="Enable GUI banner" test_ref="test_banner_gui_enabled" />
         <criterion comment="Prevent user from disabling banner" test_ref="test_prevent_user_banner_gui_enabled_change" />
       </criteria>
+      {{%- if 'ubuntu' in product %}}
+      <criterion comment="Enable GUI banner in /etc/gdm3/greeter.dconf-defaults" test_ref="test_banner_gui_enabled_dconf_defaults" />
+      {{%- endif %}}
     </criteria>
   </definition>
 
@@ -36,4 +39,17 @@
     <ind:pattern operation="pattern match">^/org/gnome/login-screen/banner-message-enable$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+      comment="GUI banner is enabled in /etc/gdm3/greeter.dconf-defaults"
+  id="test_banner_gui_enabled_dconf_defaults" version="1">
+    <ind:object object_ref="obj_banner_gui_enabled_dconf_defaults" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_banner_gui_enabled_dconf_defaults"
+  version="1">
+    <ind:filepath>/etc/gdm3/greeter.dconf-defaults</ind:filepath>
+    <ind:pattern operation="pattern match">^\[org/gnome/login-screen\]([^\n]*\n+)+?banner-message-enable=true$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/commented.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = dconf,gdm
+
+cat > /etc/gdm3/greeter.dconf-defaults <<EOF
+[org/gnome/login-screen]
+#banner-message-enable=true
+EOF

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/correct_value.pass.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 # packages = dconf,gdm
 
+{{%- if 'ubuntu' in product %}}
+cat > /etc/gdm3/greeter.dconf-defaults <<EOF
+[org/gnome/login-screen]
+banner-message-enable=true
+EOF
+
+{{%- else %}}
 source $SHARED/dconf_test_functions.sh
 
 install_dconf_and_gdm_if_needed
@@ -10,3 +17,4 @@ add_dconf_setting "org/gnome/login-screen" "banner-message-enable" "true" "{{{ d
 add_dconf_lock "org/gnome/login-screen" "banner-message-enable" "{{{ dconf_gdm_dir }}}" "00-security-settings"
 
 dconf update
+{{%- endif %}}

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/empty.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/empty.fail.sh
@@ -7,4 +7,3 @@ source $SHARED/dconf_test_functions.sh
 install_dconf_and_gdm_if_needed
 
 clean_dconf_settings
-

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/wrong_value.fail.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 # packages = dconf,gdm
 
+{{%- if 'ubuntu' in product %}}
+cat > /etc/gdm3/greeter.dconf-defaults <<EOF
+[org/gnome/login-screen]
+banner-message-enable=false
+EOF
+
+{{%- else %}}
 source $SHARED/dconf_test_functions.sh
 
 install_dconf_and_gdm_if_needed
@@ -10,3 +17,4 @@ add_dconf_setting "org/gnome/login-screen" "banner-message-enable" "false" "{{{ 
 add_dconf_lock "org/gnome/login-screen" "banner-message-enable" "{{{ dconf_gdm_dir }}}" "00-security-settings"
 
 dconf update
+{{%- endif %}}


### PR DESCRIPTION
#### Description:

Allow that the gnome DoD banner is enabled also in /etc/gdm3/greeter.dconf-defaults to better align with STIG for Ubuntu 20.04/22.04  (UBTU-20-010002, UBTU-22-271010)