### PR TITLE
Check ufw is active

### DIFF
--- a/components/ufw.yml
+++ b/components/ufw.yml
@@ -4,6 +4,7 @@ name: ufw
 packages:
 - ufw
 rules:
+- check_ufw_active
 - package_ufw_installed
 - package_ufw_removed
 - service_ufw_enabled

--- a/linux_os/guide/system/network/network-ufw/check_ufw_active/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/check_ufw_active/rule.yml
@@ -27,4 +27,5 @@ references:
 fixtext: |-
     Enable the ufw by using the following command:  
     <pre>$ sudo ufw enable</pre>
+
 platform: machine and package[ufw]

--- a/linux_os/guide/system/network/network-ufw/check_ufw_active/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/check_ufw_active/rule.yml
@@ -22,6 +22,7 @@ references:
     cis@ubuntu2004: 3.5.1.3
     cis@ubuntu2204: 3.5.1.3
     disa: CCI-002314
+    stigid@ubuntu2004: UBTU-20-010434
     stigid@ubuntu2204: UBTU-22-251015
 
 fixtext: |-

--- a/linux_os/guide/system/network/network-ufw/check_ufw_active/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/check_ufw_active/rule.yml
@@ -1,0 +1,30 @@
+documentation_complete: true
+
+title: 'Verify ufw Active'
+
+description: |-
+    Verify the ufw is enabled on the system with the following command:
+    <pre># sudo ufw status</pre>
+    If the above command returns the status as "inactive" or any type of error, this is a finding.
+
+rationale: |-
+    Remote access services, such as those providing remote access to network devices and information systems, 
+    which lack automated control capabilities, increase risk and make remote user access management difficult at best.  
+    Remote access is access to DOD nonpublic information systems by an authorized user (or an information system) communicating 
+    through an external, nonorganization-controlled network. Remote access methods include, for example, dial-up, broadband, and wireless.  
+    Ubuntu 22.04 LTS functionality (e.g., RDP) must be capable of taking enforcement action if the audit reveals unauthorized activity. 
+    Automated control of remote access sessions allows organizations to ensure ongoing compliance with remote access policies by 
+    enforcing connection rules of remote access applications on a variety of information system components.
+
+severity: medium
+
+references:
+    cis@ubuntu2004: 3.5.1.3
+    cis@ubuntu2204: 3.5.1.3
+    disa: CCI-002314
+    stigid@ubuntu2204: UBTU-22-251015
+
+fixtext: |-
+    Enable the ufw by using the following command:  
+    <pre>$ sudo ufw enable</pre>
+platform: machine and package[ufw]

--- a/linux_os/guide/system/network/network-ufw/check_ufw_active/sce/shared.sh
+++ b/linux_os/guide/system/network/network-ufw/check_ufw_active/sce/shared.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# platform = multi_platform_ubuntu
+# check-import = stdout
+
+result=$XCCDF_RESULT_FAIL
+
+if ufw status | grep -qw "active"; then
+    result=${XCCDF_RESULT_PASS}
+fi
+
+exit $result

--- a/linux_os/guide/system/network/network-ufw/check_ufw_active/tests/correct.pass.sh
+++ b/linux_os/guide/system/network/network-ufw/check_ufw_active/tests/correct.pass.sh
@@ -1,0 +1,5 @@
+# package = ufw
+
+systemctl enable --now ufw
+ufw allow ssh
+ufw -f enable

--- a/linux_os/guide/system/network/network-ufw/check_ufw_active/tests/incorrect.fail.sh
+++ b/linux_os/guide/system/network/network-ufw/check_ufw_active/tests/incorrect.fail.sh
@@ -1,0 +1,7 @@
+# package = ufw
+# remediation = none
+
+systemctl enable --now ufw
+ufw allow ssh
+ufw -f enable || exit 1
+ufw disable

--- a/linux_os/guide/system/network/network-ufw/service_ufw_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/service_ufw_enabled/rule.yml
@@ -16,7 +16,7 @@ references:
     disa: CCI-002314
     srg: SRG-OS-000297-GPOS-00115
     stigid@ubuntu2004: UBTU-20-010434
-    stigid@ubuntu2204: UBTU-22-251015
+    stigid@ubuntu2204: UBTU-22-251020
 
 ocil_clause: 'the service is not enabled'
 

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -523,6 +523,7 @@ selections:
 
     # UBTU-20-010434 The Ubuntu operating system must enable and run the uncomplicated firewall(ufw).
     - service_ufw_enabled
+    - check_ufw_active
 
     # UBTU-20-010435 The Ubuntu operating system must, for networked systems, compare internal information system clocks at least every 24 hours with a server which is synchronized to one of the redundant United States Naval Observatory (USNO) time servers, or a time server designated for the appropriate DoD network (NIPRNet/SIPRNet), and/or the Global Positioning System (GPS).
     - var_time_service_set_maxpoll=36_hours

--- a/products/ubuntu2204/profiles/stig.profile
+++ b/products/ubuntu2204/profiles/stig.profile
@@ -569,11 +569,11 @@ selections:
     # UBTU-22-412015 The Ubuntu operating system must display the date and time of the last successful account logon upon logon.
     - display_login_attempts
 
-    # UBTU-22-251015 The Ubuntu operating system must have an application firewall enabled.
-    - service_ufw_enabled
+    # UBTU-22-251015 The Ubuntu operating system must enable and run the Uncomplicated Firewall (ufw).
+    - check_ufw_active
 
     # UBTU-22-251020 The Ubuntu operating system must have an application firewall enabled.
-    # same as UBTU-22-251015
+    - service_ufw_enabled
 
     ### TODO
     # UBTU-22-291015 The Ubuntu operating system must disable all wireless network adapters.


### PR DESCRIPTION
#### Description:

- Only check whether the ufw is active after ufw service is enable instead of configuring the ufw.

#### Rationale:

- Ensure ongoing compliance with remote access policies by checking the status of Uncomplicated Firewall (ufw)