### PR TITLE
[backport] Add package_rng-tools_installed to Fedora OSPP profile

### DIFF
--- a/products/fedora/profiles/ospp.profile
+++ b/products/fedora/profiles/ospp.profile
@@ -232,4 +232,5 @@ selections:
     - dnf-automatic_security_updates_only
     - package_dnf-automatic_installed
     - timer_dnf-automatic_enabled
+    - package_rng-tools_installed
     - service_rngd_enabled


### PR DESCRIPTION
#### Description:

Backport of #12244

