### PR TITLE
Align sshd_use_approved_macs_ordered_stig with Ubuntu STIG

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/ansible/shared.yml
@@ -4,6 +4,10 @@
 # complexity = low
 # disruption = low
 
+{{%- if 'ubuntu' in product %}}
+{{{ ansible_instantiate_variables('sshd_approved_macs') }}}
+{{{ ansible_sshd_set(parameter="Macs", value="{{ sshd_approved_macs }}", config_is_distributed=sshd_distributed_config) }}}
+{{%- else %}}
 - name: "Configure sshd to use approved MACs"
   lineinfile:
     path: /etc/ssh/sshd_config
@@ -11,3 +15,4 @@
     state: present
     regexp: '^[\s]*MACs[\s]+(hmac-sha2-512(?=[\w,-@]+|$),?)?(hmac-sha2-256(?=[\w,-@]+|$),?)?[\s]*(?:#.*)?$'
     create: True
+{{%- endif %}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/bash/shared.sh
@@ -1,6 +1,12 @@
 # platform = Red Hat Enterprise Linux 7,Oracle Linux 7,multi_platform_sle,multi_platform_ubuntu
+
+{{%- if 'ubuntu' in product %}}
+{{{ bash_instantiate_variables('sshd_approved_macs') }}}
+{{{ bash_sshd_remediation(parameter="MACs", value="$sshd_approved_macs", config_is_distributed=sshd_distributed_config) }}}
+{{%- else %}}
 if grep -q -P '^\s*MACs\s+' /etc/ssh/sshd_config; then
   sed -i 's/^\s*MACs.*/MACs hmac-sha2-512,hmac-sha2-256/' /etc/ssh/sshd_config
 else
   echo "MACs hmac-sha2-512,hmac-sha2-256" >> /etc/ssh/sshd_config
 fi
+{{%- endif %}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/oval/ubuntu.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/oval/ubuntu.xml
@@ -1,0 +1,80 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("Limit the Message Authentication Codes (MACs) to those which are FIPS-approved.") }}}
+    <criteria operator="AND">
+      <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
+      <criteria comment="sshd is configured correctly or is not installed" operator="OR">
+        <criteria comment="sshd is not installed" operator="AND">
+          <extend_definition comment="sshd is not required or requirement is unset"
+            definition_ref="sshd_not_required_or_unset" />
+          <extend_definition comment="package openssh-server removed"
+            definition_ref="package_openssh-server_removed" />
+        </criteria>
+
+        <criteria comment="sshd is installed and configured" operator="AND">
+          <extend_definition comment="sshd is required or requirement is unset"
+            definition_ref="sshd_required_or_unset" />
+          <extend_definition comment="package openssh-server installed"
+            definition_ref="package_openssh-server_installed" />
+          <criteria comment="sshd is configured correctly" operator="AND">
+            <criteria comment="the configuration is correct if it exists" operator="AND">
+              <criterion comment="Check the MACs in /etc/ssh/sshd_config if any"
+                test_ref="test_{{{ rule_id }}}" />
+              <criterion comment="Check the MACs in /etc/ssh/sshd_config.d if any"
+                test_ref="test_{{{ rule_id }}}_config_dir" />
+            </criteria>
+            <criterion comment="the configuraton exists" test_ref="test_MACs_present_{{{ rule_id }}}" />
+          </criteria>
+        </criteria>
+
+      </criteria>
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="any_exist"
+    comment="tests the value of MACs setting in the /etc/ssh/sshd_config file"
+    id="test_{{{ rule_id }}}" version="1">
+    <ind:object object_ref="obj_{{{ rule_id }}}" />
+    <ind:state state_ref="state_{{{ rule_id }}}" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}" version="1">
+    <ind:filepath>/etc/ssh/sshd_config</ind:filepath>
+    <ind:pattern operation="pattern match">^[ \t]*(?i)MACs(?-i)[ \t]+(.+?)[ \t]*(?:$|#)</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="any_exist"
+    comment="tests the value of MACs setting in the /etc/ssh/sshd_config.d file"
+    id="test_{{{ rule_id }}}_config_dir" version="1">
+    <ind:object object_ref="obj_{{{ rule_id }}}_config_dir" />
+    <ind:state state_ref="state_{{{ rule_id }}}" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}_config_dir" version="1">
+    <ind:path>/etc/ssh/sshd_config.d</ind:path>
+    <ind:filename operation="pattern match">.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^[ \t]*(?i)MACs(?-i)[ \t]+(.+?)[ \t]*(?:$|#)</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_{{{ rule_id }}}" version="1">
+    <ind:subexpression datatype="string" operation="pattern match" var_ref="sshd_approved_macs"/>
+  </ind:textfilecontent54_state>
+
+  <external_variable comment="sshd approved MACs" datatype="string" id="sshd_approved_macs" version="1" />
+
+  <ind:textfilecontent54_object comment="All confs collection" id="obj_collection_obj_{{{ rule_id }}}" version="1">
+    <set>
+      <object_reference>obj_{{{ rule_id }}}</object_reference>
+      <object_reference>obj_{{{ rule_id }}}_config_dir</object_reference>
+    </set>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="test_MACs_present_{{{ rule_id }}}" version="1"
+                              check="all" check_existence="at_least_one_exists"
+                              comment="Verify that the value of MACs is present">
+    <ind:object object_ref="obj_collection_obj_{{{ rule_id }}}" />
+  </ind:textfilecontent54_test>
+
+</def-group>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/rule.yml
@@ -1,15 +1,20 @@
 documentation_complete: true
 
-
 title: 'Use Only FIPS 140-2 Validated MACs'
 
 description: |-
     Limit the MACs to those hash algorithms which are FIPS-approved.
     The following line in <tt>/etc/ssh/sshd_config</tt>
     demonstrates use of FIPS-approved MACs:
+    {{%- if 'ubuntu' in product %}}
+    <pre>MACs {{{ xccdf_value("sshd_approved_macs") }}}</pre>
+    If this line does not contain these MACs in exact order,
+    is commented out, or is missing, this is a finding.
+    {{%- else %}}
     <pre>MACs hmac-sha2-512,hmac-sha2-256</pre>
     This rule ensures that there are configured MACs mentioned
     above (or their subset), keeping the given order of algorithms.
+    {{%- endif %}}
 
 rationale: |-
     DoD Information Systems are required to use FIPS-approved cryptographic hash

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/tests/comment.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/tests/comment.fail.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
+{{% if product == "ubuntu2204" %}}
+sshd_approved_macs="hmac-sha2-512,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-256-etm@openssh.com"
+{{% else %}}
+sshd_approved_macs="hmac-sha2-512,hmac-sha2-256"
+{{% endif %}}
+
 if grep -q "^MACs" /etc/ssh/sshd_config; then
-	sed -i "s/^MACs.*/# MACs hmac-sha2-512,hmac-sha2-256/" /etc/ssh/sshd_config
+	sed -i "s/^MACs.*/# MACs $sshd_approved_macs/" /etc/ssh/sshd_config
 else
-	echo "# ciphers MACs hmac-sha2-512,hmac-sha2-256" >> /etc/ssh/sshd_config
+	echo "# ciphers MACs $sshd_approved_macs" >> /etc/ssh/sshd_config
 fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/tests/correct_reduced_list.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/tests/correct_reduced_list.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle
 
 if grep -q "^MACs" /etc/ssh/sshd_config; then
 	sed -i "s/^MACs.*/MACs hmac-sha2-512/" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/tests/correct_value.pass.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
+{{% if product == "ubuntu2204" %}}
+sshd_approved_macs="hmac-sha2-512,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-256-etm@openssh.com"
+{{% else %}}
+sshd_approved_macs="hmac-sha2-512,hmac-sha2-256"
+{{% endif %}}
+
 if grep -q "^MACs" /etc/ssh/sshd_config; then
-	sed -i "s/^MACs.*/MACs hmac-sha2-512,hmac-sha2-256/" /etc/ssh/sshd_config
+	sed -i "s/^MACs.*/MACs $sshd_approved_macs/" /etc/ssh/sshd_config
 else
-	echo 'MACs hmac-sha2-512,hmac-sha2-256' >> /etc/ssh/sshd_config
+	echo "MACs $sshd_approved_macs" >> /etc/ssh/sshd_config
 fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/tests/correct_value_config_dir.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/tests/correct_value_config_dir.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platforms = multi_platform_ubuntu
+
+sshd_approved_macs="hmac-sha2-512,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-256-etm@openssh.com"
+
+sed -i "/^MACs.*/d" /etc/ssh/sshd_config
+sed -i "/^MACs.*/d" /etc/ssh/sshd_config.d/*
+echo "MACs $sshd_approved_macs" >> /etc/ssh/sshd_config.d/test.conf

--- a/linux_os/guide/services/ssh/sshd_approved_macs.var
+++ b/linux_os/guide/services/ssh/sshd_approved_macs.var
@@ -18,3 +18,4 @@ options:
     cis_sle12: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
     cis_sle15: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
     cis_ubuntu: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
+    stig_ubuntu2204: hmac-sha2-512,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-256-etm@openssh.com

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -82,6 +82,7 @@ selections:
     - service_sshd_enabled
 
     # UBTU-20-010043 The Ubuntu operating system must configure the SSH daemon to use Message Authentication Codes (MACs) employing FIPS 140-2 approved cryptographic hashes to prevent the unauthorized disclosure of information and/or detect changes to information during transmission.
+    - sshd_approved_macs=stig
     - sshd_use_approved_macs_ordered_stig
 
     # UBTU-20-010044 The Ubuntu operating system must configure the SSH daemon to use FIPS 140-2 approved ciphers to prevent the unauthorized disclosure of information and/or detect changes to information during transmission.

--- a/products/ubuntu2204/profiles/stig.profile
+++ b/products/ubuntu2204/profiles/stig.profile
@@ -86,8 +86,8 @@ selections:
     - banner_etc_issue_net
     - sshd_enable_warning_banner_net
 
-    ### TODO
     # UBTU-22-255055 The Ubuntu operating system must configure the SSH daemon to use Message Authentication Codes (MACs) employing FIPS 140-3 approved cryptographic hashes to prevent the unauthorized disclosure of information and/or detect changes to information during transmission.
+    - sshd_approved_macs=stig_ubuntu2204
     - sshd_use_approved_macs_ordered_stig
 
     ### TODO


### PR DESCRIPTION
#### Description:

- Modify `sshd_use_approved_macs_ordered_stig` rule to better align with Ubuntu STIG (UBTU-20-010043, UBTU-22-255055)
- Switch to using `sshd_approved_macs` variable
- Switch to checking the whole set of algorithms instead of just a subset
- Extend OVAL check to allow distributed configs

#### Rationale:

- Checking just for a subset does not meet the requirement of having the algorithms in the exact same order (as specified in the STIG), because it is possible to specify only the last algorithm, which is effectively the same as specifying them in the wrong order