### PR TITLE
CMP-2543: Implement whitelist for configure-network-policies-namespaces

### DIFF
--- a/applications/openshift/networking/configure_network_policies_namespaces/oval/shared.xml
+++ b/applications/openshift/networking/configure_network_policies_namespaces/oval/shared.xml
@@ -1,8 +1,8 @@
 <def-group>
 {{% set networkpolicies_api_path = '/apis/networking.k8s.io/v1/networkpolicies' %}}
 {{% set namespaces_api_path = '/api/v1/namespaces' %}}
-{{% set networkpolicies_for_non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.namespace | startswith("openshift") | not) and (.metadata.namespace | startswith("kube-") | not) and .metadata.namespace != "default") | .metadata.namespace] | unique' %}}
-{{% set non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default")]' %}}
+{{% set networkpolicies_for_non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.namespace | startswith("openshift") | not) and (.metadata.namespace | startswith("kube-") | not) and .metadata.namespace != "default" and ({{if ne .var_network_policies_namespaces_whitelist_regex "None"}}.metadata.namespace | test("{{.var_network_policies_namespaces_whitelist_regex}}") | not{{else}}true{{end}})) | .metadata.namespace] | unique' %}}
+{{% set non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default" and ({{if ne .var_network_policies_namespaces_whitelist_regex "None"}}.metadata.name | test("{{.var_network_policies_namespaces_whitelist_regex}}") | not{{else}}true{{end}}))]' %}}
   <definition class="compliance" id="configure_network_policies_namespaces" version="1">
     {{{ oval_metadata("Ensure that application Namespaces have Network Policies defined") }}}
     <criteria>

--- a/applications/openshift/networking/configure_network_policies_namespaces/oval/shared.xml
+++ b/applications/openshift/networking/configure_network_policies_namespaces/oval/shared.xml
@@ -1,8 +1,8 @@
 <def-group>
 {{% set networkpolicies_api_path = '/apis/networking.k8s.io/v1/networkpolicies' %}}
 {{% set namespaces_api_path = '/api/v1/namespaces' %}}
-{{% set networkpolicies_for_non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.namespace | startswith("openshift") | not) and (.metadata.namespace | startswith("kube-") | not) and .metadata.namespace != "default" and ({{if ne .var_network_policies_namespaces_whitelist_regex "None"}}.metadata.namespace | test("{{.var_network_policies_namespaces_whitelist_regex}}") | not{{else}}true{{end}})) | .metadata.namespace] | unique' %}}
-{{% set non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default" and ({{if ne .var_network_policies_namespaces_whitelist_regex "None"}}.metadata.name | test("{{.var_network_policies_namespaces_whitelist_regex}}") | not{{else}}true{{end}}))]' %}}
+{{% set networkpolicies_for_non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.namespace | startswith("openshift") | not) and (.metadata.namespace | startswith("kube-") | not) and .metadata.namespace != "default" and ({{if ne .var_network_policies_namespaces_exempt_regex "None"}}.metadata.namespace | test("{{.var_network_policies_namespaces_exempt_regex}}") | not{{else}}true{{end}})) | .metadata.namespace] | unique' %}}
+{{% set non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default" and ({{if ne .var_network_policies_namespaces_exempt_regex "None"}}.metadata.name | test("{{.var_network_policies_namespaces_exempt_regex}}") | not{{else}}true{{end}}))]' %}}
   <definition class="compliance" id="configure_network_policies_namespaces" version="1">
     {{{ oval_metadata("Ensure that application Namespaces have Network Policies defined") }}}
     <criteria>
@@ -10,8 +10,17 @@
                  test_ref="test_file_for_configure_network_policies_namespaces"/>
       <criterion comment="Make sure that the file '{{{ openshift_filtered_path(namespaces_api_path, non_ctlplane_namespaces_filter) }}}' exists."
                  test_ref="test_file_for_configure_network_policies_filtered_namespaces"/>
-      <criterion comment="Make sure that all target elements exists for elements at path &#39;.items[:].spec.host&#39;"
-                 test_ref="test_elements_count_for_configure_network_policies_namespaces"/>
+      <criteria operator="OR">
+        <criterion comment="Make sure that all target elements exists for elements at path &#39;.items[:].spec.host&#39;"
+        test_ref="test_elements_count_for_configure_network_policies_namespaces"/>
+        <criteria operator="AND">
+          <criterion comment="Make sure that there are no network policies in non-ctlplane namespaces"
+          test_ref="test_configure_network_policies_namespaces"/>
+          <criterion comment="Make sure that there are no namespaces in non-ctlplane namespaces"
+          test_ref="test_configure_network_policies_filtered_namespaces"/>
+        </criteria>
+      </criteria>
+
     </criteria>
   </definition>
 
@@ -62,6 +71,10 @@
     </count>
   </local_variable>
 
+  <ind:yamlfilecontent_test id="test_configure_network_policies_namespaces" version="1" check="all" comment="Make sure there are no count for network policies in non-ctlplane namespaces" check_existence="none_exist" state_operator="AND">
+    <ind:object object_ref="object_configure_network_policies_namespaces"/>
+  </ind:yamlfilecontent_test>
+
   <ind:yamlfilecontent_object id="object_configure_network_policies_filtered_namespaces" version="1">
     <ind:filepath var_ref="configure_network_policies_filtered_namespaces_file_location"/>
     <ind:yamlpath>[:].metadata.name</ind:yamlpath>
@@ -71,6 +84,10 @@
       <object_component object_ref="object_configure_network_policies_filtered_namespaces" item_field="value" record_field="#"/>
     </count>
   </local_variable>
+
+  <ind:yamlfilecontent_test id="test_configure_network_policies_filtered_namespaces" version="1" check="all" comment="Make sure there are no count for namespaces in non-ctlplane namespaces" check_existence="none_exist" state_operator="AND">
+    <ind:object object_ref="object_configure_network_policies_filtered_namespaces"/>
+  </ind:yamlfilecontent_test>
   
   <!-- Object counts -->
   <ind:variable_test version="1" id="test_elements_count_for_configure_network_policies_namespaces" check="all"

--- a/applications/openshift/networking/configure_network_policies_namespaces/rule.yml
+++ b/applications/openshift/networking/configure_network_policies_namespaces/rule.yml
@@ -26,14 +26,14 @@ references:
 
 {{% set networkpolicies_api_path = '/apis/networking.k8s.io/v1/networkpolicies' %}}
 {{% set namespaces_api_path = '/api/v1/namespaces' %}}
-{{% set networkpolicies_for_non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.namespace | startswith("openshift") | not) and (.metadata.namespace | startswith("kube-") | not) and .metadata.namespace != "default" and ({{if ne .var_network_policies_namespaces_whitelist_regex "None"}}.metadata.namespace | test("{{.var_network_policies_namespaces_whitelist_regex}}") | not{{else}}true{{end}})) | .metadata.namespace] | unique' %}}
-{{% set non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default" and ({{if ne .var_network_policies_namespaces_whitelist_regex "None"}}.metadata.name | test("{{.var_network_policies_namespaces_whitelist_regex}}") | not{{else}}true{{end}}))]' %}}
+{{% set networkpolicies_for_non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.namespace | startswith("openshift") | not) and (.metadata.namespace | startswith("kube-") | not) and .metadata.namespace != "default" and ({{if ne .var_network_policies_namespaces_exempt_regex "None"}}.metadata.namespace | test("{{.var_network_policies_namespaces_exempt_regex}}") | not{{else}}true{{end}})) | .metadata.namespace] | unique' %}}
+{{% set non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default" and ({{if ne .var_network_policies_namespaces_exempt_regex "None"}}.metadata.name | test("{{.var_network_policies_namespaces_exempt_regex}}") | not{{else}}true{{end}}))]' %}}
 platform: not ocp4-on-hypershift
 
 ocil_clause: 'Namespaced Network Policies needs review'
 
 # same as above except filters the names only. Used in OCIL only, not in the 'warnings attribute'
-{{% set non_ctlplane_namespaces_filter_names = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default" and ({{if ne .var_network_policies_namespaces_whitelist_regex "None"}}.metadata.name | test("{{.var_network_policies_namespaces_whitelist_regex}}") | not{{else}}true{{end}})) | .metadata.name ]' %}}
+{{% set non_ctlplane_namespaces_filter_names = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default" and ({{if ne .var_network_policies_namespaces_exempt_regex "None"}}.metadata.name | test("{{.var_network_policies_namespaces_exempt_regex}}") | not{{else}}true{{end}})) | .metadata.name ]' %}}
 
 ocil: |-
     Verify that the every non-control plane namespace has an appropriate
@@ -45,6 +45,8 @@ ocil: |-
     To get all the non-control plane namespaces with a NetworkPolicy, you can do the
     following command <tt>{{{ ocil_oc_pipe_jq_filter('networkpolicies', networkpolicies_for_non_ctlplane_namespaces_filter, all_namespaces=true) }}}</tt>
 
+    Namespaces matching the variable <tt>ocp4-var-network-policies-namespaces-exempt-regex</tt> regex are excluded from this check.
+    
     Make sure that the namespaces displayed in the commands of the commands match.
 
 warnings:

--- a/applications/openshift/networking/configure_network_policies_namespaces/rule.yml
+++ b/applications/openshift/networking/configure_network_policies_namespaces/rule.yml
@@ -26,15 +26,14 @@ references:
 
 {{% set networkpolicies_api_path = '/apis/networking.k8s.io/v1/networkpolicies' %}}
 {{% set namespaces_api_path = '/api/v1/namespaces' %}}
-{{% set networkpolicies_for_non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.namespace | startswith("openshift") | not) and (.metadata.namespace | startswith("kube-") | not) and .metadata.namespace != "default") | .metadata.namespace] | unique' %}}
-{{% set non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default")]' %}}
-
+{{% set networkpolicies_for_non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.namespace | startswith("openshift") | not) and (.metadata.namespace | startswith("kube-") | not) and .metadata.namespace != "default" and ({{if ne .var_network_policies_namespaces_whitelist_regex "None"}}.metadata.namespace | test("{{.var_network_policies_namespaces_whitelist_regex}}") | not{{else}}true{{end}})) | .metadata.namespace] | unique' %}}
+{{% set non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default" and ({{if ne .var_network_policies_namespaces_whitelist_regex "None"}}.metadata.name | test("{{.var_network_policies_namespaces_whitelist_regex}}") | not{{else}}true{{end}}))]' %}}
 platform: not ocp4-on-hypershift
 
 ocil_clause: 'Namespaced Network Policies needs review'
 
 # same as above except filters the names only. Used in OCIL only, not in the 'warnings attribute'
-{{% set non_ctlplane_namespaces_filter_names = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default") | .metadata.name ]' %}}
+{{% set non_ctlplane_namespaces_filter_names = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default" and ({{if ne .var_network_policies_namespaces_whitelist_regex "None"}}.metadata.name | test("{{.var_network_policies_namespaces_whitelist_regex}}") | not{{else}}true{{end}})) | .metadata.name ]' %}}
 
 ocil: |-
     Verify that the every non-control plane namespace has an appropriate

--- a/applications/openshift/networking/configure_network_policies_namespaces/tests/ocp4/e2e.yml
+++ b/applications/openshift/networking/configure_network_policies_namespaces/tests/ocp4/e2e.yml
@@ -1,3 +1,2 @@
 ---
-default_result: FAIL
-result_after_remediation: PASS
+default_result: PASS

--- a/applications/openshift/networking/var_network_policies_namespaces_exempt_regex.var
+++ b/applications/openshift/networking/var_network_policies_namespaces_exempt_regex.var
@@ -5,7 +5,7 @@ title: 'Namespaces exempt of Network Policies'
 description: |-
     Namespaces regular expression explicitly allowed
     through network policy filters, e.g. setting value to
-    "namespace1|namespace2" will whitelist namespace
+    "namespace1|namespace2" will exempt namespace
     "namespace1" and "namespace2" for network policies checks.
 
 type: string

--- a/applications/openshift/networking/var_network_policies_namespaces_whitelist_regex.var
+++ b/applications/openshift/networking/var_network_policies_namespaces_whitelist_regex.var
@@ -1,0 +1,18 @@
+documentation_complete: true
+
+title: 'Whitelist Namespaces for Network Policies'
+
+description: |-
+    Namespaces regular expression explicitly allowed
+    through network policy filters, e.g. setting value to
+    "namespace1|namespace2" will whitelist namespace
+    "namespace1" and "namespace2" for network policies checks.
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+  default: "None"

--- a/applications/openshift/networking/var_network_policies_namespaces_whitelist_regex.var
+++ b/applications/openshift/networking/var_network_policies_namespaces_whitelist_regex.var
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Whitelist Namespaces for Network Policies'
+title: 'Namespaces exempt of Network Policies'
 
 description: |-
     Namespaces regular expression explicitly allowed

--- a/applications/openshift/networking/var_network_policies_namespaces_whitelist_regex.var
+++ b/applications/openshift/networking/var_network_policies_namespaces_whitelist_regex.var
@@ -12,7 +12,7 @@ type: string
 
 operator: equals
 
-interactive: false
+interactive: true
 
 options:
   default: "None"

--- a/tests/assertions/ocp4/ocp4-cis-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.13.yml
@@ -136,8 +136,7 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-cis-configure-network-policies-namespaces:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: PASS
   e2e-cis-controller-insecure-port-disabled:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-cis-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.14.yml
@@ -136,8 +136,7 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-cis-configure-network-policies-namespaces:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: PASS
   e2e-cis-controller-insecure-port-disabled:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-cis-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.15.yml
@@ -138,8 +138,7 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-cis-configure-network-policies-namespaces:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: PASS
   e2e-cis-controller-insecure-port-disabled:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-cis-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.16.yml
@@ -136,8 +136,7 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-cis-configure-network-policies-namespaces:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: PASS
   e2e-cis-controller-insecure-port-disabled:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.13.yml
@@ -176,8 +176,7 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-high-configure-network-policies-namespaces:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: PASS
   e2e-high-controller-insecure-port-disabled:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.14.yml
@@ -176,8 +176,7 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-high-configure-network-policies-namespaces:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: PASS
   e2e-high-controller-insecure-port-disabled:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.15.yml
@@ -180,8 +180,7 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-high-configure-network-policies-namespaces:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: PASS
   e2e-high-controller-insecure-port-disabled:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.16.yml
@@ -180,8 +180,7 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-high-configure-network-policies-namespaces:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: PASS
   e2e-high-controller-insecure-port-disabled:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.13.yml
@@ -174,8 +174,7 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-moderate-configure-network-policies-namespaces:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: PASS
   e2e-moderate-controller-insecure-port-disabled:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.14.yml
@@ -174,8 +174,7 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-moderate-configure-network-policies-namespaces:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: PASS
   e2e-moderate-controller-insecure-port-disabled:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.15.yml
@@ -171,8 +171,7 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-moderate-configure-network-policies-namespaces:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: PASS
   e2e-moderate-controller-insecure-port-disabled:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.16.yml
@@ -174,8 +174,7 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-moderate-configure-network-policies-namespaces:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: PASS
   e2e-moderate-controller-insecure-port-disabled:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.13.yml
@@ -138,8 +138,7 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-pci-dss-configure-network-policies-namespaces:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: PASS
   e2e-pci-dss-controller-insecure-port-disabled:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.14.yml
@@ -138,8 +138,7 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-pci-dss-configure-network-policies-namespaces:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: PASS
   e2e-pci-dss-controller-insecure-port-disabled:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.15.yml
@@ -138,8 +138,7 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-pci-dss-configure-network-policies-namespaces:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: PASS
   e2e-pci-dss-controller-insecure-port-disabled:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.16.yml
@@ -138,8 +138,7 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-pci-dss-configure-network-policies-namespaces:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: PASS
   e2e-pci-dss-controller-insecure-port-disabled:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-stig-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.13.yml
@@ -150,8 +150,7 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-stig-configure-network-policies-namespaces:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: PASS
   e2e-stig-container-security-operator-exists:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-stig-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.14.yml
@@ -150,8 +150,7 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-stig-configure-network-policies-namespaces:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: PASS
   e2e-stig-container-security-operator-exists:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-stig-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.15.yml
@@ -150,8 +150,7 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-stig-configure-network-policies-namespaces:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: PASS
   e2e-stig-container-security-operator-exists:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-stig-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.16.yml
@@ -150,8 +150,7 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-stig-configure-network-policies-namespaces:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: PASS
   e2e-stig-container-security-operator-exists:
     default_result: FAIL
     result_after_remediation: PASS


### PR DESCRIPTION
Added a new varible var_network_policies_namespaces_whitelist_regex, and updated the rule `configure_network_policies_namespaces` so user is able to excude namespaces by setting this variable to the regex of namespace they want to exclude for this rule
