### PR TITLE
Fix broken OVAL metadata

### DIFF
--- a/shared/templates/socket_disabled/oval.template
+++ b/shared/templates/socket_disabled/oval.template
@@ -1,6 +1,6 @@
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
-    {{{ oval_metadata("Disable {{{ SOCKETNAME }}}.socket") }}}
+    {{{ oval_metadata("Disable " ~ SOCKETNAME ~ ".socket") }}}
     <criteria>
         <criterion comment="Property LoadState of {{{ SOCKETNAME }}}.socket is masked"
             test_ref="test_socket_loadstate_is_masked_{{{ SOCKETNAME }}}"/>


### PR DESCRIPTION
It isn't possible to have triple braces inside triple braces.