### PR TITLE
Avoid tmpfiles override

### DIFF
--- a/linux_os/guide/system/logging/journald/dir_groupowner_system_journal/bash/ubuntu.sh
+++ b/linux_os/guide/system/logging/journald/dir_groupowner_system_journal/bash/ubuntu.sh
@@ -2,14 +2,18 @@
 
 TMPFILES_CONF="/usr/lib/tmpfiles.d/systemd.conf"
 
-if grep -qP "^[zZ][+]*\s+\/var\/log\/journal\s+" "$TMPFILES_CONF"; then
-    sed -i --follow-symlinks -E '/[zZ][+]*\s+\/var\/log\/journal\s*/d' "$TMPFILES_CONF"
+if ! grep -q 'Z /var/log/journal ~2750 root systemd-journal - -' "$TMPFILES_CONF"; then
+    if grep -qP "^[zZ][+]*\s+\/var\/log\/journal" "$TMPFILES_CONF"; then
+        sed -i --follow-symlinks "s/\(^[zZ][+]*\)\(\s\+\/var\/log\/journal.*\)/# \1\2/" "$TMPFILES_CONF"
+    fi
+    echo "Z /var/log/journal ~2750 root systemd-journal - -" >>"$TMPFILES_CONF"
 fi
-echo "Z /var/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
 
-if grep -qP "^[zZ][+]*\s+\/run\/log\/journal\s+" "$TMPFILES_CONF"; then
-    sed -i --follow-symlinks -E '/[zZ][+]*\s+\/run\/log\/journal\s*/d' "$TMPFILES_CONF"
+if ! grep -q 'Z /run/log/journal ~2750 root systemd-journal - -' "$TMPFILES_CONF"; then
+    if grep -qP "^[zZ][+]*\s+\/run\/log\/journal" "$TMPFILES_CONF"; then
+        sed -i --follow-symlinks "s/\(^[zZ][+]*\)\(\s\+\/run\/log\/journal.*\)/# \1\2/" "$TMPFILES_CONF"
+    fi
+    echo "Z /run/log/journal ~2750 root systemd-journal - -" >>"$TMPFILES_CONF"
 fi
-echo "Z /run/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
 
 systemd-tmpfiles --create

--- a/linux_os/guide/system/logging/journald/dir_groupowner_system_journal/bash/ubuntu.sh
+++ b/linux_os/guide/system/logging/journald/dir_groupowner_system_journal/bash/ubuntu.sh
@@ -1,17 +1,15 @@
 # platform = multi_platform_ubuntu
 
-TMPFILES_CONF="/etc/tmpfiles.d/systemd.conf"
+TMPFILES_CONF="/usr/lib/tmpfiles.d/systemd.conf"
 
-if grep -qP "^.[+]*\s+\/var\/log\/journal\s+" "$TMPFILES_CONF"; then
-    sed -i --follow-symlinks "s/\(^.[+]*\)\(\s\+\/var\/log\/journal\s\+[^ $]\+\s\+[^ $]\+\s\+\)\([^ $]\+\)/Z\2systemd-journal/" "$TMPFILES_CONF"
-else
-    echo "Z /var/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
+if grep -qP "^[zZ][+]*\s+\/var\/log\/journal\s+" "$TMPFILES_CONF"; then
+    sed -i --follow-symlinks -E '/[zZ][+]*\s+\/var\/log\/journal\s*/d' "$TMPFILES_CONF"
 fi
+echo "Z /var/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
 
-if grep -qP "^.[+]*\s+\/run\/log\/journal\s+" "$TMPFILES_CONF"; then
-    sed -i --follow-symlinks "s/\(^.[+]*\)\(\s\+\/run\/log\/journal\s\+[^ $]\+\s\+[^ $]\+\s\+\)\([^ $]\+\)/Z\2systemd-journal/" "$TMPFILES_CONF"
-else
-    echo "Z /run/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
+if grep -qP "^[zZ][+]*\s+\/run\/log\/journal\s+" "$TMPFILES_CONF"; then
+    sed -i --follow-symlinks -E '/[zZ][+]*\s+\/run\/log\/journal\s*/d' "$TMPFILES_CONF"
 fi
+echo "Z /run/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
 
 systemd-tmpfiles --create

--- a/linux_os/guide/system/logging/journald/dir_owner_system_journal/bash/ubuntu.sh
+++ b/linux_os/guide/system/logging/journald/dir_owner_system_journal/bash/ubuntu.sh
@@ -2,14 +2,18 @@
 
 TMPFILES_CONF="/usr/lib/tmpfiles.d/systemd.conf"
 
-if grep -qP "^[zZ][+]*\s+\/var\/log\/journal\s+" "$TMPFILES_CONF"; then
-    sed -i --follow-symlinks -E '/[zZ][+]*\s+\/var\/log\/journal\s*/d' "$TMPFILES_CONF"
+if ! grep -q 'Z /var/log/journal ~2750 root systemd-journal - -' "$TMPFILES_CONF"; then
+    if grep -qP "^[zZ][+]*\s+\/var\/log\/journal" "$TMPFILES_CONF"; then
+        sed -i --follow-symlinks "s/\(^[zZ][+]*\)\(\s\+\/var\/log\/journal.*\)/# \1\2/" "$TMPFILES_CONF"
+    fi
+    echo "Z /var/log/journal ~2750 root systemd-journal - -" >>"$TMPFILES_CONF"
 fi
-echo "Z /var/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
 
-if grep -qP "^[zZ][+]*\s+\/run\/log\/journal\s+" "$TMPFILES_CONF"; then
-    sed -i --follow-symlinks -E '/[zZ][+]*\s+\/run\/log\/journal\s*/d' "$TMPFILES_CONF"
+if ! grep -q 'Z /run/log/journal ~2750 root systemd-journal - -' "$TMPFILES_CONF"; then
+    if grep -qP "^[zZ][+]*\s+\/run\/log\/journal" "$TMPFILES_CONF"; then
+        sed -i --follow-symlinks "s/\(^[zZ][+]*\)\(\s\+\/run\/log\/journal.*\)/# \1\2/" "$TMPFILES_CONF"
+    fi
+    echo "Z /run/log/journal ~2750 root systemd-journal - -" >>"$TMPFILES_CONF"
 fi
-echo "Z /run/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
 
 systemd-tmpfiles --create

--- a/linux_os/guide/system/logging/journald/dir_owner_system_journal/bash/ubuntu.sh
+++ b/linux_os/guide/system/logging/journald/dir_owner_system_journal/bash/ubuntu.sh
@@ -1,17 +1,15 @@
 # platform = multi_platform_ubuntu
 
-TMPFILES_CONF="/etc/tmpfiles.d/systemd.conf"
+TMPFILES_CONF="/usr/lib/tmpfiles.d/systemd.conf"
 
-if grep -qP "^.[+]*\s+\/var\/log\/journal\s+" "$TMPFILES_CONF"; then
-    sed -i --follow-symlinks "s/\(^.[+]*\)\(\s\+\/var\/log\/journal\s\+[^ $]\+\s\+\)\([^ $]\+\)/Z\2root/" "$TMPFILES_CONF"
-else
-    echo "Z /var/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
+if grep -qP "^[zZ][+]*\s+\/var\/log\/journal\s+" "$TMPFILES_CONF"; then
+    sed -i --follow-symlinks -E '/[zZ][+]*\s+\/var\/log\/journal\s*/d' "$TMPFILES_CONF"
 fi
+echo "Z /var/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
 
-if grep -qP "^.[+]*\s+\/run\/log\/journal\s+" "$TMPFILES_CONF"; then
-    sed -i --follow-symlinks "s/\(^.[+]*\)\(\s\+\/run\/log\/journal\s\+[^ $]\+\s\+\)\([^ $]\+\)/Z\2root/" "$TMPFILES_CONF"
-else
-    echo "Z /run/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
+if grep -qP "^[zZ][+]*\s+\/run\/log\/journal\s+" "$TMPFILES_CONF"; then
+    sed -i --follow-symlinks -E '/[zZ][+]*\s+\/run\/log\/journal\s*/d' "$TMPFILES_CONF"
 fi
+echo "Z /run/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
 
 systemd-tmpfiles --create

--- a/linux_os/guide/system/logging/journald/dir_permissions_system_journal/bash/ubuntu.sh
+++ b/linux_os/guide/system/logging/journald/dir_permissions_system_journal/bash/ubuntu.sh
@@ -2,14 +2,18 @@
 
 TMPFILES_CONF="/usr/lib/tmpfiles.d/systemd.conf"
 
-if grep -qP "^[zZ][+]*\s+\/var\/log\/journal\s+" "$TMPFILES_CONF"; then
-    sed -i --follow-symlinks -E '/[zZ][+]*\s+\/var\/log\/journal\s*/d' "$TMPFILES_CONF"
+if ! grep -q 'Z /var/log/journal ~2750 root systemd-journal - -' "$TMPFILES_CONF"; then
+    if grep -qP "^[zZ][+]*\s+\/var\/log\/journal" "$TMPFILES_CONF"; then
+        sed -i --follow-symlinks "s/\(^[zZ][+]*\)\(\s\+\/var\/log\/journal.*\)/# \1\2/" "$TMPFILES_CONF"
+    fi
+    echo "Z /var/log/journal ~2750 root systemd-journal - -" >>"$TMPFILES_CONF"
 fi
-echo "Z /var/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
 
-if grep -qP "^[zZ][+]*\s+\/run\/log\/journal\s+" "$TMPFILES_CONF"; then
-    sed -i --follow-symlinks -E '/[zZ][+]*\s+\/run\/log\/journal\s*/d' "$TMPFILES_CONF"
+if ! grep -q 'Z /run/log/journal ~2750 root systemd-journal - -' "$TMPFILES_CONF"; then
+    if grep -qP "^[zZ][+]*\s+\/run\/log\/journal" "$TMPFILES_CONF"; then
+        sed -i --follow-symlinks "s/\(^[zZ][+]*\)\(\s\+\/run\/log\/journal.*\)/# \1\2/" "$TMPFILES_CONF"
+    fi
+    echo "Z /run/log/journal ~2750 root systemd-journal - -" >>"$TMPFILES_CONF"
 fi
-echo "Z /run/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
 
 systemd-tmpfiles --create

--- a/linux_os/guide/system/logging/journald/dir_permissions_system_journal/bash/ubuntu.sh
+++ b/linux_os/guide/system/logging/journald/dir_permissions_system_journal/bash/ubuntu.sh
@@ -1,17 +1,15 @@
 # platform = multi_platform_ubuntu
 
-TMPFILES_CONF="/etc/tmpfiles.d/systemd.conf"
+TMPFILES_CONF="/usr/lib/tmpfiles.d/systemd.conf"
 
-if grep -qP "^.[+]*\s+\/var\/log\/journal\s+" "$TMPFILES_CONF"; then
-    sed -i --follow-symlinks "s/\(^.[+]*\)\(\s\+\/var\/log\/journal\s\+\)\([^ $]*\)/Z\2~2750/" "$TMPFILES_CONF"
-else
-    echo "Z /var/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
+if grep -qP "^[zZ][+]*\s+\/var\/log\/journal\s+" "$TMPFILES_CONF"; then
+    sed -i --follow-symlinks -E '/[zZ][+]*\s+\/var\/log\/journal\s*/d' "$TMPFILES_CONF"
 fi
+echo "Z /var/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
 
-if grep -qP "^.[+]*\s+\/run\/log\/journal\s+" "$TMPFILES_CONF"; then
-    sed -i --follow-symlinks "s/\(^.[+]*\)\(\s\+\/run\/log\/journal\s\+\)\([^ $]*\)/Z\2~2750/" "$TMPFILES_CONF"
-else
-    echo "Z /run/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
+if grep -qP "^[zZ][+]*\s+\/run\/log\/journal\s+" "$TMPFILES_CONF"; then
+    sed -i --follow-symlinks -E '/[zZ][+]*\s+\/run\/log\/journal\s*/d' "$TMPFILES_CONF"
 fi
+echo "Z /run/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
 
 systemd-tmpfiles --create

--- a/linux_os/guide/system/logging/journald/file_groupowner_system_journal/bash/ubuntu.sh
+++ b/linux_os/guide/system/logging/journald/file_groupowner_system_journal/bash/ubuntu.sh
@@ -2,14 +2,18 @@
 
 TMPFILES_CONF="/usr/lib/tmpfiles.d/systemd.conf"
 
-if grep -qP "^[zZ][+]*\s+\/var\/log\/journal\s+" "$TMPFILES_CONF"; then
-    sed -i --follow-symlinks -E '/[zZ][+]*\s+\/var\/log\/journal\s*/d' "$TMPFILES_CONF"
+if ! grep -q 'Z /var/log/journal ~2750 root systemd-journal - -' "$TMPFILES_CONF"; then
+    if grep -qP "^[zZ][+]*\s+\/var\/log\/journal" "$TMPFILES_CONF"; then
+        sed -i --follow-symlinks "s/\(^[zZ][+]*\)\(\s\+\/var\/log\/journal.*\)/# \1\2/" "$TMPFILES_CONF"
+    fi
+    echo "Z /var/log/journal ~2750 root systemd-journal - -" >>"$TMPFILES_CONF"
 fi
-echo "Z /var/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
 
-if grep -qP "^[zZ][+]*\s+\/run\/log\/journal\s+" "$TMPFILES_CONF"; then
-    sed -i --follow-symlinks -E '/[zZ][+]*\s+\/run\/log\/journal\s*/d' "$TMPFILES_CONF"
+if ! grep -q 'Z /run/log/journal ~2750 root systemd-journal - -' "$TMPFILES_CONF"; then
+    if grep -qP "^[zZ][+]*\s+\/run\/log\/journal" "$TMPFILES_CONF"; then
+        sed -i --follow-symlinks "s/\(^[zZ][+]*\)\(\s\+\/run\/log\/journal.*\)/# \1\2/" "$TMPFILES_CONF"
+    fi
+    echo "Z /run/log/journal ~2750 root systemd-journal - -" >>"$TMPFILES_CONF"
 fi
-echo "Z /run/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
 
 systemd-tmpfiles --create

--- a/linux_os/guide/system/logging/journald/file_groupowner_system_journal/bash/ubuntu.sh
+++ b/linux_os/guide/system/logging/journald/file_groupowner_system_journal/bash/ubuntu.sh
@@ -1,17 +1,15 @@
 # platform = multi_platform_ubuntu
 
-TMPFILES_CONF="/etc/tmpfiles.d/systemd.conf"
+TMPFILES_CONF="/usr/lib/tmpfiles.d/systemd.conf"
 
-if grep -qP "^.[+]*\s+\/var\/log\/journal\s+" "$TMPFILES_CONF"; then
-    sed -i --follow-symlinks "s/\(^.[+]*\)\(\s\+\/var\/log\/journal\s\+[^ $]\+\s\+[^ $]\+\s\+\)\([^ $]\+\)/Z\2systemd-journal/" "$TMPFILES_CONF"
-else
-    echo "Z /var/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
+if grep -qP "^[zZ][+]*\s+\/var\/log\/journal\s+" "$TMPFILES_CONF"; then
+    sed -i --follow-symlinks -E '/[zZ][+]*\s+\/var\/log\/journal\s*/d' "$TMPFILES_CONF"
 fi
+echo "Z /var/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
 
-if grep -qP "^.[+]*\s+\/run\/log\/journal\s+" "$TMPFILES_CONF"; then
-    sed -i --follow-symlinks "s/\(^.[+]*\)\(\s\+\/run\/log\/journal\s\+[^ $]\+\s\+[^ $]\+\s\+\)\([^ $]\+\)/Z\2systemd-journal/" "$TMPFILES_CONF"
-else
-    echo "Z /run/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
+if grep -qP "^[zZ][+]*\s+\/run\/log\/journal\s+" "$TMPFILES_CONF"; then
+    sed -i --follow-symlinks -E '/[zZ][+]*\s+\/run\/log\/journal\s*/d' "$TMPFILES_CONF"
 fi
+echo "Z /run/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
 
 systemd-tmpfiles --create

--- a/linux_os/guide/system/logging/journald/file_owner_system_journal/bash/ubuntu.sh
+++ b/linux_os/guide/system/logging/journald/file_owner_system_journal/bash/ubuntu.sh
@@ -2,14 +2,18 @@
 
 TMPFILES_CONF="/usr/lib/tmpfiles.d/systemd.conf"
 
-if grep -qP "^[zZ][+]*\s+\/var\/log\/journal\s+" "$TMPFILES_CONF"; then
-    sed -i --follow-symlinks -E '/[zZ][+]*\s+\/var\/log\/journal\s*/d' "$TMPFILES_CONF"
+if ! grep -q 'Z /var/log/journal ~2750 root systemd-journal - -' "$TMPFILES_CONF"; then
+    if grep -qP "^[zZ][+]*\s+\/var\/log\/journal" "$TMPFILES_CONF"; then
+        sed -i --follow-symlinks "s/\(^[zZ][+]*\)\(\s\+\/var\/log\/journal.*\)/# \1\2/" "$TMPFILES_CONF"
+    fi
+    echo "Z /var/log/journal ~2750 root systemd-journal - -" >>"$TMPFILES_CONF"
 fi
-echo "Z /var/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
 
-if grep -qP "^[zZ][+]*\s+\/run\/log\/journal\s+" "$TMPFILES_CONF"; then
-    sed -i --follow-symlinks -E '/[zZ][+]*\s+\/run\/log\/journal\s*/d' "$TMPFILES_CONF"
+if ! grep -q 'Z /run/log/journal ~2750 root systemd-journal - -' "$TMPFILES_CONF"; then
+    if grep -qP "^[zZ][+]*\s+\/run\/log\/journal" "$TMPFILES_CONF"; then
+        sed -i --follow-symlinks "s/\(^[zZ][+]*\)\(\s\+\/run\/log\/journal.*\)/# \1\2/" "$TMPFILES_CONF"
+    fi
+    echo "Z /run/log/journal ~2750 root systemd-journal - -" >>"$TMPFILES_CONF"
 fi
-echo "Z /run/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
 
 systemd-tmpfiles --create

--- a/linux_os/guide/system/logging/journald/file_owner_system_journal/bash/ubuntu.sh
+++ b/linux_os/guide/system/logging/journald/file_owner_system_journal/bash/ubuntu.sh
@@ -1,17 +1,15 @@
 # platform = multi_platform_ubuntu
 
-TMPFILES_CONF="/etc/tmpfiles.d/systemd.conf"
+TMPFILES_CONF="/usr/lib/tmpfiles.d/systemd.conf"
 
-if grep -qP "^.[+]*\s+\/var\/log\/journal\s+" "$TMPFILES_CONF"; then
-    sed -i --follow-symlinks "s/\(^.[+]*\)\(\s\+\/var\/log\/journal\s\+[^ $]\+\s\+\)\([^ $]\+\)/Z\2root/" "$TMPFILES_CONF"
-else
-    echo "Z /var/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
+if grep -qP "^[zZ][+]*\s+\/var\/log\/journal\s+" "$TMPFILES_CONF"; then
+    sed -i --follow-symlinks -E '/[zZ][+]*\s+\/var\/log\/journal\s*/d' "$TMPFILES_CONF"
 fi
+echo "Z /var/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
 
-if grep -qP "^.[+]*\s+\/run\/log\/journal\s+" "$TMPFILES_CONF"; then
-    sed -i --follow-symlinks "s/\(^.[+]*\)\(\s\+\/run\/log\/journal\s\+[^ $]\+\s\+\)\([^ $]\+\)/Z\2root/" "$TMPFILES_CONF"
-else
-    echo "Z /run/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
+if grep -qP "^[zZ][+]*\s+\/run\/log\/journal\s+" "$TMPFILES_CONF"; then
+    sed -i --follow-symlinks -E '/[zZ][+]*\s+\/run\/log\/journal\s*/d' "$TMPFILES_CONF"
 fi
+echo "Z /run/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
 
 systemd-tmpfiles --create

--- a/linux_os/guide/system/logging/journald/file_permissions_system_journal/bash/ubuntu.sh
+++ b/linux_os/guide/system/logging/journald/file_permissions_system_journal/bash/ubuntu.sh
@@ -2,14 +2,18 @@
 
 TMPFILES_CONF="/usr/lib/tmpfiles.d/systemd.conf"
 
-if grep -qP "^[zZ][+]*\s+\/var\/log\/journal\s+" "$TMPFILES_CONF"; then
-    sed -i --follow-symlinks -E '/[zZ][+]*\s+\/var\/log\/journal\s*/d' "$TMPFILES_CONF"
+if ! grep -q 'Z /var/log/journal ~2750 root systemd-journal - -' "$TMPFILES_CONF"; then
+    if grep -qP "^[zZ][+]*\s+\/var\/log\/journal" "$TMPFILES_CONF"; then
+        sed -i --follow-symlinks "s/\(^[zZ][+]*\)\(\s\+\/var\/log\/journal.*\)/# \1\2/" "$TMPFILES_CONF"
+    fi
+    echo "Z /var/log/journal ~2750 root systemd-journal - -" >>"$TMPFILES_CONF"
 fi
-echo "Z /var/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
 
-if grep -qP "^[zZ][+]*\s+\/run\/log\/journal\s+" "$TMPFILES_CONF"; then
-    sed -i --follow-symlinks -E '/[zZ][+]*\s+\/run\/log\/journal\s*/d' "$TMPFILES_CONF"
+if ! grep -q 'Z /run/log/journal ~2750 root systemd-journal - -' "$TMPFILES_CONF"; then
+    if grep -qP "^[zZ][+]*\s+\/run\/log\/journal" "$TMPFILES_CONF"; then
+        sed -i --follow-symlinks "s/\(^[zZ][+]*\)\(\s\+\/run\/log\/journal.*\)/# \1\2/" "$TMPFILES_CONF"
+    fi
+    echo "Z /run/log/journal ~2750 root systemd-journal - -" >>"$TMPFILES_CONF"
 fi
-echo "Z /run/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
 
 systemd-tmpfiles --create

--- a/linux_os/guide/system/logging/journald/file_permissions_system_journal/bash/ubuntu.sh
+++ b/linux_os/guide/system/logging/journald/file_permissions_system_journal/bash/ubuntu.sh
@@ -1,17 +1,15 @@
 # platform = multi_platform_ubuntu
 
-TMPFILES_CONF="/etc/tmpfiles.d/systemd.conf"
+TMPFILES_CONF="/usr/lib/tmpfiles.d/systemd.conf"
 
-if grep -qP "^.[+]*\s+\/var\/log\/journal\s+" "$TMPFILES_CONF"; then
-    sed -i --follow-symlinks "s/\(^.[+]*\)\(\s\+\/var\/log\/journal\s\+\)\([^ $]*\)/Z\2~2750/" "$TMPFILES_CONF"
-else
-    echo "Z /var/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
+if grep -qP "^[zZ][+]*\s+\/var\/log\/journal\s+" "$TMPFILES_CONF"; then
+    sed -i --follow-symlinks -E '/[zZ][+]*\s+\/var\/log\/journal\s*/d' "$TMPFILES_CONF"
 fi
+echo "Z /var/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
 
-if grep -qP "^.[+]*\s+\/run\/log\/journal\s+" "$TMPFILES_CONF"; then
-    sed -i --follow-symlinks "s/\(^.[+]*\)\(\s\+\/run\/log\/journal\s\+\)\([^ $]*\)/Z\2~2750/" "$TMPFILES_CONF"
-else
-    echo "Z /run/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
+if grep -qP "^[zZ][+]*\s+\/run\/log\/journal\s+" "$TMPFILES_CONF"; then
+    sed -i --follow-symlinks -E '/[zZ][+]*\s+\/run\/log\/journal\s*/d' "$TMPFILES_CONF"
 fi
+echo "Z /run/log/journal ~2750 root systemd-journal - -" >> "$TMPFILES_CONF"
 
 systemd-tmpfiles --create


### PR DESCRIPTION
#### Description:

- Rename the systemd.conf to avoid override `/usr/lib/tmpfiles.d/systemd.conf`

- Remove existing line

#### Rationale:

- Avoid overriding systemd tmpfile configurations
