### PR TITLE
 Improve remediation for enable_authselect

### DIFF
--- a/linux_os/guide/system/accounts/enable_authselect/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/enable_authselect/ansible/shared.yml
@@ -6,6 +6,13 @@
 
 {{{ ansible_instantiate_variables("var_authselect_profile") }}}
 
+- name: {{{ rule_title }}} - Check Current authselect Profile
+  ansible.builtin.command:
+    cmd: authselect current
+  register: result_authselect_current
+  changed_when: false
+  failed_when: false
+
 - name: {{{ rule_title }}} - Select authselect profile
   ansible.builtin.command:
     cmd: authselect select "{{ var_authselect_profile }}"
@@ -19,6 +26,8 @@
   # • 5: Executed command must be run as root.
   # • 6: No configuration was detected.
   failed_when: false
+  when:
+    - result_authselect_current.rc != 0
 
 - name: {{{ rule_title }}} - Verify if PAM has been altered
   ansible.builtin.command:
@@ -30,18 +39,20 @@
   #   We have 1 package here. So 1 it is.
   failed_when: false
   when:
+    - result_authselect_select is not skipped
     - result_authselect_select.rc != 0
 
 - name: {{{ rule_title }}} - Informative message based on the authselect integrity check
   ansible.builtin.assert:
     that:
-      - result_altered_authselect is skipped or result_altered_authselect.rc == 0
+      - result_authselect_current.rc == 0 or result_altered_authselect is skipped or result_altered_authselect.rc == 0
     fail_msg:
-      - Files in the 'pam' package have been altered, so the authselect configuration won't be forced.
+      - authselect is not used but files from the 'pam' package have been altered, so the authselect configuration won't be forced.
 
 - name: {{{ rule_title }}} - Force authselect profile select
   ansible.builtin.command:
     cmd: authselect select --force "{{ var_authselect_profile }}"
   when:
+    - result_authselect_current.rc != 0
     - result_authselect_select.rc != 0
-    - result_altered_authselect is skipped or result_altered_authselect.rc == 0
+    - result_altered_authselect.rc == 0

--- a/linux_os/guide/system/accounts/enable_authselect/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/enable_authselect/ansible/shared.yml
@@ -13,7 +13,7 @@
   changed_when: false
   failed_when: false
 
-- name: {{{ rule_title }}} - Select authselect profile
+- name: {{{ rule_title }}} - Try to Select an authselect Profile
   ansible.builtin.command:
     cmd: authselect select "{{ var_authselect_profile }}"
   register: result_authselect_select
@@ -29,7 +29,7 @@
   when:
     - result_authselect_current.rc != 0
 
-- name: {{{ rule_title }}} - Verify if PAM has been altered
+- name: {{{ rule_title }}} - Verify If pam Has Been Altered
   ansible.builtin.command:
     cmd: rpm -qV pam
   register: result_altered_authselect
@@ -42,14 +42,14 @@
     - result_authselect_select is not skipped
     - result_authselect_select.rc != 0
 
-- name: {{{ rule_title }}} - Informative message based on the authselect integrity check
+- name: {{{ rule_title }}} - Informative Message Based on authselect Integrity Check
   ansible.builtin.assert:
     that:
       - result_authselect_current.rc == 0 or result_altered_authselect is skipped or result_altered_authselect.rc == 0
     fail_msg:
       - authselect is not used but files from the 'pam' package have been altered, so the authselect configuration won't be forced.
 
-- name: {{{ rule_title }}} - Force authselect profile select
+- name: {{{ rule_title }}} - Force authselect Profile Selection
   ansible.builtin.command:
     cmd: authselect select --force "{{ var_authselect_profile }}"
   when:

--- a/linux_os/guide/system/accounts/enable_authselect/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/enable_authselect/ansible/shared.yml
@@ -25,6 +25,7 @@
   # • 4: System configuration must be overwritten to activate an authselect profile, --force parameter is needed.
   # • 5: Executed command must be run as root.
   # • 6: No configuration was detected.
+  changed_when: result_authselect_select.rc == 0
   failed_when: false
   when:
     - result_authselect_current.rc != 0
@@ -37,6 +38,7 @@
   # - 0 if no alterations
   # - otherwise: number of failed packages
   #   We have 1 package here. So 1 it is.
+  changed_when: false
   failed_when: false
   when:
     - result_authselect_select is not skipped

--- a/linux_os/guide/system/accounts/enable_authselect/bash/shared.sh
+++ b/linux_os/guide/system/accounts/enable_authselect/bash/shared.sh
@@ -2,12 +2,16 @@
 
 {{{ bash_instantiate_variables("var_authselect_profile") }}}
 
-authselect select "$var_authselect_profile"
+authselect current
 
 if test "$?" -ne 0; then
-    if rpm --quiet --verify pam; then
-        authselect select --force "$var_authselect_profile"
-    else
-	echo "Files in the 'pam' package have been altered, so the authselect configuration won't be forced" >&2
+    authselect select "$var_authselect_profile"
+
+    if test "$?" -ne 0; then
+        if rpm --quiet --verify pam; then
+            authselect select --force "$var_authselect_profile"
+        else
+	        echo "authselect is not used but files from the 'pam' package have been altered, so the authselect configuration won't be forced." >&2
+        fi
     fi
 fi


### PR DESCRIPTION
#### Description:
 
This is a supportive rule intended to ensure `authselect` is used in a system, specially in fresh installations in some specific scenarios where `authselect` is not enabled by default. In this case, the preferred profile is selected.

However, in a scenario where a custom profile is used, even when based on the preferred profile, this rule would move again from the custom profile to the preferred profile. This is usually not a desired behavior because may cause inconsistencies between the profiles.
Custom profiles are usually there because a requirement cannot be satisfied by a default profile.

#### Rationale:

- Fixes https://issues.redhat.com/browse/RHEL-39383

#### Review Hints:

CI tests in containers are expected to fail because the containers usually don't use authselect.

The simplest test is to ensure authselect is enabled with some features.
```
authselect select minimal
authselect enable-feature with-mkhomedir
```
Then execute the `enable_authselect` remediation informing a different profile for `var_authselect_profile` variable.
A hint is to build the content, copy and edit the `enable_authselect.yml` Playbook and execute it directly.
```
./build_product rhel9
cp build/rhel9/fixes/ansible/enable_authselect.yml /tmp/enable_authselect.yml
```
Edit the Playbook to make it executable directly via `ansible-playbook`. Here is an example:
```
- name: Manual test of Ansible Remediation
  hosts: all
  remote_user: root
  vars:
    - var_authselect_profile: sssd
  tasks:
    - name: Enable authselect - Check Current authselect Profile
      ansible.builtin.command:
        cmd: authselect current
      register: result_authselect_current
      changed_when: false
      failed_when: false
      tags:
      - CCE-89732-2
      - DISA-STIG-needed_rules
      - NIST-800-53-AC-3
      - PCI-DSSv4-8.3.4
      - configure_strategy
      - enable_authselect
      - low_complexity
      - medium_disruption
      - medium_severity
      - no_reboot_needed

...
```
Then execute it in a VM.
```
cd /tmp
ansible-playbook -i <VM IP>, enable_authselect.yml
```
Check the authselect settings on the VM.