### PR TITLE
Fix ansible remediation for audispd plugin UBTU-20-010216

### DIFF
--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicro
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicro,multi_platform_ubuntu
 # reboot = false
 # strategy = configure
 # complexity = low
@@ -6,8 +6,27 @@
 {{{ ansible_instantiate_variables("var_audispd_remote_server") }}}
 {{% set audisp_config_file_path = audisp_conf_path + "/audisp-remote.conf" %}}
 
-- name: Make sure that a remote server is configured for Audispd
-  lineinfile:
+{{% if 'ubuntu' in product %}}
+{{% set audisp_config_plugin_path = audisp_conf_path + "/plugins.d/au-remote.conf" %}}
+- name: "{{{ rule_title }}} - Uncomment active for offloading to remote server"
+  ansible.builtin.lineinfile:
+    path: "{{{ audisp_config_plugin_path }}}"
+    regexp: ^(#.*)(active\s*=)
+    line: \2
+    backrefs: true
+
+- name: "{{{ rule_title }}} - Set active to true for offloading to remote server"
+  ansible.builtin.lineinfile:
+    path: "{{{ audisp_config_plugin_path }}}"
+    regexp: ^(.*)(active\s*=)(?!.*yes)
+    line: \2 yes
+    create: true
+    state: present
+    backrefs: true
+{{% endif %}}
+
+- name: "{{{ rule_title }}} - Make sure that a remote server is configured for Audispd"
+  ansible.builtin.lineinfile:
     path: "{{{ audisp_config_file_path }}}"
     line: "remote_server = {{ var_audispd_remote_server }}"
     regexp: '^\s*remote_server\s*=.*$'


### PR DESCRIPTION
#### Description:

- This commit will fix ansible remediation for audispd plugin which also ensures that the plugin is enabled within au-remote.conf.

Original PR: https://github.com/ComplianceAsCode/content/pull/11093

#### Rationale:

- Apply ubuntu specific remediation for ansible
- Align existing ansible remediation tasks to proper format
- Part of Ubuntu 2004 STIG v1r12 profile upgrade

#### Review Hints:

Build the product:
```
./build_product ubuntu2004
```

To test these changes with Ansible:
```
ansible-playbook build/ansible/ubuntu2004-playbook-stig.yml --tags "DISA-STIG-UBTU-20-010216"
```
Checkout Manual STIG OVAL definitions, and use software like DISA STIG Viewer to view definitions.
```
git checkout yunimoo:update-manual-stig-ubtu-20-v1r12
```

For reference, please review the latest artifacts: https://public.cyber.mil/stigs/downloads/