### PR TITLE
Fix SCE check for ip6tables_rules_for_open_ports

### DIFF
--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/ip6tables_rules_for_open_ports/sce/shared.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/ip6tables_rules_for_open_ports/sce/shared.sh
@@ -11,6 +11,6 @@ do
                 result=$XCCDF_RESULT_FAIL
                 break
         fi
-done < <(ss -6tuln | awk '($5!~/%lo:/ && $5!~/127.0.0.1:/ && $5!~/::1/) {split($5, a, ":"); print a[2]}i' | sort | uniq)
+    done < <(ss -6tulnH | awk '($5!~/::1/) {n=split($5, a, ":"); print a[n]}' | sort -u)
 
 exit "$result"


### PR DESCRIPTION
#### Description:
- Fix for SCE check for `ip6tables_rules_for_open_ports`

#### Rationale:
- The check incorrectly parsed ipv6 `ss -6tulp` output, separating the `ip:port` at first colon instead of last.
- Fixes https://bugs.launchpad.net/usg/+bug/2061213
