### PR TITLE
Adjust bash template (group)file_owner to follow symlinks

### DIFF
--- a/shared/templates/file_groupowner/bash.template
+++ b/shared/templates/file_groupowner/bash.template
@@ -7,18 +7,18 @@
 {{%- if RECURSIVE %}}
 {{%- set FIND_RECURSE_ARGS="" %}}
 {{%- else %}}
-{{%- set FIND_RECURSE_ARGS="-maxdepth 1" %}}
+{{%- set FIND_RECURSE_ARGS="-maxdepth 1 -L" %}}
 {{%- endif %}}
 
 {{%- for path in FILEPATH %}}
 {{%- if IS_DIRECTORY %}}
 {{%- if FILE_REGEX %}}
 
-find {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -group {{{ GID_OR_NAME }}} -regextype posix-extended -regex '{{{ FILE_REGEX[loop.index0] }}}' -exec chgrp {{{ GID_OR_NAME }}} {} \;
+find {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -group {{{ GID_OR_NAME }}} -regextype posix-extended -regex '{{{ FILE_REGEX[loop.index0] }}}' -exec chgrp -L {{{ GID_OR_NAME }}} {} \;
 {{%- else %}}
-find -H {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type d -exec chgrp {{{ GID_OR_NAME }}} {} \;
+find -H {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type d -exec chgrp -L {{{ GID_OR_NAME }}} {} \;
 {{%- endif %}}
 {{%- else %}}
-chgrp {{{ GID_OR_NAME }}} {{{ path }}}
+chgrp -L {{{ GID_OR_NAME }}} {{{ path }}}
 {{%- endif %}}
 {{%- endfor %}}

--- a/shared/templates/file_owner/bash.template
+++ b/shared/templates/file_owner/bash.template
@@ -7,18 +7,18 @@
 {{%- if RECURSIVE %}}
 {{%- set FIND_RECURSE_ARGS="" %}}
 {{%- else %}}
-{{%- set FIND_RECURSE_ARGS="-maxdepth 1" %}}
+{{%- set FIND_RECURSE_ARGS="-maxdepth 1 -L" %}}
 {{%- endif %}}
 
 {{%- for path in FILEPATH %}}
 {{%- if IS_DIRECTORY %}}
 {{%- if FILE_REGEX %}}
 
-find {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -uid {{{ FILEUID }}} -regextype posix-extended -regex '{{{ FILE_REGEX[loop.index0] }}}' -exec chown {{{ FILEUID }}} {} \;
+find {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -uid {{{ FILEUID }}} -regextype posix-extended -regex '{{{ FILE_REGEX[loop.index0] }}}' -exec chown -L {{{ FILEUID }}} {} \;
 {{%- else %}}
-find -H {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type d -exec chown {{{ FILEUID }}} {} \;
+find -H {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type d -exec chown -L {{{ FILEUID }}} {} \;
 {{%- endif %}}
 {{%- else %}}
-chown {{{ FILEUID }}} {{{ path }}}
+chown -L {{{ FILEUID }}} {{{ path }}}
 {{%- endif %}}
 {{%- endfor %}}


### PR DESCRIPTION
#### Description:

Adjust bash template groupfile_owner and file_owner to follow symlinks.

#### Rationale:
Addresses #12162