### PR TITLE
Fix OVAL for rule apt_conf_disallow_unauthenticated

### DIFF
--- a/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/oval/shared.xml
+++ b/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/oval/shared.xml
@@ -1,35 +1,27 @@
 <def-group>
-  <definition class="compliance" id="apt_conf_disallow_unauthenticated" version="1">
-    {{{ oval_metadata("Accessing a repository should be
-      allowed only when the repository is authenticated.") }}}
-    <criteria comment="Detect any usage of allow-unauthenticated option"
-      operator="OR">      
-      <criterion comment="Check /etc/apt/apt.conf file"
-      test_ref="test_unauthenticated_apt_conf" />
-    <criterion comment="Check /etc/apt/apt.conf.d/* file"
-      test_ref="test_unauthenticated_apt_conf_d" />
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("Accessing a repository should be allowed only when the repository is authenticated.") }}}
+
+    <criteria comment="Check if allow-unauthenticated is set to false or is undefined" operator="AND">
+      <criterion comment="Check if allow-unauthenticated is set to false or is undefined"
+          test_ref="test_{{{ rule_id }}}" />
     </criteria>
   </definition>
-  <ind:textfilecontent54_test check="all" check_existence="none_exist"
-  comment="Checks usage of unauthenticated in apt.conf"
-  id="test_unauthenticated_apt_conf" version="1">
-    <ind:object object_ref="obj_unauthenticated_apt_conf" />
+
+  <ind:textfilecontent54_test check="all" check_existence="any_exist"
+      comment="Checks allow-unauthenticated in apt configs"
+      id="test_{{{ rule_id }}}" version="1">
+    <ind:object object_ref="obj_{{{ rule_id }}}" />
+    <ind:state state_ref="state_{{{ rule_id }}}" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="obj_unauthenticated_apt_conf"
-  version="1">
-    <ind:filepath operation="equals">/etc/apt/apt/apt.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*APT::Get::AllowUnauthenticated(=|[\s]+)(yes|true|True);.*$</ind:pattern>
+
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}" version="1">
+    <ind:filepath operation="pattern match">/etc/apt/apt.conf(\.d/.*)?$</ind:filepath>
+    <ind:pattern operation="pattern match">^[^#]*(?i)AllowUnauthenticated(?-i)(.*)$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-  <ind:textfilecontent54_test check="all" check_existence="none_exist"
-    comment="Checks usage of unauthenticated in apt.conf.d/*"
-  id="test_unauthenticated_apt_conf_d" version="1">
-    <ind:object object_ref="obj_unauthenticated_apt_conf_d" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="obj_unauthenticated_apt_conf_d"
-  version="1">
-    <ind:filepath operation="pattern match">^/etc/apt/apt.conf.d/.*$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*APT::Get::AllowUnauthenticated(=|[\s]+)(yes|true|True);.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_{{{ rule_id }}}" version="1">
+    <ind:subexpression datatype="string" operation="pattern match">^[\s]+"false"[\s]*;[\s]*$</ind:subexpression>
+  </ind:textfilecontent54_state>
 </def-group>

--- a/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/rule.yml
+++ b/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/rule.yml
@@ -1,6 +1,5 @@
 documentation_complete: true
 
-
 title: 'Disable unauthenticated repositories in APT configuration'
 
 description: 'Unauthenticated repositories should not be used for updates.'

--- a/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/correct_commented.pass.sh
+++ b/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/correct_commented.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# platforms = multi_platform_ubuntu
+
+sed '/AllowUnauthenticated/Id' -i /etc/apt/apt.conf /etc/apt/apt.conf.d/*
+
+cat >> /etc/apt/apt.conf <<EOF
+ATP::Get
+{
+  # AllowUnauthenticated "true";
+}
+EOF

--- a/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/correct_missing.pass.sh
+++ b/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/correct_missing.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platforms = multi_platform_ubuntu
+
+sed '/AllowUnauthenticated/Id' -i /etc/apt/apt.conf /etc/apt/apt.conf.d/*
+exit 0

--- a/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/correct_value.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platforms = multi_platform_ubuntu
+
+sed '/AllowUnauthenticated/Id' -i /etc/apt/apt.conf /etc/apt/apt.conf.d/*
+
+echo 'ATP::Get::AllowUnauthenticated "false";' >> /etc/apt/apt.conf

--- a/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/correct_value_dir.pass.sh
+++ b/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/correct_value_dir.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platforms = multi_platform_ubuntu
+
+sed '/AllowUnauthenticated/Id' -i /etc/apt/apt.conf /etc/apt/apt.conf.d/*
+
+echo 'ATP::Get::AllowUnauthenticated "false";' >> /etc/apt/apt.conf.d/99-test

--- a/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/wrong_value.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platforms = multi_platform_ubuntu
+# remediation = none
+
+sed '/AllowUnauthenticated/Id' -i /etc/apt/apt.conf /etc/apt/apt.conf.d/*
+
+echo 'ATP::Get::AllowUnauthenticated "true";' >> /etc/apt/apt.conf

--- a/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/wrong_value2.fail.sh
+++ b/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/wrong_value2.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# platforms = multi_platform_ubuntu
+# remediation = none
+
+sed '/AllowUnauthenticated/Id' -i /etc/apt/apt.conf /etc/apt/apt.conf.d/*
+
+cat >> /etc/apt/apt.conf <<EOF
+ATP::Get
+{
+  AllowUnauthenticated "true";
+}
+EOF

--- a/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/wrong_value_dir.fail.sh
+++ b/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/wrong_value_dir.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platforms = multi_platform_ubuntu
+# remediation = none
+
+sed '/AllowUnauthenticated/Id' -i /etc/apt/apt.conf /etc/apt/apt.conf.d/*
+
+echo 'ATP::Get::AllowUnauthenticated "true";' >> /etc/apt/apt.conf.d/99-test

--- a/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/wrong_value_double.fail.sh
+++ b/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/wrong_value_double.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platforms = multi_platform_ubuntu
+
+sed '/AllowUnauthenticated/Id' -i /etc/apt/apt.conf /etc/apt/apt.conf.d/*
+
+echo 'ATP::Get::AllowUnauthenticated "false";' >> /etc/apt/apt.conf
+echo 'ATP::Get::AllowUnauthenticated "true";' >> /etc/apt/apt.conf


### PR DESCRIPTION
#### Description:

Reversed the logic in `apt_conf_disallow_unauthenticated` OVAL to pass when good values of the parameter `AllowUnauthenticated` are present or the parameter is undefined, instead of checking that the wrong values are not present. This also better aligns the rule with STIG UBTU-22-214010.

#### Rationale:

The previous oval was checking for existence of unwanted values (yes,true,True) in the parameter, failing to catch others, like:
- value = 1
- quoted values ("yes", "true", "True", "1")
- case permutations of values yes or true
- case permutations of keyword APT::Get::AllowUnauthenticated
- different usage of keyword (see tests wrong_value2.fail.sh)

The new version checks for the existence of case-insensitive AllowUnauthenticated keyword. It passes if it either doesn't
exist, or is well-defined to "false".
