### PR TITLE
OCP4: Increase retry wait time for OCP parsing action

### DIFF
--- a/.github/workflows/k8s-content-pr-test.yaml
+++ b/.github/workflows/k8s-content-pr-test.yaml
@@ -20,9 +20,9 @@ jobs:
       - name: Copy XCCDF files from existing content image
         uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 15
+          timeout_minutes: 20
           max_attempts: 3
-          retry_wait_seconds: 120
+          retry_wait_seconds: 300
           retry_on: error
           command: |
             mkdir -p content


### PR DESCRIPTION
Let's increase the retry wait time to 300 seconds for Gate / Kubernetes Test Content Parsing workflow, so it can have higher success rate.
