### PR TITLE
Fix "unknown predicate `-L'"

### DIFF
--- a/shared/templates/file_owner/bash.template
+++ b/shared/templates/file_owner/bash.template
@@ -5,18 +5,20 @@
 # disruption = low
 
 {{%- if RECURSIVE %}}
-{{%- set FIND_RECURSE_ARGS="" %}}
+{{%- set FIND_RECURSE_ARGS_DEP="" %}}
+{{%- set FIND_RECURSE_ARGS_SYM="" %}}
 {{%- else %}}
-{{%- set FIND_RECURSE_ARGS="-maxdepth 1 -L" %}}
+{{%- set FIND_RECURSE_ARGS_DEP="-maxdepth 1" %}}
+{{%- set FIND_RECURSE_ARGS_SYM="-L" %}}
 {{%- endif %}}
 
 {{%- for path in FILEPATH %}}
 {{%- if IS_DIRECTORY %}}
 {{%- if FILE_REGEX %}}
 
-find {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -uid {{{ FILEUID }}} -regextype posix-extended -regex '{{{ FILE_REGEX[loop.index0] }}}' -exec chown -L {{{ FILEUID }}} {} \;
+find {{{ FIND_RECURSE_ARGS_SYM }}} {{{ path }}} {{{ FIND_RECURSE_ARGS_DEP }}} -type f ! -uid {{{ FILEUID }}} -regextype posix-extended -regex '{{{ FILE_REGEX[loop.index0] }}}' -exec chown -L {{{ FILEUID }}} {} \;
 {{%- else %}}
-find -H {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type d -exec chown -L {{{ FILEUID }}} {} \;
+find -H {{{ path }}} {{{ FIND_RECURSE_ARGS_DEP }}} -type d -exec chown -L {{{ FILEUID }}} {} \;
 {{%- endif %}}
 {{%- else %}}
 chown -L {{{ FILEUID }}} {{{ path }}}


### PR DESCRIPTION
#### Description:

- Avoid potential conflict flag of -H and -L
- Fix "unknown predicate `-L'"

#### Rationale:

- When I test file_ownership_audit_configuration rule in stig profile on Ubuntu2204, error occurs:
```
Remediating rule 1/1: 'xccdf_org.ssgproject.content_rule_file_ownership_audit_configuration'
+ '[' '!' -f /.dockerenv ']'
+ '[' '!' -f /run/.containerenv ']'
+ grep -q installed
+ dpkg-query --show '--showformat=${db:Status-Status}\n' auditd
+ find /etc/audit/ -maxdepth 1 -L -type f '!' -uid 0 -regextype posix-extended -regex '^.*audit(\.rules|d\.conf)$' -exec chown -L 0 '{}' ';'
find: unknown predicate `-L'
+ find /etc/audit/rules.d/ -maxdepth 1 -L -type f '!' -uid 0 -regextype posix-extended -regex '^.*\.rules$' -exec chown -L 0 '{}' ';'
find: unknown predicate `-L'

ERROR - The remediation failed for rule 'xccdf_org.ssgproject.content_rule_file_ownership_audit_configuration'.
INFO - Script correct_owner.pass.sh using profile xccdf_org.ssgproject.content_profile_stig OK
```
According to the man find manual: 
**The five `real' options -H, -L, -P, -D and -O must appear before the first path name, if at all.**

