### PR TITLE
Fix config paths and regex for auditd_audispd_configure_remote_server

### DIFF
--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/bash/shared.sh
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/bash/shared.sh
@@ -7,7 +7,7 @@ AUDITCONFIG={{{ audisp_conf_path }}}/audisp-remote.conf
 {{% if 'ubuntu' in product %}}
 AUREMOTECONFIG={{{ audisp_conf_path }}}/plugins.d/au-remote.conf
 
-{{{ bash_replace_or_append("$AUREMOTECONFIG", '^active', 'yes') }}}
+{{{ set_config_file("$AUREMOTECONFIG", 'active', 'yes', insensitive="true", separator=" = ", separator_regex="\s*=\s*") }}}
 {{% endif %}}
 
-{{{ bash_replace_or_append("$AUDITCONFIG", '^remote_server', "$var_audispd_remote_server") }}}
+{{{ set_config_file("$AUDITCONFIG", 'remote_server', "$var_audispd_remote_server", insensitive="true", separator=" = ", separator_regex="\s*=\s*") }}}

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/bash/shared.sh
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/bash/shared.sh
@@ -5,7 +5,7 @@
 AUDITCONFIG={{{ audisp_conf_path }}}/audisp-remote.conf
 
 {{% if 'ubuntu' in product %}}
-AUREMOTECONFIG=/etc/audisp/plugins.d/au-remote.conf
+AUREMOTECONFIG={{{ audisp_conf_path }}}/plugins.d/au-remote.conf
 
 {{{ bash_replace_or_append("$AUREMOTECONFIG", '^active', 'yes') }}}
 {{% endif %}}

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/oval/shared.xml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/oval/shared.xml
@@ -20,7 +20,7 @@
     <ind:filepath>{{{ audisp_config_file_path }}}</ind:filepath>
     <!-- Allow only space (exactly) as delimiter -->
     <!-- Require at least one space before and after the equal sign -->
-    <ind:pattern operation="pattern match">^[ ]*remote_server[ ]+=[ ]+(\S+)[ ]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[ ]*(?i)remote_server(?-i)[ ]+=[ ]+(\S+)[ ]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -37,7 +37,7 @@
 
   <ind:textfilecontent54_object id="object_au_remote_config" version="1">
     <ind:filepath>{{{ auremoteconfig }}}</ind:filepath>
-    <ind:pattern operation="pattern match">^[ ]*active[ ]+=[ ]+(yes)[ ]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[ ]*(?i)active(?-i)[ ]+=[ ]+(yes)[ ]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   {{% endif %}}

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/oval/shared.xml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/oval/shared.xml
@@ -1,5 +1,5 @@
 {{% set audisp_config_file_path = audisp_conf_path + "/audisp-remote.conf" %}}
-{{% set auremoteconfig = "/etc/audisp/plugins.d/au-remote.conf" %}}
+{{% set auremoteconfig = audisp_conf_path + "/plugins.d/au-remote.conf" %}}
 <def-group>
   <definition class="compliance" id="auditd_audispd_configure_remote_server" version="1">
     {{{ oval_metadata("remote_server setting in " + audisp_config_file_path + " is set to a certain IP address or hostname") }}}

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/tests/ubuntu_commented.fail.sh
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/tests/ubuntu_commented.fail.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# packages = audit,audispd-plugins
+# platform = multi_platform_ubuntu
+# variable = var_auditspd_remote_server=logcollector
+
+{{{ set_config_file(path=audisp_conf_path + "/audisp-remote.conf",
+                    parameter="Remote_server",
+                    value="logcollector",
+                    separator=" = ") }}}
+
+{{{ set_config_file(path=audisp_conf_path + "/plugins.d/au-remote.conf",
+                    parameter="Active",
+                    value="yes",
+                    separator=" = ") }}}
+
+echo "#Remote_server = logcollector" > {{{ audisp_conf_path ~ "/audisp-remote.conf" }}}
+echo "#Active = yes" > {{{ audisp_conf_path ~ "/plugins.d/au-remote.conf" }}}

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/tests/ubuntu_correct.pass.sh
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/tests/ubuntu_correct.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit,audispd-plugins
+# platform = multi_platform_ubuntu
+# variable = var_auditspd_remote_server=logcollector
+
+echo " Remote_server = logcollector" > {{{ audisp_conf_path ~ "/audisp-remote.conf" }}}
+echo " Active = yes" > {{{ audisp_conf_path ~ "/plugins.d/au-remote.conf" }}}

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/tests/ubuntu_missing.fail.sh
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/tests/ubuntu_missing.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# packages = audit,audispd-plugins
+# platform = multi_platform_ubuntu
+# variable = var_auditspd_remote_server=logcollector
+
+echo " Remote_server = logcollector" > {{{ audisp_conf_path ~ "/audisp-remote.conf" }}}

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/tests/ubuntu_wrong.fail.sh
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/tests/ubuntu_wrong.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit,audispd-plugins
+# platform = multi_platform_ubuntu
+# variable = var_auditspd_remote_server=logcollector
+
+echo " Remote_server = wrongvalue" > {{{ audisp_conf_path ~ "/audisp-remote.conf" }}}
+echo " Active = yes" > {{{ audisp_conf_path ~ "/plugins.d/au-remote.conf" }}}

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/tests/ubuntu_wrong2.fail.sh
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/tests/ubuntu_wrong2.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit,audispd-plugins
+# platform = multi_platform_ubuntu
+# variable = var_auditspd_remote_server=logcollector
+
+echo " Remote_server = logcollector" > {{{ audisp_conf_path ~ "/audisp-remote.conf" }}}
+echo " Active = no" > {{{ audisp_conf_path ~ "/plugins.d/au-remote.conf" }}}

--- a/linux_os/guide/auditing/package_audit-audispd-plugins_installed/rule.yml
+++ b/linux_os/guide/auditing/package_audit-audispd-plugins_installed/rule.yml
@@ -34,6 +34,7 @@ template:
         pkgname@ubuntu1604: audispd-plugins
         pkgname@ubuntu1804: audispd-plugins
         pkgname@ubuntu2004: audispd-plugins
+        pkgname@ubuntu2204: audispd-plugins
 
 {{% if product in ["rhel7", "rhel8", "rhel9"] %}}
 warnings:

--- a/products/ubuntu2004/product.yml
+++ b/products/ubuntu2004/product.yml
@@ -24,6 +24,7 @@ sshd_distributed_config: "true"
 aide_bin_path: "/usr/bin/aide.wrapper"
 aide_conf_path: "/etc/aide/aide.conf"
 aide_default_path: "/etc/default/aide"
+audisp_conf_path: "/etc/audisp"
 chrony_conf_path: "/etc/chrony/chrony.conf"
 
 cpes_root: "../../shared/applicability"

--- a/products/ubuntu2204/product.yml
+++ b/products/ubuntu2204/product.yml
@@ -23,6 +23,7 @@ sshd_distributed_config: "true"
 
 aide_bin_path: "/usr/bin/aide"
 aide_conf_path: "/etc/aide/aide.conf"
+audisp_conf_path: "/etc/audit"
 chrony_conf_path: "/etc/chrony/chrony.conf"
 
 cpes_root: "../../shared/applicability"

--- a/tests/data/product_stability/ubuntu2004.yml
+++ b/tests/data/product_stability/ubuntu2004.yml
@@ -3,7 +3,7 @@ aide_also_checks_rsyslog: 'no'
 aide_bin_path: /usr/bin/aide.wrapper
 aide_conf_path: /etc/aide/aide.conf
 aide_default_path: /etc/default/aide
-audisp_conf_path: /etc/audit
+audisp_conf_path: /etc/audisp
 auid: 1000
 basic_properties_derived: true
 benchmark_id: UBUNTU_20-04


### PR DESCRIPTION
#### Description:

- Defined config paths and packages for `audisp` on Ubuntu
- Changed OVAL and remediation for `auditd_audispd_configure_remote_server` to allow case-insensitive keywords
- Added tests for `auditd_audispd_configure_remote_server`  for Ubuntu

#### Rationale:

- Fixed broken config paths/packages
- Better alignment with STIG rule UBTU-22-653020
