### PR TITLE
Update ansible remediation CCE-85972-8 to support idempotency

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/ansible/shared.yml
@@ -8,7 +8,7 @@
   command: >
     awk -F: '!$2 {print $1}' /etc/shadow
   register: users_nopasswd
-  changed_when: users_nopasswd.stdout_lines | length > 0
+  changed_when: false
 
 - name: Lock users with no password
   command: >

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/ansible/shared.yml
@@ -8,6 +8,7 @@
   command: >
     awk -F: '!$2 {print $1}' /etc/shadow
   register: users_nopasswd
+  changed_when: users_nopasswd.stdout_lines | length > 0
 
 - name: Lock users with no password
   command: >


### PR DESCRIPTION
#### Description:

- Add idempotency to the users_nopasswd compliance check for CCE-85972-8.

#### Rationale:

- Ansible should be able to run over and over again on systems and return 0 changes if nothing was actually modified on the target system. The current behavior will always return a changed value.

- Fixes: Added "changed_when" logic to only report a change if the returned stdout_lines is populated with results. If no results are returned, it will report as "ok".

#### Review Hints:

Result JSON from a run with this change:
```json
{"changed": false, "cmd": ["awk", "-F:", "!$2 {print $1}", "/etc/shadow"], "delta": "0:00:00.006307", "end": "2024-07-12 08:36:16.120933", "msg": "", "rc": 0, "start": "2024-07-12 08:36:16.114626", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
```
