### PR TITLE
Add new rule file_permissions_var_log_audit_stig

### DIFF
--- a/components/audit.yml
+++ b/components/audit.yml
@@ -310,6 +310,7 @@ rules:
 - file_permissions_etc_audit_auditd
 - file_permissions_etc_audit_rulesd
 - file_permissions_var_log_audit
+- file_permissions_var_log_audit_stig
 - grub2_audit_argument
 - grub2_audit_backlog_limit_argument
 - package_audispd-plugins_installed

--- a/linux_os/guide/auditing/auditd_configure_rules/file_permissions_var_log_audit/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_permissions_var_log_audit/rule.yml
@@ -53,7 +53,6 @@ references:
     stigid@rhel7: RHEL-07-910055
     stigid@rhel8: RHEL-08-030070
     stigid@ubuntu2004: UBTU-20-010122
-    stigid@ubuntu2204: UBTU-22-653045
 
 ocil_clause: 'any permissions are more permissive'
 

--- a/linux_os/guide/auditing/auditd_configure_rules/file_permissions_var_log_audit_stig/bash/shared.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_permissions_var_log_audit_stig/bash/shared.sh
@@ -1,0 +1,9 @@
+# platform = multi_platform_ubuntu
+
+if LC_ALL=C grep -iqw ^log_file /etc/audit/auditd.conf; then
+    FILE=$(awk -F "=" '/^log_file/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')
+else
+    FILE="/var/log/audit/audit.log"
+fi
+
+chmod 0600 -- "$(dirname "$FILE")"/*

--- a/linux_os/guide/auditing/auditd_configure_rules/file_permissions_var_log_audit_stig/oval/shared.xml
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_permissions_var_log_audit_stig/oval/shared.xml
@@ -1,0 +1,62 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="2">
+    {{{ oval_metadata("Checks for correct permissions for all audit log files.") }}}
+    <criteria operator="OR">
+      <criteria operator="AND" comment="log_file set">
+        <extend_definition comment="log_file set in auditd.conf" definition_ref="auditd_conf_log_file_not_set" negate="true" />
+        <criterion test_ref="test_{{{ rule_id }}}" negate="true" />
+      </criteria>
+      <criteria operator="AND" comment="log_file not set">
+        <extend_definition comment="log_file not set in auditd.conf" definition_ref="auditd_conf_log_file_not_set"/>
+        <criterion test_ref="test_{{{ rule_id }}}_default" negate="true" />
+      </criteria>
+    </criteria>
+  </definition>
+
+  <unix:file_test check="all" check_existence="at_least_one_exists"
+      comment="audit log files mode 0600"
+      id="test_{{{ rule_id }}}" version="1">
+    <unix:object object_ref="object_{{{ rule_id }}}" />
+    <unix:state state_ref="state_{{{ rule_id }}}_not_mode_0600" />
+  </unix:file_test>
+
+  <unix:file_object comment="audit log files" id="object_{{{ rule_id }}}" version="1">
+    <unix:path operation="equals" var_ref="audit_log_file_dir" />
+    <unix:filename operation="pattern match">^.*$</unix:filename>
+    <filter action="include">state_{{{ rule_id }}}_not_mode_0600</filter>
+  </unix:file_object>
+
+  <unix:file_test check="all" check_existence="at_least_one_exists"
+      comment="default audit log files mode 0600"
+      id="test_{{{ rule_id }}}_default" version="1">
+    <unix:object object_ref="object_{{{ rule_id }}}_default" />
+    <unix:state state_ref="state_{{{ rule_id }}}_not_mode_0600" />
+  </unix:file_test>
+
+  <unix:file_object comment="default audit log files" id="object_{{{ rule_id }}}_default" version="1">
+    <unix:path operation="equals">/var/log/audit/</unix:path>
+    <unix:filename operation="pattern match">^.*$</unix:filename>
+    <filter action="include">state_{{{ rule_id }}}_not_mode_0600</filter>
+  </unix:file_object>
+
+  <unix:file_state id="state_{{{ rule_id }}}_not_mode_0600" version="1" operator="OR">
+    <!-- if any one of these is true then mode is NOT 0600 (hence the OR operator) -->
+    <unix:suid datatype="boolean">true</unix:suid>
+    <unix:sgid datatype="boolean">true</unix:sgid>
+    <unix:sticky datatype="boolean">true</unix:sticky>
+    <unix:uexec datatype="boolean">true</unix:uexec>
+    <unix:gread datatype="boolean">true</unix:gread>
+    <unix:gwrite datatype="boolean">true</unix:gwrite>
+    <unix:gexec datatype="boolean">true</unix:gexec>
+    <unix:oread datatype="boolean">true</unix:oread>
+    <unix:owrite datatype="boolean">true</unix:owrite>
+    <unix:oexec datatype="boolean">true</unix:oexec>
+  </unix:file_state>
+
+  <!-- extract dirname from path -->
+  <local_variable id="audit_log_file_dir" datatype="string" version="1" comment="dirname of audit log files">
+    <regex_capture pattern="^(/.*/)[^/]*$">
+      <variable_component var_ref="audit_log_file_path" />
+    </regex_capture>
+  </local_variable>
+</def-group>

--- a/linux_os/guide/auditing/auditd_configure_rules/file_permissions_var_log_audit_stig/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_permissions_var_log_audit_stig/rule.yml
@@ -1,0 +1,32 @@
+documentation_complete: true
+
+title: 'System Audit Logs Must Have Mode 0600 or Less Permissive'
+
+description: |-
+    Determine where the audit logs are stored with the following command:
+    <pre>$ sudo grep -iw log_file /etc/audit/auditd.conf
+    log_file = /var/log/audit/audit.log</pre>
+
+    Using the path of the directory containing the audit logs, determine
+    if the audit log files have a mode of "600" or less by using the following command:
+    <pre>$ sudo stat -c "%n %a" /var/log/audit/*</pre>
+
+rationale: 'If users can write to audit logs, audit trails can be modified or destroyed.'
+
+severity: medium
+
+references:
+    srg: SRG-OS-000057-GPOS-00027,SRG-OS-000058-GPOS-00028
+    stigid@ubuntu2204: UBTU-22-653045
+
+fixtext: |-
+    Configure correct permissions of system audit logs.
+
+    Determine the location of the system audit logs:
+    <pre>$ sudo grep -iw log_file /etc/audit/auditd.conf
+
+    Using the path of the directory containing the audit logs,
+    configure the audit log files to have a mode of "0600" or
+    less permissive by using the following command:
+    <pre>$ sudo chmod 0600 /var/log/audit/*</pre>
+

--- a/linux_os/guide/auditing/auditd_configure_rules/file_permissions_var_log_audit_stig/tests/common.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_permissions_var_log_audit_stig/tests/common.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+sed -i "/^\s*log_file.*/d" /etc/audit/auditd.conf
+
+FILE1=/var/log/audit/audit.log
+FILE2=/var/log/audit2/audit.log
+FILE3=/var/log/audit2/audit.log.1
+
+for f in $FILE1 $FILE2 $FILE3; do
+    mkdir -p $(dirname $f)
+    touch $f
+done

--- a/linux_os/guide/auditing/auditd_configure_rules/file_permissions_var_log_audit_stig/tests/correct_value.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_permissions_var_log_audit_stig/tests/correct_value.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = audit
+
+source common.sh
+
+echo "log_file = ${FILE2}" >> /etc/audit/auditd.conf
+
+chmod 0640 ${FILE1}
+chmod 0600 ${FILE2}
+chmod 0600 ${FILE3}

--- a/linux_os/guide/auditing/auditd_configure_rules/file_permissions_var_log_audit_stig/tests/correct_value_default_file.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_permissions_var_log_audit_stig/tests/correct_value_default_file.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = audit
+
+source common.sh
+
+chmod 0600 ${FILE1}
+chmod 0640 ${FILE2}
+chmod 0640 ${FILE3}

--- a/linux_os/guide/auditing/auditd_configure_rules/file_permissions_var_log_audit_stig/tests/incorrect_value.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_permissions_var_log_audit_stig/tests/incorrect_value.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = audit
+
+source common.sh
+
+echo "log_file = ${FILE2}" >> /etc/audit/auditd.conf
+
+chmod 0600 ${FILE1}
+chmod 0640 ${FILE2}
+chmod 0600 ${FILE3}

--- a/linux_os/guide/auditing/auditd_configure_rules/file_permissions_var_log_audit_stig/tests/incorrect_value2.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_permissions_var_log_audit_stig/tests/incorrect_value2.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = audit
+
+source common.sh
+
+echo "log_file = ${FILE2}" >> /etc/audit/auditd.conf
+
+chmod 0600 ${FILE1}
+chmod 0600 ${FILE2}
+chmod 0640 ${FILE3}

--- a/linux_os/guide/auditing/auditd_configure_rules/file_permissions_var_log_audit_stig/tests/incorrect_value_default_file.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_permissions_var_log_audit_stig/tests/incorrect_value_default_file.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = audit
+
+source common.sh
+
+chmod 0640 ${FILE1}
+chmod 0600 ${FILE2}
+chmod 0600 ${FILE3}

--- a/products/ubuntu2204/profiles/stig.profile
+++ b/products/ubuntu2204/profiles/stig.profile
@@ -206,7 +206,7 @@ selections:
     - auditd_data_disk_full_action
 
     # UBTU-22-653045 The Ubuntu operating system must be configured so that audit log files are not read or write-accessible by unauthorized users.
-    - file_permissions_var_log_audit
+    - file_permissions_var_log_audit_stig
 
     # UBTU-22-653050 The Ubuntu operating system must be configured to permit only authorized users ownership of the audit log files.
     - file_ownership_var_log_audit_stig


### PR DESCRIPTION
#### Description:

- A new rule with suffix `_stig` was created from the existing rule `file_permissions_var_log_audit`
to comply with STIG for Ubuntu 22.04 which requires stricter permissions (0600) on audit logs compared to CIS (0640).
- The new rule was adapted to not only check and remediate the single log file (log_file in config or default if not present), but all the log files in the parent directory of the main log file.
- Satisfies STIG rule UBTU-22-653045