### PR TITLE
Revert "OCP4: Support multi-arch content image"

### DIFF
--- a/.github/workflows/k8s-content-pr.yaml
+++ b/.github/workflows/k8s-content-pr.yaml
@@ -91,7 +91,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
-          platforms: 'linux/amd64,linux/ppc64le,linux/s390x'
+          platforms: 'linux/amd64'
       - name: Get container info
         id: container_info
         run: |

--- a/.github/workflows/k8s-content.yaml
+++ b/.github/workflows/k8s-content.yaml
@@ -20,4 +20,3 @@ jobs:
       dockerfile_path: ./Dockerfiles/ocp4_content
       licenses: BSD
       vendor: ComplianceAsCode authors
-      platforms: 'linux/amd64,linux/ppc64le,linux/s390x'


### PR DESCRIPTION


#### Description:
This reverts commit 140fed893f66626f67dfdad0a6e8f908ebd393b2. 
This commit is causing CI fail. 

#### Rationale:
Reverting to keep CI green from known failures.

PR #12055  doesn't seem to work. It causing master to always be red.

#### Review Hints:
Review the CI failing on master, see that this commit seems to be the cause.