### PR TITLE
Do not restrict Ansible remediation of zipl_bootmap_is_up_to_date to RHEL 8 only

### DIFF
--- a/linux_os/guide/system/bootloader-zipl/zipl_bootmap_is_up_to_date/ansible/shared.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_bootmap_is_up_to_date/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 8
+# platform = multi_platform_all
 # reboot = false
 # strategy = configure
 # complexity = low


### PR DESCRIPTION
Port of https://github.com/ComplianceAsCode/content/pull/11935 to master