### PR TITLE
Allow multiple control files to add the same reference type

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -893,6 +893,7 @@ class Rule(XCCDFEntity, Templatable):
         rationale=lambda: "",
         severity=lambda: "",
         references=lambda: dict(),
+        control_references=lambda: dict(),
         components=lambda: list(),
         identifiers=lambda: dict(),
         ocil_clause=lambda: None,
@@ -1212,16 +1213,23 @@ class Rule(XCCDFEntity, Templatable):
             ident.set("system", SSG_IDENT_URIS[ident_type])
             ident.text = ident_val
 
-    def add_extra_reference(self, ref_type, ref_value):
-        if ref_type in self.references:
-            if ref_value in self.references[ref_type]:
+    def add_control_reference(self, ref_type, ref_value):
+        if ref_type in self.control_references:
+            if ref_value in self.control_references[ref_type]:
                 msg = (
                     "Rule %s already contains a '%s' reference with value '%s'." % (
                         self.id_, ref_type, ref_value))
                 raise ValueError(msg)
-            self.references[ref_type].append(ref_value)
+            self.control_references[ref_type].append(ref_value)
         else:
-            self.references[ref_type] = [ref_value]
+            self.control_references[ref_type] = [ref_value]
+
+    def merge_control_references(self):
+        for ref_type in self.control_references:
+            if ref_type in self.references:
+                self.references[ref_type].append(self.control_references[ref_type])
+            else:
+                self.references[ref_type] = self.control_references[ref_type]
 
     def to_xml_element(self, env_yaml=None):
         rule = ET.Element('{%s}Rule' % XCCDF12_NS)

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -184,7 +184,7 @@ class Control(ssg.entities.common.SelectionHandler, ssg.entities.common.XCCDFEnt
             if not rule:
                 continue
             try:
-                rule.add_extra_reference(reference_type, self.id)
+                rule.add_control_reference(reference_type, self.id)
             except ValueError as exc:
                 msg = (
                     "Please remove any duplicate listing of rule '%s' in "
@@ -527,5 +527,14 @@ class ControlsManager():
             policy.dump_yaml(filename)
 
     def add_references(self, rules):
+        # First we add all control references into a separate attribute
         for policy in self.policies.values():
             policy.add_references(rules)
+        # Then we unify them under references attribute
+        # This allows multiple control files to add references of the same type, and still track
+        # what references already existed in the rule.
+        self._merge_references(rules)
+
+    def _merge_references(self, rules):
+        for rule in rules.values():
+            rule.merge_control_references()


### PR DESCRIPTION
#### Description:

- Track references added by control files in `Rule.control_references`
- After everything is compiled by (compile_all.py), the `Rule.control_references` is merged into `Rule.references`.
  This still allows us to ensure that references are not cross added from rules and control files.
  To test this add, for example, `bsi: APP.4.4.A9` to any OCP rule.
- With this commit, the references added by the control file are tracked separately from the references loaded from the rule.yml. This allows us to differentiate references coming from the rule, and references coming from the control file.

#### Rationale:

- The build system is currently limited to a single ref type per control file. Two control files cannot add the same reference type.

#### Review Hints:

- Checkout this PR #12161
  `gh co 12161`
- Cherry-pick this commit:
  `git cherry-pick 927aeafe9f6f129c993191ecf140c88d5b0b0796`
- Build OCP4 product
  `./build_product -d ocp4`
- Check that Rule `general_namespace_separation` has two BSI references:
```xml
             <xccdf-1.2:reference href="https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf">APP.4.4.A1</xccdf-1.2:reference>
             <xccdf-1.2:reference href="https://www.bsi.bund.de/SharedDocs/Downloads/EN/BSI/Grundschutz/International/bsi_it_gs_comp_2022.pdf">SYS.1.6.A3</xccdf-1.2:reference>
```