### PR TITLE
Extend the Profile class in profile_tool

### DIFF
--- a/utils/profile_tool/profile.py
+++ b/utils/profile_tool/profile.py
@@ -44,7 +44,7 @@ class Profile:
         self.path = path
         self.title = title
         self.rules = []
-        self.variables = []
+        self.variables = {}
         self.unselected_rules = []
         profile_file = os.path.basename(path)
         self.id = profile_file.split('.profile')[0]
@@ -57,7 +57,7 @@ class Profile:
             self.rules.append(rule_id)
         else:
             variable_name, variable_value = rule_id.split('=', 1)
-            self.variables.append({variable_name: variable_value})
+            self.variables[variable_name] = variable_value
 
     def add_rules(self, rules):
         for rule in rules:

--- a/utils/profile_tool/profile.py
+++ b/utils/profile_tool/profile.py
@@ -1,3 +1,4 @@
+import os
 from ..controleval import get_parameter_from_yaml
 
 
@@ -43,7 +44,10 @@ class Profile:
         self.path = path
         self.title = title
         self.rules = []
+        self.variables = []
         self.unselected_rules = []
+        profile_file = os.path.basename(path)
+        self.id = profile_file.split('.profile')[0]
 
     def add_rule(self, rule_id):
         if rule_id.startswith("!"):
@@ -51,6 +55,9 @@ class Profile:
             return
         if "=" not in rule_id:
             self.rules.append(rule_id)
+        else:
+            variable_name, variable_value = rule_id.split('=', 1)
+            self.variables.append({'name': variable_name, 'value': variable_value})
 
     def add_rules(self, rules):
         for rule in rules:

--- a/utils/profile_tool/profile.py
+++ b/utils/profile_tool/profile.py
@@ -57,7 +57,7 @@ class Profile:
             self.rules.append(rule_id)
         else:
             variable_name, variable_value = rule_id.split('=', 1)
-            self.variables.append({'name': variable_name, 'value': variable_value})
+            self.variables.append({variable_name: variable_value})
 
     def add_rules(self, rules):
         for rule in rules:


### PR DESCRIPTION
#### Description:

I had to conduct some tests with variables in profiles and it became much easier when this class was expanded to also map variables instead of only rules. It was actually considered when the class was introduced but there was no concrete demand for this back in the time. Now there is a demand for assessment of profiles variables.

#### Rationale:

Much easier to assess profiles.

#### Review Hints:

Some small tests to make sure the existing behavior of profile_tool is not changed should be enough. e.g.:
```
$ ./build-scripts/profile_tool.py most-used-rules --products rhel9
```
