### PR TITLE
Consolidate ASCS RHEL profiles lastlog via sshd

### DIFF
--- a/controls/ism_o.yml
+++ b/controls/ism_o.yml
@@ -116,7 +116,7 @@ controls:
             - audit_rules_privileged_commands
             - audit_rules_session_events
             - audit_rules_unsuccessful_file_modification
-            - display_login_attempts
+            - sshd_print_last_log
             - sebool_auditadm_exec_content
         status: automated
 
@@ -134,7 +134,7 @@ controls:
             - audit_rules_privileged_commands
             - audit_rules_session_events
             - audit_rules_unsuccessful_file_modification
-            - display_login_attempts
+            - sshd_print_last_log
             - sebool_auditadm_exec_content
         status: automated
 

--- a/products/rhel8/profiles/ism_o.profile
+++ b/products/rhel8/profiles/ism_o.profile
@@ -101,7 +101,7 @@ selections:
 
   ## Events to be logged
   ## Identifiers 0580 / 0584 / 0582 / 0585 / 0586 / 0846 / 0957
-  - display_login_attempts
+  - sshd_print_last_log
   - sebool_auditadm_exec_content
   - audit_rules_privileged_commands
   - audit_rules_session_events

--- a/products/rhel9/profiles/ism_o.profile
+++ b/products/rhel9/profiles/ism_o.profile
@@ -101,7 +101,7 @@ selections:
 
   ## Events to be logged
   ## Identifiers 0580 / 0584 / 0582 / 0585 / 0586 / 0846 / 0957
-  - display_login_attempts
+  - sshd_print_last_log
   - sebool_auditadm_exec_content
   - audit_rules_privileged_commands
   - audit_rules_session_events


### PR DESCRIPTION
#### Description:

- Consolidating last login information to only one method - sshd based for Essential 8 and ISM_O, for RHEL8, RHEL9 and RHEL10

#### Rationale:

- As E8 and ISM O profiles were using different methods to print last login information. This results in different timestamps in logs, creating inconvenience. Using just one method is preferrable.