### PR TITLE
Add rule sshd_use_approved_ciphers back to RHEL 9 data stream

### DIFF
--- a/products/rhel9/profiles/default.profile
+++ b/products/rhel9/profiles/default.profile
@@ -556,3 +556,4 @@ selections:
     - journald_forward_to_syslog
     - rsyslog_filecreatemode
     - set_nftables_table
+    - sshd_use_approved_ciphers


### PR DESCRIPTION
In https://github.com/ComplianceAsCode/content/pull/12150 we removed sshd_use_approved_ciphers from RHEL 9 profiles.

This caused that the rule disappeared from the built data stream. That can break people tailorings. Also, it breaks the CI test /static-checks/removed-rules. For example:
https://artifacts.dev.testing-farm.io/a38de8f4-1581-4bff-b690-c3d6f854d047/

We need to add the rule back. The rule is added to the hidden default profile, which causes that the rule is present in built data stream, but isn't present in any profile.

