### PR TITLE
Disable OSPP Profile for RHEL 10

### DIFF
--- a/products/rhel10/profiles/ospp.profile
+++ b/products/rhel10/profiles/ospp.profile
@@ -1,4 +1,4 @@
-documentation_complete: true
+documentation_complete: false
 
 metadata:
     version: 4.3


### PR DESCRIPTION
#### Description:

OSPP profile should be disabled in RHEL 10 for now.

#### Rationale:
Stability