### PR TITLE
Fix value syntax for rule dconf_gnome_disable_ctrlaltdel_reboot

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/ansible/shared.yml
@@ -8,7 +8,7 @@
     dest: /etc/dconf/db/local.d/00-security-settings
     section: org/gnome/settings-daemon/plugins/media-keys
     option: logout
-    value: "''"
+    value: "['']"
     create: yes
     no_extra_spaces: yes
 

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/bash/shared.sh
@@ -1,5 +1,5 @@
 # platform = multi_platform_all
 
 
-{{{ bash_dconf_settings("org/gnome/settings-daemon/plugins/media-keys", "logout", "''", "local.d", "00-security-settings") }}}
+{{{ bash_dconf_settings("org/gnome/settings-daemon/plugins/media-keys", "logout", "['']", "local.d", "00-security-settings") }}}
 {{{ bash_dconf_lock("org/gnome/settings-daemon/plugins/media-keys", "logout", "local.d", "00-security-settings-lock") }}}

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/oval/shared.xml
@@ -20,7 +20,7 @@
   version="1">
     <ind:path>/etc/dconf/db/local.d/</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
-    <ind:pattern operation="pattern match">^\[org/gnome/settings-daemon/plugins/media-keys\]([^\n]*\n+)+?logout[\s]*=[\s]*''$</ind:pattern>
+    <ind:pattern operation="pattern match">^\[org/gnome/settings-daemon/plugins/media-keys\]([^\n]*\n+)+?logout[\s]*=[\s]*\[''\]$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/rule.yml
@@ -9,10 +9,10 @@ description: |-
     <br /><br />
     To configure the system to ignore the <tt>Ctrl-Alt-Del</tt> key sequence
     from the Graphical User Interface (GUI) instead of rebooting the system,
-    add or set <tt>logout</tt> to <tt>''</tt> in
+    add or set <tt>logout</tt> to <tt>['']</tt> in
     <tt>/etc/dconf/db/local.d/00-security-settings</tt>. For example:
     <pre>[org/gnome/settings-daemon/plugins/media-keys]
-    logout=''</pre>
+    logout=['']</pre>
     Once the settings have been added, add a lock to
     <tt>/etc/dconf/db/local.d/locks/00-security-settings-lock</tt> to prevent
     user modification. For example:
@@ -60,7 +60,7 @@ ocil: |-
     If properly configured, the output should be
     <tt>/org/gnome/settings-daemon/plugins/media-keys/logout</tt>
 
-fixtext: '{{{ fixtext_dconf_ini_file("/org/gnome/settings-daemon/plugins/media-keys", "logout", "") }}}'
+fixtext: '{{{ fixtext_dconf_ini_file("/org/gnome/settings-daemon/plugins/media-keys", "logout", "[\'\']") }}}'
 
 srg_requirement: 'The x86 Ctrl-Alt-Delete key sequence in {{{ full_name }}} must be disabled if a graphical user interface is installed.'
 

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/comment.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/comment.fail.sh
@@ -4,5 +4,5 @@
 
 install_dconf_and_gdm_if_needed
 clean_dconf_settings
-add_dconf_setting "org/gnome/settings-daemon/plugins/media-keys" "#logout" "''" "local.d" "00-security-settings"
+add_dconf_setting "org/gnome/settings-daemon/plugins/media-keys" "#logout" "['']" "local.d" "00-security-settings"
 add_dconf_lock "org/gnome/settings-daemon/plugins/media-keys" "logout" "local.d" "00-security-settings"

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/correct_value.pass.sh
@@ -4,5 +4,5 @@
 
 install_dconf_and_gdm_if_needed
 clean_dconf_settings
-add_dconf_setting "org/gnome/settings-daemon/plugins/media-keys" "logout" "''" "local.d" "00-security-settings"
+add_dconf_setting "org/gnome/settings-daemon/plugins/media-keys" "logout" "['']" "local.d" "00-security-settings"
 add_dconf_lock "org/gnome/settings-daemon/plugins/media-keys" "logout" "local.d" "00-security-settings"

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/correct_value_unlocked.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/correct_value_unlocked.fail.sh
@@ -4,4 +4,4 @@
 
 install_dconf_and_gdm_if_needed
 clean_dconf_settings
-add_dconf_setting "org/gnome/settings-daemon/plugins/media-keys" "logout" "''" "local.d" "00-security-settings"
+add_dconf_setting "org/gnome/settings-daemon/plugins/media-keys" "logout" "['']" "local.d" "00-security-settings"

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/correct_value_wrong_db.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/correct_value_wrong_db.fail.sh
@@ -4,5 +4,5 @@
 
 install_dconf_and_gdm_if_needed
 clean_dconf_settings
-add_dconf_setting "org/gnome/settings-daemon/plugins/media-keys" "logout" "''" "dummy.d" "00-security-settings"
+add_dconf_setting "org/gnome/settings-daemon/plugins/media-keys" "logout" "['']" "dummy.d" "00-security-settings"
 add_dconf_lock "org/gnome/settings-daemon/plugins/media-keys" "logout" "dummy.d" "00-security-settings"


### PR DESCRIPTION
#### Description:

- Changed the value for `logout` from `''` to `['']`.

#### Rationale:

- For the `logout` setting to work, the value has to be an array.
