### PR TITLE
Stop building -ds-1.2.xml data streams

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,6 @@ set(SSG_TARGET_OVAL_MINOR_VERSION "11" CACHE STRING "Which minor version of OVAL
 
 set(SSG_TARGET_OVAL_VERSION "${SSG_TARGET_OVAL_MAJOR_VERSION}.${SSG_TARGET_OVAL_MINOR_VERSION}")
 
-option(SSG_BUILD_SCAP_12_DS "If enabled, ssg-*-ds-1.2.xml will be built along with ssg-*-ds.xml" TRUE)
 option(SSG_OVAL_SCHEMATRON_VALIDATION_ENABLED "If enabled, schematron validation will be performed as part of the ctest tests. Schematron takes a lot of time to complete but can find more issues than just plain XSD validation." TRUE)
 option(SSG_SHELLCHECK_BASH_FIXES_VALIDATION_ENABLED "If enabled, shellcheck validation of bash fixes will be performed as part of the ctest tests." TRUE)
 option(SSG_LINKCHECKER_VALIDATION_ENABLED "If enabled, linkchecker will be used to validate URLs in all the HTML guides and tables." TRUE)
@@ -275,7 +274,6 @@ message(STATUS " ")
 message(STATUS "Build options:")
 message(STATUS "SSG vendor string: ${SSG_VENDOR}")
 message(STATUS "Target OVAL version: ${SSG_TARGET_OVAL_VERSION}")
-message(STATUS "Build SCAP 1.2 source data streams: ${SSG_BUILD_SCAP_12_DS}")
 message(STATUS "OVAL schematron validation: ${SSG_OVAL_SCHEMATRON_VALIDATION_ENABLED}")
 message(STATUS "shellcheck bash fixes validation: ${SSG_SHELLCHECK_BASH_FIXES_VALIDATION_ENABLED}")
 message(STATUS "Separate SCAP files: ${SSG_SEPARATE_SCAP_FILES_ENABLED}")

--- a/build-scripts/compose_ds.py
+++ b/build-scripts/compose_ds.py
@@ -264,7 +264,9 @@ def compose_ds(
 
     if hasattr(ET, "indent"):
         ET.indent(ds_collection, space=" ", level=0)
-    return ET.ElementTree(ds_collection)
+    ds = ET.ElementTree(ds_collection)
+    ds_13 = upgrade_ds_to_scap_13(ds)
+    return ds_13
 
 
 def upgrade_ds_to_scap_13(ds):
@@ -279,8 +281,7 @@ def upgrade_ds_to_scap_13(ds):
 
 
 def _store_ds(ds, output):
-    ds_13 = upgrade_ds_to_scap_13(ds)
-    ds_13.write(output, xml_declaration=True, encoding="utf-8")
+    ds.write(output, xml_declaration=True, encoding="utf-8")
 
 
 def append_id_to_file_name(path, id_):

--- a/build-scripts/compose_ds.py
+++ b/build-scripts/compose_ds.py
@@ -176,9 +176,7 @@ def parse_args():
     parser.add_argument("--cpe-oval", help="CPE OVAL file name")
     parser.add_argument("--enable-sce", action='store_true', help="Enable building sce data")
     parser.add_argument(
-        "--output-12", help="Output SCAP 1.2 source data stream file name")
-    parser.add_argument(
-        "--output-13", required=True,
+        "--output", required=True,
         help="Output SCAP 1.3 source data stream file name")
     parser.add_argument(
         "--multiple-ds",
@@ -280,12 +278,9 @@ def upgrade_ds_to_scap_13(ds):
     return ds
 
 
-def _store_ds(ds, output_13, output_12):
-    if output_12:
-        ds.write(output_12, xml_declaration=True, encoding="utf-8")
-
+def _store_ds(ds, output):
     ds_13 = upgrade_ds_to_scap_13(ds)
-    ds_13.write(output_13, xml_declaration=True, encoding="utf-8")
+    ds_13.write(output, xml_declaration=True, encoding="utf-8")
 
 
 def append_id_to_file_name(path, id_):
@@ -317,13 +312,12 @@ def _compose_multiple_ds(args):
         ds = compose_ds(
             xccdf, oval, ocil, cpe_dict, cpe_oval, args.enable_sce
         )
-        output_13 = _get_thin_ds_output_path(args.output_13, xccdf.replace("xccdf_", ""))
-        output_12 = None
+        output = _get_thin_ds_output_path(args.output, xccdf.replace("xccdf_", ""))
 
-        if not os.path.exists(os.path.dirname(output_13)):
-            os.makedirs(os.path.dirname(output_13))
+        if not os.path.exists(os.path.dirname(output)):
+            os.makedirs(os.path.dirname(output))
 
-        _store_ds(ds, output_13, output_12)
+        _store_ds(ds, output)
 
 
 if __name__ == "__main__":
@@ -336,4 +330,4 @@ if __name__ == "__main__":
     ds = compose_ds(
         args.xccdf, args.oval, args.ocil, args.cpe_dict, args.cpe_oval, args.enable_sce
     )
-    _store_ds(ds, args.output_13, args.output_12)
+    _store_ds(ds, args.output)

--- a/build-scripts/compose_ds.py
+++ b/build-scripts/compose_ds.py
@@ -240,10 +240,10 @@ def compose_ds(
         "{%s}data-stream-collection" % datastream_namespace)
     name = "from_xccdf_" + os.path.basename(xccdf_file_name)
     ds_collection.set("id", "scap_%s_collection_%s" % (ID_NS, name))
-    ds_collection.set("schematron-version", "1.2")
+    ds_collection.set("schematron-version", "1.3")
     ds = ET.SubElement(ds_collection, "{%s}data-stream" % datastream_namespace)
     ds.set("id", "scap_%s_datastream_%s" % (ID_NS, name))
-    ds.set("scap-version", "1.2")
+    ds.set("scap-version", "1.3")
     ds.set("use-case", "OTHER")
     dictionaries = ET.SubElement(ds, "{%s}dictionaries" % datastream_namespace)
     checklists = ET.SubElement(ds, "{%s}checklists" % datastream_namespace)
@@ -265,16 +265,6 @@ def compose_ds(
     if hasattr(ET, "indent"):
         ET.indent(ds_collection, space=" ", level=0)
     ds = ET.ElementTree(ds_collection)
-    ds_13 = upgrade_ds_to_scap_13(ds)
-    return ds_13
-
-
-def upgrade_ds_to_scap_13(ds):
-    dsc_el = ds.getroot()
-    dsc_el.set("schematron-version", "1.3")
-    ds_el = ds.find("{%s}data-stream" % datastream_namespace)
-    ds_el.set("scap-version", '1.3')
-
     # Move reference to remote OVAL content to a source data stream component
     move_patches_up_to_date_to_source_data_stream_component(ds)
     return ds

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -447,7 +447,7 @@ macro(ssg_build_sds PRODUCT)
 
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/compose_ds.py" --xccdf "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" --oval "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" --ocil "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml" --cpe-dict "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml" --cpe-oval "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml" --output-13 "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" --multiple-ds "${SSG_THIN_DS_COMPONENTS_DIR}" ${COMPOSE_EXTRA_ARGS}
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/compose_ds.py" --xccdf "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" --oval "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" --ocil "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml" --cpe-dict "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml" --cpe-oval "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml" --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" --multiple-ds "${SSG_THIN_DS_COMPONENTS_DIR}" ${COMPOSE_EXTRA_ARGS}
         COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
         DEPENDS generate-ssg-${PRODUCT}-xccdf.xml "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
         DEPENDS generate-ssg-${PRODUCT}-oval.xml "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -445,40 +445,20 @@ macro(ssg_build_sds PRODUCT)
         set(COMPOSE_EXTRA_ARGS "")
     endif()
 
-    if(SSG_BUILD_SCAP_12_DS)
-        add_custom_command(
-            OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds-1.2.xml"
-            OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
-            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/compose_ds.py" --xccdf "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" --oval "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" --ocil "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml" --cpe-dict "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml" --cpe-oval "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml" --output-12 "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds-1.2.xml" --output-13 "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" --multiple-ds "${SSG_THIN_DS_COMPONENTS_DIR}" ${COMPOSE_EXTRA_ARGS}
-            COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds-1.2.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds-1.2.xml"
-            COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
-            DEPENDS generate-ssg-${PRODUCT}-xccdf.xml "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
-            DEPENDS generate-ssg-${PRODUCT}-oval.xml "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"
-            DEPENDS generate-ssg-${PRODUCT}-ocil.xml "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
-            DEPENDS generate-ssg-${PRODUCT}-cpe-dictionary.xml "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml"
-            COMMENT "[${PRODUCT}-content] Updating data stream ssg-${PRODUCT}-ds.xml to 1.3"
-        )
-        add_custom_target(
-            generate-ssg-${PRODUCT}-ds.xml
-            DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds-1.2.xml"
-            DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
-        )
-    else()
-        add_custom_command(
-            OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
-            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/compose_ds.py" --xccdf "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" --oval "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" --ocil "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml" --cpe-dict "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml" --cpe-oval "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml" --output-13 "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" --multiple-ds "${SSG_THIN_DS_COMPONENTS_DIR}" ${COMPOSE_EXTRA_ARGS}
-            COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
-            DEPENDS generate-ssg-${PRODUCT}-xccdf.xml "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
-            DEPENDS generate-ssg-${PRODUCT}-oval.xml "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"
-            DEPENDS generate-ssg-${PRODUCT}-ocil.xml "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
-            DEPENDS generate-ssg-${PRODUCT}-cpe-dictionary.xml "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml"
-            COMMENT "[${PRODUCT}-content] Updating data stream ssg-${PRODUCT}-ds.xml to 1.3"
-        )
-        add_custom_target(
-            generate-ssg-${PRODUCT}-ds.xml
-            DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
-        )
-    endif()
+    add_custom_command(
+        OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/compose_ds.py" --xccdf "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" --oval "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" --ocil "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml" --cpe-dict "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml" --cpe-oval "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml" --output-13 "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" --multiple-ds "${SSG_THIN_DS_COMPONENTS_DIR}" ${COMPOSE_EXTRA_ARGS}
+        COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
+        DEPENDS generate-ssg-${PRODUCT}-xccdf.xml "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
+        DEPENDS generate-ssg-${PRODUCT}-oval.xml "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"
+        DEPENDS generate-ssg-${PRODUCT}-ocil.xml "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
+        DEPENDS generate-ssg-${PRODUCT}-cpe-dictionary.xml "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml"
+        COMMENT "[${PRODUCT}-content] Updating data stream ssg-${PRODUCT}-ds.xml to 1.3"
+    )
+    add_custom_target(
+        generate-ssg-${PRODUCT}-ds.xml
+        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
+    )
 
     add_test(
         NAME "xccdf-values-${PRODUCT}"
@@ -513,12 +493,6 @@ macro(ssg_build_sds PRODUCT)
             NAME "validate-ssg-${PRODUCT}-ds.xml"
             COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" ds sds-validate "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
         )
-        if(SSG_BUILD_SCAP_12_DS)
-            add_test(
-                NAME "validate-ssg-${PRODUCT}-ds-1.2.xml"
-                COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" ds sds-validate "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds-1.2.xml"
-            )
-        endif()
     endif()
     add_test(
         NAME "verify-references-ssg-${PRODUCT}-ds.xml"
@@ -845,11 +819,6 @@ macro(ssg_build_product PRODUCT)
     install(FILES "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
         DESTINATION "${SSG_CONTENT_INSTALL_DIR}")
 
-    if(SSG_BUILD_SCAP_12_DS)
-        install(FILES "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds-1.2.xml"
-            DESTINATION "${SSG_CONTENT_INSTALL_DIR}")
-    endif()
-
     # This is a common cmake trick, we need the globbing to happen at build time
     # and not configure time.
     install(
@@ -955,33 +924,12 @@ macro(ssg_build_derivative_product ORIGINAL SHORTNAME DERIVATIVE)
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds.xml"
     )
 
-    if(SSG_BUILD_SCAP_12_DS)
-        add_custom_command(
-            OUTPUT "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds-1.2.xml"
-            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/enable_derivatives.py" --enable-${SHORTNAME} -i "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-ds-1.2.xml" -o "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds-1.2.xml" "${CMAKE_CURRENT_BINARY_DIR}/product.yml" ${DERIVATIVE} --id-name ssg --cpe-items-dir "${CMAKE_CURRENT_BINARY_DIR}/cpe_items" --unlinked-cpe-oval-path "${CMAKE_CURRENT_BINARY_DIR}/cpe-oval-unlinked.xml"
-            COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds-1.2.xml" "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds-1.2.xml"
-            DEPENDS generate-ssg-${ORIGINAL}-ds.xml "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-ds.xml" "${CMAKE_BINARY_DIR}/ssg-${ORIGINAL}-ds-1.2.xml"
-            DEPENDS ${PRODUCT}-compile-all "${CMAKE_CURRENT_BINARY_DIR}/ssg_build_compile_all-${PRODUCT}"
-            COMMENT "[${DERIVATIVE}-content] generating ssg-${DERIVATIVE}-ds-1.2.xml"
-        )
-        add_custom_target(
-            generate-ssg-${DERIVATIVE}-ds-1.2.xml
-            DEPENDS "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds-1.2.xml"
-        )
-    endif()
-
     define_validate_product("${DERIVATIVE}")
     if("${VALIDATE_PRODUCT}" OR "${FORCE_VALIDATE_EVERYTHING}")
         add_test(
             NAME "validate-ssg-${DERIVATIVE}-ds.xml"
             COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" ds sds-validate "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds.xml"
         )
-        if(SSG_BUILD_SCAP_12_DS)
-            add_test(
-                NAME "validate-ssg-${DERIVATIVE}-ds-1.2.xml"
-                COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" ds sds-validate "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds-1.2.xml"
-            )
-        endif()
     endif()
 
     add_custom_target(${DERIVATIVE} ALL)
@@ -993,9 +941,6 @@ macro(ssg_build_derivative_product ORIGINAL SHORTNAME DERIVATIVE)
         generate-ssg-${DERIVATIVE}-xccdf.xml
         generate-ssg-${DERIVATIVE}-ds.xml
     )
-    if(SSG_BUILD_SCAP_12_DS)
-        add_dependencies(${DERIVATIVE}-content generate-ssg-${DERIVATIVE}-ds-1.2.xml)
-    endif()
 
     add_dependencies(zipfile generate-ssg-${DERIVATIVE}-ds.xml)
 
@@ -1032,11 +977,6 @@ macro(ssg_build_derivative_product ORIGINAL SHORTNAME DERIVATIVE)
 
     install(FILES "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds.xml"
         DESTINATION "${SSG_CONTENT_INSTALL_DIR}")
-
-    if(SSG_BUILD_SCAP_12_DS)
-        install(FILES "${CMAKE_BINARY_DIR}/ssg-${DERIVATIVE}-ds-1.2.xml"
-            DESTINATION "${SSG_CONTENT_INSTALL_DIR}")
-    endif()
 
     # This is a common cmake trick, we need the globbing to happen at build time
     # and not configure time.
@@ -1333,7 +1273,6 @@ macro(ssg_build_zipfile ZIPNAME)
         COMMAND ${CMAKE_COMMAND} -E make_directory "zipfile/${ZIPNAME}/kickstart"
         COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_SOURCE_DIR}/products/rhel*/kickstart/*-ks.cfg" -DDEST="zipfile/${ZIPNAME}/kickstart" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
         COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ssg-*-ds.xml" -DDEST="zipfile/${ZIPNAME}" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
-        COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/ssg-*-ds-1.2.xml" -DDEST="zipfile/${ZIPNAME}" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
         COMMAND ${CMAKE_COMMAND} -E make_directory "zipfile/${ZIPNAME}/bash"
         COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/bash/*.sh" -DDEST="zipfile/${ZIPNAME}/bash" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
         COMMAND ${CMAKE_COMMAND} -E make_directory "zipfile/${ZIPNAME}/ansible"

--- a/docs/manual/developer/02_building_complianceascode.md
+++ b/docs/manual/developer/02_building_complianceascode.md
@@ -422,8 +422,7 @@ it will be the `content/build` folder.
 ### SCAP XML files
 
 The SCAP XML files will be called `ssg-${PRODUCT}-${TYPE}.xml`. For example
-`ssg-rhel7-ds.xml` is the SCAP 1.3 *Red Hat Enterprise Linux 7* **source data stream**,
-and `ssg-rhel7-ds-1.2.xml` is the SCAP 1.2 **source data stream**.
+`ssg-rhel7-ds.xml` is the SCAP 1.3 *Red Hat Enterprise Linux 7* **source data stream**.
 
 We recommend using **source data stream** if you have a choice.
 The build system also generates separate XCCDF, OVAL, OCIL and CPE files:
@@ -433,7 +432,6 @@ $ ls -1 ssg-rhel7-*.xml
 ssg-rhel7-cpe-dictionary.xml
 ssg-rhel7-cpe-oval.xml
 ssg-rhel7-ds.xml
-ssg-rhel7-ds-1.2.xml
 ssg-rhel7-ocil.xml
 ssg-rhel7-oval.xml
 ssg-rhel7-xccdf.xml

--- a/docs/workshop/lab2_openscap.adoc
+++ b/docs/workshop/lab2_openscap.adoc
@@ -99,7 +99,6 @@ jinja2_cache
 rules.ninja
 ssg-ubuntu2004-cpe-dictionary.xml
 ssg-ubuntu2004-cpe-oval.xml
-ssg-ubuntu2004-ds-1.2.xml
 ssg-ubuntu2004-ds.xml
 ssg-ubuntu2004-ocil.xml
 ssg-ubuntu2004-oval.xml

--- a/scap-security-guide.spec
+++ b/scap-security-guide.spec
@@ -53,7 +53,7 @@ present in %{name} package.
 %prep
 %autosetup -p1
 
-%define cmake_defines_common -DSSG_SEPARATE_SCAP_FILES_ENABLED=OFF -DSSG_BASH_SCRIPTS_ENABLED=OFF -DSSG_BUILD_SCAP_12_DS=OFF -DSSG_BUILD_DISA_DELTA_FILES=OFF
+%define cmake_defines_common -DSSG_SEPARATE_SCAP_FILES_ENABLED=OFF -DSSG_BASH_SCRIPTS_ENABLED=OFF -DSSG_BUILD_DISA_DELTA_FILES=OFF
 %define cmake_defines_specific %{nil}
 %define centos_8_specific %{nil}
 


### PR DESCRIPTION
#### Description:

This change will stop building the  -ds-1.2.xml data streams.

These data streams are marked as SCAP 1.2 data streams, but they aren't SCAP 1.2 compatible, because we put into them OVAL 5.11 which isn't a part of SCAP 1.2 line of standards.

These data streams differ in the value of `scap-version` and `schematron-version` attributes and they don't have separate component for the remote checks used in rules `security_patches_up_to_date`, the remote OVAL check is referenced directly in the rule. Otherwise they are the same as the -ds.xml files.

#### Rationale:

Simplify, streamline, stop producing legacy artifacts.
