### PR TITLE
Populate _rule_id virtual template parameter in Automatus

### DIFF
--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -500,6 +500,7 @@ def load_templated_tests(
 def load_test(absolute_path, rule_template, local_env_yaml):
     template_name = rule_template['name']
     template_vars = rule_template['vars']
+    template_vars["_rule_id"] = local_env_yaml["rule_id"]
     # Load template parameters and apply it to the test case.
     maybe_template = ssg.templates.Template.load_template(_SHARED_TEMPLATES, template_name)
     if maybe_template is not None:


### PR DESCRIPTION
Templates have an implicit (virtual) parameter `_rule_id` that contains rule ID of the currently processed rule. This parameter is added by the build system and is passed to template preprocessing function. However, this parameter isn't set in when invoking the templating subsystem Automatus when resolving templated TSs. This causes some of the template preprocessing functions to traceback when testing templated rules in Automatus.

Addressing:

```
Traceback (most recent call last):
  File "/home/jcerny/work/git/scap-security-guide/tests/automatus.py", line 518, in <module>
    main()
  File "/home/jcerny/work/git/scap-security-guide/tests/automatus.py", line 514, in main
    options.func(options)
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/rule.py", line 676, in perform_rule_check
    checker.test_target()
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/oscap.py", line 685, in test_target
    self._test_target()
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/rule.py", line 444, in _test_target
    test_content_by_rule_id = self._get_test_content_by_rule_id(
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/rule.py", line 427, in _get_test_content_by_rule_id
    rule_test_content = self._get_rule_test_content(rule)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/rule.py", line 409, in _get_rule_test_content
    all_tests = self._load_all_tests(rule)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/rule.py", line 399, in _load_all_tests
    templated_tests = common.load_templated_tests(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/common.py", line 494, in load_templated_tests
    test = load_test(path, template, local_env_yaml)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/common.py", line 506, in load_test
    template_parameters = maybe_template.preprocess(template_vars, "tests")
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jcerny/work/git/scap-security-guide/tests/../ssg/templates.py", line 95, in preprocess
    parameters = self._preprocess_with_template_module(parameters, lang)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jcerny/work/git/scap-security-guide/tests/../ssg/templates.py", line 112, in _preprocess_with_template_module
    parameters = preprocess_mod.preprocess(parameters.copy(), lang)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jcerny/work/git/scap-security-guide/shared/templates/audit_rules_watch/template.py", line 3, in preprocess
    data["key"] = data["_rule_id"]
                  ~~~~^^^^^^^^^^^^
KeyError: '_rule_id'
```

Fixes: #11940


