### PR TITLE
Disable service_enabled templated test for service_bluetooth_disabled

### DIFF
--- a/linux_os/guide/system/network/network-wireless/wireless_software/service_bluetooth_disabled/tests/test_config.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/service_bluetooth_disabled/tests/test_config.yml
@@ -1,0 +1,2 @@
+deny_templated_scenarios:
+  - service_enabled.fail.sh


### PR DESCRIPTION
#### Description:
Disable test scenario that tries to start bluetooth service and then expect it to fail.

#### Rationale:
The service is dependent on loaded `btusb` kernel module. However, this module is not loaded by default and templated test scenario doesn't load it either.

We had similar problem in the past https://github.com/ComplianceAsCode/content/issues/11949 and now it started happening also on RHEL 8.8 and 9.2. I tried it manually on those systems and to properly start the service, I had to `modprobe btusb` (https://wiki.archlinux.org/title/Bluetooth#Installation). It will be better to disable the test scenario completely rather than creating Contest waiver.

#### Review Hints:
Try Automatus for `service_bluetooth_disabled` and see what test scenarios are not run.