### PR TITLE
OCP4: Fix e2e ci assertions

### DIFF
--- a/tests/assertions/ocp4/ocp4-cis-node-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-cis-node-4.13.yml
@@ -36,7 +36,7 @@ rule_results:
   e2e-cis-node-master-file-groupowner-ovn-cni-server-sock:
     default_result: PASS
   e2e-cis-node-master-file-groupowner-ovn-db-files:
-    default_result: NOT-APPLICABLE
+    default_result: PASS
   e2e-cis-node-master-file-groupowner-ovs-conf-db:
     default_result: PASS
   e2e-cis-node-master-file-groupowner-ovs-conf-db-lock:
@@ -236,7 +236,7 @@ rule_results:
   e2e-cis-node-worker-file-groupowner-ovn-cni-server-sock:
     default_result: PASS
   e2e-cis-node-worker-file-groupowner-ovn-db-files:
-    default_result: NOT-APPLICABLE
+    default_result: PASS
   e2e-cis-node-worker-file-groupowner-ovs-conf-db:
     default_result: PASS
   e2e-cis-node-worker-file-groupowner-ovs-conf-db-lock:

--- a/tests/assertions/ocp4/ocp4-cis-node-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-cis-node-4.14.yml
@@ -36,7 +36,7 @@ rule_results:
   e2e-cis-node-master-file-groupowner-ovn-cni-server-sock:
     default_result: PASS
   e2e-cis-node-master-file-groupowner-ovn-db-files:
-    default_result: NOT-APPLICABLE
+    default_result: PASS
   e2e-cis-node-master-file-groupowner-ovs-conf-db:
     default_result: PASS
   e2e-cis-node-master-file-groupowner-ovs-conf-db-lock:
@@ -236,7 +236,7 @@ rule_results:
   e2e-cis-node-worker-file-groupowner-ovn-cni-server-sock:
     default_result: PASS
   e2e-cis-node-worker-file-groupowner-ovn-db-files:
-    default_result: NOT-APPLICABLE
+    default_result: PASS
   e2e-cis-node-worker-file-groupowner-ovs-conf-db:
     default_result: PASS
   e2e-cis-node-worker-file-groupowner-ovs-conf-db-lock:

--- a/tests/assertions/ocp4/ocp4-cis-node-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-cis-node-4.15.yml
@@ -36,7 +36,7 @@ rule_results:
   e2e-cis-node-master-file-groupowner-ovn-cni-server-sock:
     default_result: PASS
   e2e-cis-node-master-file-groupowner-ovn-db-files:
-    default_result: NOT-APPLICABLE
+    default_result: PASS
   e2e-cis-node-master-file-groupowner-ovs-conf-db:
     default_result: PASS
   e2e-cis-node-master-file-groupowner-ovs-conf-db-lock:
@@ -236,7 +236,7 @@ rule_results:
   e2e-cis-node-worker-file-groupowner-ovn-cni-server-sock:
     default_result: PASS
   e2e-cis-node-worker-file-groupowner-ovn-db-files:
-    default_result: NOT-APPLICABLE
+    default_result: PASS
   e2e-cis-node-worker-file-groupowner-ovs-conf-db:
     default_result: PASS
   e2e-cis-node-worker-file-groupowner-ovs-conf-db-lock:

--- a/tests/assertions/ocp4/ocp4-cis-node-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-cis-node-4.16.yml
@@ -36,7 +36,7 @@ rule_results:
   e2e-cis-node-master-file-groupowner-ovn-cni-server-sock:
     default_result: PASS
   e2e-cis-node-master-file-groupowner-ovn-db-files:
-    default_result: NOT-APPLICABLE
+    default_result: PASS
   e2e-cis-node-master-file-groupowner-ovs-conf-db:
     default_result: PASS
   e2e-cis-node-master-file-groupowner-ovs-conf-db-lock:
@@ -116,7 +116,7 @@ rule_results:
   e2e-cis-node-master-file-owner-worker-service:
     default_result: PASS
   e2e-cis-node-master-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-cis-node-master-file-permissions-controller-manager-kubeconfig:
     default_result: PASS
   e2e-cis-node-master-file-permissions-etcd-data-dir:
@@ -236,7 +236,7 @@ rule_results:
   e2e-cis-node-worker-file-groupowner-ovn-cni-server-sock:
     default_result: PASS
   e2e-cis-node-worker-file-groupowner-ovn-db-files:
-    default_result: NOT-APPLICABLE
+    default_result: PASS
   e2e-cis-node-worker-file-groupowner-ovs-conf-db:
     default_result: PASS
   e2e-cis-node-worker-file-groupowner-ovs-conf-db-lock:
@@ -316,7 +316,7 @@ rule_results:
   e2e-cis-node-worker-file-owner-worker-service:
     default_result: PASS
   e2e-cis-node-worker-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-cis-node-worker-file-permissions-controller-manager-kubeconfig:
     default_result: NOT-APPLICABLE
   e2e-cis-node-worker-file-permissions-etcd-data-dir:

--- a/tests/assertions/ocp4/ocp4-high-node-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-high-node-4.13.yml
@@ -269,7 +269,8 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-high-node-master-file-permissions-var-log-kube-audit:
-    default_result: PASS
+    # nodes get INCONSISTENT because of https://bugzilla.redhat.com/show_bug.cgi?id=2001442
+    default_result: PASS or INCONSISTENT
     result_after_remediation: PASS
   e2e-high-node-master-file-permissions-var-log-oauth-audit:
     default_result: PASS

--- a/tests/assertions/ocp4/ocp4-high-node-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-high-node-4.14.yml
@@ -269,7 +269,8 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-high-node-master-file-permissions-var-log-kube-audit:
-    default_result: PASS
+    # nodes get INCONSISTENT because of https://bugzilla.redhat.com/show_bug.cgi?id=2001442
+    default_result: PASS or INCONSISTENT
     result_after_remediation: PASS
   e2e-high-node-master-file-permissions-var-log-oauth-audit:
     default_result: PASS

--- a/tests/assertions/ocp4/ocp4-high-node-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-high-node-4.15.yml
@@ -269,7 +269,8 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-high-node-master-file-permissions-var-log-kube-audit:
-    default_result: PASS
+    # nodes get INCONSISTENT because of https://bugzilla.redhat.com/show_bug.cgi?id=2001442
+    default_result: PASS or INCONSISTENT
     result_after_remediation: PASS
   e2e-high-node-master-file-permissions-var-log-oauth-audit:
     default_result: PASS

--- a/tests/assertions/ocp4/ocp4-high-node-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-high-node-4.16.yml
@@ -197,7 +197,7 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-high-node-master-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-high-node-master-file-permissions-controller-manager-kubeconfig:
     default_result: PASS
     result_after_remediation: PASS
@@ -547,7 +547,7 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-high-node-worker-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-high-node-worker-file-permissions-controller-manager-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-high-node-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-high-node-4.16.yml
@@ -269,7 +269,8 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-high-node-master-file-permissions-var-log-kube-audit:
-    default_result: PASS
+    # nodes get INCONSISTENT because of https://bugzilla.redhat.com/show_bug.cgi?id=2001442
+    default_result: PASS or INCONSISTENT
     result_after_remediation: PASS
   e2e-high-node-master-file-permissions-var-log-oauth-audit:
     default_result: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-node-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-node-4.13.yml
@@ -269,7 +269,8 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-moderate-node-master-file-permissions-var-log-kube-audit:
-    default_result: PASS
+    # nodes get INCONSISTENT because of https://bugzilla.redhat.com/show_bug.cgi?id=2001442
+    default_result: PASS or INCONSISTENT
     result_after_remediation: PASS
   e2e-moderate-node-master-file-permissions-var-log-oauth-audit:
     default_result: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-node-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-node-4.14.yml
@@ -269,7 +269,8 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-moderate-node-master-file-permissions-var-log-kube-audit:
-    default_result: PASS
+    # nodes get INCONSISTENT because of https://bugzilla.redhat.com/show_bug.cgi?id=2001442
+    default_result: PASS or INCONSISTENT
     result_after_remediation: PASS
   e2e-moderate-node-master-file-permissions-var-log-oauth-audit:
     default_result: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-node-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-node-4.15.yml
@@ -269,7 +269,8 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-moderate-node-master-file-permissions-var-log-kube-audit:
-    default_result: PASS
+    # nodes get INCONSISTENT because of https://bugzilla.redhat.com/show_bug.cgi?id=2001442
+    default_result: PASS or INCONSISTENT
     result_after_remediation: PASS
   e2e-moderate-node-master-file-permissions-var-log-oauth-audit:
     default_result: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-node-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-node-4.16.yml
@@ -269,7 +269,8 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-moderate-node-master-file-permissions-var-log-kube-audit:
-    default_result: PASS
+    # nodes get INCONSISTENT because of https://bugzilla.redhat.com/show_bug.cgi?id=2001442
+    default_result: PASS or INCONSISTENT
     result_after_remediation: PASS
   e2e-moderate-node-master-file-permissions-var-log-oauth-audit:
     default_result: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-node-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-node-4.16.yml
@@ -197,7 +197,7 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-moderate-node-master-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-moderate-node-master-file-permissions-controller-manager-kubeconfig:
     default_result: PASS
     result_after_remediation: PASS
@@ -547,7 +547,7 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-moderate-node-worker-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-moderate-node-worker-file-permissions-controller-manager-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4.13.yml
@@ -42,7 +42,7 @@ rule_results:
   e2e-pci-dss-node-master-file-groupowner-ovn-cni-server-sock:
     default_result: PASS
   e2e-pci-dss-node-master-file-groupowner-ovn-db-files:
-    default_result: NOT-APPLICABLE
+    default_result: PASS
   e2e-pci-dss-node-master-file-groupowner-ovs-conf-db:
     default_result: PASS
   e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock:
@@ -268,7 +268,7 @@ rule_results:
   e2e-pci-dss-node-worker-file-groupowner-ovn-cni-server-sock:
     default_result: PASS
   e2e-pci-dss-node-worker-file-groupowner-ovn-db-files:
-    default_result: NOT-APPLICABLE
+    default_result: PASS
   e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db:
     default_result: PASS
   e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock:

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4.13.yml
@@ -176,7 +176,8 @@ rule_results:
   e2e-pci-dss-node-master-file-permissions-scheduler-kubeconfig:
     default_result: PASS
   e2e-pci-dss-node-master-file-permissions-var-log-kube-audit:
-    default_result: PASS
+    # nodes get INCONSISTENT because of https://bugzilla.redhat.com/show_bug.cgi?id=2001442
+    default_result: PASS or INCONSISTENT
   e2e-pci-dss-node-master-file-permissions-var-log-oauth-audit:
     default_result: PASS
   e2e-pci-dss-node-master-file-permissions-var-log-ocp-audit:

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4.14.yml
@@ -42,7 +42,7 @@ rule_results:
   e2e-pci-dss-node-master-file-groupowner-ovn-cni-server-sock:
     default_result: PASS
   e2e-pci-dss-node-master-file-groupowner-ovn-db-files:
-    default_result: NOT-APPLICABLE
+    default_result: PASS
   e2e-pci-dss-node-master-file-groupowner-ovs-conf-db:
     default_result: PASS
   e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock:
@@ -268,7 +268,7 @@ rule_results:
   e2e-pci-dss-node-worker-file-groupowner-ovn-cni-server-sock:
     default_result: PASS
   e2e-pci-dss-node-worker-file-groupowner-ovn-db-files:
-    default_result: NOT-APPLICABLE
+    default_result: PASS
   e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db:
     default_result: PASS
   e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock:

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4.14.yml
@@ -176,7 +176,8 @@ rule_results:
   e2e-pci-dss-node-master-file-permissions-scheduler-kubeconfig:
     default_result: PASS
   e2e-pci-dss-node-master-file-permissions-var-log-kube-audit:
-    default_result: PASS
+    # nodes get INCONSISTENT because of https://bugzilla.redhat.com/show_bug.cgi?id=2001442
+    default_result: PASS or INCONSISTENT
   e2e-pci-dss-node-master-file-permissions-var-log-oauth-audit:
     default_result: PASS
   e2e-pci-dss-node-master-file-permissions-var-log-ocp-audit:

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4.15.yml
@@ -42,7 +42,7 @@ rule_results:
   e2e-pci-dss-node-master-file-groupowner-ovn-cni-server-sock:
     default_result: PASS
   e2e-pci-dss-node-master-file-groupowner-ovn-db-files:
-    default_result: NOT-APPLICABLE
+    default_result: PASS
   e2e-pci-dss-node-master-file-groupowner-ovs-conf-db:
     default_result: PASS
   e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock:
@@ -268,7 +268,7 @@ rule_results:
   e2e-pci-dss-node-worker-file-groupowner-ovn-cni-server-sock:
     default_result: PASS
   e2e-pci-dss-node-worker-file-groupowner-ovn-db-files:
-    default_result: NOT-APPLICABLE
+    default_result: PASS
   e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db:
     default_result: PASS
   e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock:

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4.15.yml
@@ -176,7 +176,8 @@ rule_results:
   e2e-pci-dss-node-master-file-permissions-scheduler-kubeconfig:
     default_result: PASS
   e2e-pci-dss-node-master-file-permissions-var-log-kube-audit:
-    default_result: PASS
+    # nodes get INCONSISTENT because of https://bugzilla.redhat.com/show_bug.cgi?id=2001442
+    default_result: PASS or INCONSISTENT
   e2e-pci-dss-node-master-file-permissions-var-log-oauth-audit:
     default_result: PASS
   e2e-pci-dss-node-master-file-permissions-var-log-ocp-audit:

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4.16.yml
@@ -42,7 +42,7 @@ rule_results:
   e2e-pci-dss-node-master-file-groupowner-ovn-cni-server-sock:
     default_result: PASS
   e2e-pci-dss-node-master-file-groupowner-ovn-db-files:
-    default_result: NOT-APPLICABLE
+    default_result: PASS
   e2e-pci-dss-node-master-file-groupowner-ovs-conf-db:
     default_result: PASS
   e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock:
@@ -128,7 +128,7 @@ rule_results:
   e2e-pci-dss-node-master-file-ownership-var-log-ocp-audit:
     default_result: PASS
   e2e-pci-dss-node-master-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-pci-dss-node-master-file-permissions-controller-manager-kubeconfig:
     default_result: PASS
   e2e-pci-dss-node-master-file-permissions-etcd-data-dir:
@@ -268,7 +268,7 @@ rule_results:
   e2e-pci-dss-node-worker-file-groupowner-ovn-cni-server-sock:
     default_result: PASS
   e2e-pci-dss-node-worker-file-groupowner-ovn-db-files:
-    default_result: NOT-APPLICABLE
+    default_result: PASS
   e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db:
     default_result: PASS
   e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock:
@@ -354,7 +354,7 @@ rule_results:
   e2e-pci-dss-node-worker-file-ownership-var-log-ocp-audit:
     default_result: NOT-APPLICABLE
   e2e-pci-dss-node-worker-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-pci-dss-node-worker-file-permissions-controller-manager-kubeconfig:
     default_result: NOT-APPLICABLE
   e2e-pci-dss-node-worker-file-permissions-etcd-data-dir:

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4.16.yml
@@ -176,7 +176,8 @@ rule_results:
   e2e-pci-dss-node-master-file-permissions-scheduler-kubeconfig:
     default_result: PASS
   e2e-pci-dss-node-master-file-permissions-var-log-kube-audit:
-    default_result: PASS
+    # nodes get INCONSISTENT because of https://bugzilla.redhat.com/show_bug.cgi?id=2001442
+    default_result: PASS or INCONSISTENT
   e2e-pci-dss-node-master-file-permissions-var-log-oauth-audit:
     default_result: PASS
   e2e-pci-dss-node-master-file-permissions-var-log-ocp-audit:

--- a/tests/assertions/ocp4/ocp4-stig-node-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-stig-node-4.16.yml
@@ -173,7 +173,7 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-stig-node-master-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-stig-node-master-file-permissions-controller-manager-kubeconfig:
     default_result: PASS
     result_after_remediation: PASS
@@ -484,7 +484,7 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-stig-node-worker-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-stig-node-worker-file-permissions-controller-manager-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE


### PR DESCRIPTION
Fixing expected assertion result for rule `file-permissions-cni-conf` and `file-groupowner-ovn-db-files`, `file-permissions-cni-conf` should pass on ocp version >= 4.15

Align `file-groupowner-ovn-db-files` with https://github.com/ComplianceAsCode/content/pull/11861
