### PR TITLE
Align sshd_use_approved_ciphers_ordered_stig with Ubuntu STIG

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/ansible/shared.yml
@@ -4,6 +4,10 @@
 # complexity = low
 # disruption = low
 
+{{%- if 'ubuntu' in product %}}
+{{{ ansible_instantiate_variables('sshd_approved_ciphers') }}}
+{{{ ansible_sshd_set(parameter="Ciphers", value="{{ sshd_approved_ciphers }}", config_is_distributed=sshd_distributed_config) }}}
+{{%- else %}}
 - name: "Configure sshd to use approved ciphers"
   lineinfile:
     path: /etc/ssh/sshd_config
@@ -11,3 +15,4 @@
     state: present
     regexp: '^[\s]*[Cc]iphers[\s]+(aes256-ctr(?=[\w,-@]+|$),?)?(aes192-ctr(?=[\w,-@]+|$),?)?(aes128-ctr(?=[\w,-@]+|$),?)?[\s]*(?:#.*)?$'
     create: True
+{{%- endif %}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/bash/shared.sh
@@ -1,6 +1,12 @@
 # platform = Red Hat Enterprise Linux 7,Oracle Linux 7,multi_platform_sle,multi_platform_ubuntu
+
+{{%- if 'ubuntu' in product %}}
+{{{ bash_instantiate_variables('sshd_approved_ciphers') }}}
+{{{ bash_sshd_remediation(parameter="Ciphers", value="$sshd_approved_ciphers", config_is_distributed=sshd_distributed_config) }}}
+{{%- else %}}
 if grep -q -P '^\s*[Cc]iphers\s+' /etc/ssh/sshd_config; then
   sed -i 's/^\s*[Cc]iphers.*/Ciphers aes256-ctr,aes192-ctr,aes128-ctr/' /etc/ssh/sshd_config
 else
   echo "Ciphers aes256-ctr,aes192-ctr,aes128-ctr" >> /etc/ssh/sshd_config
 fi
+{{%- endif %}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/oval/ubuntu.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/oval/ubuntu.xml
@@ -1,0 +1,80 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("Limit the ciphers to those which are FIPS-approved.") }}}
+    <criteria operator="AND">
+      <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
+      <criteria comment="sshd is configured correctly or is not installed" operator="OR">
+        <criteria comment="sshd is not installed" operator="AND">
+          <extend_definition comment="sshd is not required or requirement is unset"
+            definition_ref="sshd_not_required_or_unset" />
+          <extend_definition comment="package openssh-server removed"
+            definition_ref="package_openssh-server_removed" />
+        </criteria>
+
+        <criteria comment="sshd is installed and configured" operator="AND">
+          <extend_definition comment="sshd is required or requirement is unset"
+            definition_ref="sshd_required_or_unset" />
+          <extend_definition comment="package openssh-server installed"
+            definition_ref="package_openssh-server_installed" />
+          <criteria comment="sshd is configured correctly" operator="AND">
+            <criteria comment="the configuration is correct if it exists" operator="AND">
+              <criterion comment="Check the ciphers in /etc/ssh/sshd_config if any"
+                test_ref="test_{{{ rule_id }}}" />
+              <criterion comment="Check the ciphers in /etc/ssh/sshd_config.d if any"
+                test_ref="test_{{{ rule_id }}}_config_dir" />
+            </criteria>
+            <criterion comment="the configuraton exists" test_ref="test_ciphers_present_{{{ rule_id }}}" />
+          </criteria>
+        </criteria>
+
+      </criteria>
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="any_exist"
+    comment="tests the value of ciphers setting in the /etc/ssh/sshd_config file"
+    id="test_{{{ rule_id }}}" version="1">
+    <ind:object object_ref="obj_{{{ rule_id }}}" />
+    <ind:state state_ref="state_{{{ rule_id }}}" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}" version="1">
+    <ind:filepath>/etc/ssh/sshd_config</ind:filepath>
+    <ind:pattern operation="pattern match">^[ \t]*(?i)ciphers(?-i)[ \t]+(.+?)[ \t]*(?:$|#)</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="any_exist"
+    comment="tests the value of ciphers setting in the /etc/ssh/sshd_config.d file"
+    id="test_{{{ rule_id }}}_config_dir" version="1">
+    <ind:object object_ref="obj_{{{ rule_id }}}_config_dir" />
+    <ind:state state_ref="state_{{{ rule_id }}}" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}_config_dir" version="1">
+    <ind:path>/etc/ssh/sshd_config.d</ind:path>
+    <ind:filename operation="pattern match">.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^[ \t]*(?i)ciphers(?-i)[ \t]+(.+?)[ \t]*(?:$|#)</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_{{{ rule_id }}}" version="1">
+    <ind:subexpression datatype="string" operation="pattern match" var_ref="sshd_approved_ciphers"/>
+  </ind:textfilecontent54_state>
+
+  <external_variable comment="sshd approved ciphers" datatype="string" id="sshd_approved_ciphers" version="1" />
+
+  <ind:textfilecontent54_object comment="All confs collection" id="obj_collection_obj_{{{ rule_id }}}" version="1">
+    <set>
+      <object_reference>obj_{{{ rule_id }}}</object_reference>
+      <object_reference>obj_{{{ rule_id }}}_config_dir</object_reference>
+    </set>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="test_ciphers_present_{{{ rule_id }}}" version="1"
+                              check="all" check_existence="at_least_one_exists"
+                              comment="Verify that the value of ciphers is present">
+    <ind:object object_ref="obj_collection_obj_{{{ rule_id }}}" />
+  </ind:textfilecontent54_test>
+
+</def-group>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/rule.yml
@@ -1,15 +1,20 @@
 documentation_complete: true
 
-
 title: 'Use Only FIPS 140-2 Validated Ciphers'
 
 description: |-
     Limit the ciphers to those algorithms which are FIPS-approved.
     The following line in <tt>/etc/ssh/sshd_config</tt>
     demonstrates use of FIPS-approved ciphers:
+    {{%- if 'ubuntu' in product %}}
+    <pre>Ciphers {{{ xccdf_value("sshd_approved_ciphers") }}}</pre>
+    If this line does not contain these ciphers in exact order,
+    is commented out, or is missing, this is a finding.
+    {{%- else %}}
     <pre>Ciphers aes256-ctr,aes192-ctr,aes128-ctr</pre>
     This rule ensures that there are configured ciphers mentioned
     above (or their subset), keeping the given order of algorithms.
+    {{%- endif %}}
 
 rationale: |-
     Unapproved mechanisms that are used for authentication to the cryptographic module are not verified and therefore

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/tests/comment.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/tests/comment.fail.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
+{{% if product == "ubuntu2204" %}}
+sshd_approved_ciphers="aes256-ctr,aes256-gcm@openssh.com,aes192-ctr,aes128-ctr,aes128-gcm@openssh.com"
+{{% else %}}
+sshd_approved_ciphers="aes256-ctr,aes192-ctr,aes128-ctr"
+{{% endif %}}
+
 if grep -q "^Ciphers" /etc/ssh/sshd_config; then
-	sed -i "s/^Ciphers.*/# ciphers aes256-ctr,aes192-ctr,aes128-ctr/" /etc/ssh/sshd_config
+	sed -i "s/^Ciphers.*/# ciphers $sshd_approved_ciphers/" /etc/ssh/sshd_config
 else
-	echo "# ciphers aes256-ctr,aes192-ctr,aes128-ctr" >> /etc/ssh/sshd_config
+	echo "# ciphers $sshd_approved_ciphers" >> /etc/ssh/sshd_config
 fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/tests/correct_reduced_list.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/tests/correct_reduced_list.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle
 
 if grep -q "^Ciphers" /etc/ssh/sshd_config; then
 	sed -i "s/^Ciphers.*/Ciphers aes192-ctr,aes128-ctr/" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/tests/correct_value.pass.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
+{{% if product == "ubuntu2204" %}}
+sshd_approved_ciphers="aes256-ctr,aes256-gcm@openssh.com,aes192-ctr,aes128-ctr,aes128-gcm@openssh.com"
+{{% else %}}
+sshd_approved_ciphers="aes256-ctr,aes192-ctr,aes128-ctr"
+{{% endif %}}
+
 if grep -q "^Ciphers" /etc/ssh/sshd_config; then
-	sed -i "s/^Ciphers.*/ciphers aes256-ctr,aes192-ctr,aes128-ctr/" /etc/ssh/sshd_config
+	sed -i "s/^Ciphers.*/ciphers $sshd_approved_ciphers/" /etc/ssh/sshd_config
 else
-	echo 'ciphers aes256-ctr,aes192-ctr,aes128-ctr' >> /etc/ssh/sshd_config
+	echo "ciphers $sshd_approved_ciphers" >> /etc/ssh/sshd_config
 fi

--- a/linux_os/guide/services/ssh/sshd_approved_ciphers.var
+++ b/linux_os/guide/services/ssh/sshd_approved_ciphers.var
@@ -20,3 +20,4 @@ options:
     cis_sle12: chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
     cis_sle15: chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
     cis_ubuntu: chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com
+    stig_ubuntu2204: aes256-ctr,aes256-gcm@openssh.com,aes192-ctr,aes128-ctr,aes128-gcm@openssh.com

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -85,6 +85,7 @@ selections:
     - sshd_use_approved_macs_ordered_stig
 
     # UBTU-20-010044 The Ubuntu operating system must configure the SSH daemon to use FIPS 140-2 approved ciphers to prevent the unauthorized disclosure of information and/or detect changes to information during transmission.
+    - sshd_approved_ciphers=stig
     - sshd_use_approved_ciphers_ordered_stig
 
     # UBTU-20-010045 The Ubuntu operating system SSH server must be configured to use only FIPS-validated key exchange algorithms.

--- a/products/ubuntu2204/profiles/stig.profile
+++ b/products/ubuntu2204/profiles/stig.profile
@@ -90,8 +90,8 @@ selections:
     # UBTU-22-255055 The Ubuntu operating system must configure the SSH daemon to use Message Authentication Codes (MACs) employing FIPS 140-3 approved cryptographic hashes to prevent the unauthorized disclosure of information and/or detect changes to information during transmission.
     - sshd_use_approved_macs_ordered_stig
 
-    ### TODO
     # UBTU-22-255050 The Ubuntu operating system must configure the SSH daemon to use FIPS 140-3 approved ciphers to prevent the unauthorized disclosure of information and/or detect changes to information during transmission.
+    - sshd_approved_ciphers=stig_ubuntu2204
     - sshd_use_approved_ciphers_ordered_stig
 
     # UBTU-22-255060 The Ubuntu operating system SSH server must be configured to use only FIPS-validated key exchange algorithms.


### PR DESCRIPTION
#### Description:

- Modify `sshd_use_approved_ciphers_ordered_stig` rule to better align with Ubuntu STIG (UBTU-20-010044, UBTU-22-255050)
- Switch to using `sshd_approved_ciphers` variable
- Switch to checking the whole set of algorithms instead of just a subset
- Extend OVAL check to allow distributed configs
- Analogous to #11853 

#### Rationale:
- Checking just for a subset does not meet the requirement of having the algorithms in the exact same order (as specified in the STIG), because it is possible to specify only the last algorithm, which is effectively the same as specifying them in the wrong order