### PR TITLE
[Stabilization]: add rule configure_firewalld_ports to the rhel9 default profile

### DIFF
--- a/products/rhel9/profiles/default.profile
+++ b/products/rhel9/profiles/default.profile
@@ -552,3 +552,4 @@ selections:
     - audit_rules_unsuccessful_file_modification_fchmodat
     - sebool_polipo_session_users
     - sebool_cluster_manage_all_files
+    - configure_firewalld_ports


### PR DESCRIPTION
#### Description:

- add the rule to the default profile

#### Rationale:

- this ensures that the rule will be present in the rhel9 datastream. It used to be there at the time 9.0 was released and we don't want to introduce regression in this area.



#### Review Hints:

Check list of rules in the rhel9 datastream for the presence of configure_firewalld_ports