### PR TITLE
Enable CCN Advanced profile test in CI

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -37,12 +37,11 @@ jobs:
 - <<: *test-static-checks
   identifier: /hardening/host-os/ansible/anssi_bp28_high
   tmt_plan: /hardening/host-os/ansible/anssi_bp28_high
-# disable for now - it seems to be broken on CentOS Stream
-#- <<: *test-static-checks
-#  identifier: /hardening/host-os/ansible/ccn_advanced
-#  tmt_plan: /hardening/host-os/ansible/ccn_advanced
-#  targets:
-#    centos-stream-9: {}
+- <<: *test-static-checks
+  identifier: /hardening/host-os/ansible/ccn_advanced
+  tmt_plan: /hardening/host-os/ansible/ccn_advanced
+  targets:
+    centos-stream-9: {}
 - <<: *test-static-checks
   identifier: /hardening/host-os/ansible/cis
   tmt_plan: /hardening/host-os/ansible/cis

--- a/tests/tmt-plans/main.fmf
+++ b/tests/tmt-plans/main.fmf
@@ -16,9 +16,8 @@ report:
 /hardening/host-os/ansible/anssi_bp28_high:
     discover+: {test: /hardening/host-os/ansible/anssi_bp28_high$}
 
-# see .packit.yaml
-#/hardening/host-os/ansible/ccn_advanced:
-#    discover+: {test: /hardening/host-os/ansible/ccn_advanced$}
+/hardening/host-os/ansible/ccn_advanced:
+    discover+: {test: /hardening/host-os/ansible/ccn_advanced$}
 
 /hardening/host-os/ansible/cis:
     discover+: {test: /hardening/host-os/ansible/cis$}


### PR DESCRIPTION
#### Description:
Test also Ansible variant of CCN Advanced hardening in CI.

#### Rationale:
This is testing PR to check if CCN profile is ok to be enabled in CI.

#### Review Hints:
See Testing Farm results for CCN Advanced profile