### PR TITLE
Achieve consistent file and directory permissions for systemd journals

### DIFF
--- a/linux_os/guide/system/logging/journald/dir_groupowner_system_journal/bash/ubuntu.sh
+++ b/linux_os/guide/system/logging/journald/dir_groupowner_system_journal/bash/ubuntu.sh
@@ -1,0 +1,17 @@
+# platform = multi_platform_ubuntu
+
+TMPFILES_CONF="/etc/tmpfiles.d/systemd.conf"
+
+if grep -qP "^.[+]*\s+\/var\/log\/journal\s+" "$TMPFILES_CONF"; then
+    sed -i --follow-symlinks "s/\(^.[+]*\)\(\s\+\/var\/log\/journal\s\+[^ $]\+\s\+[^ $]\+\s\+\)\([^ $]\+\)/Z\2systemd-journal/" "$TMPFILES_CONF"
+else
+    echo "Z /var/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
+fi
+
+if grep -qP "^.[+]*\s+\/run\/log\/journal\s+" "$TMPFILES_CONF"; then
+    sed -i --follow-symlinks "s/\(^.[+]*\)\(\s\+\/run\/log\/journal\s\+[^ $]\+\s\+[^ $]\+\s\+\)\([^ $]\+\)/Z\2systemd-journal/" "$TMPFILES_CONF"
+else
+    echo "Z /run/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
+fi
+
+systemd-tmpfiles --create

--- a/linux_os/guide/system/logging/journald/dir_owner_system_journal/bash/ubuntu.sh
+++ b/linux_os/guide/system/logging/journald/dir_owner_system_journal/bash/ubuntu.sh
@@ -1,0 +1,17 @@
+# platform = multi_platform_ubuntu
+
+TMPFILES_CONF="/etc/tmpfiles.d/systemd.conf"
+
+if grep -qP "^.[+]*\s+\/var\/log\/journal\s+" "$TMPFILES_CONF"; then
+    sed -i --follow-symlinks "s/\(^.[+]*\)\(\s\+\/var\/log\/journal\s\+[^ $]\+\s\+\)\([^ $]\+\)/Z\2root/" "$TMPFILES_CONF"
+else
+    echo "Z /var/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
+fi
+
+if grep -qP "^.[+]*\s+\/run\/log\/journal\s+" "$TMPFILES_CONF"; then
+    sed -i --follow-symlinks "s/\(^.[+]*\)\(\s\+\/run\/log\/journal\s\+[^ $]\+\s\+\)\([^ $]\+\)/Z\2root/" "$TMPFILES_CONF"
+else
+    echo "Z /run/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
+fi
+
+systemd-tmpfiles --create

--- a/linux_os/guide/system/logging/journald/dir_permissions_system_journal/bash/ubuntu.sh
+++ b/linux_os/guide/system/logging/journald/dir_permissions_system_journal/bash/ubuntu.sh
@@ -1,0 +1,17 @@
+# platform = multi_platform_ubuntu
+
+TMPFILES_CONF="/etc/tmpfiles.d/systemd.conf"
+
+if grep -qP "^.[+]*\s+\/var\/log\/journal\s+" "$TMPFILES_CONF"; then
+    sed -i --follow-symlinks "s/\(^.[+]*\)\(\s\+\/var\/log\/journal\s\+\)\([^ $]*\)/Z\2~2750/" "$TMPFILES_CONF"
+else
+    echo "Z /var/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
+fi
+
+if grep -qP "^.[+]*\s+\/run\/log\/journal\s+" "$TMPFILES_CONF"; then
+    sed -i --follow-symlinks "s/\(^.[+]*\)\(\s\+\/run\/log\/journal\s\+\)\([^ $]*\)/Z\2~2750/" "$TMPFILES_CONF"
+else
+    echo "Z /run/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
+fi
+
+systemd-tmpfiles --create

--- a/linux_os/guide/system/logging/journald/file_groupowner_system_journal/bash/ubuntu.sh
+++ b/linux_os/guide/system/logging/journald/file_groupowner_system_journal/bash/ubuntu.sh
@@ -1,0 +1,17 @@
+# platform = multi_platform_ubuntu
+
+TMPFILES_CONF="/etc/tmpfiles.d/systemd.conf"
+
+if grep -qP "^.[+]*\s+\/var\/log\/journal\s+" "$TMPFILES_CONF"; then
+    sed -i --follow-symlinks "s/\(^.[+]*\)\(\s\+\/var\/log\/journal\s\+[^ $]\+\s\+[^ $]\+\s\+\)\([^ $]\+\)/Z\2systemd-journal/" "$TMPFILES_CONF"
+else
+    echo "Z /var/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
+fi
+
+if grep -qP "^.[+]*\s+\/run\/log\/journal\s+" "$TMPFILES_CONF"; then
+    sed -i --follow-symlinks "s/\(^.[+]*\)\(\s\+\/run\/log\/journal\s\+[^ $]\+\s\+[^ $]\+\s\+\)\([^ $]\+\)/Z\2systemd-journal/" "$TMPFILES_CONF"
+else
+    echo "Z /run/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
+fi
+
+systemd-tmpfiles --create

--- a/linux_os/guide/system/logging/journald/file_owner_system_journal/bash/ubuntu.sh
+++ b/linux_os/guide/system/logging/journald/file_owner_system_journal/bash/ubuntu.sh
@@ -1,0 +1,17 @@
+# platform = multi_platform_ubuntu
+
+TMPFILES_CONF="/etc/tmpfiles.d/systemd.conf"
+
+if grep -qP "^.[+]*\s+\/var\/log\/journal\s+" "$TMPFILES_CONF"; then
+    sed -i --follow-symlinks "s/\(^.[+]*\)\(\s\+\/var\/log\/journal\s\+[^ $]\+\s\+\)\([^ $]\+\)/Z\2root/" "$TMPFILES_CONF"
+else
+    echo "Z /var/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
+fi
+
+if grep -qP "^.[+]*\s+\/run\/log\/journal\s+" "$TMPFILES_CONF"; then
+    sed -i --follow-symlinks "s/\(^.[+]*\)\(\s\+\/run\/log\/journal\s\+[^ $]\+\s\+\)\([^ $]\+\)/Z\2root/" "$TMPFILES_CONF"
+else
+    echo "Z /run/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
+fi
+
+systemd-tmpfiles --create

--- a/linux_os/guide/system/logging/journald/file_permissions_system_journal/bash/ubuntu.sh
+++ b/linux_os/guide/system/logging/journald/file_permissions_system_journal/bash/ubuntu.sh
@@ -1,0 +1,17 @@
+# platform = multi_platform_ubuntu
+
+TMPFILES_CONF="/etc/tmpfiles.d/systemd.conf"
+
+if grep -qP "^.[+]*\s+\/var\/log\/journal\s+" "$TMPFILES_CONF"; then
+    sed -i --follow-symlinks "s/\(^.[+]*\)\(\s\+\/var\/log\/journal\s\+\)\([^ $]*\)/Z\2~2750/" "$TMPFILES_CONF"
+else
+    echo "Z /var/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
+fi
+
+if grep -qP "^.[+]*\s+\/run\/log\/journal\s+" "$TMPFILES_CONF"; then
+    sed -i --follow-symlinks "s/\(^.[+]*\)\(\s\+\/run\/log\/journal\s\+\)\([^ $]*\)/Z\2~2750/" "$TMPFILES_CONF"
+else
+    echo "Z /run/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
+fi
+
+systemd-tmpfiles --create

--- a/products/ubuntu2204/profiles/stig.profile
+++ b/products/ubuntu2204/profiles/stig.profile
@@ -631,25 +631,20 @@ selections:
     # UBTU-22-215025 The Ubuntu operating system must not have the "ntp" package installed
     - package_ntp_removed
 
-    ### TODO (reevaluate directory permissions)
     # UBTU-22-232027 The Ubuntu operating system must generate system journal entries without revealing information that could be exploited by adversaries
     - file_permissions_system_journal
     - dir_permissions_system_journal
 
-    ### TODO (incomplete remediation - tmpfiles.d)
     # UBTU-22-232080 The Ubuntu operating system must configure the directories used by the system journal to be owned by "root"
     - dir_owner_system_journal
 
-    ### TODO (incomplete remediation - tmpfiles.d)
     # UBTU-22-232085 The Ubuntu operating system must configure the directories used by the system journal to be group-owned by "systemd-journal"
     - dir_groupowner_system_journal
 
 
-    ### TODO (incomplete remediation - tmpfiles.d)
     # UBTU-22-232090 The Ubuntu operating system must configure the files used by the system journal to be owned by "root"
     - file_owner_system_journal
 
-    ### TODO (incomplete remediation - tmpfiles.d)
     # UBTU-22-232095 The Ubuntu operating system must configure the files used by the system journal to be group-owned by "systemd-journal"
     - file_groupowner_system_journal
 


### PR DESCRIPTION
#### Description:

- Set the appropriate permissions to the files and directories. 

#### Rationale:

- Configuring tmpfiles.d to manage permissions ensures that log files are maintained correctly after reboots.