### PR TITLE
Minor update to show XML content with problem

### DIFF
--- a/ssg/oval_object_model/oval_shorthand.py
+++ b/ssg/oval_object_model/oval_shorthand.py
@@ -9,7 +9,11 @@ def _get_xml_element_from_string_shorthand(shorthand):
     valid_oval_xml_string = "{}{}{}".format(oval_header, shorthand, oval_footer).encode(
         "utf-8"
     )
-    xml_element = ElementTree.fromstring(valid_oval_xml_string)
+    try:
+        xml_element = ElementTree.fromstring(valid_oval_xml_string)
+    except Exception as e:
+        print(f'{e}. Check the content below:')
+        print(valid_oval_xml_string)
     return xml_element.findall("./{%s}def-group/*" % OVAL_NAMESPACES.definition)
 
 


### PR DESCRIPTION
#### Description:

When working with OVAL it is not difficult spend a lot of time trying to identify a typo or an incorrect syntax. This commit include a minor update to help developers to see which content was causing an exception. This is specially helpful when multiple OVAL files are changed.

#### Rationale:

Make developers lives easier.

#### Review Hints:

Please, don't worry trying this PR right now.
I did this change when working on some more complex rules.
It happened when I tried some Jinja2 variables with OVAL objects but no longer have the information to reproduce it now.
I will come back to this PR in another opportunity to review it. For now I only documenting the change.