### PR TITLE
Add ansible remediation for no_tmux_in_shells rule

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/no_tmux_in_shells/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/no_tmux_in_shells/ansible/shared.yml
@@ -1,0 +1,11 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: {{{ rule_title }}} - Ensure tmux line not exists
+  ansible.builtin.lineinfile: 
+    path: /etc/shells
+    regex: 'tmux\s*$'
+    state: absent


### PR DESCRIPTION
#### Description:

Add ansible remediation for `no_tmux_in_shells` rule

#### Rationale:

In the task filling gaps in OL9 automation, the rule no_tmux_in_shells has a remediation deficit with ansible. The parameters was taken of bash remediation
