### PR TITLE
exclude /static-checks/diff TMT tests

### DIFF
--- a/tests/tmt-plans/main.fmf
+++ b/tests/tmt-plans/main.fmf
@@ -103,6 +103,9 @@ report:
 /static-checks:
     discover+:
         test: /static-checks
-        # exclude here due to the test failing frequently for short periods
-        # of time, as many websites have temporary availability issues
-        exclude: /static-checks/html-links
+        exclude:
+          # exclude here due to the test failing frequently for short periods
+          # of time, as many websites have temporary availability issues
+          - /static-checks/html-links
+          # these always fail, meant for manual review
+          - /static-checks/diff


### PR DESCRIPTION
#### Description:

- These started causing Testing Farm failures after we merged https://github.com/RHSecurityCompliance/contest/pull/155
- This fix may be just temporary, there might be a better long-term solution like TMT plan inheritance, so we don't have to list cases like this explicitly, but this should be GEFN.