### PR TITLE
Fix crypto policy in CIS test scenario

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/policy_default_cis_l1.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/policy_default_cis_l1.pass.sh
@@ -3,4 +3,4 @@
 # profiles = xccdf_org.ssgproject.content_profile_cis_server_l1,xccdf_org.ssgproject.content_profile_cis_workstation_l1
 # packages = crypto-policies-scripts
 
-update-crypto-policies --set "DEFAULT"
+update-crypto-policies --set "DEFAULT:NO-SHA1"


### PR DESCRIPTION
#### Description:
Fix for failing Automatus test scenarios:

- fail: configure_crypto_policy/policy_default_cis_l1.pass (profile:cis_server_l1)
- fail: configure_crypto_policy/policy_default_cis_l1.pass (profile:cis_workstation_l1)

#### Rationale:
Related to https://github.com/ComplianceAsCode/content/commit/96ceda9a6770549a04726537f15b193d22720ec2

#### Review Hints:
```
$ python3 tests/automatus.py rule --datastream build/ssg-rhel9-ds.xml --libvirt qemu:///session test-suite-rhel9 --no-reports --scenarios policy_default_cis_l1 configure_crypto_policy
```
