### PR TITLE
Move to `default` crypto policy for RHEL10 for CIS Profiles

### DIFF
--- a/controls/cis_rhel10.yml
+++ b/controls/cis_rhel10.yml
@@ -548,7 +548,7 @@ controls:
     status: automated
     rules:
       - configure_crypto_policy
-      - var_system_crypto_policy=default_nosha1
+      - var_system_crypto_policy=default
 
   - id: 1.6.2
     title: Ensure system wide crypto policy is not set in sshd configuration (Automated)


### PR DESCRIPTION


#### Description:
Move to Default crypto policy for RHEL10 for CIS Profiles

#### Rationale:

NOSHA1 policy is gone. SHA1 should be disabled by default.

Fixes #12178 

