### PR TITLE
Fix regex in file_ownership_audit_configuration

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/file_groupownership_audit_configuration/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_groupownership_audit_configuration/rule.yml
@@ -40,6 +40,6 @@ template:
             - /etc/audit/
             - /etc/audit/rules.d/
         file_regex:
-            - ^audit(\.rules|d\.conf)$
+            - ^.*audit(\.rules|d\.conf)$
             - ^.*\.rules$
         gid_or_name: '0'

--- a/linux_os/guide/auditing/auditd_configure_rules/file_ownership_audit_configuration/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_ownership_audit_configuration/rule.yml
@@ -41,6 +41,6 @@ template:
             - /etc/audit/
             - /etc/audit/rules.d/
         file_regex:
-            - ^.*/audit\(\.rules\|d\.conf\)$
+            - ^.*audit(\.rules|d\.conf)$
             - ^.*\.rules$
         fileuid: '0'

--- a/linux_os/guide/auditing/auditd_configure_rules/file_ownership_audit_configuration/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_ownership_audit_configuration/rule.yml
@@ -41,6 +41,6 @@ template:
             - /etc/audit/
             - /etc/audit/rules.d/
         file_regex:
-            - ^audit(\.rules|d\.conf)$
+            - ^.*/audit\(\.rules\|d\.conf\)$
             - ^.*\.rules$
         fileuid: '0'

--- a/linux_os/guide/auditing/auditd_configure_rules/file_permissions_audit_configuration/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_permissions_audit_configuration/rule.yml
@@ -34,7 +34,7 @@ template:
             - /etc/audit/
             - /etc/audit/rules.d/
         file_regex:
-            - .*audit\(\.rules\|d\.conf\)$
-            - .*\.rules$
+            - ^.*audit(\.rules|d\.conf)$
+            - ^.*\.rules$
         allow_stricter_permissions: "true"
         filemode: '0640'

--- a/shared/templates/file_groupowner/ansible.template
+++ b/shared/templates/file_groupowner/ansible.template
@@ -15,7 +15,7 @@
 {{%- endif %}}
 
 - name: Find {{{ path }}} file(s) matching {{{ FILE_REGEX[loop.index0] }}}{{% if RECURSIVE %}} recursively{{% endif %}}
-  command: 'find -H {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -group {{{ GID_OR_NAME }}} -regex "{{{ FILE_REGEX[loop.index0] }}}"'
+  command: 'find -H {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -group {{{ GID_OR_NAME }}} -regextype posix-extended -regex "{{{ FILE_REGEX[loop.index0] }}}"'
   register: files_found
   changed_when: False
   failed_when: False

--- a/shared/templates/file_groupowner/bash.template
+++ b/shared/templates/file_groupowner/bash.template
@@ -14,7 +14,7 @@
 {{%- if IS_DIRECTORY %}}
 {{%- if FILE_REGEX %}}
 
-find {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -group {{{ GID_OR_NAME }}} -regex '{{{ FILE_REGEX[loop.index0] }}}' -exec chgrp {{{ GID_OR_NAME }}} {} \;
+find {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -group {{{ GID_OR_NAME }}} -regextype posix-extended -regex '{{{ FILE_REGEX[loop.index0] }}}' -exec chgrp {{{ GID_OR_NAME }}} {} \;
 {{%- else %}}
 find -H {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type d -exec chgrp {{{ GID_OR_NAME }}} {} \;
 {{%- endif %}}

--- a/shared/templates/file_owner/ansible.template
+++ b/shared/templates/file_owner/ansible.template
@@ -15,7 +15,7 @@
 {{%- endif %}}
 
 - name: Find {{{ path }}} file(s) matching {{{ FILE_REGEX[loop.index0] }}}{{% if RECURSIVE %}} recursively{{% endif %}}
-  command: 'find -H {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -uid {{{ FILEUID }}} -regex "{{{ FILE_REGEX[loop.index0] }}}"'
+  command: 'find -H {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -uid {{{ FILEUID }}} -regextype posix-extended -regex "{{{ FILE_REGEX[loop.index0] }}}"'
   register: files_found
   changed_when: False
   failed_when: False

--- a/shared/templates/file_owner/bash.template
+++ b/shared/templates/file_owner/bash.template
@@ -14,7 +14,7 @@
 {{%- if IS_DIRECTORY %}}
 {{%- if FILE_REGEX %}}
 
-find {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -uid {{{ FILEUID }}} -regex '{{{ FILE_REGEX[loop.index0] }}}' -exec chown {{{ FILEUID }}} {} \;
+find {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -uid {{{ FILEUID }}} -regextype posix-extended -regex '{{{ FILE_REGEX[loop.index0] }}}' -exec chown {{{ FILEUID }}} {} \;
 {{%- else %}}
 find -H {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type d -exec chown {{{ FILEUID }}} {} \;
 {{%- endif %}}

--- a/shared/templates/file_permissions/ansible.template
+++ b/shared/templates/file_permissions/ansible.template
@@ -10,7 +10,7 @@
 {{%- if FILE_REGEX %}}
 {{% set STATE="file" %}}
 {{% set FIND_TYPE="-type f" %}}
-{{% set FIND_FILE_REGEX="-regex \"" ~ FILE_REGEX[loop.index0] ~ "\"" %}}
+{{% set FIND_FILE_REGEX="-regextype posix-extended -regex \"" ~ FILE_REGEX[loop.index0] ~ "\"" %}}
 {{%- else %}}
 {{% set STATE="directory" %}}
 {{% set FIND_TYPE="-type d" %}}

--- a/shared/templates/file_permissions/bash.template
+++ b/shared/templates/file_permissions/bash.template
@@ -25,7 +25,7 @@
 {{% for path in FILEPATH %}}
 {{%- if IS_DIRECTORY %}}
 {{%- if FILE_REGEX %}}
-find -H {{{ path }}} {{{ FIND_RECURSE_ARGS }}} {{{ PERMS }}} {{{ EXCLUDED_FILES_ARGS }}} -type f -regex '{{{ FILE_REGEX[loop.index0] }}}' -exec chmod {{{ FILEMODE }}} {} \;
+find -H {{{ path }}} {{{ FIND_RECURSE_ARGS }}} {{{ PERMS }}} {{{ EXCLUDED_FILES_ARGS }}} -type f -regextype posix-extended -regex '{{{ FILE_REGEX[loop.index0] }}}' -exec chmod {{{ FILEMODE }}} {} \;
 {{%- else %}}
 find -H {{{ path }}} {{{ FIND_RECURSE_ARGS }}} {{{ PERMS }}} -type d -exec chmod {{{ FILEMODE }}} {} \;
 {{%- endif %}}


### PR DESCRIPTION
#### Description:

This regex was not matching the files as expected. After some minor changes with escapes, it is working.

#### Rationale:

Fix CI test `Automatus Sanity / Run Tests (pull_request)`

#### Review Hints:

```
./tests/automatus.py rule --libvirt qemu:///session rhel9 --datastream build/ssg-rhel9-ds.xml --dontclean --remediate-using bash file_ownership_audit_configuration
./tests/automatus.py rule --libvirt qemu:///session rhel9 --datastream build/ssg-rhel9-ds.xml --dontclean --remediate-using ansible file_ownership_audit_configuration
```

Reference:
https://www.gnu.org/software/findutils/manual/html_node/find_html/Regular-Expressions.html#Regular-Expressions