### PR TITLE
OCPBUGS-35765: bios-enable-execution-restrictions should be excluded for ppc64le

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/enable_nx/bios_enable_execution_restrictions/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_nx/bios_enable_execution_restrictions/rule.yml
@@ -42,7 +42,8 @@ references:
     stigid@ubuntu2204: UBTU-22-213025
 
 # In aarch64 cpus the bit is XN and it is not disableable
-platform: machine and not aarch64_arch
+# In ppc64le cpus the bit is not applicable
+platform: machine and not aarch64_arch and not ppc64le_arch
 
 ocil: |-
     Verify the NX (no-execution) bit flag is set on the system.


### PR DESCRIPTION
#### Description:

OCPBUGS-35765: bios-enable-execution-restrictions should be excluded for ppc64le

#### Rationale:

- Fixes OCPBUGS-35765

#### Review Hints:

Must use the ppc64le platform to see the exclusion of the rule.