### PR TITLE
Fix missing variable for Ubuntu 22.04

### DIFF
--- a/products/ubuntu2204/product.yml
+++ b/products/ubuntu2204/product.yml
@@ -23,6 +23,7 @@ sshd_distributed_config: "true"
 
 aide_bin_path: "/usr/bin/aide"
 aide_conf_path: "/etc/aide/aide.conf"
+aide_default_path: "/etc/default/aide"
 audisp_conf_path: "/etc/audit"
 chrony_conf_path: "/etc/chrony/chrony.conf"
 

--- a/tests/data/product_stability/ubuntu2204.yml
+++ b/tests/data/product_stability/ubuntu2204.yml
@@ -2,6 +2,7 @@ aide_also_checks_audispd: 'no'
 aide_also_checks_rsyslog: 'no'
 aide_bin_path: /usr/bin/aide
 aide_conf_path: /etc/aide/aide.conf
+aide_default_path: /etc/default/aide
 audisp_conf_path: /etc/audit
 auid: 1000
 basic_properties_derived: true


### PR DESCRIPTION
#### Description:

- Define variable `aide_default_path` for Ubuntu 22.04

#### Rationale:

- If not defined, it breaks rule `aide_disable_silentreports`.
