### PR TITLE
Improve error handling when loading yaml stream

### DIFF
--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -154,7 +154,16 @@ def ordered_load(stream, Loader=yaml_Loader, object_pairs_hook=OrderedDict):
     OrderedLoader.add_constructor(
         yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
         construct_mapping)
-    return yaml.load(stream, OrderedLoader)
+
+    try:
+        yaml_loaded = yaml.load(stream, OrderedLoader)
+    except yaml.scanner.ScannerError as e:
+        print("Error when trying to load the stream: {}".format(e))
+        print("HINT: Ansible tasks names may cause expansion errors if not properly quoted.")
+        print("HINT: Check for unquoted colons or other special symbols in the stream:")
+        print("{}".format(stream))
+        sys.exit(1)
+    return yaml_loaded
 
 
 def ordered_dump(data, stream=None, Dumper=yaml_Dumper, **kwds):


### PR DESCRIPTION
#### Description:

During tests with Ansible macros it was noticed a case where the Ansible task names include "{{{ rule_title }}}" and an specific rule has special symbols in its title.
This was causing the load of the stream to fail but the exception was not clear or easy to debug.
So, it was created an exception for this case giving some hints for the developer.

#### Rationale:

- Easier development.