### PR TITLE
Simplify use of ansible_ensure_pam_module_option macro

### DIFF
--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
@@ -62,7 +62,7 @@
 - name: '{{{ rule_title }}} - Remediate by directly editing PAM files'
   block:
     {{{ ansible_ensure_pam_module_option('/etc/pam.d/smartcard-auth', 'auth', 'sufficient', 'pam_sss.so', 'allow_missing_name', '', '') | indent(4) }}}
-    {{{ ansible_ensure_pam_module_option('/etc/pam.d/system-auth', 'auth', '\[success=done authinfo_unavail=ignore ignore=ignore default=die\]', 'pam_sss.so', 'try_cert_auth', '', '') | indent(4) }}}
+    {{{ ansible_ensure_pam_module_option('/etc/pam.d/system-auth', 'auth', '[success=done authinfo_unavail=ignore ignore=ignore default=die]', 'pam_sss.so', 'try_cert_auth', '', '') | indent(4) }}}
   when:
     - not result_authselect_present.stat.exists
 {{% endif %}}


### PR DESCRIPTION
#### Description:

No need to escape special characters anymore for the control parameter in `ansible_ensure_pam_module_option` macro.
It is treated within the macro.

#### Rationale:

Simplification.

#### Review Hints:

./build_product rhel9
./tests/automatus.py rule --libvirt qemu:///session rhel9 --datastream build/ssg-rhel9-ds.xml --dontclean --remediate-using ansible sssd_enable_smartcards
