### PR TITLE
Exclude package_screen_installed from RHEL 10 OSPP

### DIFF
--- a/products/rhel10/profiles/ospp.profile
+++ b/products/rhel10/profiles/ospp.profile
@@ -21,3 +21,4 @@ description: |-
 
 selections:
     - ospp:all
+    - '!package_screen_installed'


### PR DESCRIPTION

#### Description:
Exclude package_screen_installed from RHEL 10 OSPP

#### Rationale:

Fixes #12169 
