### PR TITLE
Install dependency "xmllint" package

### DIFF
--- a/.github/workflows/automatus-ubuntu2204.yaml
+++ b/.github/workflows/automatus-ubuntu2204.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Install Deps
-        run: sudo apt-get update && sudo apt-get install -y cmake ninja-build libopenscap8 python3-yaml python3-jinja2 git python3-deepdiff python3-requests jq python3-pip
+        run: sudo apt-get update && sudo apt-get install -y cmake ninja-build libopenscap8 python3-yaml python3-jinja2 git python3-deepdiff python3-requests jq python3-pip libxml2-utils
       - name: Install deps python
         run: pip3 install gitpython xmldiff
       - name: Checkout


### PR DESCRIPTION
#### Description:

- Fix the "Could not find XMLLINT_EXECUTABLE" error 

#### Rationale:

- Use apt to install the required dependency xmllint from libxml2-utils