### PR TITLE
OCPBUGS-1316: Add missing variable reference to rules

### DIFF
--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_available/rule.yml
@@ -38,7 +38,9 @@ description: |-
   <p>
   This rule pertains to the <tt>imagefs.available</tt> setting of the <tt>evictionHard</tt>
   section.
+  {{{ kubernetes_variable_instruction(field_name="imagefs.available", variable_name="var_kubelet_evictionhard_imagefs_available") }}}
   </p>
+
 
 rationale: |-
   Garbage collection is important to ensure sufficient resource availability

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_inodesfree/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_inodesfree/rule.yml
@@ -38,6 +38,7 @@ description: |-
   <p>
   This rule pertains to the <tt>imagefs.inodesFree</tt> setting of the <tt>evictionHard</tt>
   section.
+  {{{ kubernetes_variable_instruction(field_name="imagefs.inodesFree", variable_name="var_kubelet_evictionhard_imagefs_inodesfree") }}}
   </p>
 
 rationale: |-

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_memory_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_memory_available/rule.yml
@@ -38,6 +38,7 @@ description: |-
   <p>
   This rule pertains to the <tt>memory.available</tt> setting of the <tt>evictionHard</tt>
   section.
+  {{{ kubernetes_variable_instruction(field_name="memory.available", variable_name="var_kubelet_evictionhard_memory_available") }}}
   </p>
 
 rationale: |-

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_available/rule.yml
@@ -38,6 +38,7 @@ description: |-
   <p>
   This rule pertains to the <tt>nodefs.available</tt> setting of the <tt>evictionHard</tt>
   section.
+  {{{ kubernetes_variable_instruction(field_name="nodefs.available", variable_name="var_kubelet_evictionhard_nodefs_available") }}}
   </p>
 
 rationale: |-

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_inodesfree/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_inodesfree/rule.yml
@@ -38,6 +38,7 @@ description: |-
   <p>
   This rule pertains to the <tt>nodefs.inodesFree</tt> setting of the <tt>evictionHard</tt>
   section.
+  {{{ kubernetes_variable_instruction(field_name="nodefs.inodesFree", variable_name="var_kubelet_evictionhard_nodefs_inodesfree") }}}
   </p>
 
 rationale: |-

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_imagefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_imagefs_available/rule.yml
@@ -39,6 +39,7 @@ description: |-
   <p>
   This rule pertains to the <tt>imagefs.available</tt> setting of the <tt>evictionSoft</tt>
   section.
+  {{{ kubernetes_variable_instruction(field_name="imagefs.available", variable_name="var_kubelet_evictionsoft_imagefs_available") }}}
   </p>
 
 rationale: |-

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_imagefs_inodesfree/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_imagefs_inodesfree/rule.yml
@@ -38,6 +38,7 @@ description: |-
   <p>
   This rule pertains to the <tt>imagefs.inodesFree</tt> setting of the <tt>evictionSoft</tt>
   section.
+  {{{ kubernetes_variable_instruction(field_name="imagefs.inodesFree", variable_name="var_kubelet_evictionsoft_imagefs_inodesfree") }}}
   </p>
 
 rationale: |-

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_memory_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_memory_available/rule.yml
@@ -38,6 +38,7 @@ description: |-
   <p>
   This rule pertains to the <tt>memory.available</tt> setting of the <tt>evictionSoft</tt>
   section.
+  {{{ kubernetes_variable_instruction(field_name="memory.available", variable_name="var_kubelet_evictionsoft_memory_available") }}}
   </p>
 
 rationale: |-

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_available/rule.yml
@@ -38,6 +38,7 @@ description: |-
   <p>
   This rule pertains to the <tt>nodefs.available</tt> setting of the <tt>evictionSoft</tt>
   section.
+  {{{ kubernetes_variable_instruction(field_name="nodefs.available", variable_name="var_kubelet_evictionsoft_nodefs_available") }}}
   </p>
 
 rationale: |-

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_inodesfree/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_inodesfree/rule.yml
@@ -38,6 +38,7 @@ description: |-
   <p>
   This rule pertains to the <tt>nodefs.inodesFree</tt> setting of the <tt>evictionSoft</tt>
   section.
+  {{{ kubernetes_variable_instruction(field_name="nodefs.inodesFree", variable_name="var_kubelet_evictionsoft_nodefs_inodesfree") }}}
   </p>
 
 rationale: |-

--- a/shared/macros/10-kubernetes.jinja
+++ b/shared/macros/10-kubernetes.jinja
@@ -177,7 +177,7 @@ spec:
 {{%- endmacro -%}}
 
 {{%- macro kubernetes_variable_instruction(field_name='', variable_name='') -%}}
-Remediations for the {{{ field_name }}} field will be set to {{ .{{{ variable_name }}} }} based on variable {{{ variable_name }}}.
+Remediation will set field {{{ field_name }}} to {{ .{{{ variable_name }}} }} based on the variable {{{ variable_name }}}.
 {{%- endmacro -%}}
 
 

--- a/shared/macros/10-kubernetes.jinja
+++ b/shared/macros/10-kubernetes.jinja
@@ -176,6 +176,10 @@ spec:
         overwrite: true
 {{%- endmacro -%}}
 
+{{%- macro kubernetes_variable_instruction(field_name='', variable_name='') -%}}
+Remediations for the {{{ field_name }}} field will be set to {{ .{{{ variable_name }}} }} based on variable {{{ variable_name }}}.
+{{%- endmacro -%}}
+
 
 {{#
   Macro which generates Kubernetes remediation in MachineConfig format with


### PR DESCRIPTION
Some of the kubeletconfig rules does not have not contains reference to variable being used in its remediation, this PR adds that reference to those rules. Related BUG: https://issues.redhat.com/browse/OCPBUGS-1316

