### PR TITLE
RHEL-09-232045: align with STIG

### DIFF
--- a/controls/stig_rhel9.yml
+++ b/controls/stig_rhel9.yml
@@ -990,6 +990,7 @@ controls:
         title: All RHEL 9 local initialization files must have mode 0740 or less permissive.
         rules:
             - file_permission_user_init_files_root
+            - var_user_initialization_files_regex=all_dotfiles
         status: automated
 
     -   id: RHEL-09-232050

--- a/tests/data/profile_stability/rhel9/stig.profile
+++ b/tests/data/profile_stability/rhel9/stig.profile
@@ -575,6 +575,7 @@ selections:
 - var_networkmanager_dns_mode=none
 - var_multiple_time_servers=stig
 - var_time_service_set_maxpoll=18_hours
+- var_user_initialization_files_regex=all_dotfiles
 - login_banner_text=dod_banners
 - var_authselect_profile=sssd
 unselected_groups: []

--- a/tests/data/profile_stability/rhel9/stig_gui.profile
+++ b/tests/data/profile_stability/rhel9/stig_gui.profile
@@ -583,6 +583,7 @@ selections:
 - var_networkmanager_dns_mode=none
 - var_multiple_time_servers=stig
 - var_time_service_set_maxpoll=18_hours
+- var_user_initialization_files_regex=all_dotfiles
 - login_banner_text=dod_banners
 - var_authselect_profile=sssd
 unselected_groups: []


### PR DESCRIPTION
#### Description:

- change the variable var_user_initialization_files_regex to all_dotfiles for RHEL 9 stig and stig_gui profile

#### Rationale:

- better alignment with official STIG

#### Review Hints:

1. ensure that your testing environment has at least one user with id > 999 and existing home directory (see #11778 for explanation)
2. oscap xccdf eval --remediate --profile stig --rule xccdf_org.ssgproject.content_rule_file_permission_user_init_files_root ssg-rhel9-ds.xml
3. oscap xccdf eval --profile '(all)' --rule xccdf_mil.disa.stig_rule_SV-257889r925654_rule disa-stig-rhel9-v1r1-xccdf-scap.xml