### PR TITLE
Fix missing OL platform clauses

### DIFF
--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/ansible/shared.yml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 8,Oracle Linux 7,Oracle Linux 8
+# platform = Red Hat Enterprise Linux 8,multi_platform_ol
 # reboot = true
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_sle
+# platform = multi_platform_rhel,multi_platform_sle,multi_platform_ol
 # reboot = false
 # strategy = restrict
 # complexity = low


### PR DESCRIPTION
#### Description:

update xwindows_remove_packages ansible remediation 
update accounts_password_set_max_life_existing ansible remediation

#### Rationale:

In the task filling gaps in OL9 automation, the rules xwindows_remove_packages and accounts_password_set_max_life_existing has a missing clauses for OL into ansible remediation
