### PR TITLE
Restrict the list of accepted shells in no_shelllogin_for_systemaccounts

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/oval/shared.xml
@@ -71,7 +71,7 @@
   <!-- Get all /etc/passwd entries having shell defined as OVAL object -->
   <ind:textfilecontent54_object id="object_etc_passwd_entries" version="1">
     <ind:filepath>/etc/passwd</ind:filepath>
-    <ind:pattern operation="pattern match">^(?!root).*:x:([\d]+):[\d]+:[^:]*:[^:]*:(?!\/usr\/sbin\/nologin|\/sbin\/nologin|\/bin\/sync|\/sbin\/shutdown|\/sbin\/halt|\/bin\/false|\/usr\/bin\/false).*$</ind:pattern>
+    <ind:pattern operation="pattern match">^(?!root).*:x:([\d]+):[\d]+:[^:]*:[^:]*:(?!\/usr\/sbin\/nologin|\/sbin\/nologin|\/bin\/sync|\/sbin\/shutdown|\/sbin\/halt).*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 


### PR DESCRIPTION
#### Description:

There were already long discussions in the past about the cons of using `/bin/false`.
More recently the topic was also discussed in CIS Community and unanimously agreed to use `/sbin/nologin` for a user shell when it is not desired the respective user to interact with a shell.
This is also in alignment with STIG recommendations.
In addition, the approach is in all other related rules in the project.

Therefore, this OVAL was updated to the minimal list of shells.

#### Rationale:

- Better alignment with Policies and other related rules.
- Partially Fixes #11698

#### Review Hints:

automatus tests should be enough.
