### PR TITLE
Set OVAL version from 5.11 to 5.11.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ set(SSG_VERSION "${SSG_MAJOR_VERSION}.${SSG_MINOR_VERSION}.${SSG_PATCH_VERSION}"
 set(SSG_VENDOR "ssgproject" CACHE STRING "Specify the XCCDF 1.2 vendor string.")
 
 set(SSG_TARGET_OVAL_MAJOR_VERSION "5" CACHE STRING "Which major version of OVAL are we targetting. Only 5 is supported at the moment.")
-set(SSG_TARGET_OVAL_MINOR_VERSION "11" CACHE STRING "Which minor version of OVAL are we targetting. Only 11 is supported at the moment.")
+set(SSG_TARGET_OVAL_MINOR_VERSION "11.2" CACHE STRING "Which minor version of OVAL are we targetting. Only 11, up to 11.2, is supported at the moment.")
 
 set(SSG_TARGET_OVAL_VERSION "${SSG_TARGET_OVAL_MAJOR_VERSION}.${SSG_TARGET_OVAL_MINOR_VERSION}")
 
@@ -178,8 +178,8 @@ cmake_dependent_option(ENABLE_PYTHON_COVERAGE "Enable Python tests with coverage
 
 find_package(OpenSCAP REQUIRED)
 
-if(NOT SSG_TARGET_OVAL_VERSION VERSION_EQUAL "5.11")
-    message(WARNING "You are targeting OVAL version ${SSG_TARGET_OVAL_VERSION}. In SSG we support/test 5.11 only!")
+if(NOT SSG_TARGET_OVAL_VERSION VERSION_EQUAL "5.11.2")
+    message(WARNING "You are targeting OVAL version ${SSG_TARGET_OVAL_VERSION}. In SSG we support/test up to 5.11.2!")
 endif()
 
 # OCP4 requires non-standard extensions. Vanilla OpenSCAP 1.2 doesn't support

--- a/build_product
+++ b/build_product
@@ -14,7 +14,7 @@
 # ARG_USE_ENV([ADDITIONAL_CMAKE_OPTIONS],[],[Whitespace-separated string of arguments to pass to CMake])
 # ARG_POSITIONAL_INF([product],[Products to build, ALL means all products],[0],[ALL])
 # ARG_DEFAULTS_POS([])
-# ARG_TYPE_GROUP_SET([oval_ver],[VERSION],[oval],[5.11,auto])
+# ARG_TYPE_GROUP_SET([oval_ver],[VERSION],[oval],[5.11.2,auto])
 # ARG_TYPE_GROUP_SET([builder_type],[BUILDER],[builder],[make,ninja,auto])
 # ARG_HELP([Wipes out contents of the 'build' directory and builds only and only the given products.])
 # ARGBASH_GO()
@@ -38,12 +38,12 @@ die()
 
 oval_ver()
 {
-	local _allowed=("5.11" "auto") _seeking="$1"
+	local _allowed=("5.11.2" "auto") _seeking="$1"
 	for element in "${_allowed[@]}"
 	do
 		test "$element" = "$_seeking" && echo "$element" && return 0
 	done
-	die "Value '$_seeking' (of argument '$2') doesn't match the list of allowed values: '5.11' and 'auto'" 4
+	die "Value '$_seeking' (of argument '$2') doesn't match the list of allowed values: '5.11.2' and 'auto'" 4
 }
 
 
@@ -87,7 +87,7 @@ print_help()
 	printf '%s\n' "Wipes out contents of the 'build' directory and builds only and only the given products."
 	printf 'Usage: %s [-o|--oval <VERSION>] [-b|--builder <BUILDER>] [-j|--jobs <arg>] [--(no-)debug] [--(no-)derivatives] [--(no-)ansible-playbooks] [--(no-)bash-scripts] [-d|--(no-)datastream-only] [-p|--(no-)profiling] [-h|--help] [<product-1>] ... [<product-n>] ...\n' "$0"
 	printf '\t%s\n' "<product>: Products to build, ALL means all products (defaults for <product>: 'ALL')"
-	printf '\t%s\n' "-o, --oval: OVAL version. Can be one of: '5.11' or 'auto' (default: 'auto')"
+	printf '\t%s\n' "-o, --oval: OVAL version. Can be one of: '5.11.2' or 'auto' (default: 'auto')"
 	printf '\t%s\n' "-b, --builder: Builder engine. Can be one of: 'make', 'ninja' and 'auto' (default: 'auto')"
 	printf '\t%s\n' "-j, --jobs: Count of simultaneous jobs (default: 'auto')"
 	printf '\t%s\n' "--debug, --no-debug: Make a debug build with draft profiles (off by default)"
@@ -381,7 +381,7 @@ all_cmake_products=(
 )
 
 DEFAULT_OVAL_MAJOR_VERSION=5
-DEFAULT_OVAL_MINOR_VERSION=11
+DEFAULT_OVAL_MINOR_VERSION=11.2
 
 build_type_option="-DCMAKE_BUILD_TYPE=Release"
 

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_sufficiently_large_partition/oval/shared.xml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_sufficiently_large_partition/oval/shared.xml
@@ -1,8 +1,9 @@
 <def-group>
-  <definition class="compliance" id="auditd_audispd_configure_sufficiently_large_partition" version="1">
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("Configure a sufficiently large partition for audit logs.") }}}
     <criteria>
-        <criterion comment="Check that the partition with audit logs is at least 10G large" test_ref="test_aacsflp" />
+      <criterion test_ref="test_aacsflp"
+        comment="Check that the partition with audit logs is at least 10G large"/>
     </criteria>
   </definition>
 
@@ -10,22 +11,27 @@
   <linux:partition_object id="obj_aacsflp_audit_partition" version="1">
     <linux:mount_point operation="equals">/var/log/audit</linux:mount_point>
   </linux:partition_object>
+
   <!-- total partition size in bytes -->
-  <local_variable id="var_aacsflp_audit_partition_size" comment="total capacity (in bytes) of the audit partition" datatype="string" version="1">
+  <local_variable id="var_aacsflp_audit_partition_size" datatype="string" version="1"
+    comment="total capacity (in bytes) of the audit partition">
     <arithmetic arithmetic_operation="multiply">
-      <object_component item_field="block_size" object_ref="obj_aacsflp_audit_partition" />
-      <object_component item_field="total_space" object_ref="obj_aacsflp_audit_partition" />
+      <object_component object_ref="obj_aacsflp_audit_partition" item_field="block_size"/>
+      <object_component object_ref="obj_aacsflp_audit_partition" item_field="total_space"/>
     </arithmetic>
   </local_variable>
+
   <ind:variable_object id="obj_aacsflp_audit_partition_size" version="1">
     <ind:var_ref>var_aacsflp_audit_partition_size</ind:var_ref>
   </ind:variable_object>
 
-  <ind:variable_test id="test_aacsflp" version="1" check="all" check_existence="all_exist" comment="Check that the partition with audit logs is at least 10G large">
-    <ind:object object_ref="obj_aacsflp_audit_partition_size" />
-    <ind:state state_ref="state_aacsflp_partition_sufficiently_large" />
+  <ind:variable_test id="test_aacsflp" check="all" check_existence="all_exist" version="1"
+    comment="Check that the partition with audit logs is at least 10G large">
+    <ind:object object_ref="obj_aacsflp_audit_partition_size"/>
+    <ind:state state_ref="state_aacsflp_partition_sufficiently_large"/>
   </ind:variable_test>
+
   <ind:variable_state id="state_aacsflp_partition_sufficiently_large" version="1">
-      <ind:value operation="greater than or equal" datatype="int">10000000000</ind:value>
+    <ind:value operation="greater than or equal" datatype="int">10000000000</ind:value>
   </ind:variable_state>
 </def-group>


### PR DESCRIPTION
#### Description:

Investigating the issue #11891 it was noticed that OpenSCAP scanner was returning error for rule `auditd_audispd_configure_sufficiently_large_partition` because the OVAL in this rule was using an OVAL property only present in OVAL 5.11.2, but our content was defined as version `5.11` (without .2).

OVAL version 5.11.2 was released in 2016 and we are likely already using it for long time.

#### Rationale:

- Fixes #11891

#### Review Hints:

First take a look in #11891

There is no test scenario or remediation for this rule because it is about partition and tests are not that simple to be created. Therefore, we should test it in the traditional way using a RHEL9 VM, for example.

`./build_product rhel9`

Copy the generated DataStream to this RHEL9 VM:
`scp build/ssg-rhel9-ds.xml root@<ip or host>:`

Start a SSH session to this VM and executes a scan for the rule `auditd_audispd_configure_sufficiently_large_partition`:
`oscap xccdf eval --profile stig --rule xccdf_org.ssgproject.content_rule_auditd_audispd_configure_sufficiently_large_partition --results-arf /tmp/arf.xml --report /tmp/report.html --oval-results ssg-rhel9-ds.xml`

After this PR, the result will be "Pass" or "Fail" based on the partition size mounted on `/var/log/audit`. Before this PR, the error shown in #11891 is reproduced.

A good way to confirm the check is accurate is examining the `/tmp/arf.xml` file.
For example, in the VM I used this was the relevant information about the partition table:
```
# df -h
Filesystem                     Size  Used Avail Use% Mounted on
...
/dev/mapper/VolGroup-audit     507M   32M  475M   7% /var/log/audit
...
```
and this was the result of the scan:
```
Title   Configure a Sufficiently Large Partition for Audit Logs
Rule    xccdf_org.ssgproject.content_rule_auditd_audispd_configure_sufficiently_large_partition
Ident   CCE-88173-0
Result  fail
```
To confirm the result, this was the relevant information in `/tmp/arf.xml` file:
```
                <system_data>
                  <ind-sys:variable_item id="1059257" status="exists">
                    <ind-sys:var_ref>oval:ssg-var_aacsflp_audit_partition_size:var:1</ind-sys:var_ref>
                    <ind-sys:value>531267584</ind-sys:value>
                  </ind-sys:variable_item>
                  <lin-sys:partition_item id="1059256" status="exists">
                    <lin-sys:mount_point>/var/log/audit</lin-sys:mount_point>
                    <lin-sys:device>/dev/mapper/VolGroup-audit</lin-sys:device>
                    <lin-sys:uuid>50934914-4c90-407b-bcee-268a5a76f641</lin-sys:uuid>
                    <lin-sys:fs_type>xfs</lin-sys:fs_type>
                    <lin-sys:mount_options>rw</lin-sys:mount_options>
                    <lin-sys:mount_options>seclabel</lin-sys:mount_options>
                    <lin-sys:mount_options>nosuid</lin-sys:mount_options>
                    <lin-sys:mount_options>nodev</lin-sys:mount_options>
                    <lin-sys:mount_options>noexec</lin-sys:mount_options>
                    <lin-sys:mount_options>relatime</lin-sys:mount_options>
                    <lin-sys:mount_options>attr2</lin-sys:mount_options>
                    <lin-sys:mount_options>inode64</lin-sys:mount_options>
                    <lin-sys:mount_options>logbufs=8</lin-sys:mount_options>
                    <lin-sys:mount_options>logbsize=32k</lin-sys:mount_options>
                    <lin-sys:mount_options>noquota</lin-sys:mount_options>
                    <lin-sys:mount_options>bind</lin-sys:mount_options>
                    <lin-sys:total_space datatype="int">129704</lin-sys:total_space>
                    <lin-sys:space_used datatype="int">9171</lin-sys:space_used>
                    <lin-sys:space_left datatype="int">120533</lin-sys:space_left>
                    <lin-sys:block_size datatype="int">4096</lin-sys:block_size>
                  </lin-sys:partition_item>
                </system_data>
...
               <test test_id="oval:ssg-test_aacsflp:tst:1" version="1" check_existence="all_exist" check="all" result="false">
                  <tested_item item_id="1059257" result="false"/>
                  <tested_variable variable_id="oval:ssg-var_aacsflp_audit_partition_size:var:1">531267584</tested_variable>
                </test>
```
In this case, 531267584 is the partition size in bytes, or 507M.