### PR TITLE
Improve identity provider timeout polling

### DIFF
--- a/applications/openshift/authentication/idp_is_configured/tests/ocp4/e2e-remediation.sh
+++ b/applications/openshift/authentication/idp_is_configured/tests/ocp4/e2e-remediation.sh
@@ -25,8 +25,5 @@ spec:
 EOF
 
 
-echo "waiting for authentication operator to become progressing"
-oc wait clusteroperator authentication --for=condition=PROGRESSING
-
-echo "waiting for authentication operator to become ready"
-oc wait clusteroperator authentication --for=condition=Available
+echo "waiting for a stable cluster"
+oc adm wait-for-stable-cluster


### PR DESCRIPTION
One of our tests for OpenShift uses a manual remediation to install an
identity provider before rescanning the environment. Something we've
noticed is that the remediation will timeout in e2e runs because the
authentication operator isn't ready yet after configuring the new
identity provider.

The default timeout is only 30 seconds, which likely isn't long enough
to restart the authentication operator.

We can make this remediation more robust by using `oc adm
wait-for-stable-cluster`, which waits up to an hour for the
authentication operator to come up. It also reduces the number of things
we need to check for by encapsulating the checks into a single command.
