### PR TITLE
Fix SCE checks for iptables_loopback_traffic

### DIFF
--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_ipv6_loopback_traffic/sce/ubuntu.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_ipv6_loopback_traffic/sce/ubuntu.sh
@@ -10,12 +10,12 @@ fi
 regex="\s+[0-9]+\s+[0-9]+\s+ACCEPT\s+all\s+lo\s+\*\s+::\/0\s+::\/0[[:space:]]+[0-9]+\s+[0-9]+\s+DROP\s+all\s+\*\s+\*\s+::1\s+::\/0"
 
 # Check chain INPUT for loopback related rules
-if ! ip6tables -L INPUT -v -n | grep -Ezq "$regex" ; then
+if ! ip6tables -L INPUT -v -n -x | grep -Ezq "$regex" ; then
     exit "$XCCDF_RESULT_FAIL"
 fi
 
  # Check chain OUTPUT for loopback related rules
-if ! ip6tables -L OUTPUT -v -n | grep -Eq "\s[0-9]+\s+[0-9]+\s+ACCEPT\s+all\s+\*\s+lo\s+::\/0\s+::\/0" ; then
+if ! ip6tables -L OUTPUT -v -n -x | grep -Eq "\s[0-9]+\s+[0-9]+\s+ACCEPT\s+all\s+\*\s+lo\s+::\/0\s+::\/0" ; then
     exit "$XCCDF_RESULT_FAIL"
 fi
 

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_loopback_traffic/sce/ubuntu.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_loopback_traffic/sce/ubuntu.sh
@@ -5,12 +5,12 @@
 regex="\s+[0-9]+\s+[0-9]+\s+ACCEPT\s+all\s+--\s+lo\s+\*\s+0\.0\.0\.0\/0\s+0\.0\.0\.0\/0[[:space:]]+[0-9]+\s+[0-9]+\s+DROP\s+all\s+--\s+\*\s+\*\s+127\.0\.0\.0\/8\s+0\.0\.0\.0\/0"
 
 # Check chain INPUT for loopback related rules
-if ! iptables -L INPUT -v -n | grep -Ezq "$regex" ; then
+if ! iptables -L INPUT -v -n -x | grep -Ezq "$regex" ; then
     exit "$XCCDF_RESULT_FAIL"
 fi
 
 # Check chain OUTPUT for loopback related rules
-if ! iptables -L OUTPUT -v -n | grep -Eq "\s[0-9]+\s+[0-9]+\s+ACCEPT\s+all\s+--\s+\*\s+lo\s+0\.0\.0\.0\/0\s+0\.0\.0\.0\/0" ; then
+if ! iptables -L OUTPUT -v -n -x | grep -Eq "\s[0-9]+\s+[0-9]+\s+ACCEPT\s+all\s+--\s+\*\s+lo\s+0\.0\.0\.0\/0\s+0\.0\.0\.0\/0" ; then
     exit "$XCCDF_RESULT_FAIL"
 fi
 


### PR DESCRIPTION
#### Description:

- Fix for SCE check for `set_loopback_traffic` and `set_ipv6_loopback_traffic`

#### Rationale:

- The checks failed when the counters in iptables were large enough and were formatted to human readable format (K, M).
- Fixes https://bugs.launchpad.net/usg/+bug/2061215
