### PR TITLE
Fix title of var_networkmanager_dns_mode

### DIFF
--- a/linux_os/guide/system/network/networkmanager/var_networkmanager_dns_mode.var
+++ b/linux_os/guide/system/network/networkmanager/var_networkmanager_dns_mode.var
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'NetoworkManager DNS Mode'
+title: 'NetworkManager DNS Mode'
 
 type: string
 


### PR DESCRIPTION
#### Description:

Fix title of var_networkmanager_dns_mode

#### Rationale:
So I don't have to `[sic]` myself when I talk about the title.