### PR TITLE
Add missing rule package_pam_pwquality_installed to Ubuntu 22.04 CIS profile

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/package_pam_pwquality_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/package_pam_pwquality_installed/rule.yml
@@ -26,6 +26,7 @@ identifiers:
 
 references:
     cis@ubuntu2004: 5.3.1
+    cis@ubuntu2204: 5.4.1
     disa: CCI-000366
     srg: SRG-OS-000480-GPOS-00225
     stigid@ubuntu2004: UBTU-20-010057

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -847,6 +847,7 @@ selections:
 
     ## 5.4 Configure PAM ##
     ### 5.4.1 Ensure password creation requirements are configured (Automated)
+    - package_pam_pwquality_installed
     - var_password_pam_minlen=14
     - accounts_password_pam_minlen
     - var_password_pam_minclass=4


### PR DESCRIPTION
#### Description:

- Add missing rule `package_pam_pwquality_installed` to Ubuntu 22.04 CIS profile

#### Rationale:

- Fixes https://bugs.launchpad.net/usg/+bug/2065113