### PR TITLE
Add and modify rules file/dir_permissions_system_journal

### DIFF
--- a/components/systemd.yml
+++ b/components/systemd.yml
@@ -8,6 +8,7 @@ packages:
 rules:
 - coredump_disable_backtraces
 - coredump_disable_storage
+- dir_permissions_system_journal
 - disable_ctrlaltdel_burstaction
 - file_groupowner_etc_crypttab
 - file_groupowner_system_journal

--- a/linux_os/guide/system/logging/journald/dir_permissions_system_journal/rule.yml
+++ b/linux_os/guide/system/logging/journald/dir_permissions_system_journal/rule.yml
@@ -1,0 +1,43 @@
+documentation_complete: true
+
+title: 'Verify Permissions on the system journal directories'
+
+description: |-
+    Verify the /run/log/journal and /var/log/journal directories have
+    permissions set to "2750" or less permissive by using the following command:
+    <pre>
+    $ sudo find /run/log/journal /var/log/journal  -type d -exec stat -c "%n %a" {} \;
+    </pre>
+    If any output returned has a permission set greater than "2750", this is a finding.
+
+rationale: |-
+    Any operating system providing too much information in error messages risks
+    compromising the data and security of the structure, and content of error messages
+    needs to be carefully considered by the organization.
+
+references:
+    disa: CCI-001312
+    stigid@ubuntu2204: UBTU-22-232027
+
+severity: medium
+
+fixtext: |
+    Configure the system to set the appropriate permissions to the files and directories
+    used by the systemd journal:
+    Add or modify the following lines in the "/etc/tmpfiles.d/systemd.conf" file:
+    <pre>
+    z /run/log/journal 2750 root systemd-journal - -
+    Z /run/log/journal/%m ~2750 root systemd-journal - -
+    z /var/log/journal 2750 root systemd-journal - -
+    z /var/log/journal/%m 2750 root systemd-journal - -
+    </pre>
+    Restart the system for the changes to take effect.
+
+template:
+    name: file_permissions
+    vars:
+        filepath:
+            - /run/log/journal/
+            - /var/log/journal/
+        recursive: 'true'
+        filemode: '2750'

--- a/linux_os/guide/system/logging/journald/file_permissions_system_journal/rule.yml
+++ b/linux_os/guide/system/logging/journald/file_permissions_system_journal/rule.yml
@@ -4,27 +4,67 @@ documentation_complete: true
 title: 'Verify Permissions on the system journal'
 
 description: |-
-  {{{ describe_file_permissions(file="/var/log/journal/.*/system.journal", perms="0640") }}}
+    {{%- if 'ubuntu' in product %}}
+    Verify all files in the /run/log/journal and /var/log/journal directories have
+    permissions set to "640" or less permissive by using the following command:
+    <pre>
+    $ sudo find /run/log/journal /var/log/journal  -type f -exec stat -c "%n %a" {} \;
+    </pre>
+    If any output returned has a permission set greater than "640", this is a finding.
+    {{%- else %}}
+    {{{ describe_file_permissions(file="/var/log/journal/.*/system.journal", perms="0640") }}}
+    {{%- endif %}}
 
 rationale: |-
-  RHCOS must protect system  journal file from any type of unauthorized access by setting file permissions. 
+    {{%- if 'ubuntu' in product %}}
+    Any operating system providing too much information in error messages risks
+    compromising the data and security of the structure, and content of error messages
+    needs to be carefully considered by the organization.
+    {{%- else %}}
+    RHCOS must protect system  journal file from any type of unauthorized access by setting file permissions.
+    {{%- endif %}}
 
 identifiers:
-  cce@rhcos4: CCE-86509-7
+    cce@rhcos4: CCE-86509-7
 
 severity: medium
 
+fixtext: |
+    {{%- if 'ubuntu' in product %}}
+    Configure the system to set the appropriate permissions to the files and directories
+    used by the systemd journal:
+    Add or modify the following lines in the "/etc/tmpfiles.d/systemd.conf" file:
+    <pre>
+    z /var/log/journal/%m/system.journal 0640 root systemd-journal - -
+    </pre>
+    Restart the system for the changes to take effect.
+    {{%- endif %}}
+
 references:
-  srg: SRG-APP-000118-CTR-000240
+    disa: CCI-001312
+    srg: SRG-APP-000118-CTR-000240
+    stigid@ubuntu2204: UBTU-22-232027
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/log/journal/.*/system.journal", perms="-rw-r-----") }}}'
 
 ocil: |-
-  {{{ ocil_file_permissions(file="/var/log/journal/.*/system.journal", perms="-rw-r-----") }}}
+    {{{ ocil_file_permissions(file="/var/log/journal/.*/system.journal", perms="-rw-r-----") }}}
 
 template:
-  name: file_permissions
-  vars:
-    filepath: ^/var/log/journal/.*/system.journal$
-    filemode: '0640'
-    filepath_is_regex: "true"
+    name: file_permissions
+    vars:
+        {{%- if 'ubuntu' in product %}}
+        filepath:
+            - /run/log/journal/
+            - /var/log/journal/
+        recursive: 'true'
+        file_regex: ^.*$
+        filemode: '0640'
+
+        {{%- else %}}
+        filepath: ^/var/log/journal/.*/system.journal$
+        filemode: '0640'
+        filepath_is_regex: "true"
+
+        {{%- endif %}}
+

--- a/products/ubuntu2204/profiles/stig.profile
+++ b/products/ubuntu2204/profiles/stig.profile
@@ -636,9 +636,10 @@ selections:
     # Analogous to package_telnetd_removed
     # UBTU-22-215020 The Ubuntu operating system must not have the "systemd-timesyncd" package installed
 
-    ### TODO (rule needed; reevaluate permissions)
-    # Similar to file_permissions_library_dirs and dir_permissions_library_dirs
+    ### TODO (reevaluate directory permissions)
     # UBTU-22-232027 The Ubuntu operating system must generate system journal entries without revealing information that could be exploited by adversaries
+    - file_permissions_system_journal
+    - dir_permissions_system_journal
 
     ### TODO (rule needed)
     # Analogous to directory_ownership_var_log_audit


### PR DESCRIPTION
#### Description:

- New rule for auditing permissions of /var/log/journal
- Satisfies STIG requirement UBTU-22-232027
- Modified existing rule file_permissions_system_journal
