### PR TITLE
Honour the no_quotes paramter of oval_check_dropin_file macro

### DIFF
--- a/shared/macros/10-oval.jinja
+++ b/shared/macros/10-oval.jinja
@@ -630,6 +630,12 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
     </criteria>
     {{%- endif %}}
   </definition>
+
+  {{%- set quotes = "'\"" -%}}
+  {{%- if no_quotes == "true" %}}
+  {{%- set quotes = "" -%}}
+  {{%- endif %}}
+
   {{{ oval_line_in_file_test(path, parameter) }}}
   {{{ oval_line_in_file_object(path, section, prefix_regex, parameter, separator_regex, false, multi_value) }}}
   {{{ oval_line_in_file_state(value, multi_value, quotes) }}}


### PR DESCRIPTION

#### Description:

- Handle correctly the no_quotes parameter of the macro

#### Rationale:

- Process the no_quotes param, , so it affects the quotes parameter of called oval_line_in_file_state macro 

- Fixes https://github.com/ComplianceAsCode/content/pull/12054#discussion_r1677491922

- Thanks to @marcusburghardt and @vojtapolasek for their feedback on this in context of #12054 :bow:
