### PR TITLE
Fix ansible lint for SLE platforms

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
@@ -6,7 +6,7 @@
 
 - name: {{{ rule_title }}} - Set List of Mount Points Which Permits Execution of Privileged Commands
   ansible.builtin.set_fact:
-    privileged_mount_points: "{{(ansible_facts.mounts | rejectattr('options', 'search', 'noexec|nosuid') | rejectattr('mount', 'match', '/proc($|/.*$)') | map(attribute='mount') | list ) }}"
+    privileged_mount_points: "{{ (ansible_facts.mounts | rejectattr('options', 'search', 'noexec|nosuid') | rejectattr('mount', 'match', '/proc($|/.*$)') | map(attribute='mount') | list ) }}"
 
 - name: {{{ rule_title }}} - Search for Privileged Commands in Eligible Mount Points
   ansible.builtin.shell:

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_unlock_time/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_unlock_time/ansible/shared.yml
@@ -6,5 +6,5 @@
 
 {{{ ansible_instantiate_variables("var_accounts_passwords_pam_tally2_unlock_time") }}}
 
-{{{ ansible_ensure_pam_module_option('/etc/pam.d/login', 'auth', 'required', 'pam_tally2.so', 'unlock_time', "{{var_accounts_passwords_pam_tally2_unlock_time}}", '') }}}
+{{{ ansible_ensure_pam_module_option('/etc/pam.d/login', 'auth', 'required', 'pam_tally2.so', 'unlock_time', "{{ var_accounts_passwords_pam_tally2_unlock_time }}", '') }}}
 {{{ ansible_ensure_pam_module_option('/etc/pam.d/common-account', 'account', 'required', 'pam_tally2.so', '', '', '') }}}

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/ansible/shared.yml
@@ -16,7 +16,7 @@
 {{% if 'sle' in product %}}
 - name: "{{{ rule_title }}} - Ensure Repositories Are Updated"
   ansible.builtin.command: zypper -q --no-remote ref
-  ignore_errors: True
+  failed_when: false
 {{% endif %}}
 
 - name: "{{{ rule_title }}} - Ensure AIDE Is Installed"

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/ansible/shared.yml
@@ -23,5 +23,5 @@
     value: '1'
     no_extra_spaces: True
   # regex filters grep output for files ending in .repo and matching section names.
-  loop: "{{ repo_grep_results.stdout |regex_findall( '(.+\\.repo):\\[(.+)\\]\\n?' ) if repo_grep_results is not skipped else []}}"
+  loop: "{{ repo_grep_results.stdout |regex_findall( '(.+\\.repo):\\[(.+)\\]\\n?' ) if repo_grep_results is not skipped else [] }}"
   when: repo_grep_results is not skipped

--- a/shared/templates/rsyslog_logfiles_attributes_modify/ansible.template
+++ b/shared/templates/rsyslog_logfiles_attributes_modify/ansible.template
@@ -25,7 +25,7 @@
   ansible.builtin.shell: |
     {{%- if not 'debian' in product %}}
     set -o pipefail{{% endif %}}
-    awk '/)/{f=0} /include\(/{f=1} f{nf=gensub("^(include\\(|\\s*)file=\"(\\S+)\".*","\\2",1); if($0!=nf){print nf}}' {{ rsyslog_etc_config }} || true
+    awk '/)/{f=0} /include\(/{f=1} f{ nf=gensub("^(include\\(|\\s*)file=\"(\\S+)\".*","\\2",1); if($0!=nf){ print nf }}' {{ rsyslog_etc_config }} || true
   register: rsyslog_new_inc
   changed_when: False
 


### PR DESCRIPTION
#### Description:

- Fixes in SLES specific ansible to make lint checks pass

#### Rationale:

- Small patches in ansible remediations

- Fixes #6726 

[ansible-lint-output.txt](https://github.com/ComplianceAsCode/content/files/15142819/ansible-lint.txt)
