### PR TITLE
OCP4: Optimize ingress trusted ca remediation

### DIFF
--- a/applications/openshift/networking/default_ingress_ca_replaced/tests/ocp4/e2e-remediation.sh
+++ b/applications/openshift/networking/default_ingress_ca_replaced/tests/ocp4/e2e-remediation.sh
@@ -1,34 +1,16 @@
 #!/bin/bash
 
 # Reuse an existing certificate so we don't have to regenerate one.
-BUNDLE=$(oc get configmap -n openshift-apiserver trusted-ca-bundle -o json | jq '.data."ca-bundle.crt"')
+oc get secrets -n openshift-ingress-operator router-ca -o json | jq '.data."tls.crt"' | tr -d '"' | base64 -d > /tmp/ca-tls.crt
 
 # Create it in the openshift-config namespace. If we don't do this, the
 # machineconfig cluster operator will fail to find it and eventually go into a
 # degraded state.
-cat << EOF | oc create -f -
-apiVersion: v1
-kind: ConfigMap
-data:
-  ca-bundle.crt: $BUNDLE
-metadata:
-  name: trusted-ca-bundle
-  namespace: openshift-config
-EOF
-
-cat << EOF | oc create -f -
-apiVersion: v1
-kind: ConfigMap
-data:
-  ca-bundle.crt: $BUNDLE
-metadata:
-  name: trusted-ca-bundle
-  namespace: openshift-config-managed
-EOF
+oc create configmap custom-trusted-ca-bundle -n openshift-config --from-file=ca-bundle.crt=/tmp/ca-tls.crt
 
 # Update the trustedCA to point to the new configmap. This is effectively the
 # remediation we're checking for.
-oc patch proxies.config cluster --type merge -p '{"spec":{"trustedCA":{"name":"trusted-ca-bundle"}}}'
+oc patch proxies.config cluster --type merge -p '{"spec":{"trustedCA":{"name":"custom-trusted-ca-bundle"}}}'
 
 # This will bounce a bunch of the clusteroperators. Let's make sure they're all
 # stable for a couple of minutes before moving on.

--- a/applications/openshift/networking/ingress_controller_certificate/tests/ocp4/e2e-remediation.sh
+++ b/applications/openshift/networking/ingress_controller_certificate/tests/ocp4/e2e-remediation.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
 
-# we are using an existing default secret name for testing, so it won't cause any subsequent failures on testing routes.
-oc patch ingresscontroller.operator default --type merge -p '{"spec":{"defaultCertificate":{"name":"router-certs-default"}}}' -n openshift-ingress-operator
+# Make a copy of existing router-certs-default secret to reuse it for testing, we can't just use it directly because it might get deleted when the defaultCertificate is set.
+oc get secret router-certs-default -n openshift-ingress -o json | jq '.data."tls.crt"' | tr -d '"' | base64 -d > /tmp/ingress-tls.crt
+oc get secret router-certs-default -n openshift-ingress -o json | jq '.data."tls.key"' | tr -d '"' | base64 -d > /tmp/ingress-tls.key
+oc create secret tls router-certs-default-duplicate --cert=/tmp/ingress-tls.crt --key=/tmp/ingress-tls.key -n openshift-ingress
+
+# Update the defaultCertificate to point to the new secret. This is effectively the remediation we're checking for.
+# Note: we are using an existing default secret name for testing, so it won't cause any subsequent failures on testing routes.
+oc patch ingresscontroller.operator default --type merge -p '{"spec":{"defaultCertificate":{"name":"router-certs-default-duplicate"}}}' -n openshift-ingress-operator


### PR DESCRIPTION
Let's optimize how we test remediation for ingress cert, we will fetch the default self-sign CA used by the ingress operator and then make it as trusted CA, and then in ingress cert remediation we will make a copy of self-generated ingress wildcard cert, and then use it as the default cert. It looks like the router-certs-default is removed when a custom cert is configured.


https://docs.openshift.com/container-platform/4.16/security/certificate_types_descriptions/ingress-certificates.html#location
