### PR TITLE
Fixed PAM configuration of pkcs11 module in common-auth file

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/ansible/shared.yml
@@ -13,7 +13,7 @@
 {{%- if 'sle' in product %}}
   {{%- set pam_pkcs11_control_flag = "sufficient" %}}
 {{%- else %}}
-  {{%- set pam_pkcs11_control_flag = "\u005Bsuccess=2 default=ignore\u005D" %}}
+  {{%- set pam_pkcs11_control_flag = "\u005Bsuccess=3 default=ignore\u005D" %}}
 {{% endif %}}
 
 - name: "{{{ rule_title }}} - Gather List of Packages"

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/bash/shared.sh
@@ -1,6 +1,6 @@
 # platform = multi_platform_sle,multi_platform_ubuntu
 {{% if 'ubuntu' in product %}}
-{{{ bash_ensure_pam_module_option('/etc/pam.d/common-auth', 'auth', '[success=2 default=ignore]', 'pam_pkcs11.so', '', '', '# here are the per-package modules') }}}
+{{{ bash_ensure_pam_module_option('/etc/pam.d/common-auth', 'auth', '[success=3 default=ignore]', 'pam_pkcs11.so', '', '', '# here are the per-package modules') }}}
 {{% else %}}
 {{{ bash_ensure_pam_module_options('/etc/pam.d/common-auth', 'auth','sufficient', 'pam_pkcs11.so', '', '', '') }}}
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/rule.yml
@@ -15,7 +15,7 @@ description: |-
     <pre># grep pam_pkcs11.so /etc/pam.d/common-auth
 
     {{% if 'ubuntu' in product %}}
-    auth [success=2 default=ignore] pam_pkcs11.so</pre>
+    auth [success=3 default=ignore] pam_pkcs11.so</pre>
     {{% else %}}
     auth sufficient pam_pkcs11.so</pre>
     {{% endif %}}
@@ -82,7 +82,7 @@ ocil: |-
     <pre># grep pam_pkcs11.so /etc/pam.d/common-auth
 
     {{% if 'ubuntu' in product %}}
-    auth [success=2 default=ignore] pam_pkcs11.so</pre>
+    auth [success=3 default=ignore] pam_pkcs11.so</pre>
     {{% else %}}
     auth sufficient pam_pkcs11.so</pre>
     {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/commented.fail.sh
@@ -2,7 +2,7 @@
 # platform = multi_platform_ubuntu,multi_platform_sle
 # packages = libpam-pkcs11
 {{% if 'ubuntu' in product %}}
-sed -i '/^auth.*pam_unix.so/i # auth [success=2 default=ignore] pam_pkcs11.so' /etc/pam.d/common-auth
+sed -i '/^auth.*pam_unix.so/i # auth [success=3 default=ignore] pam_pkcs11.so' /etc/pam.d/common-auth
 {{% else %}}
 echo '# auth sufficient pam_pkcs11.so' > /etc/pam.d/common-auth
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/correct.pass.sh
@@ -3,7 +3,7 @@
 # packages = libpam-pkcs11
 
 {{% if 'ubuntu' in product %}}
-sed -i '/^auth.*pam_unix.so/i auth [success=2 default=ignore] pam_pkcs11.so' /etc/pam.d/common-auth
+sed -i '/^auth.*pam_unix.so/i auth [success=3 default=ignore] pam_pkcs11.so' /etc/pam.d/common-auth
 {{% else %}}
 echo 'auth sufficient pam_pkcs11.so' > /etc/pam.d/common-auth
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/substring.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/substring.fail.sh
@@ -3,7 +3,7 @@
 # packages = libpam-pkcs11
 
 {{% if 'ubuntu' in product %}}
-sed -i '/^auth.*pam_unix.so/i aauth [success=2 default=ignore] pam_pkcs11.so' /etc/pam.d/common-auth
+sed -i '/^auth.*pam_unix.so/i aauth [success=3 default=ignore] pam_pkcs11.so' /etc/pam.d/common-auth
 {{% else %}}
 echo 'aauth sufficient pam_pkcs11.so' > /etc/pam.d/common-auth
 {{% endif %}}


### PR DESCRIPTION
#### Description:

- Corrected the ordering of modules to match the desired authentication sequence.

#### Rationale:

- The current PAM configuration has an issue with the actions for pam_pkcs11 and pam_unix. 

