### PR TITLE
Fix Bash remediation of firewalld-based rules for offline mode

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/bash/shared.sh
@@ -8,34 +8,38 @@
 {{{ bash_package_install("NetworkManager") }}}
 {{{ bash_instantiate_variables("firewalld_sshd_zone") }}}
 
-if systemctl is-active NetworkManager && systemctl is-active firewalld; then
-    # First make sure the SSH service is enabled in run-time for the proper zone.
-    # This is to avoid connection issues when new interfaces are addeded to this zone.
-    firewall-cmd --zone="$firewalld_sshd_zone" --add-service=ssh
-
-    # This will collect all NetworkManager connections names
-    readarray -t nm_connections < <(nmcli -f UUID,TYPE con | grep ethernet | awk '{ print $1 }')
-    # If the connection is not yet assigned to a firewalld zone, assign it to the proper zone.
-    # This will not change connections which are already assigned to any firewalld zone.
-    for connection in "${nm_connections[@]}"; do
-        current_zone=$(nmcli -f connection.zone connection show "$connection" | awk '{ print $2}')
-        if [ $current_zone = "--" ]; then
-            nmcli connection modify "$connection" connection.zone $firewalld_sshd_zone
-        fi
-    done
-    systemctl restart NetworkManager
-
-    # Active zones are zones with at least one interface assigned to it.
-    # It is possible that traffic is comming by any active interface and consequently any
-    # active zone. So, this make sure all active zones are permanently allowing SSH service.
-    readarray -t firewalld_active_zones < <(firewall-cmd --get-active-zones | grep -v interfaces)
-    for zone in "${firewalld_active_zones[@]}"; do
-        firewall-cmd --permanent --zone="$zone" --add-service=ssh
-    done
-    firewall-cmd --reload
+if {{{ in_chrooted_environment }}}; then
+    # TODO: NM (nmcli) now has --offline mode support, and it could operate without NM service.
+    # See: https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/merge_requests/1183
+    # The feature is not quite straighforward (and probably incomplete), though.
+    echo "Not applicable in offline mode. Remediation aborted!"
 else
-    echo "
-    firewalld and NetworkManager services are not active. Remediation aborted!
-    This remediation could not be applied because it depends on firewalld and NetworkManager services running.
-    The service is not started by this remediation in order to prevent connection issues."
+    if systemctl is-active NetworkManager && systemctl is-active firewalld; then
+        # First make sure the SSH service is enabled in run-time for the proper zone.
+        # This is to avoid connection issues when new interfaces are addeded to this zone.
+        firewall-cmd --zone="$firewalld_sshd_zone" --add-service=ssh
+
+        # This will collect all NetworkManager connections names
+        readarray -t nm_connections < <(nmcli -f UUID,TYPE con | grep ethernet | awk '{ print $1 }')
+        # If the connection is not yet assigned to a firewalld zone, assign it to the proper zone.
+        # This will not change connections which are already assigned to any firewalld zone.
+        for connection in "${nm_connections[@]}"; do
+            current_zone=$(nmcli -f connection.zone connection show "$connection" | awk '{ print $2}')
+            if [ $current_zone = "--" ]; then
+                nmcli connection modify "$connection" connection.zone $firewalld_sshd_zone
+            fi
+        done
+        systemctl restart NetworkManager
+
+        # Active zones are zones with at least one interface assigned to it.
+        # It is possible that traffic is comming by any active interface and consequently any
+        # active zone. So, this make sure all active zones are permanently allowing SSH service.
+        readarray -t firewalld_active_zones < <(firewall-cmd --get-active-zones | grep -v interfaces)
+        for zone in "${firewalld_active_zones[@]}"; do
+            firewall-cmd --permanent --zone="$zone" --add-service=ssh
+        done
+        firewall-cmd --reload
+    else
+        echo "The firewalld or NetworkManager service is not active. Remediation aborted!"
+    fi
 fi

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_restricted/bash/shared.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_restricted/bash/shared.sh
@@ -6,13 +6,14 @@
 
 {{{ bash_package_install("firewalld") }}}
 
-if systemctl is-active firewalld; then
-    firewall-cmd --permanent --zone=trusted --add-rich-rule='rule family=ipv4 source address="127.0.0.1" destination not address="127.0.0.1" drop'
-    firewall-cmd --permanent --zone=trusted --add-rich-rule='rule family=ipv6 source address="::1" destination not address="::1" drop'
-    firewall-cmd --reload
+ipv4_rule='rule family=ipv4 source address="127.0.0.1" destination not address="127.0.0.1" drop'
+ipv6_rule='rule family=ipv6 source address="::1" destination not address="::1" drop'
+
+if {{{ in_chrooted_environment }}}; then
+    firewall-offline-cmd --zone=trusted --add-rich-rule="${ipv4_rule}"
+    firewall-offline-cmd --zone=trusted --add-rich-rule="${ipv6_rule}"
 else
-    echo "
-    firewalld service is not active. Remediation aborted!
-    This remediation could not be applied because it depends on firewalld service running.
-    The service is not started by this remediation in order to prevent connection issues."
+    firewall-cmd --permanent --zone=trusted --add-rich-rule="${ipv4_rule}"
+    firewall-cmd --permanent --zone=trusted --add-rich-rule="${ipv6_rule}"
+    firewall-cmd --reload
 fi

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_trusted/bash/shared.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_trusted/bash/shared.sh
@@ -6,12 +6,9 @@
 
 {{{ bash_package_install("firewalld") }}}
 
-if systemctl is-active firewalld; then
+if {{{ in_chrooted_environment }}}; then
+    firewall-offline-cmd --zone=trusted --add-interface=lo
+else
     firewall-cmd --permanent --zone=trusted --add-interface=lo
     firewall-cmd --reload
-else
-    echo "
-    firewalld service is not active. Remediation aborted!
-    This remediation could not be applied because it depends on firewalld service running.
-    The service is not started by this remediation in order to prevent connection issues."
 fi


### PR DESCRIPTION
#### Description:

- Remediation scripts now use `firewall-offline-cmd` (where possible) or nicely bail out when running in chroot.

- We also now check the offline mode marker (chroot) instead of the service status as the service may be active but not belonging to the target system (host service).


#### Rationale:

- Correct offline mode support.

- Fixes #11625
- Fixes #11564

#### Review Hints:

- Inspired by the [configure_firewalld_rate_limiting](https://github.com/ComplianceAsCode/content/blob/44b81ca8e3085b8452d8a58d912fb554b1993351/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/bash/shared.sh) rule.