### PR TITLE
Enable dconf profiles in Ubuntu CIS/STIG profiles

### DIFF
--- a/linux_os/guide/system/software/gnome/enable_dconf_user_profile/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/enable_dconf_user_profile/bash/shared.sh
@@ -1,3 +1,3 @@
-# platform = multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_sle
 
 echo -e 'user-db:user\nsystem-db:gdm' > /etc/dconf/profile/gdm

--- a/linux_os/guide/system/software/gnome/enable_dconf_user_profile/bash/ubuntu.sh
+++ b/linux_os/guide/system/software/gnome/enable_dconf_user_profile/bash/ubuntu.sh
@@ -1,0 +1,18 @@
+# platform = multi_platform_ubuntu
+
+# configure two dconf profiles:
+# - gdm: required for banner/user_list settings
+# - use': required for screenlock,automount,ctrlaltdel,... settings
+gdm_profile_path=/etc/dconf/profile/gdm
+user_profile_path=/etc/dconf/profile/user
+
+mkdir -p /etc/dconf/profile
+[[ -e "$gdm_profile_path" ]] || echo > "$gdm_profile_path"
+[[ -e "$user_profile_path" ]] || echo > "$user_profile_path"
+
+if ! grep -Pzq "(?s)^\s*user-db:user.*\n\s*system-db:gdm" "$gdm_profile_path"; then
+    sed -i --follow-symlinks "1s/^/user-db:user\nsystem-db:gdm\n/" "$gdm_profile_path"
+fi
+if ! grep -Pzq "(?s)^\s*user-db:user.*\n\s*system-db:local" "$user_profile_path"; then
+    sed -i --follow-symlinks "1s/^/user-db:user\nsystem-db:local\n/" "$user_profile_path"
+fi

--- a/linux_os/guide/system/software/gnome/enable_dconf_user_profile/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/enable_dconf_user_profile/oval/shared.xml
@@ -13,7 +13,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_dconf_user_profile"
   version="2">
-    {{% if product in ['sle12', 'sle15', 'ubuntu2004', 'ubuntu2204'] %}}
+    {{% if product in ['sle12', 'sle15'] %}}
       <ind:filepath>/etc/dconf/profile/gdm</ind:filepath>
       <ind:pattern operation="pattern match">^user-db:user\nsystem-db:gdm$</ind:pattern>
     {{% else %}}

--- a/linux_os/guide/system/software/gnome/enable_dconf_user_profile/oval/ubuntu.xml
+++ b/linux_os/guide/system/software/gnome/enable_dconf_user_profile/oval/ubuntu.xml
@@ -1,0 +1,37 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("The DConf User and gdm profiles should have the correct DB configured.") }}}
+    <criteria operator="OR">
+      <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
+      <criteria operator="AND">
+        <criterion comment="dconf gdm profile exists" test_ref="test_dconf_gdm_profile" />
+        <criterion comment="dconf user profile exists" test_ref="test_dconf_user_profile" />
+      </criteria>
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+      comment="dconf gdm profile exists and uses gdm.d database"
+      id="test_dconf_gdm_profile" version="1">
+    <ind:object object_ref="obj_dconf_gdm_profile" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_dconf_gdm_profile" version="1">
+    <ind:filepath>/etc/dconf/profile/gdm</ind:filepath>
+    <ind:pattern operation="pattern match">(?ms)^\s*user-db:user\s*.*\n\s*system-db:gdm\s*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+      comment="dconf user profile exists and uses local.d database"
+      id="test_dconf_user_profile" version="1">
+    <ind:object object_ref="obj_dconf_user_profile" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_dconf_user_profile" version="1">
+    <ind:filepath>/etc/dconf/profile/user</ind:filepath>
+    <ind:pattern operation="pattern match">(?ms)^\s*user-db:user\s*.*\n\s*system-db:local\s*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/linux_os/guide/system/software/gnome/enable_dconf_user_profile/rule.yml
+++ b/linux_os/guide/system/software/gnome/enable_dconf_user_profile/rule.yml
@@ -1,6 +1,5 @@
 documentation_complete: true
 
-
 title: 'Configure GNOME3 DConf User Profile'
 
 description: |-
@@ -9,11 +8,22 @@ description: |-
     highest priority. As such the DConf User profile should always exist and be
     configured correctly.
     <br /><br />
-    {{% if product in ["sle12", "sle15", "ubuntu2004", "ubuntu2204"] %}}
+    {{% if product in ["sle12", "sle15"] %}}
     To make sure that the user profile is configured correctly, the <tt>/etc/dconf/profile/gdm</tt>
     should be set as follows:
     <pre>user-db:user
     system-db:gdm
+    </pre>
+    {{% elif 'ubuntu' in product %}}
+    To make sure that the gdm profile is configured correctly, the <tt>/etc/dconf/profile/gdm</tt>
+    should be set as follows:
+    <pre>user-db:user
+    system-db:gdm
+    </pre>
+    To make sure that the user profile is configured correctly, the <tt>/etc/dconf/profile/user</tt>
+    should be set as follows:
+    <pre>user-db:user
+    system-db:local
     </pre>
     {{% else %}}
     To make sure that the user profile is configured correctly, the <tt>/etc/dconf/profile/user</tt>
@@ -51,11 +61,20 @@ ocil_clause: 'DConf User profile does not exist or is not configured correctly'
 ocil: |-
     To verify that the DConf User profile is configured correctly, run the following
     command:
-    {{% if product in ["sle12", "sle15", "ubuntu2004", "ubuntu2204"] %}}
+    {{% if product in ["sle12", "sle15"] %}}
     <pre>$ cat /etc/dconf/profile/gdm</pre>
     The output should show the following:
     <pre>user-db:user
     system-db:gdm</pre>
+    {{% elif 'ubuntu' in product %}}
+    <pre>$ cat /etc/dconf/profile/gdm</pre>
+    The output should show the following:
+    <pre>user-db:user
+    system-db:gdm</pre>
+    <pre>$ cat /etc/dconf/profile/user</pre>
+    The output should show the following:
+    <pre>user-db:user
+    system-db:local
     {{% else %}}
     <pre>$ cat /etc/dconf/profile/user</pre>
     The output should show the following:

--- a/linux_os/guide/system/software/gnome/enable_dconf_user_profile/tests/commented.fail.sh
+++ b/linux_os/guide/system/software/gnome/enable_dconf_user_profile/tests/commented.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+cat > /etc/dconf/profile/gdm <<EOF
+#user-db:user
+system-db:gdm
+EOF
+
+cat > /etc/dconf/profile/user <<EOF
+user-db:user
+#system-db:local
+EOF

--- a/linux_os/guide/system/software/gnome/enable_dconf_user_profile/tests/correct.pass.sh
+++ b/linux_os/guide/system/software/gnome/enable_dconf_user_profile/tests/correct.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+cat > /etc/dconf/profile/gdm <<EOF
+user-db:user
+system-db:gdm
+EOF
+
+cat > /etc/dconf/profile/user <<EOF
+user-db:user
+system-db:local
+EOF

--- a/linux_os/guide/system/software/gnome/enable_dconf_user_profile/tests/correct_messy.pass.sh
+++ b/linux_os/guide/system/software/gnome/enable_dconf_user_profile/tests/correct_messy.pass.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+cat > /etc/dconf/profile/gdm <<EOF
+# this 
+  user-db:user  
+# is
+# really
+# messy
+# system-db:gdm  
+  system-db:gdm  
+# stuff
+EOF
+
+cat > /etc/dconf/profile/user <<EOF
+
+user-db:user
+system-db:site
+system-db:distro
+system-db:local
+
+EOF

--- a/linux_os/guide/system/software/gnome/enable_dconf_user_profile/tests/missing.fail.sh
+++ b/linux_os/guide/system/software/gnome/enable_dconf_user_profile/tests/missing.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+rm -f /etc/dconf/profile/gdm
+rm -f /etc/dconf/profile/user

--- a/linux_os/guide/system/software/gnome/enable_dconf_user_profile/tests/wrong.fail.sh
+++ b/linux_os/guide/system/software/gnome/enable_dconf_user_profile/tests/wrong.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+cat > /etc/dconf/profile/gdm <<EOF
+user-db:user
+system-db:local
+EOF
+
+cat > /etc/dconf/profile/user <<EOF
+user-db:user
+system-db:gdm
+EOF

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -13,6 +13,7 @@ selections:
     - account_temp_expire_date
 
     # UBTU-20-010002 The Ubuntu operating system must enable the graphical user logon banner to display the Standard Mandatory DoD Notice and Consent Banner before granting local access to the system via a graphical user logon.
+    - enable_dconf_user_profile
     - dconf_gnome_banner_enabled
 
     # UBTU-20-010003 The Ubuntu operating system must display the Standard Mandatory DoD Notice and Consent Banner before granting local access to the system via a graphical user logon.

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -194,6 +194,7 @@ selections:
     # Skip due to being Level 2
 
     ### 1.8.2 Ensure GDM login banner is configured (Automated)
+    - enable_dconf_user_profile
     - login_banner_text=cis_default
     - dconf_gnome_banner_enabled
     - dconf_gnome_login_banner_text


### PR DESCRIPTION
#### Description:

Modified Ubuntu profiles to enable dconf profiles `gdm` and `user`.

#### Rationale:

On Ubuntu, dconf profiles `gdm` and `user` are not explictly configured by default. When the profiles aren't explicitly
defined and don't point to `gdm.d` and `local.d` dconf databases, respectively, the remediations from dconf rules will have no affect on gnome settings and the checks will give false positives.

The rules that are affected on Ubuntu:
- dconf_gnome_banner_enabled
- dconf_gnome_disable_automount
- dconf_gnome_disable_automount_open
- dconf_gnome_disable_autorun
- dconf_gnome_disable_ctrlaltdel_reboot
- dconf_gnome_disable_user_list
- dconf_gnome_login_banner_text
- dconf_gnome_screensaver_idle_delay
- dconf_gnome_screensaver_lock_delay
- dconf_gnome_screensaver_lock_enabled