### PR TITLE
[stabilization] `firewalld_sshd_port_enabled` add zone to all connections

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/ansible/shared.yml
@@ -22,7 +22,7 @@
   block:
     - name: '{{{ rule_title }}} - Collect NetworkManager connections names'
       ansible.builtin.shell:
-        cmd: nmcli -f UUID,TYPE con | grep ethernet | awk '{ print $1 }'
+        cmd: nmcli -g UUID,TYPE con | grep -v loopback | awk -F ':' '{ print $1 }'
       register: result_nmcli_cmd_connections_names
       changed_when: false
 

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/bash/shared.sh
@@ -20,7 +20,7 @@ else
         firewall-cmd --zone="$firewalld_sshd_zone" --add-service=ssh
 
         # This will collect all NetworkManager connections names
-        readarray -t nm_connections < <(nmcli -f UUID,TYPE con | grep ethernet | awk '{ print $1 }')
+        readarray -t nm_connections < <(nmcli -g UUID,TYPE con | grep -v loopback | awk -F ':' '{ print $1 }')
         # If the connection is not yet assigned to a firewalld zone, assign it to the proper zone.
         # This will not change connections which are already assigned to any firewalld zone.
         for connection in "${nm_connections[@]}"; do

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/customized_zone_configured.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/customized_zone_configured.pass.sh
@@ -10,7 +10,7 @@ systemctl start firewalld NetworkManager
 firewall-cmd --zone=work --add-service=ssh
 
 # Collect all NetworkManager connections names.
-readarray -t nm_connections < <(nmcli -f UUID,TYPE con | grep ethernet | awk '{ print $1 }')
+readarray -t nm_connections < <(nmcli -g UUID,TYPE con | grep -v loopback | awk -F ':' '{ print $1 }')
 
 # If the connection is not yet assigned to a firewalld zone, assign it to the proper zone.
 # This will not change connections which are already assigned to any firewalld zone.

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/customized_zone_without_ssh.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/customized_zone_without_ssh.fail.sh
@@ -10,7 +10,7 @@ systemctl start firewalld NetworkManager
 firewall-cmd --zone=work --add-service=ssh
 
 # Collect all NetworkManager connections names.
-readarray -t nm_connections < <(nmcli -f UUID,TYPE con | grep ethernet | awk '{ print $1 }')
+readarray -t nm_connections < <(nmcli -g UUID,TYPE con | grep -v loopback | awk -F ':' '{ print $1 }')
 
 # If the connection is not yet assigned to a firewalld zone, assign it to the proper zone.
 # This will not change connections which are already assigned to any firewalld zone.

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/new_zone_configured.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/new_zone_configured.pass.sh
@@ -15,7 +15,7 @@ firewall-cmd --reload
 firewall-cmd --zone=$custom_zone_name --add-service=ssh
 
 # Collect all NetworkManager connections names.
-readarray -t nm_connections < <(nmcli -f UUID,TYPE con | grep ethernet | awk '{ print $1 }')
+readarray -t nm_connections < <(nmcli -g UUID,TYPE con | grep -v loopback | awk -F ':' '{ print $1 }')
 
 # If the connection is not yet assigned to a firewalld zone, assign it to the proper zone.
 # This will not change connections which are already assigned to any firewalld zone.

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/new_zone_without_ssh.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/new_zone_without_ssh.fail.sh
@@ -15,7 +15,7 @@ firewall-cmd --reload
 firewall-cmd --zone=$custom_zone_name --add-service=ssh
 
 # Collect all NetworkManager connections names.
-readarray -t nm_connections < <(nmcli -f UUID,TYPE con | grep ethernet | awk '{ print $1 }')
+readarray -t nm_connections < <(nmcli -g UUID,TYPE con | grep -v loopback | awk -F ':' '{ print $1 }')
 
 # If the connection is not yet assigned to a firewalld zone, assign it to the proper zone.
 # This will not change connections which are already assigned to any firewalld zone.

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/only_nics_configured.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/only_nics_configured.fail.sh
@@ -10,7 +10,7 @@ systemctl start firewalld NetworkManager
 firewall-cmd --zone=work --add-service=ssh
 
 # Collect all NetworkManager connections names.
-readarray -t nm_connections < <(nmcli -f UUID,TYPE con | grep ethernet | awk '{ print $1 }')
+readarray -t nm_connections < <(nmcli -g UUID,TYPE con | grep -v loopback | awk -F ':' '{ print $1 }')
 
 # If the connection is not yet assigned to a firewalld zone, assign it to the proper zone.
 # This will not change connections which are already assigned to any firewalld zone.

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/only_zones_configured.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/only_zones_configured.fail.sh
@@ -10,7 +10,7 @@ systemctl start firewalld NetworkManager
 firewall-cmd --zone=work --add-service=ssh
 
 # Collect all NetworkManager connections names.
-readarray -t nm_connections < <(nmcli -f UUID,TYPE con | grep ethernet | awk '{ print $1 }')
+readarray -t nm_connections < <(nmcli -g UUID,TYPE con | grep -v loopback | awk -F ':' '{ print $1 }')
 
 # If the connection is already assigned to a firewalld zone, removes the assignment.
 # This will not change connections which are not assigned to any firewalld zone.

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/zones_and_nics_configured.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/zones_and_nics_configured.pass.sh
@@ -10,7 +10,7 @@ systemctl start firewalld NetworkManager
 firewall-cmd --zone=work --add-service=ssh
 
 # Collect all NetworkManager connections names.
-readarray -t nm_connections < <(nmcli -f UUID,TYPE con | grep ethernet | awk '{ print $1 }')
+readarray -t nm_connections < <(nmcli -g UUID,TYPE con | grep -v loopback | awk -F ':' '{ print $1 }')
 
 # If the connection is not yet assigned to a firewalld zone, assign it to the proper zone.
 # This will not change connections which are already assigned to any firewalld zone.

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/zones_and_nics_ok_no_custom_files.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/zones_and_nics_ok_no_custom_files.pass.sh
@@ -10,7 +10,7 @@ systemctl start firewalld NetworkManager
 firewall-cmd --zone=work --add-service=ssh
 
 # Collect all NetworkManager connections names.
-readarray -t nm_connections < <(nmcli -f UUID,TYPE con | grep ethernet | awk '{ print $1 }')
+readarray -t nm_connections < <(nmcli -g UUID,TYPE con | grep -v loopback | awk -F ':' '{ print $1 }')
 
 # If the connection is not yet assigned to a firewalld zone, assign it to the proper zone.
 # This will not change connections which are already assigned to any firewalld zone.

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/zones_and_nics_ok_port_changed.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/zones_and_nics_ok_port_changed.pass.sh
@@ -10,7 +10,7 @@ systemctl start firewalld NetworkManager
 firewall-cmd --zone=work --add-service=ssh
 
 # Collect all NetworkManager connections names.
-readarray -t nm_connections < <(nmcli -f UUID,TYPE con | grep ethernet | awk '{ print $1 }')
+readarray -t nm_connections < <(nmcli -g UUID,TYPE con | grep -v loopback | awk -F ':' '{ print $1 }')
 
 # If the connection is not yet assigned to a firewalld zone, assign it to the proper zone.
 # This will not change connections which are already assigned to any firewalld zone.


### PR DESCRIPTION
#### Description:
Configure `zone=...` for all non-loopback connections on the system. `ethernet` is not the only type that can be connected to machine https://docs.fedoraproject.org/en-US/quick-docs/configuring-ip-networking-with-nmcli/#_the_nmcli_options

#### Rationale:

Fixes issue when remediation failed on system with `infiniband` connection.

Fixes #12233 

#### Review Hints:
```
python3 tests/automatus.py rule --libvirt qemu:///session test-suite-rhel8 --datastream build/ssg-rhel8-ds.xml --remediate-using bash --no-reports firewalld_sshd_port_enabled
python3 tests/automatus.py rule --libvirt qemu:///session test-suite-rhel8 --datastream build/ssg-rhel8-ds.xml --remediate-using ansible --no-reports firewalld_sshd_port_enabled
python3 tests/automatus.py rule --libvirt qemu:///session test-suite-rhel9 --datastream build/ssg-rhel9-ds.xml --remediate-using bash --no-reports firewalld_sshd_port_enabled
python3 tests/automatus.py rule --libvirt qemu:///session test-suite-rhel9 --datastream build/ssg-rhel9-ds.xml --remediate-using bash --no-reports firewalld_sshd_port_enabled
```
and see Testing Farm CI
and ideally test on aarch64 system, the one with `infiniband` connection