### PR TITLE
[stabilization] Fix rule chronyd_or_ntpd_set_maxpoll

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -692,10 +692,12 @@ class Group(XCCDFEntity):
                  r'(service_.*_(enabled|disabled))|' +
                  r'install_smartcard_packages|' +
                  r'sshd_set_keepalive(_0)?|' +
-                 r'sshd_set_idle_timeout$')
+                 r'sshd_set_idle_timeout|' +
+                 r'chronyd_specify_remote_server$')
         priority_order = ["enable_authselect", "installed", "install_smartcard_packages", "removed",
                           "enabled", "disabled", "sshd_set_keepalive_0",
-                          "sshd_set_keepalive", "sshd_set_idle_timeout"]
+                          "sshd_set_keepalive", "sshd_set_idle_timeout",
+                          "chronyd_specify_remote_server"]
         rules_in_group = reorder_according_to_ordering(rules_in_group, priority_order, regex)
 
         # Add rules in priority order, first all packages installed, then removed,


### PR DESCRIPTION
This is a back port of #11960 to the stabilization-v0.1.73 branch.


Rule chronyd_or_ntpd_set_maxpoll was failing Ansible remediation in the STIG profile.

The reason was that the configuration was changed by a remediation for chronyd_specify_remote_server which was executed later than remediation for chronyd_or_ntpd_set_maxpoll. This problem will be fixed by explicit ordering for the rule chronyd_specify_remote_server, which will be put before chronyd_or_ntpd_set_maxpoll. This change will put chronyd_specify_remote_server before other rules in the ntp group.

Fixes: https://github.com/ComplianceAsCode/content/issues/11934