### PR TITLE
Fix dirs in sysctl template for Ubuntu 20.04/22.04

### DIFF
--- a/shared/templates/sysctl/ansible.template
+++ b/shared/templates/sysctl/ansible.template
@@ -19,7 +19,7 @@
       - "/run/sysctl.d/"
       - "/usr/local/lib/sysctl.d/"
 {{% endif %}}
-{{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel7", "rhel8", "rhel9", "sle12", "sle15"] %}}
+{{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel7", "rhel8", "rhel9", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] %}}
       - "/usr/lib/sysctl.d/"
 {{% endif %}}
     contains: '^[\s]*{{{ SYSCTLVAR }}}.*$'

--- a/shared/templates/sysctl/bash.template
+++ b/shared/templates/sysctl/bash.template
@@ -7,7 +7,7 @@
 # Comment out any occurrences of {{{ SYSCTLVAR }}} from /etc/sysctl.d/*.conf files
 {{% if product in [ "sle12", "sle15"] %}}
 for f in /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf; do
-{{% elif product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel7", "rhel8", "rhel9"] %}}
+{{% elif product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel7", "rhel8", "rhel9", "ubuntu2004", "ubuntu2204"] %}}
 for f in /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf; do
 {{% else %}}
 for f in /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf; do

--- a/shared/templates/sysctl/oval.template
+++ b/shared/templates/sysctl/oval.template
@@ -188,7 +188,7 @@
   <ind:textfilecontent54_object id="object_static_etc_lib_sysctls_{{{ rule_id }}}" version="1">
     <set>
       <object_reference>object_static_etc_sysctls_{{{ rule_id }}}</object_reference>
-{{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel7", "rhel8", "rhel9"] %}}
+{{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel7", "rhel8", "rhel9", "ubuntu2004", "ubuntu2204"] %}}
       <object_reference>object_static_lib_sysctld_{{{ rule_id }}}</object_reference>
 {{% endif %}}
     </set>
@@ -235,7 +235,7 @@
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
     {{{ sysctl_match() }}}
   </ind:textfilecontent54_object>
-{{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel7", "rhel8", "rhel9"] %}}
+{{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel7", "rhel8", "rhel9", "ubuntu2004", "ubuntu2204"] %}}
   <ind:textfilecontent54_object id="object_static_lib_sysctld_{{{ rule_id }}}" version="1">
     <ind:path>/lib/sysctl.d</ind:path>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>


### PR DESCRIPTION
#### Description:

- Modified sysctl template to treat `/lib/sysctl.d` as a package-managed directory on Ubuntu.

#### Rationale:

- On Ubuntu `/lib` is symlinked to `/usr/lib`, thus `/lib/sysctl.d` contains package-managed configs, which should not be modified and can be incorrect if overridden elsewhere (`/run`, `/usr/local`, `/etc`). See #10637 

