### PR TITLE
Fix rule file_permissions_backup_etc_shadow for SLE15/SLE12

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_shadow/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-{{% if "ubuntu" in product or "debian" or "sle" in product %}}
+{{% if "ubuntu" in product or "debian" in product or "sle" in product %}}
     {{% set target_perms_octal="0640" %}}
     {{% set target_perms="-rw-r-----" %}}
 {{% else %}}

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_shadow/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-{{% if "ubuntu" in product or "debian" in product %}}
+{{% if "ubuntu" in product or "debian" or "sle" in product %}}
     {{% set target_perms_octal="0640" %}}
     {{% set target_perms="-rw-r-----" %}}
 {{% else %}}
@@ -59,4 +59,6 @@ template:
         filemode@ubuntu1804: '0640'
         filemode@ubuntu2004: '0640'
         filemode@ubuntu2204: '0640'
+        filemode@sle12: '0640'
+        filemode@sle15: '0640'
         missing_file_pass: 'true'


### PR DESCRIPTION
#### Description:

- _Fix target permissions on /etc/shadow- for SLE15/SLE12_

#### Rationale:

- _According to CIS SLE 15 Benchmark v1.1.1 and CIS SLE 12 Benchmark v3.1.0 "verify /etc/shadow- access is 0640 or more restrictive"_

