### PR TITLE
Fix accounts_umask_etc_bashrc

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/ansible/shared.yml
@@ -14,7 +14,7 @@
 - name: Check if umask in {{{ etc_bash_rc }}} is already set
   ansible.builtin.lineinfile:
     path: {{{ etc_bash_rc }}}
-    regexp: ^[^#]*\bumask\s+
+    regexp: ^[^#]*\bumask\s+\d+$
     state: absent
   check_mode: true
   changed_when: false
@@ -23,8 +23,8 @@
 - name: Replace user umask in {{{ etc_bash_rc }}}
   ansible.builtin.replace:
     path: {{{ etc_bash_rc }}}
-    regexp: ^([^#]*\b)umask(\s*)
-    replace: \g<1>umask\g<2>{{ var_accounts_user_umask }}
+    regexp: ^([^#]*\b)umask\s+\d+$
+    replace: \g<1>umask {{ var_accounts_user_umask }}
   when:
   - umask_replace.found > 0
 

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/oval/shared.xml
@@ -16,7 +16,7 @@
   <ind:textfilecontent54_object id="obj_umask_from_etc_bashrc"
   comment="Umask value from {{{ etc_bash_rc }}}" version="1">
     <ind:filepath>{{{ etc_bash_rc }}}</ind:filepath>
-    <ind:pattern operation="pattern match">^[^#]*\bumask\s+([^#\s]*)</ind:pattern>
+    <ind:pattern operation="pattern match">^[^#]*\bumask\s+(\d{3})\s*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/wrong_and_mangled_and_not_at_the_begining_of_line.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/wrong_and_mangled_and_not_at_the_begining_of_line.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# packages = bash
+
+# This TS is a regression test for https://github.com/ComplianceAsCode/content/issues/11937
+
+sed -i '/umask/d' /etc/bashrc
+echo "    [ \`umask\` -eq 0 ] && umask 027022" >> /etc/bashrc
+umask 000

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/wrong_and_not_at_the_begining_of_line.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/wrong_and_not_at_the_begining_of_line.fail.sh
@@ -2,5 +2,5 @@
 # packages = bash
 
 sed -i '/umask/d' /etc/bashrc
-echo "    [ `umask` -eq 0 ] && umask 022" >> /etc/bashrc
+echo "    [ \`umask\` -eq 0 ] && umask 022" >> /etc/bashrc
 umask 000


### PR DESCRIPTION
Fix accounts_umask_etc_bashrc content misalignment with RHEL 9 DISA STIG.

- Only valid umask values (3-digits) will match in OVAL
- Do not concatenate original value with the new value in Ansible remediation
- Add a regression test for #11937
- Fix bash quoting in test scenario

Fixes: #11937
