### PR TITLE
Add rule file_group_ownership_var_log_audit_stig

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/file_group_ownership_var_log_audit_stig/bash/shared.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_group_ownership_var_log_audit_stig/bash/shared.sh
@@ -1,0 +1,11 @@
+# platform = multi_platform_ubuntu
+
+if LC_ALL=C grep -iw log_file /etc/audit/auditd.conf; then
+  FILE=$(awk -F "=" '/^log_file/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')
+else
+  FILE="/var/log/audit/audit.log"
+fi
+
+{{{ bash_auditd_config_set("log_group", "root") }}}
+
+chgrp root $FILE

--- a/linux_os/guide/auditing/auditd_configure_rules/file_group_ownership_var_log_audit_stig/oval/shared.xml
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_group_ownership_var_log_audit_stig/oval/shared.xml
@@ -1,0 +1,50 @@
+<def-group>
+    <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("Checks that all audit log files are group owned by the root user.") }}}
+    <criteria operator="OR">
+      <criteria operator="AND" comment="log_file set">
+        <extend_definition comment="log file set in auditd.conf"
+          definition_ref="auditd_conf_log_file_not_set" negate="true" />
+        <extend_definition comment="log_group in auditd.conf is root"
+          definition_ref="auditd_conf_log_group_not_root" negate="true"/>
+        <criterion comment="audit log files are root group owned"
+          test_ref="{{{ rule_id }}}_test_group_ownership"/>
+      </criteria>
+      <criteria operator="AND" comment="log_file not set">
+        <extend_definition comment="log file not set in auditd.conf"
+          definition_ref="auditd_conf_log_file_not_set" />
+        <extend_definition comment="log_group in auditd.conf is root"
+          definition_ref="auditd_conf_log_group_not_root" negate="true" />
+        <criterion comment="default audit log files are root group owned"
+          test_ref="{{{ rule_id }}}_test_group_ownership_default"/>
+      </criteria>
+    </criteria>
+  </definition>
+
+  <unix:file_test check="all" check_existence="none_exist" comment="audit log files gid root"
+  id="{{{ rule_id }}}_test_group_ownership" version="1">
+    <unix:object object_ref="{{{ rule_id }}}_object_group_ownership" />
+  </unix:file_test>
+
+  <unix:file_test check="all" check_existence="none_exist" comment="audit log files gid root"
+  id="{{{ rule_id }}}_test_group_ownership_default" version="1">
+    <unix:object object_ref="{{{ rule_id }}}_object_group_ownership_default" />
+  </unix:file_test>
+
+  <unix:file_object comment="audit log files" id="{{{ rule_id }}}_object_group_ownership"
+  version="1">
+    <unix:filepath operation="equals" var_ref="audit_log_file_path" />
+    <filter action="include">{{{ rule_id }}}_state_group_owner_not_root</filter>
+  </unix:file_object>
+
+  <unix:file_object comment="/var/log/audit files"
+  id="{{{ rule_id }}}_object_group_ownership_default" version="1">
+    <unix:filepath operation="equals">/var/log/audit/audit.log</unix:filepath>
+    <filter action="include">{{{ rule_id }}}_state_group_owner_not_root</filter>
+  </unix:file_object>
+
+  <unix:file_state id="{{{ rule_id }}}_state_group_owner_not_root" version="1" operator="OR">
+    <unix:group_id datatype="int" operation="not equal">0</unix:group_id>
+  </unix:file_state>
+
+</def-group>

--- a/linux_os/guide/auditing/auditd_configure_rules/file_group_ownership_var_log_audit_stig/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_group_ownership_var_log_audit_stig/rule.yml
@@ -1,0 +1,44 @@
+documentation_complete: true
+
+title: 'System Audit Logs Must Be Group Owned By Root'
+
+# This rule is specific to STIG, which has stricted requirements for group ownership
+# For CIS, use rule "file_group_ownership_var_log_audit"
+
+description: |-
+    All audit logs must be group owned by root user.
+
+    Determine where the audit logs are stored with the following command:
+    <pre>$ sudo grep -iw log_file /etc/audit/auditd.conf
+    log_file = /var/log/audit/audit.log</pre>
+
+    Using the path of the directory containing the audit logs, determine if the audit log files
+    are owned by the "root" group by using the following command:
+    <pre>$ sudo stat -c "%n %G" /var/log/audit/*
+    /var/log/audit/audit.log root</pre>
+    If the audit log files are owned by a group other than "root", this is a finding.
+
+    To remediate, configure the audit log directory and its underlying files to be owned by "root"
+    group.
+
+    Set the "log_group" parameter of the audit configuration file to the "root" value so when a
+    new log file is created, its group owner is properly set:
+    <pre>$ sudo sed -i '/^log_group/D' /etc/audit/auditd.conf
+    $ sudo sed -i /^log_file/a'log_group = root' /etc/audit/auditd.conf</pre>
+
+    Last, signal the audit daemon to reload the configuration file to update the group owners
+    of existing files:
+    <pre>$ sudo systemctl kill auditd -s SIGHUP</pre>
+
+rationale: |-
+    Unauthorized disclosure of audit records can reveal system and configuration data to
+    attackers, thus compromising its confidentiality.
+
+severity: medium
+
+references:
+    disa: CCI-000162
+    srg: SRG-OS-000057-GPOS-00027,SRG-OS-000058-GPOS-00028,SRG-OS-000059-GPOS-00029,SRG-OS-000206-GPOS-00084
+    stigid@ubuntu2004: UBTU-20-010124
+    stigid@ubuntu2204: UBTU-22-653055
+

--- a/linux_os/guide/auditing/auditd_configure_rules/file_group_ownership_var_log_audit_stig/tests/common.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_group_ownership_var_log_audit_stig/tests/common.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+sed -i "/^\s*log_file.*/d" /etc/audit/auditd.conf
+sed -i "/^\s*log_group.*/d" /etc/audit/auditd.conf
+
+groupadd group_test
+rm -f /var/log/audit/*
+mkdir -p /var/log/audit2
+
+FILE1=/var/log/audit/audit.log
+FILE2=/var/log/audit2/audit.log
+
+touch ${FILE1}
+touch ${FILE2}

--- a/linux_os/guide/auditing/auditd_configure_rules/file_group_ownership_var_log_audit_stig/tests/correct_value.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_group_ownership_var_log_audit_stig/tests/correct_value.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# packages = audit
+
+source common.sh
+
+echo "log_group = root" >> /etc/audit/auditd.conf
+echo "log_file = ${FILE2}" >> /etc/audit/auditd.conf
+
+chgrp root ${FILE2}

--- a/linux_os/guide/auditing/auditd_configure_rules/file_group_ownership_var_log_audit_stig/tests/correct_value_default_file.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_group_ownership_var_log_audit_stig/tests/correct_value_default_file.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# packages = audit
+
+source common.sh
+
+echo "log_group = root" >> /etc/audit/auditd.conf
+
+chgrp root ${FILE1}

--- a/linux_os/guide/auditing/auditd_configure_rules/file_group_ownership_var_log_audit_stig/tests/wrong_value.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_group_ownership_var_log_audit_stig/tests/wrong_value.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# packages = audit
+
+source common.sh
+
+echo "log_group = root" >> /etc/audit/auditd.conf
+echo "log_file = ${FILE2}" >> /etc/audit/auditd.conf
+
+chgrp group_test ${FILE2}

--- a/linux_os/guide/auditing/auditd_configure_rules/file_group_ownership_var_log_audit_stig/tests/wrong_value_default_file.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_group_ownership_var_log_audit_stig/tests/wrong_value_default_file.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# packages = audit
+
+source common.sh
+
+echo "log_group = root" >> /etc/audit/auditd.conf
+
+chgrp group_test ${FILE1}

--- a/linux_os/guide/auditing/auditd_configure_rules/file_group_ownership_var_log_audit_stig/tests/wrong_value_non-root_group.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_group_ownership_var_log_audit_stig/tests/wrong_value_non-root_group.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# packages = audit
+
+source common.sh
+
+echo "log_group = group_test" >> /etc/audit/auditd.conf
+echo "log_file = ${FILE2}" >> /etc/audit/auditd.conf
+
+chgrp root ${FILE1}
+chgrp root ${FILE2}

--- a/products/ubuntu2204/profiles/stig.profile
+++ b/products/ubuntu2204/profiles/stig.profile
@@ -211,9 +211,8 @@ selections:
     # UBTU-22-653050 The Ubuntu operating system must be configured to permit only authorized users ownership of the audit log files.
     - file_ownership_var_log_audit_stig
 
-    ### TODO (double check, focal uses _stig)
     # UBTU-22-653055 The Ubuntu operating system must permit only authorized groups ownership of the audit log files.
-    - file_group_ownership_var_log_audit
+    - file_group_ownership_var_log_audit_stig
 
     # UBTU-22-653060 The Ubuntu operating system must be configured so that the audit log directory is not write-accessible by unauthorized users.
     - directory_permissions_var_log_audit


### PR DESCRIPTION
#### Description:

 - Update UBTU-22-653055 (file_group_ownership_var_log_audit_stig) to STIG v1r10: auditd logs can no longer be group-owned by adm, only by root
 - Update OVAL and Bash remediation and fix to allow only root
 - Fix tests
 - Needs to be upstreamed

#### Rationale:

To limit audit log file ownership to root ensures compliance with UBTU-22-653055.