### PR TITLE
Adjust how `add_kubernetes_rule.py` determines template filepath

### DIFF
--- a/utils/add_kubernetes_rule.py
+++ b/utils/add_kubernetes_rule.py
@@ -267,7 +267,6 @@ def createPlatformRuleFunc(args):
         for line in lines:
             if 'GET' in line:
                 fetch_line = line
-                break
 
         if len(fetch_line) > 0:
             # extract the object url from the debug line


### PR DESCRIPTION

#### Description:

- Adjust how `utils/add_kubernetes_rule.py` determines the resouces  `filepath`.
  - Let's use the last GET attempt instead of the first one. In some cases `oc` makes multiple requests.

 ```
$ oc get subscriptions.operators.coreos.com cluster-kube-descheduler-operator -n descheduler-operator --loglevel=6
I0614 17:26:23.990375  707335 loader.go:373] Config loaded from file:  /home/wsato/openshift/cluster-bot/cluster-bot-2024-06-14-132324.kubeconfig.txt
I0614 17:26:23.997814  707335 discovery.go:214] Invalidating discovery information
I0614 17:26:24.603751  707335 round_trippers.go:553] GET https://api.ci-ln-2xmvwv2-76ef8.origin-ci-int-aws.dev.rhcloud.com:6443/api?timeout=32s 200 OK in 605 milliseconds
I0614 17:26:24.779482  707335 round_trippers.go:553] GET https://api.ci-ln-2xmvwv2-76ef8.origin-ci-int-aws.dev.rhcloud.com:6443/apis?timeout=32s 200 OK in 168 milliseconds
I0614 17:26:24.966879  707335 round_trippers.go:553] GET https://api.ci-ln-2xmvwv2-76ef8.origin-ci-int-aws.dev.rhcloud.com:6443/apis/operators.coreos.com/v1alpha1/namespaces/descheduler-operator/subscriptions/cluster-kube-descheduler-operator 200 OK in 171 milliseconds
NAME                                PACKAGE                             SOURCE             CHANNEL
cluster-kube-descheduler-operator   cluster-kube-descheduler-operator   redhat-operators   stable
```

#### Rationale:

- Depending on the OpenShift resource being checked, `oc` comamnd may make multiple requests.
So let's use the last request sent to determine the url of the resource.

#### Review Hints:

- Get an OCP cluster;
- Install Kube Descheduler Operator;
- `./utils/add_kubernetes_rule.py create platform --rule test --name cluster-kube-descheduler-operator --namespace descheduler-operator --type subscriptions.operators.coreos.com --title "test" --description "test" --match-entity "at least one" --yamlpath '.status.installedCSV' --match "clusterkubedescheduleroperator.*" --regex`
- ./build_product -d ocp4
- Build fails

