### PR TITLE
OCPBUGS-304: exclude rhacs-operator namespace from resource limit rules

### DIFF
--- a/applications/openshift/general/resource_requests_limits_in_daemonset/rule.yml
+++ b/applications/openshift/general/resource_requests_limits_in_daemonset/rule.yml
@@ -25,9 +25,7 @@ identifiers: {}
 
 references:
   nist: SC-6
-
-{{% set jqfilter = '[ .items[] | select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not) | select( .spec.template.spec.containers[].resources.requests.cpu == null  or  .spec.template.spec.containers[].resources.requests.memory == null or .spec.template.spec.containers[].resources.limits.cpu == null  or  .spec.template.spec.containers[].resources.limits.memory == null )  | .metadata.name ]' %}}
-
+{{% set jqfilter = '[ .items[] | select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not)  | select(.metadata.namespace != "rhacs-operator" and ({{if ne .var_daemonset_limit_namespaces_exempt_regex "None"}}.metadata.namespace | test("{{.var_daemonset_limit_namespaces_exempt_regex}}") | not{{else}}true{{end}})) | select( .spec.template.spec.containers[].resources.requests.cpu == null  or  .spec.template.spec.containers[].resources.requests.memory == null or .spec.template.spec.containers[].resources.limits.cpu == null  or  .spec.template.spec.containers[].resources.limits.memory == null )  | .metadata.name ]' %}}
 ocil_clause: 'Resource requests and limits is not set'
 
 ocil: |-

--- a/applications/openshift/general/resource_requests_limits_in_deployment/rule.yml
+++ b/applications/openshift/general/resource_requests_limits_in_deployment/rule.yml
@@ -26,7 +26,7 @@ identifiers: {}
 references:
   nist: SC-6
 
-{{% set jqfilter = '[ .items[] | select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not) | select( .spec.template.spec.containers[].resources.requests.cpu == null  or  .spec.template.spec.containers[].resources.requests.memory == null or .spec.template.spec.containers[].resources.limits.cpu == null  or  .spec.template.spec.containers[].resources.limits.memory == null )  | .metadata.name ]' %}}
+{{% set jqfilter = '[ .items[] | select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not) | select(.metadata.namespace != "rhacs-operator" and ({{if ne .var_deployment_limit_namespaces_exempt_regex "None"}}.metadata.namespace | test("{{.var_deployment_limit_namespaces_exempt_regex}}") | select( .spec.template.spec.containers[].resources.requests.cpu == null  or  .spec.template.spec.containers[].resources.requests.memory == null or .spec.template.spec.containers[].resources.limits.cpu == null  or  .spec.template.spec.containers[].resources.limits.memory == null )  | .metadata.name ]' %}}
 
 ocil_clause: 'Resource requests and limits is not set'
 

--- a/applications/openshift/general/resource_requests_limits_in_statefulset/rule.yml
+++ b/applications/openshift/general/resource_requests_limits_in_statefulset/rule.yml
@@ -26,7 +26,7 @@ identifiers: {}
 references:
   nist: SC-6
 
-{{% set jqfilter = '[ .items[] | select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not) | select( .spec.template.spec.containers[].resources.requests.cpu == null  or  .spec.template.spec.containers[].resources.requests.memory == null or .spec.template.spec.containers[].resources.limits.cpu == null  or  .spec.template.spec.containers[].resources.limits.memory == null )  | .metadata.name ]' %}}
+{{% set jqfilter = '[ .items[] | select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not) | select(.metadata.namespace != "rhacs-operator" and ({{if ne .var_statefulset_limit_namespaces_exempt_regex "None"}}.metadata.namespace | test("{{.var_statefulset_limit_namespaces_exempt_regex}}") | select( .spec.template.spec.containers[].resources.requests.cpu == null  or  .spec.template.spec.containers[].resources.requests.memory == null or .spec.template.spec.containers[].resources.limits.cpu == null  or  .spec.template.spec.containers[].resources.limits.memory == null )  | .metadata.name ]' %}}
 
 ocil_clause: 'Resource requests and limits is not set'
 

--- a/applications/openshift/general/var_daemonset_limit_namespaces_exempt_regex.var
+++ b/applications/openshift/general/var_daemonset_limit_namespaces_exempt_regex.var
@@ -1,0 +1,18 @@
+documentation_complete: true
+
+title: 'Namespaces exempt of Daemonset Resource Limit'
+
+description: |-
+    Namespaces regular expression explicitly allowed
+    through daemonset resource filters, e.g. setting value to
+    "namespace1|namespace2" will exempt namespace
+    "namespace1" and "namespace2" for daemonset resource limit checks.
+
+type: string
+
+operator: equals
+
+interactive: true
+
+options:
+  default: "None"

--- a/applications/openshift/general/var_deployment_limit_namespaces_exempt_regex.var
+++ b/applications/openshift/general/var_deployment_limit_namespaces_exempt_regex.var
@@ -1,0 +1,18 @@
+documentation_complete: true
+
+title: 'Namespaces exempt of Deployment Resource Limit'
+
+description: |-
+    Namespaces regular expression explicitly allowed
+    through deployment resource filters, e.g. setting value to
+    "namespace1|namespace2" will exempt namespace
+    "namespace1" and "namespace2" for deployment resource limit checks.
+
+type: string
+
+operator: equals
+
+interactive: true
+
+options:
+  default: "None"

--- a/applications/openshift/general/var_statefulset_limit_namespaces_exempt_regex.var
+++ b/applications/openshift/general/var_statefulset_limit_namespaces_exempt_regex.var
@@ -1,0 +1,18 @@
+documentation_complete: true
+
+title: 'Namespaces exempt of Statefulset Resource Limit'
+
+description: |-
+    Namespaces regular expression explicitly allowed
+    through statefulset resource filters, e.g. setting value to
+    "namespace1|namespace2" will exempt namespace
+    "namespace1" and "namespace2" for statefulset resource limit checks.
+
+type: string
+
+operator: equals
+
+interactive: true
+
+options:
+  default: "None"


### PR DESCRIPTION
Added three new variables to be able to exclude namespaces: 

`var_daemonset_limit_namespaces_exempt_regex` for rule `resource_requests_limits_in_daemonset` `var_deployment_limit_namespaces_exempt_regex` for rule `resource_requests_limits_in_deployment` `var_statefulset_limit_namespaces_exempt_regex` for rule `resource_requests_limits_in_statefulset`

`rhacs-operator` namespace has also been excluded by default.

Link to Jira Bug: https://issues.redhat.com/browse/OCPBUGS-304, https://issues.redhat.com/browse/CMP-2400

Additional namespace should be excluded using those variables
