### PR TITLE
OCPBUGS-38314: Update OCIL permissions to be consistent with check

### DIFF
--- a/applications/openshift/master/file_permissions_kube_controller_manager/rule.yml
+++ b/applications/openshift/master/file_permissions_kube_controller_manager/rule.yml
@@ -23,10 +23,10 @@ references:
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", perms="-rw-r--r--") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", perms="-rw-------") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", perms="-rw-r--r--") }}}
+    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", perms="-rw-------") }}}
 
 platforms:
     - ocp4-master-node


### PR DESCRIPTION
A previous commit updated the checks for
file_permissions_kube_controller_manager to use 0600 while updating the
CIS profile to align with version 1.4.0:

  https://github.com/ComplianceAsCode/content/commit/26bce1c1611b20b5b7c8958f00b8bc8f7707257e#diff-d306ac1866706221acd21ee7acf9f5bfabf5edd1e710dba121fa67a9de7ddfe3

However, the OCIL macros weren't updated, which means they were still
using the 644 permissions in rendered versions of the rule, which caused
confusion for readers.

This commit updates the OCIL by changing the inputs of the macros so
they're consistent with the permissions the check is looking for.
