### PR TITLE
Fix broken exception message

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1586,6 +1586,7 @@ class BuildLoader(DirectoryLoader):
         loader.sce_metadata = self.sce_metadata
         # Do it this way so we only have to parse the component metadata once.
         loader.rule_to_components = self.rule_to_components
+        loader.components_dir = self.components_dir
         return loader
 
     def export_group_to_file(self, filename):


### PR DESCRIPTION
Fixing `None` shown in the following message:

```
ValueError: The rule 'package_ntp_removed' isn't mapped to any component! Insert the rule ID to at least one file in 'None'.

```
#### Review Hints:

Remove a rule from a component file in the `/components` directory, then build content
