### PR TITLE
Add not used platforms and rules to  `most-used-components` command

### DIFF
--- a/build-scripts/profile_tool.py
+++ b/build-scripts/profile_tool.py
@@ -315,7 +315,7 @@ def parse_most_used_components(subparsers):
         default=get_available_products_with_components_root(),
     )
     parser_most_used_components.add_argument(
-        "--used-rules",
+        "--rules",
         default=False,
         action="store_true",
         help=(

--- a/build-scripts/profile_tool.py
+++ b/build-scripts/profile_tool.py
@@ -323,6 +323,12 @@ def parse_most_used_components(subparsers):
             "in the profiles in given product."
         ),
     )
+    parser_most_used_components.add_argument(
+        "--not-used",
+        default=False,
+        action="store_true",
+        help="Adds to list not used components or rules with zero value.",
+    )
 
 
 def get_available_products_with_components_root():

--- a/build-scripts/profile_tool.py
+++ b/build-scripts/profile_tool.py
@@ -324,10 +324,13 @@ def parse_most_used_components(subparsers):
         ),
     )
     parser_most_used_components.add_argument(
-        "--not-used",
+        "--all",
         default=False,
         action="store_true",
-        help="Adds to list not used components or rules with zero value.",
+        help=(
+            "List all components and rules in the output, including unused "
+            "components and unused rules."
+        ),
     )
 
 

--- a/docs/manual/developer/05_tools_and_utilities.md
+++ b/docs/manual/developer/05_tools_and_utilities.md
@@ -79,11 +79,11 @@ Optionally, you can use this command to limit the statistics for a specific prod
     $ ./build-scripts/profile_tool.py most-used-components --products rhel9
 ```
 
-You can also get a list of the most used components with used rules for the RHEL9 product, you can use the `--used-rules` flag.
+You can also get a list of the most used components with used rules for the RHEL9 product, you can use the `--rules` flag.
 As shown in this command:
 
 ```bash
-    $ ./build-scripts/profile_tool.py most-used-components --products rhel9 --used-rules
+    $ ./build-scripts/profile_tool.py most-used-components --products rhel9 --rules
 ```
 
 The result will be a list of rules with the number of uses in the profiles.

--- a/docs/manual/developer/05_tools_and_utilities.md
+++ b/docs/manual/developer/05_tools_and_utilities.md
@@ -86,6 +86,13 @@ As shown in this command:
     $ ./build-scripts/profile_tool.py most-used-components --products rhel9 --rules
 ```
 
+You can also use the `--all` flag to get a list of all components and rules in the output, including unused components and unused rules.
+As shown in this command:
+
+```bash
+    $ ./build-scripts/profile_tool.py most-used-components --products rhel9 --all
+```
+
 The result will be a list of rules with the number of uses in the profiles.
 The list can be generated as plain text, JSON or CVS.
 Via the `--format FORMAT` parameter.

--- a/utils/profile_tool/common.py
+++ b/utils/profile_tool/common.py
@@ -29,3 +29,7 @@ def merge_dicts(dict_a, dict_b, delim):
         value_b = dict_b.get(key, {})
         out[key] = str(value) + _format_value_b(value_b, delim)
     return out
+
+
+def remove_zero_counts(dict_):
+    return {key: value for key, value in dict_.items() if value != 0}

--- a/utils/profile_tool/most_used_components.py
+++ b/utils/profile_tool/most_used_components.py
@@ -18,19 +18,22 @@ if not PYTHON_2:
 
 
 def _count_rules_components(component_name, rules, used_rules_of_components_out):
-    used_rules = defaultdict(int)
-    if component_name in used_rules_of_components_out:
-        used_rules = used_rules_of_components_out[component_name]
+    used_rules = used_rules_of_components_out[component_name]
     for rule in rules:
         used_rules[rule] += 1
-    used_rules_of_components_out[component_name] = used_rules
 
 
 def _count_components(components, rules_list, components_out, used_rules_of_components_out):
     for component_name, component in components.items():
         intersection = set(component.rules).intersection(set(rules_list))
+        components_out[component_name] += 0
         if len(intersection) > 0:
             components_out[component_name] += 1
+        if component_name not in used_rules_of_components_out:
+            used_rules_of_components_out[component_name] = {
+                rule_id: 0 for rule_id in component.rules
+            }
+
         _count_rules_components(component_name, intersection, used_rules_of_components_out)
 
 

--- a/utils/profile_tool/most_used_components.py
+++ b/utils/profile_tool/most_used_components.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 import ssg.components
 
 from .most_used_rules import _sorted_dict_by_num_value
-from .common import generate_output, merge_dicts
+from .common import generate_output, merge_dicts, remove_zero_counts
 
 PYTHON_2 = sys.version_info[0] < 3
 
@@ -69,11 +69,22 @@ def _sort_rules_of_components(used_rules_of_components):
     return out
 
 
+def _remove_zero_counts_of(used_rules_of_components):
+    return {
+        component_name: remove_zero_counts(rules_dict)
+        for component_name, rules_dict in used_rules_of_components.items()
+    }
+
+
 def command_most_used_components(args):
     components = defaultdict(int)
     used_rules_of_components = {}
 
     _process_all_products_from_controls(components, used_rules_of_components, args.products)
+
+    if not args.not_used:
+        components = remove_zero_counts(components)
+        used_rules_of_components = _remove_zero_counts_of(used_rules_of_components)
 
     sorted_components = _sorted_dict_by_num_value(components)
     csv_header = "component_name,count_of_profiles"

--- a/utils/profile_tool/most_used_components.py
+++ b/utils/profile_tool/most_used_components.py
@@ -82,7 +82,7 @@ def command_most_used_components(args):
 
     _process_all_products_from_controls(components, used_rules_of_components, args.products)
 
-    if not args.not_used:
+    if not args.all:
         components = remove_zero_counts(components)
         used_rules_of_components = _remove_zero_counts_of(used_rules_of_components)
 

--- a/utils/profile_tool/most_used_components.py
+++ b/utils/profile_tool/most_used_components.py
@@ -88,7 +88,7 @@ def command_most_used_components(args):
 
     sorted_components = _sorted_dict_by_num_value(components)
     csv_header = "component_name,count_of_profiles"
-    if args.used_rules:
+    if args.rules:
         csv_header = "component_name,count_of_profiles,used_rules:count_of_profiles"
         delim = " "
         if args.format == "csv":


### PR DESCRIPTION
#### Description:
This PR adds the `--all` flag to the `most-used-components` command of the `profile_tool.py` file, which Lists all components and rules in the output, including unused components and unused rules.

#### Review Hints:
To get a list of the most used components including not-used components for product RHEL9 you can run this command:
```bash
./build-scripts/profile_tool.py most-used-components --products rhel9 --all
```

To get a list of the most used components, including unused components and rules for the RHEL9 product, you can run this command:
```bash
./build-scripts/profile_tool.py most-used-components --products rhel9 --all --rules
```