### PR TITLE
Align wireless_disable_interfaces with Ubuntu 22.04 STIG

### DIFF
--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/bash/ubuntu.sh
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/bash/ubuntu.sh
@@ -1,8 +1,6 @@
 # platform = multi_platform_ubuntu
 
-if command -v nmcli >/dev/null 2>&1 ; then
-    nmcli radio all off
-elif [ -n "$(find /sys/class/net/*/ -type d -name wireless)" ]; then
+if [ -n "$(find /sys/class/net/*/ -type d -name wireless)" ]; then
     interfaces=$(find /sys/class/net/*/wireless -type d -name wireless | xargs -0 dirname | xargs basename)
 
     for i in $interfaces; do

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/oval/ubuntu.xml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/oval/ubuntu.xml
@@ -1,0 +1,16 @@
+<def-group>
+  <definition class="compliance" id="wireless_disable_interfaces" version="1">
+    {{{ oval_metadata("All wireless interfaces should be disabled.") }}}
+    <criteria>
+      <criterion comment="query /proc/net/wireless" test_ref="test_wireless_disable_interfaces" />
+    </criteria>
+  </definition>
+  <ind:textfilecontent54_test check="all" check_existence="none_exist" comment="query /proc/net/wireless" id="test_wireless_disable_interfaces" version="1">
+    <ind:object object_ref="object_wireless_disable_interfaces" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_wireless_disable_interfaces" version="1">
+    <ind:filepath>/proc/net/wireless</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*\S+:\s</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/rule.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/rule.yml
@@ -14,6 +14,10 @@ description: |-
     Also remove the configuration files for every wifi adapter from
     <tt>/etc/wicked/ifconfig/&lt;WIFI-INTERFACE&gt;.xml</tt> to prevent future
     connections.
+    {{% elif 'ubuntu' in product %}}
+    Verify that there are no wireless interfaces configured on the system
+    with the following command:
+    <pre>$ ls -L -d /sys/class/net/*/wireless | xargs dirname | xargs basename -a</pre>
     {{% else %}}
     Configure the system to disable all wireless network interfaces with the following command:
     <pre>$ sudo nmcli radio all off</pre>
@@ -93,6 +97,9 @@ ocil: |-
 
     If a wireless interface is configured it must be documented and approved by
     the local Authorizing Official.
+    {{% elif 'ubuntu' in product %}}
+    <pre>$ ls -L -d /sys/class/net/*/wireless | xargs dirname | xargs basename -a</pre>
+    Note: This requirement is Not Applicable for systems that do not have physical wireless network radios.
     {{% else %}}
     Note: This requirement is Not Applicable for systems that do not have physical wireless network radios.
 
@@ -107,8 +114,26 @@ ocil: |-
     {{% endif %}}
 
 fixtext: |-
+    {{% if 'ubuntu' in product %}}
+    List all the wireless interfaces with the following command:
+    <pre>$ ls -L -d /sys/class/net/*/wireless | xargs dirname | xargs basename -a</pre>
+    For each interface, configure the system to disable wireless network
+    interfaces with the following command:
+    <pre>$ sudo ifdown <tt>interface name</tt></pre>
+    For each interface listed, find their respective module with the
+    following command:
+    <pre>$ basename $(readlink -f /sys/class/net/<tt>interface name</tt>/device/driver)</pre>
+    where <tt>interface name</tt> must be substituted by the actual interface name.
+    Create a file in the <tt>/etc/modprobe.d</tt> directory and for each module,
+    add the following line:
+    <pre>install <tt>module name</tt> /bin/true</pre>
+    For each module from the system, execute the following command to
+    remove it:
+    <pre>$ sudo modprobe -r <tt>module name</tt></pre>
+    {{% else %}}
     Configure the system to disable all wireless network interfaces with the following command:
     <pre>$ nmcli radio all off</pre>
+    {{% endif %}}
 
 srg_requirement: '{{{ full_name }}} wireless network adapters must be disabled.'
 


### PR DESCRIPTION
#### Description:

- Created Ubuntu-specific OVAL to check /proc/net/wireless for enabled interfaces.
  The existing implementation relies on the interface name starting with
  "wl", which could be overriden.
- Modified remediation to disable the driver modules as suggested by CIS and STIG,
  instead of disabling wifi using nmcli.