### PR TITLE
Add forgotten e2e manual remediation

### DIFF
--- a/ocp-resources/e2e/spo-install.yaml
+++ b/ocp-resources/e2e/spo-install.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: openshift-security-profiles
+labels:
+  openshift.io/cluster-monitoring: "true"
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: security-profiles-operator
+  namespace: openshift-security-profiles
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: security-profiles-operator-sub
+  namespace: openshift-security-profiles
+spec:
+  channel: release-alpha-rhel-8
+  installPlanApproval: Automatic
+  name: security-profiles-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
#### Description:

- Add manual remediation to install `security-profiles-ooperator`

#### Rationale:

- This file is required for manual remediation of security_profiles_operator_exists to work.

- Follow up of #12076, #12315