### PR TITLE
Change default hashing algorithm settings in ANSSI profiles for RHEL

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/var_password_hashing_algorithm.var
+++ b/linux_os/guide/system/accounts/accounts-pam/var_password_hashing_algorithm.var
@@ -16,4 +16,4 @@ options:
     default: SHA512
     SHA512: SHA512
     SHA256: SHA256
-    yescrypt: yescrypt
+    yescrypt: YESCRYPT

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/var_password_pam_unix_rounds.var
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/var_password_pam_unix_rounds.var
@@ -3,7 +3,7 @@ documentation_complete: true
 title: Password Hashing algorithm
 
 description: |-
-    Specify the number of SHA rounds for the system password encryption algorithm.
+    Specify the number of rounds for the system password encryption algorithm.
     Defines the value set in <tt>/etc/pam.d/system-auth</tt> and <tt>/etc/pam.d/password-auth</tt>
 
 type: number

--- a/products/rhel8/profiles/anssi_bp28_enhanced.profile
+++ b/products/rhel8/profiles/anssi_bp28_enhanced.profile
@@ -21,6 +21,8 @@ description: |-
 
 selections:
     - anssi:all:enhanced
+    - var_password_hashing_algorithm=SHA512
+    - var_password_pam_unix_rounds=65536
     - '!timer_logrotate_enabled'
     # Following rules once had a prodtype incompatible with the rhel8 product
     - '!cracklib_accounts_password_pam_minlen'

--- a/products/rhel8/profiles/anssi_bp28_high.profile
+++ b/products/rhel8/profiles/anssi_bp28_high.profile
@@ -21,6 +21,8 @@ description: |-
 
 selections:
     - anssi:all:high
+    - var_password_hashing_algorithm=SHA512
+    - var_password_pam_unix_rounds=65536
     # the following rule renders UEFI systems unbootable
     - '!sebool_secure_mode_insmod'
     - '!timer_logrotate_enabled'

--- a/products/rhel8/profiles/anssi_bp28_intermediary.profile
+++ b/products/rhel8/profiles/anssi_bp28_intermediary.profile
@@ -21,6 +21,8 @@ description: |-
 
 selections:
   - anssi:all:intermediary
+  - var_password_hashing_algorithm=SHA512
+  - var_password_pam_unix_rounds=65536
   # Following rules once had a prodtype incompatible with the rhel8 product
   - '!cracklib_accounts_password_pam_minlen'
   - '!accounts_passwords_pam_tally2_deny_root'

--- a/products/rhel8/profiles/anssi_bp28_minimal.profile
+++ b/products/rhel8/profiles/anssi_bp28_minimal.profile
@@ -21,6 +21,8 @@ description: |-
 
 selections:
   - anssi:all:minimal
+  - var_password_hashing_algorithm=SHA512
+  - var_password_pam_unix_rounds=65536
   # Following rules once had a prodtype incompatible with the rhel8 product
   - '!cracklib_accounts_password_pam_minlen'
   - '!accounts_passwords_pam_tally2_deny_root'

--- a/products/rhel9/profiles/anssi_bp28_enhanced.profile
+++ b/products/rhel9/profiles/anssi_bp28_enhanced.profile
@@ -21,6 +21,8 @@ description: |-
 
 selections:
     - anssi:all:enhanced
+    - var_password_hashing_algorithm=SHA512
+    - var_password_pam_unix_rounds=65536
     # Following rules once had a prodtype incompatible with the rhel9 product
     - '!partition_for_opt'
     - '!accounts_passwords_pam_tally2_deny_root'

--- a/products/rhel9/profiles/anssi_bp28_high.profile
+++ b/products/rhel9/profiles/anssi_bp28_high.profile
@@ -21,6 +21,8 @@ description: |-
 
 selections:
     - anssi:all:high
+    - var_password_hashing_algorithm=SHA512
+    - var_password_pam_unix_rounds=65536
     # the following rule renders UEFI systems unbootable
     - '!sebool_secure_mode_insmod'
     # Following rules once had a prodtype incompatible with the rhel9 product

--- a/products/rhel9/profiles/anssi_bp28_intermediary.profile
+++ b/products/rhel9/profiles/anssi_bp28_intermediary.profile
@@ -21,6 +21,8 @@ description: |-
 
 selections:
   - anssi:all:intermediary
+  - var_password_hashing_algorithm=SHA512
+  - var_password_pam_unix_rounds=65536
   # Following rules once had a prodtype incompatible with the rhel9 product
   - '!partition_for_opt'
   - '!cracklib_accounts_password_pam_minlen'

--- a/products/rhel9/profiles/anssi_bp28_minimal.profile
+++ b/products/rhel9/profiles/anssi_bp28_minimal.profile
@@ -21,6 +21,8 @@ description: |-
 
 selections:
   - anssi:all:minimal
+  - var_password_hashing_algorithm=SHA512
+  - var_password_pam_unix_rounds=65536
   # Following rules once had a prodtype incompatible with the rhel9 product
   - '!cracklib_accounts_password_pam_minlen'
   - '!accounts_passwords_pam_tally2_deny_root'


### PR DESCRIPTION
#### Description:

ANSSI allows two hashing algorithms with `pam_unix.so`: `sha512` and `yescrypt`.
Currently, RHEL products use `sha512` by default, which is already compliant.
Therefore, the respective ANSSI profiles were updated to check for `sha512` values instead of `yescrypt`.
This will better align to system default settings and avoid unnecessary changes.

#### Rationale:

- Fixes https://issues.redhat.com/browse/RHEL-44983
- Fixes https://github.com/ComplianceAsCode/content/issues/11806

#### Review Hints:

After applying the remediation for `accounts_password_pam_unix_rounds_system_auth` rule from ANSSI profiles for RHEL, the number of `rounds` configured for pam_unix.so in `/etc/pam.d/system-auth` is now appropriated to `sha512`.

The most relevant variable is `var_password_pam_unix_rounds` but I also updated `var_password_hashing_algorithm` variable option to ensure `/etc/login.defs` is also aligned with default settings.