### PR TITLE
Fixing rule title for CMP-2485

### DIFF
--- a/applications/openshift/networking/route_ip_whitelist/rule.yml
+++ b/applications/openshift/networking/route_ip_whitelist/rule.yml
@@ -1,5 +1,5 @@
 
-title: Ensure that all Routes has rate limit enabled 
+title: Ensure that all Routes has IP whitelist annotation 
 
 description: |-
   OpenShift has an option to set the IP whitelist for Routes [1] when


### PR DESCRIPTION
#### Description:

Rule `route_ip_whitelist` had an incorrect title and it is pointing to `routes_rate_limit`. 

#### Rationale:

Fixes  [CMP-2485](https://issues.redhat.com/browse/CMP-2485)

#### Review Hints:
Both the rules `ocp4-route-ip-whitelist` and `ocp4-routes-rate-limit` in compliance operator v1.4.0 have the title Ensure that all Routes has rate limit enabled.