### PR TITLE
Add note to FIPS sshd rules regarding unknown result

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/rule.yml
@@ -71,3 +71,8 @@ warnings:
         party review by an accredited lab. While open source software is
         capable of meeting this, it does not meet FIPS-140 unless the vendor
         submits to this process.
+    {{% if 'ubuntu' in product %}}
+    - audit: |-
+        The audit returns <tt>unknown</tt> instead of <tt>pass</tt> if sshd is correctly configured
+        but the system crypto modules are not FIPS certified.
+    {{% endif %}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/rule.yml
@@ -87,3 +87,8 @@ warnings:
         third party review by an accredited lab. While open source software is
         capable of meeting this, it does not meet FIPS-140 unless the vendor
         submits to this process.
+    {{% if 'ubuntu' in product %}}
+    - audit: |-
+        The audit returns <tt>unknown</tt> instead of <tt>pass</tt> if sshd is correctly configured
+        but the system crypto modules are not FIPS certified.
+    {{% endif %}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/rule.yml
@@ -64,3 +64,8 @@ warnings:
         party review by an accredited lab. While open source software is
         capable of meeting this, it does not meet FIPS-140 unless the vendor
         submits to this process.
+    {{% if 'ubuntu' in product %}}
+    - audit: |-
+        The audit returns <tt>unknown</tt> instead of <tt>pass</tt> if sshd is correctly configured
+        but the system crypto modules are not FIPS certified.
+    {{% endif %}}


### PR DESCRIPTION
#### Description:

- Add note to FIPS sshd rules regarding `unknown` result which happens when OS is not FIPS certified but the sshd configuration is otherwise compliant
