### PR TITLE
Add ansible automation for configure_usbguard_auditbackend 

### DIFF
--- a/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/ansible/shared.yml
+++ b/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/ansible/shared.yml
@@ -1,0 +1,13 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+{{{ ansible_set_config_file(file="/etc/usbguard/usbguard-daemon.conf",
+                  parameter="AuditBackend",
+                  value="LinuxAudit",
+                  create=true,
+                  separator="=",
+                  separator_regex="=",
+                  prefix_regex="^\s*") }}}

--- a/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/tests/commented.fail.sh
+++ b/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/tests/commented.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = usbguard
 
 mkdir -p /etc/usbguard
 cat << EOF > /etc/usbguard/usbguard-daemon.conf

--- a/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/tests/missing.fail.sh
+++ b/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/tests/missing.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = usbguard
 
 mkdir -p /etc/usbguard
 cat << EOF > /etc/usbguard/usbguard-daemon.conf

--- a/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/tests/present.pass.sh
+++ b/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/tests/present.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = usbguard
 
 mkdir -p /etc/usbguard
 cat << EOF > /etc/usbguard/usbguard-daemon.conf

--- a/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/tests/wrong_value.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = usbguard
 
 mkdir -p /etc/usbguard
 cat << EOF > /etc/usbguard/usbguard-daemon.conf


### PR DESCRIPTION
#### Description:

Add ansible remediation for `configure_usbguard_auditbackend` rule

Update all tests without the clause `# packages = usbguard`

#### Rationale:

In the task filling gaps in OL9 automation, the rule `configure_usbguard_auditbackend` has a remediation deficit with ansible. The parameters for the macro was taken of bash remediation.
