### PR TITLE
Minor update to output milestone information

### DIFF
--- a/utils/release_helper.py
+++ b/utils/release_helper.py
@@ -245,11 +245,14 @@ def create_repo_milestone(repo, name) -> None:
         future_stabilization_date = get_next_stabilization_date(future_release_date)
         formatted_date_stabilization = get_date_for_message(future_stabilization_date)
         milestone_description = (
-            f'Milestone for the release {name}'
+            f'Milestone for the release {name}. '
             f'Stabilization phase starts on {formatted_date_stabilization}')
         try:
             repo.create_milestone(
                 title=name, description=milestone_description, due_on=estimated_release_date)
+            print(f'Milestone {name} successfully created with the following information:')
+            print(f'Description: {milestone_description}')
+            print(f'Due on: {estimated_release_date}')
         except Exception as e:
             print(f'Error: {e}')
             exit(1)


### PR DESCRIPTION
#### Description:

When a new milestone is created it might be useful to also output the description and "due on" date so we don't need to use the web interface to check the information.

#### Rationale:

Make the release process easier for whoever is conducting it.

#### Review Hints:

The update if very simple and probably don't need any technical test.
It might be tricky to test now during the stabilization phase but could be tested in another repo.