### PR TITLE
templates: add rhel10 to conditional macros where rhel9 is mentioned

### DIFF
--- a/shared/templates/grub2_bootloader_argument/oval.template
+++ b/shared/templates/grub2_bootloader_argument/oval.template
@@ -13,7 +13,7 @@
 {{% set system_with_expanded_kernel_options_in_grub_cfg = false -%}}
 {{% set system_with_bios_and_uefi_support = false -%}}
 
-{{% if product in ["fedora", "ol9", "rhel9"] -%}}
+{{% if product in ["fedora", "ol9", "rhel9", "rhel10"] -%}}
 {{% set system_with_expanded_kernel_options_in_loader_entries = true %}}
 {{%- endif -%}}
 

--- a/shared/templates/grub2_bootloader_argument/tests/invalid_rescue.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/invalid_rescue.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# platform = Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Red Hat Enterprise Linux 9,Red Hat Enterprise Linux 10,multi_platform_fedora
 # packages = grub2,grubby
 {{%- if ARG_VARIABLE %}}
 # variables = {{{ ARG_VARIABLE }}}=correct_value

--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value_entries.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value_entries.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# platform = Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Red Hat Enterprise Linux 9,Red Hat Enterprise Linux 10,multi_platform_fedora
 # packages = grub2,grubby
 
 source common.sh

--- a/shared/templates/grub2_bootloader_argument_absent/oval.template
+++ b/shared/templates/grub2_bootloader_argument_absent/oval.template
@@ -12,7 +12,7 @@
 {{% set system_with_expanded_kernel_options_in_grub_cfg = false -%}}
 {{% set system_with_bios_and_uefi_support = false -%}}
 
-{{% if product in ["ol9", "rhel9"] -%}}
+{{% if product in ["ol9", "rhel9", "rhel10"] -%}}
 {{% set system_with_expanded_kernel_options_in_loader_entries = true %}}
 {{%- endif -%}}
 

--- a/shared/templates/sebool/ansible.template
+++ b/shared/templates/sebool/ansible.template
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = low
 
-{{% if product in ['ol8', 'ol9', 'rhel8', 'rhel9'] %}}
+{{% if product in ['ol8', 'ol9', 'rhel8', 'rhel9', 'rhel10'] %}}
 {{% set PACKAGE_NAME = "python3-libsemanage" %}}
 {{% elif product == "sle15" %}}
 {{% set PACKAGE_NAME = "policycoreutils" %}}

--- a/shared/templates/sebool/bash.template
+++ b/shared/templates/sebool/bash.template
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = low
 
-{{% if product in ['ol8', 'ol9', 'rhel8', 'rhel9'] %}}
+{{% if product in ['ol8', 'ol9', 'rhel8', 'rhel9', 'rhel10'] %}}
 {{{ bash_package_install("python3-libsemanage") }}}
 {{% elif product == "sle15" %}}
 {{{ bash_package_install("policycoreutils") }}}


### PR DESCRIPTION
#### Description:

- for templates sebool, grub2_bootloader_argument_absent and grub2_bootloader_argument
- there are sometimes macros which modify behavior of the template based on the product
- add rhel10 to such lists where rhel9 is
- I tested it on RHEL 10 with automatus template mode

#### Rationale:

- ensure that correct checks and remediations are built for RHEL 10



#### Review Hints:

1. ./build_product rhel10
2. cd tests
3. python automatus.py template --libvirt qemu:///system rhel10  sebool
4. python automatus.py template --libvirt qemu:///system rhel10  grub2_bootloader_argument_absent
5. python automatus.py template --libvirt qemu:///system rhel10  grub2_bootloader_argument

Tests should pass. Note that when testing grub2_bootloader_argument, there will be one rule failing; grub2_kernel_trust_cpu_rng. This rule should not be affected by this PR, because the PR modifies the template OVAL but this particular rule has its own OVAL. Nevertheless, it is broken on RHEL 10 and should be reported as an issue.