### PR TITLE
Fix platforms -> platform in test metadata

### DIFF
--- a/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/correct_commented.pass.sh
+++ b/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/correct_commented.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platforms = multi_platform_ubuntu
+# platform = multi_platform_ubuntu
 
 sed '/AllowUnauthenticated/Id' -i /etc/apt/apt.conf /etc/apt/apt.conf.d/*
 

--- a/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/correct_missing.pass.sh
+++ b/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/correct_missing.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platforms = multi_platform_ubuntu
+# platform = multi_platform_ubuntu
 
 sed '/AllowUnauthenticated/Id' -i /etc/apt/apt.conf /etc/apt/apt.conf.d/*
 exit 0

--- a/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/correct_value.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platforms = multi_platform_ubuntu
+# platform = multi_platform_ubuntu
 
 sed '/AllowUnauthenticated/Id' -i /etc/apt/apt.conf /etc/apt/apt.conf.d/*
 

--- a/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/correct_value_dir.pass.sh
+++ b/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/correct_value_dir.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platforms = multi_platform_ubuntu
+# platform = multi_platform_ubuntu
 
 sed '/AllowUnauthenticated/Id' -i /etc/apt/apt.conf /etc/apt/apt.conf.d/*
 

--- a/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/wrong_value.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platforms = multi_platform_ubuntu
+# platform = multi_platform_ubuntu
 # remediation = none
 
 sed '/AllowUnauthenticated/Id' -i /etc/apt/apt.conf /etc/apt/apt.conf.d/*

--- a/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/wrong_value2.fail.sh
+++ b/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/wrong_value2.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platforms = multi_platform_ubuntu
+# platform = multi_platform_ubuntu
 # remediation = none
 
 sed '/AllowUnauthenticated/Id' -i /etc/apt/apt.conf /etc/apt/apt.conf.d/*

--- a/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/wrong_value_dir.fail.sh
+++ b/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/wrong_value_dir.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platforms = multi_platform_ubuntu
+# platform = multi_platform_ubuntu
 # remediation = none
 
 sed '/AllowUnauthenticated/Id' -i /etc/apt/apt.conf /etc/apt/apt.conf.d/*

--- a/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/wrong_value_double.fail.sh
+++ b/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/tests/wrong_value_double.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platforms = multi_platform_ubuntu
+# platform = multi_platform_ubuntu
 
 sed '/AllowUnauthenticated/Id' -i /etc/apt/apt.conf /etc/apt/apt.conf.d/*
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/tests/correct_value_config_dir.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/tests/correct_value_config_dir.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platforms = multi_platform_ubuntu
+# platform = multi_platform_ubuntu
 
 sshd_approved_macs="hmac-sha2-512,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-256-etm@openssh.com"
 

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/correct_value_defaults.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/correct_value_defaults.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platforms = multi_platform_ubuntu
+# platform = multi_platform_ubuntu
 # packages = dconf,gdm
 
 clean_dconf_settings

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/wrong_value_defaults.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/wrong_value_defaults.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platforms = multi_platform_ubuntu
+# platform = multi_platform_ubuntu
 # packages = dconf,gdm
 
 clean_dconf_settings

--- a/linux_os/guide/system/network/network-ufw/ufw_rate_limit/tests/allow.fail.sh
+++ b/linux_os/guide/system/network/network-ufw/ufw_rate_limit/tests/allow.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platforms = multi_platform_ubuntu
+# platform = multi_platform_ubuntu
 # packages = ufw
 # remediation = none
 

--- a/linux_os/guide/system/network/network-ufw/ufw_rate_limit/tests/correct.pass.sh
+++ b/linux_os/guide/system/network/network-ufw/ufw_rate_limit/tests/correct.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platforms = multi_platform_ubuntu
+# platform = multi_platform_ubuntu
 # packages = ufw
 
 source common.sh

--- a/linux_os/guide/system/network/network-ufw/ufw_rate_limit/tests/default_allow.fail.sh
+++ b/linux_os/guide/system/network/network-ufw/ufw_rate_limit/tests/default_allow.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platforms = multi_platform_ubuntu
+# platform = multi_platform_ubuntu
 # packages = ufw
 
 source common.sh

--- a/linux_os/guide/system/network/network-ufw/ufw_rate_limit/tests/disabled.fail.sh
+++ b/linux_os/guide/system/network/network-ufw/ufw_rate_limit/tests/disabled.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platforms = multi_platform_ubuntu
+# platform = multi_platform_ubuntu
 # packages = ufw
 
 source common.sh


### PR DESCRIPTION
#### Description:

`grep -lr '# platforms = ' linux_os | xargs sed -i "s/# platforms =/# platform =/"`

The keyword `platforms` is not valid.

#### Rationale:

Make the tests work as expected.