### PR TITLE
Fix pwquality package name for Ubuntu 22.04

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/package_pam_pwquality_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/package_pam_pwquality_installed/rule.yml
@@ -45,5 +45,6 @@ template:
     vars:
         pkgname: libpwquality
         pkgname@ubuntu2004: libpam-pwquality
+        pkgname@ubuntu2204: libpam-pwquality
 
 platform: package[pam]


### PR DESCRIPTION
#### Description:

- Change package name to `libpam-pwquality` on Ubuntu 22.04
