### PR TITLE
Disable RHEL 10 content for 0.1.73 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ option(SSG_PRODUCT_OPENSUSE "If enabled, the openSUSE SCAP content will be built
 option(SSG_PRODUCT_RHEL7 "If enabled, the RHEL7 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
 option(SSG_PRODUCT_RHEL8 "If enabled, the RHEL8 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
 option(SSG_PRODUCT_RHEL9 "If enabled, the RHEL9 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
-option(SSG_PRODUCT_RHEL10 "If enabled, the RHEL10 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
+option(SSG_PRODUCT_RHEL10 "If enabled, the RHEL10 SCAP content will be built" FALSE)
 option(SSG_PRODUCT_RHV4 "If enabled, the RHV4 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
 option(SSG_PRODUCT_SLE12 "If enabled, the SLE12 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
 option(SSG_PRODUCT_SLE15 "If enabled, the SLE15 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})


### PR DESCRIPTION
#### Description:

Disable RHEL 10 content for 0.1.73 release

#### Rationale:
Pre beta OS should be shipped.

#### Review Hints:
1. `rm -rf build/*`
1. `cmake -B build .`
1. Observe that `-- RHEL 10: OFF`
