### PR TITLE
Revert changes to no_empty_passwords for Ubuntu

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/ansible/shared.yml
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = medium
 {{% if 'ubuntu' in product %}}
-{{%- set pam_config_paths = "['/etc/pam.d/common-password', '/etc/pam.d/common-auth']" %}}
+{{%- set pam_config_paths = "['/etc/pam.d/common-password']" %}}
 {{% else %}}
 {{%- set pam_config_paths = "['/etc/pam.d/system-auth', '/etc/pam.d/password-auth']" -%}}
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/bash/shared.sh
@@ -11,9 +11,8 @@ for FILE in ${NULLOK_FILES}; do
    sed --follow-symlinks -i 's/\<nullok\>//g' ${FILE}
 done
 {{% elif 'ubuntu' in product %}}
-for FILE in "/etc/pam.d/common-auth" "/etc/pam.d/common-password"; do
-    sed -i 's/\(.*pam_unix\.so.*\)\s\<nullok\>\(.*\)/\1\2/g' ${FILE}
-done
+FILE="/etc/pam.d/common-password"
+sed -i 's/\(.*pam_unix\.so.*\)\s\<nullok\>\(.*\)/\1\2/g' ${FILE}
 {{% else %}}
 if [ -f /usr/bin/authselect ]; then
     {{{ bash_enable_authselect_feature('without-nullok') }}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/oval/shared.xml
@@ -15,7 +15,7 @@
 {{% if product in ['sle12', 'sle15'] %}}
     <ind:filepath operation="pattern match">^/etc/pam.d/.*$</ind:filepath>
 {{% elif 'ubuntu' in product %}}
-    <ind:filepath operation="pattern match">^/etc/pam.d/common-(auth|password)</ind:filepath>
+    <ind:filepath operation="pattern match">^/etc/pam.d/common-password</ind:filepath>
 {{% else %}}
     <ind:filepath operation="pattern match">^/etc/pam.d/(system|password)-auth$</ind:filepath>
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/no_nullok.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/no_nullok.pass.sh
@@ -2,7 +2,6 @@
 # platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ubuntu
 
 {{% if 'ubuntu' in product %}}
-sed -i --follow-symlinks '/nullok/d' /etc/pam.d/common-auth
 sed -i --follow-symlinks '/nullok/d' /etc/pam.d/common-password
 {{% else %}}
 sed -i --follow-symlinks '/nullok/d' /etc/pam.d/system-auth

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_present.fail.sh
@@ -2,7 +2,7 @@
 # platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ubuntu
 
 {{% if 'ubuntu' in product %}}
-for FILE in "/etc/pam.d/common-auth" "/etc/pam.d/common-password"; do
+for FILE in "/etc/pam.d/common-password"; do
     if ! grep -q "^[^#].*pam_unix\.so.*nullok" ${FILE}; then
         sed -i 's/\([\s]pam_unix\.so\)/\1 nullok/g' ${FILE}
     fi


### PR DESCRIPTION
#### Description:

- Revert changes to STIG rule UBTU-20-010463 (`no_empty_passwords`)

#### Rationale:

- In PR #11282 , the check for STIG rule UBTU-20-010463 (`no_empty_passwords`) was modified to also remove nullok from common-auth. A new version of STIG has since been released, not including the proposed change, thus we are reverting the change in the check logic.
