### PR TITLE
Add "is_substring" variable to grub2_bootloader_argument template

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/poisoning/grub2_slub_debug_argument/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/poisoning/grub2_slub_debug_argument/rule.yml
@@ -42,6 +42,7 @@ template:
     vars:
         arg_name: slub_debug
         arg_variable: var_slub_debug_options
+        is_substring@ol8: "true"
 
 fixtext: |-
     {{{ describe_grub2_argument("slub_debug=" ~ xccdf_value("var_slub_debug_options")) | indent(4) }}}

--- a/shared/templates/grub2_bootloader_argument/oval.template
+++ b/shared/templates/grub2_bootloader_argument/oval.template
@@ -241,7 +241,13 @@
   datatype="string" version="1">
     <concat>
       <literal_component>^(?:.*\s)?{{{ ARG_NAME }}}=</literal_component>
+      {{% if IS_SUBSTRING == "true" %}}
+      <literal_component>\S*</literal_component>
+      {{% endif %}}
       <variable_component var_ref="{{{ ARG_VARIABLE }}}" />
+      {{% if IS_SUBSTRING == "true" %}}
+      <literal_component>\S*</literal_component>
+      {{% endif %}}
       <literal_component>(?:\s.*)?$</literal_component>
     </concat>
   </local_variable>

--- a/shared/templates/grub2_bootloader_argument/template.py
+++ b/shared/templates/grub2_bootloader_argument/template.py
@@ -13,6 +13,9 @@ def preprocess(data, lang):
     else:
         data["arg_name_value"] = data["arg_name"] + "=" + data["arg_value"]
 
+    if 'is_substring' not in data:
+        data["is_substring"] = "false"
+
     if lang == "oval":
         # escape dot, this is used in oval regex
         data["escaped_arg_name_value"] = data["arg_name_value"].replace(".", "\\.")

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_substring_left.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_substring_left.pass.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+{{% if IS_SUBSTRING != "true" %}}
+# platform = Not Applicable
+{{% else %}}
+# platform = multi_platform_all
+{{% endif %}}
+{{%- if 'ubuntu' in product %}}
+# packages = grub2
+{{%- else %}}
+# packages = grub2,grubby
+{{%- endif %}}
+
+{{%- if ARG_VARIABLE %}}
+# variables = {{{ ARG_VARIABLE }}}=correct_value
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+{{%- endif %}}
+
+{{%- set ARG_NAME_VALUE= ARG_NAME_VALUE ~ "A" %}}
+
+source common.sh
+
+{{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_substring_right.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_substring_right.pass.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+{{% if IS_SUBSTRING != "true" %}}
+# platform = Not Applicable
+{{% else %}}
+# platform = multi_platform_all
+{{% endif %}}
+{{%- if 'ubuntu' in product %}}
+# packages = grub2
+{{%- else %}}
+# packages = grub2,grubby
+{{%- endif %}}
+
+{{%- if ARG_VARIABLE %}}
+# variables = {{{ ARG_VARIABLE }}}=correct_value
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+{{%- endif %}}
+
+{{%- set ARG_NAME_VALUE = (ARG_NAME_VALUE | replace("=","=A")) %}}
+
+source common.sh
+
+{{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}


### PR DESCRIPTION
#### Description:

- Add the `is_substring` variable to `grub2_bootloader_argument` template. And set it to False as default
  - This argument only applies to OVAL, as a robust remediation could be tricky to handle any case 
- Set `is_substring` to true in `grub2_slub_debug_argument` rule for OL8

#### Rationale:

- With OL8 STIG v1R10 update the requirement OL08-00-010423 allows P to be a sub string of the configuration
> If "slub_debug" does not contain "P", is missing, or is commented out, this is a finding.

**Note:** @ComplianceAsCode/red-hatters  This could also be applicable to RHEL8, please let me know if I should make the update for RHEL8 also

#### Review Hints:

- Added automatus tests to validate this change
