### PR TITLE
Add subscription file for ROSA installs

### DIFF
--- a/ocp-resources/compliance-operator-rosa-subscription.yaml
+++ b/ocp-resources/compliance-operator-rosa-subscription.yaml
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: compliance-operator-sub
+  namespace: openshift-compliance
+spec:
+  channel: alpha
+  name: compliance-operator
+  source: compliance-operator
+  sourceNamespace: openshift-marketplace
+  config:
+    nodeSelector:
+      node-role.kubernetes.io/worker: ""


### PR DESCRIPTION
Since ROSA clusters only have worker nodes, we need to modify the
subscription to allow the operator to schedule on worker nodes.

Without this, ROSA installations will spin waiting for master nodes to
schedule on.

This will get wired up to CI through the ocp4e2e test suite in a
separate PR:

  https://github.com/ComplianceAsCode/ocp4e2e/pull/41
