### PR TITLE
Fix zipl_bootmap_is_up_to_date

### DIFF
--- a/linux_os/guide/system/bootloader-zipl/zipl_bootmap_is_up_to_date/ansible/shared.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_bootmap_is_up_to_date/ansible/shared.yml
@@ -16,9 +16,16 @@
         path: /etc/zipl.conf
       register: zipl_conf
 
-    # TODO: handle /boot/loader/entries/*.conf
+    - name: "Obtain stats of /boot/loader/entries"
+      stat:
+        path: /boot/loader/entries
+      register: boot_loader_entries
 
     - name: "Update zIPL bootmap"
       command: /usr/sbin/zipl
       changed_when: True
-      when: boot_bootmap.stat.mtime is defined and zipl_conf.stat.mtime is defined and  boot_bootmap.stat.mtime < zipl_conf.stat.mtime
+      when:
+      - boot_bootmap.stat.mtime is defined
+      - zipl_conf.stat.mtime is defined
+      - boot_loader_entries.stat.mtime is defined
+      - boot_bootmap.stat.mtime < zipl_conf.stat.mtime or boot_bootmap.stat.mtime < boot_loader_entries.stat.mtime

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -693,11 +693,13 @@ class Group(XCCDFEntity):
                  r'install_smartcard_packages|' +
                  r'sshd_set_keepalive(_0)?|' +
                  r'sshd_set_idle_timeout|' +
-                 r'chronyd_specify_remote_server$')
+                 r'chronyd_specify_remote_server|' +
+                 r'zipl_.*_argument(_absent)?$')
         priority_order = ["enable_authselect", "installed", "install_smartcard_packages", "removed",
                           "enabled", "disabled", "sshd_set_keepalive_0",
                           "sshd_set_keepalive", "sshd_set_idle_timeout",
-                          "chronyd_specify_remote_server"]
+                          "chronyd_specify_remote_server",
+                          "argument"]
         rules_in_group = reorder_according_to_ordering(rules_in_group, priority_order, regex)
 
         # Add rules in priority order, first all packages installed, then removed,


### PR DESCRIPTION
First, we prioritize order of all zIPL rules that are changing the bootloader arguments in order to put them before
`zipl_bootmap_is_up_to_date`. This should ensure that the fixed rule `zipl_bootmap_is_up_to_date` isn't broken by remediations executed later.

Second, we align the Ansible remediation in `zipl_bootmap_is_up_to_date` to consider modification time of `/boot/loader/entries/`.

Fixes #11944


