### PR TITLE
Extend mount_option_nodev_nonroot_local_partitions

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/ansible/shared.yml
@@ -8,7 +8,7 @@
   setup:
     gather_subset: mounts
 
-- name: Ensure non-root local partitions are mounted with nodev option
+- name: "{{{ rule_title }}}: Ensure non-root local partitions are mounted with nodev option"
   mount:
     path: "{{ item.mount }}"
     src: "{{ item.device }}"
@@ -20,3 +20,9 @@
     - "item.options is not search('nodev')"
   with_items:
     - "{{ ansible_facts.mounts }}"
+
+- name: "{{{ rule_title }}}: Ensure non-root local partitions are present with nodev option in /etc/fstab"
+  ansible.builtin.replace:
+    path: /etc/fstab
+    regexp: '^\s*(?!#)(/dev/\S+|UUID=\S+)\s+(/\w\S*)\s+(\S+)\s+(?!nodev)(\S+)(.*)$'
+    replace: '\1 \2 \3 \4,nodev \5'

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/bash/shared.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/bash/shared.sh
@@ -23,3 +23,6 @@ for partition_record in "${partitions_records[@]}"; do
         {{{ bash_ensure_partition_is_mounted("$mount_point") | indent(8)}}}
     fi
 done
+
+# Remediate unmounted /etc/fstab entries
+sed -i -E '/nodev/! s;^\s*(/dev/\S+|UUID=\S+)\s+(/\w\S*)\s+(\S+)\s+(\S+)(.*)$;\1 \2 \3 \4,nodev \5;' /etc/fstab

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/oval/shared.xml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/oval/shared.xml
@@ -6,9 +6,11 @@
       should exist in the /dev directory on the root partition or within chroot
       jails built for system services. All other locations should not allow
       character and block devices.") }}}
-    <criteria>
+    <criteria operator="AND">
       <criterion comment="nodev on local filesystems"
       test_ref="test_nodev_nonroot_local_partitions" negate="true" />
+      <criterion comment="nodev on local filesystems in /etc/fstab"
+      test_ref="test_nodev_nonroot_local_partitions_in_fstab" />
     </criteria>
   </definition>
   <linux:partition_test check="all" check_existence="all_exist"
@@ -18,8 +20,14 @@
     <linux:state state_ref="state_local_nodev" />
   </linux:partition_test>
   <linux:partition_object id="object_non_root_partitions" version="1">
-    <!-- look at all partitions except root -->
-    <linux:mount_point operation="pattern match">^/\w.*$</linux:mount_point>
+    <!--
+      Look at all partitions except / (root), /boot and /efi. The / is
+      excluded because nodev is allowed on / by the rule text. The /boot and
+      /efi are excluded because they are special paritions that are
+      usually handled by a systemd mount which causes troubles if the rule is
+      used in operating system installation.
+      -->
+    <linux:mount_point operation="pattern match">^/(?!boot|efi)\w.*$</linux:mount_point>
     <filter action="include">state_local_nodev</filter>
   </linux:partition_object>
   <linux:partition_state id="state_local_nodev" version="1">
@@ -28,4 +36,21 @@
     <linux:mount_options datatype="string" entity_check="all"
     operation="not equal">nodev</linux:mount_options>
   </linux:partition_state>
+
+  <ind:textfilecontent54_test check="all" version="1" check_existence="any_exist"
+    comment="nodev on local filesystems in /etc/fstab"
+    id="test_nodev_nonroot_local_partitions_in_fstab">
+    <ind:object object_ref="object_non_root_partitions_in_fstab" />
+    <ind:state state_ref="state_non_root_partitions_in_fstab" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object version="1" id="object_non_root_partitions_in_fstab">
+    <ind:filepath>/etc/fstab</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*(?!#)(?:/dev/\S+|UUID=\S+)\s+/\w\S*\s+\S+\s+(\S+)</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state version="1"
+    id="state_non_root_partitions_in_fstab">
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    <ind:subexpression operation="pattern match">nodev</ind:subexpression>
+  </ind:textfilecontent54_state>
 </def-group>

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/tests/complex.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/tests/complex.fail.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+cat >/etc/fstab <<ENDOF
+
+
+#
+# /etc/fstab
+# Created by anaconda on Wed Aug  7 08:51:34 2025
+#
+# Accessible filesystems, by reference, are maintained under '/dev/disk/'.
+# See man pages fstab(5), findfs(8), mount(8) and/or blkid(8) for more info.
+#
+# After editing this file, run 'systemctl daemon-reload' to update systemd
+# units generated from this file.
+#
+/dev/mapper/system-root /                       xfs     defaults        0 0
+UUID=07fc30bd-875f-48bd-8863-e62e49e42716 /boot                   xfs     defaults,nosuid        0 0
+/dev/mapper/system-home /home                   xfs     defaults,noexec,nosuid        0 0
+/dev/mapper/system-tmp  /tmp                    xfs     defaults,noexec,nosuid        0 0
+/dev/mapper/system-var  /var                    xfs     defaults        0 0
+/dev/mapper/system-varlog /var/log                xfs     defaults,noexec,nosuid        0 0
+/dev/mapper/system-varlogaudit /var/log/audit          xfs     defaults,noexec,nosuid        0 0
+/dev/mapper/system-vartmp /var/tmp                xfs     defaults,noexec,nosuid        0 0
+/dev/mapper/system-swap none                    swap    defaults        0 0
+tmpfs /dev/shm tmpfs defaults,relatime,inode64,noexec,nosuid 0 0
+ENDOF

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/tests/no_nodev_in_fstab.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/tests/no_nodev_in_fstab.fail.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+# Add nodev option to all records in fstab to ensure that test will
+# run on environment where everything is set correctly for rule check.
+cp /etc/fstab /etc/fstab.backup
+sed -i -e '/^#/d' -e '/^$/d' -e 's/\bnodev\b/,/g' -e 's/,,//g' -e 's/\s,\s/defaults/g' /etc/fstab.backup
+awk '{$4 = $4",nodev"; print}' /etc/fstab.backup > /etc/fstab
+# Remount all partitions. (--all option can't be used because it doesn't
+# mount e.g. /boot partition
+declare -a partitions=( $(awk '{print $2}' /etc/fstab | grep "^/\w") )
+for partition in ${partitions[@]}; do
+    mount -o remount "$partition"
+done
+
+# partition intentionally not mounted to test /etc/fstab detection
+PARTITION="/dev/new_partition1"; create_partition
+make_fstab_given_partition_line "/tmp/partition1" ext2 defaults
+
+# partition intentionally not mounted to test /etc/fstab detection
+PARTITION="/dev/new_partition2"; create_partition
+make_fstab_given_partition_line "/tmp/partition2" ext2 defaults


### PR DESCRIPTION
### Description:

The OVAL check is extended to read also data directly from the `/etc/fstab` file. This is useful in environments where the mount points are not mounted and OVAL partition objects don't match. For example, this happens in the Image Builder environment.

Similar to: https://github.com/ComplianceAsCode/content/pull/10200

Fixes: https://issues.redhat.com/browse/RHEL-45018

### Review hints:
```
 python3 tests/automatus.py rule  --dontclean --libvirt qemu:///system ssgts_rhel9 mount_option_nodev_nonroot_local_partitions
```

```
cd ~/work/git/contest
tmt -c distro=rhel-9 -c arch=x86_64 run -vvva -e CONTEST_CONTENT_PR=12270 -e CONTEST_OSCAP_PR=2143 -e CONTEST_LEAVE_GUEST_RUNNING=1  plans -n /plans/default provision -h connect -k ~/.ssh/id_rsa -u root -g $YOUR_HOST_NAME -h fmf -t '/hardening/image-builder/anssi_bp28_high$' report -h html

```

