### PR TITLE
Return condition to test firewalld service state in firewalld_loopback_traffic rules

### DIFF
--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_restricted/bash/shared.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_restricted/bash/shared.sh
@@ -12,8 +12,13 @@ ipv6_rule='rule family=ipv6 source address="::1" destination not address="::1" d
 if {{{ in_chrooted_environment }}}; then
     firewall-offline-cmd --zone=trusted --add-rich-rule="${ipv4_rule}"
     firewall-offline-cmd --zone=trusted --add-rich-rule="${ipv6_rule}"
-else
+elif systemctl is-active firewalld; then
     firewall-cmd --permanent --zone=trusted --add-rich-rule="${ipv4_rule}"
     firewall-cmd --permanent --zone=trusted --add-rich-rule="${ipv6_rule}"
     firewall-cmd --reload
+else
+    echo "
+    firewalld service is not active. Remediation aborted!
+    This remediation could not be applied because it depends on firewalld service running.
+    The service is not started by this remediation in order to prevent connection issues."
 fi

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_restricted/tests/service_stopped.fail.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_restricted/tests/service_stopped.fail.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# packages = firewalld
+# remediation = none
+
+# Ensure the required service is started
+systemctl start firewalld
+
+# Ensure the trusted zone is overridden by an equivalent file in /etc/firewalld/zones
+firewall-cmd --permanent --zone=trusted --add-service=http
+
+# Ensure the there is no rich-rule restricting loopback traffic in trusted zone
+firewall-cmd --permanent --zone=trusted --remove-rich-rule='rule family=ipv4 source address="127.0.0.1" destination not address="127.0.0.1" drop'
+firewall-cmd --permanent --zone=trusted --remove-rich-rule='rule family=ipv6 source address="::1" destination not address="::1" drop'
+
+mv -f /etc/firewalld/zones/trusted.xml /usr/lib/firewalld/zones/trusted.xml
+
+# Ensure the required service is stopped
+systemctl stop firewalld

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_trusted/bash/shared.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_trusted/bash/shared.sh
@@ -8,7 +8,12 @@
 
 if {{{ in_chrooted_environment }}}; then
     firewall-offline-cmd --zone=trusted --add-interface=lo
-else
+elif systemctl is-active firewalld; then
     firewall-cmd --permanent --zone=trusted --add-interface=lo
     firewall-cmd --reload
+else
+    echo "
+    firewalld service is not active. Remediation aborted!
+    This remediation could not be applied because it depends on firewalld service running.
+    The service is not started by this remediation in order to prevent connection issues."
 fi

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_trusted/tests/service_stopped.fail.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_trusted/tests/service_stopped.fail.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# packages = firewalld
+# remediation = none
+
+# Ensure the required service is started
+systemctl start firewalld
+
+# Ensure the trusted zone is overridden by an equivalent file in /etc/firewalld/zones
+firewall-cmd --permanent --zone=trusted --add-service=http
+
+# Ensure the lo interface is assigned to the custom trusted zone
+firewall-cmd --permanent --zone=trusted --remove-interface=lo
+
+mv -f /etc/firewalld/zones/trusted.xml /usr/lib/firewalld/zones/trusted.xml
+
+# Ensure the required service is stopped
+systemctl stop firewalld


### PR DESCRIPTION
#### Description:

After the #11868 the condition to test the `firewalld` service state before trying to run `firewalld-cmd` was removed, causing the remediation to report error when the service is stopped.
This change also created a misalignment with Ansible remediation.
This commit returns the condition to keep the alignment and better report the case to users.

#### Rationale:

- Ensure alignment between Ansible and Bash remediation
- Clear information to users

#### Review Hints:

automatus tests should be enough.
Some CI tests using containers are expected to fail.