### PR TITLE
Modify ubuntu remediation for dconf_gnome_banner_enabled

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/bash/shared.sh
@@ -3,6 +3,9 @@
 {{% if 'ubuntu' in product %}}
 {{{ bash_enable_dconf_user_profile(profile="user", database="local") }}}
 {{{ bash_enable_dconf_user_profile(profile="gdm", database="gdm") }}}
+# Duplicate the setting also in 'greeter.dconf-defaults' for consistency with
+# 'dconf_gnome_login_banner_text' and better alignment with STIG V1R1.
+{{{ set_config_file("/etc/gdm3/greeter.dconf-defaults", "banner-message-enable", value="true", create='no', insert_after="\[org/gnome/login-screen\]", insert_before="", separator="=", separator_regex="", prefix_regex="^\s*") }}}
 {{% endif %}}
 
 {{{ bash_dconf_settings("org/gnome/login-screen", "banner-message-enable", "true", dconf_gdm_dir, "00-security-settings") }}}

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/correct_value_defaults.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/correct_value_defaults.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# platforms = multi_platform_ubuntu
+# packages = dconf,gdm
+
+clean_dconf_settings
+
+cat > /etc/gdm3/greeter.dconf-defaults <<EOF
+[org/gnome/login-screen]
+banner-message-enable=true
+EOF
+
+dconf update

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/wrong_value_defaults.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/wrong_value_defaults.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# platforms = multi_platform_ubuntu
+# packages = dconf,gdm
+
+clean_dconf_settings
+
+cat > /etc/gdm3/greeter.dconf-defaults <<EOF
+[org/gnome/login-screen]
+banner-message-enable=false
+EOF
+
+dconf update


### PR DESCRIPTION
#### Description:
- The remediation was modified to enable the banner also in `greeter.dconf-defaults` and not only in the dconf database.

#### Rationale:
- This is to be consistent with the remediation in related rule `dconf_gnome_login_banner_text` and be better aligned with STIG V1R1.

