### PR TITLE
Update product stability for openembedded

### DIFF
--- a/tests/data/product_stability/openembedded.yml
+++ b/tests/data/product_stability/openembedded.yml
@@ -18,6 +18,14 @@ cpes:
     check_id: installed_OS_is_poky
     name: 'cpe:/o:openembedded:poky:'
     title: OpenEmbedded Poky reference distribution
+- petalinux:
+    check_id: installed_OS_is_petalinux
+    name: 'cpe:/o:openembedded:petalinux:'
+    title: OpenEmbedded petalinux distribution
+- harden:
+    check_id: installed_OS_is_oeharden
+    name: 'cpe:/o:openembedded:harden:'
+    title: OpenEmbedded Harden distribution
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
 faillock_path: /var/run/faillock


### PR DESCRIPTION
#### Description:

Update product stability for openembedded.

#### Rationale:

So the tests pass and thus the nightly build works.

Expected due to #12026 