### PR TITLE
Fix tests for sssd_offline_cred_expiration for Ubuntu

### DIFF
--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/cache_credentials_false.pass.sh
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/cache_credentials_false.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = sssd
 
 # platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 source common.sh

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/comment.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/comment.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = sssd
 
 source common.sh
 

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/common.sh
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/common.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
+# packages = sssd
 
 SSSD_CONF="/etc/sssd/sssd.conf"
 
+{{% if 'ubuntu' not in product %}}
 yum -y install /usr/lib/systemd/system/sssd.service
+{{% endif %}}
 systemctl enable sssd
 mkdir -p /etc/sssd
 touch $SSSD_CONF

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/correct_value.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = sssd
 
 source common.sh
 

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/correct_value_conf_d.pass.sh
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/correct_value_conf_d.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = sssd
 
 source common.sh
 

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/correct_value_dropin.pass.sh
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/correct_value_dropin.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = sssd
 
 source common.sh
 

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/wrong_section.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/wrong_section.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = sssd
 
 source common.sh
 

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/wrong_value.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = sssd
 
 source common.sh
 

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/wrong_value_conf_d.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/wrong_value_conf_d.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = sssd
 
 source common.sh
 


### PR DESCRIPTION
#### Description:

- Add `sssd` package to `sssd_offline_cred_expiration` tests

#### Rationale:

- `sssd` is not installed by default on Ubuntu
