### PR TITLE
OCPBUGS-33945: select required SSHD timeout rule

### DIFF
--- a/controls/nist_rhcos4.yml
+++ b/controls/nist_rhcos4.yml
@@ -260,7 +260,7 @@ controls:
   rules:
   - sshd_set_idle_timeout
   - var_sshd_set_keepalive=0
-  - sshd_set_keepalive_0
+  - sshd_set_keepalive
   description: |-
     The organization requires that users log out when [Assignment: organization-defined time-period of expected inactivity or description of when to log out].
 
@@ -1405,7 +1405,7 @@ controls:
   rules:
   - sshd_set_idle_timeout
   - var_sshd_set_keepalive=0
-  - sshd_set_keepalive_0
+  - sshd_set_keepalive
   description: "The information system automatically terminates a user session after\
     \ [Assignment: organization-defined conditions or trigger events requiring session\
     \ disconnect].\n\nSupplemental Guidance:  This control addresses the termination\
@@ -1588,7 +1588,7 @@ controls:
   - configure_openssl_crypto_policy
   - file_permissions_sshd_config
   - var_sshd_set_keepalive=0
-  - sshd_set_keepalive_0
+  - sshd_set_keepalive
   - var_system_crypto_policy=fips
   - configure_crypto_policy
   - sshd_set_idle_timeout
@@ -5110,7 +5110,7 @@ controls:
   - audit_rules_unsuccessful_file_modification_removexattr
   - audit_rules_etc_gshadow_openat
   - var_sshd_set_keepalive=0
-  - sshd_set_keepalive_0
+  - sshd_set_keepalive
   - partition_for_var_log_audit
   - auditd_data_retention_space_left
   - coreos_page_poison_kernel_argument
@@ -13213,7 +13213,7 @@ controls:
   rules:
   - sshd_set_idle_timeout
   - var_sshd_set_keepalive=0
-  - sshd_set_keepalive_0
+  - sshd_set_keepalive
   description: |-
     The information system terminates the network connection associated with a communications session at the end of the session or after [Assignment: organization-defined time period] of inactivity.
     Supplemental Guidance:  This control applies to both internal and external networks. Terminating network connections associated with communications sessions include, for example, de-allocating associated TCP/IP address/port pairs at the operating system level, or de-allocating networking assignments at the application level if multiple application sessions are using a single, operating system-level network connection. Time periods of inactivity may be established by organizations and include, for example, time periods by type of network access or for specific network accesses.

--- a/tests/assertions/ocp4/rhcos4-high-4.13.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.13.yml
@@ -617,7 +617,10 @@ rule_results:
   e2e-high-master-sshd-limit-user-access:
     default_result: FAIL
     result_after_remediation: FAIL
-  e2e-high-master-sshd-set-keepalive-0:
+  e2e-high-master-sshd-set-idle-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sshd-set-keepalive:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-sysctl-fs-protected-hardlinks:
@@ -1340,7 +1343,10 @@ rule_results:
   e2e-high-worker-sshd-limit-user-access:
     default_result: FAIL
     result_after_remediation: FAIL
-  e2e-high-worker-sshd-set-keepalive-0:
+  e2e-high-worker-sshd-set-idle-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sshd-set-keepalive:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-sysctl-fs-protected-hardlinks:

--- a/tests/assertions/ocp4/rhcos4-high-4.14.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.14.yml
@@ -617,7 +617,10 @@ rule_results:
   e2e-high-master-sshd-limit-user-access:
     default_result: FAIL
     result_after_remediation: FAIL
-  e2e-high-master-sshd-set-keepalive-0:
+  e2e-high-master-sshd-set-idle-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sshd-set-keepalive:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-sysctl-fs-protected-hardlinks:
@@ -1340,7 +1343,10 @@ rule_results:
   e2e-high-worker-sshd-limit-user-access:
     default_result: FAIL
     result_after_remediation: FAIL
-  e2e-high-worker-sshd-set-keepalive-0:
+  e2e-high-worker-sshd-set-idle-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sshd-set-keepalive:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-sysctl-fs-protected-hardlinks:

--- a/tests/assertions/ocp4/rhcos4-high-4.15.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.15.yml
@@ -612,7 +612,10 @@ rule_results:
     result_after_remediation: PASS
   e2e-high-master-sshd-limit-user-access:
     default_result: FAIL
-  e2e-high-master-sshd-set-keepalive-0:
+  e2e-high-master-sshd-set-idle-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sshd-set-keepalive:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-sysctl-fs-protected-hardlinks:
@@ -1329,7 +1332,10 @@ rule_results:
     result_after_remediation: PASS
   e2e-high-worker-sshd-limit-user-access:
     default_result: FAIL
-  e2e-high-worker-sshd-set-keepalive-0:
+  e2e-high-worker-sshd-set-idle-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sshd-set-keepalive:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-sysctl-fs-protected-hardlinks:

--- a/tests/assertions/ocp4/rhcos4-high-4.16.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.16.yml
@@ -612,7 +612,10 @@ rule_results:
     result_after_remediation: PASS
   e2e-high-master-sshd-limit-user-access:
     default_result: FAIL
-  e2e-high-master-sshd-set-keepalive-0:
+  e2e-high-master-sshd-set-idle-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sshd-set-keepalive:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-sysctl-fs-protected-hardlinks:
@@ -1329,7 +1332,10 @@ rule_results:
     result_after_remediation: PASS
   e2e-high-worker-sshd-limit-user-access:
     default_result: FAIL
-  e2e-high-worker-sshd-set-keepalive-0:
+  e2e-high-worker-sshd-set-idle-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sshd-set-keepalive:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-sysctl-fs-protected-hardlinks:

--- a/tests/assertions/ocp4/rhcos4-moderate-4.13.yml
+++ b/tests/assertions/ocp4/rhcos4-moderate-4.13.yml
@@ -609,7 +609,10 @@ rule_results:
     result_after_remediation: PASS
   e2e-moderate-master-sshd-limit-user-access:
     default_result: FAIL
-  e2e-moderate-master-sshd-set-keepalive-0:
+  e2e-moderate-master-sshd-set-idle-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sshd-set-keepalive:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-sysctl-fs-protected-hardlinks:
@@ -1323,7 +1326,10 @@ rule_results:
     result_after_remediation: PASS
   e2e-moderate-worker-sshd-limit-user-access:
     default_result: FAIL
-  e2e-moderate-worker-sshd-set-keepalive-0:
+  e2e-moderate-worker-sshd-set-idle-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sshd-set-keepalive:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-sysctl-fs-protected-hardlinks:

--- a/tests/assertions/ocp4/rhcos4-moderate-4.14.yml
+++ b/tests/assertions/ocp4/rhcos4-moderate-4.14.yml
@@ -609,7 +609,10 @@ rule_results:
     result_after_remediation: PASS
   e2e-moderate-master-sshd-limit-user-access:
     default_result: FAIL
-  e2e-moderate-master-sshd-set-keepalive-0:
+  e2e-moderate-master-sshd-set-idle-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sshd-set-keepalive:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-sysctl-fs-protected-hardlinks:
@@ -1323,7 +1326,10 @@ rule_results:
     result_after_remediation: PASS
   e2e-moderate-worker-sshd-limit-user-access:
     default_result: FAIL
-  e2e-moderate-worker-sshd-set-keepalive-0:
+  e2e-moderate-worker-sshd-set-idle-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sshd-set-keepalive:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-sysctl-fs-protected-hardlinks:

--- a/tests/assertions/ocp4/rhcos4-moderate-4.15.yml
+++ b/tests/assertions/ocp4/rhcos4-moderate-4.15.yml
@@ -609,7 +609,10 @@ rule_results:
     result_after_remediation: PASS
   e2e-moderate-master-sshd-limit-user-access:
     default_result: FAIL
-  e2e-moderate-master-sshd-set-keepalive-0:
+  e2e-moderate-master-sshd-set-idle-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sshd-set-keepalive:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-sysctl-fs-protected-hardlinks:
@@ -1323,7 +1326,10 @@ rule_results:
     result_after_remediation: PASS
   e2e-moderate-worker-sshd-limit-user-access:
     default_result: FAIL
-  e2e-moderate-worker-sshd-set-keepalive-0:
+  e2e-moderate-worker-sshd-set-idle-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sshd-set-keepalive:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-sysctl-fs-protected-hardlinks:

--- a/tests/assertions/ocp4/rhcos4-moderate-4.16.yml
+++ b/tests/assertions/ocp4/rhcos4-moderate-4.16.yml
@@ -609,7 +609,10 @@ rule_results:
     result_after_remediation: PASS
   e2e-moderate-master-sshd-limit-user-access:
     default_result: FAIL
-  e2e-moderate-master-sshd-set-keepalive-0:
+  e2e-moderate-master-sshd-set-idle-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sshd-set-keepalive:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-sysctl-fs-protected-hardlinks:
@@ -1323,7 +1326,10 @@ rule_results:
     result_after_remediation: PASS
   e2e-moderate-worker-sshd-limit-user-access:
     default_result: FAIL
-  e2e-moderate-worker-sshd-set-keepalive-0:
+  e2e-moderate-worker-sshd-set-idle-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sshd-set-keepalive:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-sysctl-fs-protected-hardlinks:


### PR DESCRIPTION

#### Description:

- The rule `sshd_set_idle_timeout` used to require rule `sshd_set_keepalive_0` for Red Hat linuxes.
  But after #11815 it started to require rules `sshd_set_keepalive`.
  This selects the rule that satifyes the requirement.

#### Rationale:

- Rule requirement alignment in OCP4 `high` and `moderate` profiles.

#### Review Hints:

- CCRs for `sshd_set_idle_timeout` appears after ``rhcos4-high` or `rhcos4-moderate`.