### PR TITLE
Split out TMT plans to separate Packit jobs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -19,20 +19,58 @@ jobs:
   - centos-stream-8-x86_64
   - centos-stream-9-x86_64
 
-- &test
-  job: tests
-  trigger: pull_request
-  fmf_path: tests/tmt-plans
-  targets:
-    epel-7:
-      distros: [ centos-7 ]
-    centos-stream-8: { }
-    centos-stream-9: { }
-
-- <<: *test
-  trigger: commit
-  branch: "gh-readonly-queue/.*"
-
 - <<: *build
   trigger: commit
   branch: "gh-readonly-queue/.*"
+
+- &test-static-checks
+  job: tests
+  trigger: pull_request
+  fmf_path: tests/tmt-plans
+  identifier: /static-checks
+  tmt_plan: /static-checks
+  targets:
+    epel-7:
+      distros: [ centos-7 ]
+    centos-stream-8: {}
+    centos-stream-9: {}
+
+# when modifying this, modify also tests/tmt-plans/
+
+- <<: *test-static-checks
+  identifier: /hardening/host-os/ansible/anssi_bp28_high
+  tmt_plan: /hardening/host-os/ansible/anssi_bp28_high
+  targets:
+    centos-stream-8: {}
+    centos-stream-9: {}
+- <<: *test-static-checks
+  identifier: /hardening/host-os/ansible/cis
+  tmt_plan: /hardening/host-os/ansible/cis
+- <<: *test-static-checks
+  identifier: /hardening/host-os/ansible/ospp
+  tmt_plan: /hardening/host-os/ansible/ospp
+- <<: *test-static-checks
+  identifier: /hardening/host-os/ansible/pci-dss
+  tmt_plan: /hardening/host-os/ansible/pci-dss
+- <<: *test-static-checks
+  identifier: /hardening/host-os/ansible/stig
+  tmt_plan: /hardening/host-os/ansible/stig
+
+- <<: *test-static-checks
+  identifier: /hardening/host-os/oscap/anssi_bp28_high
+  tmt_plan: /hardening/host-os/oscap/anssi_bp28_high
+  targets:
+    centos-stream-8: {}
+    centos-stream-9: {}
+- <<: *test-static-checks
+  identifier: /hardening/host-os/oscap/cis
+  tmt_plan: /hardening/host-os/oscap/cis
+- <<: *test-static-checks
+  identifier: /hardening/host-os/oscap/ospp
+  tmt_plan: /hardening/host-os/oscap/ospp
+- <<: *test-static-checks
+  identifier: /hardening/host-os/oscap/pci-dss
+  tmt_plan: /hardening/host-os/oscap/pci-dss
+- <<: *test-static-checks
+  identifier: /hardening/host-os/oscap/stig
+  tmt_plan: /hardening/host-os/oscap/stig

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -44,8 +44,37 @@ jobs:
     centos-stream-8: {}
     centos-stream-9: {}
 - <<: *test-static-checks
+  identifier: /hardening/host-os/ansible/ccn_advanced
+  tmt_plan: /hardening/host-os/ansible/ccn_advanced
+  targets:
+    centos-stream-9: {}
+- <<: *test-static-checks
   identifier: /hardening/host-os/ansible/cis
   tmt_plan: /hardening/host-os/ansible/cis
+- <<: *test-static-checks
+  identifier: /hardening/host-os/ansible/cis_server_l1
+  tmt_plan: /hardening/host-os/ansible/cis_server_l1
+- <<: *test-static-checks
+  identifier: /hardening/host-os/ansible/cis_workstation_l1
+  tmt_plan: /hardening/host-os/ansible/cis_workstation_l1
+- <<: *test-static-checks
+  identifier: /hardening/host-os/ansible/cis_workstation_l2
+  tmt_plan: /hardening/host-os/ansible/cis_workstation_l2
+- <<: *test-static-checks
+  identifier: /hardening/host-os/ansible/cui
+  tmt_plan: /hardening/host-os/ansible/cui
+- <<: *test-static-checks
+  identifier: /hardening/host-os/ansible/e8
+  tmt_plan: /hardening/host-os/ansible/e8
+- <<: *test-static-checks
+  identifier: /hardening/host-os/ansible/hipaa
+  tmt_plan: /hardening/host-os/ansible/hipaa
+- <<: *test-static-checks
+  identifier: /hardening/host-os/ansible/ism_o
+  tmt_plan: /hardening/host-os/ansible/ism_o
+  targets:
+    centos-stream-8: {}
+    centos-stream-9: {}
 - <<: *test-static-checks
   identifier: /hardening/host-os/ansible/ospp
   tmt_plan: /hardening/host-os/ansible/ospp
@@ -63,8 +92,37 @@ jobs:
     centos-stream-8: {}
     centos-stream-9: {}
 - <<: *test-static-checks
+  identifier: /hardening/host-os/oscap/ccn_advanced
+  tmt_plan: /hardening/host-os/oscap/ccn_advanced
+  targets:
+    centos-stream-9: {}
+- <<: *test-static-checks
   identifier: /hardening/host-os/oscap/cis
   tmt_plan: /hardening/host-os/oscap/cis
+- <<: *test-static-checks
+  identifier: /hardening/host-os/oscap/cis_server_l1
+  tmt_plan: /hardening/host-os/oscap/cis_server_l1
+- <<: *test-static-checks
+  identifier: /hardening/host-os/oscap/cis_workstation_l1
+  tmt_plan: /hardening/host-os/oscap/cis_workstation_l1
+- <<: *test-static-checks
+  identifier: /hardening/host-os/oscap/cis_workstation_l2
+  tmt_plan: /hardening/host-os/oscap/cis_workstation_l2
+- <<: *test-static-checks
+  identifier: /hardening/host-os/oscap/cui
+  tmt_plan: /hardening/host-os/oscap/cui
+- <<: *test-static-checks
+  identifier: /hardening/host-os/oscap/e8
+  tmt_plan: /hardening/host-os/oscap/e8
+- <<: *test-static-checks
+  identifier: /hardening/host-os/oscap/hipaa
+  tmt_plan: /hardening/host-os/oscap/hipaa
+- <<: *test-static-checks
+  identifier: /hardening/host-os/oscap/ism_o
+  tmt_plan: /hardening/host-os/oscap/ism_o
+  targets:
+    centos-stream-8: {}
+    centos-stream-9: {}
 - <<: *test-static-checks
   identifier: /hardening/host-os/oscap/ospp
   tmt_plan: /hardening/host-os/oscap/ospp

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -43,11 +43,12 @@ jobs:
   targets:
     centos-stream-8: {}
     centos-stream-9: {}
-- <<: *test-static-checks
-  identifier: /hardening/host-os/ansible/ccn_advanced
-  tmt_plan: /hardening/host-os/ansible/ccn_advanced
-  targets:
-    centos-stream-9: {}
+# disable for now - it seems to be broken on CentOS Stream
+#- <<: *test-static-checks
+#  identifier: /hardening/host-os/ansible/ccn_advanced
+#  tmt_plan: /hardening/host-os/ansible/ccn_advanced
+#  targets:
+#    centos-stream-9: {}
 - <<: *test-static-checks
   identifier: /hardening/host-os/ansible/cis
   tmt_plan: /hardening/host-os/ansible/cis

--- a/tests/tmt-plans/main.fmf
+++ b/tests/tmt-plans/main.fmf
@@ -19,13 +19,14 @@ report:
       - when: distro <= centos-7
         enabled: false
 
-/hardening/host-os/ansible/ccn_advanced:
-    discover+: {test: /hardening/host-os/ansible/ccn_advanced$}
-    adjust+:
-      - when: distro <= centos-7
-        enabled: false
-      - when: distro < centos-stream-9
-        enabled: false
+# see .packit.yaml
+#/hardening/host-os/ansible/ccn_advanced:
+#    discover+: {test: /hardening/host-os/ansible/ccn_advanced$}
+#    adjust+:
+#      - when: distro <= centos-7
+#        enabled: false
+#      - when: distro < centos-stream-9
+#        enabled: false
 
 /hardening/host-os/ansible/cis:
     discover+: {test: /hardening/host-os/ansible/cis$}

--- a/tests/tmt-plans/main.fmf
+++ b/tests/tmt-plans/main.fmf
@@ -15,18 +15,10 @@ report:
 
 /hardening/host-os/ansible/anssi_bp28_high:
     discover+: {test: /hardening/host-os/ansible/anssi_bp28_high$}
-    adjust+:
-      - when: distro <= centos-7
-        enabled: false
 
 # see .packit.yaml
 #/hardening/host-os/ansible/ccn_advanced:
 #    discover+: {test: /hardening/host-os/ansible/ccn_advanced$}
-#    adjust+:
-#      - when: distro <= centos-7
-#        enabled: false
-#      - when: distro < centos-stream-9
-#        enabled: false
 
 /hardening/host-os/ansible/cis:
     discover+: {test: /hardening/host-os/ansible/cis$}
@@ -51,9 +43,6 @@ report:
 
 /hardening/host-os/ansible/ism_o:
     discover+: {test: /hardening/host-os/ansible/ism_o$}
-    adjust+:
-      - when: distro <= centos-7
-        enabled: false
 
 /hardening/host-os/ansible/ospp:
     discover+: {test: /hardening/host-os/ansible/ospp$}
@@ -70,17 +59,9 @@ report:
 
 /hardening/host-os/oscap/anssi_bp28_high:
     discover+: {test: /hardening/host-os/oscap/anssi_bp28_high$}
-    adjust+:
-      - when: distro <= centos-7
-        enabled: false
 
 /hardening/host-os/oscap/ccn_advanced:
     discover+: {test: /hardening/host-os/oscap/ccn_advanced$}
-    adjust+:
-      - when: distro <= centos-7
-        enabled: false
-      - when: distro < centos-stream-9
-        enabled: false
 
 /hardening/host-os/oscap/cis:
     discover+: {test: /hardening/host-os/oscap/cis$}
@@ -105,9 +86,6 @@ report:
 
 /hardening/host-os/oscap/ism_o:
     discover+: {test: /hardening/host-os/oscap/ism_o$}
-    adjust+:
-      - when: distro <= centos-7
-        enabled: false
 
 /hardening/host-os/oscap/ospp:
     discover+: {test: /hardening/host-os/oscap/ospp$}

--- a/tests/tmt-plans/main.fmf
+++ b/tests/tmt-plans/main.fmf
@@ -14,26 +14,21 @@ report:
 #
 
 /hardening/host-os/ansible/anssi_bp28_high:
-    summary: Destructive ANSSI BP-028 (high) profile test (Ansible)
     discover+: {test: /hardening/host-os/ansible/anssi_bp28_high$}
     adjust+:
       - when: distro <= centos-7
         enabled: false
 
 /hardening/host-os/ansible/cis:
-    summary: Destructive CIS Server Level 2 profile test (Ansible)
     discover+: {test: /hardening/host-os/ansible/cis$}
 
 /hardening/host-os/ansible/ospp:
-    summary: Destructive OSPP profile test (Ansible)
     discover+: {test: /hardening/host-os/ansible/ospp$}
 
 /hardening/host-os/ansible/pci-dss:
-    summary: Destructive PCI-DSS profile test (Ansible)
     discover+: {test: /hardening/host-os/ansible/pci-dss$}
 
 /hardening/host-os/ansible/stig:
-    summary: Destructive STIG profile test (Ansible)
     discover+: {test: /hardening/host-os/ansible/stig$}
 
 #
@@ -41,26 +36,21 @@ report:
 #
 
 /hardening/host-os/oscap/anssi_bp28_high:
-    summary: Destructive ANSSI-BP-028 (high) profile test (Bash)
     discover+: {test: /hardening/host-os/oscap/anssi_bp28_high$}
     adjust+:
       - when: distro <= centos-7
         enabled: false
 
 /hardening/host-os/oscap/cis:
-    summary: Destructive CIS Server Level 2 profile test (Bash)
     discover+: {test: /hardening/host-os/oscap/cis$}
 
 /hardening/host-os/oscap/ospp:
-    summary: Destructive OSPP profile test (Bash)
     discover+: {test: /hardening/host-os/oscap/ospp$}
 
 /hardening/host-os/oscap/pci-dss:
-    summary: Destructive PCI-DSS profile test (Bash)
     discover+: {test: /hardening/host-os/oscap/pci-dss$}
 
 /hardening/host-os/oscap/stig:
-    summary: Destructive STIG profile test (Bash)
     discover+: {test: /hardening/host-os/oscap/stig$}
 
 #
@@ -68,7 +58,6 @@ report:
 #
 
 /static-checks:
-    summary: Sanity non-destructive tests
     discover+:
         test: /static-checks
         # exclude here due to the test failing frequently for short periods

--- a/tests/tmt-plans/main.fmf
+++ b/tests/tmt-plans/main.fmf
@@ -19,8 +19,40 @@ report:
       - when: distro <= centos-7
         enabled: false
 
+/hardening/host-os/ansible/ccn_advanced:
+    discover+: {test: /hardening/host-os/ansible/ccn_advanced$}
+    adjust+:
+      - when: distro <= centos-7
+        enabled: false
+      - when: distro < centos-stream-9
+        enabled: false
+
 /hardening/host-os/ansible/cis:
     discover+: {test: /hardening/host-os/ansible/cis$}
+
+/hardening/host-os/ansible/cis_server_l1:
+    discover+: {test: /hardening/host-os/ansible/cis_server_l1$}
+
+/hardening/host-os/ansible/cis_workstation_l1:
+    discover+: {test: /hardening/host-os/ansible/cis_workstation_l1$}
+
+/hardening/host-os/ansible/cis_workstation_l2:
+    discover+: {test: /hardening/host-os/ansible/cis_workstation_l2$}
+
+/hardening/host-os/ansible/cui:
+    discover+: {test: /hardening/host-os/ansible/cui$}
+
+/hardening/host-os/ansible/e8:
+    discover+: {test: /hardening/host-os/ansible/e8$}
+
+/hardening/host-os/ansible/hipaa:
+    discover+: {test: /hardening/host-os/ansible/hipaa$}
+
+/hardening/host-os/ansible/ism_o:
+    discover+: {test: /hardening/host-os/ansible/ism_o$}
+    adjust+:
+      - when: distro <= centos-7
+        enabled: false
 
 /hardening/host-os/ansible/ospp:
     discover+: {test: /hardening/host-os/ansible/ospp$}
@@ -41,8 +73,40 @@ report:
       - when: distro <= centos-7
         enabled: false
 
+/hardening/host-os/oscap/ccn_advanced:
+    discover+: {test: /hardening/host-os/oscap/ccn_advanced$}
+    adjust+:
+      - when: distro <= centos-7
+        enabled: false
+      - when: distro < centos-stream-9
+        enabled: false
+
 /hardening/host-os/oscap/cis:
     discover+: {test: /hardening/host-os/oscap/cis$}
+
+/hardening/host-os/oscap/cis_server_l1:
+    discover+: {test: /hardening/host-os/oscap/cis_server_l1$}
+
+/hardening/host-os/oscap/cis_workstation_l1:
+    discover+: {test: /hardening/host-os/oscap/cis_workstation_l1$}
+
+/hardening/host-os/oscap/cis_workstation_l2:
+    discover+: {test: /hardening/host-os/oscap/cis_workstation_l2$}
+
+/hardening/host-os/oscap/cui:
+    discover+: {test: /hardening/host-os/oscap/cui$}
+
+/hardening/host-os/oscap/e8:
+    discover+: {test: /hardening/host-os/oscap/e8$}
+
+/hardening/host-os/oscap/hipaa:
+    discover+: {test: /hardening/host-os/oscap/hipaa$}
+
+/hardening/host-os/oscap/ism_o:
+    discover+: {test: /hardening/host-os/oscap/ism_o$}
+    adjust+:
+      - when: distro <= centos-7
+        enabled: false
 
 /hardening/host-os/oscap/ospp:
     discover+: {test: /hardening/host-os/oscap/ospp$}

--- a/tests/tmt-plans/main.fmf
+++ b/tests/tmt-plans/main.fmf
@@ -35,9 +35,6 @@ report:
 /hardening/host-os/ansible/stig:
     summary: Destructive STIG profile test (Ansible)
     discover+: {test: /hardening/host-os/ansible/stig$}
-    adjust+:
-      - when: distro <= centos-8
-        enabled: false
 
 #
 # Hardening via oscap xccdf eval --remediate


### PR DESCRIPTION
#### Description:

This is another attempt at https://github.com/ComplianceAsCode/content/pull/11807 with only the `.packit.yaml` split, as other changes were done in https://github.com/ComplianceAsCode/content/pull/11809 already.

The separate Packit jobs should be easy to re-run via `/packit rerun-failed`, avoiding the re-running of already-passed tests, which are the typical sources of (random) failures now.

This also removes unused merge queue code for tests, as leaving it in place would lead to a lot more copy/pasted `.packit.yaml` code.

#### Review Hints:

- Note that, prior to merging this, "required checks" for this project will need to be adjusted to include these individual jobs (via a wildcard, or manually -- wildcarding is possible for GH Actions, but I'm not sure about Packit CI actions).