### PR TITLE
CMP-2460: PCI-DSS 4 requirement 8

### DIFF
--- a/applications/openshift/authentication/var_oauth_inactivity_timeout.var
+++ b/applications/openshift/authentication/var_oauth_inactivity_timeout.var
@@ -12,4 +12,5 @@ interactive: false
 
 options:
     10m0s: "10m0s"
+    15m0s: "15m0s"
     default: "10m0s"

--- a/controls/pcidss_4_ocp4.yml
+++ b/controls/pcidss_4_ocp4.yml
@@ -2331,9 +2331,7 @@ controls:
       - base
     status: not applicable
     notes: |-
-      This parent requirement does not set one specific combination of Multi-factor authentication
-      (MFA), so we can't enforce the use of smartcards or any specific solution. The systems
-      usually support MFA but the chosen solution depends on site policies.
+      Multi-factor authenticators are managed externally to OpenShift by the identity provider
     controls:
     - id: 8.4.1
       title: MFA is implemented for all non-console access into the CDE for personnel with
@@ -2355,13 +2353,15 @@ controls:
         entity's network that could access or impact the CDE.
       levels:
         - base
-      status: pending
+      status: not applicable
 
   - id: '8.5'
     title: Multi-factor authentication (MFA) systems are configured to prevent misuse.
     levels:
       - base
-    status: pending
+    status: not applicable
+    notes: |-
+      Multi-factor authenticators are managed externally to OpenShift by the identity provider
     controls:
     - id: 8.5.1
       title: MFA systems are properly implemented.
@@ -2374,10 +2374,7 @@ controls:
         - Success of all authentication factors is required before access is granted.
       levels:
         - base
-      status: pending
-      notes: |-
-        Each site might have a different MFA solution and each solution has its own capabilities.
-        This requirement demands manual assessment based on site policies.
+      status: not applicable
 
   - id: '8.6'
     title: Use of application and system accounts and associated authentication factors is

--- a/controls/pcidss_4_ocp4.yml
+++ b/controls/pcidss_4_ocp4.yml
@@ -2023,7 +2023,7 @@ controls:
       managed throughout an account's lifecycle.
     levels:
       - base
-    status: pending
+    status: automated
     controls:
     - id: 8.2.1
       title: All users are assigned a unique ID before access to system components or cardholder
@@ -2035,12 +2035,26 @@ controls:
         on point-of-sale terminals).
       levels:
         - base
-      status: planned
+      status: automated
       notes: |-
-        The rules selected in this requirement are incomplete. Missing remediation and test
-        scenarios. They should include test scenarios and likely remediation or a warning
-        informing why a remediation is not present.
-      rules: []
+        Openshift should be configured to work with an external third-party identity provider.
+        Through the chosen identity provider, unique identifiers can be setup for each user.
+        See more at https://docs.openshift.com/container-platform/4.16/authentication/understanding-identity-provider.html
+
+        However, the payment entity's processes and responsible personal still need to examined
+        to check whether each user is uniquely associated with an individual.
+      rules:
+        - idp_is_configured
+      related_rules:
+        # This control can be partially implemented with the following RHCOS rules
+        - no_direct_root_logins
+        - account_unique_id
+        - account_unique_name
+        - accounts_no_uid_except_zero
+        - accounts_root_gid_zero
+        - group_unique_id
+        - group_unique_name
+        - audit_rules_immutable_login_uids
 
     - id: 8.2.2
       title: Group, shared, or generic accounts, or other shared authentication credentials are
@@ -2054,24 +2068,37 @@ controls:
         - Every action taken is attributable to an individual user.
       levels:
         - base
-      status: pending
+      status: automated
       notes: |-
-        This requirement is complemented by 8.2.1 and related to 8.3.5.
-      rules: []
+        Access tokens that are issued by OpenShift upon authentication should only be used by the
+        person for whom it was issued.
+      rules:
+        - kubeadmin_removed
+      related_rules:
+        # This control can also be implemented with the following RHCOS rules
+        - no_direct_root_logins
 
     - id: 8.2.3
       title: 'Additional requirement for service providers only: Service providers with remote
         access to customer premises use unique authentication factors for each customer premises.'
       levels:
         - base
-      status: pending
+      status: not applicable
+      notes: |-
+        The payment entity itself is also required to not use group, shared, or generic IDs,
+        passwords, or other authentication methods. Access tokens that are issued by
+        OpenShift upon authentication should only be used by the person
+        for whom it was issued.
 
     - id: 8.2.4
       title: Addition, deletion, and modification of user IDs, authentication factors, and other
         identifier objects are managed
       levels:
         - base
-      status: pending
+      status: not applicable
+      notes: |-
+        Only the payment entity can assess whether the access privileges granted to users are
+        appropriate and documented, and propperly reflected in the configured identity provider.
 
     - id: 8.2.5
       title: Access for terminated users is immediately revoked.
@@ -2079,9 +2106,11 @@ controls:
         The accounts of terminated users cannot be used.
       levels:
         - base
-      status: pending
+      status: not applicable
       notes: |-
-        This requirement depends on site policies for user termination.
+        Revocation of access for terminated users are performed by the third-party
+        identity provider. Additionaly, OpenShift nor the identity provider cannot by itself
+        determine the users associated with an individual.
 
     - id: 8.2.6
       title: Inactive user accounts are removed or disabled within 90 days of inactivity.
@@ -2089,9 +2118,12 @@ controls:
         Inactive user accounts cannot be used.
       levels:
         - base
-      status: pending
+      status: not applicable
       notes: |-
-        Also related to requirements 2.2.2 and 8.3.5.
+        Removal or disabling of inactive user accounts within 90 days are handled with the
+        identity provider.
+        All user IDs, including those handled by third parties to access, support, or maintain
+        system components via remote access, are handled externally to OpenShift.
       rules: []
 
     - id: 8.2.7
@@ -2099,7 +2131,11 @@ controls:
         remote access are managed.
       levels:
         - base
-      status: pending
+      status: not applicable
+      notes: |-
+        Similar to how accounts for employees are managed, accounts for third parties are also
+        managed by the configured identity provider, and under responsibility of the payment
+        entity.
 
     - id: 8.2.8
       title: If a user session has been idle for more than 15 minutes, the user is required to
@@ -2112,8 +2148,14 @@ controls:
         from being performed while the console/PC is unattended.
       levels:
         - base
-      status: pending
-      rules: []
+      status: automated
+      notes: |-
+        Session timeouts can be enabled with OpenShift to limit the amount of
+        time that a session can be active. However, the payment entity also needs to control the
+        user's and administrator's idle session timeouts on their payment applications as well.
+      rules:
+        - oauth_or_oauthclient_inactivity_timeout
+        - var_oauth_inactivity_timeout=15m0s
 
   - id: '8.3'
     title: Strong authentication for users and administrators is established and managed.

--- a/controls/pcidss_4_ocp4.yml
+++ b/controls/pcidss_4_ocp4.yml
@@ -2024,6 +2024,12 @@ controls:
     levels:
       - base
     status: automated
+    notes: |-
+      For this control to be satisfiable an identity provider must be used and the kubeadmin user
+      needs to be removed.
+    rules:
+      - idp_is_configured
+      - kubeadmin_removed
     controls:
     - id: 8.2.1
       title: All users are assigned a unique ID before access to system components or cardholder
@@ -2162,6 +2168,12 @@ controls:
     levels:
       - base
     status: not applicable
+    notes: |-
+      For this control to be satisfiable an identity provider must be used and the kubeadmin user
+      needs to be removed.
+    rules:
+      - idp_is_configured
+      - kubeadmin_removed
     controls:
     - id: 8.3.1
       title: All user access to system components for users and administrators is authenticated.

--- a/controls/pcidss_4_ocp4.yml
+++ b/controls/pcidss_4_ocp4.yml
@@ -2161,14 +2161,23 @@ controls:
     title: Strong authentication for users and administrators is established and managed.
     levels:
       - base
-    status: pending
+    status: not applicable
     controls:
     - id: 8.3.1
       title: All user access to system components for users and administrators is authenticated.
+      description: |-
+        All user access to system components for users and administrators is authenticated via at
+        least one of the following authentication factors:
+        - Something you know, such as a password or passphrase.
+        - Something you have, such as a token device or smart card.
+        - Something you are, such as a biometric element.
       levels:
         - base
-      status: pending
-      rules: []
+      status: not applicable
+      notes: |-
+        The type of authenticators to be used (for example, password or passphrase,
+        token device or smart card, or biometrics) are managed externally
+        to OpenShift by the identity provider
 
     - id: 8.3.2
       title: Strong cryptography is used to render all authentication factors unreadable during
@@ -2178,10 +2187,11 @@ controls:
         interception of communications or from stored data.
       levels:
         - base
-      status: pending
+      status: not applicable
       notes: |-
-        There are similar rules that might be redundant for some distros.
-      rules: []
+        The protection of the authentication credentials such as rendering the passwords and
+        passphrases unreadable during transmission and the storage of credentials on system
+        components is the responsibility of the third-party identity provider.
 
     - id: 8.3.3
       title: User identity is verified before modifying any authentication factor.
@@ -2190,12 +2200,12 @@ controls:
         authorized user.
       levels:
         - base
-      status: pending
+      status: not applicable
       notes: |-
-        This requirement is about processes, such as password resets, provisioning new hardware or
-        software tokens, and generating new keys. It is common that these activities involve help
-        desk teams and administrators and the involved people should ensure identities are properly
-        verified.
+        Modification of authentication credentials is handled by the third-party identity provider.
+        All access to modify parameters for authentication tokens or for generating keys  within
+        OpenShift is managed with RBAC and requires prior authentication before the user is
+        authorized to act.
 
     - id: 8.3.4
       title: Invalid authentication attempts are limited.
@@ -2205,8 +2215,12 @@ controls:
         confirmed.
       levels:
         - base
-      status: pending
-      rules: []
+      status: not applicable
+      notes: |-
+        Account lockout for failed attempts are managed by the identity provider as all
+        authentication attempts that occur prior to granting access from OpenShift.
+        Establishing a threshold for limiting repeated failed attempts are configured with
+        the chosen identity provider.
 
     - id: 8.3.5
       title: If passwords/passphrases are used as authentication factors to meet Requirement
@@ -2216,10 +2230,11 @@ controls:
         - Forced to be changed immediately after the first use.
       levels:
         - base
-      status: pending
+      status: not applicable
       notes: |-
-        Also related to requirement 2.2.2, 8.2.2 and 8.2.6.
-      rules: []
+        Parameters for authenticators such as password length, maximum password
+        age, minimum password age, password history, and requirements to change
+        the password on first use are handled by the third-party identity provider.
 
     - id: 8.3.6
       title: If passwords/passphrases are used as authentication factors to meet Requirement
@@ -2232,14 +2247,11 @@ controls:
         force attack.
       levels:
         - base
-      status: pending
+      status: not applicable
       notes: |-
-        This requirement is not intended to apply to:
-        - User accounts on point-of-sale terminals that have access to only one card number at a
-        time to facilitate a single transaction (such as IDs used by cashiers on point-of-sale
-        terminals).
-        - Application or system accounts, which are governed by requirements in section 8.6.
-      rules: []
+        Parameters for authenticators such as password length, maximum password
+        age, minimum password age, password history, and requirements to change
+        the password on first use are handled by the third-party identity provider.
 
     - id: 8.3.7
       title: Individuals are not allowed to submit a new password/passphrase that is the same as
@@ -2249,18 +2261,17 @@ controls:
         months.
       levels:
         - base
-      status: pending
+      status: not applicable
       notes: |-
-        This requirement is not intended to apply to user accounts on point-of-sale terminals that
-        have access to only one card number at a time to facilitate a single transaction (such as
-        IDs used by cashiers on point-of-sale terminals).
-      rules: []
+        Parameters for authenticators such as password length, maximum password
+        age, minimum password age, password history, and requirements to change
+        the password on first use are handled by the third-party identity provider.
 
     - id: 8.3.8
       title: Authentication policies and procedures are documented and communicated to all users.
       levels:
         - base
-      status: pending
+      status: not applicable
 
     - id: 8.3.9
       title: If passwords/passphrases are used as the only authentication factor for user access
@@ -2275,12 +2286,11 @@ controls:
         resources is automatically determined accordingly.
       levels:
         - base
-      status: pending
+      status: not applicable
       notes: |-
-        The requirement does not explicitily define the number of days before the password
-        expiration to warn the users, but the relevant rules were selected here as they do not
-        cause any problems in combination with password lifetime rules.
-      rules: []
+        Parameters for authenticators such as password length, maximum password
+        age, minimum password age, password history, and requirements to change
+        the password on first use are handled by the third-party identity provider.
 
     - id: 8.3.10
       title: 'Additional requirement for service providers only: If passwords/passphrases are used
@@ -2289,7 +2299,7 @@ controls:
         users.'
       levels:
         - base
-      status: pending
+      status: not applicable
       controls:
       - id: 8.3.10.1
         title: 'Additional requirement for service providers only: If passwords/passphrases are
@@ -2297,9 +2307,11 @@ controls:
           single-factor authentication implementation) they should have a limited lifetime.'
         levels:
           - base
-        status: pending
+        status: not applicable
         notes: |-
-          This requirement is already covered by 8.3.9.
+          Parameters for authenticators such as password length, maximum password
+          age, minimum password age, password history, and requirements to change
+          the password on first use are handled by the third-party identity provider.
 
     - id: 8.3.11
       title: Where authentication factors such as physical or logical security tokens, smart
@@ -2307,13 +2319,17 @@ controls:
         is controlled.'
       levels:
         - base
-      status: pending
+      status: not applicable
+      notes: |-
+        The type of authenticators to be used (for example, password or passphrase,
+        token device or smart card, or biometrics) are managed externally
+        to OpenShift by the identity provider
 
   - id: '8.4'
     title: Multi-factor authentication (MFA) is implemented to secure access into the CDE.
     levels:
       - base
-    status: pending
+    status: not applicable
     notes: |-
       This parent requirement does not set one specific combination of Multi-factor authentication
       (MFA), so we can't enforce the use of smartcards or any specific solution. The systems
@@ -2324,7 +2340,7 @@ controls:
         administrative access.
       levels:
         - base
-      status: pending
+      status: not applicable
 
     - id: 8.4.2
       title: MFA is implemented for all access into the CDE.
@@ -2332,7 +2348,7 @@ controls:
         Access into the CDE cannot be obtained by the use of a single authentication factor.
       levels:
         - base
-      status: pending
+      status: not applicable
 
     - id: 8.4.3
       title: MFA is implemented for all remote network access originating from outside the

--- a/controls/pcidss_4_ocp4.yml
+++ b/controls/pcidss_4_ocp4.yml
@@ -2381,7 +2381,7 @@ controls:
       strictly managed.
     levels:
       - base
-    status: pending
+    status: supported
     controls:
     - id: 8.6.1
       title: If accounts used by systems or applications can be used for interactive login, they
@@ -2395,13 +2395,14 @@ controls:
         - Every action taken is attributable to an individual user.
       levels:
         - base
-      status: pending
+      status: not applicable
       notes: |-
-        This requirement is related to 2.2.2, 2.2.6, 8.2.1 and 8.2.2. Specifically on 8.2.2 system
-        accounts usage is restricted. Exceptions to system accounts should be manually checked to
-        ensure the requirements in description. This requirement although implements some extra
-        controls regarding root account.
+        All user IDs, including those handled by third parties to access, support, or maintain
+        system components via remote access, are handled externally to OpenShift.
       rules: []
+      related_rules:
+        # The following RHCOS rule can also contribute to the implementation of this control.
+        - securetty_root_login_console_only
 
     - id: 8.6.2
       title: Passwords/passphrases for any application and system accounts that can be used for
@@ -2412,7 +2413,9 @@ controls:
         unauthorized personnel.
       levels:
         - base
-      status: pending
+      status: supported
+      notes: |-
+        OpenShift can be integrated with a Vault to manage secrets.
 
     - id: 8.6.3
       title: Passwords/passphrases for any application and system accounts are protected against
@@ -2425,9 +2428,11 @@ controls:
         frequently the entity changes the passwords/passphrases.
       levels:
         - base
-      status: pending
+      status: not applicable
       notes: |-
-        Related to requirements 8.3.6 and 8.3.9.
+        Parameters for authenticators such as password length, maximum password
+        age, minimum password age, password history, and requirements to change
+        the password on first use are handled by the third-party identity provider.
 
   - id: '9.1'
     title: Processes and mechanisms for restricting physical access to cardholder data are defined

--- a/controls/pcidss_4_ocp4.yml
+++ b/controls/pcidss_4_ocp4.yml
@@ -2167,7 +2167,7 @@ controls:
     title: Strong authentication for users and administrators is established and managed.
     levels:
       - base
-    status: not applicable
+    status: partial
     notes: |-
       For this control to be satisfiable an identity provider must be used and the kubeadmin user
       needs to be removed.
@@ -2199,11 +2199,16 @@ controls:
         interception of communications or from stored data.
       levels:
         - base
-      status: not applicable
+      status: partial
       notes: |-
         The protection of the authentication credentials such as rendering the passwords and
         passphrases unreadable during transmission and the storage of credentials on system
         components is the responsibility of the third-party identity provider.
+
+        If LDAP is used as the identity provider, we do not allow it to run with the
+        'insecure' flag on.
+      rules:
+        - ocp_no_ldap_insecure
 
     - id: 8.3.3
       title: User identity is verified before modifying any authentication factor.
@@ -2227,12 +2232,17 @@ controls:
         confirmed.
       levels:
         - base
-      status: not applicable
+      status: partial
       notes: |-
         Account lockout for failed attempts are managed by the identity provider as all
         authentication attempts that occur prior to granting access from OpenShift.
         Establishing a threshold for limiting repeated failed attempts are configured with
         the chosen identity provider.
+
+        In this control we do not allow usage of htpasswd as the identity provider, as it
+        doesn't provide user lockout feature.
+      rules:
+        - ocp_idp_no_htpasswd
 
     - id: 8.3.5
       title: If passwords/passphrases are used as authentication factors to meet Requirement

--- a/controls/pcidss_4_ocp4.yml
+++ b/controls/pcidss_4_ocp4.yml
@@ -2009,22 +2009,14 @@ controls:
         are Documented, Kept up to date, In use and Known to all affected parties.
       levels:
         - base
-      status: pending
-      notes: |-
-        Examine documentation and interview personnel to verify that security policies and
-        operational procedures identified in Requirement 8 are managed in accordance with all
-        elements specified in this requirement.
+      status: not applicable
 
     - id: 8.1.2
       title: Roles and responsibilities for performing activities in Requirement 8 are documented,
         assigned, and understood.
       levels:
         - base
-      status: pending
-      notes: |-
-        Examine documentation and interview personnel to verify that day-to-day responsibilities
-        for performing all the activities in Requirement 8 are documented, assigned and understood
-        by the assigned personnel.
+      status: not applicable
 
   - id: '8.2'
     title: User identification and related accounts for users and administrators are strictly

--- a/controls/pcidss_4_ocp4.yml
+++ b/controls/pcidss_4_ocp4.yml
@@ -2039,9 +2039,9 @@ controls:
       notes: |-
         Openshift should be configured to work with an external third-party identity provider.
         Through the chosen identity provider, unique identifiers can be setup for each user.
-        See more at https://docs.openshift.com/container-platform/4.16/authentication/understanding-identity-provider.html
+        See more at https://docs.openshift.com/container-platform/latest/authentication/understanding-identity-provider.html
 
-        However, the payment entity's processes and responsible personal still need to examined
+        However, the payment entity's processes and responsible personal still need to be examined
         to check whether each user is uniquely associated with an individual.
       rules:
         - idp_is_configured
@@ -2098,7 +2098,7 @@ controls:
       status: not applicable
       notes: |-
         Only the payment entity can assess whether the access privileges granted to users are
-        appropriate and documented, and propperly reflected in the configured identity provider.
+        appropriate and documented, and properly reflected in the configured identity provider.
 
     - id: 8.2.5
       title: Access for terminated users is immediately revoked.
@@ -2109,7 +2109,7 @@ controls:
       status: not applicable
       notes: |-
         Revocation of access for terminated users are performed by the third-party
-        identity provider. Additionaly, OpenShift nor the identity provider cannot by itself
+        identity provider. Additionally, OpenShift nor the identity provider cannot by itself
         determine the users associated with an individual.
 
     - id: 8.2.6


### PR DESCRIPTION
#### Description:

- `8.1` is not applicable
  Managing users identification and the its processes is responsibility of the payment entity.
- `8.2` is automated
  Identification in OpenShift is handled by an identity provider, and most requirements are not applicable. However, Openshift can prevent login from shared generic users like `root` and `kubeadmin`.
- `8.3`, `8.4` and `8.5` are not applicable
  These requirements are to be implemented in the identity provider deployed by the payment entity.
- `8.6` is supported
  To prevent hardcoding of secrets in scripts and applications, Openshift supports integration with third party secret vaults.