### PR TITLE
Do not run `package_audit-libs_installed` package removal test scenarios

### DIFF
--- a/linux_os/guide/auditing/package_audit-libs_installed/tests/test_config.yml
+++ b/linux_os/guide/auditing/package_audit-libs_installed/tests/test_config.yml
@@ -1,0 +1,3 @@
+deny_templated_scenarios:
+  - package-installed-removed.fail.sh
+  - package-removed.fail.sh


### PR DESCRIPTION
#### Description:
Exclude test scenarios that remove audit-libs package.

#### Rationale:
After removing the package, it's not possible to ssh to the system:
```
kex_exchange_identification: read: Connection reset by peer
Connection reset by 192.168.122.110 port 22
Failed to connect!
```
causing:
```
ERROR - Script package-installed-removed.fail.sh using profile (all) found issue:
ERROR - Rule xccdf_org.ssgproject.content_rule_package_audit-libs_installed has not been evaluated! Wrong profile selected in test scenario or there has been problem starting the evaluation. Please inspect the log file /home/mlysonek/SCAP/content/logs/rule-custom-2024-06-27-1521/package_audit-libs_installed-package-installed-removed.fail.sh-initial.verbose.log for details.
ERROR - The initial scan failed for rule 'xccdf_org.ssgproject.content_rule_package_audit-libs_installed'.
```

#### Review Hints:
`$ python3 tests/automatus.py rule --datastream build/ssg-rhel9-ds.xml --libvirt qemu:///session test-suite-rhel9 --no-reports package_audit-libs_installed`