### PR TITLE
OCPBUGS-31674: coreos_kernel_options -update entries file path

### DIFF
--- a/shared/templates/coreos_kernel_option/oval.template
+++ b/shared/templates/coreos_kernel_option/oval.template
@@ -14,11 +14,11 @@
     <criteria operator="AND">
       <criteria operator="OR">
         <criteria operator="AND">
-            {{{- oval_file_absent_criterion('/boot/loader/entries/ostree-2-.*.conf')}}}
-            {{{- oval_argument_value_in_line_criterion('/boot/loader/entries/ostree-1-.*.conf', ARG_NAME, ARG_VALUE, 'Linux kernel', negate=ARG_NEGATE) }}}
+            {{{- oval_file_absent_criterion('/boot/loader/entries/ostree-2.*.conf')}}}
+            {{{- oval_argument_value_in_line_criterion('/boot/loader/entries/ostree-1.*.conf', ARG_NAME, ARG_VALUE, 'Linux kernel', negate=ARG_NEGATE) }}}
         </criteria>
         <criteria operator="AND">
-            {{{- oval_argument_value_in_line_criterion('/boot/loader/entries/ostree-2-.*.conf', ARG_NAME, ARG_VALUE, 'Linux kernel', negate=ARG_NEGATE) }}}
+            {{{- oval_argument_value_in_line_criterion('/boot/loader/entries/ostree-2.*.conf', ARG_NAME, ARG_VALUE, 'Linux kernel', negate=ARG_NEGATE) }}}
         </criteria>
       </criteria>
       <criteria operator="AND">
@@ -27,11 +27,11 @@
     </criteria>
   </definition>
 
-  {{{- oval_file_absent('/boot/loader/entries/ostree-2-.*.conf') }}}
+  {{{- oval_file_absent('/boot/loader/entries/ostree-2.*.conf') }}}
   {{{-
-  oval_argument_value_in_line_test('/boot/loader/entries/ostree-1-.*.conf', ARG_NAME, ARG_VALUE, 'options ', is_regex=ARG_IS_REGEX) }}}
+  oval_argument_value_in_line_test('/boot/loader/entries/ostree-1.*.conf', ARG_NAME, ARG_VALUE, 'options ', is_regex=ARG_IS_REGEX) }}}
 
-  {{{- oval_argument_value_in_line_test('/boot/loader/entries/ostree-2-.*.conf', ARG_NAME, ARG_VALUE, 'options ', is_regex=ARG_IS_REGEX) }}}
+  {{{- oval_argument_value_in_line_test('/boot/loader/entries/ostree-2.*.conf', ARG_NAME, ARG_VALUE, 'options ', is_regex=ARG_IS_REGEX) }}}
 
   {{{- oval_argument_value_in_line_test('/proc/cmdline', ARG_NAME, ARG_VALUE, 'BOOT_IMAGE', is_regex=ARG_IS_REGEX) }}}
 </def-group>


### PR DESCRIPTION
#### Description:

- Loosen the regex so that it matches  `4.15` and `4.16` files.
  -  `4.15`: `/boot/loader/entries/ostree-1-rhcos.conf`
  -  `4.16`: `/boot/loader/entries/ostree-1.conf`
- This change is backwards compatible.

#### Rationale:

- In OCP 4.16 the file where kernel boot options are configured changed.

- Fixes OCPBUGS-31674
