### PR TITLE
OCP4: Support multi-arch content image

### DIFF
--- a/.github/workflows/k8s-content-pr.yaml
+++ b/.github/workflows/k8s-content-pr.yaml
@@ -91,7 +91,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
-          platforms: 'linux/amd64'
+          platforms: 'linux/amd64,linux/ppc64le,linux/s390x'
       - name: Get container info
         id: container_info
         run: |

--- a/.github/workflows/k8s-content.yaml
+++ b/.github/workflows/k8s-content.yaml
@@ -20,3 +20,4 @@ jobs:
       dockerfile_path: ./Dockerfiles/ocp4_content
       licenses: BSD
       vendor: ComplianceAsCode authors
+      platforms: 'linux/amd64,linux/ppc64le,linux/s390x'


### PR DESCRIPTION
Let's start building multi-arch content images so that we can enable early testing.
