### PR TITLE
[Stabilization]: add when conditional to Ansible remediation of sssd_enable_pam_services

### DIFF
--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/ansible/shared.yml
@@ -18,6 +18,7 @@
     replace: '\1,pam'
   with_items: "{{ sssd_conf_d_files.files | map(attribute='path') }}"
   register: modify_lines_sssd_conf_d_files
+  when: sssd_conf_d_files.matched is defined and sssd_conf_d_files.matched >= 1
 
 - name: {{{ rule_title }}} - Find /etc/sssd/sssd.conf
   ansible.builtin.stat:


### PR DESCRIPTION
#### Description:

- add a when conditional so that the task replacing values in files within /etc/sssd/conf.d directory is not executed in case no files are found

#### Rationale:

- older Ansible versions might terminate prematurely if there are no config files found in /etc/sssd/conf.d directory


#### Review Hints:

1. provision RHEL 7 machine with official Ansible version 2.9.27
2. ./build_product rhel7
3. upload the stig ansible playbook to the machine
4. now in the machine, run
```
ansible-playbook -u root -i localhost, -c local --tags sssd_enable_pam_services playbook.yml
```

If you build the content before this PR, it should crash. It should finish without errors when this PR is added.