### PR TITLE
fix for issue 11909

### DIFF
--- a/products/debian12/profiles/standard.profile
+++ b/products/debian12/profiles/standard.profile
@@ -31,8 +31,8 @@ selections:
     - sshd_disable_root_login
     - sshd_disable_empty_passwords
     - sshd_allow_only_protocol2
-    - var_sshd_set_keepalive=0
-    - sshd_set_keepalive_0
+    - var_sshd_set_keepalive=1
+    - sshd_set_keepalive
     - rsyslog_files_ownership
     - rsyslog_files_groupownership
     - rsyslog_files_permissions


### PR DESCRIPTION
#### Description:

fix a bug in debian standard profile that was causing openscap exiting on an assertion.

- See issue #11909.
- use sshd_keep_alive instead of sshd_keep_alive_0

#### Rationale

- Fixes #11909

-  As debian 12 openssh version is 9.2, sshd_keep_alive_0 should be replaced with sshd_keep_alive.
- adding the rule satisfies the dependencies of sshd_set_timeout rule. The dependency was previously missing (as a consequence, the scanner exited with an assertion)
