### PR TITLE
Add set_nftables_table to default RHEL 9 profile

### DIFF
--- a/products/rhel9/profiles/default.profile
+++ b/products/rhel9/profiles/default.profile
@@ -555,3 +555,4 @@ selections:
     - configure_firewalld_ports
     - journald_forward_to_syslog
     - rsyslog_filecreatemode
+    - set_nftables_table


### PR DESCRIPTION
#### Description:

Add set_nftables_table to default RHEL 9 profile

#### Rationale:
Make the tests pass
