### PR TITLE
Fix dconf_gdm_dir on OL9

### DIFF
--- a/tests/data/product_stability/ol9.yml
+++ b/tests/data/product_stability/ol9.yml
@@ -18,7 +18,7 @@ cpes:
     name: cpe:/o:oracle:linux:9
     title: Oracle Linux 9
 cpes_root: ../../shared/applicability
-dconf_gdm_dir: gdm.d
+dconf_gdm_dir: local.d
 faillock_path: /var/log/faillock
 families:
 - rhel-like


### PR DESCRIPTION

#### Description:

Fix dconf_gdm_dir in the stable products files on OL9.

#### Rationale:
It is causing the nightly builds to fail.


