### PR TITLE
Align audit_xattr rules with Ubuntu 22.04 STIG

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fremovexattr/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fremovexattr/rule.yml
@@ -11,13 +11,13 @@ description: |-
     startup (the default), add the following line to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
     <pre>-a always,exit -F arch=b32 -S fremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b32 -S fremovexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     <br /><br />
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S fremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b64 -S fremovexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     <br /><br />
@@ -25,13 +25,13 @@ description: |-
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
     <pre>-a always,exit -F arch=b32 -S fremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b32 -S fremovexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     <br /><br />
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S fremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b64 -S fremovexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
 
@@ -78,6 +78,7 @@ references:
     stigid@sle12: SLES-12-020370
     stigid@sle15: SLES-15-030190
     stigid@ubuntu2004: UBTU-20-010147
+    stigid@ubuntu2204: UBTU-22-654180
 
 {{{ complete_ocil_entry_audit_syscall(syscall="fremovexattr") }}}
 
@@ -101,6 +102,7 @@ template:
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
         check_root_user@ubuntu2004: "true"
+        check_root_user@ubuntu2204: "true"
         syscall_grouping:
           - fremovexattr
           - lremovexattr

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fsetxattr/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fsetxattr/rule.yml
@@ -9,24 +9,24 @@ description: |-
     startup (the default), add the following line to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
     <pre>-a always,exit -F arch=b32 -S fsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b32 -S fsetxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S fsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b64 -S fsetxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
     <pre>-a always,exit -F arch=b32 -S fsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b32 -S fsetxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S fsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b64 -S fsetxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
 
@@ -73,6 +73,7 @@ references:
     stigid@sle12: SLES-12-020370
     stigid@sle15: SLES-15-030190
     stigid@ubuntu2004: UBTU-20-010144
+    stigid@ubuntu2204: UBTU-22-654180
 
 {{{ complete_ocil_entry_audit_syscall(syscall="fsetxattr") }}}
 
@@ -96,6 +97,7 @@ template:
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
         check_root_user@ubuntu2004: "true"
+        check_root_user@ubuntu2204: "true"
         syscall_grouping:
           - fremovexattr
           - lremovexattr

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lremovexattr/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lremovexattr/rule.yml
@@ -11,13 +11,13 @@ description: |-
     startup (the default), add the following line to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
     <pre>-a always,exit -F arch=b32 -S lremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b32 -S lremovexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     <br /><br />
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S lremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b64 -S lremovexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     <br /><br />
@@ -25,13 +25,13 @@ description: |-
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
     <pre>-a always,exit -F arch=b32 -S lremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b32 -S lremovexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     <br /><br />
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S lremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b64 -S lremovexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
 
@@ -78,6 +78,7 @@ references:
     stigid@sle12: SLES-12-020370
     stigid@sle15: SLES-15-030190
     stigid@ubuntu2004: UBTU-20-010146
+    stigid@ubuntu2204: UBTU-22-654180
 
 {{{ complete_ocil_entry_audit_syscall(syscall="lremovexattr") }}}
 
@@ -101,6 +102,7 @@ template:
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
         check_root_user@ubuntu2004: "true"
+        check_root_user@ubuntu2204: "true"
         syscall_grouping:
           - fremovexattr
           - lremovexattr

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lsetxattr/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lsetxattr/rule.yml
@@ -9,24 +9,24 @@ description: |-
     startup (the default), add the following line to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
     <pre>-a always,exit -F arch=b32 -S lsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b32 -S lsetxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S lsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b64 -S lsetxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
     <pre>-a always,exit -F arch=b32 -S lsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b32 -S lsetxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S lsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b64 -S lsetxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
 
@@ -73,6 +73,7 @@ references:
     stigid@sle12: SLES-12-020370
     stigid@sle15: SLES-15-030190
     stigid@ubuntu2004: UBTU-20-010143
+    stigid@ubuntu2204: UBTU-22-654180
 
 {{{ complete_ocil_entry_audit_syscall(syscall="lsetxattr") }}}
 
@@ -96,6 +97,7 @@ template:
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
         check_root_user@ubuntu2004: "true"
+        check_root_user@ubuntu2204: "true"
         syscall_grouping:
           - fremovexattr
           - lremovexattr

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_removexattr/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_removexattr/rule.yml
@@ -10,13 +10,13 @@ description: |-
     program to read audit rules during daemon startup (the default), add the
     following line to a file with suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
     <pre>-a always,exit -F arch=b32 -S removexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b32 -S removexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     <br /><br />
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S removexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b64 -S removexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     <br /><br />
@@ -24,13 +24,13 @@ description: |-
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
     <pre>-a always,exit -F arch=b32 -S removexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b32 -S removexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     <br /><br />
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S removexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b64 -S removexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
 
@@ -77,6 +77,7 @@ references:
     stigid@sle12: SLES-12-020370
     stigid@sle15: SLES-15-030190
     stigid@ubuntu2004: UBTU-20-010145
+    stigid@ubuntu2204: UBTU-22-654180
 
 {{{ complete_ocil_entry_audit_syscall(syscall="removexattr") }}}
 
@@ -100,6 +101,7 @@ template:
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
         check_root_user@ubuntu2004: "true"
+        check_root_user@ubuntu2204: "true"
         syscall_grouping:
           - fremovexattr
           - lremovexattr

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_setxattr/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_setxattr/rule.yml
@@ -9,24 +9,24 @@ description: |-
     startup (the default), add the following line to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
     <pre>-a always,exit -F arch=b32 -S setxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b32 -S setxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S setxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b64 -S setxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
     <pre>-a always,exit -F arch=b32 -S setxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b32 -S setxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S setxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b64 -S setxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
 
@@ -97,6 +97,7 @@ template:
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
         check_root_user@ubuntu2004: "true"
+        check_root_user@ubuntu2204: "true"
         syscall_grouping:
           - fremovexattr
           - lremovexattr

--- a/shared/templates/audit_rules_dac_modification/tests/correct_rules.pass.sh
+++ b/shared/templates/audit_rules_dac_modification/tests/correct_rules.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+# packages = audit
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules

--- a/shared/templates/audit_rules_dac_modification/tests/rules_not_there.fail.sh
+++ b/shared/templates/audit_rules_dac_modification/tests/rules_not_there.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+# packages = audit
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules

--- a/shared/templates/audit_rules_dac_modification/tests/wrong_list_action.fail.sh
+++ b/shared/templates/audit_rules_dac_modification/tests/wrong_list_action.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+# packages = audit
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules

--- a/shared/templates/audit_rules_dac_modification/tests/wrong_syscall.fail.sh
+++ b/shared/templates/audit_rules_dac_modification/tests/wrong_syscall.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+# packages = audit
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules


### PR DESCRIPTION
#### Description:

- Enable `check_root_user` (-F auid=0) on Ubuntu 22.04 and fix text
- Add missing STIG IDs
- Add missing package in tests

#### Rationale:

- Required by STIG ID UBTU-22-654180
