### PR TITLE
Disable remediation for smartcard_pam_enabled on Ubuntu 22.04

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_sle,Ubuntu 20.04
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_sle,Ubuntu 20.04
 {{% if 'ubuntu' in product %}}
 {{{ bash_ensure_pam_module_option('/etc/pam.d/common-auth', 'auth', '[success=2 default=ignore]', 'pam_pkcs11.so', '', '', '# here are the per-package modules') }}}
 {{% else %}}


### PR DESCRIPTION
#### Description:

- Disable remediation for `smartcard_pam_enabled` on Ubuntu 22.04

#### Rationale:

- The current remediation is not considered reliable enough for critical PAM configuration and will be disabled until a better solution is implemented.
- The remediation breaks the PAM auth configuration on a clean Ubuntu Desktop 22.04 installation which ships with `libpam-sss`, which adds `auth [success=1...] libpam_sss.so` to the stack.
- The PAM rules should ideally rely on `pam-auth-update` as was implemented in recent CIS releases.