### PR TITLE
Update bash remediation to fix bug into account_disable_inactivity* 

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/bash/shared.sh
@@ -16,13 +16,17 @@ fi
 {{{ bash_ensure_pam_module_line("$PAM_FILE_PATH",
                                 'auth',
                                 'sufficient', 
-                                'pam_unix.so') }}}
+                                'pam_unix.so',
+                                '^\s*auth.*required.*pam_lastlog\.so.*') }}}
 # Ensure pam_unix.so is configured after pam_lastlog.so
 if ! grep -Pz \
     "auth\s*required\s*pam_lastlog\.so[^#]*inactive=35[\s\S]*\n\s*auth\s*sufficient\s*pam_unix\.so"\
     "$PAM_FILE_PATH"  ; then
-    PAM_LASTLOG_LINE="$(grep -oP '^\s*auth.*pam_lastlog\.so.*' $PAM_FILE_PATH)"
-    sed -i "0,/^\s*auth.*pam_unix\.so.*/i$PAM_LASTLOG_LINE" "$PAM_FILE_PATH"
+    readarray -t pam_lastlog_lines <<< $(grep -oP '^\s*auth.*pam_lastlog\.so[^#]*inactive=35.*' $PAM_FILE_PATH)
+    sed -i "/^\s*auth.*pam_lastlog\.so[^#]*inactive=35.*/d" "$PAM_FILE_PATH"
+    for line in "${pam_lastlog_lines[@]}"; do
+        sed -i "/^\s*auth.*pam_unix\.so.*/i$line" "$PAM_FILE_PATH"
+    done
 fi
 if [ -f /usr/bin/authselect ]; then
     authselect apply-changes -b --backup=after-hardening-pam_lastlog.so-inactive.backup

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/bash/shared.sh
@@ -22,7 +22,7 @@ fi
 if ! grep -Pz \
     "auth\s*required\s*pam_lastlog\.so[^#]*inactive=35[\s\S]*\n\s*auth\s*sufficient\s*pam_unix\.so"\
     "$PAM_FILE_PATH"  ; then
-    readarray -t pam_lastlog_lines <<< $(grep -oP '^\s*auth.*pam_lastlog\.so[^#]*inactive=35.*' $PAM_FILE_PATH)
+    readarray -t pam_lastlog_lines <<< "$(grep -oP '^\s*auth.*pam_lastlog\.so[^#]*inactive=35.*' $PAM_FILE_PATH)"
     sed -i "/^\s*auth.*pam_lastlog\.so[^#]*inactive=35.*/d" "$PAM_FILE_PATH"
     for line in "${pam_lastlog_lines[@]}"; do
         sed -i "/^\s*auth.*pam_unix\.so.*/i$line" "$PAM_FILE_PATH"

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/bash/shared.sh
@@ -16,13 +16,17 @@ fi
 {{{ bash_ensure_pam_module_line("$PAM_FILE_PATH",
                                 'auth',
                                 'sufficient',
-                                'pam_unix.so') }}}
+                                'pam_unix.so',
+                                '^\s*auth.*required.*pam_lastlog\.so.*') }}}
 # Ensure pam_unix.so is configured after pam_lastlog.so
 if ! grep -Pz \
     "auth\s*required\s*pam_lastlog\.so[^#]*inactive=35[\s\S]*\n\s*auth\s*sufficient\s*pam_unix\.so"\
     "$PAM_FILE_PATH"  ; then
-    PAM_LASTLOG_LINE="$(grep -oP '^\s*auth.*pam_lastlog\.so.*' $PAM_FILE_PATH)"
-    sed -i "0,/^\s*auth.*pam_unix\.so.*/i$PAM_LASTLOG_LINE" "$PAM_FILE_PATH"
+    readarray -t pam_lastlog_lines <<< $(grep -oP '^\s*auth.*pam_lastlog\.so[^#]*inactive=35.*' $PAM_FILE_PATH)
+    sed -i "/^\s*auth.*pam_lastlog\.so[^#]*inactive=35.*/d" "$PAM_FILE_PATH"
+    for line in "${pam_lastlog_lines[@]}"; do
+        sed -i "/^\s*auth.*pam_unix\.so.*/i$line" "$PAM_FILE_PATH"
+    done
 fi
 if [ -f /usr/bin/authselect ]; then
     authselect apply-changes -b --backup=after-hardening-pam_lastlog.so-inactive.backup

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/bash/shared.sh
@@ -22,7 +22,7 @@ fi
 if ! grep -Pz \
     "auth\s*required\s*pam_lastlog\.so[^#]*inactive=35[\s\S]*\n\s*auth\s*sufficient\s*pam_unix\.so"\
     "$PAM_FILE_PATH"  ; then
-    readarray -t pam_lastlog_lines <<< $(grep -oP '^\s*auth.*pam_lastlog\.so[^#]*inactive=35.*' $PAM_FILE_PATH)
+    readarray -t pam_lastlog_lines <<< "$(grep -oP '^\s*auth.*pam_lastlog\.so[^#]*inactive=35.*' $PAM_FILE_PATH)"
     sed -i "/^\s*auth.*pam_lastlog\.so[^#]*inactive=35.*/d" "$PAM_FILE_PATH"
     for line in "${pam_lastlog_lines[@]}"; do
         sed -i "/^\s*auth.*pam_unix\.so.*/i$line" "$PAM_FILE_PATH"


### PR DESCRIPTION
#### Description:

Update bash remediation to fix bug into `account_disable_inactivity_system_auth` and `account_disable_inactivity_password_auth`. 

Fix the way to delete and insert the existent lines.

#### Rationale:

The `account_disable_inactivity_password_auth` and `account_disable_inactivity_system_auth` bash remediation has a bug when ensure the correct order of lines into file. The script inserts the `pam_lastlog.so` line after each line from 0 to where it finds the `pam_unix.so` line

#### Note:

I believe this error can be resolved with a change to the `bash_ensure_pam_module_line` macro. That macro accepts a regular expression to ensure the expected line is inserted this regex match, but only if the expected line is not there, it doesn't reorder in case order was wrong.