### PR TITLE
Add insensitive option to ansible_lineinfile macro

### DIFF
--- a/linux_os/guide/services/mail/postfix_client/postfix_network_listening_disabled/ansible/shared.yml
+++ b/linux_os/guide/services/mail/postfix_client/postfix_network_listening_disabled/ansible/shared.yml
@@ -9,4 +9,4 @@
   package_facts:
     manager: auto
 
-{{{ ansible_lineinfile(msg='Make changes to Postfix configuration file', path='/etc/postfix/main.cf', regex='^inet_interfaces\s*=\s.*', new_line='inet_interfaces = {{ var_postfix_inet_interfaces }}', create='no', state='present', insert_after='^inet_interfaces\s*=\s.*', when='"postfix" in ansible_facts.packages') }}}
+{{{ ansible_lineinfile(msg='Make changes to Postfix configuration file', path='/etc/postfix/main.cf', regex='^inet_interfaces\s*=\s.*', insensitive='false', new_line='inet_interfaces = {{ var_postfix_inet_interfaces }}', create='no', state='present', insert_after='^inet_interfaces\s*=\s.*', when='"postfix" in ansible_facts.packages') }}}

--- a/linux_os/guide/services/ntp/ntpd_configure_restrictions/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/ntpd_configure_restrictions/ansible/shared.yml
@@ -4,5 +4,5 @@
 # strategy = configure
 # disruption = low
 
-{{{ ansible_lineinfile(msg='Configure ipv4 restrictions for ntpd', path='/etc/ntp.conf', regex='', new_line='restrict -4 default kod nomodify notrap nopeer noquery', create='yes', state='present') }}}
-{{{ ansible_lineinfile(msg='Configure ipv6 restrictions for ntpd', path='/etc/ntp.conf', regex='', new_line='restrict -6 default kod nomodify notrap nopeer noquery', create='yes', state='present') }}}
+{{{ ansible_lineinfile(msg='Configure ipv4 restrictions for ntpd', path='/etc/ntp.conf', regex='', insensitive=false, new_line='restrict -4 default kod nomodify notrap nopeer noquery', create='yes', state='present') }}}
+{{{ ansible_lineinfile(msg='Configure ipv6 restrictions for ntpd', path='/etc/ntp.conf', regex='', insensitive=false, new_line='restrict -6 default kod nomodify notrap nopeer noquery', create='yes', state='present') }}}

--- a/linux_os/guide/services/ssh/ssh_client/ssh_client_rekey_limit/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_client/ssh_client_rekey_limit/ansible/shared.yml
@@ -5,7 +5,7 @@
 # disruption = low
 {{{ ansible_instantiate_variables("var_ssh_client_rekey_limit_size", "var_ssh_client_rekey_limit_time") }}}
 
-{{{ ansible_lineinfile(msg='Ensure RekeyLimit is not configured in /etc/ssh/ssh_config', path='/etc/ssh/ssh_config', regex='^\s*RekeyLimit.*$', create='no', state='absent') }}}
+{{{ ansible_lineinfile(msg='Ensure RekeyLimit is not configured in /etc/ssh/ssh_config', path='/etc/ssh/ssh_config', regex='^\s*RekeyLimit.*$', insensitive=false, create='no', state='absent') }}}
 
 - name: Collect all include config files for ssh client which configure RekeyLimit
   find:
@@ -21,4 +21,4 @@
     state: "absent"
   loop: "{{ ssh_config_include_files.files }}"
 
-{{{ ansible_lineinfile(msg='Ensure that rekey limit is set to {{ var_ssh_client_rekey_limit_size }} {{ var_ssh_client_rekey_limit_time }} in /etc/ssh/ssh_config.d/02-rekey-limit.conf', path='/etc/ssh/ssh_config.d/02-rekey-limit.conf', regex='^\s*RekeyLimit.*$', new_line='RekeyLimit {{ var_ssh_client_rekey_limit_size }} {{ var_ssh_client_rekey_limit_time }}', create='yes', state='present') }}}
+{{{ ansible_lineinfile(msg='Ensure that rekey limit is set to {{ var_ssh_client_rekey_limit_size }} {{ var_ssh_client_rekey_limit_time }} in /etc/ssh/ssh_config.d/02-rekey-limit.conf', path='/etc/ssh/ssh_config.d/02-rekey-limit.conf', regex='^\s*RekeyLimit.*$', insensitive=false, new_line='RekeyLimit {{ var_ssh_client_rekey_limit_size }} {{ var_ssh_client_rekey_limit_time }}', create='yes', state='present') }}}

--- a/linux_os/guide/services/usbguard/usbguard_allow_hid/ansible/shared.yml
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hid/ansible/shared.yml
@@ -4,4 +4,4 @@
 # strategy = configure
 # disruption = low
 
-{{{ ansible_lineinfile(msg='Allow HID devices', path='/etc/usbguard/rules.conf', regex='', new_line='allow with-interface match-all { 03:*:* }', create='yes', state='present') }}}
+{{{ ansible_lineinfile(msg='Allow HID devices', path='/etc/usbguard/rules.conf', regex='', insensitive=false, new_line='allow with-interface match-all { 03:*:* }', create='yes', state='present') }}}

--- a/linux_os/guide/services/usbguard/usbguard_allow_hub/ansible/shared.yml
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hub/ansible/shared.yml
@@ -4,4 +4,4 @@
 # strategy = configure
 # disruption = low
 
-{{{ ansible_lineinfile(msg='Allow hubs', path='/etc/usbguard/rules.conf', regex='', new_line='allow with-interface match-all { 09:00:* }', create='yes', state='present') }}}
+{{{ ansible_lineinfile(msg='Allow hubs', path='/etc/usbguard/rules.conf', regex='', insensitive=false, new_line='allow with-interface match-all { 09:00:* }', create='yes', state='present') }}}

--- a/linux_os/guide/system/accounts/accounts-pam/enable_pam_namespace/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/enable_pam_namespace/ansible/shared.yml
@@ -8,5 +8,6 @@
   msg="Make changes to /etc/pam.d/login",
   path="/etc/pam.d/login",
   regex="^\s*session\s+required\s+pam_namespace.so\s*$",
+  insensitive=false,
   new_line="session    required     pam_namespace.so"
 ) }}}

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/ansible/shared.yml
@@ -3,4 +3,4 @@
 # strategy = configure
 # complexity = low
 # disruption = low
-{{{ ansible_only_lineinfile(None, "/etc/tmux.conf", "\s*bind\s+\w\s+lock-session.*$", "bind X lock-session", create="true", mode="0644") }}}
+{{{ ansible_only_lineinfile(None, "/etc/tmux.conf", "\s*bind\s+\w\s+lock-session.*$", "bind X lock-session", insensitive="false", create="true", mode="0644") }}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_tmp/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_tmp/ansible/shared.yml
@@ -17,5 +17,6 @@
   msg="Make changes to /etc/security/namespace.conf",
   path="/etc/security/namespace.conf",
   regex="^\s*/tmp\s+/tmp/tmp-inst/\s+level\s+root,adm$",
+  insensitive=false,
   new_line="/tmp     /tmp/tmp-inst/        level      root,adm"
 ) }}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_var_tmp/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_var_tmp/ansible/shared.yml
@@ -17,5 +17,6 @@
   msg="Make changes to /etc/security/namespace.conf",
   path="/etc/security/namespace.conf",
   regex="^\s*/var/tmp\s+/var/tmp/tmp-inst/\s+level\s+root,adm$",
+  insensitive=false,
   new_line="/var/tmp /var/tmp/tmp-inst/    level      root,adm"
 ) }}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
@@ -27,5 +27,5 @@
     replace: typeset -xr TMOUT={{ var_accounts_tmout }}
   register: profile_replaced
 
-{{{ ansible_lineinfile("", "/etc/profile.d/tmout.sh", regex='TMOUT=', new_line='typeset -xr TMOUT={{ var_accounts_tmout }}',
+{{{ ansible_lineinfile("", "/etc/profile.d/tmout.sh", regex='TMOUT=', insensitive=false, new_line='typeset -xr TMOUT={{ var_accounts_tmout }}',
     create='yes', state='present', when="profile_replaced is defined and not profile_replaced.changed" + " and bashrc_replaced is defined and not bashrc_replaced.changed" if product in ["ol7"]) }}}

--- a/linux_os/guide/system/permissions/permissions_local/file_permissions_local_var_log_messages/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/permissions_local/file_permissions_local_var_log_messages/ansible/shared.yml
@@ -4,7 +4,7 @@
 # strategy = configure
 # disruption = low
 
-{{{ ansible_lineinfile(msg='Configure permission for /var/log/messages', path='/etc/permissions.local', regex='^\/var\/log\/messages\s+root.*', new_line='/var/log/messages root:root 640', create='yes', state='present', register='update_permissions_local_result') }}}
+{{{ ansible_lineinfile(msg='Configure permission for /var/log/messages', path='/etc/permissions.local', regex='^\/var\/log\/messages\s+root.*', insensitive=false, new_line='/var/log/messages root:root 640', create='yes', state='present', register='update_permissions_local_result') }}}
 
 - name: "Correct file permissions after update /etc/permissions.local"
   shell: >

--- a/linux_os/guide/system/permissions/permissions_local/permissions_local_audit_binaries/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/permissions_local/permissions_local_audit_binaries/ansible/shared.yml
@@ -4,7 +4,7 @@
 # strategy = configure
 # disruption = low
 
-{{{ ansible_lineinfile(msg='Configure permission for /usr/sbin/audispd', path='/etc/permissions.local', regex='^\/usr\/sbin\/audispd\s+root.*', new_line='/usr/sbin/audispd root:root 0750', create='yes', state='present', register='update_permissions_local_result_audispd') }}}
+{{{ ansible_lineinfile(msg='Configure permission for /usr/sbin/audispd', path='/etc/permissions.local', regex='^\/usr\/sbin\/audispd\s+root.*', insensitive=false, new_line='/usr/sbin/audispd root:root 0750', create='yes', state='present', register='update_permissions_local_result_audispd') }}}
 
 - name: "Correct file permissions after update /usr/sbin/audispd"
   shell: >
@@ -12,7 +12,7 @@
     chkstat --set --system
   when: update_permissions_local_result_audispd.changed
 
-{{{ ansible_lineinfile(msg='Configure permission for /usr/sbin/auditctl', path='/etc/permissions.local', regex='^\/usr\/sbin\/auditctl\s+root.*', new_line='/usr/sbin/auditctl root:root 0750', create='yes', state='present', register='update_permissions_local_result_auditctl') }}}
+{{{ ansible_lineinfile(msg='Configure permission for /usr/sbin/auditctl', path='/etc/permissions.local', regex='^\/usr\/sbin\/auditctl\s+root.*', insensitive=false, new_line='/usr/sbin/auditctl root:root 0750', create='yes', state='present', register='update_permissions_local_result_auditctl') }}}
 
 - name: "Correct file permissions after update /usr/sbin/auditctl"
   shell: >
@@ -20,7 +20,7 @@
     chkstat --set --system
   when: update_permissions_local_result_auditctl.changed
 
-{{{ ansible_lineinfile(msg='Configure permission for /usr/sbin/auditd', path='/etc/permissions.local', regex='^\/usr\/sbin\/auditd\s+root.*', new_line='/usr/sbin/auditd root:root 0750', create='yes', state='present', register='update_permissions_local_result_auditd') }}}
+{{{ ansible_lineinfile(msg='Configure permission for /usr/sbin/auditd', path='/etc/permissions.local', regex='^\/usr\/sbin\/auditd\s+root.*', insensitive=false, new_line='/usr/sbin/auditd root:root 0750', create='yes', state='present', register='update_permissions_local_result_auditd') }}}
 
 - name: "Correct file permissions after update /usr/sbin/auditd"
   shell: >
@@ -28,7 +28,7 @@
     chkstat --set --system
   when: update_permissions_local_result_auditd.changed
 
-{{{ ansible_lineinfile(msg='Configure permission for /usr/sbin/ausearch', path='/etc/permissions.local', regex='^\/usr\/sbin\/ausearch\s+root.*', new_line='/usr/sbin/ausearch root:root 0755', create='yes', state='present', register='update_permissions_local_result_ausearch') }}}
+{{{ ansible_lineinfile(msg='Configure permission for /usr/sbin/ausearch', path='/etc/permissions.local', regex='^\/usr\/sbin\/ausearch\s+root.*', insensitive=false, new_line='/usr/sbin/ausearch root:root 0755', create='yes', state='present', register='update_permissions_local_result_ausearch') }}}
 
 - name: "Correct file permissions after update /usr/sbin/ausearch"
   shell: >
@@ -36,7 +36,7 @@
     chkstat --set --system
   when: update_permissions_local_result_ausearch.changed
 
-{{{ ansible_lineinfile(msg='Configure permission for /usr/sbin/aureport', path='/etc/permissions.local', regex='^\/usr\/sbin\/aureport\s+root.*', new_line='/usr/sbin/aureport root:root 0755', create='yes', state='present', register='update_permissions_local_result_aureport') }}}
+{{{ ansible_lineinfile(msg='Configure permission for /usr/sbin/aureport', path='/etc/permissions.local', regex='^\/usr\/sbin\/aureport\s+root.*', insensitive=false, new_line='/usr/sbin/aureport root:root 0755', create='yes', state='present', register='update_permissions_local_result_aureport') }}}
 
 - name: "Correct file permissions after update /usr/sbin/aureport"
   shell: >
@@ -44,7 +44,7 @@
     chkstat --set --system
   when: update_permissions_local_result_aureport.changed
 
-{{{ ansible_lineinfile(msg='Configure permission for /usr/sbin/autrace', path='/etc/permissions.local', regex='^\/usr\/sbin\/autrace\s+root.*', new_line='/usr/sbin/autrace root:root 0750', create='yes', state='present', register='update_permissions_local_result_autrace') }}}
+{{{ ansible_lineinfile(msg='Configure permission for /usr/sbin/autrace', path='/etc/permissions.local', regex='^\/usr\/sbin\/autrace\s+root.*', insensitive=false, new_line='/usr/sbin/autrace root:root 0750', create='yes', state='present', register='update_permissions_local_result_autrace') }}}
 
 - name: "Correct file permissions after update /usr/sbin/autrace"
   shell: >
@@ -52,7 +52,7 @@
     chkstat --set --system
   when: update_permissions_local_result_autrace.changed
 
-{{{ ansible_lineinfile(msg='Configure permission for /usr/sbin/augenrules', path='/etc/permissions.local', regex='^\/usr\/sbin\/augenrules\s+root.*', new_line='/usr/sbin/augenrules root:root 0750', create='yes', state='present', register='update_permissions_local_result_augenrules') }}}
+{{{ ansible_lineinfile(msg='Configure permission for /usr/sbin/augenrules', path='/etc/permissions.local', regex='^\/usr\/sbin\/augenrules\s+root.*', insensitive=false, new_line='/usr/sbin/augenrules root:root 0750', create='yes', state='present', register='update_permissions_local_result_augenrules') }}}
 
 - name: "Correct file permissions after update /usr/sbin/augenrules"
   shell: >

--- a/linux_os/guide/system/software/sudo/sudoers_default_includedir/ansible/shared.yml
+++ b/linux_os/guide/system/software/sudo/sudoers_default_includedir/ansible/shared.yml
@@ -4,9 +4,9 @@
 # complexity = low
 # disruption = low
 
-{{{ ansible_only_lineinfile(msg='Ensure sudo only has the default includedir', line_regex='^#includedir.*$', path='/etc/sudoers', new_line='#includedir /etc/sudoers.d') }}}
-{{{ ansible_lineinfile(msg='Ensure sudoers doesn\'t include other non-default file', regex='^[#@]include[\s]+.*$', path='/etc/sudoers', state='absent') }}}
-{{{ ansible_lineinfile(msg='Ensure sudoers doesn\'t have non-default includedir', regex='^@includedir[\s]+.*$', path='/etc/sudoers', state='absent') }}}
+{{{ ansible_only_lineinfile(msg='Ensure sudo only has the default includedir', line_regex='^#includedir.*$', insensitive=false, path='/etc/sudoers', new_line='#includedir /etc/sudoers.d') }}}
+{{{ ansible_lineinfile(msg='Ensure sudoers doesn\'t include other non-default file', regex='^[#@]include[\s]+.*$', insensitive=false, path='/etc/sudoers', state='absent') }}}
+{{{ ansible_lineinfile(msg='Ensure sudoers doesn\'t have non-default includedir', regex='^@includedir[\s]+.*$', insensitive=false, path='/etc/sudoers', state='absent') }}}
 - name: "Find out if /etc/sudoers.d/* files contain file or directory includes"
   find:
     path: "/etc/sudoers.d"

--- a/linux_os/guide/system/software/sudo/sudoers_validate_passwd/ansible/shared.yml
+++ b/linux_os/guide/system/software/sudo/sudoers_validate_passwd/ansible/shared.yml
@@ -38,6 +38,6 @@
 {{{- delete_line_in_sudoers_file("Defaults rootpw") }}}
 {{{- delete_line_in_sudoers_file("Defaults runaspw") }}}
 
-{{{ ansible_only_lineinfile(msg='Ensure that Defaults !targetpw is defined in sudoers', line_regex='^Defaults !targetpw$', path='/etc/sudoers', new_line='Defaults !targetpw') }}}
-{{{ ansible_only_lineinfile(msg='Ensure that Defaults !rootpw is defined in sudoers', line_regex='^Defaults !rootpw$', path='/etc/sudoers', new_line='Defaults !rootpw') }}}
-{{{ ansible_only_lineinfile(msg='Ensure that Defaults !runaspw is defined in sudoers', line_regex='^Defaults !runaspw$', path='/etc/sudoers', new_line='Defaults !runaspw') }}}
+{{{ ansible_only_lineinfile(msg='Ensure that Defaults !targetpw is defined in sudoers', line_regex='^Defaults !targetpw$', insensitive=false, path='/etc/sudoers', new_line='Defaults !targetpw') }}}
+{{{ ansible_only_lineinfile(msg='Ensure that Defaults !rootpw is defined in sudoers', line_regex='^Defaults !rootpw$', insensitive=false, path='/etc/sudoers', new_line='Defaults !rootpw') }}}
+{{{ ansible_only_lineinfile(msg='Ensure that Defaults !runaspw is defined in sudoers', line_regex='^Defaults !runaspw$', insensitive=false, path='/etc/sudoers', new_line='Defaults !runaspw') }}}

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -28,12 +28,14 @@ value: :code:`Setting={{ varname1 }}`
   Note that all string-like parameters are single quoted in the YAML.
 
 #}}
-{{%- macro ansible_lineinfile(msg='', path='', mode='', regex='', new_line='', create='no', state='present', with_items='', register='', when='', validate='', insert_after='', insert_before='', check_mode=False) -%}}
+{{%- macro ansible_lineinfile(msg='', path='', mode='', regex='', insensitive='false', new_line='', create='no', state='present', with_items='', register='', when='', validate='', insert_after='', insert_before='', check_mode=False) -%}}
 - name: "{{{ msg or rule_title }}}"
   lineinfile:
     path: '{{{ path }}}'
     create: {{{ create }}}
-    {{%- if regex %}}
+    {{%- if regex and insensitive %}}
+    regexp: '(?i){{{ regex }}}'
+    {{%- else %}}
     regexp: '{{{ regex }}}'
     {{%- endif %}}
     {{%- if mode %}}
@@ -120,17 +122,17 @@ value: :code:`Setting={{ varname1 }}`
   the new line is appended to the file.
 
 #}}
-{{%- macro ansible_only_lineinfile(msg, path, line_regex, new_line, create='no', block=False, validate='', insert_after='', insert_before='', mode='') -%}}
+{{%- macro ansible_only_lineinfile(msg, path, line_regex, new_line, insensitive='false', create='no', block=False, validate='', insert_after='', insert_before='', mode='') -%}}
 {{%- if block %}}
 - name: "{{{ msg or rule_title }}}"
   block:
-    {{{ ansible_lineinfile("Check for duplicate values", path, mode=mode, regex=line_regex, create=create, state='absent', register='dupes', check_mode=True)|indent }}}
-    {{{ ansible_lineinfile("Deduplicate values from " + path, path, mode=mode, regex=line_regex, create=create, state='absent', when='dupes.found is defined and dupes.found > 1')|indent }}}
-    {{{ ansible_lineinfile("Insert correct line to " + path, path, mode=mode, regex=line_regex, new_line=new_line, create=create, state='present', validate=validate, insert_after=insert_after, insert_before=insert_before)|indent }}}
+    {{{ ansible_lineinfile("Check for duplicate values", path, mode=mode, regex=line_regex, insensitive=insensitive, create=create, state='absent', register='dupes', check_mode=True)|indent }}}
+    {{{ ansible_lineinfile("Deduplicate values from " + path, path, mode=mode, regex=line_regex, insensitive=insensitive, create=create, state='absent', when='dupes.found is defined and dupes.found > 1')|indent }}}
+    {{{ ansible_lineinfile("Insert correct line to " + path, path, mode=mode, regex=line_regex, insensitive=insensitive, new_line=new_line, create=create, state='present', validate=validate, insert_after=insert_after, insert_before=insert_before)|indent }}}
 {{%- else %}}
-{{{ ansible_lineinfile("Check for duplicate values", path, mode=mode, regex=line_regex, create=create, state='absent', register='dupes', check_mode=True) }}}
-{{{ ansible_lineinfile("Deduplicate values from " + path, path, mode=mode, regex=line_regex, create=create, state='absent', when='dupes.found is defined and dupes.found > 1') }}}
-{{{ ansible_lineinfile("Insert correct line into " + path, path, mode=mode, regex=line_regex, new_line=new_line, create=create, state='present', validate=validate, insert_after=insert_after, insert_before=insert_before) }}}
+{{{ ansible_lineinfile("Check for duplicate values", path, mode=mode, regex=line_regex, insensitive=insensitive, create=create, state='absent', register='dupes', check_mode=True) }}}
+{{{ ansible_lineinfile("Deduplicate values from " + path, path, mode=mode, regex=line_regex, insensitive=insensitive, create=create, state='absent', when='dupes.found is defined and dupes.found > 1') }}}
+{{{ ansible_lineinfile("Insert correct line into " + path, path, mode=mode, regex=line_regex, insensitive=insensitive, new_line=new_line, create=create, state='present', validate=validate, insert_after=insert_after, insert_before=insert_before) }}}
 {{%- endif %}}
 {{%- endmacro %}}
 
@@ -142,8 +144,8 @@ value: :code:`Setting={{ varname1 }}`
   instead of lineinfile-based solutions.
 
 #}}
-{{%- macro ansible_set_config_file(msg, file, parameter, separator=' ', separator_regex='\s+', value='', prefix_regex='^\s*', create='no', validate='', insert_after='', insert_before='', mode='') %}}
-{{{ ansible_only_lineinfile(msg, file, prefix_regex + parameter + separator_regex, parameter + separator + value, create=create, block=True, validate=validate, insert_after=insert_after, insert_before=insert_before, mode=mode) }}}
+{{%- macro ansible_set_config_file(msg, file, parameter, separator=' ', separator_regex='\s+', value='', prefix_regex='^\s*', insensitive='false', create='no', validate='', insert_after='', insert_before='', mode='') %}}
+{{{ ansible_only_lineinfile(msg, file, prefix_regex + parameter + separator_regex, parameter + separator + value, insensitive=insensitive, create=create, block=True, validate=validate, insert_after=insert_after, insert_before=insert_before, mode=mode) }}}
 {{%- endmacro %}}
 
 
@@ -155,7 +157,7 @@ value: :code:`Setting={{ varname1 }}`
   solutions.
 
 #}}
-{{%- macro ansible_set_config_file_dir(msg, config_file, config_dir, set_file, parameter, separator=' ', separator_regex='\s+', value='', prefix_regex='^\s*', create='no', validate='', insert_after='', insert_before='') %}}
+{{%- macro ansible_set_config_file_dir(msg, config_file, config_dir, set_file, parameter, separator=' ', separator_regex='\s+', value='', prefix_regex='^\s*', insensitive='false', create='no', validate='', insert_after='', insert_before='') %}}
 {{%- set var_dir = config_dir | replace("/", "_") | replace("-", "_") | replace(".", "_") -%}}
 {{%- set dir_exists = var_dir + "_exists" -%}}
 {{%- set dir_parameter = var_dir + "_has_parameter" -%}}
@@ -166,11 +168,11 @@ value: :code:`Setting={{ varname1 }}`
 {{%- set new_line = parameter + separator + value -%}}
 - name: '{{{ msg or rule_title }}}'
   block:
-    {{{ ansible_lineinfile("Deduplicate values from " + config_file, config_file, regex=line_regex, create='no', state='absent')|indent }}}
+    {{{ ansible_lineinfile("Deduplicate values from " + config_file, config_file, regex=line_regex, insensitive=insensitive, create='no', state='absent')|indent }}}
     {{{ ansible_stat("Check if " + config_dir + " exists", path=config_dir, register=dir_exists)|indent }}}
     {{{ ansible_find("Check if the parameter " + parameter + " is present in " + config_dir, paths=config_dir, contains=line_regex, register=dir_parameter, when=find_when)|indent }}}
-    {{{ ansible_lineinfile("Remove parameter from files in " + config_dir, path="{{ item.path }}", regex=line_regex, state="absent", with_items=lineinfile_items, when=lineinfile_when)|indent }}}
-    {{{ ansible_lineinfile("Insert correct line to " + set_file, set_file, regex=line_regex, new_line=new_line, create=create, state='present', validate=validate, insert_after=insert_after, insert_before=insert_before)|indent }}}
+    {{{ ansible_lineinfile("Remove parameter from files in " + config_dir, path="{{ item.path }}", regex=line_regex, insensitive=insensitive, state="absent", with_items=lineinfile_items, when=lineinfile_when)|indent }}}
+    {{{ ansible_lineinfile("Insert correct line to " + set_file, set_file, regex=line_regex, insensitive=insensitive, new_line=new_line, create=create, state='present', validate=validate, insert_after=insert_after, insert_before=insert_before)|indent }}}
 {{%- endmacro %}}
 
 


### PR DESCRIPTION
#### Description:

- Add `insensitive` option to `ansible_lineinfile`, `ansible_only_lineinfile` and `ansible_set_config_file_dir` macros
- Applies `(?i)` for case insensitivity on regex if `insensitive` option is enabled
- `insensitive` option is default to `false`

#### Rationale:

- Bash remediation supports insensitive cases for `set_config_file` macro, which would be helpful to have for Ansible
- https://github.com/ComplianceAsCode/content/pull/12293#discussion_r1716411816

#### Review Hints:

Build the product and test
```
./build_product
cd build
ctest

cd ../tests
./automatus.py ... use related products to test
```
