### PR TITLE
Mark some scenarios as specific to SCE

### DIFF
--- a/linux_os/guide/system/network/network-nftables/set_nftables_table/tests/nftables_incorrect_family.fail.sh
+++ b/linux_os/guide/system/network/network-nftables/set_nftables_table/tests/nftables_incorrect_family.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# check = sce
 # variables = var_nftables_family=inet,var_nftables_table=filter
 
 var_nftables_family="ip"

--- a/linux_os/guide/system/network/network-nftables/set_nftables_table/tests/nftables_no_tables.fail.sh
+++ b/linux_os/guide/system/network/network-nftables/set_nftables_table/tests/nftables_no_tables.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# check = sce
 # variables = var_nftables_family=inet,var_nftables_table=filter
 
 nft list tables |

--- a/linux_os/guide/system/network/network-nftables/set_nftables_table/tests/nftables_table_present.pass.sh
+++ b/linux_os/guide/system/network/network-nftables/set_nftables_table/tests/nftables_table_present.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# check = sce
 # variables = var_nftables_family=inet,var_nftables_table=filter
 
 var_nftables_family="inet"

--- a/tests/README.md
+++ b/tests/README.md
@@ -182,6 +182,10 @@ The header consists of comments (starting by `#`). Possible keys are:
   variables (XCCDF Values), use the `variables` key instead. This key is
   intended to be used in regression testing of bugs in profiles, it isn't
   intended for casual use.
+- `check` is a string specifying one of the available check engine types
+  (`oval`, `sce`, `any`). It specifies for which check engine the scenario should
+  be executed. The special value `any` means that this scenario works with any
+  check engine and it's the default behavior that is used if this key isn't provided.
 - `remediation` is a string specifying one of the allowed remediation types (eg.
   `bash`, `ansible`, `none`). The `none` value means that the tested rule has no
   implemented remediation. The `none` value can also be used in case that

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -533,6 +533,13 @@ class RuleChecker(oscap.Checker):
 
 
     def _check_rule_scenario(self, scenario, remote_rule_dir, rule_id, remediation_available):
+        if "sce" in scenario.script_params["check"] and not self.test_env.sce_support:
+            logging.warning(
+                "Scenario {0} is used for SCE testing but OpenSCAP installed "
+                "on the back end doesn't support SCE. To test SCE, please "
+                "install the openscap-engine-sce package on the back end.".format(scenario.script)
+            )
+            return
         if not _apply_script(
                 remote_rule_dir, self.test_env, scenario.script):
             logging.error("Environment failed to prepare, skipping test")

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -11,6 +11,7 @@ import time
 
 import ssg_test_suite
 from ssg_test_suite import common
+from ssg_test_suite.log import LogHelper
 
 
 class SavedState(object):
@@ -62,6 +63,7 @@ class TestEnv(object):
         self.running_state = None
 
         self.scanning_mode = scanning_mode
+        self.sce_support = False
         self.backend = None
         self.ssh_port = None
 
@@ -101,6 +103,7 @@ class TestEnv(object):
         by subsequent procedures.
         """
         self.refresh_connection_parameters()
+        self.check_sce_support()
 
     def refresh_connection_parameters(self):
         self.domain_ip = self.get_ip_address()
@@ -198,6 +201,16 @@ class TestEnv(object):
 
     def offline_scan(self, args, verbose_path):
         raise NotImplementedError()
+
+    def check_sce_support(self):
+        log_file_name = os.path.join(LogHelper.LOG_DIR, "env-preparation.log")
+        with open(log_file_name, 'a') as log_file:
+            oscap_output = self.execute_ssh_command("oscap --version", log_file)
+            sce_regex = r"SCE Version: [\d.]+ \(from libopenscap_sce.so.\d+\)"
+            for line in oscap_output.splitlines():
+                if re.match(sce_regex, line):
+                    self.sce_support = True
+                    return
 
 
 class VMTestEnv(TestEnv):

--- a/tests/ssg_test_suite/xml_operations.py
+++ b/tests/ssg_test_suite/xml_operations.py
@@ -12,6 +12,12 @@ from ssg.constants import ansible_system as ansible_rem_system
 from ssg.constants import puppet_system as puppet_rem_system
 from ssg.constants import anaconda_system as anaconda_rem_system
 from ssg.constants import ignition_system as ignition_rem_system
+from ssg.constants import oval_namespace, SCE_SYSTEM
+
+CHECK_SYSTEM_URI_TO_TYPE = {
+    oval_namespace: "oval",
+    SCE_SYSTEM: "sce",
+}
 
 SYSTEM_ATTRIBUTE = {
     'bash': bash_rem_system,
@@ -307,3 +313,20 @@ def find_fix_in_benchmark(datastream, benchmark_id, rule_id, fix_type='bash', lo
 
     fix = rule.find("xccdf-1.2:fix[@system='{0}']".format(system_attribute), PREFIX_TO_NS)
     return fix
+
+
+def find_checks_in_rule(datastream, benchmark_id, rule_id):
+    """
+    Return check types for given rule from benchmark.
+    """
+    checks = set()
+    rule = find_rule_in_benchmark(datastream, benchmark_id, rule_id)
+    if rule is None:
+        return checks
+    check_els = rule.findall("xccdf-1.2:check", PREFIX_TO_NS)
+    for check_el in check_els:
+        system = check_el.get("system")
+        check = CHECK_SYSTEM_URI_TO_TYPE.get(system, None)
+        if check is not None:
+            checks.add(check)
+    return checks

--- a/tests/unit/ssg_test_suite/data/correct.pass.sh
+++ b/tests/unit/ssg_test_suite/data/correct.pass.sh
@@ -2,6 +2,7 @@
 # packages = sudo,authselect
 # platform = multi_platform_rhel,Fedora
 # profiles = xccdf_org.ssgproject.content_profile_cis
+# check = oval
 # remediation = none
 # variables = var_password_pam_remember=5,var_password_pam_remember_control_flag=requisite
 

--- a/tests/unit/ssg_test_suite/test_rule.py
+++ b/tests/unit/ssg_test_suite/test_rule.py
@@ -25,6 +25,8 @@ def test_scenario():
     assert "xccdf_org.ssgproject.content_profile_cis" in \
         s.script_params["profiles"]
     assert OSCAP_PROFILE_ALL_ID not in s.script_params["profiles"]
+    assert len(s.script_params["check"]) == 1
+    assert "oval" in s.script_params["check"]
     assert len(s.script_params["remediation"]) == 1
     assert "none" in s.script_params["remediation"]
     assert len(s.script_params["variables"]) == 2
@@ -38,6 +40,10 @@ def test_scenario():
     assert not s.matches_regex(r"^wrong")
     assert s.matches_platform({"cpe:/o:redhat:enterprise_linux:7"})
     assert not s.matches_platform({"cpe:/o:debian:debian:8"})
+    assert s.matches_check({"oval"})
+    assert not s.matches_check({"sce"})
+    assert not s.matches_check({"fancy_unsupported_language"})
+    assert not s.matches_check({})
 
 def test_scenario_defaults():
     file_name = "correct_defaults.pass.sh"
@@ -52,6 +58,8 @@ def test_scenario_defaults():
     assert len(s.script_params["packages"]) == 0
     assert len(s.script_params["platform"]) == 1
     assert "multi_platform_all" in s.script_params["platform"]
+    assert len(s.script_params["check"]) == 1
+    assert "any" in s.script_params["check"]
     assert len(s.script_params["remediation"]) == 1
     assert "all" in s.script_params["remediation"]
     assert len(s.script_params["variables"]) == 0


### PR DESCRIPTION
#### Description:
We introduce a new test scenarios header `check` that allows to mark test scenarios as specific to a single check engine type. For example, adding header `check = sce` to a test scenario marks this test scenario as specific only to SCE. If SCE check isn't available, such scenario will be skipped. If the `check` header isn't specified in a test scenario, the test scenario will work with any check type.

For SCE test scenarios we will also check if SCE support is installed in OpenSCAP in the back end and we will skip the test if SCE support isn't available there.

#### Rationale:
Fixes: #12030

#### Review Hints:

1.  ./build_product -d rhel9 
2. python3 tests/automatus.py rule --libvirt qemu:///system ssgts_rhel9 set_nftables_table
3. ADDITIONAL_CMAKE_OPTIONS="-DSSG_SCE_ENABLED=ON" ./build_product -d rhel9 
4. repeat the automatus command in step 2
5. remove openscap-engine-sce from the virtual machine
6. repeat the automatus command in step 2
