### PR TITLE
Exclude talk-server install test scenario

### DIFF
--- a/linux_os/guide/services/obsolete/talk/package_talk-server_removed/tests/test_config.yml
+++ b/linux_os/guide/services/obsolete/talk/package_talk-server_removed/tests/test_config.yml
@@ -1,0 +1,2 @@
+deny_templated_scenarios:
+  - package-installed.fail.sh


### PR DESCRIPTION
#### Description:
Exclude templated test scenario for `talk-server` package as the package is not available in RHEL8 and RHEL9 causing:
```
+ yum install -y talk-server
Error: Unable to find a match: talk-server
```

#### Rationale:
Causes failing daily productization in both Bash and Ansible per-rule test cases.

#### Review Hints:
```
$ python3 tests/automatus.py rule --datastream build/ssg-rhel9-ds.xml --libvirt qemu:///session test-suite-rhel9 --no-reports package_talk-server_removed
```
there should be no
```
ERROR - Rule 'package_talk-server_removed' test setup script 'package-installed.fail.sh' failed with exit code 1
ERROR - Environment failed to prepare, skipping test
```
in the output.