### PR TITLE
Add OCP4 4.21 PCI-DSS assertion files

### DIFF
--- a/tests/assertions/ocp4/ocp4-pci-dss-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.12.yml
@@ -1,0 +1,337 @@
+rule_results:
+  e2e-pci-dss-accounts-restrict-service-account-tokens:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-pci-dss-accounts-unique-service-account:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-pci-dss-api-server-admission-control-plugin-alwaysadmit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-admission-control-plugin-alwayspullimages:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-admission-control-plugin-namespacelifecycle:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-admission-control-plugin-noderestriction:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-admission-control-plugin-scc:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-admission-control-plugin-service-account:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-anonymous-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-api-priority-gate-enabled:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-api-server-audit-log-maxbackup:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-audit-log-maxsize:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-audit-log-path:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-auth-mode-no-aa:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-auth-mode-rbac:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-basic-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-bind-address:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-client-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-encryption-provider-cipher:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-etcd-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-etcd-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-etcd-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-https-for-kubelet-conn:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-insecure-bind-address:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-insecure-port:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-api-server-kubelet-certificate-authority:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-kubelet-client-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-kubelet-client-cert-pre-4-9:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-api-server-kubelet-client-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-kubelet-client-key-pre-4-9:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-api-server-oauth-https-serving-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-openshift-https-serving-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-profiling-protected-by-rbac:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-request-timeout:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-service-account-lookup:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-service-account-public-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-tls-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-tls-cipher-suites:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-tls-private-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-token-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-audit-log-forwarding-enabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-audit-log-forwarding-webhook:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-audit-logging-enabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-audit-profile-set:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-configure-network-policies:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-configure-network-policies-hypershift-hosted:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-configure-network-policies-namespaces:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-controller-insecure-port-disabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-controller-secure-port:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-controller-service-account-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-controller-service-account-private-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-controller-use-service-account:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-etcd-auto-tls:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-etcd-cert-file:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-etcd-check-cipher-suite:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-etcd-client-cert-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-etcd-key-file:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-etcd-peer-auto-tls:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-etcd-peer-cert-file:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-etcd-peer-client-cert-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-etcd-peer-key-file:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-file-groupowner-proxy-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-file-integrity-exists:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-file-integrity-notification-enabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-file-owner-proxy-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-file-permissions-proxy-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-general-apply-scc:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-pci-dss-general-default-namespace-use:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-pci-dss-general-default-seccomp-profile:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-pci-dss-general-namespaces-in-use:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-pci-dss-idp-is-configured:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-kubeadmin-removed:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-pci-dss-kubelet-configure-tls-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-kubelet-configure-tls-cert-pre-4-9:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-kubelet-configure-tls-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-kubelet-configure-tls-key-pre-4-9:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-kubelet-disable-readonly-port:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-machine-volume-encrypted:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-ocp-allowed-registries:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-pci-dss-ocp-allowed-registries-for-import:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-pci-dss-ocp-api-server-audit-log-maxbackup:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-ocp-api-server-audit-log-maxsize:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-ocp-insecure-allowed-registries-for-import:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-ocp-insecure-registries:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-ocp-no-ldap-insecure:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-openshift-api-server-audit-log-path:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-rbac-cluster-roles-defined:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-rbac-debug-role-protects-pprof:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-rbac-least-privilege:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-pci-dss-rbac-limit-cluster-admin:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-pci-dss-rbac-limit-secrets-access:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-pci-dss-rbac-pod-creation-access:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-pci-dss-rbac-roles-defined:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-rbac-wildcard-use:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-pci-dss-routes-protected-by-tls:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-scansettingbinding-exists:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-scc-drop-container-capabilities:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-pci-dss-scc-limit-container-allowed-capabilities:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-scc-limit-ipc-namespace:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-pci-dss-scc-limit-net-raw-capability:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-pci-dss-scc-limit-network-namespace:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-pci-dss-scc-limit-privilege-escalation:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-pci-dss-scc-limit-privileged-containers:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-pci-dss-scc-limit-process-id-namespace:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-pci-dss-scc-limit-root-containers:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-pci-dss-scheduler-profiling-protected-by-rbac:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-scheduler-service-protected-by-rbac:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-secrets-consider-external-storage:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-pci-dss-secrets-no-environment-variables:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-pci-dss-storageclass-encryption-enabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-tls-version-check-apiserver:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-tls-version-check-router:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4.12.yml
@@ -1,0 +1,453 @@
+rule_results:
+  e2e-pci-dss-node-master-directory-permissions-var-log-kube-audit:
+    default_result: PASS
+  e2e-pci-dss-node-master-directory-permissions-var-log-oauth-audit:
+    default_result: PASS
+  e2e-pci-dss-node-master-directory-permissions-var-log-ocp-audit:
+    default_result: PASS
+  e2e-pci-dss-node-master-etcd-unique-ca:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-groupowner-cni-conf:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-groupowner-controller-manager-kubeconfig:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-groupowner-etcd-data-dir:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-groupowner-etcd-data-files:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-groupowner-etcd-member:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-groupowner-etcd-pki-cert-files:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-groupowner-ip-allocations:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-master-file-groupowner-kube-apiserver:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-groupowner-kube-controller-manager:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-groupowner-kube-scheduler:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-groupowner-kubelet-conf:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-groupowner-master-admin-kubeconfigs:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-groupowner-multus-conf:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-groupowner-openshift-pki-cert-files:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-groupowner-openshift-pki-key-files:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-groupowner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-master-file-groupowner-ovn-cni-server-sock:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-groupowner-ovn-db-files:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-groupowner-ovs-pid:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-groupowner-ovs-vswitchd-pid:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-groupowner-ovsdb-server-pid:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-groupowner-scheduler-kubeconfig:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-groupowner-worker-ca:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-groupowner-worker-kubeconfig:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-groupowner-worker-service:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-owner-cni-conf:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-owner-controller-manager-kubeconfig:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-owner-etcd-data-dir:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-owner-etcd-data-files:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-owner-etcd-member:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-owner-etcd-pki-cert-files:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-owner-ip-allocations:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-master-file-owner-kube-apiserver:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-owner-kube-controller-manager:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-owner-kube-scheduler:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-owner-kubelet:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-owner-kubelet-conf:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-owner-master-admin-kubeconfigs:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-owner-multus-conf:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-owner-openshift-pki-cert-files:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-owner-openshift-pki-key-files:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-owner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-master-file-owner-ovn-cni-server-sock:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-owner-ovn-db-files:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-owner-ovs-conf-db:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-owner-ovs-conf-db-lock:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-owner-ovs-pid:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-owner-ovs-sys-id-conf:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-owner-ovs-vswitchd-pid:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-owner-ovsdb-server-pid:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-owner-scheduler-kubeconfig:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-owner-worker-ca:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-owner-worker-kubeconfig:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-owner-worker-service:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-ownership-var-log-kube-audit:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-ownership-var-log-oauth-audit:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-ownership-var-log-ocp-audit:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-permissions-cni-conf:
+    default_result: FAIL
+  e2e-pci-dss-node-master-file-permissions-controller-manager-kubeconfig:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-permissions-etcd-data-dir:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-permissions-etcd-data-files:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-permissions-etcd-member:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-permissions-etcd-pki-cert-files:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-permissions-ip-allocations:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-master-file-permissions-kube-apiserver:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-permissions-kube-controller-manager:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-permissions-kubelet-conf:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-permissions-master-admin-kubeconfigs:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-permissions-multus-conf:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-permissions-openshift-pki-cert-files:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-permissions-openshift-pki-key-files:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-permissions-ovn-cni-server-sock:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-permissions-ovn-db-files:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-permissions-ovs-conf-db:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-permissions-ovs-conf-db-lock:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-permissions-ovs-pid:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-permissions-ovs-sys-id-conf:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-permissions-ovs-vswitchd-pid:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-permissions-ovsdb-server-pid:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-permissions-scheduler:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-permissions-scheduler-kubeconfig:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-permissions-var-log-kube-audit:
+    default_result: INCONSISTENT
+  e2e-pci-dss-node-master-file-permissions-var-log-oauth-audit:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-permissions-var-log-ocp-audit:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-permissions-worker-ca:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-permissions-worker-kubeconfig:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-permissions-worker-service:
+    default_result: PASS
+  e2e-pci-dss-node-master-file-perms-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-master-kubelet-anonymous-auth:
+    default_result: PASS
+  e2e-pci-dss-node-master-kubelet-authorization-mode:
+    default_result: PASS
+  e2e-pci-dss-node-master-kubelet-configure-client-ca:
+    default_result: PASS
+  e2e-pci-dss-node-master-kubelet-configure-event-creation:
+    default_result: PASS
+  e2e-pci-dss-node-master-kubelet-configure-tls-cipher-suites:
+    default_result: PASS
+  e2e-pci-dss-node-master-kubelet-enable-cert-rotation:
+    default_result: PASS
+  e2e-pci-dss-node-master-kubelet-enable-client-cert-rotation:
+    default_result: PASS
+  e2e-pci-dss-node-master-kubelet-enable-iptables-util-chains:
+    default_result: PASS
+  e2e-pci-dss-node-master-kubelet-enable-server-cert-rotation:
+    default_result: PASS
+  e2e-pci-dss-node-master-kubelet-enable-streaming-connections:
+    default_result: PASS
+  e2e-pci-dss-node-master-kubelet-eviction-thresholds-set-hard-imagefs-available:
+    default_result: PASS
+  e2e-pci-dss-node-master-kubelet-eviction-thresholds-set-hard-memory-available:
+    default_result: PASS
+  e2e-pci-dss-node-master-kubelet-eviction-thresholds-set-hard-nodefs-available:
+    default_result: PASS
+  e2e-pci-dss-node-master-kubelet-eviction-thresholds-set-hard-nodefs-inodesfree:
+    default_result: PASS
+  e2e-pci-dss-node-master-partition-for-var-log-kube-apiserver:
+    default_result: MANUAL
+  e2e-pci-dss-node-master-partition-for-var-log-oauth-apiserver:
+    default_result: MANUAL
+  e2e-pci-dss-node-master-partition-for-var-log-openshift-apiserver:
+    default_result: MANUAL
+  e2e-pci-dss-node-master-tls-version-check-masters-workers:
+    default_result: PASS
+  e2e-pci-dss-node-worker-directory-permissions-var-log-kube-audit:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-directory-permissions-var-log-oauth-audit:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-directory-permissions-var-log-ocp-audit:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-etcd-unique-ca:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-cni-conf:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-groupowner-controller-manager-kubeconfig:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-etcd-data-dir:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-etcd-data-files:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-etcd-member:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-etcd-pki-cert-files:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ip-allocations:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-kube-apiserver:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-kube-controller-manager:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-kube-scheduler:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-kubelet-conf:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-groupowner-master-admin-kubeconfigs:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-multus-conf:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-groupowner-openshift-pki-cert-files:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-openshift-pki-key-files:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovn-cni-server-sock:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-groupowner-ovn-db-files:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-groupowner-ovs-pid:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-groupowner-ovs-vswitchd-pid:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-groupowner-ovsdb-server-pid:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-groupowner-scheduler-kubeconfig:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-worker-ca:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-groupowner-worker-kubeconfig:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-groupowner-worker-service:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-owner-cni-conf:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-owner-controller-manager-kubeconfig:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-owner-etcd-data-dir:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-owner-etcd-data-files:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-owner-etcd-member:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-owner-etcd-pki-cert-files:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-owner-ip-allocations:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-owner-kube-apiserver:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-owner-kube-controller-manager:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-owner-kube-scheduler:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-owner-kubelet:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-owner-kubelet-conf:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-owner-master-admin-kubeconfigs:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-owner-multus-conf:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-owner-openshift-pki-cert-files:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-owner-openshift-pki-key-files:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-owner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-owner-ovn-cni-server-sock:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-owner-ovn-db-files:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-owner-ovs-conf-db:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-owner-ovs-conf-db-lock:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-owner-ovs-pid:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-owner-ovs-sys-id-conf:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-owner-ovs-vswitchd-pid:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-owner-ovsdb-server-pid:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-owner-scheduler-kubeconfig:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-owner-worker-ca:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-owner-worker-kubeconfig:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-owner-worker-service:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-ownership-var-log-kube-audit:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-ownership-var-log-oauth-audit:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-ownership-var-log-ocp-audit:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-permissions-cni-conf:
+    default_result: FAIL
+  e2e-pci-dss-node-worker-file-permissions-controller-manager-kubeconfig:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-permissions-etcd-data-dir:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-permissions-etcd-data-files:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-permissions-etcd-member:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-permissions-etcd-pki-cert-files:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-permissions-ip-allocations:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-permissions-kube-apiserver:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-permissions-kube-controller-manager:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-permissions-kubelet-conf:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-permissions-master-admin-kubeconfigs:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-permissions-multus-conf:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-permissions-openshift-pki-cert-files:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-permissions-openshift-pki-key-files:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-permissions-ovn-cni-server-sock:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-permissions-ovn-db-files:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-permissions-ovs-conf-db:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-permissions-ovs-conf-db-lock:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-permissions-ovs-pid:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-permissions-ovs-sys-id-conf:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-permissions-ovs-vswitchd-pid:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-permissions-ovsdb-server-pid:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-permissions-scheduler:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-permissions-scheduler-kubeconfig:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-permissions-var-log-kube-audit:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-permissions-var-log-oauth-audit:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-permissions-var-log-ocp-audit:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-permissions-worker-ca:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-permissions-worker-kubeconfig:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-permissions-worker-service:
+    default_result: PASS
+  e2e-pci-dss-node-worker-file-perms-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-kubelet-anonymous-auth:
+    default_result: PASS
+  e2e-pci-dss-node-worker-kubelet-authorization-mode:
+    default_result: PASS
+  e2e-pci-dss-node-worker-kubelet-configure-client-ca:
+    default_result: PASS
+  e2e-pci-dss-node-worker-kubelet-configure-event-creation:
+    default_result: PASS
+  e2e-pci-dss-node-worker-kubelet-configure-tls-cipher-suites:
+    default_result: PASS
+  e2e-pci-dss-node-worker-kubelet-enable-cert-rotation:
+    default_result: PASS
+  e2e-pci-dss-node-worker-kubelet-enable-client-cert-rotation:
+    default_result: PASS
+  e2e-pci-dss-node-worker-kubelet-enable-iptables-util-chains:
+    default_result: PASS
+  e2e-pci-dss-node-worker-kubelet-enable-server-cert-rotation:
+    default_result: PASS
+  e2e-pci-dss-node-worker-kubelet-enable-streaming-connections:
+    default_result: PASS
+  e2e-pci-dss-node-worker-kubelet-eviction-thresholds-set-hard-imagefs-available:
+    default_result: PASS
+  e2e-pci-dss-node-worker-kubelet-eviction-thresholds-set-hard-memory-available:
+    default_result: PASS
+  e2e-pci-dss-node-worker-kubelet-eviction-thresholds-set-hard-nodefs-available:
+    default_result: PASS
+  e2e-pci-dss-node-worker-kubelet-eviction-thresholds-set-hard-nodefs-inodesfree:
+    default_result: PASS
+  e2e-pci-dss-node-worker-partition-for-var-log-kube-apiserver:
+    default_result: MANUAL
+  e2e-pci-dss-node-worker-partition-for-var-log-oauth-apiserver:
+    default_result: MANUAL
+  e2e-pci-dss-node-worker-partition-for-var-log-openshift-apiserver:
+    default_result: MANUAL
+  e2e-pci-dss-node-worker-tls-version-check-masters-workers:
+    default_result: PASS


### PR DESCRIPTION
#### Description:

- Add profile assertion files for OCP 4.12 

#### Rationale:

- These were missing in https://github.com/ComplianceAsCode/content/pull/12216
- Support for OCP 4.12 ends on January 2025, lets keep testing the profiles until then.
