### PR TITLE
[stabilization] do not restrict Ansible remediation of zipl_bootmap_is_up_to_date to RHEL 8 only

### DIFF
--- a/linux_os/guide/system/bootloader-zipl/zipl_bootmap_is_up_to_date/ansible/shared.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_bootmap_is_up_to_date/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 8
+# platform = multi_platform_all
 # reboot = false
 # strategy = configure
 # complexity = low


### PR DESCRIPTION
#### Description:

- change the platform of the remediation to multi_platform_all

#### Rationale:

- the bash remediation is applicable to all products, there is no apparent reason why the Ansible remediaiton should be restricted to RHEL 8 only


#### Review Hints:

1. access an s390 machine
2. run Automatus tests on this rule