### PR TITLE
Align chronyd_sync_clock to Ubuntu 22.04 STIG

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_sync_clock/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_sync_clock/rule.yml
@@ -1,5 +1,10 @@
 documentation_complete: true
 
+{{% if product == 'ubuntu2204' -%}}
+{{% set makestep_line = 'makestep 1 1' -%}}
+{{% else -%}}
+{{% set makestep_line = 'makestep 1 -1' -%}}
+{{% endif -%}}
 
 title: 'Synchronize internal information system clocks'
 
@@ -29,16 +34,16 @@ ocil: |-
     authoritative time source when the time difference is greater than one
     second. Check the value of "makestep" by running the following command:
     <pre>$ sudo grep makestep {{{ chrony_conf_path }}}
-    makestep 1 -1</pre>
+    {{{ makestep_line }}}</pre>
 
-    If it is not set to "1 -1", edit the {{{ chrony_conf_path }}} file
+    If it is not set to the above value, edit the {{{ chrony_conf_path }}} file
     and add:
-    <pre>makestep 1 -1</pre>
+    <pre>{{{ makestep_line }}}</pre>
     Restart the chrony service:
     <pre>$ sudo systemctl restart chrony.service</pre>
 
 template:
     name: "lineinfile"
     vars:
-        text: "makestep 1 -1"
+        text: {{{ makestep_line }}}
         path: {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_sync_clock/tests/commented.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_sync_clock/tests/commented.fail.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 # packages = chrony
 
+{{% if product == 'ubuntu2204' -%}}
+echo "# makestep 1 1" >> {{{ chrony_conf_path }}}
+{{% else -%}}
 echo "# makestep 1 -1" >> {{{ chrony_conf_path }}}
+{{% endif -%}}

--- a/linux_os/guide/services/ntp/chronyd_sync_clock/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_sync_clock/tests/correct_value.pass.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 # packages = chrony
 
+{{% if product == 'ubuntu2204' -%}}
+echo "makestep 1 1" >> {{{ chrony_conf_path }}}
+{{% else -%}}
 echo "makestep 1 -1" >> {{{ chrony_conf_path }}}
+{{% endif -%}}


### PR DESCRIPTION
#### Description:

Switch to using `makestep 1 1`  in Ubuntu 2204 to align with STIG rule UBTU-22-252015 
