### PR TITLE
Add through Fedora 45 for Fedora CPEs

### DIFF
--- a/products/fedora/product.yml
+++ b/products/fedora/product.yml
@@ -34,7 +34,7 @@ cpes:
 
   - fedora_43:
       name: "cpe:/o:fedoraproject:fedora:43"
-      title: "Fedora 37"
+      title: "Fedora 43"
       check_id: installed_OS_is_fedora
 
   - fedora_42:

--- a/products/fedora/product.yml
+++ b/products/fedora/product.yml
@@ -22,6 +22,31 @@ dconf_gdm_dir: "distro.d"
 
 cpes_root: "../../shared/applicability"
 cpes:
+  - fedora_45:
+      name: "cpe:/o:fedoraproject:fedora:45"
+      title: "Fedora 45"
+      check_id: installed_OS_is_fedora
+
+  - fedora_44:
+      name: "cpe:/o:fedoraproject:fedora:44"
+      title: "Fedora 44"
+      check_id: installed_OS_is_fedora
+
+  - fedora_43:
+      name: "cpe:/o:fedoraproject:fedora:43"
+      title: "Fedora 37"
+      check_id: installed_OS_is_fedora
+
+  - fedora_42:
+      name: "cpe:/o:fedoraproject:fedora:42"
+      title: "Fedora 42"
+      check_id: installed_OS_is_fedora
+
+  - fedora_41:
+      name: "cpe:/o:fedoraproject:fedora:41"
+      title: "Fedora 41"
+      check_id: installed_OS_is_fedora
+
   - fedora_40:
       name: "cpe:/o:fedoraproject:fedora:40"
       title: "Fedora 40"
@@ -30,21 +55,6 @@ cpes:
   - fedora_39:
       name: "cpe:/o:fedoraproject:fedora:39"
       title: "Fedora 39"
-      check_id: installed_OS_is_fedora
-
-  - fedora_38:
-      name: "cpe:/o:fedoraproject:fedora:38"
-      title: "Fedora 38"
-      check_id: installed_OS_is_fedora
-
-  - fedora_37:
-      name: "cpe:/o:fedoraproject:fedora:37"
-      title: "Fedora 37"
-      check_id: installed_OS_is_fedora
-
-  - fedora_36:
-      name: "cpe:/o:fedoraproject:fedora:36"
-      title: "Fedora 36"
       check_id: installed_OS_is_fedora
 
 # Retrieve the fingerprint as follows:

--- a/tests/data/product_stability/fedora.yml
+++ b/tests/data/product_stability/fedora.yml
@@ -11,6 +11,26 @@ chrony_conf_path: /etc/chrony.conf
 chrony_d_path: /etc/chrony.d/
 components_root: ../../components
 cpes:
+- fedora_45:
+    check_id: installed_OS_is_fedora
+    name: cpe:/o:fedoraproject:fedora:45
+    title: Fedora 45
+- fedora_44:
+    check_id: installed_OS_is_fedora
+    name: cpe:/o:fedoraproject:fedora:44
+    title: Fedora 44
+- fedora_43:
+    check_id: installed_OS_is_fedora
+    name: cpe:/o:fedoraproject:fedora:43
+    title: Fedora 37
+- fedora_42:
+    check_id: installed_OS_is_fedora
+    name: cpe:/o:fedoraproject:fedora:42
+    title: Fedora 42
+- fedora_41:
+    check_id: installed_OS_is_fedora
+    name: cpe:/o:fedoraproject:fedora:41
+    title: Fedora 41
 - fedora_40:
     check_id: installed_OS_is_fedora
     name: cpe:/o:fedoraproject:fedora:40
@@ -19,18 +39,6 @@ cpes:
     check_id: installed_OS_is_fedora
     name: cpe:/o:fedoraproject:fedora:39
     title: Fedora 39
-- fedora_38:
-    check_id: installed_OS_is_fedora
-    name: cpe:/o:fedoraproject:fedora:38
-    title: Fedora 38
-- fedora_37:
-    check_id: installed_OS_is_fedora
-    name: cpe:/o:fedoraproject:fedora:37
-    title: Fedora 37
-- fedora_36:
-    check_id: installed_OS_is_fedora
-    name: cpe:/o:fedoraproject:fedora:36
-    title: Fedora 36
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: distro.d
 faillock_path: /var/run/faillock

--- a/tests/data/product_stability/fedora.yml
+++ b/tests/data/product_stability/fedora.yml
@@ -22,7 +22,7 @@ cpes:
 - fedora_43:
     check_id: installed_OS_is_fedora
     name: cpe:/o:fedoraproject:fedora:43
-    title: Fedora 37
+    title: Fedora 43
 - fedora_42:
     check_id: installed_OS_is_fedora
     name: cpe:/o:fedoraproject:fedora:42


### PR DESCRIPTION
#### Description:

Add through Fedora 45 for Fedora CPEs.

#### Rationale:

Keeping the project up-to-date.

