### PR TITLE
Build empty OVAL

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -418,14 +418,14 @@ macro(ssg_build_xml_final PRODUCT LANGUAGE)
         add_custom_command(
             OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-${LANGUAGE}.xml"
             COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-${LANGUAGE}.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-${LANGUAGE}.xml"
-            DEPENDS generate-${PRODUCT}-xccdf-oval-ocil "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
+            DEPENDS generate-${PRODUCT}-xccdf-oval-ocil "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-${LANGUAGE}.xml"
             COMMENT "[${PRODUCT}-content] generating ssg-${PRODUCT}-${LANGUAGE}.xml"
         )
     else()
         add_custom_command(
             OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-${LANGUAGE}.xml"
             COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-${LANGUAGE}.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-${LANGUAGE}.xml"
-            DEPENDS generate-${PRODUCT}-xccdf-oval-ocil "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
+            DEPENDS generate-${PRODUCT}-xccdf-oval-ocil "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-${LANGUAGE}.xml"
             COMMENT "[${PRODUCT}-content] generating ssg-${PRODUCT}-${LANGUAGE}.xml"
         )
     endif()

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/sce/shared.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/sce/shared.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# platform = multi_platform_ubuntu
 # check-import = stdout
 
 # Pass rule if IPv6 is disabled on kernel

--- a/ssg/build_renumber.py
+++ b/ssg/build_renumber.py
@@ -164,9 +164,6 @@ class OVALFileLinker(FileLinker):
         """
         Write internal tree to the file in self.linked_fname.
         """
-        if self.oval_document.is_empty():
-            return
-
         with open(self.linked_fname, "wb+") as fd:
             self.oval_document.save_as_xml(fd)
 

--- a/ssg/oval_object_model/oval_document.py
+++ b/ssg/oval_object_model/oval_document.py
@@ -158,18 +158,30 @@ class OVALDocument(OVALContainer):
 
         root = self._get_oval_definition_el()
         root.append(self._get_generator_el())
-        root.append(
-            self._get_component_el(
-                "definitions", self.definitions, definitions_selection
+        if definitions_selection:
+            root.append(
+                self._get_component_el(
+                    "definitions", self.definitions, definitions_selection)
             )
-        )
-        root.append(self._get_component_el("tests", self.tests, tests_selection))
-        root.append(self._get_component_el("objects", self.objects, objects_selection))
+        if tests_selection:
+            root.append(
+                self._get_component_el(
+                    "tests", self.tests, tests_selection)
+            )
+        if objects_selection:
+            root.append(
+                self._get_component_el(
+                    "objects", self.objects, objects_selection)
+            )
         if states_selection:
-            root.append(self._get_component_el("states", self.states, states_selection))
+            root.append(
+                self._get_component_el(
+                    "states", self.states, states_selection)
+            )
         if variables_selection:
             root.append(
-                self._get_component_el("variables", self.variables, variables_selection)
+                self._get_component_el(
+                    "variables", self.variables, variables_selection)
             )
         return root
 


### PR DESCRIPTION
If we build a thin data stream for a rule that doesn't contain any OVAL check, the build fails because no OVAL file is generated.  In this situation, we will generate a minimal OVAL file that doesn't contain any checks.  Unfortunately, not building the OVAL file at all would be difficult to be handle by CMake, therefore, we will have a minimal valid OVAL file as a work around. The artifact doesn't matter because thin data streams aren't shipped.

Fixes: #12228