### PR TITLE
OCPBUGS-33194: Fix text in rule file_groupowner_ovs_conf_db_lock

### DIFF
--- a/applications/openshift/master/file_groupowner_ovs_conf_db_lock/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_lock/rule.yml
@@ -6,7 +6,7 @@ platform: ocp4-node
 title: 'Verify Group Who Owns The Open vSwitch Configuration Database Lock'
 
 description: |-
-    Check if the group owner of <code>/etc/openvswitch/conf.db.~lock~</code> is
+    Check if the group owner of <code>/etc/openvswitch/.conf.db.~lock~</code> is
     <code>hugetlbfs</code> on architectures other than s390x or <code>openvswitch</code>
     on s390x.
 
@@ -28,12 +28,12 @@ references:
     srg: SRG-APP-000516-CTR-001325
 
 ocil_clause: |-
-  <code>/etc/openvswitch/conf.db.~lock~</code> does not have a group owner of
+  <code>/etc/openvswitch/.conf.db.~lock~</code> does not have a group owner of
   code>hugetlbfs</code> on architectures other than s390x or <code>openvswitch</code>
   on s390x.
 
 ocil: |-
-    To check the group ownership of <code>/etc/openvswitch/conf.db~lock~</code>,
+    To check the group ownership of <code>/etc/openvswitch/.conf.db~lock~</code>,
     you'll need to log into a node in the cluster.
     As a user with administrator privileges, log into a node in the relevant pool:
     <pre>
@@ -45,7 +45,7 @@ ocil: |-
     </pre>
     Then,
     run the command:
-    <pre>$ ls -lL /etc/openvswitch/conf.db~lock~</pre>
+    <pre>$ ls -lL /etc/openvswitch/.conf.db~lock~</pre>
     If properly configured, the output should indicate the following group-owner:
     <code>hugetlbfs</code> on architectures other than s390x. On s390x, the
     group-owner should be <code>openvswitch</code>.


### PR DESCRIPTION

#### Description:

- The correct path for the db lock file is:
  /etc/openvswitch/.conf.db.\~lock~
- Note: the rule checked the correct path. Only the description was incorrect.

#### Rationale:

- The rule description should be accurate.