### PR TITLE
Fix references section in the workshop artificial rule data.

### DIFF
--- a/docs/workshop/data/accounts_tmout/rule_yml
+++ b/docs/workshop/data/accounts_tmout/rule_yml
@@ -23,12 +23,11 @@ identifiers:
     cce@sle15: CCE-83269-1
 
 references:
-    anssi: R29
     cis-csc: 1,12,15,16
-    cis@rhel8: 5.5.3
-    cis@sle12: 5.5.4
+    cis@sle12: 5.4.4
     cis@sle15: 5.4.4
     cis@ubuntu2004: 5.4.5
+    cis@ubuntu2204: 5.5.5
     cobit5: DSS05.04,DSS05.10,DSS06.10
     cui: 3.1.11
     disa: CCI-000057,CCI-001133,CCI-002361
@@ -45,6 +44,7 @@ references:
     stigid@sle12: SLES-12-010090
     stigid@sle15: SLES-15-010130
     stigid@ubuntu2004: UBTU-20-010013
+    stigid@ubuntu2204: UBTU-22-412030
 
 ocil_clause: 'value of TMOUT is not less than or equal to expected setting'
 


### PR DESCRIPTION

#### Description:
- Fix references section in the workshop artificial rule data.
- This fixes a problem when building the content:
"ValueError: Rule accounts_tmout contains anssi reference, but this reference type is provided by anssi controls. Please remove the reference from rule.yml."

#### Rationale:

- Fixes online workshop: https://github.com/ComplianceAsCode/content/blob/master/docs/workshop/README.adoc?
