### PR TITLE
[stable] Remove old and broken tldp.org link

### DIFF
--- a/linux_os/guide/system/software/disk_partitioning/group.yml
+++ b/linux_os/guide/system/software/disk_partitioning/group.yml
@@ -25,5 +25,3 @@ description: |-
     scheme was used, it is possible but nontrivial to
     modify it to create separate logical volumes for the directories
     listed above. The Logical Volume Manager (LVM) makes this possible.
-    See the LVM HOWTO at {{{ weblink(link="http://tldp.org/HOWTO/LVM-HOWTO/") }}}
-    for more detailed information on LVM.


### PR DESCRIPTION
#### Description:

 Remove old and broken tldp.org link.

#### Rationale:

Found the SSL cert is invalid and while figuring if would be fixed realized the docs are old.

Backport of #12284