### PR TITLE
ensure that var_sshd_set_keepalive is not set to 0 in rhel8 and rhel9 profiles

### DIFF
--- a/controls/ccn_rhel9.yml
+++ b/controls/ccn_rhel9.yml
@@ -324,7 +324,7 @@ controls:
       - sshd_idle_timeout_value=15_minutes
       - sshd_set_idle_timeout
       - sshd_set_keepalive
-      - var_sshd_set_keepalive=0
+      - var_sshd_set_keepalive=1
 
   - id: A.5.SEC-RHEL8
     title: Local and Remote Console Inactivity is Controlled

--- a/controls/cis_rhel9.yml
+++ b/controls/cis_rhel9.yml
@@ -2018,7 +2018,7 @@ controls:
       - sshd_idle_timeout_value=15_minutes
       - sshd_set_idle_timeout
       - sshd_set_keepalive
-      - var_sshd_set_keepalive=0
+      - var_sshd_set_keepalive=1
 
   - id: 5.3.1
     title: Ensure sudo is installed (Automated)

--- a/controls/pcidss_4.yml
+++ b/controls/pcidss_4.yml
@@ -1979,7 +1979,7 @@ controls:
         - sshd_set_idle_timeout
         - sshd_idle_timeout_value=15_minutes
         - sshd_set_keepalive
-        - var_sshd_set_keepalive=0
+        - var_sshd_set_keepalive=1
       related_rules:
         - sshd_set_keepalive_0
 

--- a/products/rhel8/profiles/cjis.profile
+++ b/products/rhel8/profiles/cjis.profile
@@ -105,7 +105,7 @@ selections:
     - dconf_gnome_screensaver_mode_blank
     - sshd_allow_only_protocol2
     - sshd_set_idle_timeout
-    - var_sshd_set_keepalive=0
+    - var_sshd_set_keepalive=1
     - sshd_set_keepalive_0
     - disable_host_auth
     - sshd_disable_root_login

--- a/products/rhel8/profiles/hipaa.profile
+++ b/products/rhel8/profiles/hipaa.profile
@@ -64,7 +64,7 @@ selections:
     - sshd_do_not_permit_user_env
     - sshd_enable_strictmodes
     - sshd_enable_warning_banner
-    - var_sshd_set_keepalive=0
+    - var_sshd_set_keepalive=1
     - sshd_set_keepalive_0
     - encrypt_partitions
     - var_system_crypto_policy=fips

--- a/products/rhel8/profiles/ospp.profile
+++ b/products/rhel8/profiles/ospp.profile
@@ -63,7 +63,7 @@ selections:
     - sshd_disable_empty_passwords
     - sshd_disable_kerb_auth
     - sshd_disable_gssapi_auth
-    - var_sshd_set_keepalive=0
+    - var_sshd_set_keepalive=1
     - sshd_set_keepalive_0
     - sshd_enable_warning_banner
     - sshd_rekey_limit

--- a/products/rhel8/profiles/rht-ccp.profile
+++ b/products/rhel8/profiles/rht-ccp.profile
@@ -90,7 +90,7 @@ selections:
     - package_telnet_removed
     - sshd_allow_only_protocol2
     - sshd_set_idle_timeout
-    - var_sshd_set_keepalive=0
+    - var_sshd_set_keepalive=1
     - sshd_set_keepalive_0
     - disable_host_auth
     - sshd_disable_root_login

--- a/products/rhel9/profiles/hipaa.profile
+++ b/products/rhel9/profiles/hipaa.profile
@@ -59,7 +59,7 @@ selections:
     - sshd_do_not_permit_user_env
     - sshd_enable_strictmodes
     - sshd_enable_warning_banner
-    - var_sshd_set_keepalive=0
+    - var_sshd_set_keepalive=1
     - encrypt_partitions
     - var_system_crypto_policy=fips
     - configure_crypto_policy

--- a/tests/data/profile_stability/rhel7/pci-dss.profile
+++ b/tests/data/profile_stability/rhel7/pci-dss.profile
@@ -299,7 +299,7 @@ selections:
 - inactivity_timeout_value=15_minutes
 - var_screensaver_lock_delay=10_seconds
 - sshd_idle_timeout_value=15_minutes
-- var_sshd_set_keepalive=0
+- var_sshd_set_keepalive=1
 - var_account_disable_post_pw_expiration=90
 - var_system_crypto_policy=default_policy
 - var_sshd_set_login_grace_time=60

--- a/tests/data/profile_stability/rhel8/ospp.profile
+++ b/tests/data/profile_stability/rhel8/ospp.profile
@@ -231,7 +231,7 @@ selections:
 - zipl_bootmap_is_up_to_date
 - zipl_page_poison_argument
 - zipl_slub_debug_argument
-- var_sshd_set_keepalive=0
+- var_sshd_set_keepalive=1
 - var_rekey_limit_size=1G
 - var_rekey_limit_time=1hour
 - var_accounts_user_umask=027

--- a/tests/data/profile_stability/rhel8/pci-dss.profile
+++ b/tests/data/profile_stability/rhel8/pci-dss.profile
@@ -297,7 +297,7 @@ selections:
 - inactivity_timeout_value=15_minutes
 - var_screensaver_lock_delay=10_seconds
 - sshd_idle_timeout_value=15_minutes
-- var_sshd_set_keepalive=0
+- var_sshd_set_keepalive=1
 - var_account_disable_post_pw_expiration=90
 - var_system_crypto_policy=default_policy
 - var_sshd_set_login_grace_time=60

--- a/tests/data/profile_stability/rhel9/cis.profile
+++ b/tests/data/profile_stability/rhel9/cis.profile
@@ -387,7 +387,7 @@ selections:
 - var_password_pam_minlen=14
 - var_pam_wheel_group_for_su=cis
 - sshd_idle_timeout_value=15_minutes
-- var_sshd_set_keepalive=0
+- var_sshd_set_keepalive=1
 - var_sshd_set_login_grace_time=60
 - var_sshd_max_sessions=10
 - var_sshd_set_maxstartups=10:30:60

--- a/tests/data/profile_stability/rhel9/cis_server_l1.profile
+++ b/tests/data/profile_stability/rhel9/cis_server_l1.profile
@@ -301,7 +301,7 @@ selections:
 - var_password_pam_minlen=14
 - var_pam_wheel_group_for_su=cis
 - sshd_idle_timeout_value=15_minutes
-- var_sshd_set_keepalive=0
+- var_sshd_set_keepalive=1
 - var_sshd_set_login_grace_time=60
 - var_sshd_max_sessions=10
 - var_sshd_set_maxstartups=10:30:60

--- a/tests/data/profile_stability/rhel9/cis_workstation_l1.profile
+++ b/tests/data/profile_stability/rhel9/cis_workstation_l1.profile
@@ -297,7 +297,7 @@ selections:
 - var_password_pam_minlen=14
 - var_pam_wheel_group_for_su=cis
 - sshd_idle_timeout_value=15_minutes
-- var_sshd_set_keepalive=0
+- var_sshd_set_keepalive=1
 - var_sshd_set_login_grace_time=60
 - var_sshd_max_sessions=10
 - var_sshd_set_maxstartups=10:30:60

--- a/tests/data/profile_stability/rhel9/cis_workstation_l2.profile
+++ b/tests/data/profile_stability/rhel9/cis_workstation_l2.profile
@@ -381,7 +381,7 @@ selections:
 - var_password_pam_minlen=14
 - var_pam_wheel_group_for_su=cis
 - sshd_idle_timeout_value=15_minutes
-- var_sshd_set_keepalive=0
+- var_sshd_set_keepalive=1
 - var_sshd_set_login_grace_time=60
 - var_sshd_max_sessions=10
 - var_sshd_set_maxstartups=10:30:60

--- a/tests/data/profile_stability/rhel9/pci-dss.profile
+++ b/tests/data/profile_stability/rhel9/pci-dss.profile
@@ -289,7 +289,7 @@ selections:
 - inactivity_timeout_value=15_minutes
 - var_screensaver_lock_delay=10_seconds
 - sshd_idle_timeout_value=15_minutes
-- var_sshd_set_keepalive=0
+- var_sshd_set_keepalive=1
 - var_account_disable_post_pw_expiration=90
 - var_system_crypto_policy=default_policy
 - var_sshd_set_login_grace_time=60


### PR DESCRIPTION
#### Description:

- modify all instances of var_sshd_set_keepalive variable so that it is not set to 0
- focus on rhel8 and rhel9 products, but in case it is common in a control file, modify rather the control file
- update profile stability tests

#### Rationale:

- context: after merging of #11815  the rule sshd_set_keepalive starts being active in many profiles.
- that is fine, but the interpretation of the value "0" of this variable by sshd changed. In recent versions of ssh, if the value is set to "0", it disables the connection termination. That effectively goes against the reason why this configuration is used in hardening scenarios.


#### Review Hints:

- build rhel8 and rhel9 products
- check compiled profiles if there is not a case when var_sshd_set_keepalive is set to 0