### PR TITLE
Add ocp4 pci dss references

### DIFF
--- a/controls/cis_ocp_1_4_0/section-4.yml
+++ b/controls/cis_ocp_1_4_0/section-4.yml
@@ -131,6 +131,7 @@ controls:
       status: automated
       rules:
         - kubelet_configure_event_creation
+        - var_event_record_qps=50
       levels: [ level_2, ]
     - id: 4.2.9
       title: Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate

--- a/controls/pcidss_4.yml
+++ b/controls/pcidss_4.yml
@@ -2787,7 +2787,6 @@ controls:
       rules:
         - var_auditd_name_format=fqd
         - auditd_name_format
-        - audit_profile_set
 
   - id: '10.3'
     title: Audit logs are protected from destruction and unauthorized modifications.

--- a/controls/pcidss_4_ocp4.yml
+++ b/controls/pcidss_4_ocp4.yml
@@ -5,6 +5,7 @@ version: '4.0'
 source: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
 levels:
 - id: base
+reference_type: pcidss4
 
 controls:
   - id: '1.1'

--- a/controls/pcidss_4_ocp4.yml
+++ b/controls/pcidss_4_ocp4.yml
@@ -387,6 +387,8 @@ controls:
         This control is also addressed by applying the OpenShift CIS recommendations.
       rules:
         - scansettingbinding_exists
+      controls:
+        - cis_ocp_1_4_0:all:level_2
 
     - id: 2.2.2
       title: Vendor default accounts are managed

--- a/docs/manual/developer/03_creating_content.md
+++ b/docs/manual/developer/03_creating_content.md
@@ -700,6 +700,7 @@ Nesting can be accomplished both by
 * nesting whole control definitions, or by
 * nesting references to existing controls in the `policy:control` format, where the `policy:` part can be skipped
 if the reference points to a control in that policy.
+ * To nest all controls of a policy level, use `all` followed by the level. e.g: `cis_ocp4_1_4_0:all:level_2`.
 
 Nesting using references allows reuse of controls across multiple policies.
 

--- a/products/ocp4/profiles/cis-1-4.profile
+++ b/products/ocp4/profiles/cis-1-4.profile
@@ -31,7 +31,6 @@ selections:
     - cis_ocp_1_4_0:all
     ### Variables
     - var_openshift_audit_profile=WriteRequestBodies
-    - var_event_record_qps=50
     ### Helper Rules
     ### This is a helper rule to fetch the required api resource for detecting OCP version
     - version_detect_in_ocp

--- a/products/ocp4/profiles/cis-1-5.profile
+++ b/products/ocp4/profiles/cis-1-5.profile
@@ -32,7 +32,6 @@ selections:
     - cis_ocp_1_4_0:all
     ### Variables
     - var_openshift_audit_profile=WriteRequestBodies
-    - var_event_record_qps=50
     ### Helper Rules
     ### This is a helper rule to fetch the required api resource for detecting OCP version
     - version_detect_in_ocp

--- a/products/ocp4/profiles/pci-dss-3-2.profile
+++ b/products/ocp4/profiles/pci-dss-3-2.profile
@@ -16,7 +16,8 @@ title: 'PCI-DSS v3.2.1 Control Baseline for Red Hat OpenShift Container Platform
 description: |-
     Ensures PCI-DSS v3.2.1 security configuration settings are applied.
 
-filter_rules: '"ocp4-node" not in platforms and "ocp4-master-node" not in platforms'
+filter_rules: '"ocp4-node" not in platforms and "ocp4-master-node" not in platforms and "ocp4-node-on-sdn" not in platforms and "ocp4-node-on-ovn" not in platforms'
+
 
 # Req-2.2
 extends: cis

--- a/products/ocp4/profiles/pci-dss-4-0.profile
+++ b/products/ocp4/profiles/pci-dss-4-0.profile
@@ -16,7 +16,7 @@ title: 'PCI-DSS v4.0.0 Control Baseline for Red Hat OpenShift Container Platform
 description: |-
     Ensures PCI-DSS v4.0.0 security configuration settings are applied.
 
-filter_rules: '"ocp4-node" not in platforms and "ocp4-master-node" not in platforms'
+filter_rules: '"ocp4-node" not in platforms and "ocp4-master-node" not in platforms and "ocp4-node-on-sdn" not in platforms and "ocp4-node-on-ovn" not in platforms'
 
 # Req-2.2
 extends: cis

--- a/products/ocp4/profiles/pci-dss-4-0.profile
+++ b/products/ocp4/profiles/pci-dss-4-0.profile
@@ -18,8 +18,6 @@ description: |-
 
 filter_rules: '"ocp4-node" not in platforms and "ocp4-master-node" not in platforms and "ocp4-node-on-sdn" not in platforms and "ocp4-node-on-ovn" not in platforms'
 
-# Req-2.2
-extends: cis
 
 selections:
     - pcidss_4_ocp4:all:base

--- a/products/ocp4/profiles/pci-dss-node-4-0.profile
+++ b/products/ocp4/profiles/pci-dss-node-4-0.profile
@@ -18,8 +18,5 @@ description: |-
 
 filter_rules: '"ocp4-node" in platforms or "ocp4-master-node" in platforms or "ocp4-node-on-sdn" in platforms or "ocp4-node-on-ovn" in platforms'
 
-# Req-2.2
-extends: cis-node
-
 selections:
     - pcidss_4_ocp4:all:base

--- a/products/ocp4/profiles/pci-dss-node.profile
+++ b/products/ocp4/profiles/pci-dss-node.profile
@@ -17,4 +17,4 @@ description: |-
     Ensures PCI-DSS v3.2.1 security configuration settings are applied.
 
 # Req-2.2
-extends: pci-dss-node-3-2
+extends: pci-dss-node-4-0

--- a/products/ocp4/profiles/pci-dss.profile
+++ b/products/ocp4/profiles/pci-dss.profile
@@ -17,4 +17,4 @@ description: |-
     Ensures PCI-DSS v3.2.1 security configuration settings are applied.
 
 # Req-2.2
-extends: pci-dss-3-2
+extends: pci-dss-4-0

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -177,7 +177,7 @@ class Control(ssg.entities.common.SelectionHandler, ssg.entities.common.XCCDFEnt
         return data
 
     def add_references(self, reference_type, rules):
-        for selection in self.rules:
+        for selection in self.selections:
             if "=" in selection:
                 continue
             rule = rules.get(selection)

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -456,14 +456,25 @@ class ControlsManager():
             for control in policy.controls:
                 self._resolve_control(pid, control)
 
+    def _get_foreign_subcontrols(self, policy_id, req):
+        if req.startswith("all"):
+            _, level_id = req.split(":", 1)
+            return self.get_all_controls_of_level(policy_id, level_id)
+        else:
+            return [self.get_control(policy_id, req)]
+
     def _resolve_control(self, pid, control):
         for sub_name in control.controls:
             policy_id = pid
             if ":" in sub_name:
-                policy_id, sub_name = sub_name.split(":", 1)
-            subcontrol = self.get_control(policy_id, sub_name)
-            self._resolve_control(pid, subcontrol)
-            control.update_with(subcontrol)
+                policy_id, req = sub_name.split(":", 1)
+                subcontrols = self._get_foreign_subcontrols(policy_id, req)
+            else:
+                subcontrols = [self.get_control(policy_id, sub_name)]
+
+            for subcontrol in subcontrols:
+                self._resolve_control(policy_id, subcontrol)
+                control.update_with(subcontrol)
 
     def get_control(self, policy_id, control_id):
         policy = self._get_policy(policy_id)


### PR DESCRIPTION
#### Description:

- Removes `ocp4` rule from `pcidss_4.yml`.
  Rule `audit_profile_set` is an OCP4, and it was breaking auto referencing in `pcidss_4_ocp4.yml`
- Adds auto referencing to `pcidss_4_ocp4.yml`.
- Add capability to import all controls of a specific level from a foreign policy.
  - For example, the OCP4 PCI-DSS v4.0 control file imports all OCP4 CIS controls in Req 2.2 with `cis_ocp_1_4_0:all:level_2`

#### Rationale:

- Ensures the rules used in PCI-DSS v4 profile reference the requirement they are supporting.

#### Review Hints:

- Checkout compliance-operator
- `gh co 594`
- `$ CONTENT_IMAGE=ghcr.io/complianceascode/k8scontent:12309 make deploy-local`
```
$ oc get rule ocp4-api-server-tls-cert -oyaml
...
id: xccdf_org.ssgproject.content_rule_api_server_tls_cert
kind: Rule
metadata:
  annotations:
    compliance.openshift.io/image-digest: pb-upstream-ocp45qsp7
    compliance.openshift.io/profiles: upstream-ocp4-high,upstream-ocp4-nerc-cip,upstream-ocp4-cis-1-4,upstream-ocp4-moderate-rev-4,upstream-ocp4-cis,upstream-ocp4-cis-1-5,upstream-ocp4-moderate,upstream-ocp4-pci-dss,upstream-ocp4-pci-dss-3-2,upstream-ocp4-high-rev-4,upstream-ocp4-pci-dss-4-0
    compliance.openshift.io/rule: api-server-tls-cert
    control.compliance.openshift.io/CIS-OCP: 1.2.28
    control.compliance.openshift.io/NERC-CIP: CIP-003-8 R4.2;CIP-007-3 R5.1
    control.compliance.openshift.io/NIST-800-53: SC-8;SC-8(1);SC-8(2)
    control.compliance.openshift.io/PCI-DSS: Req-2.2;Req-2.2.3;Req-2.3
->  control.compliance.openshift.io/PCI-DSS-4-0: 2.2.5;2.2.7;4.2.1  <-
    control.compliance.openshift.io/STIG: SRG-APP-000441-CTR-001090;SRG-APP-000442-CTR-001095
    policies.open-cluster-management.io/controls: CIP-003-8 R4.2,CIP-007-3 R5.1,SC-8,SC-8(1),SC-8(2),Req-2.2,Req-2.2.3,Req-2.3,SRG-APP-000441-CTR-001090,SRG-APP-000442-CTR-001095,1.2.28,2.2.5,2.2.7,4.2.1
    policies.open-cluster-management.io/standards: NERC-CIP,NIST-800-53,PCI-DSS,STIG,CIS-OCP,PCI-DSS-4-0
...
```