### PR TITLE
Fix OCP node OVN check

### DIFF
--- a/applications/openshift/master/file_groupowner_ovn_cni_server_sock/tests/ocp4/4.12.yml
+++ b/applications/openshift/master/file_groupowner_ovn_cni_server_sock/tests/ocp4/4.12.yml
@@ -1,3 +1,0 @@
----
-default_result: PASS
-

--- a/applications/openshift/master/file_groupowner_ovn_cni_server_sock/tests/ocp4/4.13.yml
+++ b/applications/openshift/master/file_groupowner_ovn_cni_server_sock/tests/ocp4/4.13.yml
@@ -1,3 +1,0 @@
----
-default_result: PASS
-

--- a/applications/openshift/master/file_groupowner_ovn_cni_server_sock/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_ovn_cni_server_sock/tests/ocp4/e2e.yml
@@ -1,3 +1,3 @@
 ---
-default_result: NOT-APPLICABLE
+default_result: PASS
 

--- a/applications/openshift/master/file_groupowner_ovn_db_files/tests/ocp4/4.12.yml
+++ b/applications/openshift/master/file_groupowner_ovn_db_files/tests/ocp4/4.12.yml
@@ -1,3 +1,0 @@
----
-default_result: PASS
-

--- a/applications/openshift/master/file_groupowner_ovn_db_files/tests/ocp4/4.13.yml
+++ b/applications/openshift/master/file_groupowner_ovn_db_files/tests/ocp4/4.13.yml
@@ -1,3 +1,0 @@
----
-default_result: PASS
-

--- a/applications/openshift/master/file_groupowner_ovn_db_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_groupowner_ovn_db_files/tests/ocp4/e2e.yml
@@ -1,3 +1,3 @@
 ---
-default_result: NOT-APPLICABLE
+default_result: PASS
 

--- a/applications/openshift/master/file_owner_ovn_cni_server_sock/tests/ocp4/4.12.yml
+++ b/applications/openshift/master/file_owner_ovn_cni_server_sock/tests/ocp4/4.12.yml
@@ -1,3 +1,0 @@
----
-default_result: PASS
-

--- a/applications/openshift/master/file_owner_ovn_cni_server_sock/tests/ocp4/4.13.yml
+++ b/applications/openshift/master/file_owner_ovn_cni_server_sock/tests/ocp4/4.13.yml
@@ -1,3 +1,0 @@
----
-default_result: PASS
-

--- a/applications/openshift/master/file_owner_ovn_cni_server_sock/tests/ocp4/4.14.yml
+++ b/applications/openshift/master/file_owner_ovn_cni_server_sock/tests/ocp4/4.14.yml
@@ -1,3 +1,0 @@
----
-default_result: NOT-APPLICABLE
-

--- a/applications/openshift/master/file_owner_ovn_cni_server_sock/tests/ocp4/4.15.yml
+++ b/applications/openshift/master/file_owner_ovn_cni_server_sock/tests/ocp4/4.15.yml
@@ -1,3 +1,0 @@
----
-default_result: NOT-APPLICABLE
-

--- a/applications/openshift/master/file_owner_ovn_cni_server_sock/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_ovn_cni_server_sock/tests/ocp4/e2e.yml
@@ -1,5 +1,2 @@
 ---
-default_result:
-  master: PASS
-  worker: NOT-APPLICABLE
-
+default_result: PASS

--- a/applications/openshift/master/file_owner_ovn_db_files/tests/ocp4/4.12.yml
+++ b/applications/openshift/master/file_owner_ovn_db_files/tests/ocp4/4.12.yml
@@ -1,3 +1,0 @@
----
-default_result: PASS
-

--- a/applications/openshift/master/file_owner_ovn_db_files/tests/ocp4/4.13.yml
+++ b/applications/openshift/master/file_owner_ovn_db_files/tests/ocp4/4.13.yml
@@ -1,3 +1,0 @@
----
-default_result: PASS
-

--- a/applications/openshift/master/file_owner_ovn_db_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_owner_ovn_db_files/tests/ocp4/e2e.yml
@@ -1,3 +1,3 @@
 ---
-default_result: NOT-APPLICABLE
+default_result: PASS
 

--- a/applications/openshift/master/file_permissions_ovn_cni_server_sock/tests/ocp4/4.12.yml
+++ b/applications/openshift/master/file_permissions_ovn_cni_server_sock/tests/ocp4/4.12.yml
@@ -1,3 +1,0 @@
----
-default_result: PASS
-

--- a/applications/openshift/master/file_permissions_ovn_cni_server_sock/tests/ocp4/4.13.yml
+++ b/applications/openshift/master/file_permissions_ovn_cni_server_sock/tests/ocp4/4.13.yml
@@ -1,3 +1,0 @@
----
-default_result: PASS
-

--- a/applications/openshift/master/file_permissions_ovn_cni_server_sock/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_ovn_cni_server_sock/tests/ocp4/e2e.yml
@@ -1,3 +1,3 @@
 ---
-default_result: NOT-APPLICABLE
+default_result: PASS
 

--- a/applications/openshift/master/file_permissions_ovn_db_files/tests/ocp4/4.12.yml
+++ b/applications/openshift/master/file_permissions_ovn_db_files/tests/ocp4/4.12.yml
@@ -1,3 +1,0 @@
----
-default_result: PASS
-

--- a/applications/openshift/master/file_permissions_ovn_db_files/tests/ocp4/4.13.yml
+++ b/applications/openshift/master/file_permissions_ovn_db_files/tests/ocp4/4.13.yml
@@ -1,3 +1,0 @@
----
-default_result: PASS
-

--- a/applications/openshift/master/file_permissions_ovn_db_files/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_ovn_db_files/tests/ocp4/e2e.yml
@@ -1,3 +1,3 @@
 ---
-default_result: NOT-APPLICABLE
+default_result: PASS
 

--- a/shared/applicability/oval/installed_app_is_ocp4_node.xml
+++ b/shared/applicability/oval/installed_app_is_ocp4_node.xml
@@ -24,7 +24,7 @@
 
   <!-- helpers for ovn/sdn network cpe check-->
   <local_variable id="ocp4_node_network_file_location" datatype="string" comment="The actual filepath of the network file to scan." version="1">
-      <literal_component>/etc/kubernetes/cni/net.d/00-multus.conf</literal_component>
+      <literal_component>/var/run/multus/cni/net.d/10-ovn-kubernetes.conf</literal_component>
   </local_variable>
 
   <unix:file_test id="test_file_for_ocp4_node_network" check="only one" comment="Find the actual file for the network to be scanned." version="1">
@@ -37,7 +37,7 @@
 
   <ind:yamlfilecontent_object id="object_ocp4_platform_node_network" version="1">
       <ind:filepath var_ref="ocp4_node_network_file_location"/>
-      <ind:yamlpath>.delegates[0].type</ind:yamlpath>
+      <ind:yamlpath>.type</ind:yamlpath>
   </ind:yamlfilecontent_object>
 
   <!-- Check for OpenShift Container Platform 4 using specific network type -->


### PR DESCRIPTION
#### Description:

-  The OVAL check for OCP node platform check was outdated and only worked correctly on 4.12 and 4.13.
  - The checked path has different contents on 4.14+
- Let's check OVN config on a path that is common for 4.12+.
  -  `/var/run/multus/cni/net.d/10-ovn-kubernetes.conf`
- Delete e2e files for 4.12 and 4.13 that are aligned with the default `e2e.yml` file.
 
#### Rationale:

- The way multus-shim configures OVN on 4.12 and 4.13 is different from 4.14 on.

#### Review hints:
Manually tested on 4.12 and 4.14:
```console
oc get ccr | grep ovn 
upstream-ocp4-cis-node-master-file-groupowner-ovn-cni-server-sock                      PASS     medium
upstream-ocp4-cis-node-master-file-groupowner-ovn-db-files                             PASS     medium
upstream-ocp4-cis-node-master-file-owner-ovn-cni-server-sock                           PASS     medium
upstream-ocp4-cis-node-master-file-owner-ovn-db-files                                  PASS     medium
upstream-ocp4-cis-node-master-file-permissions-ovn-cni-server-sock                     PASS     medium
upstream-ocp4-cis-node-master-file-permissions-ovn-db-files                            PASS     medium
upstream-ocp4-cis-node-worker-file-groupowner-ovn-cni-server-sock                      PASS     medium
upstream-ocp4-cis-node-worker-file-groupowner-ovn-db-files                             PASS     medium
upstream-ocp4-cis-node-worker-file-owner-ovn-cni-server-sock                           PASS     medium
upstream-ocp4-cis-node-worker-file-owner-ovn-db-files                                  PASS     medium
upstream-ocp4-cis-node-worker-file-permissions-ovn-cni-server-sock                     PASS     medium
upstream-ocp4-cis-node-worker-file-permissions-ovn-db-files                            PASS     medium
```

Raw results before patch:
```xml
<definition definition_id="oval:ssg-installed_app_is_ocp4_node_on_openshift-ovn:def:1" result="false" version="1">
  <criteria operator="AND" result="false">
    <criterion test_ref="oval:ssg-test_ocp4_on_openshift-ovn:tst:1" version="1" result="false"/>
    <criterion test_ref="oval:ssg-test_file_for_ocp4_node_network:tst:1" version="1" result="true"/>
  </criteria>
</definition>
```

Raw resutlts after patch:
```xml
<definition definition_id="oval:ssg-installed_app_is_ocp4_node_on_openshift-ovn:def:1" result="true" version="1">
  <criteria operator="AND" result="true">
    <criterion test_ref="oval:ssg-test_ocp4_on_openshift-ovn:tst:1" version="1" result="true"/>
    <criterion test_ref="oval:ssg-test_file_for_ocp4_node_network:tst:1" version="1" result="true"/>
  </criteria>
</definition>
```