### PR TITLE
Create dconf db directory for local profile

### DIFF
--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -2503,6 +2503,9 @@ if ! grep -Pzq "(?s)^\s*user-db:user.*\n\s*system-db:{{{ database }}}" "${dconf_
     sed -i --follow-symlinks "1s/^/user-db:user\nsystem-db:{{{ database }}}\n/" "${dconf_profile_path}"
 fi
 
+# Make sure the corresponding directories exist
+mkdir -p /etc/dconf/db/{{{ database }}}.d
+
 # Make sure permissions allow regular users to read dconf settings.
 # Also define the umask to avoid `dconf update` changing permissions.
 chmod -R u=rwX,go=rX /etc/dconf/profile


### PR DESCRIPTION
#### Description:

- Make sure the corresponding database directories exist for user profile

#### Rationale:

- The enable_dconf_user_profile rule need create `user` profile for screenlock,automount,ctrlaltdel,... settings, but doesn't create the local.d db directory automatically which causes the dconf to throw out warning
