### PR TITLE
Add forgoten rules from PCI-DSS V3.2.1 to V4.0

### DIFF
--- a/controls/pcidss_4_ocp4.yml
+++ b/controls/pcidss_4_ocp4.yml
@@ -3363,6 +3363,7 @@ controls:
       filesystem.
     rules:
       - file_integrity_exists
+      - file_integrity_notification_enabled
 
   - id: '11.6'
     title: Unauthorized changes on payment pages are detected and responded to.

--- a/controls/pcidss_4_ocp4.yml
+++ b/controls/pcidss_4_ocp4.yml
@@ -1260,6 +1260,7 @@ controls:
         - ingress_controller_certificate
         - ingress_controller_tls_security_profile
         - kubelet_configure_tls_min_version
+        - routes_protected_by_tls
 
       controls:
       - id: 4.2.1.1


### PR DESCRIPTION
#### Description:

- These rules are part v3.2.1 and were not added during development of v4.0.
  Still, they are relevant for these requirements.

#### Rationale:

- More thorough implementation of PCI-DSS v4.0