### PR TITLE
Introduce `/rpmbuild-ctest-fedora` CI for all Fedora versions

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -35,6 +35,11 @@ jobs:
 # when modifying this, modify also tests/tmt-plans/
 
 - <<: *test-static-checks
+  identifier: /static-checks-fedora
+  tmt_plan: /static-checks-fedora
+  targets:
+    fedora-all: {}
+- <<: *test-static-checks
   identifier: /hardening/host-os/ansible/anssi_bp28_high
   tmt_plan: /hardening/host-os/ansible/anssi_bp28_high
 - <<: *test-static-checks

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -27,7 +27,7 @@ jobs:
   trigger: pull_request
   fmf_path: tests/tmt-plans
   identifier: /static-checks
-  tmt_plan: /static-checks
+  tmt_plan: /static-checks$
   targets:
     centos-stream-8: {}
     centos-stream-9: {}
@@ -36,89 +36,89 @@ jobs:
 
 - <<: *test-static-checks
   identifier: /static-checks-fedora
-  tmt_plan: /static-checks-fedora
+  tmt_plan: /static-checks-fedora$
   targets:
     fedora-all: {}
 - <<: *test-static-checks
   identifier: /hardening/host-os/ansible/anssi_bp28_high
-  tmt_plan: /hardening/host-os/ansible/anssi_bp28_high
+  tmt_plan: /hardening/host-os/ansible/anssi_bp28_high$
 - <<: *test-static-checks
   identifier: /hardening/host-os/ansible/ccn_advanced
-  tmt_plan: /hardening/host-os/ansible/ccn_advanced
+  tmt_plan: /hardening/host-os/ansible/ccn_advanced$
   targets:
     centos-stream-9: {}
 - <<: *test-static-checks
   identifier: /hardening/host-os/ansible/cis
-  tmt_plan: /hardening/host-os/ansible/cis
+  tmt_plan: /hardening/host-os/ansible/cis$
 - <<: *test-static-checks
   identifier: /hardening/host-os/ansible/cis_server_l1
-  tmt_plan: /hardening/host-os/ansible/cis_server_l1
+  tmt_plan: /hardening/host-os/ansible/cis_server_l1$
 - <<: *test-static-checks
   identifier: /hardening/host-os/ansible/cis_workstation_l1
-  tmt_plan: /hardening/host-os/ansible/cis_workstation_l1
+  tmt_plan: /hardening/host-os/ansible/cis_workstation_l1$
 - <<: *test-static-checks
   identifier: /hardening/host-os/ansible/cis_workstation_l2
-  tmt_plan: /hardening/host-os/ansible/cis_workstation_l2
+  tmt_plan: /hardening/host-os/ansible/cis_workstation_l2$
 - <<: *test-static-checks
   identifier: /hardening/host-os/ansible/cui
-  tmt_plan: /hardening/host-os/ansible/cui
+  tmt_plan: /hardening/host-os/ansible/cui$
 - <<: *test-static-checks
   identifier: /hardening/host-os/ansible/e8
-  tmt_plan: /hardening/host-os/ansible/e8
+  tmt_plan: /hardening/host-os/ansible/e8$
 - <<: *test-static-checks
   identifier: /hardening/host-os/ansible/hipaa
-  tmt_plan: /hardening/host-os/ansible/hipaa
+  tmt_plan: /hardening/host-os/ansible/hipaa$
 - <<: *test-static-checks
   identifier: /hardening/host-os/ansible/ism_o
-  tmt_plan: /hardening/host-os/ansible/ism_o
+  tmt_plan: /hardening/host-os/ansible/ism_o$
 - <<: *test-static-checks
   identifier: /hardening/host-os/ansible/ospp
-  tmt_plan: /hardening/host-os/ansible/ospp
+  tmt_plan: /hardening/host-os/ansible/ospp$
 - <<: *test-static-checks
   identifier: /hardening/host-os/ansible/pci-dss
-  tmt_plan: /hardening/host-os/ansible/pci-dss
+  tmt_plan: /hardening/host-os/ansible/pci-dss$
 - <<: *test-static-checks
   identifier: /hardening/host-os/ansible/stig
-  tmt_plan: /hardening/host-os/ansible/stig
+  tmt_plan: /hardening/host-os/ansible/stig$
 
 - <<: *test-static-checks
   identifier: /hardening/host-os/oscap/anssi_bp28_high
-  tmt_plan: /hardening/host-os/oscap/anssi_bp28_high
+  tmt_plan: /hardening/host-os/oscap/anssi_bp28_high$
 - <<: *test-static-checks
   identifier: /hardening/host-os/oscap/ccn_advanced
-  tmt_plan: /hardening/host-os/oscap/ccn_advanced
+  tmt_plan: /hardening/host-os/oscap/ccn_advanced$
   targets:
     centos-stream-9: {}
 - <<: *test-static-checks
   identifier: /hardening/host-os/oscap/cis
-  tmt_plan: /hardening/host-os/oscap/cis
+  tmt_plan: /hardening/host-os/oscap/cis$
 - <<: *test-static-checks
   identifier: /hardening/host-os/oscap/cis_server_l1
-  tmt_plan: /hardening/host-os/oscap/cis_server_l1
+  tmt_plan: /hardening/host-os/oscap/cis_server_l1$
 - <<: *test-static-checks
   identifier: /hardening/host-os/oscap/cis_workstation_l1
-  tmt_plan: /hardening/host-os/oscap/cis_workstation_l1
+  tmt_plan: /hardening/host-os/oscap/cis_workstation_l1$
 - <<: *test-static-checks
   identifier: /hardening/host-os/oscap/cis_workstation_l2
-  tmt_plan: /hardening/host-os/oscap/cis_workstation_l2
+  tmt_plan: /hardening/host-os/oscap/cis_workstation_l2$
 - <<: *test-static-checks
   identifier: /hardening/host-os/oscap/cui
-  tmt_plan: /hardening/host-os/oscap/cui
+  tmt_plan: /hardening/host-os/oscap/cui$
 - <<: *test-static-checks
   identifier: /hardening/host-os/oscap/e8
-  tmt_plan: /hardening/host-os/oscap/e8
+  tmt_plan: /hardening/host-os/oscap/e8$
 - <<: *test-static-checks
   identifier: /hardening/host-os/oscap/hipaa
-  tmt_plan: /hardening/host-os/oscap/hipaa
+  tmt_plan: /hardening/host-os/oscap/hipaa$
 - <<: *test-static-checks
   identifier: /hardening/host-os/oscap/ism_o
-  tmt_plan: /hardening/host-os/oscap/ism_o
+  tmt_plan: /hardening/host-os/oscap/ism_o$
 - <<: *test-static-checks
   identifier: /hardening/host-os/oscap/ospp
-  tmt_plan: /hardening/host-os/oscap/ospp
+  tmt_plan: /hardening/host-os/oscap/ospp$
 - <<: *test-static-checks
   identifier: /hardening/host-os/oscap/pci-dss
-  tmt_plan: /hardening/host-os/oscap/pci-dss
+  tmt_plan: /hardening/host-os/oscap/pci-dss$
 - <<: *test-static-checks
   identifier: /hardening/host-os/oscap/stig
-  tmt_plan: /hardening/host-os/oscap/stig
+  tmt_plan: /hardening/host-os/oscap/stig$

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -35,8 +35,8 @@ jobs:
 # when modifying this, modify also tests/tmt-plans/
 
 - <<: *test-static-checks
-  identifier: /static-checks-fedora
-  tmt_plan: /static-checks-fedora$
+  identifier: /rpmbuild-ctest-fedora
+  tmt_plan: /rpmbuild-ctest-fedora$
   targets:
     fedora-all: {}
 - <<: *test-static-checks

--- a/tests/tmt-plans/main.fmf
+++ b/tests/tmt-plans/main.fmf
@@ -110,5 +110,5 @@ report:
           - /static-checks/diff
 
 # Fedora specific plan
-/static-checks-fedora:
+/rpmbuild-ctest-fedora:
     discover+: {test: /static-checks/rpmbuild-ctest}

--- a/tests/tmt-plans/main.fmf
+++ b/tests/tmt-plans/main.fmf
@@ -108,3 +108,7 @@ report:
           - /static-checks/html-links
           # these always fail, meant for manual review
           - /static-checks/diff
+
+# Fedora specific plan
+/static-checks-fedora:
+    discover+: {test: /static-checks/rpmbuild-ctest}


### PR DESCRIPTION
#### Description:
Re-introduce `rpmbuild-ctest` for all supported Fedora versions. The test takes srpm, builds it from sources, and runs ctest for all Fedora enabled products.

`rpmbuild-ctest` got necessary update related in https://github.com/RHSecurityCompliance/contest/pull/224 Now, it installs recommended packages to enable more unit tests.

Also improve TMT plan regexes to not match multiple profiles.
Before:
[testing-farm:centos-stream-8-x86_64:/hardening/host-os/ansible/cis](https://artifacts.dev.testing-farm.io/5f7e67b8-3724-4cf4-ad27-80e571522ef7/) - matches all `cis` profiles because of regex match
After:
[testing-farm:centos-stream-8-x86_64:/hardening/host-os/ansible/cis](https://artifacts.dev.testing-farm.io/c9e0f240-9681-4677-adca-225ef8fbe648/) - matches only `cis` profile as intended

#### Rationale:
Recently, one of our unit tests was failing on Fedora Rawhide and it was not caught by CI.

#### Review Hints:
See Testing Farm `/rpmbuild-ctest-fedora` Fedora jobs.