### PR TITLE
Correct the platform

### DIFF
--- a/components/ufw.yml
+++ b/components/ufw.yml
@@ -13,3 +13,4 @@ rules:
 - ufw_only_required_services
 - ufw_rate_limit
 - ufw_rules_for_open_ports
+- package_iptables-persistent_removed

--- a/linux_os/guide/system/network/network-iptables/package_iptables-persistent_removed/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/package_iptables-persistent_removed/rule.yml
@@ -12,7 +12,7 @@ rationale: |-
 
 severity: medium
 
-platform: package[iptables]
+platform: package[ufw]
 
 references:
     cis@ubuntu2004: 3.5.1.2


### PR DESCRIPTION
#### Description:

- Correct the platform detection for rule `package_iptables-persistent_removed`

#### Rationale:

- As the cis rule indicates: remove iptables-persistent if ufw is installed