### PR TITLE
Disable check for 'auditd_audispd_configure_sufficiently_large_partition' on Ubuntu 22.04

### DIFF
--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_sufficiently_large_partition/oval/shared.xml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_sufficiently_large_partition/oval/shared.xml
@@ -1,3 +1,4 @@
+{{% if product not in ['ubuntu2204'] %}}
 {{% if target_oval_version >= [5, 11.2] %}}
 <def-group oval_version="5.11.2">
   <definition class="compliance" id="auditd_audispd_configure_sufficiently_large_partition" version="1">
@@ -30,4 +31,5 @@
       <ind:value operation="greater than or equal" datatype="int">10000000000</ind:value>
   </ind:variable_state>
 </def-group>
+{{% endif %}}
 {{% endif %}}

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_sufficiently_large_partition/rule.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_sufficiently_large_partition/rule.yml
@@ -1,6 +1,5 @@
 documentation_complete: true
 
-
 title: 'Configure a Sufficiently Large Partition for Audit Logs'
 
 description: |-
@@ -11,8 +10,11 @@ description: |-
 
     The partition size needed to capture a week's worth of audit records is
     based on the activity level of the system and the total storage capacity
-    available. In normal circumstances, 10.0 GB of storage space for audit
+    available.
+    {{% if product not in ['ubuntu2204'] %}}
+    In normal circumstances, 10.0 GB of storage space for audit
     records will be sufficient.
+    {{% endif %}}
 
     Determine which partition the audit records are being written to with the
     following command:


### PR DESCRIPTION
#### Description:

- The check for `auditd_audispd_configure_sufficiently_large_partition` is disabled on Ubuntu 22.04.

#### Rationale:

- STIG for Ubuntu 22.04 no longer accepts 10GB as a sufficiently large partition.
