### PR TITLE
Fix Ubuntu faillock

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/commented.fail.sh
@@ -2,7 +2,7 @@
 # platform = multi_platform_ubuntu,multi_platform_sle
 # packages = libpam-pkcs11
 {{% if 'ubuntu' in product %}}
-echo '# auth [success=2 default=ignore] pam_pkcs11.so' > /etc/pam.d/common-auth
+sed -i '/^auth.*pam_unix.so/i # auth [success=2 default=ignore] pam_pkcs11.so' /etc/pam.d/common-auth
 {{% else %}}
 echo '# auth sufficient pam_pkcs11.so' > /etc/pam.d/common-auth
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/correct.pass.sh
@@ -3,7 +3,7 @@
 # packages = libpam-pkcs11
 
 {{% if 'ubuntu' in product %}}
-echo 'auth [success=2 default=ignore] pam_pkcs11.so' > /etc/pam.d/common-auth
+sed -i '/^auth.*pam_unix.so/i auth [success=2 default=ignore] pam_pkcs11.so' /etc/pam.d/common-auth
 {{% else %}}
 echo 'auth sufficient pam_pkcs11.so' > /etc/pam.d/common-auth
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/nothing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/nothing.fail.sh
@@ -2,4 +2,4 @@
 # platform = multi_platform_ubuntu,multi_platform_sle
 # packages = libpam-pkcs11
 
-echo > /etc/pam.d/common-auth
+echo "auth	[success=1 default=ignore]	pam_unix.so nullok" > /etc/pam.d/common-auth

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/substring.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/substring.fail.sh
@@ -3,7 +3,7 @@
 # packages = libpam-pkcs11
 
 {{% if 'ubuntu' in product %}}
-echo 'aauth [success=2 default=ignore] pam_pkcs11.so' > /etc/pam.d/common-auth
+sed -i '/^auth.*pam_unix.so/i aauth [success=2 default=ignore] pam_pkcs11.so' /etc/pam.d/common-auth
 {{% else %}}
 echo 'aauth sufficient pam_pkcs11.so' > /etc/pam.d/common-auth
 {{% endif %}}

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -988,7 +988,7 @@ fi
 #}}
 {{%- macro bash_pam_faillock_parameter_value(option, value='', authfail=True) -%}}
 {{% if 'ubuntu' in product %}}
-AUTH_FILES=("/etc/pam.d/common-auth" "/etc/pam.d/password-auth")
+AUTH_FILES=("/etc/pam.d/common-auth")
 {{% else %}}
 AUTH_FILES=("/etc/pam.d/system-auth" "/etc/pam.d/password-auth")
 {{% endif %}}


### PR DESCRIPTION
#### Description:

- Complete the #11488
- Fix tests

#### Rationale:

-  Remove unused file /etc/pam.d/password-auth to avoid false failed check