### PR TITLE
Fix ocil text of rule ensure_rtc_utc_configuration

### DIFF
--- a/linux_os/guide/system/logging/ensure_rtc_utc_configuration/rule.yml
+++ b/linux_os/guide/system/logging/ensure_rtc_utc_configuration/rule.yml
@@ -33,7 +33,7 @@ ocil_clause: 'the system real-time clock is not configured to use UTC as its tim
 
 ocil: |-
     To verify that the system real-time clock is set to UTC or GMT, run the following command:
-    {{% if product in ['sle12','sle15'] %}}
+    {{% if product in ['sle12','sle15'] or 'ubuntu' in product %}}
     <pre># timedatectl status | grep -i "time zone"</pre>
     <pre># Time zone: UTC (UTC, +0000)</pre>
     {{% else %}}


### PR DESCRIPTION
#### Description:

- Fix ocil text of rule ensure_rtc_utc_configuration

#### Rationale:

- The output of Ubuntu systemctl also use "Time zone"