### PR TITLE
Fix banner_etc_issue_net in Ubuntu 20.04 STIG

### DIFF
--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -75,6 +75,7 @@ selections:
 
     # UBTU-20-010038 The Ubuntu operating system must display the Standard Mandatory DoD Notice and Consent Banner before granting any local or remote connection to the system.
     - banner_etc_issue_net
+    - remote_login_banner_text=dod_banners
     - sshd_enable_warning_banner_net
 
     # UBTU-20-010042 The Ubuntu operating system must use SSH to protect the confidentiality and integrity of transmitted information.


### PR DESCRIPTION
Description:

 - Initialize the DoD banner variable in the rule UBTU-20-010038
 - Fixes https://github.com/ComplianceAsCode/content/issues/11985

Rationale:
 - If not initialized, the corresponding tests would fail