### PR TITLE
Update OCP profile assertion files

### DIFF
--- a/tests/assertions/ocp4/ocp4-stig-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.13.yml
@@ -244,15 +244,15 @@ rule_results:
   e2e-stig-oauth-logout-url-set:
     default_result: FAIL
     result_after_remediation: PASS
+  e2e-stig-oauth-or-oauthclient-inactivity-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
   e2e-stig-oauth-or-oauthclient-token-maxage:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-oauth-provider-selection-set:
     default_result: FAIL
     result_after_remediation: PASS
-  e2e-stig-oauthclient-inactivity-timeout:
-    default_result: FAIL
-    result_after_remediation: FAIL
   e2e-stig-ocp-allowed-registries:
     default_result: FAIL
     result_after_remediation: FAIL

--- a/tests/assertions/ocp4/ocp4-stig-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.14.yml
@@ -244,15 +244,15 @@ rule_results:
   e2e-stig-oauth-logout-url-set:
     default_result: FAIL
     result_after_remediation: PASS
+  e2e-stig-oauth-or-oauthclient-inactivity-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
   e2e-stig-oauth-or-oauthclient-token-maxage:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-oauth-provider-selection-set:
     default_result: FAIL
     result_after_remediation: PASS
-  e2e-stig-oauthclient-inactivity-timeout:
-    default_result: FAIL
-    result_after_remediation: FAIL
   e2e-stig-ocp-allowed-registries:
     default_result: FAIL
     result_after_remediation: FAIL

--- a/tests/assertions/ocp4/ocp4-stig-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.15.yml
@@ -244,15 +244,15 @@ rule_results:
   e2e-stig-oauth-logout-url-set:
     default_result: FAIL
     result_after_remediation: PASS
+  e2e-stig-oauth-or-oauthclient-inactivity-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
   e2e-stig-oauth-or-oauthclient-token-maxage:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-oauth-provider-selection-set:
     default_result: FAIL
     result_after_remediation: PASS
-  e2e-stig-oauthclient-inactivity-timeout:
-    default_result: FAIL
-    result_after_remediation: FAIL
   e2e-stig-ocp-allowed-registries:
     default_result: FAIL
     result_after_remediation: FAIL

--- a/tests/assertions/ocp4/ocp4-stig-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.16.yml
@@ -244,15 +244,15 @@ rule_results:
   e2e-stig-oauth-logout-url-set:
     default_result: FAIL
     result_after_remediation: PASS
+  e2e-stig-oauth-or-oauthclient-inactivity-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
   e2e-stig-oauth-or-oauthclient-token-maxage:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-oauth-provider-selection-set:
     default_result: FAIL
     result_after_remediation: PASS
-  e2e-stig-oauthclient-inactivity-timeout:
-    default_result: FAIL
-    result_after_remediation: FAIL
   e2e-stig-ocp-allowed-registries:
     default_result: FAIL
     result_after_remediation: FAIL


### PR DESCRIPTION


#### Description:

- Update the  STIG profile assertion files:
  - Add `oauth_or_oauthclient_inactivity_timeout` 
  - Remove rule `oauthclient_inactivity_timeout`
- Follow up from https://github.com/ComplianceAsCode/content/pull/11870

#### Rationale:

- We check the results from individual rules in profile e2e tests.

#### Review Hints:

- Run STIG e2e with these profile assertion files.
