### PR TITLE
Remove sshd_use_approved_ciphers from RHEL 9 & 10 Profiles

### DIFF
--- a/controls/cis_rhel10.yml
+++ b/controls/cis_rhel10.yml
@@ -1518,7 +1518,7 @@ controls:
       Introduced in CIS RHEL9 v2.0.0
       The status was automated but we need to double check the approach used in this rule.
       Therefore I moved it to pending until deeper investigation.
-    rules:
+    related_rules:
       - sshd_use_approved_ciphers
       - sshd_approved_ciphers=cis_rhel8
 

--- a/controls/cis_rhel9.yml
+++ b/controls/cis_rhel9.yml
@@ -1518,7 +1518,7 @@ controls:
       Introduced in CIS RHEL9 v2.0.0
       The status was automated but we need to double check the approach used in this rule.
       Therefore I moved it to pending until deeper investigation.
-    rules:
+    related_rules:
       - sshd_use_approved_ciphers
       - sshd_approved_ciphers=cis_rhel9
 

--- a/tests/data/profile_stability/rhel9/cis.profile
+++ b/tests/data/profile_stability/rhel9/cis.profile
@@ -361,7 +361,6 @@ selections:
 - sshd_set_max_auth_tries
 - sshd_set_max_sessions
 - sshd_set_maxstartups
-- sshd_use_approved_ciphers
 - sshd_use_strong_kex
 - sshd_use_strong_macs
 - sudo_add_use_pty
@@ -421,7 +420,6 @@ selections:
 - var_sshd_set_keepalive=1
 - sshd_strong_macs=cis_rhel9
 - sshd_strong_kex=cis_rhel9
-- sshd_approved_ciphers=cis_rhel9
 - sysctl_net_ipv6_conf_all_accept_ra_value=disabled
 - sysctl_net_ipv6_conf_default_accept_ra_value=disabled
 - sysctl_net_ipv4_tcp_syncookies_value=enabled

--- a/tests/data/profile_stability/rhel9/cis_server_l1.profile
+++ b/tests/data/profile_stability/rhel9/cis_server_l1.profile
@@ -266,7 +266,6 @@ selections:
 - sshd_set_max_auth_tries
 - sshd_set_max_sessions
 - sshd_set_maxstartups
-- sshd_use_approved_ciphers
 - sshd_use_strong_kex
 - sshd_use_strong_macs
 - sudo_add_use_pty
@@ -324,7 +323,6 @@ selections:
 - var_sshd_set_keepalive=1
 - sshd_strong_macs=cis_rhel9
 - sshd_strong_kex=cis_rhel9
-- sshd_approved_ciphers=cis_rhel9
 - sysctl_net_ipv6_conf_all_accept_ra_value=disabled
 - sysctl_net_ipv6_conf_default_accept_ra_value=disabled
 - sysctl_net_ipv4_tcp_syncookies_value=enabled

--- a/tests/data/profile_stability/rhel9/cis_workstation_l1.profile
+++ b/tests/data/profile_stability/rhel9/cis_workstation_l1.profile
@@ -259,7 +259,6 @@ selections:
 - sshd_set_max_auth_tries
 - sshd_set_max_sessions
 - sshd_set_maxstartups
-- sshd_use_approved_ciphers
 - sshd_use_strong_kex
 - sshd_use_strong_macs
 - sudo_add_use_pty
@@ -316,7 +315,6 @@ selections:
 - var_sshd_set_keepalive=1
 - sshd_strong_macs=cis_rhel9
 - sshd_strong_kex=cis_rhel9
-- sshd_approved_ciphers=cis_rhel9
 - sysctl_net_ipv6_conf_all_accept_ra_value=disabled
 - sysctl_net_ipv6_conf_default_accept_ra_value=disabled
 - sysctl_net_ipv4_tcp_syncookies_value=enabled

--- a/tests/data/profile_stability/rhel9/cis_workstation_l2.profile
+++ b/tests/data/profile_stability/rhel9/cis_workstation_l2.profile
@@ -356,7 +356,6 @@ selections:
 - sshd_set_max_auth_tries
 - sshd_set_max_sessions
 - sshd_set_maxstartups
-- sshd_use_approved_ciphers
 - sshd_use_strong_kex
 - sshd_use_strong_macs
 - sudo_add_use_pty
@@ -414,7 +413,6 @@ selections:
 - var_sshd_set_keepalive=1
 - sshd_strong_macs=cis_rhel9
 - sshd_strong_kex=cis_rhel9
-- sshd_approved_ciphers=cis_rhel9
 - sysctl_net_ipv6_conf_all_accept_ra_value=disabled
 - sysctl_net_ipv6_conf_default_accept_ra_value=disabled
 - sysctl_net_ipv4_tcp_syncookies_value=enabled


### PR DESCRIPTION
#### Description:

Remove sshd_use_approved_ciphers from RHEL 9 & 10 CIS profiles.
#### Rationale:
Address #12096 by taking the easy way out and removing the rule.

The rule needs major changes and that will most likely not happen before the release.

