### PR TITLE
fix xccdf_value substitution with dotnotation

### DIFF
--- a/applications/openshift/api-server/api_server_request_timeout/rule.yml
+++ b/applications/openshift/api-server/api_server_request_timeout/rule.yml
@@ -50,7 +50,7 @@ ocil_clause: '<tt>min-request-timeout</tt> is not set or is not set to an approp
 ocil: |-
     Run the following command:
     <pre>$ oc get configmap config -n openshift-kube-apiserver -ojson | jq -r '.data["config.yaml"]' | jq '.apiServerArguments["min-request-timeout"]'</pre>
-    The output should return <pre> {{ .var_api_min_request_timeout }} </pre>.
+    The output should return <pre>{{ .var_api_min_request_timeout }}</pre>.
 
 warnings:
 - general: |-

--- a/applications/openshift/api-server/api_server_request_timeout/rule.yml
+++ b/applications/openshift/api-server/api_server_request_timeout/rule.yml
@@ -50,7 +50,7 @@ ocil_clause: '<tt>min-request-timeout</tt> is not set or is not set to an approp
 ocil: |-
     Run the following command:
     <pre>$ oc get configmap config -n openshift-kube-apiserver -ojson | jq -r '.data["config.yaml"]' | jq '.apiServerArguments["min-request-timeout"]'</pre>
-    The output should return <pre> {{{ xccdf_value("var_api_min_request_timeout") }}} </pre>.
+    The output should return <pre> {{ .var_api_min_request_timeout }} </pre>.
 
 warnings:
 - general: |-

--- a/applications/openshift/authentication/oauth_inactivity_timeout/rule.yml
+++ b/applications/openshift/authentication/oauth_inactivity_timeout/rule.yml
@@ -61,7 +61,7 @@ ocil_clause: 'OAuth server inactivity timeout is not configured'
 ocil: |-
   To check if the OAuth server timeout is configured, run the following command:
   <pre>oc get oauth cluster -ojsonpath='{.spec.tokenConfig.accessTokenInactivityTimeout}'</pre>
-  the output should return <pre> {{{ xccdf_value("var_oauth_inactivity_timeout") }}} </pre>.
+  the output should return <pre> {{ .var_oauth_inactivity_timeout }} </pre>.
 
 severity: medium
 

--- a/applications/openshift/authentication/oauth_inactivity_timeout/rule.yml
+++ b/applications/openshift/authentication/oauth_inactivity_timeout/rule.yml
@@ -61,7 +61,7 @@ ocil_clause: 'OAuth server inactivity timeout is not configured'
 ocil: |-
   To check if the OAuth server timeout is configured, run the following command:
   <pre>oc get oauth cluster -ojsonpath='{.spec.tokenConfig.accessTokenInactivityTimeout}'</pre>
-  the output should return <pre> {{ .var_oauth_inactivity_timeout }} </pre>.
+  the output should return <pre>{{ .var_oauth_inactivity_timeout }}</pre>.
 
 severity: medium
 

--- a/applications/openshift/kubelet/kubelet_configure_event_creation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_event_creation/rule.yml
@@ -49,7 +49,7 @@ ocil_clause: 'event creation limits are not configured'
 ocil: |-
     Run the following command on the kubelet node(s):
     <pre>$ for NODE_NAME in $(oc get nodes -ojsonpath='{.items[*].metadata.name}'); do oc get --raw /api/v1/nodes/$NODE_NAME/proxy/configz | jq '.kubeletconfig|.kind="KubeletConfiguration"|.apiVersion="kubelet.config.k8s.io/v1beta1"' | grep eventRecordQPS; done</pre>
-    The output should return <tt>{{{ xccdf_value("var_event_record_qps") }}}</tt>.
+    The output should return <tt>{{ .var_event_record_qps }}</tt>.
 
 references:
     cis@ocp4: 4.2.8

--- a/applications/openshift/kubelet/kubelet_enable_streaming_connections_deprecated/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_streaming_connections_deprecated/rule.yml
@@ -31,7 +31,7 @@ ocil_clause: 'the streaming connection timeouts are not disabled'
 ocil: |-
     Run the following command on the kubelet node(s):
     <pre>$ sudo grep streamingConnectionIdleTimeout {{{ kubeletconf_path }}}</pre>
-    The output should return <tt>{{{ xccdf_value("var_streaming_connection_timeouts") }}}</tt>.
+    The output should return <tt>{{ .var_streaming_connection_timeouts }}</tt>.
 
 references:
     cis@eks: 3.2.5


### PR DESCRIPTION
#### Description:

fix xccdf_variable substitution with dotnotation

#### Rationale:

there are multiple rules which use xccdf_value notation to refer to variables in the `ocil` field. these result in an empty string in the compliance operator. example in the case of `api_server_request_timeout`

`api_server_request_timeout` defines the variable `var_api_min_request_timeout`
```ocil: |-
    Run the following command:
    <pre>$ oc get configmap config -n openshift-kube-apiserver -ojson | jq -r '.data["config.yaml"]' | jq '.apiServerArguments["min-request-timeout"]'</pre>
    The output should return <pre> {{{ xccdf_value("var_api_min_request_timeout") }}} </pre>.
```

this results in a build/rules/ of
```ocil: 'Run the following command:

    <pre>$ oc get configmap config -n openshift-kube-apiserver -ojson | jq -r ''.data["config.yaml"]''
    | jq ''.apiServerArguments["min-request-timeout"]''</pre>

    The output should return <pre> <sub idref="var_api_min_request_timeout" /> </pre>.'
```

BUT in the CO CCR the instruction (which seems to map to ocil) is:
```instructions: |-
  Run the following command:
  $ oc get configmap config -n openshift-kube-apiserver -ojson | jq -r '.data["config.yaml"]' | jq '.apiServerArguments["min-request-timeout"]'
  The output should return   .
```

so the variable does not get inserted into the field.

this is consistent also in other checks. But the same method works for the `description` field.

#### Review Hints:

to check the result, you have to check the output of the `instruction` field in the compliancecheckresult resource of each rule

also there may be the same issue with `ocil_clause` fields, but I do not have the output of ocil_clause