### PR TITLE
Add rule set_password_hashing_algorithm_systemauth to Ubuntu STIG profile

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/bash/shared.sh
@@ -2,6 +2,13 @@
 
 {{% if product in ["sle15", "sle12"] -%}}
 {{{ bash_ensure_pam_module_configuration('/etc/pam.d/common-password', 'password', 'required', 'pam_unix.so', 'sha512', '', '') }}}
+{{% elif 'ubuntu' in product -%}}
+# Can't use macro bash_ensure_pam_module_configuration because the control
+# contains special characters and is not static ([success=N default=ignore)
+PAM_FILE_PATH=/etc/pam.d/common-password
+if ! grep -qP '^\s*password\s+.*\s+pam_unix.so\s+.*\s+sha512\b' "$PAM_FILE_PATH"; then
+  sed -i -E --follow-symlinks '/\s*password\s+.*\s+pam_unix.so.*/ s/$/ sha512/' "$PAM_FILE_PATH"
+fi
 {{%- else -%}}
 {{{ bash_ensure_pam_module_configuration('/etc/pam.d/system-auth', 'password', 'sufficient', 'pam_unix.so', 'sha512', '', '') }}}
 {{%- endif %}}

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/oval/shared.xml
@@ -17,6 +17,9 @@
     {{% if product in ['sle12', 'sle15'] %}}
       <ind:filepath>/etc/pam.d/common-password</ind:filepath>
       <ind:pattern operation="pattern match">^[\s]*password[\s]+(?:(?:required))[\s]+pam_unix\.so[\s]+.*sha512.*$</ind:pattern>
+    {{% elif 'ubuntu' in product %}}
+      <ind:filepath>/etc/pam.d/common-password</ind:filepath>
+      <ind:pattern operation="pattern match">^[\s]*password[\s]+(?:\[success=\d+\s+default=ignore\])[\s]+pam_unix\.so[\s]+[^#]*[\s]sha512(\s.*)?$</ind:pattern>
     {{% else %}}
       <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
       <ind:pattern operation="pattern match">^[\s]*password[\s]+(?:(?:required)|(?:sufficient))[\s]+pam_unix\.so[\s]+.*sha512.*$</ind:pattern>

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/rule.yml
@@ -3,7 +3,7 @@ documentation_complete: true
 
 title: "Set PAM''s Password Hashing Algorithm"
 
-{{% if product in ["sle12", "sle15"] %}}
+{{% if product in ["sle12", "sle15"] or 'ubuntu' in product %}}
 {{% set pam_passwd_file_path = "/etc/pam.d/common-password" %}}
 {{% else %}}
 {{% set pam_passwd_file_path = "/etc/pam.d/system-auth" %}}
@@ -19,6 +19,8 @@ description: |-
     <br />
     {{% if product in ["sle12", "sle15"] %}}
     <pre>password    required    pam_unix.so sha512 <i>other arguments...</i></pre>
+    {{% elif 'ubuntu' in product %}}
+    <pre>password    [success=1 default=ignore]   pam_unix.so sha512 <i>other arguments...</i></pre>
     {{% else %}}
     <pre>password    sufficient    pam_unix.so sha512 <i>other arguments...</i></pre>
     {{% endif %}}
@@ -69,6 +71,7 @@ references:
     stigid@rhel8: RHEL-08-010159
     stigid@sle12: SLES-12-010230
     stigid@sle15: SLES-15-020170
+    stigid@ubuntu2204: UBTU-22-611055
 
 ocil_clause: '"sha512" is missing, or is commented out'
 
@@ -80,6 +83,8 @@ ocil: |-
     <pre>$ sudo grep "^password.*pam_unix\.so.*sha512" {{{ pam_passwd_file_path }}}
     {{% if product in ["sle12", "sle15"] -%}}
     password required pam_unix.so sha512
+    {{% elif 'ubuntu' in product %}}
+    password [success=1 default=ignore] pam_unix.so sha512
     {{% else %}}
     password sufficient pam_unix.so sha512
     {{%- endif -%}}
@@ -88,7 +93,7 @@ ocil: |-
 platform: package[pam]
 
 fixtext: |-
-    {{% if product in ['ol9', 'rhel9'] -%}}
+    {{% if product in ['ol9', 'rhel9', 'ubuntu2204'] -%}}
     Configure {{{ full_name }}} to use a FIPS 140-3 approved cryptographic hashing algorithm for system authentication.
     {{% else %}}
     Configure {{{ full_name }}} to use a FIPS 140-2 approved cryptographic hashing algorithm for system authentication.
@@ -97,6 +102,8 @@ fixtext: |-
     Edit/modify the following line in the "{{{ pam_passwd_file_path }}}" file to include the sha512 option for pam_unix.so:
     {{% if product in ['sle12', 'sle15'] -%}}
     password required pam_unix.so sha512
+    {{% elif 'ubuntu' in product %}}
+    password [success=1 default=ignore] pam_unix.so sha512
     {{% else %}}
     password sufficient pam_unix.so sha512
     {{%- endif %}}

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/commented_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/commented_value.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# remediation = none
+
+sed -i --follow-symlinks '/^\s*password.*pam_unix\.so/ s/sha512//g' /etc/pam.d/common-password
+sed -i --follow-symlinks '/^\s*password.*pam_unix\.so/ s/$/ # sha512/' /etc/pam.d/common-password
+

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/correct.pass.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
-# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ubuntu
 
+{{% if 'ubuntu' in product %}}
+pam_file="/etc/pam.d/common-password"
+
+if ! grep -q "^\s*password.*pam_unix\.so.*sha512" "$pam_file"; then
+	sed -i --follow-symlinks '/^\s*password.*pam_unix\.so/ s/$/ sha512/' "$pam_file"
+fi
+{{% else %}}
 pam_file="/etc/pam.d/system-auth"
 
 if ! grep -q "^password.*sufficient.*pam_unix\.so.*sha512" "$pam_file"; then
 	sed -i --follow-symlinks '/^password.*sufficient.*pam_unix\.so/ s/$/ sha512/' "$pam_file"
 fi
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/missing.fail.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
-# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ubuntu
 
+{{% if 'ubuntu' in product %}}
+sed -i --follow-symlinks '/^\s*password.*pam_unix\.so/ s/sha512//g' "/etc/pam.d/common-password"
+{{% else %}}
 sed -i --follow-symlinks '/^password.*sufficient.*pam_unix\.so/ s/sha512//g' "/etc/pam.d/system-auth"
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/wrong_value_concat.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/wrong_value_concat.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+sed -i --follow-symlinks '/^\s*password.*pam_unix\.so/ s/sha512//g' /etc/pam.d/common-password
+sed -i --follow-symlinks '/^\s*password.*pam_unix\.so/ s/$/ sha5122/' /etc/pam.d/common-password
+

--- a/products/ubuntu2204/profiles/stig.profile
+++ b/products/ubuntu2204/profiles/stig.profile
@@ -620,9 +620,8 @@ selections:
     # UBTU-22-654225 The Ubuntu operating system must generate audit records when successful/unsuccessful attempts to modify the /etc/sudoers.d directory occur
     - audit_rules_sudoers_d
 
-    ### TODO (rule needed; reevaluate requirement)
-    # Analogous to set_password_hashing_algorithm_passwordauth
     # UBTU-22-611055 The Ubuntu operating system must store only encrypted representations of passwords
+    - set_password_hashing_algorithm_systemauth
 
     ### TODO (rule needed)
     # Analogous to audit_rules_login_events_lastlog


### PR DESCRIPTION
#### Description:

- Modified bash and OVAL of `set_password_hashing_algorithm_systemauth` to use the correct pathname (`/etc/pam.d/common-password`) and control (`[success=... ]`) on Ubuntu.
- Added to Ubuntu STIG profile

#### Rationale:

- Satisfies STIG UBTU-22-611055