### PR TITLE
Add PCI-DSS v4.0 assertion files

### DIFF
--- a/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
@@ -34,7 +34,7 @@ identifiers:
   cce@ocp4: CCE-84080-1
 
 platforms:
-  - (ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12 or ocp4.13 or ocp4.14 or ocp4.15 or ocp4.16) and not ocp4-on-hypershift-hosted
+  - (ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12 or ocp4.13 or ocp4.14 or ocp4.15 or ocp4.16 or ocp4.17) and not ocp4-on-hypershift-hosted
 
 severity: high
 

--- a/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
@@ -34,7 +34,7 @@ identifiers:
   cce@ocp4: CCE-83591-8
 
 platforms:
-  - (ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12 or ocp4.13 or ocp4.14 or ocp4.15 or ocp4.16) and not ocp4-on-hypershift-hosted
+  - (ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12 or ocp4.13 or ocp4.14 or ocp4.15 or ocp4.16 or ocp4.17) and not ocp4-on-hypershift-hosted
 
 severity: high
 

--- a/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
@@ -27,7 +27,7 @@ identifiers:
     cce@ocp4: CCE-83396-2
 
 platforms:
-  - (ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12 or ocp4.13 or ocp4.14 or ocp4.15 or ocp4.16) and not ocp4-on-hypershift-hosted
+  - (ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12 or ocp4.13 or ocp4.14 or ocp4.15 or ocp4.16 or ocp4.17) and not ocp4-on-hypershift-hosted
 
 references:
     cis@ocp4: 4.2.9

--- a/applications/openshift/kubelet/kubelet_configure_tls_key/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_key/rule.yml
@@ -27,7 +27,7 @@ identifiers:
     cce@ocp4: CCE-90614-9
 
 platforms:
-  - (ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12 or ocp4.13 or ocp4.14 or ocp4.15 or ocp4.16) and not ocp4-on-hypershift-hosted
+  - (ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12 or ocp4.13 or ocp4.14 or ocp4.15 or ocp4.16 or ocp4.17) and not ocp4-on-hypershift-hosted
 
 references:
     cis@ocp4: 4.2.9

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.12.yml
@@ -1,0 +1,352 @@
+rule_results:
+ e2e-pci-dss-4-0-accounts-restrict-service-account-tokens:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-accounts-unique-service-account:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-acs-sensor-exists:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-alert-receiver-configured:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-alwaysadmit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-alwayspullimages:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-namespacelifecycle:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-noderestriction:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-scc:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-service-account:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-anonymous-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-audit-log-maxbackup:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-audit-log-maxsize:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-audit-log-path:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-auth-mode-no-aa:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-auth-mode-rbac:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-basic-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-bind-address:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-client-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-encryption-provider-cipher:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-etcd-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-etcd-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-etcd-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-https-for-kubelet-conn:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-insecure-bind-address:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-kubelet-certificate-authority:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-kubelet-client-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-kubelet-client-cert-pre-4-9:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-api-server-kubelet-client-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-kubelet-client-key-pre-4-9:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-api-server-oauth-https-serving-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-openshift-https-serving-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-profiling-protected-by-rbac:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-request-timeout:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-service-account-lookup:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-service-account-public-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-tls-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-tls-cipher-suites:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-tls-private-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-tls-security-profile:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-token-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-audit-error-alert-exists:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-audit-log-forwarding-enabled:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-audit-log-forwarding-webhook:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-audit-logging-enabled:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-audit-profile-set:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-configure-network-policies:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-configure-network-policies-hypershift-hosted:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-configure-network-policies-namespaces:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-container-security-operator-exists:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-insecure-port-disabled:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-secure-port:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-service-account-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-service-account-private-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-use-service-account:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-auto-tls:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-cert-file:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-client-cert-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-key-file:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-peer-auto-tls:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-peer-cert-file:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-peer-client-cert-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-peer-key-file:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-file-groupowner-proxy-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-file-integrity-exists:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-file-integrity-notification-enabled:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-file-owner-proxy-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-file-permissions-proxy-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-general-apply-scc:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-general-default-namespace-use:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-general-default-seccomp-profile:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-general-namespaces-in-use:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-idp-is-configured:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ingress-controller-certificate:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ingress-controller-tls-security-profile:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-kubeadmin-removed:
+   default_result: FAIL
+   result_after_remediation: FAIL
+ e2e-pci-dss-4-0-kubelet-configure-tls-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-kubelet-configure-tls-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-kubelet-disable-readonly-port:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-machine-volume-encrypted:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-oauth-or-oauthclient-inactivity-timeout:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-allowed-registries:
+   default_result: FAIL
+   result_after_remediation: FAIL
+ e2e-pci-dss-4-0-ocp-allowed-registries-for-import:
+   default_result: FAIL
+   result_after_remediation: FAIL
+ e2e-pci-dss-4-0-ocp-api-server-audit-log-maxbackup:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-api-server-audit-log-maxsize:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-idp-no-htpasswd:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-insecure-allowed-registries-for-import:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-insecure-registries:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-no-ldap-insecure:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-openshift-api-server-audit-log-path:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-rbac-cluster-roles-defined:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-rbac-debug-role-protects-pprof:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-rbac-least-privilege:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-rbac-limit-cluster-admin:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-rbac-limit-secrets-access:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-rbac-pod-creation-access:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-rbac-roles-defined:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-rbac-wildcard-use:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-routes-protected-by-tls:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-scansettingbinding-exists:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-scc-drop-container-capabilities:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-container-allowed-capabilities:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-scc-limit-ipc-namespace:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-net-raw-capability:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-network-namespace:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-privilege-escalation:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-privileged-containers:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-process-id-namespace:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-root-containers:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scheduler-profiling-protected-by-rbac:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-scheduler-service-protected-by-rbac:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-secrets-consider-external-storage:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-secrets-no-environment-variables:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-security-profiles-operator-exists:
+   default_result: FAIL
+   result_after_remediation: FAIL
+ e2e-pci-dss-4-0-storageclass-encryption-enabled:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-tls-version-check-apiserver:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-tls-version-check-router:
+   default_result: PASS
+   result_after_remediation: PASS 

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.12.yml
@@ -340,7 +340,7 @@ rule_results:
    result_after_remediation: MANUAL
  e2e-pci-dss-4-0-security-profiles-operator-exists:
    default_result: FAIL
-   result_after_remediation: FAIL
+   result_after_remediation: PASS
  e2e-pci-dss-4-0-storageclass-encryption-enabled:
    default_result: PASS
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.13.yml
@@ -1,0 +1,352 @@
+rule_results:
+ e2e-pci-dss-4-0-accounts-restrict-service-account-tokens:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-accounts-unique-service-account:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-acs-sensor-exists:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-alert-receiver-configured:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-alwaysadmit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-alwayspullimages:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-namespacelifecycle:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-noderestriction:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-scc:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-service-account:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-anonymous-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-audit-log-maxbackup:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-audit-log-maxsize:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-audit-log-path:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-auth-mode-no-aa:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-auth-mode-rbac:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-basic-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-bind-address:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-client-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-encryption-provider-cipher:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-etcd-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-etcd-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-etcd-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-https-for-kubelet-conn:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-insecure-bind-address:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-kubelet-certificate-authority:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-kubelet-client-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-kubelet-client-cert-pre-4-9:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-api-server-kubelet-client-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-kubelet-client-key-pre-4-9:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-api-server-oauth-https-serving-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-openshift-https-serving-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-profiling-protected-by-rbac:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-request-timeout:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-service-account-lookup:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-service-account-public-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-tls-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-tls-cipher-suites:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-tls-private-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-tls-security-profile:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-token-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-audit-error-alert-exists:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-audit-log-forwarding-enabled:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-audit-log-forwarding-webhook:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-audit-logging-enabled:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-audit-profile-set:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-configure-network-policies:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-configure-network-policies-hypershift-hosted:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-configure-network-policies-namespaces:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-container-security-operator-exists:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-insecure-port-disabled:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-secure-port:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-service-account-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-service-account-private-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-use-service-account:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-auto-tls:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-cert-file:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-client-cert-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-key-file:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-peer-auto-tls:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-peer-cert-file:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-peer-client-cert-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-peer-key-file:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-file-groupowner-proxy-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-file-integrity-exists:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-file-integrity-notification-enabled:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-file-owner-proxy-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-file-permissions-proxy-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-general-apply-scc:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-general-default-namespace-use:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-general-default-seccomp-profile:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-general-namespaces-in-use:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-idp-is-configured:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ingress-controller-certificate:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ingress-controller-tls-security-profile:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-kubeadmin-removed:
+   default_result: FAIL
+   result_after_remediation: FAIL
+ e2e-pci-dss-4-0-kubelet-configure-tls-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-kubelet-configure-tls-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-kubelet-disable-readonly-port:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-machine-volume-encrypted:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-oauth-or-oauthclient-inactivity-timeout:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-allowed-registries:
+   default_result: FAIL
+   result_after_remediation: FAIL
+ e2e-pci-dss-4-0-ocp-allowed-registries-for-import:
+   default_result: FAIL
+   result_after_remediation: FAIL
+ e2e-pci-dss-4-0-ocp-api-server-audit-log-maxbackup:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-api-server-audit-log-maxsize:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-idp-no-htpasswd:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-insecure-allowed-registries-for-import:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-insecure-registries:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-no-ldap-insecure:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-openshift-api-server-audit-log-path:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-rbac-cluster-roles-defined:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-rbac-debug-role-protects-pprof:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-rbac-least-privilege:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-rbac-limit-cluster-admin:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-rbac-limit-secrets-access:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-rbac-pod-creation-access:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-rbac-roles-defined:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-rbac-wildcard-use:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-routes-protected-by-tls:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-scansettingbinding-exists:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-scc-drop-container-capabilities:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-container-allowed-capabilities:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-scc-limit-ipc-namespace:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-net-raw-capability:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-network-namespace:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-privilege-escalation:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-privileged-containers:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-process-id-namespace:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-root-containers:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scheduler-profiling-protected-by-rbac:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-scheduler-service-protected-by-rbac:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-secrets-consider-external-storage:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-secrets-no-environment-variables:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-security-profiles-operator-exists:
+   default_result: FAIL
+   result_after_remediation: FAIL
+ e2e-pci-dss-4-0-storageclass-encryption-enabled:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-tls-version-check-apiserver:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-tls-version-check-router:
+   default_result: PASS
+   result_after_remediation: PASS 

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.13.yml
@@ -340,7 +340,7 @@ rule_results:
    result_after_remediation: MANUAL
  e2e-pci-dss-4-0-security-profiles-operator-exists:
    default_result: FAIL
-   result_after_remediation: FAIL
+   result_after_remediation: PASS
  e2e-pci-dss-4-0-storageclass-encryption-enabled:
    default_result: PASS
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.14.yml
@@ -1,0 +1,352 @@
+rule_results:
+ e2e-pci-dss-4-0-accounts-restrict-service-account-tokens:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-accounts-unique-service-account:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-acs-sensor-exists:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-alert-receiver-configured:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-alwaysadmit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-alwayspullimages:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-namespacelifecycle:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-noderestriction:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-scc:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-service-account:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-anonymous-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-audit-log-maxbackup:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-audit-log-maxsize:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-audit-log-path:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-auth-mode-no-aa:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-auth-mode-rbac:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-basic-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-bind-address:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-client-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-encryption-provider-cipher:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-etcd-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-etcd-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-etcd-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-https-for-kubelet-conn:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-insecure-bind-address:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-kubelet-certificate-authority:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-kubelet-client-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-kubelet-client-cert-pre-4-9:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-api-server-kubelet-client-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-kubelet-client-key-pre-4-9:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-api-server-oauth-https-serving-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-openshift-https-serving-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-profiling-protected-by-rbac:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-request-timeout:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-service-account-lookup:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-service-account-public-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-tls-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-tls-cipher-suites:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-tls-private-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-tls-security-profile:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-token-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-audit-error-alert-exists:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-audit-log-forwarding-enabled:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-audit-log-forwarding-webhook:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-audit-logging-enabled:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-audit-profile-set:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-configure-network-policies:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-configure-network-policies-hypershift-hosted:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-configure-network-policies-namespaces:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-container-security-operator-exists:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-insecure-port-disabled:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-secure-port:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-service-account-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-service-account-private-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-use-service-account:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-auto-tls:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-cert-file:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-client-cert-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-key-file:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-peer-auto-tls:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-peer-cert-file:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-peer-client-cert-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-peer-key-file:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-file-groupowner-proxy-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-file-integrity-exists:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-file-integrity-notification-enabled:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-file-owner-proxy-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-file-permissions-proxy-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-general-apply-scc:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-general-default-namespace-use:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-general-default-seccomp-profile:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-general-namespaces-in-use:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-idp-is-configured:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ingress-controller-certificate:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ingress-controller-tls-security-profile:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-kubeadmin-removed:
+   default_result: FAIL
+   result_after_remediation: FAIL
+ e2e-pci-dss-4-0-kubelet-configure-tls-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-kubelet-configure-tls-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-kubelet-disable-readonly-port:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-machine-volume-encrypted:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-oauth-or-oauthclient-inactivity-timeout:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-allowed-registries:
+   default_result: FAIL
+   result_after_remediation: FAIL
+ e2e-pci-dss-4-0-ocp-allowed-registries-for-import:
+   default_result: FAIL
+   result_after_remediation: FAIL
+ e2e-pci-dss-4-0-ocp-api-server-audit-log-maxbackup:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-api-server-audit-log-maxsize:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-idp-no-htpasswd:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-insecure-allowed-registries-for-import:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-insecure-registries:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-no-ldap-insecure:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-openshift-api-server-audit-log-path:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-rbac-cluster-roles-defined:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-rbac-debug-role-protects-pprof:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-rbac-least-privilege:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-rbac-limit-cluster-admin:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-rbac-limit-secrets-access:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-rbac-pod-creation-access:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-rbac-roles-defined:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-rbac-wildcard-use:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-routes-protected-by-tls:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-scansettingbinding-exists:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-scc-drop-container-capabilities:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-container-allowed-capabilities:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-scc-limit-ipc-namespace:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-net-raw-capability:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-network-namespace:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-privilege-escalation:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-privileged-containers:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-process-id-namespace:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-root-containers:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scheduler-profiling-protected-by-rbac:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-scheduler-service-protected-by-rbac:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-secrets-consider-external-storage:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-secrets-no-environment-variables:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-security-profiles-operator-exists:
+   default_result: FAIL
+   result_after_remediation: FAIL
+ e2e-pci-dss-4-0-storageclass-encryption-enabled:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-tls-version-check-apiserver:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-tls-version-check-router:
+   default_result: PASS
+   result_after_remediation: PASS 

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.14.yml
@@ -340,7 +340,7 @@ rule_results:
    result_after_remediation: MANUAL
  e2e-pci-dss-4-0-security-profiles-operator-exists:
    default_result: FAIL
-   result_after_remediation: FAIL
+   result_after_remediation: PASS
  e2e-pci-dss-4-0-storageclass-encryption-enabled:
    default_result: PASS
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.15.yml
@@ -1,0 +1,352 @@
+rule_results:
+ e2e-pci-dss-4-0-accounts-restrict-service-account-tokens:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-accounts-unique-service-account:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-acs-sensor-exists:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-alert-receiver-configured:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-alwaysadmit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-alwayspullimages:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-namespacelifecycle:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-noderestriction:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-scc:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-service-account:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-anonymous-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-audit-log-maxbackup:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-audit-log-maxsize:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-audit-log-path:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-auth-mode-no-aa:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-auth-mode-rbac:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-basic-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-bind-address:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-client-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-encryption-provider-cipher:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-etcd-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-etcd-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-etcd-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-https-for-kubelet-conn:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-insecure-bind-address:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-kubelet-certificate-authority:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-kubelet-client-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-kubelet-client-cert-pre-4-9:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-api-server-kubelet-client-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-kubelet-client-key-pre-4-9:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-api-server-oauth-https-serving-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-openshift-https-serving-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-profiling-protected-by-rbac:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-request-timeout:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-service-account-lookup:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-service-account-public-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-tls-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-tls-cipher-suites:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-tls-private-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-tls-security-profile:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-token-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-audit-error-alert-exists:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-audit-log-forwarding-enabled:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-audit-log-forwarding-webhook:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-audit-logging-enabled:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-audit-profile-set:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-configure-network-policies:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-configure-network-policies-hypershift-hosted:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-configure-network-policies-namespaces:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-container-security-operator-exists:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-insecure-port-disabled:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-secure-port:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-service-account-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-service-account-private-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-use-service-account:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-auto-tls:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-cert-file:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-client-cert-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-key-file:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-peer-auto-tls:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-peer-cert-file:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-peer-client-cert-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-peer-key-file:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-file-groupowner-proxy-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-file-integrity-exists:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-file-integrity-notification-enabled:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-file-owner-proxy-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-file-permissions-proxy-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-general-apply-scc:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-general-default-namespace-use:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-general-default-seccomp-profile:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-general-namespaces-in-use:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-idp-is-configured:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ingress-controller-certificate:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ingress-controller-tls-security-profile:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-kubeadmin-removed:
+   default_result: FAIL
+   result_after_remediation: FAIL
+ e2e-pci-dss-4-0-kubelet-configure-tls-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-kubelet-configure-tls-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-kubelet-disable-readonly-port:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-machine-volume-encrypted:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-oauth-or-oauthclient-inactivity-timeout:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-allowed-registries:
+   default_result: FAIL
+   result_after_remediation: FAIL
+ e2e-pci-dss-4-0-ocp-allowed-registries-for-import:
+   default_result: FAIL
+   result_after_remediation: FAIL
+ e2e-pci-dss-4-0-ocp-api-server-audit-log-maxbackup:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-api-server-audit-log-maxsize:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-idp-no-htpasswd:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-insecure-allowed-registries-for-import:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-insecure-registries:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-no-ldap-insecure:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-openshift-api-server-audit-log-path:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-rbac-cluster-roles-defined:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-rbac-debug-role-protects-pprof:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-rbac-least-privilege:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-rbac-limit-cluster-admin:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-rbac-limit-secrets-access:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-rbac-pod-creation-access:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-rbac-roles-defined:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-rbac-wildcard-use:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-routes-protected-by-tls:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-scansettingbinding-exists:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-scc-drop-container-capabilities:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-container-allowed-capabilities:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-scc-limit-ipc-namespace:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-net-raw-capability:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-network-namespace:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-privilege-escalation:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-privileged-containers:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-process-id-namespace:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-root-containers:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scheduler-profiling-protected-by-rbac:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-scheduler-service-protected-by-rbac:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-secrets-consider-external-storage:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-secrets-no-environment-variables:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-security-profiles-operator-exists:
+   default_result: FAIL
+   result_after_remediation: FAIL
+ e2e-pci-dss-4-0-storageclass-encryption-enabled:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-tls-version-check-apiserver:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-tls-version-check-router:
+   default_result: PASS
+   result_after_remediation: PASS 

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.15.yml
@@ -340,7 +340,7 @@ rule_results:
    result_after_remediation: MANUAL
  e2e-pci-dss-4-0-security-profiles-operator-exists:
    default_result: FAIL
-   result_after_remediation: FAIL
+   result_after_remediation: PASS
  e2e-pci-dss-4-0-storageclass-encryption-enabled:
    default_result: PASS
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.16.yml
@@ -1,0 +1,352 @@
+rule_results:
+ e2e-pci-dss-4-0-accounts-restrict-service-account-tokens:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-accounts-unique-service-account:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-acs-sensor-exists:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-alert-receiver-configured:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-alwaysadmit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-alwayspullimages:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-namespacelifecycle:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-noderestriction:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-scc:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-service-account:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-anonymous-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-audit-log-maxbackup:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-audit-log-maxsize:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-audit-log-path:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-auth-mode-no-aa:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-auth-mode-rbac:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-basic-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-bind-address:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-client-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-encryption-provider-cipher:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-etcd-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-etcd-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-etcd-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-https-for-kubelet-conn:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-insecure-bind-address:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-kubelet-certificate-authority:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-kubelet-client-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-kubelet-client-cert-pre-4-9:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-api-server-kubelet-client-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-kubelet-client-key-pre-4-9:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-api-server-oauth-https-serving-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-openshift-https-serving-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-profiling-protected-by-rbac:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-request-timeout:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-service-account-lookup:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-service-account-public-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-tls-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-tls-cipher-suites:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-tls-private-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-tls-security-profile:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-token-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-audit-error-alert-exists:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-audit-log-forwarding-enabled:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-audit-log-forwarding-webhook:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-audit-logging-enabled:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-audit-profile-set:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-configure-network-policies:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-configure-network-policies-hypershift-hosted:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-configure-network-policies-namespaces:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-container-security-operator-exists:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-insecure-port-disabled:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-secure-port:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-service-account-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-service-account-private-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-use-service-account:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-auto-tls:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-cert-file:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-client-cert-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-key-file:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-peer-auto-tls:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-peer-cert-file:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-peer-client-cert-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-peer-key-file:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-file-groupowner-proxy-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-file-integrity-exists:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-file-integrity-notification-enabled:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-file-owner-proxy-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-file-permissions-proxy-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-general-apply-scc:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-general-default-namespace-use:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-general-default-seccomp-profile:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-general-namespaces-in-use:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-idp-is-configured:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ingress-controller-certificate:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ingress-controller-tls-security-profile:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-kubeadmin-removed:
+   default_result: FAIL
+   result_after_remediation: FAIL
+ e2e-pci-dss-4-0-kubelet-configure-tls-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-kubelet-configure-tls-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-kubelet-disable-readonly-port:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-machine-volume-encrypted:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-oauth-or-oauthclient-inactivity-timeout:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-allowed-registries:
+   default_result: FAIL
+   result_after_remediation: FAIL
+ e2e-pci-dss-4-0-ocp-allowed-registries-for-import:
+   default_result: FAIL
+   result_after_remediation: FAIL
+ e2e-pci-dss-4-0-ocp-api-server-audit-log-maxbackup:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-api-server-audit-log-maxsize:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-idp-no-htpasswd:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-insecure-allowed-registries-for-import:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-insecure-registries:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-no-ldap-insecure:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-openshift-api-server-audit-log-path:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-rbac-cluster-roles-defined:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-rbac-debug-role-protects-pprof:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-rbac-least-privilege:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-rbac-limit-cluster-admin:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-rbac-limit-secrets-access:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-rbac-pod-creation-access:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-rbac-roles-defined:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-rbac-wildcard-use:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-routes-protected-by-tls:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-scansettingbinding-exists:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-scc-drop-container-capabilities:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-container-allowed-capabilities:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-scc-limit-ipc-namespace:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-net-raw-capability:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-network-namespace:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-privilege-escalation:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-privileged-containers:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-process-id-namespace:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-root-containers:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scheduler-profiling-protected-by-rbac:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-scheduler-service-protected-by-rbac:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-secrets-consider-external-storage:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-secrets-no-environment-variables:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-security-profiles-operator-exists:
+   default_result: FAIL
+   result_after_remediation: FAIL
+ e2e-pci-dss-4-0-storageclass-encryption-enabled:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-tls-version-check-apiserver:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-tls-version-check-router:
+   default_result: PASS
+   result_after_remediation: PASS 

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.16.yml
@@ -340,7 +340,7 @@ rule_results:
    result_after_remediation: MANUAL
  e2e-pci-dss-4-0-security-profiles-operator-exists:
    default_result: FAIL
-   result_after_remediation: FAIL
+   result_after_remediation: PASS
  e2e-pci-dss-4-0-storageclass-encryption-enabled:
    default_result: PASS
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.17.yml
@@ -340,7 +340,7 @@ rule_results:
    result_after_remediation: MANUAL
  e2e-pci-dss-4-0-security-profiles-operator-exists:
    default_result: FAIL
-   result_after_remediation: FAIL
+   result_after_remediation: PASS
  e2e-pci-dss-4-0-storageclass-encryption-enabled:
    default_result: PASS
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.17.yml
@@ -1,0 +1,352 @@
+rule_results:
+ e2e-pci-dss-4-0-accounts-restrict-service-account-tokens:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-accounts-unique-service-account:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-acs-sensor-exists:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-alert-receiver-configured:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-alwaysadmit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-alwayspullimages:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-namespacelifecycle:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-noderestriction:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-scc:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-admission-control-plugin-service-account:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-anonymous-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-audit-log-maxbackup:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-audit-log-maxsize:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-audit-log-path:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-auth-mode-no-aa:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-auth-mode-rbac:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-basic-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-bind-address:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-client-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-encryption-provider-cipher:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-etcd-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-etcd-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-etcd-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-https-for-kubelet-conn:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-insecure-bind-address:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-kubelet-certificate-authority:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-kubelet-client-cert:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-api-server-kubelet-client-cert-pre-4-9:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-api-server-kubelet-client-key:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-api-server-kubelet-client-key-pre-4-9:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-api-server-oauth-https-serving-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-openshift-https-serving-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-profiling-protected-by-rbac:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-request-timeout:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-service-account-lookup:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-service-account-public-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-tls-cert:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-tls-cipher-suites:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-tls-private-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-tls-security-profile:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-api-server-token-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-audit-error-alert-exists:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-audit-log-forwarding-enabled:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-audit-log-forwarding-webhook:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-audit-logging-enabled:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-audit-profile-set:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-configure-network-policies:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-configure-network-policies-hypershift-hosted:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-configure-network-policies-namespaces:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-container-security-operator-exists:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-insecure-port-disabled:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-secure-port:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-service-account-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-service-account-private-key:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-controller-use-service-account:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-auto-tls:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-cert-file:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-client-cert-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-key-file:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-peer-auto-tls:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-peer-cert-file:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-peer-client-cert-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-etcd-peer-key-file:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-file-groupowner-proxy-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-file-integrity-exists:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-file-integrity-notification-enabled:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-file-owner-proxy-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-file-permissions-proxy-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-general-apply-scc:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-general-default-namespace-use:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-general-default-seccomp-profile:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-general-namespaces-in-use:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-idp-is-configured:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ingress-controller-certificate:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ingress-controller-tls-security-profile:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-kubeadmin-removed:
+   default_result: FAIL
+   result_after_remediation: FAIL
+ e2e-pci-dss-4-0-kubelet-configure-tls-cert:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-kubelet-configure-tls-key:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-kubelet-disable-readonly-port:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-machine-volume-encrypted:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-oauth-or-oauthclient-inactivity-timeout:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-allowed-registries:
+   default_result: FAIL
+   result_after_remediation: FAIL
+ e2e-pci-dss-4-0-ocp-allowed-registries-for-import:
+   default_result: FAIL
+   result_after_remediation: FAIL
+ e2e-pci-dss-4-0-ocp-api-server-audit-log-maxbackup:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-api-server-audit-log-maxsize:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-idp-no-htpasswd:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-insecure-allowed-registries-for-import:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-insecure-registries:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-ocp-no-ldap-insecure:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-openshift-api-server-audit-log-path:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-rbac-cluster-roles-defined:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-rbac-debug-role-protects-pprof:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-rbac-least-privilege:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-rbac-limit-cluster-admin:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-rbac-limit-secrets-access:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-rbac-pod-creation-access:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-rbac-roles-defined:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-rbac-wildcard-use:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-routes-protected-by-tls:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-scansettingbinding-exists:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-scc-drop-container-capabilities:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-container-allowed-capabilities:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-scc-limit-ipc-namespace:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-net-raw-capability:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-network-namespace:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-privilege-escalation:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-privileged-containers:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-process-id-namespace:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scc-limit-root-containers:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-scheduler-profiling-protected-by-rbac:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-scheduler-service-protected-by-rbac:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-secrets-consider-external-storage:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-secrets-no-environment-variables:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-4-0-security-profiles-operator-exists:
+   default_result: FAIL
+   result_after_remediation: FAIL
+ e2e-pci-dss-4-0-storageclass-encryption-enabled:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-tls-version-check-apiserver:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-4-0-tls-version-check-router:
+   default_result: PASS
+   result_after_remediation: PASS 

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.12.yml
@@ -1,0 +1,685 @@
+rule_results:
+ e2e-pci-dss-node-4-0-master-directory-access-var-log-kube-audit:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-directory-access-var-log-oauth-audit:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-directory-access-var-log-ocp-audit:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-directory-permissions-var-log-kube-audit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-directory-permissions-var-log-oauth-audit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-directory-permissions-var-log-ocp-audit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-etcd-unique-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-cni-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-controller-manager-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-etcd-data-dir:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-etcd-data-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-etcd-member:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-etcd-pki-cert-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-ip-allocations:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-master-file-groupowner-kube-apiserver:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-kube-controller-manager:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-kube-scheduler:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-kubelet-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-master-admin-kubeconfigs:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-multus-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-openshift-pki-cert-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-openshift-pki-key-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-openshift-sdn-cniserver-config:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-master-file-groupowner-ovn-cni-server-sock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-ovn-db-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-ovs-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-ovs-vswitchd-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-ovsdb-server-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-scheduler-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-worker-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-worker-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-worker-service:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-cni-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-controller-manager-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-etcd-data-dir:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-etcd-data-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-etcd-member:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-etcd-pki-cert-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-ip-allocations:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-master-file-owner-kube-apiserver:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-kube-controller-manager:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-kube-scheduler:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-kubelet:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-kubelet-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-master-admin-kubeconfigs:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-multus-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-openshift-pki-cert-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-openshift-pki-key-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-openshift-sdn-cniserver-config:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-master-file-owner-ovn-cni-server-sock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-ovn-db-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-ovs-conf-db:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-ovs-conf-db-lock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-ovs-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-ovs-sys-id-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-ovs-vswitchd-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-ovsdb-server-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-scheduler-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-worker-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-worker-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-worker-service:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-ownership-var-log-kube-audit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-ownership-var-log-oauth-audit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-ownership-var-log-ocp-audit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-cni-conf:
+   default_result: FAIL
+   result_after_remediation: FAIL
+ e2e-pci-dss-node-4-0-master-file-permissions-controller-manager-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-etcd-data-dir:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-etcd-data-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-etcd-member:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-etcd-pki-cert-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-ip-allocations:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-master-file-permissions-kube-apiserver:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-kube-controller-manager:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-kubelet-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-master-admin-kubeconfigs:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-multus-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-openshift-pki-cert-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-openshift-pki-key-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-ovn-cni-server-sock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-ovn-db-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-ovs-conf-db:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-ovs-conf-db-lock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-ovs-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-ovs-sys-id-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-ovs-vswitchd-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-ovsdb-server-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-scheduler:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-scheduler-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-var-log-kube-audit:
+   default_result: INCONSISTENT
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-var-log-oauth-audit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-var-log-ocp-audit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-worker-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-worker-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-worker-service:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-perms-openshift-sdn-cniserver-config:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-master-kubelet-anonymous-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-authorization-mode:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-configure-client-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-configure-event-creation:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-configure-tls-cipher-suites:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-configure-tls-min-version:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-enable-cert-rotation:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-enable-client-cert-rotation:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-enable-iptables-util-chains:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-enable-server-cert-rotation:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-enable-streaming-connections:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-eviction-thresholds-set-hard-imagefs-available:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-eviction-thresholds-set-hard-memory-available:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-eviction-thresholds-set-hard-nodefs-available:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-eviction-thresholds-set-hard-nodefs-inodesfree:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-tls-version-check-masters-workers:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-directory-access-var-log-kube-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-directory-access-var-log-oauth-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-directory-access-var-log-ocp-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-directory-permissions-var-log-kube-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-directory-permissions-var-log-oauth-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-directory-permissions-var-log-ocp-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-etcd-unique-ca:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-cni-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-controller-manager-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-etcd-data-dir:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-etcd-data-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-etcd-member:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-etcd-pki-cert-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-ip-allocations:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-kube-apiserver:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-kube-controller-manager:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-kube-scheduler:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-kubelet-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-master-admin-kubeconfigs:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-multus-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-openshift-pki-cert-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-openshift-pki-key-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-openshift-sdn-cniserver-config:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-ovn-cni-server-sock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-ovn-db-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-vswitchd-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-ovsdb-server-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-scheduler-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-worker-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-worker-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-worker-service:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-cni-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-controller-manager-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-etcd-data-dir:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-etcd-data-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-etcd-member:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-etcd-pki-cert-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-ip-allocations:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-kube-apiserver:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-kube-controller-manager:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-kube-scheduler:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-kubelet:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-kubelet-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-master-admin-kubeconfigs:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-multus-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-openshift-pki-cert-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-openshift-pki-key-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-openshift-sdn-cniserver-config:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-ovn-cni-server-sock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-ovn-db-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-ovs-conf-db:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-ovs-conf-db-lock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-ovs-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-ovs-sys-id-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-ovs-vswitchd-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-ovsdb-server-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-scheduler-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-worker-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-worker-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-worker-service:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-ownership-var-log-kube-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-ownership-var-log-oauth-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-ownership-var-log-ocp-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-cni-conf:
+   default_result: FAIL
+   result_after_remediation: FAIL
+ e2e-pci-dss-node-4-0-worker-file-permissions-controller-manager-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-etcd-data-dir:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-etcd-data-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-etcd-member:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-etcd-pki-cert-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-ip-allocations:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-kube-apiserver:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-kube-controller-manager:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-kubelet-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-master-admin-kubeconfigs:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-multus-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-openshift-pki-cert-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-openshift-pki-key-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-ovn-cni-server-sock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-ovn-db-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-ovs-conf-db:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-ovs-conf-db-lock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-ovs-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-ovs-sys-id-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-ovs-vswitchd-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-ovsdb-server-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-scheduler:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-scheduler-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-var-log-kube-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-var-log-oauth-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-var-log-ocp-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-worker-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-worker-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-worker-service:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-perms-openshift-sdn-cniserver-config:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-kubelet-anonymous-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-authorization-mode:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-configure-client-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-configure-event-creation:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-configure-tls-cipher-suites:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-configure-tls-min-version:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-enable-cert-rotation:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-enable-client-cert-rotation:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-enable-iptables-util-chains:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-enable-server-cert-rotation:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-enable-streaming-connections:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-eviction-thresholds-set-hard-imagefs-available:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-eviction-thresholds-set-hard-memory-available:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-eviction-thresholds-set-hard-nodefs-available:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-eviction-thresholds-set-hard-nodefs-inodesfree:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-tls-version-check-masters-workers:
+   default_result: PASS
+   result_after_remediation: PASS 

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.13.yml
@@ -1,0 +1,685 @@
+rule_results:
+  e2e-pci-dss-node-4-0-master-directory-access-var-log-kube-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-directory-access-var-log-oauth-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-directory-access-var-log-ocp-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-directory-permissions-var-log-kube-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-directory-permissions-var-log-oauth-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-directory-permissions-var-log-ocp-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-etcd-unique-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-cni-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-controller-manager-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-etcd-data-dir:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-etcd-data-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-etcd-member:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-etcd-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-groupowner-kube-apiserver:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-kube-controller-manager:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-kube-scheduler:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-master-admin-kubeconfigs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-openshift-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-openshift-pki-key-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-scheduler-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-cni-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-controller-manager-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-etcd-data-dir:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-etcd-data-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-etcd-member:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-etcd-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-owner-kube-apiserver:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-kube-controller-manager:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-kube-scheduler:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-kubelet:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-master-admin-kubeconfigs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-openshift-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-openshift-pki-key-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-owner-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-scheduler-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-ownership-var-log-kube-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-ownership-var-log-oauth-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-ownership-var-log-ocp-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-cni-conf:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-pci-dss-node-4-0-master-file-permissions-controller-manager-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-etcd-data-dir:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-etcd-data-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-etcd-member:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-etcd-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-permissions-kube-apiserver:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-kube-controller-manager:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-master-admin-kubeconfigs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-openshift-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-openshift-pki-key-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-scheduler:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-scheduler-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-var-log-kube-audit:
+    default_result: INCONSISTENT
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-var-log-oauth-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-var-log-ocp-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-perms-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-kubelet-anonymous-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-authorization-mode:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-configure-client-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-configure-event-creation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-configure-tls-cipher-suites:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-configure-tls-min-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-enable-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-enable-client-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-enable-iptables-util-chains:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-enable-server-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-enable-streaming-connections:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-eviction-thresholds-set-hard-imagefs-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-eviction-thresholds-set-hard-memory-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-eviction-thresholds-set-hard-nodefs-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-eviction-thresholds-set-hard-nodefs-inodesfree:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-tls-version-check-masters-workers:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-directory-access-var-log-kube-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-directory-access-var-log-oauth-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-directory-access-var-log-ocp-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-directory-permissions-var-log-kube-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-directory-permissions-var-log-oauth-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-directory-permissions-var-log-ocp-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-etcd-unique-ca:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-cni-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-controller-manager-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-etcd-data-dir:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-etcd-data-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-etcd-member:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-etcd-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-kube-apiserver:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-kube-controller-manager:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-kube-scheduler:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-master-admin-kubeconfigs:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-openshift-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-openshift-pki-key-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-scheduler-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-cni-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-controller-manager-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-etcd-data-dir:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-etcd-data-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-etcd-member:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-etcd-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-kube-apiserver:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-kube-controller-manager:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-kube-scheduler:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-kubelet:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-master-admin-kubeconfigs:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-openshift-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-openshift-pki-key-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-scheduler-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-ownership-var-log-kube-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-ownership-var-log-oauth-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-ownership-var-log-ocp-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-cni-conf:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-pci-dss-node-4-0-worker-file-permissions-controller-manager-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-etcd-data-dir:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-etcd-data-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-etcd-member:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-etcd-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-kube-apiserver:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-kube-controller-manager:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-master-admin-kubeconfigs:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-openshift-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-openshift-pki-key-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-scheduler:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-scheduler-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-var-log-kube-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-var-log-oauth-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-var-log-ocp-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-perms-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-kubelet-anonymous-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-authorization-mode:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-configure-client-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-configure-event-creation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-configure-tls-cipher-suites:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-configure-tls-min-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-enable-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-enable-client-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-enable-iptables-util-chains:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-enable-server-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-enable-streaming-connections:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-eviction-thresholds-set-hard-imagefs-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-eviction-thresholds-set-hard-memory-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-eviction-thresholds-set-hard-nodefs-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-eviction-thresholds-set-hard-nodefs-inodesfree:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-tls-version-check-masters-workers:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.14.yml
@@ -1,0 +1,685 @@
+rule_results:
+  e2e-pci-dss-node-4-0-master-directory-access-var-log-kube-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-directory-access-var-log-oauth-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-directory-access-var-log-ocp-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-directory-permissions-var-log-kube-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-directory-permissions-var-log-oauth-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-directory-permissions-var-log-ocp-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-etcd-unique-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-cni-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-controller-manager-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-etcd-data-dir:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-etcd-data-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-etcd-member:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-etcd-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-groupowner-kube-apiserver:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-kube-controller-manager:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-kube-scheduler:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-master-admin-kubeconfigs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-openshift-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-openshift-pki-key-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-scheduler-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-cni-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-controller-manager-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-etcd-data-dir:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-etcd-data-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-etcd-member:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-etcd-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-owner-kube-apiserver:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-kube-controller-manager:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-kube-scheduler:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-kubelet:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-master-admin-kubeconfigs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-openshift-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-openshift-pki-key-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-owner-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-scheduler-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-ownership-var-log-kube-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-ownership-var-log-oauth-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-ownership-var-log-ocp-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-cni-conf:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-pci-dss-node-4-0-master-file-permissions-controller-manager-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-etcd-data-dir:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-etcd-data-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-etcd-member:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-etcd-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-permissions-kube-apiserver:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-kube-controller-manager:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-master-admin-kubeconfigs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-openshift-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-openshift-pki-key-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-scheduler:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-scheduler-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-var-log-kube-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-var-log-oauth-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-var-log-ocp-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-perms-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-kubelet-anonymous-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-authorization-mode:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-configure-client-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-configure-event-creation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-configure-tls-cipher-suites:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-configure-tls-min-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-enable-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-enable-client-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-enable-iptables-util-chains:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-enable-server-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-enable-streaming-connections:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-eviction-thresholds-set-hard-imagefs-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-eviction-thresholds-set-hard-memory-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-eviction-thresholds-set-hard-nodefs-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-eviction-thresholds-set-hard-nodefs-inodesfree:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-tls-version-check-masters-workers:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-directory-access-var-log-kube-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-directory-access-var-log-oauth-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-directory-access-var-log-ocp-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-directory-permissions-var-log-kube-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-directory-permissions-var-log-oauth-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-directory-permissions-var-log-ocp-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-etcd-unique-ca:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-cni-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-controller-manager-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-etcd-data-dir:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-etcd-data-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-etcd-member:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-etcd-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-kube-apiserver:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-kube-controller-manager:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-kube-scheduler:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-master-admin-kubeconfigs:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-openshift-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-openshift-pki-key-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-scheduler-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-cni-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-controller-manager-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-etcd-data-dir:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-etcd-data-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-etcd-member:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-etcd-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-kube-apiserver:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-kube-controller-manager:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-kube-scheduler:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-kubelet:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-master-admin-kubeconfigs:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-openshift-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-openshift-pki-key-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-scheduler-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-ownership-var-log-kube-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-ownership-var-log-oauth-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-ownership-var-log-ocp-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-cni-conf:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-pci-dss-node-4-0-worker-file-permissions-controller-manager-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-etcd-data-dir:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-etcd-data-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-etcd-member:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-etcd-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-kube-apiserver:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-kube-controller-manager:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-master-admin-kubeconfigs:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-openshift-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-openshift-pki-key-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-scheduler:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-scheduler-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-var-log-kube-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-var-log-oauth-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-var-log-ocp-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-perms-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-kubelet-anonymous-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-authorization-mode:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-configure-client-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-configure-event-creation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-configure-tls-cipher-suites:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-configure-tls-min-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-enable-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-enable-client-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-enable-iptables-util-chains:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-enable-server-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-enable-streaming-connections:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-eviction-thresholds-set-hard-imagefs-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-eviction-thresholds-set-hard-memory-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-eviction-thresholds-set-hard-nodefs-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-eviction-thresholds-set-hard-nodefs-inodesfree:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-tls-version-check-masters-workers:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.15.yml
@@ -1,0 +1,685 @@
+rule_results:
+  e2e-pci-dss-node-4-0-master-directory-access-var-log-kube-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-directory-access-var-log-oauth-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-directory-access-var-log-ocp-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-directory-permissions-var-log-kube-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-directory-permissions-var-log-oauth-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-directory-permissions-var-log-ocp-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-etcd-unique-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-cni-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-controller-manager-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-etcd-data-dir:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-etcd-data-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-etcd-member:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-etcd-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-groupowner-kube-apiserver:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-kube-controller-manager:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-kube-scheduler:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-master-admin-kubeconfigs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-openshift-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-openshift-pki-key-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-scheduler-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-cni-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-controller-manager-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-etcd-data-dir:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-etcd-data-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-etcd-member:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-etcd-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-owner-kube-apiserver:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-kube-controller-manager:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-kube-scheduler:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-kubelet:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-master-admin-kubeconfigs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-openshift-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-openshift-pki-key-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-owner-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-scheduler-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-owner-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-ownership-var-log-kube-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-ownership-var-log-oauth-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-ownership-var-log-ocp-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-cni-conf:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-pci-dss-node-4-0-master-file-permissions-controller-manager-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-etcd-data-dir:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-etcd-data-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-etcd-member:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-etcd-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-permissions-kube-apiserver:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-kube-controller-manager:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-master-admin-kubeconfigs:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-openshift-pki-cert-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-openshift-pki-key-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-scheduler:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-scheduler-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-var-log-kube-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-var-log-oauth-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-var-log-ocp-audit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-permissions-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-perms-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-kubelet-anonymous-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-authorization-mode:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-configure-client-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-configure-event-creation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-configure-tls-cipher-suites:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-configure-tls-min-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-enable-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-enable-client-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-enable-iptables-util-chains:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-enable-server-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-enable-streaming-connections:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-eviction-thresholds-set-hard-imagefs-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-eviction-thresholds-set-hard-memory-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-eviction-thresholds-set-hard-nodefs-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-kubelet-eviction-thresholds-set-hard-nodefs-inodesfree:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-tls-version-check-masters-workers:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-directory-access-var-log-kube-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-directory-access-var-log-oauth-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-directory-access-var-log-ocp-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-directory-permissions-var-log-kube-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-directory-permissions-var-log-oauth-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-directory-permissions-var-log-ocp-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-etcd-unique-ca:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-cni-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-controller-manager-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-etcd-data-dir:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-etcd-data-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-etcd-member:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-etcd-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-kube-apiserver:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-kube-controller-manager:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-kube-scheduler:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-master-admin-kubeconfigs:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-openshift-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-openshift-pki-key-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-scheduler-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-groupowner-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-cni-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-controller-manager-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-etcd-data-dir:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-etcd-data-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-etcd-member:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-etcd-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-kube-apiserver:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-kube-controller-manager:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-kube-scheduler:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-kubelet:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-master-admin-kubeconfigs:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-openshift-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-openshift-pki-key-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-scheduler-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-owner-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-owner-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-ownership-var-log-kube-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-ownership-var-log-oauth-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-ownership-var-log-ocp-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-cni-conf:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-pci-dss-node-4-0-worker-file-permissions-controller-manager-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-etcd-data-dir:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-etcd-data-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-etcd-member:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-etcd-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-ip-allocations:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-kube-apiserver:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-kube-controller-manager:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-kubelet-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-master-admin-kubeconfigs:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-multus-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-openshift-pki-cert-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-openshift-pki-key-files:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-ovn-cni-server-sock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-ovn-db-files:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-ovs-conf-db:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-ovs-conf-db-lock:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-ovs-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-ovs-sys-id-conf:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-ovs-vswitchd-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-ovsdb-server-pid:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-scheduler:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-scheduler-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-var-log-kube-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-var-log-oauth-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-var-log-ocp-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-permissions-worker-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-worker-kubeconfig:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-permissions-worker-service:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-file-perms-openshift-sdn-cniserver-config:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-kubelet-anonymous-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-authorization-mode:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-configure-client-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-configure-event-creation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-configure-tls-cipher-suites:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-configure-tls-min-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-enable-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-enable-client-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-enable-iptables-util-chains:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-enable-server-cert-rotation:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-enable-streaming-connections:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-eviction-thresholds-set-hard-imagefs-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-eviction-thresholds-set-hard-memory-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-eviction-thresholds-set-hard-nodefs-available:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-kubelet-eviction-thresholds-set-hard-nodefs-inodesfree:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-worker-tls-version-check-masters-workers:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.16.yml
@@ -1,0 +1,685 @@
+rule_results:
+ e2e-pci-dss-node-4-0-master-directory-access-var-log-kube-audit:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-directory-access-var-log-oauth-audit:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-directory-access-var-log-ocp-audit:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-directory-permissions-var-log-kube-audit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-directory-permissions-var-log-oauth-audit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-directory-permissions-var-log-ocp-audit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-etcd-unique-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-cni-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-controller-manager-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-etcd-data-dir:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-etcd-data-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-etcd-member:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-etcd-pki-cert-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-ip-allocations:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-master-file-groupowner-kube-apiserver:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-kube-controller-manager:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-kube-scheduler:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-kubelet-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-master-admin-kubeconfigs:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-multus-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-openshift-pki-cert-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-openshift-pki-key-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-openshift-sdn-cniserver-config:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-master-file-groupowner-ovn-cni-server-sock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-ovn-db-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-ovs-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-ovs-vswitchd-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-ovsdb-server-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-scheduler-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-worker-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-worker-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-worker-service:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-cni-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-controller-manager-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-etcd-data-dir:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-etcd-data-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-etcd-member:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-etcd-pki-cert-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-ip-allocations:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-master-file-owner-kube-apiserver:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-kube-controller-manager:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-kube-scheduler:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-kubelet:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-kubelet-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-master-admin-kubeconfigs:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-multus-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-openshift-pki-cert-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-openshift-pki-key-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-openshift-sdn-cniserver-config:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-master-file-owner-ovn-cni-server-sock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-ovn-db-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-ovs-conf-db:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-ovs-conf-db-lock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-ovs-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-ovs-sys-id-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-ovs-vswitchd-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-ovsdb-server-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-scheduler-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-worker-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-worker-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-worker-service:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-ownership-var-log-kube-audit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-ownership-var-log-oauth-audit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-ownership-var-log-ocp-audit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-cni-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-controller-manager-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-etcd-data-dir:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-etcd-data-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-etcd-member:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-etcd-pki-cert-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-ip-allocations:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-master-file-permissions-kube-apiserver:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-kube-controller-manager:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-kubelet-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-master-admin-kubeconfigs:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-multus-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-openshift-pki-cert-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-openshift-pki-key-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-ovn-cni-server-sock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-ovn-db-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-ovs-conf-db:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-ovs-conf-db-lock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-ovs-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-ovs-sys-id-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-ovs-vswitchd-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-ovsdb-server-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-scheduler:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-scheduler-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-var-log-kube-audit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-var-log-oauth-audit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-var-log-ocp-audit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-worker-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-worker-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-worker-service:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-perms-openshift-sdn-cniserver-config:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-master-kubelet-anonymous-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-authorization-mode:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-configure-client-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-configure-event-creation:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-configure-tls-cipher-suites:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-configure-tls-min-version:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-enable-cert-rotation:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-enable-client-cert-rotation:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-enable-iptables-util-chains:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-enable-server-cert-rotation:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-enable-streaming-connections:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-eviction-thresholds-set-hard-imagefs-available:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-eviction-thresholds-set-hard-memory-available:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-eviction-thresholds-set-hard-nodefs-available:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-eviction-thresholds-set-hard-nodefs-inodesfree:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-tls-version-check-masters-workers:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-directory-access-var-log-kube-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-directory-access-var-log-oauth-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-directory-access-var-log-ocp-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-directory-permissions-var-log-kube-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-directory-permissions-var-log-oauth-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-directory-permissions-var-log-ocp-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-etcd-unique-ca:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-cni-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-controller-manager-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-etcd-data-dir:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-etcd-data-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-etcd-member:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-etcd-pki-cert-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-ip-allocations:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-kube-apiserver:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-kube-controller-manager:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-kube-scheduler:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-kubelet-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-master-admin-kubeconfigs:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-multus-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-openshift-pki-cert-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-openshift-pki-key-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-openshift-sdn-cniserver-config:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-ovn-cni-server-sock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-ovn-db-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-vswitchd-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-ovsdb-server-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-scheduler-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-worker-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-worker-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-worker-service:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-cni-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-controller-manager-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-etcd-data-dir:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-etcd-data-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-etcd-member:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-etcd-pki-cert-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-ip-allocations:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-kube-apiserver:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-kube-controller-manager:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-kube-scheduler:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-kubelet:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-kubelet-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-master-admin-kubeconfigs:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-multus-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-openshift-pki-cert-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-openshift-pki-key-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-openshift-sdn-cniserver-config:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-ovn-cni-server-sock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-ovn-db-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-ovs-conf-db:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-ovs-conf-db-lock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-ovs-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-ovs-sys-id-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-ovs-vswitchd-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-ovsdb-server-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-scheduler-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-worker-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-worker-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-worker-service:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-ownership-var-log-kube-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-ownership-var-log-oauth-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-ownership-var-log-ocp-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-cni-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-controller-manager-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-etcd-data-dir:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-etcd-data-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-etcd-member:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-etcd-pki-cert-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-ip-allocations:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-kube-apiserver:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-kube-controller-manager:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-kubelet-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-master-admin-kubeconfigs:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-multus-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-openshift-pki-cert-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-openshift-pki-key-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-ovn-cni-server-sock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-ovn-db-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-ovs-conf-db:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-ovs-conf-db-lock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-ovs-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-ovs-sys-id-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-ovs-vswitchd-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-ovsdb-server-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-scheduler:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-scheduler-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-var-log-kube-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-var-log-oauth-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-var-log-ocp-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-worker-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-worker-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-worker-service:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-perms-openshift-sdn-cniserver-config:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-kubelet-anonymous-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-authorization-mode:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-configure-client-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-configure-event-creation:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-configure-tls-cipher-suites:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-configure-tls-min-version:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-enable-cert-rotation:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-enable-client-cert-rotation:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-enable-iptables-util-chains:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-enable-server-cert-rotation:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-enable-streaming-connections:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-eviction-thresholds-set-hard-imagefs-available:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-eviction-thresholds-set-hard-memory-available:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-eviction-thresholds-set-hard-nodefs-available:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-eviction-thresholds-set-hard-nodefs-inodesfree:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-tls-version-check-masters-workers:
+   default_result: PASS
+   result_after_remediation: PASS 

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.17.yml
@@ -1,0 +1,685 @@
+rule_results:
+ e2e-pci-dss-node-4-0-master-directory-access-var-log-kube-audit:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-directory-access-var-log-oauth-audit:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-directory-access-var-log-ocp-audit:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-directory-permissions-var-log-kube-audit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-directory-permissions-var-log-oauth-audit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-directory-permissions-var-log-ocp-audit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-etcd-unique-ca:
+   default_result: FAIL
+   result_after_remediation: FAIL
+ e2e-pci-dss-node-4-0-master-file-groupowner-cni-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-controller-manager-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-etcd-data-dir:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-etcd-data-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-etcd-member:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-etcd-pki-cert-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-ip-allocations:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-master-file-groupowner-kube-apiserver:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-kube-controller-manager:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-kube-scheduler:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-kubelet-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-master-admin-kubeconfigs:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-multus-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-openshift-pki-cert-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-openshift-pki-key-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-openshift-sdn-cniserver-config:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-master-file-groupowner-ovn-cni-server-sock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-ovn-db-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-ovs-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-ovs-vswitchd-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-ovsdb-server-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-scheduler-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-worker-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-worker-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-groupowner-worker-service:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-cni-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-controller-manager-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-etcd-data-dir:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-etcd-data-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-etcd-member:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-etcd-pki-cert-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-ip-allocations:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-master-file-owner-kube-apiserver:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-kube-controller-manager:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-kube-scheduler:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-kubelet:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-kubelet-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-master-admin-kubeconfigs:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-multus-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-openshift-pki-cert-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-openshift-pki-key-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-openshift-sdn-cniserver-config:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-master-file-owner-ovn-cni-server-sock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-ovn-db-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-ovs-conf-db:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-ovs-conf-db-lock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-ovs-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-ovs-sys-id-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-ovs-vswitchd-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-ovsdb-server-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-scheduler-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-worker-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-worker-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-owner-worker-service:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-ownership-var-log-kube-audit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-ownership-var-log-oauth-audit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-ownership-var-log-ocp-audit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-cni-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-controller-manager-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-etcd-data-dir:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-etcd-data-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-etcd-member:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-etcd-pki-cert-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-ip-allocations:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-master-file-permissions-kube-apiserver:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-kube-controller-manager:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-kubelet-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-master-admin-kubeconfigs:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-multus-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-openshift-pki-cert-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-openshift-pki-key-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-ovn-cni-server-sock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-ovn-db-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-ovs-conf-db:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-ovs-conf-db-lock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-ovs-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-ovs-sys-id-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-ovs-vswitchd-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-ovsdb-server-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-scheduler:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-scheduler-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-var-log-kube-audit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-var-log-oauth-audit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-var-log-ocp-audit:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-worker-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-worker-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-permissions-worker-service:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-file-perms-openshift-sdn-cniserver-config:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-master-kubelet-anonymous-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-authorization-mode:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-configure-client-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-configure-event-creation:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-configure-tls-cipher-suites:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-configure-tls-min-version:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-enable-cert-rotation:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-enable-client-cert-rotation:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-enable-iptables-util-chains:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-enable-server-cert-rotation:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-enable-streaming-connections:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-eviction-thresholds-set-hard-imagefs-available:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-eviction-thresholds-set-hard-memory-available:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-eviction-thresholds-set-hard-nodefs-available:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-kubelet-eviction-thresholds-set-hard-nodefs-inodesfree:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-master-tls-version-check-masters-workers:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-directory-access-var-log-kube-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-directory-access-var-log-oauth-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-directory-access-var-log-ocp-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-directory-permissions-var-log-kube-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-directory-permissions-var-log-oauth-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-directory-permissions-var-log-ocp-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-etcd-unique-ca:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-cni-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-controller-manager-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-etcd-data-dir:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-etcd-data-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-etcd-member:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-etcd-pki-cert-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-ip-allocations:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-kube-apiserver:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-kube-controller-manager:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-kube-scheduler:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-kubelet-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-master-admin-kubeconfigs:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-multus-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-openshift-pki-cert-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-openshift-pki-key-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-openshift-sdn-cniserver-config:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-ovn-cni-server-sock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-ovn-db-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-vswitchd-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-ovsdb-server-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-scheduler-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-groupowner-worker-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-worker-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-groupowner-worker-service:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-cni-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-controller-manager-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-etcd-data-dir:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-etcd-data-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-etcd-member:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-etcd-pki-cert-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-ip-allocations:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-kube-apiserver:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-kube-controller-manager:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-kube-scheduler:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-kubelet:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-kubelet-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-master-admin-kubeconfigs:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-multus-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-openshift-pki-cert-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-openshift-pki-key-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-openshift-sdn-cniserver-config:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-ovn-cni-server-sock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-ovn-db-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-ovs-conf-db:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-ovs-conf-db-lock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-ovs-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-ovs-sys-id-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-ovs-vswitchd-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-ovsdb-server-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-scheduler-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-owner-worker-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-worker-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-owner-worker-service:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-ownership-var-log-kube-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-ownership-var-log-oauth-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-ownership-var-log-ocp-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-cni-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-controller-manager-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-etcd-data-dir:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-etcd-data-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-etcd-member:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-etcd-pki-cert-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-ip-allocations:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-kube-apiserver:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-kube-controller-manager:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-kubelet-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-master-admin-kubeconfigs:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-multus-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-openshift-pki-cert-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-openshift-pki-key-files:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-ovn-cni-server-sock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-ovn-db-files:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-ovs-conf-db:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-ovs-conf-db-lock:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-ovs-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-ovs-sys-id-conf:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-ovs-vswitchd-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-ovsdb-server-pid:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-scheduler:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-scheduler-kubeconfig:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-var-log-kube-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-var-log-oauth-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-var-log-ocp-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-file-permissions-worker-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-worker-kubeconfig:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-permissions-worker-service:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-file-perms-openshift-sdn-cniserver-config:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-4-0-worker-kubelet-anonymous-auth:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-authorization-mode:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-configure-client-ca:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-configure-event-creation:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-configure-tls-cipher-suites:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-configure-tls-min-version:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-enable-cert-rotation:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-enable-client-cert-rotation:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-enable-iptables-util-chains:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-enable-server-cert-rotation:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-enable-streaming-connections:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-eviction-thresholds-set-hard-imagefs-available:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-eviction-thresholds-set-hard-memory-available:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-eviction-thresholds-set-hard-nodefs-available:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-kubelet-eviction-thresholds-set-hard-nodefs-inodesfree:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-4-0-worker-tls-version-check-masters-workers:
+   default_result: PASS
+   result_after_remediation: PASS 

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.17.yml
@@ -18,8 +18,8 @@ rule_results:
    default_result: PASS
    result_after_remediation: PASS
  e2e-pci-dss-node-4-0-master-etcd-unique-ca:
-   default_result: FAIL
-   result_after_remediation: FAIL
+  default_result: PASS
+  result_after_remediation: PASS
  e2e-pci-dss-node-4-0-master-file-groupowner-cni-conf:
    default_result: PASS
    result_after_remediation: PASS


### PR DESCRIPTION
#### Description:

- Assertion files for pci-dss-4-0 and pci-dss-node-4-0 on ocp > 4.12
- Enable the following rules on 4.17:
  - `api_server_kubelet_client_cert`
  - `api_server_kubelet_client_key`
  - `kubelet_configure_tls_cert`
  - `kubelet_configure_tls_key`

#### Rationale:

- These asssertion files ensure the profile results are not drifting without us noticing.

#### Notes
- Some assertion files are misssing, they will added in this PR briefly.