### PR TITLE
Include test scenario for multiple partitions

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_multiple_partitions.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_multiple_partitions.fail.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# packages = audit
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
+
+. $SHARED/partition.sh
+
+for num in 1 2; do
+    # PARTITION variable is used in $SHARED/partition.sh
+    PARTITION="/dev/new_partition$num"
+    MOUNT_POINT="/mnt/partition$num"
+
+    mkdir -p $MOUNT_POINT
+    create_partition
+    make_fstab_given_partition_line $MOUNT_POINT ext2
+    mount_partition $MOUNT_POINT
+
+    touch $MOUNT_POINT/priv_cmd
+    chmod +xs $MOUNT_POINT/priv_cmd
+done


### PR DESCRIPTION
#### Description:

An issue in the Ansible remediation was fixed by #11174 and later improved by #11263 but no test scenario was included to test this condition where there are privileged commands in different partitions.

#### Rationale:

- Better test scenarios coverage
- Related to [RHEL-25828](https://issues.redhat.com/browse/RHEL-25828)

#### Review Hints:

automatus tests should be enough.
It could also be checked the reports generated by automatus tests in the reports folder.
