### PR TITLE
Add assertion file for RHCOS4 E8 profile tests on 4.13

### DIFF
--- a/tests/assertions/ocp4/rhcos4-e8-4.13.yml
+++ b/tests/assertions/ocp4/rhcos4-e8-4.13.yml
@@ -1,0 +1,301 @@
+rule_results:
+ e2e-e8-master-accounts-no-uid-except-zero:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-e8-master-audit-rules-dac-modification-chmod:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-audit-rules-dac-modification-chown:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-audit-rules-execution-chcon:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-audit-rules-execution-restorecon:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-audit-rules-execution-semanage:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-audit-rules-execution-setfiles:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-audit-rules-execution-setsebool:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-audit-rules-execution-seunshare:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-audit-rules-kernel-module-loading-delete:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-audit-rules-kernel-module-loading-finit:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-audit-rules-kernel-module-loading-init:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-audit-rules-login-events:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-audit-rules-login-events-faillock:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-audit-rules-login-events-lastlog:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-audit-rules-login-events-tallylog:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-audit-rules-networkconfig-modification:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-audit-rules-sysadmin-actions:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-audit-rules-time-adjtimex:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-audit-rules-time-clock-settime:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-audit-rules-time-settimeofday:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-audit-rules-time-stime:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-audit-rules-time-watch-localtime:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-audit-rules-usergroup-modification:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-auditd-data-retention-flush:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-e8-master-auditd-freq:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-e8-master-auditd-local-events:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-e8-master-auditd-log-format:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-e8-master-auditd-name-format:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-auditd-write-logs:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-e8-master-configure-crypto-policy:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-configure-ssh-crypto-policy:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-e8-master-no-empty-passwords:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-selinux-policytype:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-e8-master-selinux-state:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-e8-master-sshd-disable-empty-passwords:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-sshd-disable-gssapi-auth:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-sshd-disable-rhosts:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-sshd-disable-root-login:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-sshd-disable-user-known-hosts:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-sshd-do-not-permit-user-env:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-sshd-enable-strictmodes:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-sshd-print-last-log:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-sshd-set-loglevel-info:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-sysctl-kernel-dmesg-restrict:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-sysctl-kernel-kptr-restrict:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-e8-master-sysctl-kernel-randomize-va-space:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-sysctl-kernel-unprivileged-bpf-disabled:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-sysctl-kernel-yama-ptrace-scope:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-master-sysctl-net-core-bpf-jit-harden:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-accounts-no-uid-except-zero:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-e8-worker-audit-rules-dac-modification-chmod:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-audit-rules-dac-modification-chown:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-audit-rules-execution-chcon:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-audit-rules-execution-restorecon:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-audit-rules-execution-semanage:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-audit-rules-execution-setfiles:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-audit-rules-execution-setsebool:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-audit-rules-execution-seunshare:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-audit-rules-kernel-module-loading-delete:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-audit-rules-kernel-module-loading-finit:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-audit-rules-kernel-module-loading-init:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-audit-rules-login-events:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-audit-rules-login-events-faillock:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-audit-rules-login-events-lastlog:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-audit-rules-login-events-tallylog:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-audit-rules-networkconfig-modification:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-audit-rules-sysadmin-actions:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-audit-rules-time-adjtimex:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-audit-rules-time-clock-settime:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-audit-rules-time-settimeofday:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-audit-rules-time-stime:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-audit-rules-time-watch-localtime:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-audit-rules-usergroup-modification:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-auditd-data-retention-flush:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-e8-worker-auditd-freq:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-e8-worker-auditd-local-events:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-e8-worker-auditd-log-format:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-e8-worker-auditd-name-format:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-auditd-write-logs:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-e8-worker-configure-crypto-policy:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-configure-ssh-crypto-policy:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-e8-worker-no-empty-passwords:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-selinux-policytype:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-e8-worker-selinux-state:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-e8-worker-sshd-disable-empty-passwords:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-sshd-disable-gssapi-auth:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-sshd-disable-rhosts:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-sshd-disable-root-login:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-sshd-disable-user-known-hosts:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-sshd-do-not-permit-user-env:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-sshd-enable-strictmodes:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-sshd-print-last-log:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-sshd-set-loglevel-info:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-sysctl-kernel-dmesg-restrict:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-sysctl-kernel-kptr-restrict:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-e8-worker-sysctl-kernel-randomize-va-space:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-sysctl-kernel-unprivileged-bpf-disabled:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-sysctl-kernel-yama-ptrace-scope:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-e8-worker-sysctl-net-core-bpf-jit-harden:
+   default_result: FAIL
+   result_after_remediation: PASS


### PR DESCRIPTION
We're in the process of consolidating all the test assertions for e2e
testing to single files that describe all the results for a particular
scan. This makes it easier to reuse the e2e testing framework for
testing managed offerings, like ROSA.

This commit adds an assertion file for RHCOS4 E8. Test coverage should
be exactly the same as with the assertions in each rule directory.
