### PR TITLE
[Stabilization]: Ensure that security_patches_up_to_date is not built with remediations

### DIFF
--- a/linux_os/guide/system/software/updating/security_patches_up_to_date/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/security_patches_up_to_date/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_all
+# platform = multi_platform_alinux,multi_platform_anolis,multi_platform_fedora,multi_platform_ol,multi_platform_sle,multi_platform_ubuntu,multi_platform_uos
 # reboot = true
 # strategy = patch
 # complexity = low

--- a/linux_os/guide/system/software/updating/security_patches_up_to_date/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/security_patches_up_to_date/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,multi_platform_sle
+# platform = multi_platform_ol,multi_platform_sle
 # reboot = true
 # strategy = patch
 # complexity = low


### PR DESCRIPTION
#### Description:

- modify list of supported platforms for Ansible and Bash remediations for security_patches_up_to_date

#### Rationale:

- the rule is being phased out of RH products

#### Review Hints:

- build the content and ensure that remediations are not present in the resulting content, e.g. playbooks etc