### PR TITLE
Fix automatus for ubuntu2204

### DIFF
--- a/.github/workflows/automatus-ubuntu2204.yaml
+++ b/.github/workflows/automatus-ubuntu2204.yaml
@@ -90,7 +90,7 @@ jobs:
         run: ssh-keygen -N '' -t rsa -f ~/.ssh/id_rsa
       - name: Build test suite container
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        run: podman build --build-arg "CLIENT_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)" -t ssg_test_suite -f test_suite-ubt22
+        run: podman build --build-arg "CLIENT_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)" -t ssg_test_suite -f test_suite-ubuntu2204
         working-directory: ./Dockerfiles
       - name: Get oscap-ssh
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}

--- a/.github/workflows/automatus-ubuntu2204.yaml
+++ b/.github/workflows/automatus-ubuntu2204.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Install Deps
-        run: sudo apt-get update && sudo apt-get install -y cmake ninja-build libopenscap8 python3-yaml python3-jinja2 git python3-deepdiff python3-requests jq python3-pip libxml2-utils
+        run: sudo apt-get update && sudo apt-get install -y cmake ninja-build libopenscap8 python3-yaml python3-jinja2 git python3-deepdiff python3-requests jq python3-pip libxml2-utils xsltproc
       - name: Install deps python
         run: pip3 install gitpython xmldiff compliance-trestle==2.4.0 lxml lxml-stubs requests
       - name: Checkout

--- a/Dockerfiles/test_suite-ubuntu2204
+++ b/Dockerfiles/test_suite-ubuntu2204
@@ -15,7 +15,7 @@ RUN true \
         && true
 
 RUN true \
-        && for key_type in rsa ecdsa; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
+        && for key_type in rsa ecdsa; do true | ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
         && mkdir -p /root/.ssh \
         && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
         && chmod og-rw /root/.ssh "$AUTH_KEYS" \

--- a/Dockerfiles/test_suite-ubuntu2204
+++ b/Dockerfiles/test_suite-ubuntu2204
@@ -15,10 +15,9 @@ RUN true \
         && true
 
 RUN true \
-        && for key_type in rsa ecdsa; do true | ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
+        && ssh-keygen -A \
         && mkdir -p /root/.ssh \
         && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
         && chmod og-rw /root/.ssh "$AUTH_KEYS" \
         && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
 && true
-

--- a/Dockerfiles/test_suite-ubuntu2204
+++ b/Dockerfiles/test_suite-ubuntu2204
@@ -9,7 +9,7 @@ ARG ADDITIONAL_PACKAGES
 # Install Python so Ansible remediations can work
 # Don't clean all, as the test scenario may require package install.
 RUN true \
-        && apt-get update && apt-get install -y openssh-client openssh-server openscap \
+        && apt-get update && apt-get install -y openssh-client openssh-server libopenscap8 \
 		python3 \
 		$ADDITIONAL_PACKAGES \
         && true

--- a/Dockerfiles/test_suite-ubuntu2204
+++ b/Dockerfiles/test_suite-ubuntu2204
@@ -1,0 +1,24 @@
+# This Dockerfile is a minimal example for a Ubuntu 22.04 test suite target container.
+FROM ubuntu:22.04
+
+ENV AUTH_KEYS=/root/.ssh/authorized_keys
+
+ARG CLIENT_PUBLIC_KEY
+ARG ADDITIONAL_PACKAGES
+
+# Install Python so Ansible remediations can work
+# Don't clean all, as the test scenario may require package install.
+RUN true \
+        && apt-get update && apt-get install -y openssh-clients openssh-server openscap-scanner \
+		python3 \
+		$ADDITIONAL_PACKAGES \
+        && true
+
+RUN true \
+        && for key_type in rsa ecdsa; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
+        && mkdir -p /root/.ssh \
+        && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
+        && chmod og-rw /root/.ssh "$AUTH_KEYS" \
+        && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
+&& true
+

--- a/Dockerfiles/test_suite-ubuntu2204
+++ b/Dockerfiles/test_suite-ubuntu2204
@@ -9,7 +9,7 @@ ARG ADDITIONAL_PACKAGES
 # Install Python so Ansible remediations can work
 # Don't clean all, as the test scenario may require package install.
 RUN true \
-        && apt-get update && apt-get install -y openssh-clients openssh-server openscap-scanner \
+        && apt-get update && apt-get install -y openssh-client openssh-server openscap \
 		python3 \
 		$ADDITIONAL_PACKAGES \
         && true

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/no_tmux_in_shells/tests/example.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/no_tmux_in_shells/tests/example.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if grep -q 'tmux\s*$' /etc/shells ; then
+	sed -i '/tmux\s*$/d' /etc/shells
+fi


### PR DESCRIPTION
Description:

Install `xsltproc` for Automatus content build on Ubuntu 22.04.

Rationale:

So the tests work.
Review Hints:
- Review the CI and ensure that "Automatus Ubuntu 22.04" passes.
- Once approved I will remove the example commit that triggered the CI.