### PR TITLE
Adding OCP4 multi-arch support

### DIFF
--- a/.github/workflows/k8s-content-pr.yaml
+++ b/.github/workflows/k8s-content-pr.yaml
@@ -91,7 +91,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
-          platforms: 'linux/amd64'
+          platforms: 'linux/amd64,linux/ppc64le,linux/s390x'
       - name: Get container info
         id: container_info
         run: |

--- a/.github/workflows/k8s-content.yaml
+++ b/.github/workflows/k8s-content.yaml
@@ -20,3 +20,4 @@ jobs:
       dockerfile_path: ./Dockerfiles/ocp4_content
       licenses: BSD
       vendor: ComplianceAsCode authors
+      platforms: 'linux/amd64,linux/ppc64le,linux/s390x'

--- a/Dockerfiles/ocp4_content
+++ b/Dockerfiles/ocp4_content
@@ -1,5 +1,3 @@
-# This dockerfile builds the content in the current repo for OCP4
-
 FROM registry.fedoraproject.org/fedora-minimal:latest as builder
 
 WORKDIR /content
@@ -8,10 +6,46 @@ RUN microdnf -y install cmake make git /usr/bin/python3 python3-pyyaml python3-j
 
 COPY . .
 
-RUN ./build_product --datastream-only --debug ocp4 rhcos4 eks
+
+# Enable only certain profiles on ppc64le and s390x
+RUN if [ "$(uname -m)" == "x86_64" ]; then \
+    echo "Building OpenShift and RHCOS content for x86_64"; \
+    else echo "Building OpenShift content for $(uname -m)" && \
+        # Disable all profiles first
+        find . -name "*.profile" -exec sed -i 's/\(documentation_complete: \).*/\1false/' '{}' \; && \
+        # Enable the default.profiles as they maintain a list rules to be added to the datastream
+        find . -name "default\.profile" -exec sed -i 's/\(documentation_complete: \).*/\1true/' '{}' \; && \
+        sed -i 's/\(documentation_complete: \).*/\1true/' \
+        products/ocp4/profiles/pci-dss-node-3-2.profile \
+        products/ocp4/profiles/pci-dss-3-2.profile \
+        products/ocp4/profiles/pci-dss-node.profile \
+        products/ocp4/profiles/pci-dss.profile \
+        products/ocp4/profiles/cis-node.profile \
+        products/ocp4/profiles/cis.profile \
+        products/ocp4/profiles/cis-node-1-4.profile \
+        products/ocp4/profiles/cis-1-4.profile \
+        products/ocp4/profiles/cis-node-1-5.profile \
+        products/ocp4/profiles/cis-1-5.profile \
+        products/ocp4/profiles/moderate-node.profile \
+        products/ocp4/profiles/moderate.profile \
+        products/ocp4/profiles/moderate-node-rev-4.profile \
+        products/ocp4/profiles/moderate-rev-4.profile && \
+        # OCPBUGS-32794: Ensure stability of rules shipped
+        # Before building the content we re-enable all profiles as hidden, this will include any rule selected
+        # by these profiles in the data stream without creating a profile for them.
+        grep -lr 'documentation_complete: false' ./products | xargs -I '{}' \
+        sed -i -e 's/\(documentation_complete: \).*/\1true/' -e '/documentation_complete/a hidden: true' {}; \
+    fi
+
+# Build the OpenShift, EKS, and RHCOS content for x86 architectures. Only build
+# OpenShift content for ppc64le and s390x architectures since we're not
+# including any RHCOS profiles on those architectures right now anyway.
+RUN if [ "$(uname -m)" = "x86_64" ]; then \
+        ./build_product ocp4 rhcos4 eks --datastream-only; \
+        else ./build_product ocp4 --datastream-only; \
+        fi
 
 FROM registry.access.redhat.com/ubi8/ubi-micro:latest
+
 WORKDIR /
-COPY --from=builder /content/build/ssg-ocp4-ds.xml .
-COPY --from=builder /content/build/ssg-rhcos4-ds.xml .
-COPY --from=builder /content/build/ssg-eks-ds.xml .
+COPY --from=builder /content/build/ssg-*-ds.xml .


### PR DESCRIPTION
Let's skip sbom, before we have https://github.com/metal-toolbox/container-push/pull/77 landed. Modified Dockerfile so we only build certain profiles for s390x and ppc64le. Update github action to build for s390x and ppc64le.
