### PR TITLE
[stabilization] Recollect facts in mount_option_nodev_nonroot_local_partitions

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/ansible/shared.yml
@@ -4,6 +4,10 @@
 # complexity = low
 # disruption = high
 
+- name: "{{{ rule_title }}}: Refresh facts"
+  setup:
+    gather_subset: mounts
+
 - name: Ensure non-root local partitions are mounted with nodev option
   mount:
     path: "{{ item.mount }}"


### PR DESCRIPTION
This is a port of #11941 to the stabilization-v0.1.73 branch.

This patch changes the Ansible code for rule
mount_option_nodev_nonroot_local_partitions so that Ansible id forced to refresh facts about mount points right before running the Ansible Task for this rule.  The data in facts that were collected at the beginning of the play can be outdated at point when this Ansible Task is executed if there is some other Ansible Task that changes mount points, for example if the Ansible Tasks for rule mount_option_boot_nosuid is before the Ansible Task for rule mount_option_nodev_nonroot_local_partitions.

Fixes: #11933


