### PR TITLE
Align sshd_use_approved_kex_ordered_stig with Ubuntu STIG

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/bash/shared.sh
@@ -3,8 +3,13 @@
 KEX_ALGOS="ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,\
 diffie-hellman-group-exchange-sha256"
 
+{{%- if 'ubuntu' in product %}}
+{{{ bash_sshd_remediation(parameter="KexAlgorithms", value="$KEX_ALGOS", config_is_distributed=sshd_distributed_config) }}}
+{{%- else %}}
+
 if grep -q -P '^\s*KexAlgorithms\s+' /etc/ssh/sshd_config; then
   sed -i "s/^\s*KexAlgorithms.*/KexAlgorithms ${KEX_ALGOS}/" /etc/ssh/sshd_config
 else
   echo "KexAlgorithms ${KEX_ALGOS}" >> /etc/ssh/sshd_config
 fi
+{{%- endif %}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/oval/ubuntu.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/oval/ubuntu.xml
@@ -1,0 +1,78 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("Limit the KexAlgorithms to those which are FIPS-approved.") }}}
+    <criteria operator="AND">
+      <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
+      <criteria comment="sshd is configured correctly or is not installed" operator="OR">
+        <criteria comment="sshd is not installed" operator="AND">
+          <extend_definition comment="sshd is not required or requirement is unset"
+            definition_ref="sshd_not_required_or_unset" />
+          <extend_definition comment="package openssh-server removed"
+            definition_ref="package_openssh-server_removed" />
+        </criteria>
+
+        <criteria comment="sshd is installed and configured" operator="AND">
+          <extend_definition comment="sshd is required or requirement is unset"
+            definition_ref="sshd_required_or_unset" />
+          <extend_definition comment="package openssh-server installed"
+            definition_ref="package_openssh-server_installed" />
+          <criteria comment="sshd is configured correctly" operator="AND">
+            <criteria comment="the configuration is correct if it exists" operator="AND">
+              <criterion comment="Check the KexAlgorithms in /etc/ssh/sshd_config if any"
+                test_ref="test_{{{ rule_id }}}" />
+              <criterion comment="Check the KexAlgorithms in /etc/ssh/sshd_config.d if any"
+                test_ref="test_{{{ rule_id }}}_config_dir" />
+            </criteria>
+            <criterion comment="the configuraton exists" test_ref="test_KexAlgorithms_present_{{{ rule_id }}}" />
+          </criteria>
+        </criteria>
+
+      </criteria>
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="any_exist"
+    comment="tests the value of KexAlgorithms setting in the /etc/ssh/sshd_config file"
+    id="test_{{{ rule_id }}}" version="1">
+    <ind:object object_ref="obj_{{{ rule_id }}}" />
+    <ind:state state_ref="state_{{{ rule_id }}}" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}" version="1">
+    <ind:filepath>/etc/ssh/sshd_config</ind:filepath>
+    <ind:pattern operation="pattern match">^[ \t]*(?i)KexAlgorithms(?-i)[ \t]+(.+?)[ \t]*(?:$|#)</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="any_exist"
+    comment="tests the value of KexAlgorithms setting in the /etc/ssh/sshd_config.d file"
+    id="test_{{{ rule_id }}}_config_dir" version="1">
+    <ind:object object_ref="obj_{{{ rule_id }}}_config_dir" />
+    <ind:state state_ref="state_{{{ rule_id }}}" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}_config_dir" version="1">
+    <ind:path>/etc/ssh/sshd_config.d</ind:path>
+    <ind:filename operation="pattern match">.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^[ \t]*(?i)KexAlgorithms(?-i)[ \t]+(.+?)[ \t]*(?:$|#)</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_{{{ rule_id }}}" version="1">
+      <ind:subexpression datatype="string" operation="pattern match">ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_object comment="All confs collection" id="obj_collection_obj_{{{ rule_id }}}" version="1">
+    <set>
+      <object_reference>obj_{{{ rule_id }}}</object_reference>
+      <object_reference>obj_{{{ rule_id }}}_config_dir</object_reference>
+    </set>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="test_KexAlgorithms_present_{{{ rule_id }}}" version="1"
+                              check="all" check_existence="at_least_one_exists"
+                              comment="Verify that the value of KexAlgorithms is present">
+    <ind:object object_ref="obj_collection_obj_{{{ rule_id }}}" />
+  </ind:textfilecontent54_test>
+
+</def-group>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/rule.yml
@@ -8,7 +8,7 @@
 {{% set path='/etc/ssh/sshd_config' %}}
 {{% set conf="KexAlgorithms ecdh-sha1-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521" ~
              ",diffie-hellman-group-exchange-sha256"  %}}
-{{% elif product in ['sle12','sle15','ubuntu2004'] %}}
+{{% elif product in ['sle12','sle15','ubuntu2004', 'ubuntu2204'] %}}
 {{% set path='/etc/ssh/sshd_config' %}}
 {{% set conf="KexAlgorithms ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521" ~
              ",diffie-hellman-group-exchange-sha256"  %}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/common.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/common.sh
@@ -5,13 +5,15 @@ CONF_PREFIX="CRYPTO_POLICY='-oKexAlgorithms="
 KEX_ALGOS="ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512"
 CONF_SUFIX="'"
 CONF_PREFIX_REGEX="^\s*CRYPTO_POLICY"
-{{% elif product in ['ol7','rhel7','sle12','sle15','ubuntu2004'] %}}
+{{% elif product in ['ol7','rhel7','sle12','sle15','ubuntu2004', 'ubuntu2204'] %}}
 FILE_PATH='/etc/ssh/sshd_config'
+FILE_PATH_CONFIGDIR='/etc/ssh/sshd_config.d'
 CONF_PREFIX="KexAlgorithms "
 KEX_ALGOS="ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256"
 CONF_PREFIX_REGEX="^\s*KexAlgorithms"
+CONF_SUFIX=""
 {{% endif %}}
 
-sed -iE "/${CONF_PREFIX_REGEX}/d" "${FILE_PATH}"
+sed -iE "/${CONF_PREFIX_REGEX}/Id" "${FILE_PATH}"
 
 CONF="${CONF_PREFIX}${KEX_ALGOS}${CONF_SUFIX}"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/conflict.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/conflict.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+source common.sh
+
+echo "${CONF}" >> "${FILE_PATH}"
+CONF="${CONF_PREFIX}non-valid-256${CONF_SUFIX}"
+echo "${CONF}" >> "${FILE_PATH}"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/conflict_directory.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/conflict_directory.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# platform = multi_platform_ubuntu
+
+source common.sh
+
+echo "${CONF}" >> "${FILE_PATH}"
+CONF="${CONF_PREFIX}non-valid-256${CONF_SUFIX}"
+echo "${CONF}" >> "${FILE_PATH_CONFIGDIR}/test.conf"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/correct_reduced_list.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/correct_reduced_list.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle
 
 source common.sh
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/correct_value_configdir.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/correct_value_configdir.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+source common.sh
+
+echo "${CONF}" >> "${FILE_PATH_CONFIGDIR}/test.conf"


### PR DESCRIPTION
#### Description:

- Modify sshd_use_approved_kex_ordered_stig rule to better align with Ubuntu STIG (UBTU-20-010045, UBTU-22-255060)
- Switch to checking the whole set of algorithms instead of just a subset
- Extend OVAL check to allow distributed configs
- Analogous to https://github.com/ComplianceAsCode/content/pull/11853

#### Rationale:
- Checking just for a subset does not meet the requirement of having the algorithms in the exact same order (as specified in the STIG), because it is possible to specify only the last algorithm, which is effectively the same as specifying them in the wrong order