### PR TITLE
Support all boolean values in dnf.conf

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/oval/shared.xml
@@ -22,7 +22,7 @@
   
   <ind:textfilecontent54_object id="object_ensure_gpgcheck_globally_activated" comment="gpgcheck set in {{{ pkg_manager_config_file }}}" version="1">
     <ind:filepath>{{{ pkg_manager_config_file }}}</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*gpgcheck\s*=\s*1|True|yes\s*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*gpgcheck\s*=\s*(1|True|yes)\s*$</ind:pattern>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>  
 
@@ -34,7 +34,7 @@
 
   <ind:textfilecontent54_object id="object_test_ensure_gpgcheck_globally_no_deactivated" comment="0_off_no_false set in {{{ pkg_manager_config_file }}}" version="1">
     <ind:filepath>{{{ pkg_manager_config_file }}}</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*gpgcheck\s*=\s*0|off|no|false\s*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*gpgcheck\s*=\s*(0|off|no|false)\s*$</ind:pattern>
     <ind:instance datatype="int" operation="equals">0</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/oval/shared.xml
@@ -1,6 +1,6 @@
 <def-group>
 
-  <definition class="compliance" id="ensure_gpgcheck_globally_activated" version="1">
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("The gpgcheck option should be used to ensure that checking
       of an RPM package's signature always occurs prior to its
       installation.") }}}
@@ -22,7 +22,7 @@
   
   <ind:textfilecontent54_object id="object_ensure_gpgcheck_globally_activated" comment="gpgcheck set in {{{ pkg_manager_config_file }}}" version="1">
     <ind:filepath>{{{ pkg_manager_config_file }}}</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*gpgcheck\s*=\s*1\s*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*gpgcheck\s*=\s*1|True|yes\s*$</ind:pattern>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>  
 

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/tests/correct_value.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 {{% if 'sle' in product %}}
 # packages = libselinux1
-{{% else %}} 
+{{% else %}}
 # packages = python3-libselinux
 {{% endif %}}
 

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/tests/correct_value_true.pass.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/tests/correct_value_true.pass.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+{{% if 'sle' in product %}}
+# packages = libselinux1
+{{% else %}}
+# packages = python3-libselinux
+{{% endif %}}
+
+. $SHARED/group_updating_utils.sh
+
+config_file="$(find_config_file)"
+
+if grep -q "^gpgcheck" "$config_file"; then
+	sed -i "s/^gpgcheck.*/gpgcheck=True/" "$config_file"
+else
+	echo "gpgcheck=True" >> "$config_file"
+fi

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/tests/correct_value_yes.pass.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/tests/correct_value_yes.pass.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+{{% if 'sle' in product %}}
+# packages = libselinux1
+{{% else %}}
+# packages = python3-libselinux
+{{% endif %}}
+
+. $SHARED/group_updating_utils.sh
+
+config_file="$(find_config_file)"
+
+if grep -q "^gpgcheck" "$config_file"; then
+	sed -i "s/^gpgcheck.*/gpgcheck=yes/" "$config_file"
+else
+	echo "gpgcheck=yes" >> "$config_file"
+fi

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/tests/line_not_there.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 {{% if 'sle' in product %}}
 # packages = libselinux1
-{{% else %}} 
+{{% else %}}
 # packages = python3-libselinux
 {{% endif %}}
 

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/tests/wrong_value.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 {{% if 'sle' in product %}}
 # packages = libselinux1
-{{% else %}} 
+{{% else %}}
 # packages = python3-libselinux
 {{% endif %}}
 

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/tests/wrong_value_false.fail.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/tests/wrong_value_false.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 {{% if 'sle' in product %}}
 # packages = libselinux1
-{{% else %}} 
+{{% else %}}
 # packages = python3-libselinux
 {{% endif %}}
 

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/tests/wrong_value_no.fail.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/tests/wrong_value_no.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 {{% if 'sle' in product %}}
 # packages = libselinux1
-{{% else %}} 
+{{% else %}}
 # packages = python3-libselinux
 {{% endif %}}
 

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/tests/wrong_value_off.fail.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/tests/wrong_value_off.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 {{% if 'sle' in product %}}
 # packages = libselinux1
-{{% else %}} 
+{{% else %}}
 # packages = python3-libselinux
 {{% endif %}}
 


### PR DESCRIPTION
#### Description:

According to `dnf.conf` man, "1", "True" and "yes" are accepted values for boolean.

#### Rationale:

More flexibility for valid values during the assessment.