### PR TITLE
Fix OL7 GH Action

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -10,25 +10,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
   cancel-in-progress: true
 jobs:
-  validate-ol7:
-    name: Build, Test on Oracle Linux 7 (Container)
-    runs-on: ubuntu-latest
-    container:
-      image: oraclelinux:7.9
-    steps:
-      - name: Install Deps
-        run: yum install -y cmake make openscap-utils PyYAML libxslt xml-common python-jinja2 python-setuptools openscap openscap-scanner
-      - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
-      - name: Build
-        run: |-
-          ./build_product ol7
-        env:
-          ADDITIONAL_CMAKE_OPTIONS: "-DSSG_OVAL_SCHEMATRON_VALIDATION_ENABLED=OFF"
-      - name: Test
-        run: ctest -j2 --output-on-failure -E unique-stigids
-        working-directory: ./build
-
   validate-sle:
     name: Build, Test on SLE 15 (Container)
     runs-on: ubuntu-latest

--- a/.github/workflows/gate_ol7.yml
+++ b/.github/workflows/gate_ol7.yml
@@ -1,0 +1,30 @@
+name: Gate OL7
+on:
+    push:
+        branches: [ '*', '!stabilization*', '!stable*', '!master' ]
+    pull_request:
+        branches: [ 'master', 'stabilization*' ]
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}
+    cancel-in-progress: true
+env:
+    ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+jobs:
+    validate-ol7:
+        name: Build, Test on Oracle Linux 7 (Container)
+        runs-on: ubuntu-latest
+        container:
+            image: oraclelinux:7.9
+        steps:
+            -   name: Install Deps
+                run: yum install -y cmake make openscap-utils PyYAML libxslt xml-common python-jinja2 python-setuptools openscap openscap-scanner
+            -   name: Checkout
+                uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+            -   name: Build
+                run: |-
+                    ./build_product ol7
+                env:
+                    ADDITIONAL_CMAKE_OPTIONS: "-DSSG_OVAL_SCHEMATRON_VALIDATION_ENABLED=OFF"
+            -   name: Test
+                run: ctest -j2 --output-on-failure -E unique-stigids
+                working-directory: ./build


### PR DESCRIPTION

#### Description:

Move OL7 to its own file and set ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION

#### Rationale:

So that the actions will run for now.

This needed as node 20 doesn't work with the glib version in EL7.

Also see [this blog post](https://github.blog/changelog/2024-05-17-updated-dates-for-actions-runner-using-node20-instead-of-node16-by-default/) from GitHub.

