### PR TITLE
Add profile assertion files for OCP 4.12

### DIFF
--- a/tests/assertions/ocp4/ocp4-cis-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.12.yml
@@ -1,0 +1,295 @@
+rule_results:
+  e2e-cis-accounts-restrict-service-account-tokens:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-cis-accounts-unique-service-account:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-cis-api-server-admission-control-plugin-alwaysadmit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-admission-control-plugin-alwayspullimages:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-admission-control-plugin-namespacelifecycle:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-admission-control-plugin-noderestriction:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-admission-control-plugin-scc:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-admission-control-plugin-service-account:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-anonymous-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-api-priority-gate-enabled:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-cis-api-server-audit-log-maxbackup:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-audit-log-maxsize:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-audit-log-path:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-auth-mode-no-aa:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-auth-mode-rbac:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-basic-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-bind-address:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-client-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-encryption-provider-cipher:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-cis-api-server-etcd-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-etcd-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-etcd-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-https-for-kubelet-conn:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-insecure-bind-address:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-insecure-port:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-cis-api-server-kubelet-certificate-authority:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-kubelet-client-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-kubelet-client-cert-pre-4-9:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-cis-api-server-kubelet-client-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-kubelet-client-key-pre-4-9:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-cis-api-server-oauth-https-serving-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-openshift-https-serving-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-profiling-protected-by-rbac:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-request-timeout:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-service-account-lookup:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-service-account-public-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-tls-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-tls-cipher-suites:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-tls-private-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-api-server-token-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-audit-log-forwarding-enabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-cis-audit-log-forwarding-webhook:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-cis-audit-logging-enabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-audit-profile-set:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-cis-configure-network-policies:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-configure-network-policies-hypershift-hosted:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-cis-configure-network-policies-namespaces:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-controller-insecure-port-disabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-controller-secure-port:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-controller-service-account-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-controller-service-account-private-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-controller-use-service-account:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-etcd-auto-tls:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-etcd-cert-file:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-etcd-client-cert-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-etcd-key-file:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-etcd-peer-auto-tls:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-etcd-peer-cert-file:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-etcd-peer-client-cert-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-etcd-peer-key-file:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-file-groupowner-proxy-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-cis-file-owner-proxy-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-cis-file-permissions-proxy-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-cis-general-apply-scc:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-cis-general-default-namespace-use:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-cis-general-default-seccomp-profile:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-cis-general-namespaces-in-use:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-cis-idp-is-configured:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-cis-kubeadmin-removed:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-cis-kubelet-configure-tls-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-kubelet-configure-tls-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-kubelet-disable-readonly-port:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-ocp-allowed-registries:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-cis-ocp-allowed-registries-for-import:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-cis-ocp-api-server-audit-log-maxbackup:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-ocp-api-server-audit-log-maxsize:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-ocp-insecure-allowed-registries-for-import:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-ocp-insecure-registries:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-openshift-api-server-audit-log-path:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-rbac-debug-role-protects-pprof:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-rbac-least-privilege:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-cis-rbac-limit-cluster-admin:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-cis-rbac-limit-secrets-access:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-cis-rbac-pod-creation-access:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-cis-rbac-wildcard-use:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-cis-scc-drop-container-capabilities:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-cis-scc-limit-container-allowed-capabilities:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-scc-limit-ipc-namespace:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-cis-scc-limit-net-raw-capability:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-cis-scc-limit-network-namespace:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-cis-scc-limit-privilege-escalation:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-cis-scc-limit-privileged-containers:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-cis-scc-limit-process-id-namespace:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-cis-scc-limit-root-containers:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-cis-scheduler-profiling-protected-by-rbac:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-scheduler-service-protected-by-rbac:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-cis-secrets-consider-external-storage:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-cis-secrets-no-environment-variables:
+    default_result: MANUAL
+    result_after_remediation: MANUAL

--- a/tests/assertions/ocp4/ocp4-cis-node-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-cis-node-4.12.yml
@@ -1,0 +1,401 @@
+rule_results:
+  e2e-cis-node-master-etcd-unique-ca:
+    default_result: PASS
+  e2e-cis-node-master-file-groupowner-cni-conf:
+    default_result: PASS
+  e2e-cis-node-master-file-groupowner-controller-manager-kubeconfig:
+    default_result: PASS
+  e2e-cis-node-master-file-groupowner-etcd-data-dir:
+    default_result: PASS
+  e2e-cis-node-master-file-groupowner-etcd-data-files:
+    default_result: PASS
+  e2e-cis-node-master-file-groupowner-etcd-member:
+    default_result: PASS
+  e2e-cis-node-master-file-groupowner-etcd-pki-cert-files:
+    default_result: PASS
+  e2e-cis-node-master-file-groupowner-ip-allocations:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-master-file-groupowner-kube-apiserver:
+    default_result: PASS
+  e2e-cis-node-master-file-groupowner-kube-controller-manager:
+    default_result: PASS
+  e2e-cis-node-master-file-groupowner-kube-scheduler:
+    default_result: PASS
+  e2e-cis-node-master-file-groupowner-kubelet-conf:
+    default_result: PASS
+  e2e-cis-node-master-file-groupowner-master-admin-kubeconfigs:
+    default_result: PASS
+  e2e-cis-node-master-file-groupowner-multus-conf:
+    default_result: PASS
+  e2e-cis-node-master-file-groupowner-openshift-pki-cert-files:
+    default_result: PASS
+  e2e-cis-node-master-file-groupowner-openshift-pki-key-files:
+    default_result: PASS
+  e2e-cis-node-master-file-groupowner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-master-file-groupowner-ovn-cni-server-sock:
+    default_result: PASS
+  e2e-cis-node-master-file-groupowner-ovn-db-files:
+    default_result: PASS
+  e2e-cis-node-master-file-groupowner-ovs-conf-db:
+    default_result: PASS
+  e2e-cis-node-master-file-groupowner-ovs-conf-db-lock:
+    default_result: PASS
+  e2e-cis-node-master-file-groupowner-ovs-pid:
+    default_result: PASS
+  e2e-cis-node-master-file-groupowner-ovs-sys-id-conf:
+    default_result: PASS
+  e2e-cis-node-master-file-groupowner-ovs-vswitchd-pid:
+    default_result: PASS
+  e2e-cis-node-master-file-groupowner-ovsdb-server-pid:
+    default_result: PASS
+  e2e-cis-node-master-file-groupowner-scheduler-kubeconfig:
+    default_result: PASS
+  e2e-cis-node-master-file-groupowner-worker-ca:
+    default_result: PASS
+  e2e-cis-node-master-file-groupowner-worker-kubeconfig:
+    default_result: PASS
+  e2e-cis-node-master-file-groupowner-worker-service:
+    default_result: PASS
+  e2e-cis-node-master-file-owner-cni-conf:
+    default_result: PASS
+  e2e-cis-node-master-file-owner-controller-manager-kubeconfig:
+    default_result: PASS
+  e2e-cis-node-master-file-owner-etcd-data-dir:
+    default_result: PASS
+  e2e-cis-node-master-file-owner-etcd-data-files:
+    default_result: PASS
+  e2e-cis-node-master-file-owner-etcd-member:
+    default_result: PASS
+  e2e-cis-node-master-file-owner-etcd-pki-cert-files:
+    default_result: PASS
+  e2e-cis-node-master-file-owner-ip-allocations:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-master-file-owner-kube-apiserver:
+    default_result: PASS
+  e2e-cis-node-master-file-owner-kube-controller-manager:
+    default_result: PASS
+  e2e-cis-node-master-file-owner-kube-scheduler:
+    default_result: PASS
+  e2e-cis-node-master-file-owner-kubelet:
+    default_result: PASS
+  e2e-cis-node-master-file-owner-kubelet-conf:
+    default_result: PASS
+  e2e-cis-node-master-file-owner-master-admin-kubeconfigs:
+    default_result: PASS
+  e2e-cis-node-master-file-owner-multus-conf:
+    default_result: PASS
+  e2e-cis-node-master-file-owner-openshift-pki-cert-files:
+    default_result: PASS
+  e2e-cis-node-master-file-owner-openshift-pki-key-files:
+    default_result: PASS
+  e2e-cis-node-master-file-owner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-master-file-owner-ovn-cni-server-sock:
+    default_result: PASS
+  e2e-cis-node-master-file-owner-ovn-db-files:
+    default_result: PASS
+  e2e-cis-node-master-file-owner-ovs-conf-db:
+    default_result: PASS
+  e2e-cis-node-master-file-owner-ovs-conf-db-lock:
+    default_result: PASS
+  e2e-cis-node-master-file-owner-ovs-pid:
+    default_result: PASS
+  e2e-cis-node-master-file-owner-ovs-sys-id-conf:
+    default_result: PASS
+  e2e-cis-node-master-file-owner-ovs-vswitchd-pid:
+    default_result: PASS
+  e2e-cis-node-master-file-owner-ovsdb-server-pid:
+    default_result: PASS
+  e2e-cis-node-master-file-owner-scheduler-kubeconfig:
+    default_result: PASS
+  e2e-cis-node-master-file-owner-worker-ca:
+    default_result: PASS
+  e2e-cis-node-master-file-owner-worker-kubeconfig:
+    default_result: PASS
+  e2e-cis-node-master-file-owner-worker-service:
+    default_result: PASS
+  e2e-cis-node-master-file-permissions-cni-conf:
+    default_result: FAIL
+  e2e-cis-node-master-file-permissions-controller-manager-kubeconfig:
+    default_result: PASS
+  e2e-cis-node-master-file-permissions-etcd-data-dir:
+    default_result: PASS
+  e2e-cis-node-master-file-permissions-etcd-data-files:
+    default_result: PASS
+  e2e-cis-node-master-file-permissions-etcd-member:
+    default_result: PASS
+  e2e-cis-node-master-file-permissions-etcd-pki-cert-files:
+    default_result: PASS
+  e2e-cis-node-master-file-permissions-ip-allocations:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-master-file-permissions-kube-apiserver:
+    default_result: PASS
+  e2e-cis-node-master-file-permissions-kube-controller-manager:
+    default_result: PASS
+  e2e-cis-node-master-file-permissions-kubelet-conf:
+    default_result: PASS
+  e2e-cis-node-master-file-permissions-master-admin-kubeconfigs:
+    default_result: PASS
+  e2e-cis-node-master-file-permissions-multus-conf:
+    default_result: PASS
+  e2e-cis-node-master-file-permissions-openshift-pki-cert-files:
+    default_result: PASS
+  e2e-cis-node-master-file-permissions-openshift-pki-key-files:
+    default_result: PASS
+  e2e-cis-node-master-file-permissions-ovn-cni-server-sock:
+    default_result: PASS
+  e2e-cis-node-master-file-permissions-ovn-db-files:
+    default_result: PASS
+  e2e-cis-node-master-file-permissions-ovs-conf-db:
+    default_result: PASS
+  e2e-cis-node-master-file-permissions-ovs-conf-db-lock:
+    default_result: PASS
+  e2e-cis-node-master-file-permissions-ovs-pid:
+    default_result: PASS
+  e2e-cis-node-master-file-permissions-ovs-sys-id-conf:
+    default_result: PASS
+  e2e-cis-node-master-file-permissions-ovs-vswitchd-pid:
+    default_result: PASS
+  e2e-cis-node-master-file-permissions-ovsdb-server-pid:
+    default_result: PASS
+  e2e-cis-node-master-file-permissions-scheduler:
+    default_result: PASS
+  e2e-cis-node-master-file-permissions-scheduler-kubeconfig:
+    default_result: PASS
+  e2e-cis-node-master-file-permissions-worker-ca:
+    default_result: PASS
+  e2e-cis-node-master-file-permissions-worker-kubeconfig:
+    default_result: PASS
+  e2e-cis-node-master-file-permissions-worker-service:
+    default_result: PASS
+  e2e-cis-node-master-file-perms-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-master-kubelet-anonymous-auth:
+    default_result: PASS
+  e2e-cis-node-master-kubelet-authorization-mode:
+    default_result: PASS
+  e2e-cis-node-master-kubelet-configure-client-ca:
+    default_result: PASS
+  e2e-cis-node-master-kubelet-configure-event-creation:
+    default_result: PASS
+  e2e-cis-node-master-kubelet-configure-tls-cipher-suites:
+    default_result: PASS
+  e2e-cis-node-master-kubelet-enable-cert-rotation:
+    default_result: PASS
+  e2e-cis-node-master-kubelet-enable-client-cert-rotation:
+    default_result: PASS
+  e2e-cis-node-master-kubelet-enable-iptables-util-chains:
+    default_result: PASS
+  e2e-cis-node-master-kubelet-enable-server-cert-rotation:
+    default_result: PASS
+  e2e-cis-node-master-kubelet-enable-streaming-connections:
+    default_result: PASS
+  e2e-cis-node-master-kubelet-eviction-thresholds-set-hard-imagefs-available:
+    default_result: PASS
+  e2e-cis-node-master-kubelet-eviction-thresholds-set-hard-memory-available:
+    default_result: PASS
+  e2e-cis-node-master-kubelet-eviction-thresholds-set-hard-nodefs-available:
+    default_result: PASS
+  e2e-cis-node-master-kubelet-eviction-thresholds-set-hard-nodefs-inodesfree:
+    default_result: PASS
+  e2e-cis-node-worker-etcd-unique-ca:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-groupowner-cni-conf:
+    default_result: PASS
+  e2e-cis-node-worker-file-groupowner-controller-manager-kubeconfig:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-groupowner-etcd-data-dir:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-groupowner-etcd-data-files:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-groupowner-etcd-member:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-groupowner-etcd-pki-cert-files:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-groupowner-ip-allocations:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-groupowner-kube-apiserver:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-groupowner-kube-controller-manager:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-groupowner-kube-scheduler:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-groupowner-kubelet-conf:
+    default_result: PASS
+  e2e-cis-node-worker-file-groupowner-master-admin-kubeconfigs:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-groupowner-multus-conf:
+    default_result: PASS
+  e2e-cis-node-worker-file-groupowner-openshift-pki-cert-files:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-groupowner-openshift-pki-key-files:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-groupowner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-groupowner-ovn-cni-server-sock:
+    default_result: PASS
+  e2e-cis-node-worker-file-groupowner-ovn-db-files:
+    default_result: PASS
+  e2e-cis-node-worker-file-groupowner-ovs-conf-db:
+    default_result: PASS
+  e2e-cis-node-worker-file-groupowner-ovs-conf-db-lock:
+    default_result: PASS
+  e2e-cis-node-worker-file-groupowner-ovs-pid:
+    default_result: PASS
+  e2e-cis-node-worker-file-groupowner-ovs-sys-id-conf:
+    default_result: PASS
+  e2e-cis-node-worker-file-groupowner-ovs-vswitchd-pid:
+    default_result: PASS
+  e2e-cis-node-worker-file-groupowner-ovsdb-server-pid:
+    default_result: PASS
+  e2e-cis-node-worker-file-groupowner-scheduler-kubeconfig:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-groupowner-worker-ca:
+    default_result: PASS
+  e2e-cis-node-worker-file-groupowner-worker-kubeconfig:
+    default_result: PASS
+  e2e-cis-node-worker-file-groupowner-worker-service:
+    default_result: PASS
+  e2e-cis-node-worker-file-owner-cni-conf:
+    default_result: PASS
+  e2e-cis-node-worker-file-owner-controller-manager-kubeconfig:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-owner-etcd-data-dir:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-owner-etcd-data-files:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-owner-etcd-member:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-owner-etcd-pki-cert-files:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-owner-ip-allocations:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-owner-kube-apiserver:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-owner-kube-controller-manager:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-owner-kube-scheduler:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-owner-kubelet:
+    default_result: PASS
+  e2e-cis-node-worker-file-owner-kubelet-conf:
+    default_result: PASS
+  e2e-cis-node-worker-file-owner-master-admin-kubeconfigs:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-owner-multus-conf:
+    default_result: PASS
+  e2e-cis-node-worker-file-owner-openshift-pki-cert-files:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-owner-openshift-pki-key-files:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-owner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-owner-ovn-cni-server-sock:
+    default_result: PASS
+  e2e-cis-node-worker-file-owner-ovn-db-files:
+    default_result: PASS
+  e2e-cis-node-worker-file-owner-ovs-conf-db:
+    default_result: PASS
+  e2e-cis-node-worker-file-owner-ovs-conf-db-lock:
+    default_result: PASS
+  e2e-cis-node-worker-file-owner-ovs-pid:
+    default_result: PASS
+  e2e-cis-node-worker-file-owner-ovs-sys-id-conf:
+    default_result: PASS
+  e2e-cis-node-worker-file-owner-ovs-vswitchd-pid:
+    default_result: PASS
+  e2e-cis-node-worker-file-owner-ovsdb-server-pid:
+    default_result: PASS
+  e2e-cis-node-worker-file-owner-scheduler-kubeconfig:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-owner-worker-ca:
+    default_result: PASS
+  e2e-cis-node-worker-file-owner-worker-kubeconfig:
+    default_result: PASS
+  e2e-cis-node-worker-file-owner-worker-service:
+    default_result: PASS
+  e2e-cis-node-worker-file-permissions-cni-conf:
+    default_result: FAIL
+  e2e-cis-node-worker-file-permissions-controller-manager-kubeconfig:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-permissions-etcd-data-dir:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-permissions-etcd-data-files:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-permissions-etcd-member:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-permissions-etcd-pki-cert-files:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-permissions-ip-allocations:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-permissions-kube-apiserver:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-permissions-kube-controller-manager:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-permissions-kubelet-conf:
+    default_result: PASS
+  e2e-cis-node-worker-file-permissions-master-admin-kubeconfigs:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-permissions-multus-conf:
+    default_result: PASS
+  e2e-cis-node-worker-file-permissions-openshift-pki-cert-files:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-permissions-openshift-pki-key-files:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-permissions-ovn-cni-server-sock:
+    default_result: PASS
+  e2e-cis-node-worker-file-permissions-ovn-db-files:
+    default_result: PASS
+  e2e-cis-node-worker-file-permissions-ovs-conf-db:
+    default_result: PASS
+  e2e-cis-node-worker-file-permissions-ovs-conf-db-lock:
+    default_result: PASS
+  e2e-cis-node-worker-file-permissions-ovs-pid:
+    default_result: PASS
+  e2e-cis-node-worker-file-permissions-ovs-sys-id-conf:
+    default_result: PASS
+  e2e-cis-node-worker-file-permissions-ovs-vswitchd-pid:
+    default_result: PASS
+  e2e-cis-node-worker-file-permissions-ovsdb-server-pid:
+    default_result: PASS
+  e2e-cis-node-worker-file-permissions-scheduler:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-permissions-scheduler-kubeconfig:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-file-permissions-worker-ca:
+    default_result: PASS
+  e2e-cis-node-worker-file-permissions-worker-kubeconfig:
+    default_result: PASS
+  e2e-cis-node-worker-file-permissions-worker-service:
+    default_result: PASS
+  e2e-cis-node-worker-file-perms-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+  e2e-cis-node-worker-kubelet-anonymous-auth:
+    default_result: PASS
+  e2e-cis-node-worker-kubelet-authorization-mode:
+    default_result: PASS
+  e2e-cis-node-worker-kubelet-configure-client-ca:
+    default_result: PASS
+  e2e-cis-node-worker-kubelet-configure-event-creation:
+    default_result: PASS
+  e2e-cis-node-worker-kubelet-configure-tls-cipher-suites:
+    default_result: PASS
+  e2e-cis-node-worker-kubelet-enable-cert-rotation:
+    default_result: PASS
+  e2e-cis-node-worker-kubelet-enable-client-cert-rotation:
+    default_result: PASS
+  e2e-cis-node-worker-kubelet-enable-iptables-util-chains:
+    default_result: PASS
+  e2e-cis-node-worker-kubelet-enable-server-cert-rotation:
+    default_result: PASS
+  e2e-cis-node-worker-kubelet-enable-streaming-connections:
+    default_result: PASS
+  e2e-cis-node-worker-kubelet-eviction-thresholds-set-hard-imagefs-available:
+    default_result: PASS
+  e2e-cis-node-worker-kubelet-eviction-thresholds-set-hard-memory-available:
+    default_result: PASS
+  e2e-cis-node-worker-kubelet-eviction-thresholds-set-hard-nodefs-available:
+    default_result: PASS
+  e2e-cis-node-worker-kubelet-eviction-thresholds-set-hard-nodefs-inodesfree:
+    default_result: PASS

--- a/tests/assertions/ocp4/ocp4-e8-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-e8-4.12.yml
@@ -1,0 +1,37 @@
+rule_results:
+  e2e-e8-api-server-encryption-provider-cipher:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-api-server-tls-cipher-suites:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-e8-ocp-allowed-registries:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-e8-ocp-allowed-registries-for-import:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-e8-ocp-idp-no-htpasswd:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-e8-rbac-limit-cluster-admin:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-e8-rbac-pod-creation-access:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-e8-rbac-wildcard-use:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-e8-scc-limit-container-allowed-capabilities:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-e8-scc-limit-privilege-escalation:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-e8-scc-limit-privileged-containers:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-e8-scc-limit-root-containers:
+    default_result: MANUAL
+    result_after_remediation: MANUAL

--- a/tests/assertions/ocp4/ocp4-high-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.12.yml
@@ -1,0 +1,406 @@
+rule_results:
+  e2e-high-accounts-restrict-service-account-tokens:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-accounts-unique-service-account:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-alert-receiver-configured:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-api-server-admission-control-plugin-alwaysadmit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-admission-control-plugin-alwayspullimages:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-admission-control-plugin-namespacelifecycle:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-admission-control-plugin-noderestriction:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-admission-control-plugin-scc:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-admission-control-plugin-securitycontextdeny:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-admission-control-plugin-service-account:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-anonymous-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-api-priority-flowschema-catch-all:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-api-priority-gate-enabled:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-api-server-audit-log-maxbackup:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-audit-log-maxsize:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-audit-log-path:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-auth-mode-no-aa:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-auth-mode-node:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-auth-mode-rbac:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-basic-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-bind-address:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-client-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-encryption-provider-cipher:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-api-server-etcd-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-etcd-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-etcd-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-https-for-kubelet-conn:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-insecure-bind-address:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-insecure-port:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-api-server-kubelet-certificate-authority:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-kubelet-client-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-kubelet-client-cert-pre-4-9:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-api-server-kubelet-client-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-kubelet-client-key-pre-4-9:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-api-server-no-adm-ctrl-plugins-disabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-oauth-https-serving-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-openshift-https-serving-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-profiling-protected-by-rbac:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-request-timeout:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-service-account-lookup:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-service-account-public-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-tls-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-tls-cipher-suites:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-tls-private-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-tls-security-profile:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-token-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-audit-error-alert-exists:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-audit-log-forwarding-enabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-audit-log-forwarding-uses-tls:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-audit-log-forwarding-webhook:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-audit-logging-enabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-audit-profile-set:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-banner-or-login-template-set:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-cluster-logging-operator-exist:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-cluster-version-operator-exists:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-cluster-version-operator-verify-integrity:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-cluster-wide-proxy-set:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-high-compliance-notification-enabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-configure-network-policies:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-configure-network-policies-hypershift-hosted:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-configure-network-policies-namespaces:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-controller-insecure-port-disabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-controller-rotate-kubelet-server-certs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-controller-secure-port:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-controller-service-account-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-controller-service-account-private-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-controller-use-service-account:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-default-ingress-ca-replaced:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-etcd-auto-tls:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-etcd-cert-file:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-etcd-client-cert-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-etcd-key-file:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-etcd-peer-auto-tls:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-etcd-peer-cert-file:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-etcd-peer-client-cert-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-etcd-peer-key-file:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-file-groupowner-proxy-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-file-integrity-exists:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-file-integrity-notification-enabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-file-owner-proxy-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-file-permissions-proxy-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-fips-mode-enabled-on-all-nodes:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-general-apply-scc:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-general-configure-imagepolicywebhook:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-general-default-namespace-use:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-general-default-seccomp-profile:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-general-namespaces-in-use:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-gitops-operator-exists:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-idp-is-configured:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-ingress-controller-certificate:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-ingress-controller-tls-security-profile:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-kubeadmin-removed:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-high-kubelet-configure-tls-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-kubelet-configure-tls-cert-pre-4-9:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-kubelet-configure-tls-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-kubelet-disable-readonly-port:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-oauth-or-oauthclient-inactivity-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-oauth-or-oauthclient-token-maxage:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-ocp-allowed-registries:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-high-ocp-allowed-registries-for-import:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-high-ocp-api-server-audit-log-maxbackup:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-ocp-api-server-audit-log-maxsize:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-ocp-idp-no-htpasswd:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-ocp-insecure-allowed-registries-for-import:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-ocp-insecure-registries:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-ocp-no-ldap-insecure:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-openshift-api-server-audit-log-path:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-openshift-motd-exists:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-rbac-debug-role-protects-pprof:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-rbac-least-privilege:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-rbac-limit-cluster-admin:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-rbac-limit-secrets-access:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-rbac-pod-creation-access:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-rbac-wildcard-use:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-resource-requests-limits-in-daemonset:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-resource-requests-limits-in-deployment:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-resource-requests-limits-in-statefulset:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-resource-requests-quota:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-route-ip-whitelist:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-routes-protected-by-tls:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-routes-rate-limit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-scansettingbinding-exists:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-scc-drop-container-capabilities:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-scc-limit-container-allowed-capabilities:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-scc-limit-ipc-namespace:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-scc-limit-net-raw-capability:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-scc-limit-network-namespace:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-scc-limit-privilege-escalation:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-scc-limit-privileged-containers:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-scc-limit-process-id-namespace:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-scc-limit-root-containers:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-scheduler-profiling-protected-by-rbac:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-scheduler-service-protected-by-rbac:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-secrets-consider-external-storage:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-secrets-no-environment-variables:
+    default_result: MANUAL
+    result_after_remediation: MANUAL

--- a/tests/assertions/ocp4/ocp4-high-node-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-high-node-4.12.yml
@@ -1,0 +1,721 @@
+rule_results:
+  e2e-high-node-master-directory-access-var-log-kube-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-node-master-directory-access-var-log-oauth-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-node-master-directory-access-var-log-ocp-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-node-master-directory-permissions-var-log-kube-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-directory-permissions-var-log-oauth-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-directory-permissions-var-log-ocp-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-etcd-unique-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-groupowner-cni-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-groupowner-controller-manager-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-groupowner-etcd-data-dir:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-groupowner-etcd-data-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-groupowner-etcd-member:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-groupowner-etcd-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-groupowner-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-master-file-groupowner-kube-apiserver:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-groupowner-kube-controller-manager:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-groupowner-kube-scheduler:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-groupowner-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-groupowner-master-admin-kubeconfigs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-groupowner-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-groupowner-openshift-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-groupowner-openshift-pki-key-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-groupowner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-master-file-groupowner-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-groupowner-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-groupowner-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-groupowner-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-groupowner-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-groupowner-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-groupowner-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-groupowner-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-groupowner-scheduler-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-groupowner-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-groupowner-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-groupowner-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-owner-cni-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-owner-controller-manager-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-owner-etcd-data-dir:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-owner-etcd-data-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-owner-etcd-member:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-owner-etcd-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-owner-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-master-file-owner-kube-apiserver:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-owner-kube-controller-manager:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-owner-kube-scheduler:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-owner-kubelet:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-owner-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-owner-master-admin-kubeconfigs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-owner-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-owner-openshift-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-owner-openshift-pki-key-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-owner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-master-file-owner-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-owner-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-owner-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-owner-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-owner-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-owner-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-owner-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-owner-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-owner-scheduler-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-owner-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-owner-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-owner-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-ownership-var-log-kube-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-ownership-var-log-oauth-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-ownership-var-log-ocp-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-cni-conf:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-high-node-master-file-permissions-controller-manager-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-etcd-data-dir:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-etcd-data-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-etcd-member:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-etcd-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-master-file-permissions-kube-apiserver:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-kube-controller-manager:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-kubelet:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-master-admin-kubeconfigs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-openshift-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-openshift-pki-key-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-scheduler:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-scheduler-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-var-log-kube-audit:
+    default_result: INCONSISTENT
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-var-log-oauth-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-var-log-ocp-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-permissions-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-file-perms-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-master-kubelet-anonymous-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-kubelet-authorization-mode:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-kubelet-configure-client-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-kubelet-configure-event-creation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-kubelet-configure-tls-cipher-suites:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-kubelet-configure-tls-min-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-kubelet-enable-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-kubelet-enable-client-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-kubelet-enable-iptables-util-chains:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-kubelet-enable-protect-kernel-defaults:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-node-master-kubelet-enable-protect-kernel-sysctl:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-kubelet-enable-server-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-kubelet-enable-streaming-connections:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-kubelet-eviction-thresholds-set-hard-imagefs-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-kubelet-eviction-thresholds-set-hard-memory-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-kubelet-eviction-thresholds-set-hard-nodefs-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-kubelet-eviction-thresholds-set-hard-nodefs-inodesfree:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-master-partition-for-var-log-kube-apiserver:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-node-master-partition-for-var-log-oauth-apiserver:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-node-master-partition-for-var-log-openshift-apiserver:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-node-master-reject-unsigned-images-by-default:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-node-worker-directory-access-var-log-kube-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-directory-access-var-log-oauth-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-directory-access-var-log-ocp-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-directory-permissions-var-log-kube-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-directory-permissions-var-log-oauth-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-directory-permissions-var-log-ocp-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-etcd-unique-ca:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-groupowner-cni-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-groupowner-controller-manager-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-groupowner-etcd-data-dir:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-groupowner-etcd-data-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-groupowner-etcd-member:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-groupowner-etcd-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-groupowner-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-groupowner-kube-apiserver:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-groupowner-kube-controller-manager:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-groupowner-kube-scheduler:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-groupowner-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-groupowner-master-admin-kubeconfigs:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-groupowner-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-groupowner-openshift-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-groupowner-openshift-pki-key-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-groupowner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-groupowner-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-groupowner-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-groupowner-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-groupowner-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-groupowner-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-groupowner-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-groupowner-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-groupowner-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-groupowner-scheduler-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-groupowner-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-groupowner-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-groupowner-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-owner-cni-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-owner-controller-manager-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-owner-etcd-data-dir:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-owner-etcd-data-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-owner-etcd-member:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-owner-etcd-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-owner-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-owner-kube-apiserver:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-owner-kube-controller-manager:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-owner-kube-scheduler:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-owner-kubelet:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-owner-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-owner-master-admin-kubeconfigs:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-owner-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-owner-openshift-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-owner-openshift-pki-key-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-owner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-owner-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-owner-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-owner-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-owner-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-owner-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-owner-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-owner-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-owner-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-owner-scheduler-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-owner-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-owner-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-owner-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-ownership-var-log-kube-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-ownership-var-log-oauth-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-ownership-var-log-ocp-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-permissions-cni-conf:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-high-node-worker-file-permissions-controller-manager-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-permissions-etcd-data-dir:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-permissions-etcd-data-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-permissions-etcd-member:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-permissions-etcd-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-permissions-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-permissions-kube-apiserver:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-permissions-kube-controller-manager:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-permissions-kubelet:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-permissions-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-permissions-master-admin-kubeconfigs:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-permissions-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-permissions-openshift-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-permissions-openshift-pki-key-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-permissions-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-permissions-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-permissions-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-permissions-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-permissions-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-permissions-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-permissions-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-permissions-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-permissions-scheduler:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-permissions-scheduler-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-permissions-var-log-kube-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-permissions-var-log-oauth-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-permissions-var-log-ocp-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-file-permissions-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-permissions-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-permissions-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-file-perms-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-node-worker-kubelet-anonymous-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-kubelet-authorization-mode:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-kubelet-configure-client-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-kubelet-configure-event-creation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-kubelet-configure-tls-cipher-suites:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-kubelet-configure-tls-min-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-kubelet-enable-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-kubelet-enable-client-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-kubelet-enable-iptables-util-chains:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-kubelet-enable-protect-kernel-defaults:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-node-worker-kubelet-enable-protect-kernel-sysctl:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-kubelet-enable-server-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-kubelet-enable-streaming-connections:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-kubelet-eviction-thresholds-set-hard-imagefs-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-kubelet-eviction-thresholds-set-hard-memory-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-kubelet-eviction-thresholds-set-hard-nodefs-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-kubelet-eviction-thresholds-set-hard-nodefs-inodesfree:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-node-worker-partition-for-var-log-kube-apiserver:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-node-worker-partition-for-var-log-oauth-apiserver:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-node-worker-partition-for-var-log-openshift-apiserver:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-node-worker-reject-unsigned-images-by-default:
+    default_result: FAIL
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.12.yml
@@ -1,0 +1,397 @@
+rule_results:
+  e2e-moderate-accounts-restrict-service-account-tokens:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-accounts-unique-service-account:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-api-server-admission-control-plugin-alwaysadmit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-admission-control-plugin-alwayspullimages:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-admission-control-plugin-namespacelifecycle:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-admission-control-plugin-noderestriction:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-admission-control-plugin-scc:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-admission-control-plugin-securitycontextdeny:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-admission-control-plugin-service-account:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-anonymous-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-api-priority-flowschema-catch-all:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-api-priority-gate-enabled:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-api-server-audit-log-maxbackup:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-audit-log-maxsize:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-audit-log-path:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-auth-mode-no-aa:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-auth-mode-node:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-auth-mode-rbac:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-basic-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-bind-address:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-client-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-encryption-provider-cipher:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-api-server-etcd-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-etcd-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-etcd-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-https-for-kubelet-conn:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-insecure-bind-address:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-insecure-port:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-api-server-kubelet-certificate-authority:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-kubelet-client-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-kubelet-client-cert-pre-4-9:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-api-server-kubelet-client-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-kubelet-client-key-pre-4-9:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-api-server-no-adm-ctrl-plugins-disabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-oauth-https-serving-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-openshift-https-serving-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-profiling-protected-by-rbac:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-request-timeout:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-service-account-lookup:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-service-account-public-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-tls-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-tls-cipher-suites:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-tls-private-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-tls-security-profile:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-token-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-audit-error-alert-exists:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-audit-log-forwarding-enabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-audit-log-forwarding-uses-tls:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-audit-log-forwarding-webhook:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-audit-logging-enabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-audit-profile-set:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-banner-or-login-template-set:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-cluster-version-operator-exists:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-cluster-version-operator-verify-integrity:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-cluster-wide-proxy-set:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-moderate-compliance-notification-enabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-configure-network-policies:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-configure-network-policies-hypershift-hosted:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-configure-network-policies-namespaces:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-controller-insecure-port-disabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-controller-rotate-kubelet-server-certs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-controller-secure-port:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-controller-service-account-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-controller-service-account-private-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-controller-use-service-account:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-default-ingress-ca-replaced:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-etcd-auto-tls:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-etcd-cert-file:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-etcd-client-cert-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-etcd-key-file:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-etcd-peer-auto-tls:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-etcd-peer-cert-file:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-etcd-peer-client-cert-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-etcd-peer-key-file:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-file-groupowner-proxy-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-file-integrity-exists:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-file-integrity-notification-enabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-file-owner-proxy-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-file-permissions-proxy-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-fips-mode-enabled-on-all-nodes:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-general-apply-scc:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-general-configure-imagepolicywebhook:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-general-default-namespace-use:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-general-default-seccomp-profile:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-general-namespaces-in-use:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-idp-is-configured:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-ingress-controller-certificate:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-ingress-controller-tls-security-profile:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-kubeadmin-removed:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-moderate-kubelet-configure-tls-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-kubelet-configure-tls-cert-pre-4-9:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-kubelet-configure-tls-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-kubelet-disable-readonly-port:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-oauth-or-oauthclient-inactivity-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-oauth-or-oauthclient-token-maxage:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-ocp-allowed-registries:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-moderate-ocp-allowed-registries-for-import:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-moderate-ocp-api-server-audit-log-maxbackup:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-ocp-api-server-audit-log-maxsize:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-ocp-idp-no-htpasswd:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-ocp-insecure-allowed-registries-for-import:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-ocp-insecure-registries:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-ocp-no-ldap-insecure:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-openshift-api-server-audit-log-path:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-openshift-motd-exists:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-rbac-debug-role-protects-pprof:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-rbac-least-privilege:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-rbac-limit-cluster-admin:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-rbac-limit-secrets-access:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-rbac-pod-creation-access:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-rbac-wildcard-use:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-resource-requests-limits-in-daemonset:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-resource-requests-limits-in-deployment:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-resource-requests-limits-in-statefulset:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-resource-requests-quota:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-route-ip-whitelist:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-routes-protected-by-tls:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-routes-rate-limit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-scansettingbinding-exists:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-scc-drop-container-capabilities:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-scc-limit-container-allowed-capabilities:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-scc-limit-ipc-namespace:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-scc-limit-net-raw-capability:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-scc-limit-network-namespace:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-scc-limit-privilege-escalation:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-scc-limit-privileged-containers:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-scc-limit-process-id-namespace:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-scc-limit-root-containers:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-scheduler-profiling-protected-by-rbac:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-scheduler-service-protected-by-rbac:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-secrets-consider-external-storage:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-secrets-no-environment-variables:
+    default_result: MANUAL
+    result_after_remediation: MANUAL

--- a/tests/assertions/ocp4/ocp4-moderate-node-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-node-4.12.yml
@@ -1,0 +1,721 @@
+rule_results:
+  e2e-moderate-node-master-directory-access-var-log-kube-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-node-master-directory-access-var-log-oauth-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-node-master-directory-access-var-log-ocp-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-node-master-directory-permissions-var-log-kube-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-directory-permissions-var-log-oauth-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-directory-permissions-var-log-ocp-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-etcd-unique-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-groupowner-cni-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-groupowner-controller-manager-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-groupowner-etcd-data-dir:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-groupowner-etcd-data-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-groupowner-etcd-member:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-groupowner-etcd-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-groupowner-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-master-file-groupowner-kube-apiserver:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-groupowner-kube-controller-manager:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-groupowner-kube-scheduler:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-groupowner-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-groupowner-master-admin-kubeconfigs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-groupowner-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-groupowner-openshift-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-groupowner-openshift-pki-key-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-groupowner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-master-file-groupowner-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-groupowner-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-groupowner-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-groupowner-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-groupowner-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-groupowner-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-groupowner-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-groupowner-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-groupowner-scheduler-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-groupowner-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-groupowner-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-groupowner-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-owner-cni-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-owner-controller-manager-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-owner-etcd-data-dir:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-owner-etcd-data-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-owner-etcd-member:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-owner-etcd-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-owner-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-master-file-owner-kube-apiserver:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-owner-kube-controller-manager:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-owner-kube-scheduler:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-owner-kubelet:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-owner-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-owner-master-admin-kubeconfigs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-owner-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-owner-openshift-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-owner-openshift-pki-key-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-owner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-master-file-owner-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-owner-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-owner-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-owner-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-owner-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-owner-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-owner-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-owner-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-owner-scheduler-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-owner-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-owner-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-owner-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-ownership-var-log-kube-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-ownership-var-log-oauth-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-ownership-var-log-ocp-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-cni-conf:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-moderate-node-master-file-permissions-controller-manager-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-etcd-data-dir:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-etcd-data-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-etcd-member:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-etcd-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-master-file-permissions-kube-apiserver:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-kube-controller-manager:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-kubelet:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-master-admin-kubeconfigs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-openshift-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-openshift-pki-key-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-scheduler:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-scheduler-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-var-log-kube-audit:
+    default_result: INCONSISTENT
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-var-log-oauth-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-var-log-ocp-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-permissions-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-file-perms-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-master-kubelet-anonymous-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-kubelet-authorization-mode:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-kubelet-configure-client-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-kubelet-configure-event-creation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-kubelet-configure-tls-cipher-suites:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-kubelet-configure-tls-min-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-kubelet-enable-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-kubelet-enable-client-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-kubelet-enable-iptables-util-chains:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-kubelet-enable-protect-kernel-defaults:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-node-master-kubelet-enable-protect-kernel-sysctl:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-kubelet-enable-server-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-kubelet-enable-streaming-connections:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-kubelet-eviction-thresholds-set-hard-imagefs-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-kubelet-eviction-thresholds-set-hard-memory-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-kubelet-eviction-thresholds-set-hard-nodefs-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-kubelet-eviction-thresholds-set-hard-nodefs-inodesfree:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-master-partition-for-var-log-kube-apiserver:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-node-master-partition-for-var-log-oauth-apiserver:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-node-master-partition-for-var-log-openshift-apiserver:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-node-master-reject-unsigned-images-by-default:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-directory-access-var-log-kube-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-directory-access-var-log-oauth-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-directory-access-var-log-ocp-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-directory-permissions-var-log-kube-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-directory-permissions-var-log-oauth-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-directory-permissions-var-log-ocp-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-etcd-unique-ca:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-groupowner-cni-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-groupowner-controller-manager-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-groupowner-etcd-data-dir:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-groupowner-etcd-data-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-groupowner-etcd-member:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-groupowner-etcd-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-groupowner-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-groupowner-kube-apiserver:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-groupowner-kube-controller-manager:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-groupowner-kube-scheduler:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-groupowner-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-groupowner-master-admin-kubeconfigs:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-groupowner-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-groupowner-openshift-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-groupowner-openshift-pki-key-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-groupowner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-groupowner-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-groupowner-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-groupowner-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-groupowner-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-groupowner-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-groupowner-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-groupowner-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-groupowner-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-groupowner-scheduler-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-groupowner-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-groupowner-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-groupowner-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-owner-cni-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-owner-controller-manager-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-owner-etcd-data-dir:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-owner-etcd-data-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-owner-etcd-member:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-owner-etcd-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-owner-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-owner-kube-apiserver:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-owner-kube-controller-manager:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-owner-kube-scheduler:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-owner-kubelet:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-owner-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-owner-master-admin-kubeconfigs:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-owner-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-owner-openshift-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-owner-openshift-pki-key-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-owner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-owner-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-owner-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-owner-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-owner-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-owner-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-owner-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-owner-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-owner-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-owner-scheduler-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-owner-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-owner-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-owner-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-ownership-var-log-kube-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-ownership-var-log-oauth-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-ownership-var-log-ocp-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-permissions-cni-conf:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-moderate-node-worker-file-permissions-controller-manager-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-permissions-etcd-data-dir:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-permissions-etcd-data-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-permissions-etcd-member:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-permissions-etcd-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-permissions-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-permissions-kube-apiserver:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-permissions-kube-controller-manager:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-permissions-kubelet:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-permissions-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-permissions-master-admin-kubeconfigs:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-permissions-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-permissions-openshift-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-permissions-openshift-pki-key-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-permissions-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-permissions-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-permissions-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-permissions-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-permissions-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-permissions-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-permissions-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-permissions-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-permissions-scheduler:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-permissions-scheduler-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-permissions-var-log-kube-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-permissions-var-log-oauth-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-permissions-var-log-ocp-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-file-permissions-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-permissions-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-permissions-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-file-perms-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-node-worker-kubelet-anonymous-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-kubelet-authorization-mode:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-kubelet-configure-client-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-kubelet-configure-event-creation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-kubelet-configure-tls-cipher-suites:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-kubelet-configure-tls-min-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-kubelet-enable-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-kubelet-enable-client-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-kubelet-enable-iptables-util-chains:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-kubelet-enable-protect-kernel-defaults:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-kubelet-enable-protect-kernel-sysctl:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-kubelet-enable-server-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-kubelet-enable-streaming-connections:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-kubelet-eviction-thresholds-set-hard-imagefs-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-kubelet-eviction-thresholds-set-hard-memory-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-kubelet-eviction-thresholds-set-hard-nodefs-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-kubelet-eviction-thresholds-set-hard-nodefs-inodesfree:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-node-worker-partition-for-var-log-kube-apiserver:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-node-worker-partition-for-var-log-oauth-apiserver:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-node-worker-partition-for-var-log-openshift-apiserver:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-node-worker-reject-unsigned-images-by-default:
+    default_result: FAIL
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-stig-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.12.yml
@@ -1,0 +1,370 @@
+rule_results:
+  e2e-stig-accounts-restrict-service-account-tokens:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-accounts-unique-service-account:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-api-server-admission-control-plugin-alwaysadmit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-admission-control-plugin-alwayspullimages:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-admission-control-plugin-namespacelifecycle:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-admission-control-plugin-noderestriction:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-admission-control-plugin-scc:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-admission-control-plugin-securitycontextdeny:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-admission-control-plugin-service-account:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-anonymous-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-api-priority-flowschema-catch-all:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-api-priority-gate-enabled:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-api-server-audit-log-maxbackup:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-audit-log-maxsize:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-audit-log-path:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-auth-mode-no-aa:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-auth-mode-node:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-auth-mode-rbac:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-basic-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-bind-address:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-encryption-provider-cipher:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-api-server-etcd-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-etcd-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-https-for-kubelet-conn:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-insecure-bind-address:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-insecure-port:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-api-server-kubelet-certificate-authority:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-kubelet-client-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-kubelet-client-cert-pre-4-9:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-api-server-kubelet-client-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-kubelet-client-key-pre-4-9:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-api-server-no-adm-ctrl-plugins-disabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-oauth-https-serving-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-openshift-https-serving-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-profiling-protected-by-rbac:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-request-timeout:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-service-account-lookup:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-service-account-public-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-tls-cipher-suites:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-tls-security-profile:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-token-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-audit-error-alert-exists:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-audit-log-forwarding-enabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-audit-log-forwarding-uses-tls:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-audit-profile-set:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-classification-banner:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-cluster-logging-operator-exist:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-cluster-version-operator-exists:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-cluster-version-operator-verify-integrity:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-configure-network-policies:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-configure-network-policies-namespaces:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-container-security-operator-exists:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-controller-insecure-port-disabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-controller-rotate-kubelet-server-certs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-controller-secure-port:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-controller-service-account-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-controller-service-account-private-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-controller-use-service-account:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-etcd-auto-tls:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-etcd-cert-file:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-etcd-client-cert-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-etcd-key-file:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-etcd-peer-auto-tls:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-etcd-peer-client-cert-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-file-groupowner-proxy-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-file-integrity-exists:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-file-owner-proxy-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-file-permissions-proxy-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-fips-mode-enabled-on-all-nodes:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-general-apply-scc:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-general-configure-imagepolicywebhook:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-general-default-namespace-use:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-general-default-seccomp-profile:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-general-namespaces-in-use:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-idp-is-configured:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-image-pruner-active:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-imagestream-sets-schedule:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-stig-ingress-controller-tls-security-profile:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-kubeadmin-removed:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-stig-kubelet-disable-readonly-port:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-oauth-login-template-set:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-oauth-logout-url-set:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-oauth-or-oauthclient-inactivity-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-oauth-or-oauthclient-token-maxage:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-oauth-provider-selection-set:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-ocp-allowed-registries:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-stig-ocp-allowed-registries-for-import:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-stig-ocp-api-server-audit-log-maxbackup:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-ocp-api-server-audit-log-maxsize:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-ocp-idp-no-htpasswd:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-ocp-insecure-allowed-registries-for-import:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-ocp-insecure-registries:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-ocp-no-ldap-insecure:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-openshift-api-server-audit-log-path:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-openshift-motd-exists:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-project-config-and-template-network-policy:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-project-config-and-template-resource-quota:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-rbac-debug-role-protects-pprof:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-rbac-least-privilege:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-rbac-limit-cluster-admin:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-rbac-limit-secrets-access:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-rbac-logging-del:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-rbac-logging-mod:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-rbac-logging-view:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-rbac-pod-creation-access:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-rbac-wildcard-use:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-resource-requests-quota-per-project:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-stig-routes-rate-limit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-scansettingbinding-exists:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-scansettings-have-schedule:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-scc-drop-container-capabilities:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-scc-limit-container-allowed-capabilities:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-scc-limit-host-dir-volume-plugin:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-scc-limit-host-ports:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-scc-limit-ipc-namespace:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-scc-limit-net-raw-capability:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-scc-limit-network-namespace:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-scc-limit-privilege-escalation:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-scc-limit-privileged-containers:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-scc-limit-process-id-namespace:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-scc-limit-root-containers:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-secrets-consider-external-storage:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-secrets-no-environment-variables:
+    default_result: MANUAL
+    result_after_remediation: MANUAL

--- a/tests/assertions/ocp4/ocp4-stig-node-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-stig-node-4.12.yml
@@ -1,0 +1,637 @@
+rule_results:
+  e2e-stig-node-master-etcd-unique-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-groupowner-cni-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-groupowner-controller-manager-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-groupowner-etcd-data-dir:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-groupowner-etcd-data-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-groupowner-etcd-member:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-groupowner-etcd-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-groupowner-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-master-file-groupowner-kube-apiserver:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-groupowner-kube-controller-manager:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-groupowner-kube-scheduler:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-groupowner-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-groupowner-master-admin-kubeconfigs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-groupowner-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-groupowner-openshift-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-groupowner-openshift-pki-key-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-groupowner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-master-file-groupowner-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-groupowner-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-groupowner-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-groupowner-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-groupowner-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-groupowner-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-groupowner-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-groupowner-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-groupowner-scheduler-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-groupowner-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-groupowner-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-groupowner-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-owner-cni-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-owner-controller-manager-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-owner-etcd-data-dir:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-owner-etcd-data-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-owner-etcd-member:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-owner-etcd-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-owner-groupowner-permissions-pod-logs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-owner-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-master-file-owner-kube-apiserver:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-owner-kube-controller-manager:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-owner-kube-scheduler:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-owner-kubelet:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-owner-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-owner-master-admin-kubeconfigs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-owner-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-owner-openshift-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-owner-openshift-pki-key-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-owner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-master-file-owner-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-owner-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-owner-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-owner-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-owner-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-owner-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-owner-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-owner-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-owner-scheduler-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-owner-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-owner-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-owner-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-permissions-cni-conf:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-stig-node-master-file-permissions-controller-manager-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-permissions-etcd-data-dir:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-permissions-etcd-data-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-permissions-etcd-member:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-permissions-etcd-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-permissions-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-master-file-permissions-kube-apiserver:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-permissions-kube-controller-manager:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-permissions-kubelet:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-permissions-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-permissions-master-admin-kubeconfigs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-permissions-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-permissions-openshift-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-permissions-openshift-pki-key-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-permissions-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-permissions-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-permissions-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-permissions-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-permissions-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-permissions-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-permissions-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-permissions-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-permissions-scheduler:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-permissions-scheduler-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-permissions-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-permissions-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-permissions-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-file-perms-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-master-kubelet-anonymous-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-kubelet-authorization-mode:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-kubelet-configure-client-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-kubelet-configure-event-creation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-kubelet-configure-tls-cipher-suites:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-kubelet-configure-tls-min-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-kubelet-enable-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-kubelet-enable-client-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-kubelet-enable-iptables-util-chains:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-kubelet-enable-protect-kernel-defaults:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-node-master-kubelet-enable-protect-kernel-sysctl:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-kubelet-enable-server-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-kubelet-enable-streaming-connections:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-kubelet-eviction-thresholds-set-hard-imagefs-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-kubelet-eviction-thresholds-set-hard-memory-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-kubelet-eviction-thresholds-set-hard-nodefs-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-kubelet-eviction-thresholds-set-hard-nodefs-inodesfree:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-master-reject-unsigned-images-by-default:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-node-worker-etcd-unique-ca:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-groupowner-cni-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-groupowner-controller-manager-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-groupowner-etcd-data-dir:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-groupowner-etcd-data-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-groupowner-etcd-member:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-groupowner-etcd-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-groupowner-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-groupowner-kube-apiserver:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-groupowner-kube-controller-manager:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-groupowner-kube-scheduler:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-groupowner-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-groupowner-master-admin-kubeconfigs:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-groupowner-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-groupowner-openshift-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-groupowner-openshift-pki-key-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-groupowner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-groupowner-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-groupowner-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-groupowner-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-groupowner-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-groupowner-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-groupowner-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-groupowner-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-groupowner-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-groupowner-scheduler-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-groupowner-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-groupowner-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-groupowner-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-owner-cni-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-owner-controller-manager-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-owner-etcd-data-dir:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-owner-etcd-data-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-owner-etcd-member:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-owner-etcd-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-owner-groupowner-permissions-pod-logs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-owner-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-owner-kube-apiserver:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-owner-kube-controller-manager:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-owner-kube-scheduler:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-owner-kubelet:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-owner-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-owner-master-admin-kubeconfigs:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-owner-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-owner-openshift-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-owner-openshift-pki-key-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-owner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-owner-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-owner-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-owner-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-owner-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-owner-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-owner-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-owner-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-owner-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-owner-scheduler-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-owner-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-owner-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-owner-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-permissions-cni-conf:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-stig-node-worker-file-permissions-controller-manager-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-permissions-etcd-data-dir:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-permissions-etcd-data-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-permissions-etcd-member:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-permissions-etcd-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-permissions-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-permissions-kube-apiserver:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-permissions-kube-controller-manager:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-permissions-kubelet:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-permissions-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-permissions-master-admin-kubeconfigs:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-permissions-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-permissions-openshift-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-permissions-openshift-pki-key-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-permissions-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-permissions-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-permissions-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-permissions-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-permissions-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-permissions-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-permissions-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-permissions-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-permissions-scheduler:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-permissions-scheduler-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-file-permissions-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-permissions-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-permissions-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-file-perms-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-node-worker-kubelet-anonymous-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-kubelet-authorization-mode:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-kubelet-configure-client-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-kubelet-configure-event-creation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-kubelet-configure-tls-cipher-suites:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-kubelet-configure-tls-min-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-kubelet-enable-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-kubelet-enable-client-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-kubelet-enable-iptables-util-chains:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-kubelet-enable-protect-kernel-defaults:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-node-worker-kubelet-enable-protect-kernel-sysctl:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-kubelet-enable-server-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-kubelet-enable-streaming-connections:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-kubelet-eviction-thresholds-set-hard-imagefs-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-kubelet-eviction-thresholds-set-hard-memory-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-kubelet-eviction-thresholds-set-hard-nodefs-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-kubelet-eviction-thresholds-set-hard-nodefs-inodesfree:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-node-worker-reject-unsigned-images-by-default:
+    default_result: FAIL
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-e8-4.12.yml
+++ b/tests/assertions/ocp4/rhcos4-e8-4.12.yml
@@ -1,0 +1,301 @@
+rule_results:
+  e2e-e8-master-accounts-no-uid-except-zero:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-e8-master-audit-rules-dac-modification-chmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-audit-rules-dac-modification-chown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-audit-rules-execution-chcon:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-audit-rules-execution-restorecon:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-audit-rules-execution-semanage:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-audit-rules-execution-setfiles:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-audit-rules-execution-setsebool:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-audit-rules-execution-seunshare:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-audit-rules-kernel-module-loading-delete:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-audit-rules-kernel-module-loading-finit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-audit-rules-kernel-module-loading-init:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-audit-rules-login-events:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-audit-rules-login-events-faillock:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-audit-rules-login-events-lastlog:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-audit-rules-login-events-tallylog:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-audit-rules-networkconfig-modification:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-audit-rules-sysadmin-actions:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-audit-rules-time-adjtimex:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-audit-rules-time-clock-settime:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-audit-rules-time-settimeofday:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-audit-rules-time-stime:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-audit-rules-time-watch-localtime:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-audit-rules-usergroup-modification:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-auditd-data-retention-flush:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-e8-master-auditd-freq:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-e8-master-auditd-local-events:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-e8-master-auditd-log-format:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-e8-master-auditd-name-format:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-auditd-write-logs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-e8-master-configure-crypto-policy:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-configure-ssh-crypto-policy:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-e8-master-no-empty-passwords:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-selinux-policytype:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-e8-master-selinux-state:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-e8-master-sshd-disable-empty-passwords:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-sshd-disable-gssapi-auth:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-sshd-disable-rhosts:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-sshd-disable-root-login:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-e8-master-sshd-disable-user-known-hosts:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-sshd-do-not-permit-user-env:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-sshd-enable-strictmodes:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-sshd-print-last-log:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-sshd-set-loglevel-info:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-sysctl-kernel-dmesg-restrict:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-sysctl-kernel-kptr-restrict:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-e8-master-sysctl-kernel-randomize-va-space:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-sysctl-kernel-unprivileged-bpf-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-sysctl-kernel-yama-ptrace-scope:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-master-sysctl-net-core-bpf-jit-harden:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-accounts-no-uid-except-zero:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-e8-worker-audit-rules-dac-modification-chmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-audit-rules-dac-modification-chown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-audit-rules-execution-chcon:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-audit-rules-execution-restorecon:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-audit-rules-execution-semanage:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-audit-rules-execution-setfiles:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-audit-rules-execution-setsebool:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-audit-rules-execution-seunshare:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-audit-rules-kernel-module-loading-delete:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-audit-rules-kernel-module-loading-finit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-audit-rules-kernel-module-loading-init:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-audit-rules-login-events:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-audit-rules-login-events-faillock:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-audit-rules-login-events-lastlog:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-audit-rules-login-events-tallylog:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-audit-rules-networkconfig-modification:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-audit-rules-sysadmin-actions:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-audit-rules-time-adjtimex:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-audit-rules-time-clock-settime:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-audit-rules-time-settimeofday:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-audit-rules-time-stime:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-audit-rules-time-watch-localtime:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-audit-rules-usergroup-modification:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-auditd-data-retention-flush:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-e8-worker-auditd-freq:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-e8-worker-auditd-local-events:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-e8-worker-auditd-log-format:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-e8-worker-auditd-name-format:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-auditd-write-logs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-e8-worker-configure-crypto-policy:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-configure-ssh-crypto-policy:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-e8-worker-no-empty-passwords:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-selinux-policytype:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-e8-worker-selinux-state:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-e8-worker-sshd-disable-empty-passwords:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-sshd-disable-gssapi-auth:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-sshd-disable-rhosts:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-sshd-disable-root-login:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-e8-worker-sshd-disable-user-known-hosts:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-sshd-do-not-permit-user-env:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-sshd-enable-strictmodes:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-sshd-print-last-log:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-sshd-set-loglevel-info:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-sysctl-kernel-dmesg-restrict:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-sysctl-kernel-kptr-restrict:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-e8-worker-sysctl-kernel-randomize-va-space:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-sysctl-kernel-unprivileged-bpf-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-sysctl-kernel-yama-ptrace-scope:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-e8-worker-sysctl-net-core-bpf-jit-harden:
+    default_result: FAIL
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-high-4.12.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.12.yml
@@ -1,0 +1,1453 @@
+rule_results:
+  e2e-high-master-accounts-no-uid-except-zero:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-dac-modification-chmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-dac-modification-chown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-dac-modification-fchmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-dac-modification-fchmodat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-dac-modification-fchown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-dac-modification-fchownat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-dac-modification-fremovexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-dac-modification-fsetxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-dac-modification-lchown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-dac-modification-lremovexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-dac-modification-lsetxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-dac-modification-removexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-dac-modification-setxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-etc-group-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-etc-group-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-etc-group-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-etc-gshadow-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-etc-gshadow-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-etc-gshadow-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-etc-passwd-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-etc-passwd-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-etc-passwd-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-etc-shadow-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-etc-shadow-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-etc-shadow-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-execution-chcon:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-execution-restorecon:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-execution-semanage:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-execution-setfiles:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-execution-setsebool:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-execution-seunshare:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-file-deletion-events-rename:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-file-deletion-events-renameat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-file-deletion-events-rmdir:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-file-deletion-events-unlink:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-file-deletion-events-unlinkat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-immutable:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-kernel-module-loading-delete:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-kernel-module-loading-finit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-kernel-module-loading-init:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-login-events-faillock:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-login-events-lastlog:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-login-events-tallylog:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-mac-modification:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-media-export:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-networkconfig-modification:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-chage:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-chsh:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-crontab:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-gpasswd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-mount:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-newgidmap:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-newgrp:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-newuidmap:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-pam-timestamp-check:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-passwd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-postdrop:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-postqueue:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-pt-chown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-ssh-keysign:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-su:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-sudo:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-sudoedit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-umount:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-unix-chkpwd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-userhelper:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-usernetctl:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-session-events:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-sysadmin-actions:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-time-adjtimex:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-time-clock-settime:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-time-settimeofday:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-time-stime:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-time-watch-localtime:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-chmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-chown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-creat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-fchmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-fchmodat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-fchown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-fchownat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-fremovexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-fsetxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-ftruncate:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-lchown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-lremovexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-lsetxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-open-by-handle-at-o-creat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-open-by-handle-at-o-trunc-write:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-open-by-handle-at-rule-order:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-open-o-creat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-open-rule-order:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-openat-o-creat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-openat-o-trunc-write:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-openat-rule-order:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-removexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-rename:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-renameat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-setxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-truncate:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-unlink:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-unlinkat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-usergroup-modification-group:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-usergroup-modification-gshadow:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-usergroup-modification-opasswd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-usergroup-modification-passwd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-usergroup-modification-shadow:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-auditd-data-disk-error-action:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-auditd-data-disk-full-action:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-auditd-data-retention-admin-space-left-action:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-auditd-data-retention-flush:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-auditd-data-retention-max-log-file:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-auditd-data-retention-max-log-file-action:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-auditd-data-retention-num-logs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-auditd-data-retention-space-left:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-auditd-data-retention-space-left-action:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-auditd-freq:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-auditd-local-events:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-auditd-log-format:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-auditd-name-format:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-auditd-write-logs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-banner-etc-issue:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-bios-disable-usb-boot:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-master-chronyd-client-only:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-chronyd-no-chronyc-network:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-chronyd-or-ntpd-set-maxpoll:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-chronyd-or-ntpd-specify-multiple-servers:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-chronyd-or-ntpd-specify-remote-server:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-configure-crypto-policy:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-configure-kerberos-crypto-policy:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-configure-openssl-crypto-policy:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-configure-ssh-crypto-policy:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-configure-usbguard-auditbackend:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: PASS
+  e2e-high-master-coredump-disable-backtraces:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-coredump-disable-storage:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-coreos-audit-backlog-limit-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-coreos-audit-option:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-coreos-disable-interactive-boot:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-coreos-enable-selinux-kernel-argument:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-coreos-nousb-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-coreos-page-poison-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-coreos-pti-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-coreos-vsyscall-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-directory-access-var-log-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-directory-permissions-var-log-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-disable-ctrlaltdel-burstaction:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-disable-ctrlaltdel-reboot:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-disable-users-coredumps:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-enable-fips-mode:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-ensure-logrotate-activated:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-file-groupowner-sshd-config:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-file-owner-sshd-config:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-file-ownership-var-log-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-file-permissions-sshd-config:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-file-permissions-sshd-private-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-file-permissions-sshd-pub-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-file-permissions-var-log-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-atm-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-bluetooth-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-can-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-cfg80211-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-cramfs-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-firewire-core-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-freevxfs-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-hfs-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-hfsplus-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-iwlmvm-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-iwlwifi-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-jffs2-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-mac80211-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-sctp-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-squashfs-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-tipc-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-udf-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-usb-storage-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-no-direct-root-logins:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-no-empty-passwords:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-no-netrc-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-no-shelllogin-for-systemaccounts:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-no-tmux-in-shells:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-package-audit-installed:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-package-iptables-installed:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-master-package-iptables-nft-installed:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-master-package-sudo-installed:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-package-usbguard-installed:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-partition-for-var-log:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-master-partition-for-var-log-audit:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-master-require-singleuser-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-selinux-policytype:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-selinux-state:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-service-auditd-enabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-service-autofs-disabled:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-master-service-bluetooth-disabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-service-chronyd-or-ntpd-enabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-service-debug-shell-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-service-sshd-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-service-systemd-coredump-disabled:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-high-master-service-usbguard-enabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sshd-disable-rhosts:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sshd-limit-user-access:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-high-master-sshd-set-idle-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sshd-set-keepalive:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-fs-protected-hardlinks:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-fs-protected-symlinks:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-kernel-core-pattern:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-kernel-dmesg-restrict:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-kernel-kexec-load-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-kernel-kptr-restrict:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-kernel-perf-event-paranoid:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-kernel-unprivileged-bpf-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-kernel-yama-ptrace-scope:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-core-bpf-jit-harden:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-conf-all-accept-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-conf-all-accept-source-route:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-conf-all-log-martians:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-conf-all-rp-filter:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-conf-all-secure-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-conf-all-send-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-conf-default-accept-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-conf-default-accept-source-route:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-conf-default-log-martians:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-conf-default-rp-filter:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-conf-default-secure-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-conf-default-send-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-icmp-echo-ignore-broadcasts:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-icmp-ignore-bogus-error-responses:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-tcp-syncookies:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv6-conf-all-accept-ra:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv6-conf-all-accept-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv6-conf-all-accept-source-route:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv6-conf-default-accept-ra:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv6-conf-default-accept-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv6-conf-default-accept-source-route:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-usbguard-allow-hid-and-hub:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-wireless-disable-in-bios:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-master-wireless-disable-interfaces:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-worker-accounts-no-uid-except-zero:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-dac-modification-chmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-dac-modification-chown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-dac-modification-fchmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-dac-modification-fchmodat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-dac-modification-fchown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-dac-modification-fchownat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-dac-modification-fremovexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-dac-modification-fsetxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-dac-modification-lchown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-dac-modification-lremovexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-dac-modification-lsetxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-dac-modification-removexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-dac-modification-setxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-etc-group-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-etc-group-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-etc-group-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-etc-gshadow-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-etc-gshadow-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-etc-gshadow-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-etc-passwd-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-etc-passwd-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-etc-passwd-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-etc-shadow-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-etc-shadow-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-etc-shadow-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-execution-chcon:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-execution-restorecon:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-execution-semanage:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-execution-setfiles:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-execution-setsebool:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-execution-seunshare:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-file-deletion-events-rename:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-file-deletion-events-renameat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-file-deletion-events-rmdir:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-file-deletion-events-unlink:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-file-deletion-events-unlinkat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-immutable:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-kernel-module-loading-delete:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-kernel-module-loading-finit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-kernel-module-loading-init:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-login-events-faillock:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-login-events-lastlog:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-login-events-tallylog:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-mac-modification:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-media-export:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-networkconfig-modification:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-chage:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-chsh:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-crontab:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-gpasswd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-mount:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-newgidmap:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-newgrp:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-newuidmap:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-pam-timestamp-check:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-passwd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-postdrop:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-postqueue:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-pt-chown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-ssh-keysign:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-su:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-sudo:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-sudoedit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-umount:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-unix-chkpwd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-userhelper:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-usernetctl:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-session-events:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-sysadmin-actions:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-time-adjtimex:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-time-clock-settime:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-time-settimeofday:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-time-stime:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-time-watch-localtime:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-chmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-chown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-creat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-fchmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-fchmodat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-fchown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-fchownat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-fremovexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-fsetxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-ftruncate:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-lchown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-lremovexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-lsetxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at-o-creat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at-o-trunc-write:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at-rule-order:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-open-o-creat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-open-rule-order:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-openat-o-creat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-openat-o-trunc-write:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-openat-rule-order:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-removexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-rename:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-renameat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-setxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-truncate:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-unlink:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-unlinkat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-usergroup-modification-group:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-usergroup-modification-gshadow:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-usergroup-modification-opasswd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-usergroup-modification-passwd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-usergroup-modification-shadow:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-auditd-data-disk-error-action:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-auditd-data-disk-full-action:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-auditd-data-retention-admin-space-left-action:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-auditd-data-retention-flush:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-auditd-data-retention-max-log-file:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-auditd-data-retention-max-log-file-action:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-auditd-data-retention-num-logs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-auditd-data-retention-space-left:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-auditd-data-retention-space-left-action:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-auditd-freq:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-auditd-local-events:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-auditd-log-format:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-auditd-name-format:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-auditd-write-logs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-banner-etc-issue:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-bios-disable-usb-boot:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-worker-chronyd-client-only:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-chronyd-no-chronyc-network:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-chronyd-or-ntpd-set-maxpoll:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-chronyd-or-ntpd-specify-multiple-servers:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-chronyd-or-ntpd-specify-remote-server:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-configure-crypto-policy:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-configure-kerberos-crypto-policy:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-configure-openssl-crypto-policy:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-configure-ssh-crypto-policy:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-configure-usbguard-auditbackend:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: PASS
+  e2e-high-worker-coredump-disable-backtraces:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-coredump-disable-storage:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-coreos-audit-backlog-limit-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-coreos-audit-option:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-coreos-disable-interactive-boot:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-coreos-enable-selinux-kernel-argument:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-coreos-nousb-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-coreos-page-poison-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-coreos-pti-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-coreos-vsyscall-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-directory-access-var-log-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-directory-permissions-var-log-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-disable-ctrlaltdel-burstaction:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-disable-ctrlaltdel-reboot:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-disable-users-coredumps:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-enable-fips-mode:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-ensure-logrotate-activated:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-file-groupowner-sshd-config:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-file-owner-sshd-config:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-file-ownership-var-log-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-file-permissions-sshd-config:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-file-permissions-sshd-private-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-file-permissions-sshd-pub-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-file-permissions-var-log-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-atm-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-bluetooth-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-can-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-cfg80211-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-cramfs-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-firewire-core-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-freevxfs-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-hfs-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-hfsplus-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-iwlmvm-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-iwlwifi-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-jffs2-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-mac80211-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-sctp-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-squashfs-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-tipc-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-udf-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-usb-storage-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-no-direct-root-logins:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-no-empty-passwords:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-no-netrc-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-no-shelllogin-for-systemaccounts:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-no-tmux-in-shells:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-package-audit-installed:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-package-iptables-installed:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-worker-package-iptables-nft-installed:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-worker-package-sudo-installed:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-package-usbguard-installed:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-partition-for-var-log:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-worker-partition-for-var-log-audit:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-worker-require-singleuser-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-selinux-policytype:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-selinux-state:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-service-auditd-enabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-service-autofs-disabled:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-worker-service-bluetooth-disabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-service-chronyd-or-ntpd-enabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-service-debug-shell-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-service-sshd-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-service-systemd-coredump-disabled:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-high-worker-service-usbguard-enabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sshd-disable-rhosts:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sshd-limit-user-access:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-high-worker-sshd-set-idle-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sshd-set-keepalive:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-fs-protected-hardlinks:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-fs-protected-symlinks:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-kernel-core-pattern:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-kernel-dmesg-restrict:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-kernel-kexec-load-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-kernel-kptr-restrict:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-kernel-perf-event-paranoid:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-kernel-unprivileged-bpf-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-kernel-yama-ptrace-scope:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-core-bpf-jit-harden:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-conf-all-accept-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-conf-all-accept-source-route:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-conf-all-log-martians:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-conf-all-rp-filter:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-conf-all-secure-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-conf-all-send-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-conf-default-accept-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-conf-default-accept-source-route:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-conf-default-log-martians:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-conf-default-rp-filter:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-conf-default-secure-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-conf-default-send-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-icmp-echo-ignore-broadcasts:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-icmp-ignore-bogus-error-responses:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-tcp-syncookies:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv6-conf-all-accept-ra:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv6-conf-all-accept-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv6-conf-all-accept-source-route:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv6-conf-default-accept-ra:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv6-conf-default-accept-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv6-conf-default-accept-source-route:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-usbguard-allow-hid-and-hub:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-wireless-disable-in-bios:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-worker-wireless-disable-interfaces:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/rhcos4-high-4.2.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.2.yml
@@ -1,0 +1,1453 @@
+rule_results:
+  e2e-high-master-accounts-no-uid-except-zero:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-dac-modification-chmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-dac-modification-chown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-dac-modification-fchmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-dac-modification-fchmodat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-dac-modification-fchown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-dac-modification-fchownat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-dac-modification-fremovexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-dac-modification-fsetxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-dac-modification-lchown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-dac-modification-lremovexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-dac-modification-lsetxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-dac-modification-removexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-dac-modification-setxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-etc-group-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-etc-group-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-etc-group-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-etc-gshadow-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-etc-gshadow-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-etc-gshadow-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-etc-passwd-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-etc-passwd-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-etc-passwd-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-etc-shadow-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-etc-shadow-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-etc-shadow-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-execution-chcon:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-execution-restorecon:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-execution-semanage:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-execution-setfiles:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-execution-setsebool:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-execution-seunshare:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-file-deletion-events-rename:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-file-deletion-events-renameat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-file-deletion-events-rmdir:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-file-deletion-events-unlink:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-file-deletion-events-unlinkat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-immutable:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-kernel-module-loading-delete:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-kernel-module-loading-finit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-kernel-module-loading-init:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-login-events-faillock:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-login-events-lastlog:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-login-events-tallylog:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-mac-modification:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-media-export:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-networkconfig-modification:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-chage:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-chsh:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-crontab:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-gpasswd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-mount:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-newgidmap:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-newgrp:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-newuidmap:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-pam-timestamp-check:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-passwd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-postdrop:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-postqueue:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-pt-chown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-ssh-keysign:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-su:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-sudo:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-sudoedit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-umount:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-unix-chkpwd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-userhelper:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-privileged-commands-usernetctl:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-session-events:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-sysadmin-actions:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-time-adjtimex:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-time-clock-settime:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-time-settimeofday:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-time-stime:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-time-watch-localtime:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-chmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-chown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-creat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-fchmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-fchmodat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-fchown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-fchownat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-fremovexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-fsetxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-ftruncate:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-lchown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-lremovexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-lsetxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-open-by-handle-at-o-creat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-open-by-handle-at-o-trunc-write:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-open-by-handle-at-rule-order:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-open-o-creat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-open-rule-order:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-openat-o-creat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-openat-o-trunc-write:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-openat-rule-order:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-removexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-rename:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-renameat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-setxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-truncate:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-unlink:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-unsuccessful-file-modification-unlinkat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-usergroup-modification-group:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-usergroup-modification-gshadow:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-usergroup-modification-opasswd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-usergroup-modification-passwd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-audit-rules-usergroup-modification-shadow:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-auditd-data-disk-error-action:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-auditd-data-disk-full-action:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-auditd-data-retention-admin-space-left-action:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-auditd-data-retention-flush:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-auditd-data-retention-max-log-file:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-auditd-data-retention-max-log-file-action:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-auditd-data-retention-num-logs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-auditd-data-retention-space-left:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-auditd-data-retention-space-left-action:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-auditd-freq:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-auditd-local-events:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-auditd-log-format:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-auditd-name-format:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-auditd-write-logs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-banner-etc-issue:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-bios-disable-usb-boot:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-master-chronyd-client-only:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-chronyd-no-chronyc-network:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-chronyd-or-ntpd-set-maxpoll:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-chronyd-or-ntpd-specify-multiple-servers:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-chronyd-or-ntpd-specify-remote-server:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-configure-crypto-policy:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-configure-kerberos-crypto-policy:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-configure-openssl-crypto-policy:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-configure-ssh-crypto-policy:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-configure-usbguard-auditbackend:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: PASS
+  e2e-high-master-coredump-disable-backtraces:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-coredump-disable-storage:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-coreos-audit-backlog-limit-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-coreos-audit-option:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-coreos-disable-interactive-boot:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-coreos-enable-selinux-kernel-argument:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-coreos-nousb-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-coreos-page-poison-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-coreos-pti-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-coreos-vsyscall-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-directory-access-var-log-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-directory-permissions-var-log-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-disable-ctrlaltdel-burstaction:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-disable-ctrlaltdel-reboot:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-disable-users-coredumps:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-enable-fips-mode:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-ensure-logrotate-activated:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-file-groupowner-sshd-config:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-file-owner-sshd-config:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-file-ownership-var-log-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-file-permissions-sshd-config:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-file-permissions-sshd-private-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-file-permissions-sshd-pub-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-file-permissions-var-log-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-atm-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-bluetooth-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-can-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-cfg80211-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-cramfs-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-firewire-core-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-freevxfs-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-hfs-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-hfsplus-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-iwlmvm-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-iwlwifi-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-jffs2-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-mac80211-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-sctp-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-squashfs-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-tipc-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-udf-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-kernel-module-usb-storage-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-no-direct-root-logins:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-no-empty-passwords:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-no-netrc-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-no-shelllogin-for-systemaccounts:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-no-tmux-in-shells:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-package-audit-installed:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-package-iptables-installed:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-master-package-iptables-nft-installed:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-master-package-sudo-installed:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-package-usbguard-installed:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-partition-for-var-log:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-master-partition-for-var-log-audit:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-master-require-singleuser-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-selinux-policytype:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-selinux-state:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-service-auditd-enabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-service-autofs-disabled:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-master-service-bluetooth-disabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-service-chronyd-or-ntpd-enabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-service-debug-shell-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-service-sshd-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-service-systemd-coredump-disabled:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-high-master-service-usbguard-enabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sshd-disable-rhosts:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sshd-limit-user-access:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-high-master-sshd-set-idle-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sshd-set-keepalive:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-fs-protected-hardlinks:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-fs-protected-symlinks:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-kernel-core-pattern:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-kernel-dmesg-restrict:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-kernel-kexec-load-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-kernel-kptr-restrict:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-kernel-perf-event-paranoid:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-kernel-unprivileged-bpf-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-kernel-yama-ptrace-scope:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-core-bpf-jit-harden:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-conf-all-accept-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-conf-all-accept-source-route:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-conf-all-log-martians:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-conf-all-rp-filter:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-conf-all-secure-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-conf-all-send-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-conf-default-accept-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-conf-default-accept-source-route:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-conf-default-log-martians:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-conf-default-rp-filter:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-conf-default-secure-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-conf-default-send-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-icmp-echo-ignore-broadcasts:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-icmp-ignore-bogus-error-responses:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv4-tcp-syncookies:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv6-conf-all-accept-ra:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv6-conf-all-accept-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv6-conf-all-accept-source-route:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv6-conf-default-accept-ra:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv6-conf-default-accept-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-sysctl-net-ipv6-conf-default-accept-source-route:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-usbguard-allow-hid-and-hub:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-master-wireless-disable-in-bios:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-master-wireless-disable-interfaces:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-worker-accounts-no-uid-except-zero:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-dac-modification-chmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-dac-modification-chown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-dac-modification-fchmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-dac-modification-fchmodat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-dac-modification-fchown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-dac-modification-fchownat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-dac-modification-fremovexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-dac-modification-fsetxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-dac-modification-lchown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-dac-modification-lremovexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-dac-modification-lsetxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-dac-modification-removexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-dac-modification-setxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-etc-group-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-etc-group-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-etc-group-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-etc-gshadow-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-etc-gshadow-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-etc-gshadow-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-etc-passwd-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-etc-passwd-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-etc-passwd-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-etc-shadow-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-etc-shadow-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-etc-shadow-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-execution-chcon:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-execution-restorecon:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-execution-semanage:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-execution-setfiles:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-execution-setsebool:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-execution-seunshare:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-file-deletion-events-rename:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-file-deletion-events-renameat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-file-deletion-events-rmdir:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-file-deletion-events-unlink:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-file-deletion-events-unlinkat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-immutable:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-kernel-module-loading-delete:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-kernel-module-loading-finit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-kernel-module-loading-init:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-login-events-faillock:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-login-events-lastlog:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-login-events-tallylog:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-mac-modification:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-media-export:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-networkconfig-modification:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-chage:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-chsh:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-crontab:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-gpasswd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-mount:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-newgidmap:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-newgrp:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-newuidmap:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-pam-timestamp-check:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-passwd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-postdrop:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-postqueue:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-pt-chown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-ssh-keysign:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-su:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-sudo:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-sudoedit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-umount:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-unix-chkpwd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-userhelper:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-privileged-commands-usernetctl:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-session-events:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-sysadmin-actions:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-time-adjtimex:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-time-clock-settime:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-time-settimeofday:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-time-stime:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-time-watch-localtime:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-chmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-chown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-creat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-fchmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-fchmodat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-fchown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-fchownat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-fremovexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-fsetxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-ftruncate:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-lchown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-lremovexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-lsetxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at-o-creat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at-o-trunc-write:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at-rule-order:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-open-o-creat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-open-rule-order:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-openat-o-creat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-openat-o-trunc-write:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-openat-rule-order:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-removexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-rename:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-renameat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-setxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-truncate:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-unlink:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-unsuccessful-file-modification-unlinkat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-usergroup-modification-group:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-usergroup-modification-gshadow:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-usergroup-modification-opasswd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-usergroup-modification-passwd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-audit-rules-usergroup-modification-shadow:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-auditd-data-disk-error-action:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-auditd-data-disk-full-action:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-auditd-data-retention-admin-space-left-action:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-auditd-data-retention-flush:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-auditd-data-retention-max-log-file:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-auditd-data-retention-max-log-file-action:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-auditd-data-retention-num-logs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-auditd-data-retention-space-left:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-auditd-data-retention-space-left-action:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-auditd-freq:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-auditd-local-events:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-auditd-log-format:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-auditd-name-format:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-auditd-write-logs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-banner-etc-issue:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-bios-disable-usb-boot:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-worker-chronyd-client-only:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-chronyd-no-chronyc-network:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-chronyd-or-ntpd-set-maxpoll:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-chronyd-or-ntpd-specify-multiple-servers:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-chronyd-or-ntpd-specify-remote-server:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-configure-crypto-policy:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-configure-kerberos-crypto-policy:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-configure-openssl-crypto-policy:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-configure-ssh-crypto-policy:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-configure-usbguard-auditbackend:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: PASS
+  e2e-high-worker-coredump-disable-backtraces:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-coredump-disable-storage:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-coreos-audit-backlog-limit-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-coreos-audit-option:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-coreos-disable-interactive-boot:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-coreos-enable-selinux-kernel-argument:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-coreos-nousb-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-coreos-page-poison-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-coreos-pti-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-coreos-vsyscall-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-directory-access-var-log-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-directory-permissions-var-log-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-disable-ctrlaltdel-burstaction:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-disable-ctrlaltdel-reboot:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-disable-users-coredumps:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-enable-fips-mode:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-ensure-logrotate-activated:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-file-groupowner-sshd-config:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-file-owner-sshd-config:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-file-ownership-var-log-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-file-permissions-sshd-config:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-file-permissions-sshd-private-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-file-permissions-sshd-pub-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-file-permissions-var-log-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-atm-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-bluetooth-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-can-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-cfg80211-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-cramfs-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-firewire-core-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-freevxfs-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-hfs-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-hfsplus-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-iwlmvm-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-iwlwifi-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-jffs2-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-mac80211-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-sctp-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-squashfs-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-tipc-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-udf-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-kernel-module-usb-storage-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-no-direct-root-logins:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-no-empty-passwords:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-no-netrc-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-no-shelllogin-for-systemaccounts:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-no-tmux-in-shells:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-package-audit-installed:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-package-iptables-installed:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-worker-package-iptables-nft-installed:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-worker-package-sudo-installed:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-package-usbguard-installed:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-partition-for-var-log:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-worker-partition-for-var-log-audit:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-worker-require-singleuser-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-selinux-policytype:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-selinux-state:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-service-auditd-enabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-service-autofs-disabled:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-high-worker-service-bluetooth-disabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-service-chronyd-or-ntpd-enabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-service-debug-shell-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-service-sshd-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-service-systemd-coredump-disabled:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-high-worker-service-usbguard-enabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sshd-disable-rhosts:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sshd-limit-user-access:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-high-worker-sshd-set-idle-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sshd-set-keepalive:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-fs-protected-hardlinks:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-fs-protected-symlinks:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-kernel-core-pattern:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-kernel-dmesg-restrict:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-kernel-kexec-load-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-kernel-kptr-restrict:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-kernel-perf-event-paranoid:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-kernel-unprivileged-bpf-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-kernel-yama-ptrace-scope:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-core-bpf-jit-harden:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-conf-all-accept-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-conf-all-accept-source-route:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-conf-all-log-martians:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-conf-all-rp-filter:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-conf-all-secure-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-conf-all-send-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-conf-default-accept-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-conf-default-accept-source-route:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-conf-default-log-martians:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-conf-default-rp-filter:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-conf-default-secure-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-conf-default-send-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-icmp-echo-ignore-broadcasts:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-icmp-ignore-bogus-error-responses:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv4-tcp-syncookies:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv6-conf-all-accept-ra:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv6-conf-all-accept-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv6-conf-all-accept-source-route:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv6-conf-default-accept-ra:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv6-conf-default-accept-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-sysctl-net-ipv6-conf-default-accept-source-route:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-usbguard-allow-hid-and-hub:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-high-worker-wireless-disable-in-bios:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-high-worker-wireless-disable-interfaces:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/rhcos4-moderate-4.12.yml
+++ b/tests/assertions/ocp4/rhcos4-moderate-4.12.yml
@@ -1,0 +1,1447 @@
+rule_results:
+  e2e-moderate-master-accounts-no-uid-except-zero:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-dac-modification-chmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-dac-modification-chown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-dac-modification-fchmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-dac-modification-fchmodat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-dac-modification-fchown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-dac-modification-fchownat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-dac-modification-fremovexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-dac-modification-fsetxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-dac-modification-lchown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-dac-modification-lremovexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-dac-modification-lsetxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-dac-modification-removexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-dac-modification-setxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-etc-group-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-etc-group-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-etc-group-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-etc-gshadow-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-etc-gshadow-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-etc-gshadow-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-etc-passwd-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-etc-passwd-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-etc-passwd-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-etc-shadow-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-etc-shadow-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-etc-shadow-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-execution-chcon:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-execution-restorecon:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-execution-semanage:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-execution-setfiles:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-execution-setsebool:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-execution-seunshare:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-file-deletion-events-rename:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-file-deletion-events-renameat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-file-deletion-events-rmdir:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-file-deletion-events-unlink:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-file-deletion-events-unlinkat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-immutable:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-kernel-module-loading-delete:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-kernel-module-loading-finit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-kernel-module-loading-init:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-login-events-faillock:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-login-events-lastlog:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-login-events-tallylog:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-mac-modification:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-media-export:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-networkconfig-modification:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-privileged-commands-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-privileged-commands-chage:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-privileged-commands-chsh:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-privileged-commands-crontab:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-privileged-commands-gpasswd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-privileged-commands-mount:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-privileged-commands-newgidmap:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-privileged-commands-newgrp:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-privileged-commands-newuidmap:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-privileged-commands-pam-timestamp-check:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-privileged-commands-passwd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-privileged-commands-postdrop:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-privileged-commands-postqueue:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-privileged-commands-pt-chown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-privileged-commands-ssh-keysign:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-privileged-commands-su:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-privileged-commands-sudo:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-privileged-commands-sudoedit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-privileged-commands-umount:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-privileged-commands-unix-chkpwd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-privileged-commands-userhelper:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-privileged-commands-usernetctl:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-session-events:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-sysadmin-actions:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-time-adjtimex:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-time-clock-settime:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-time-settimeofday:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-time-stime:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-time-watch-localtime:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-chmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-chown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-creat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-fchmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-fchmodat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-fchown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-fchownat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-fremovexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-fsetxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-ftruncate:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-lchown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-lremovexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-lsetxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-by-handle-at-o-creat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-by-handle-at-o-trunc-write:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-by-handle-at-rule-order:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-o-creat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-rule-order:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-openat-o-creat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-openat-o-trunc-write:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-openat-rule-order:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-removexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-rename:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-renameat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-setxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-truncate:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-unlink:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-unsuccessful-file-modification-unlinkat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-usergroup-modification-group:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-usergroup-modification-gshadow:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-usergroup-modification-opasswd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-usergroup-modification-passwd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-audit-rules-usergroup-modification-shadow:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-auditd-data-disk-error-action:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-auditd-data-disk-full-action:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-auditd-data-retention-admin-space-left-action:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-auditd-data-retention-flush:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-auditd-data-retention-max-log-file:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-auditd-data-retention-max-log-file-action:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-auditd-data-retention-num-logs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-auditd-data-retention-space-left:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-auditd-data-retention-space-left-action:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-auditd-freq:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-auditd-local-events:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-auditd-log-format:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-auditd-name-format:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-auditd-write-logs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-banner-etc-issue:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-bios-disable-usb-boot:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-master-chronyd-client-only:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-chronyd-no-chronyc-network:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-chronyd-or-ntpd-set-maxpoll:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-chronyd-or-ntpd-specify-multiple-servers:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-chronyd-or-ntpd-specify-remote-server:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-configure-crypto-policy:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-configure-kerberos-crypto-policy:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-configure-openssl-crypto-policy:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-configure-ssh-crypto-policy:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-configure-usbguard-auditbackend:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: PASS
+  e2e-moderate-master-coredump-disable-backtraces:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-coredump-disable-storage:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-coreos-audit-backlog-limit-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-coreos-audit-option:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-coreos-disable-interactive-boot:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-coreos-enable-selinux-kernel-argument:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-coreos-nousb-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-coreos-page-poison-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-coreos-pti-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-coreos-vsyscall-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-directory-access-var-log-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-directory-permissions-var-log-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-disable-ctrlaltdel-burstaction:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-disable-ctrlaltdel-reboot:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-disable-users-coredumps:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-enable-fips-mode:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-ensure-logrotate-activated:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-file-groupowner-sshd-config:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-file-owner-sshd-config:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-file-ownership-var-log-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-file-permissions-sshd-config:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-file-permissions-sshd-private-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-file-permissions-sshd-pub-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-file-permissions-var-log-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-kernel-module-atm-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-kernel-module-bluetooth-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-kernel-module-can-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-kernel-module-cfg80211-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-kernel-module-cramfs-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-kernel-module-firewire-core-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-kernel-module-freevxfs-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-kernel-module-hfs-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-kernel-module-hfsplus-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-kernel-module-iwlmvm-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-kernel-module-iwlwifi-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-kernel-module-jffs2-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-kernel-module-mac80211-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-kernel-module-sctp-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-kernel-module-squashfs-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-kernel-module-tipc-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-kernel-module-udf-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-kernel-module-usb-storage-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-no-direct-root-logins:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-no-empty-passwords:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-no-netrc-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-no-shelllogin-for-systemaccounts:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-no-tmux-in-shells:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-package-audit-installed:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-package-iptables-installed:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-master-package-iptables-nft-installed:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-master-package-sudo-installed:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-package-usbguard-installed:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-partition-for-var-log:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-master-partition-for-var-log-audit:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-master-require-singleuser-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-selinux-policytype:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-selinux-state:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-service-auditd-enabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-service-autofs-disabled:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-master-service-bluetooth-disabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-service-chronyd-or-ntpd-enabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-service-debug-shell-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-service-systemd-coredump-disabled:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-moderate-master-service-usbguard-enabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sshd-disable-rhosts:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sshd-limit-user-access:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-moderate-master-sshd-set-idle-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sshd-set-keepalive:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-fs-protected-hardlinks:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-fs-protected-symlinks:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-kernel-core-pattern:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-kernel-dmesg-restrict:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-kernel-kexec-load-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-kernel-kptr-restrict:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-kernel-perf-event-paranoid:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-kernel-unprivileged-bpf-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-kernel-yama-ptrace-scope:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-net-core-bpf-jit-harden:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-net-ipv4-conf-all-accept-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-net-ipv4-conf-all-accept-source-route:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-net-ipv4-conf-all-log-martians:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-net-ipv4-conf-all-rp-filter:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-net-ipv4-conf-all-secure-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-net-ipv4-conf-all-send-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-net-ipv4-conf-default-accept-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-net-ipv4-conf-default-accept-source-route:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-net-ipv4-conf-default-log-martians:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-net-ipv4-conf-default-rp-filter:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-net-ipv4-conf-default-secure-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-net-ipv4-conf-default-send-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-net-ipv4-icmp-echo-ignore-broadcasts:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-net-ipv4-icmp-ignore-bogus-error-responses:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-net-ipv4-tcp-syncookies:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-net-ipv6-conf-all-accept-ra:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-net-ipv6-conf-all-accept-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-net-ipv6-conf-all-accept-source-route:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-net-ipv6-conf-default-accept-ra:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-net-ipv6-conf-default-accept-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-sysctl-net-ipv6-conf-default-accept-source-route:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-usbguard-allow-hid-and-hub:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-master-wireless-disable-in-bios:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-master-wireless-disable-interfaces:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-worker-accounts-no-uid-except-zero:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-dac-modification-chmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-dac-modification-chown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-dac-modification-fchmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-dac-modification-fchmodat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-dac-modification-fchown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-dac-modification-fchownat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-dac-modification-fremovexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-dac-modification-fsetxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-dac-modification-lchown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-dac-modification-lremovexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-dac-modification-lsetxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-dac-modification-removexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-dac-modification-setxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-etc-group-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-etc-group-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-etc-group-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-etc-gshadow-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-etc-gshadow-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-etc-gshadow-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-etc-passwd-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-etc-passwd-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-etc-passwd-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-etc-shadow-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-etc-shadow-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-etc-shadow-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-execution-chcon:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-execution-restorecon:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-execution-semanage:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-execution-setfiles:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-execution-setsebool:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-execution-seunshare:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-file-deletion-events-rename:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-file-deletion-events-renameat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-file-deletion-events-rmdir:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-file-deletion-events-unlink:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-file-deletion-events-unlinkat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-immutable:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-kernel-module-loading-delete:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-kernel-module-loading-finit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-kernel-module-loading-init:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-login-events-faillock:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-login-events-lastlog:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-login-events-tallylog:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-mac-modification:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-media-export:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-networkconfig-modification:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-privileged-commands-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-privileged-commands-chage:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-privileged-commands-chsh:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-privileged-commands-crontab:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-privileged-commands-gpasswd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-privileged-commands-mount:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-privileged-commands-newgidmap:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-privileged-commands-newgrp:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-privileged-commands-newuidmap:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-privileged-commands-pam-timestamp-check:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-privileged-commands-passwd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-privileged-commands-postdrop:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-privileged-commands-postqueue:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-privileged-commands-pt-chown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-privileged-commands-ssh-keysign:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-privileged-commands-su:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-privileged-commands-sudo:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-privileged-commands-sudoedit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-privileged-commands-umount:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-privileged-commands-unix-chkpwd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-privileged-commands-userhelper:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-privileged-commands-usernetctl:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-session-events:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-sysadmin-actions:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-time-adjtimex:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-time-clock-settime:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-time-settimeofday:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-time-stime:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-time-watch-localtime:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-chmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-chown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-creat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-fchmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-fchmodat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-fchown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-fchownat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-fremovexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-fsetxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-ftruncate:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-lchown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-lremovexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-lsetxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at-o-creat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at-o-trunc-write:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at-rule-order:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-o-creat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-rule-order:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-openat-o-creat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-openat-o-trunc-write:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-openat-rule-order:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-removexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-rename:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-renameat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-setxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-truncate:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-unlink:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-unsuccessful-file-modification-unlinkat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-usergroup-modification-group:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-usergroup-modification-gshadow:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-usergroup-modification-opasswd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-usergroup-modification-passwd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-audit-rules-usergroup-modification-shadow:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-auditd-data-disk-error-action:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-auditd-data-disk-full-action:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-auditd-data-retention-admin-space-left-action:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-auditd-data-retention-flush:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-auditd-data-retention-max-log-file:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-auditd-data-retention-max-log-file-action:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-auditd-data-retention-num-logs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-auditd-data-retention-space-left:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-auditd-data-retention-space-left-action:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-auditd-freq:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-auditd-local-events:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-auditd-log-format:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-auditd-name-format:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-auditd-write-logs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-banner-etc-issue:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-bios-disable-usb-boot:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-worker-chronyd-client-only:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-chronyd-no-chronyc-network:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-chronyd-or-ntpd-set-maxpoll:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-chronyd-or-ntpd-specify-multiple-servers:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-chronyd-or-ntpd-specify-remote-server:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-configure-crypto-policy:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-configure-kerberos-crypto-policy:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-configure-openssl-crypto-policy:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-configure-ssh-crypto-policy:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-configure-usbguard-auditbackend:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: PASS
+  e2e-moderate-worker-coredump-disable-backtraces:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-coredump-disable-storage:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-coreos-audit-backlog-limit-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-coreos-audit-option:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-coreos-disable-interactive-boot:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-coreos-enable-selinux-kernel-argument:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-coreos-nousb-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-coreos-page-poison-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-coreos-pti-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-coreos-vsyscall-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-directory-access-var-log-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-directory-permissions-var-log-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-disable-ctrlaltdel-burstaction:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-disable-ctrlaltdel-reboot:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-disable-users-coredumps:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-enable-fips-mode:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-ensure-logrotate-activated:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-file-groupowner-sshd-config:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-file-owner-sshd-config:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-file-ownership-var-log-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-file-permissions-sshd-config:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-file-permissions-sshd-private-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-file-permissions-sshd-pub-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-file-permissions-var-log-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-kernel-module-atm-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-kernel-module-bluetooth-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-kernel-module-can-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-kernel-module-cfg80211-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-kernel-module-cramfs-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-kernel-module-firewire-core-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-kernel-module-freevxfs-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-kernel-module-hfs-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-kernel-module-hfsplus-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-kernel-module-iwlmvm-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-kernel-module-iwlwifi-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-kernel-module-jffs2-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-kernel-module-mac80211-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-kernel-module-sctp-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-kernel-module-squashfs-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-kernel-module-tipc-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-kernel-module-udf-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-kernel-module-usb-storage-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-no-direct-root-logins:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-no-empty-passwords:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-no-netrc-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-no-shelllogin-for-systemaccounts:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-no-tmux-in-shells:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-package-audit-installed:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-package-iptables-installed:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-worker-package-iptables-nft-installed:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-worker-package-sudo-installed:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-package-usbguard-installed:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-partition-for-var-log:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-worker-partition-for-var-log-audit:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-worker-require-singleuser-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-selinux-policytype:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-selinux-state:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-service-auditd-enabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-service-autofs-disabled:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-moderate-worker-service-bluetooth-disabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-service-chronyd-or-ntpd-enabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-service-debug-shell-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-service-systemd-coredump-disabled:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-moderate-worker-service-usbguard-enabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sshd-disable-rhosts:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sshd-limit-user-access:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-moderate-worker-sshd-set-idle-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sshd-set-keepalive:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-fs-protected-hardlinks:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-fs-protected-symlinks:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-kernel-core-pattern:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-kernel-dmesg-restrict:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-kernel-kexec-load-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-kernel-kptr-restrict:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-kernel-perf-event-paranoid:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-kernel-unprivileged-bpf-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-kernel-yama-ptrace-scope:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-net-core-bpf-jit-harden:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-net-ipv4-conf-all-accept-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-net-ipv4-conf-all-accept-source-route:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-net-ipv4-conf-all-log-martians:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-net-ipv4-conf-all-rp-filter:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-net-ipv4-conf-all-secure-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-net-ipv4-conf-all-send-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-net-ipv4-conf-default-accept-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-net-ipv4-conf-default-accept-source-route:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-net-ipv4-conf-default-log-martians:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-net-ipv4-conf-default-rp-filter:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-net-ipv4-conf-default-secure-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-net-ipv4-conf-default-send-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-net-ipv4-icmp-echo-ignore-broadcasts:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-net-ipv4-icmp-ignore-bogus-error-responses:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-net-ipv4-tcp-syncookies:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-net-ipv6-conf-all-accept-ra:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-net-ipv6-conf-all-accept-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-net-ipv6-conf-all-accept-source-route:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-net-ipv6-conf-default-accept-ra:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-net-ipv6-conf-default-accept-redirects:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-sysctl-net-ipv6-conf-default-accept-source-route:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-usbguard-allow-hid-and-hub:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-moderate-worker-wireless-disable-in-bios:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-moderate-worker-wireless-disable-interfaces:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/rhcos4-stig-4.12.yml
+++ b/tests/assertions/ocp4/rhcos4-stig-4.12.yml
@@ -1,0 +1,715 @@
+rule_results:
+  e2e-stig-master-audit-access-failed:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-create-failed:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-delete-failed:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-immutable-login-uids:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-modify-failed:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-dac-modification-chmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-dac-modification-chown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-dac-modification-fchmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-dac-modification-fchmodat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-dac-modification-fchown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-dac-modification-fchownat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-dac-modification-fremovexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-dac-modification-fsetxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-dac-modification-lchown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-dac-modification-lremovexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-dac-modification-lsetxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-dac-modification-removexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-dac-modification-setxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-dac-modification-umount:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-dac-modification-umount2:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-execution-chcon:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-execution-semanage:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-execution-setfiles:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-execution-setsebool:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-file-deletion-events-rename:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-file-deletion-events-renameat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-file-deletion-events-rmdir:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-file-deletion-events-unlink:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-file-deletion-events-unlinkat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-immutable:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-kernel-module-loading-delete:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-kernel-module-loading-finit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-kernel-module-loading-init:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-login-events-faillock:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-login-events-lastlog:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-login-events-tallylog:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-media-export:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-chage:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-chsh:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-crontab:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-dbus-daemon-launch-helper:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-fusermount:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-fusermount3:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-gpasswd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-grub2-set-bootflag:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-mount:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-mount-nfs:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-newgrp:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-pam-timestamp-check:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-passwd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-pkexec:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-polkit-helper:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-postdrop:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-postqueue:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-pt-chown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-ssh-keysign:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-sssd-krb5-child:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-sssd-ldap-child:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-sssd-proxy-child:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-sssd-selinux-child:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-su:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-sudo:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-sudoedit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-umount:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-unix-chkpwd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-userhelper:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-utempter:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-privileged-commands-write:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-session-events:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-sysadmin-actions:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-unsuccessful-file-modification-creat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-unsuccessful-file-modification-ftruncate:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-unsuccessful-file-modification-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-unsuccessful-file-modification-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-unsuccessful-file-modification-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-unsuccessful-file-modification-rename:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-unsuccessful-file-modification-renameat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-unsuccessful-file-modification-truncate:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-unsuccessful-file-modification-unlink:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-unsuccessful-file-modification-unlinkat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-usergroup-modification:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-usergroup-modification-group:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-usergroup-modification-gshadow:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-usergroup-modification-opasswd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-usergroup-modification-passwd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-audit-rules-usergroup-modification-shadow:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-auditd-data-disk-error-action:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-auditd-data-retention-max-log-file-action-stig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-master-auditd-log-format:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-master-bios-enable-execution-restrictions:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-master-chronyd-or-ntpd-specify-remote-server:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-master-configure-usbguard-auditbackend:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: PASS
+  e2e-stig-master-coreos-audit-backlog-limit-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-coreos-audit-option:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-coreos-enable-selinux-kernel-argument:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-master-coreos-page-poison-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-coreos-slub-debug-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-coreos-vsyscall-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-file-groupowner-system-journal:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-master-file-groupowner-var-log:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-master-file-owner-system-journal:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-master-file-owner-var-log:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-master-file-ownership-var-log-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-master-file-permissions-system-journal:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-master-file-permissions-var-log:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-master-file-permissions-var-log-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-master-kernel-module-usb-storage-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-package-usbguard-installed:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-partition-for-var-log-audit:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-master-selinux-policytype:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-master-selinux-state:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-master-service-chronyd-or-ntpd-enabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-master-service-sshd-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-service-usbguard-enabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-sshd-disable-root-login:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-master-sysctl-kernel-dmesg-restrict:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-sysctl-kernel-perf-event-paranoid:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-sysctl-kernel-randomize-va-space:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-master-usbguard-allow-hid-and-hub:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-access-failed:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-create-failed:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-delete-failed:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-immutable-login-uids:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-modify-failed:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-dac-modification-chmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-dac-modification-chown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-dac-modification-fchmod:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-dac-modification-fchmodat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-dac-modification-fchown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-dac-modification-fchownat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-dac-modification-fremovexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-dac-modification-fsetxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-dac-modification-lchown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-dac-modification-lremovexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-dac-modification-lsetxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-dac-modification-removexattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-dac-modification-setxattr:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-dac-modification-umount:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-dac-modification-umount2:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-execution-chcon:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-execution-semanage:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-execution-setfiles:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-execution-setsebool:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-file-deletion-events-rename:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-file-deletion-events-renameat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-file-deletion-events-rmdir:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-file-deletion-events-unlink:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-file-deletion-events-unlinkat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-immutable:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-kernel-module-loading-delete:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-kernel-module-loading-finit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-kernel-module-loading-init:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-login-events-faillock:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-login-events-lastlog:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-login-events-tallylog:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-media-export:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-chage:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-chsh:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-crontab:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-dbus-daemon-launch-helper:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-fusermount:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-fusermount3:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-gpasswd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-grub2-set-bootflag:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-mount:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-mount-nfs:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-newgrp:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-pam-timestamp-check:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-passwd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-pkexec:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-polkit-helper:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-postdrop:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-postqueue:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-pt-chown:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-ssh-keysign:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-sssd-krb5-child:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-sssd-ldap-child:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-sssd-proxy-child:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-sssd-selinux-child:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-su:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-sudo:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-sudoedit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-umount:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-unix-chkpwd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-userhelper:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-utempter:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-privileged-commands-write:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-session-events:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-sysadmin-actions:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-unsuccessful-file-modification-creat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-unsuccessful-file-modification-ftruncate:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-unsuccessful-file-modification-open:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-unsuccessful-file-modification-openat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-unsuccessful-file-modification-rename:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-unsuccessful-file-modification-renameat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-unsuccessful-file-modification-truncate:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-unsuccessful-file-modification-unlink:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-unsuccessful-file-modification-unlinkat:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-usergroup-modification:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-usergroup-modification-group:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-usergroup-modification-gshadow:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-usergroup-modification-opasswd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-usergroup-modification-passwd:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-audit-rules-usergroup-modification-shadow:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-auditd-data-disk-error-action:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-auditd-data-retention-max-log-file-action-stig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-worker-auditd-log-format:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-worker-bios-enable-execution-restrictions:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-worker-chronyd-or-ntpd-specify-remote-server:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-worker-configure-usbguard-auditbackend:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: PASS
+  e2e-stig-worker-coreos-audit-backlog-limit-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-coreos-audit-option:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-coreos-enable-selinux-kernel-argument:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-worker-coreos-page-poison-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-coreos-slub-debug-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-coreos-vsyscall-kernel-argument:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-file-groupowner-system-journal:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-worker-file-groupowner-var-log:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-worker-file-owner-system-journal:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-worker-file-owner-var-log:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-worker-file-ownership-var-log-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-worker-file-permissions-system-journal:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-worker-file-permissions-var-log:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-worker-file-permissions-var-log-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-worker-kernel-module-usb-storage-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-package-usbguard-installed:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-partition-for-var-log-audit:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-worker-selinux-policytype:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-worker-selinux-state:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-worker-service-chronyd-or-ntpd-enabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-worker-service-sshd-disabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-service-usbguard-enabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-sshd-disable-root-login:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-worker-sysctl-kernel-dmesg-restrict:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-sysctl-kernel-perf-event-paranoid:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-sysctl-kernel-randomize-va-space:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-worker-usbguard-allow-hid-and-hub:
+    default_result: FAIL
+    result_after_remediation: PASS


### PR DESCRIPTION
#### Description:

- Add profile assertion files for OCP 4.12
  - Results based on tests run on https://github.com/openshift/release/pull/54636

#### Rationale:

- Support for OCP 4.12 ends on January 2025, lets keep testing the profiles until then.