### PR TITLE
Fix chronyd remote server filepath dir regex

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/oval/shared.xml
@@ -15,7 +15,7 @@
 
   <ind:textfilecontent54_object comment="Ensure at least one NTP server is set"
   id="object_chronyd_remote_server" version="1">
-    <ind:filepath operation="pattern match">^({{{ chrony_conf_path }}}|{{{ chrony_d_path }}}/.+\.conf)$</ind:filepath>
+    <ind:filepath operation="pattern match">^({{{ chrony_conf_path }}}|{{{ chrony_d_path }}}.+\.conf)$</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*(?:server|pool)[\s]+.+$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/products/debian12/product.yml
+++ b/products/debian12/product.yml
@@ -20,7 +20,7 @@ init_system: "systemd"
 oval_feed_url: "https://www.debian.org/security/oval/oval-definitions-bookworm.xml.bz2"
 
 chrony_conf_path: "/etc/chrony/chrony.conf"
-chrony_d_path: "/etc/chrony/chrony.d"
+chrony_d_path: "/etc/chrony/chrony.d/"
   
 cpes_root: "../../shared/applicability"
 cpes:

--- a/tests/data/product_stability/debian12.yml
+++ b/tests/data/product_stability/debian12.yml
@@ -8,7 +8,7 @@ basic_properties_derived: true
 benchmark_id: DEBIAN-12
 benchmark_root: ../../linux_os/guide
 chrony_conf_path: /etc/chrony/chrony.conf
-chrony_d_path: /etc/chrony/chrony.d
+chrony_d_path: /etc/chrony/chrony.d/
 cpes:
 - debian12:
     check_id: installed_OS_is_debian12


### PR DESCRIPTION
#### Description:

- Fixes the regular expression that matches `chrony.d/*.conf` files.
  Remove extra forward slash in `chronyd_specify_remote_server` OVAL filepath

#### Rationale:

- The rule was likely only working for Debian regarding drop-in chronyd files, as its `product.yml` configured a `chrony_d_path` without a trailing slash.

#### Review Hints:

- The default path in the project already contains a trailing forward slash, the rule's filepath was adding an extra slash and causing rule not to be found.
  - https://github.com/ComplianceAsCode/content/blob/e1869849346024f40803f4251025e2749ed91adc/ssg/constants.py#L449
- This is a follow up from #12084
  - CC: @a-skr 