### PR TITLE
Add rule file_owner_journalctl

### DIFF
--- a/components/systemd.yml
+++ b/components/systemd.yml
@@ -13,6 +13,7 @@ rules:
 - file_groupowner_etc_crypttab
 - file_groupowner_system_journal
 - file_owner_etc_crypttab
+- file_owner_journalctl
 - file_owner_system_journal
 - file_permissions_etc_crypttab
 - file_permissions_system_journal

--- a/linux_os/guide/system/logging/journald/file_owner_journalctl/rule.yml
+++ b/linux_os/guide/system/logging/journald/file_owner_journalctl/rule.yml
@@ -1,0 +1,36 @@
+documentation_complete: true
+
+title: 'Verify Owner on the journalctl Command'
+
+description: |-
+    Verify that the "journalctl" command is owned by "root" by
+    using the following command:
+    <pre>
+    $ sudo find /usr/bin/journalctl -exec stat -c "%n %U" {} \;
+    </pre>
+    If any output returned is not owned by "root", this is a finding.
+
+rationale: |-
+    Only authorized personnel should be aware of errors and the details of the errors.
+    Error messages are an indicator of an organization's operational state or can
+    identify the operating system or platform. Additionally, personally identifiable
+    information (PII) and operational information must not be revealed through error
+    messages to unauthorized personnel or their designated representatives.
+
+references:
+    disa: CCI-001314
+    stigid@ubuntu2204: UBTU-22-232100
+
+severity: medium
+
+fixtext: |
+    Configure "journalctl" to be owned by "root":
+    <pre>
+    $ sudo chown root /usr/bin/journalctl
+    </pre>
+
+template:
+    name: file_owner
+    vars:
+        filepath: /usr/bin/journalctl
+        fileuid: '0'

--- a/products/ubuntu2204/profiles/stig.profile
+++ b/products/ubuntu2204/profiles/stig.profile
@@ -656,9 +656,8 @@ selections:
     # Analogous to file_group_ownership_var_log_audit
     # UBTU-22-232095 The Ubuntu operating system must configure the files used by the system journal to be group-owned by "systemd-journal"
 
-    ### TODO (rule needed)
-    # Similar to file_ownership_var_log_audit
     # UBTU-22-232100 The Ubuntu operating system must be configured so that the "journalctl" command is owned by "root"
+    - file_owner_journalctl
 
     ### TODO (rule needed)
     # Similar to file_group_ownership_var_log_audit


### PR DESCRIPTION
#### Description:

- New rule for auditing ownership of journalctl command
- Satisfies STIG requirement UBTU-22-232100
- Based on file_owner_system_journal
