### PR TITLE
remove logind_session_timeout from stig_gui profiles

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/logind_session_timeout/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/logind_session_timeout/rule.yml
@@ -40,7 +40,6 @@ references:
     pcidss: Req-8.1.8
     srg: SRG-OS-000163-GPOS-00072
     stigid@ol8: OL08-00-020035
-    stigid@rhel8: RHEL-08-020035
 
 ocil_clause: "the option is not configured"
 

--- a/products/rhel10/profiles/stig_gui.profile
+++ b/products/rhel10/profiles/stig_gui.profile
@@ -30,3 +30,5 @@ selections:
     # Limiting user namespaces cause issues with user apps, such as Firefox and Cheese
     # https://issues.redhat.com/browse/RHEL-10416
     - '!sysctl_user_max_user_namespaces'
+    # locking of idle sessions is handled by screensaver when GUI is present, the following rule is therefore redundant
+    - '!logind_session_timeout'

--- a/products/rhel8/profiles/stig_gui.profile
+++ b/products/rhel8/profiles/stig_gui.profile
@@ -46,3 +46,6 @@ selections:
     # Limiting user namespaces cause issues with user apps, such as Firefox and Cheese
     # https://issues.redhat.com/browse/RHEL-10416
     - '!sysctl_user_max_user_namespaces'
+
+    # locking of idle sessions is handled by screensaver when GUI is present, the following rule is therefore redundant
+    - '!logind_session_timeout'

--- a/products/rhel9/profiles/stig_gui.profile
+++ b/products/rhel9/profiles/stig_gui.profile
@@ -47,3 +47,5 @@ selections:
     # Limiting user namespaces cause issues with user apps, such as Firefox and Cheese
     # https://issues.redhat.com/browse/RHEL-10416
     - '!sysctl_user_max_user_namespaces'
+    # locking of idle sessions is handled by screensaver when GUI is present, the following rule is therefore redundant
+    - '!logind_session_timeout'

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -225,7 +225,6 @@ selections:
 - accounts_password_all_shadowed_sha512
 - rsyslog_cron_logging
 - package_sendmail_removed
-- logind_session_timeout
 - configure_tmux_lock_after_time
 - accounts_password_set_min_life_existing
 - audit_rules_file_deletion_events_renameat

--- a/tests/data/profile_stability/rhel9/stig_gui.profile
+++ b/tests/data/profile_stability/rhel9/stig_gui.profile
@@ -348,7 +348,6 @@ selections:
 - kernel_module_tipc_disabled
 - kernel_module_usb-storage_disabled
 - libreswan_approved_tunnels
-- logind_session_timeout
 - mount_option_boot_efi_nosuid
 - mount_option_boot_nodev
 - mount_option_boot_nosuid


### PR DESCRIPTION
#### Description:

- deselect the rule in stig_gui profiles for rhel8, rhel9m, rhel10 products
- add explaining comment
- remove rhel8 stigid from the rule as it is static

#### Rationale:

- it was agreed that mechanism for locking of idle sessions is handled well enough by Gnome screensaver in the case of GUI profiles, the rule was worsening user experience in this case

#### Review Hints:

- review list of rules in stig_gui profiles