### PR TITLE
Ensure code consistency by using aide_conf_path var

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/policy/stig/shared.yml
@@ -25,7 +25,7 @@ vuldiscussion: |-
 checktext: |-
     Check that AIDE is properly configured to protect the integrity of the audit tools with the following command:
 
-    $ sudo cat /etc/aide.conf | grep /usr/sbin/au
+    $ sudo cat {{{ aide_conf_path }}} | grep /usr/sbin/au
 
     /usr/sbin/auditctl p+i+n+u+g+s+b+acl+xattrs+sha512
     /usr/sbin/auditd p+i+n+u+g+s+b+acl+xattrs+sha512
@@ -39,7 +39,7 @@ checktext: |-
     If any of the audit tools listed above do not have a corresponding line, ask the SA to indicate what cryptographic mechanisms are being used to protect the integrity of the audit tools.  If there is no evidence of integrity protection, this is a finding.
 
 fixtext: |-
-    Add or update the following lines to "/etc/aide.conf", to protect the integrity of the audit tools.
+    Add or update the following lines to {{{ aide_conf_path }}}, to protect the integrity of the audit tools.
 
     /usr/sbin/auditctl p+i+n+u+g+s+b+acl+xattrs+sha512
     /usr/sbin/auditd p+i+n+u+g+s+b+acl+xattrs+sha512

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/rule.yml
@@ -63,7 +63,7 @@ ocil: |-
     If one or more lines are missing, this is a finding.
 
 fixtext: |-
-    Add or update the following lines to "/etc/aide.conf", to protect the integrity of the audit tools.
+    Add or update the following lines to {{{ aide_conf_path }}}, to protect the integrity of the audit tools.
 
     <pre>
     {{{ aide_files() }}}

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/correct.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/correct.pass.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_ubuntu
 # packages = aide
 
 aide --init
 
 
 declare -a bins
-bins=('/usr/sbin/auditctl' '/usr/sbin/auditd' '/usr/sbin/augenrules' '/usr/sbin/aureport' '/usr/sbin/ausearch' '/usr/sbin/autrace' '/usr/sbin/rsyslogd')
+bins=('/usr/sbin/auditctl' '/usr/sbin/auditd' '/usr/sbin/augenrules' '/usr/sbin/aureport' '/usr/sbin/ausearch' '/usr/sbin/autrace' '/usr/sbin/rsyslogd' '/usr/sbin/audispd')
 
 for theFile in "${bins[@]}"
 do
-    echo "$theFile p+i+n+u+g+s+b+acl+xattrs+sha512"  >> /etc/aide.conf
+    echo "$theFile p+i+n+u+g+s+b+acl+xattrs+sha512"  >> {{{ aide_conf_path }}}
 done

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/correct_with_selinux.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/correct_with_selinux.pass.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_ubuntu
 # packages = aide
 
 declare -a bins
-bins=('/usr/sbin/auditctl' '/usr/sbin/auditd' '/usr/sbin/augenrules' '/usr/sbin/aureport' '/usr/sbin/ausearch' '/usr/sbin/autrace' '/usr/sbin/rsyslogd')
+bins=('/usr/sbin/auditctl' '/usr/sbin/auditd' '/usr/sbin/augenrules' '/usr/sbin/aureport' '/usr/sbin/ausearch' '/usr/sbin/autrace' '/usr/sbin/rsyslogd' '/usr/sbin/audispd')
 
 for theFile in "${bins[@]}"
 do
-    echo "$theFile p+i+n+u+g+s+b+acl+selinux+xattrs+sha512" >> /etc/aide.conf
+    echo "$theFile p+i+n+u+g+s+b+acl+selinux+xattrs+sha512" >> {{{ aide_conf_path }}}
 done

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/extra_suffix.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/extra_suffix.fail.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_ubuntu
 # packages = aide
 
 declare -a bins
-bins=('/usr/sbin/auditctl' '/usr/sbin/auditd' '/usr/sbin/augenrules' '/usr/sbin/aureport' '/usr/sbin/ausearch' '/usr/sbin/autrace' '/usr/sbin/rsyslogd')
+bins=('/usr/sbin/auditctl' '/usr/sbin/auditd' '/usr/sbin/augenrules' '/usr/sbin/aureport' '/usr/sbin/ausearch' '/usr/sbin/autrace' '/usr/sbin/rsyslogd' '/usr/sbin/audispd')
 
 for theFile in "${bins[@]}"
 do
-    echo "$theFile p+i+n+u+g+s+b+acl+selinux+xattrs+sha5122" >> /etc/aide.conf
+    echo "$theFile p+i+n+u+g+s+b+acl+selinux+xattrs+sha5122" >> {{{ aide_conf_path }}}
 done

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/not_config.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/not_config.fail.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_ubuntu
 # packages = aide
 
 aide --init
 
 declare -a bins
-bins=('/usr/sbin/auditctl' '/usr/sbin/auditd' '/usr/sbin/augenrules' '/usr/sbin/aureport' '/usr/sbin/ausearch' '/usr/sbin/autrace' '/usr/sbin/rsyslogd')
+bins=('/usr/sbin/auditctl' '/usr/sbin/auditd' '/usr/sbin/augenrules' '/usr/sbin/aureport' '/usr/sbin/ausearch' '/usr/sbin/autrace' '/usr/sbin/rsyslogd' '/usr/sbin/audispd')
 
 for theFile in "${bins[@]}"
 do
-    echo sed -i "s#^.*${theFile}.*##g" /etc/aide.conf
+    echo sed -i "s#^.*${theFile}.*##g" {{{ aide_conf_path }}}
 done


### PR DESCRIPTION
#### Description:

- Make use of `aide_conf_path` var in rule aide_check_audit_tools to ensure consistency
- Enable tests for Ubuntu

#### Rationale:

- Some part of the rule `aide_check_audit_tools` still use hard-coded aide conf path