### PR TITLE
Fix typos in notes for ocp4 controls

### DIFF
--- a/controls/nist_ocp4.yml
+++ b/controls/nist_ocp4.yml
@@ -16545,7 +16545,7 @@ controls:
 - id: SI-14
   status: pending
   notes: |-
-    A control response for SI-15 is planned. Engineering progress can be
+    A control response for SI-14 is planned. Engineering progress can be
     tracked via:
 
     https://issues.redhat.com/browse/CMP-561
@@ -16553,7 +16553,7 @@ controls:
 - id: SI-14(1)
   status: pending
   notes: |-
-    A control response for SI-15 is planned. Engineering progress can be
+    A control response for SI-14(1) is planned. Engineering progress can be
     tracked via:
 
     https://issues.redhat.com/browse/CMP-562


### PR DESCRIPTION
#### Description:

A couple of notes don't match the control id or the title of the Jira issue they reference. Fix the typos in those notes.
