### PR TITLE
Add rule dir_owner_system_journal

### DIFF
--- a/components/systemd.yml
+++ b/components/systemd.yml
@@ -9,6 +9,7 @@ rules:
 - coredump_disable_backtraces
 - coredump_disable_storage
 - dir_permissions_system_journal
+- dir_owner_system_journal
 - disable_ctrlaltdel_burstaction
 - file_groupowner_etc_crypttab
 - file_groupowner_system_journal

--- a/linux_os/guide/system/logging/journald/dir_owner_system_journal/rule.yml
+++ b/linux_os/guide/system/logging/journald/dir_owner_system_journal/rule.yml
@@ -1,0 +1,43 @@
+documentation_complete: true
+
+title: 'Verify owner of system journal directories'
+
+description: |-
+    Verify the /run/log/journal and /var/log/journal directories are owned by
+    "root" by using the following command:
+    <pre>
+    $ sudo find /run/log/journal /var/log/journal  -type d -exec stat -c "%n %U" {} \;
+    </pre>
+    If any output returned is not owned by "root", this is a finding.
+
+rationale: |-
+    Only authorized personnel should be aware of errors and the details of the errors.
+    Error messages are an indicator of an organization's operational state or can identify
+    the operating system or platform. Additionally, personally identifiable information
+    (PII) and operational information must not be revealed through error messages to
+    unauthorized personnel or their designated representatives.
+
+references:
+    disa: CCI-001314
+    stigid@ubuntu2204: UBTU-22-232080
+
+severity: medium
+
+fixtext: |
+    Configure the system to set the appropriate ownership to the directories
+    used by the systemd journal. Add or modify the following lines in the
+    "/usr/lib/tmpfiles.d/systemd.conf" file:
+    <pre>
+    z /run/log/journal 2640 root systemd-journal - -
+    z /var/log/journal 2640 root systemd-journal - -
+    </pre>
+    Restart the system for the changes to take effect.
+
+template:
+    name: file_owner
+    vars:
+        filepath:
+            - /run/log/journal/
+            - /var/log/journal/
+        recursive: 'true'
+        fileuid: '0'

--- a/products/ubuntu2204/profiles/stig.profile
+++ b/products/ubuntu2204/profiles/stig.profile
@@ -640,9 +640,9 @@ selections:
     - file_permissions_system_journal
     - dir_permissions_system_journal
 
-    ### TODO (rule needed)
-    # Analogous to directory_ownership_var_log_audit
+    ### TODO (incomplete remediation - tmpfiles.d)
     # UBTU-22-232080 The Ubuntu operating system must configure the directories used by the system journal to be owned by "root"
+    - dir_owner_system_journal
 
     ### TODO (rule needed)
     # Analogous to directory_group_ownership_var_log_audit


### PR DESCRIPTION
#### Description:

- New rule for checking ownership of /var/log/journal dirs
- Satisfies STIG requirement UBTU-22-232080
- Based on existing rule `file_owner_system_journal`.
