### PR TITLE
Add new rule install_endpoint_security_software

### DIFF
--- a/components/operating-system.yml
+++ b/components/operating-system.yml
@@ -11,6 +11,7 @@ rules:
 - ensure_iptables_are_flushed
 - has_nonlocal_mta
 - install_antivirus
+- install_endpoint_security_software
 - install_hids
 - installed_OS_is_FIPS_certified
 - installed_OS_is_vendor_supported

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/group.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/group.yml
@@ -6,6 +6,8 @@ description: |-
     Endpoint protection security software that is not provided or supported
     {{% if 'ol' in product %}}
     by Oracle Corporation can be installed to provide complementary or duplicative
+    {{% elif 'ubuntu' in product %}}
+    by Canonical can be installed to provide complementary or duplicative
     {{% else %}}
     by Red Hat can be installed to provide complementary or duplicative
     {{% endif %}}

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/install_endpoint_security_software/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/install_endpoint_security_software/rule.yml
@@ -1,0 +1,27 @@
+documentation_complete: true
+
+title: 'Install an Endpoint Security Solution'
+
+description: |-
+    Verify that an Endpoint Security Solution has been deployed on the operating system.  
+    If there is not an Endpoint Security Solution deployed, this is a finding.
+
+rationale: |-
+    Without the use of automated mechanisms to scan for security flaws on a continuous
+    and/or periodic basis, the operating system or other system components may remain
+    vulnerable to the exploits presented by undetected software flaws.
+
+    To support this requirement, the operating system may have an integrated solution
+    incorporating continuous scanning and periodic scanning using other tools,
+    as specified in the requirement.
+
+severity: medium
+
+references:
+    disa: CCI-001233
+    stigid@ubuntu2204: UBTU-22-211010
+
+fixtext: |-
+    Install an Endpoint Security Solution that can provide a continuous mechanism to
+    monitor the state of system components with regard to flaw remediation and
+    threat prevention.

--- a/products/ubuntu2204/profiles/stig.profile
+++ b/products/ubuntu2204/profiles/stig.profile
@@ -451,9 +451,8 @@ selections:
     # UBTU-22-231010 Ubuntu operating systems handling data requiring "data at rest" protections must employ cryptographic mechanisms to prevent unauthorized disclosure and modification of the information at rest.
     - encrypt_partitions
 
-    ### TODO
-    # UBTU-22-211010 The Ubuntu operating system must deploy Endpoint Security for Linux Threat Prevention (ENSLTP).
-    #- package_mfetp_installed
+    # UBTU-22-211010 The Ubuntu operating system must deploy an Endpoint Security Solution.
+    - install_endpoint_security_software
 
     # UBTU-22-232026 The Ubuntu operating system must generate error messages that provide information necessary for corrective actions without revealing information that could be exploited by adversaries.
     - permissions_local_var_log


### PR DESCRIPTION
#### Description:

- The generic rule `install_endpoint_security_software` was created because STIG for Ubuntu 22.04 no longer explicitly specifies the endpoint security vendor (rule UBTU-22-211010).
- The rule does not have an automated check or fix.
