### PR TITLE
Add a minimum cluster stability timeout for OpenShift e2e remediation

### DIFF
--- a/applications/openshift/authentication/idp_is_configured/tests/ocp4/e2e-remediation.sh
+++ b/applications/openshift/authentication/idp_is_configured/tests/ocp4/e2e-remediation.sh
@@ -26,4 +26,4 @@ EOF
 
 
 echo "waiting for a stable cluster"
-oc adm wait-for-stable-cluster
+oc adm wait-for-stable-cluster --minimum-stable-period 2m


### PR DESCRIPTION
The OpenShift content has a manual remeidation for setting up an
identity provider, which includes creating a secret, updating the
authentication configuration, and bouncing the authentication operator.

The test suite needs to make sure the authentication operator is up and
ready before it continues, and we recently updated the logic to make
sure it was ready by using the `oc adm wait-for-stable-cluster` command.
This command is ideal because it checks all cluster operators are
running and stable, not just the authentication operator.

One side-effect of using this command though is that it polls on
successful cluster conditions. We were using it from the perspective
that the command would exit gracefully when the cluster was stable,
which isn't the case.

However, we can pass and argument to the command to force an exit after
the cluster is stable for a certain period of time. This commit updates
the command to do that so that the command doesn't hang and cause
timeouts in our testing.
