### PR TITLE
Fix #11898 issue

### DIFF
--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_cron_allow/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_cron_allow/rule.yml
@@ -3,12 +3,18 @@ documentation_complete: true
 
 title: 'Verify Group Who Owns /etc/cron.allow file'
 
+{{% if "ubuntu" in product %}}
+    {{% set target_group="crontab" %}}
+{{% else %}}
+    {{% set target_group="root" %}}
+{{% endif %}}
+
 description: |-
-    If <tt>/etc/cron.allow</tt> exists, it must be group-owned by <tt>root</tt>.
-    {{{ describe_file_group_owner(file="/etc/cron.allow", group="root") }}}
+    If <tt>/etc/cron.allow</tt> exists, it must be group-owned by <tt>{{{ target_group }}}</tt>.
+    {{{ describe_file_group_owner(file="/etc/cron.allow", group=target_group) }}}
 
 rationale: |-
-    If the owner of the cron.allow file is not set to root, the possibility exists for an
+    If the owner of the cron.allow file is not set to {{{ target_group }}}, the possibility exists for an
     unauthorized user to view or edit sensitive information.
 
 severity: medium
@@ -37,14 +43,18 @@ references:
     stigid@ol7: OL07-00-021120
     stigid@rhel7: RHEL-07-021120
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/cron.allow", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/cron.allow", group=target_group) }}}'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="/etc/cron.allow", group="root") }}}
+    {{{ ocil_file_group_owner(file="/etc/cron.allow", group=target_group) }}}
 
 template:
     name: file_groupowner
     vars:
         filepath: /etc/cron.allow
         missing_file_pass: 'true'
+{{% if "ubuntu" in product %}}
+        gid_or_name: 'crontab'
+{{% else %}}
         gid_or_name: '0'
+{{% endif %}}


### PR DESCRIPTION
#### Description:

This use crontab as group owner for `/etc/cron.allow` file on Ubuntu.

#### Rationale:

- Fixes #11898

#### Review Hints:

Build the product:

```
./build_product ubuntu2204
```

To test these changes with Ansible:

```
ansible-playbook build/ansible/ubuntu2204-playbook-cis_level1_server.yml --tags "file_groupowner_cron_allow"
```

To test changes with bash, run the remediation sections: `xccdf_org.ssgproject.content_rule_file_groupowner_cron_allow`

Expected output:

```
Title   Verify Group Who Owns /etc/cron.allow file
Rule    xccdf_org.ssgproject.content_rule_file_groupowner_cron_allow
Result  pass
```