### PR TITLE
Add rule file_permissions_journalctl

### DIFF
--- a/components/systemd.yml
+++ b/components/systemd.yml
@@ -18,6 +18,7 @@ rules:
 - file_owner_journalctl
 - file_owner_system_journal
 - file_permissions_etc_crypttab
+- file_permissions_journalctl
 - file_permissions_system_journal
 - journald_compress
 - journald_forward_to_syslog

--- a/linux_os/guide/system/logging/journald/file_permissions_journalctl/rule.yml
+++ b/linux_os/guide/system/logging/journald/file_permissions_journalctl/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+title: 'Verify Permissions on the journal command'
+
+description: |-
+    Verify that the "journalctl" command has a permission set of "740" by
+    using the following command:
+    <pre>
+     $ sudo find /usr/bin/journalctl -exec stat -c "%n %a" {} \;
+    </pre>
+    If "journalctl" is not set to "740", this is a finding.
+
+rationale: |-
+    Any operating system providing too much information in error messages risks
+    compromising the data and security of the structure, and content of error messages
+    needs to be carefully considered by the organization.
+
+references:
+    disa: CCI-001312
+    stigid@ubuntu2204: UBTU-22-232140
+
+severity: medium
+
+fixtext: |
+    Configure "journalctl" to have a permission set of "740":
+    <pre>
+    $ sudo chmod 740 /usr/bin/journalctl
+    </pre>
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /usr/bin/journalctl
+        filemode: '0740'

--- a/products/ubuntu2204/profiles/stig.profile
+++ b/products/ubuntu2204/profiles/stig.profile
@@ -660,6 +660,5 @@ selections:
     # Similar to file_group_ownership_var_log_audit
     # UBTU-22-232105 The Ubuntu operating system must be configured so that the "journalctl" command is group-owned by "root"
 
-    ### TODO (rule needed)
-    # Similar to file_permissions_var_log_audit
     # UBTU-22-232140 The Ubuntu operating system must be configured so that the "journalctl" command is not accessible by unauthorized users
+    - file_permissions_journalctl


### PR DESCRIPTION
#### Description:

- New rule for auditing permissions of journalctl command
- Satisfies STIG requirement UBTU-22-232140
- Based on file_permissions_system_journal
