### PR TITLE
OCPBUGS-35854: etcd_unique_ca bundle path for OCP 4.17

### DIFF
--- a/applications/openshift/etcd/etcd_unique_ca/oval/shared.xml
+++ b/applications/openshift/etcd/etcd_unique_ca/oval/shared.xml
@@ -26,8 +26,9 @@
       <object_component item_field="hash" object_ref="obj_etcd_ca_file_hash" />
     </local_variable>
 
+    <!--- In OCP 4.17 the ca-bundle certs were moved to etcd-all-bundles/server-ca-bundle.crt -->
     <ind:filehash58_object id="obj_etcd_ca_file_hash" version="1">
-      <ind:filepath>/etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-serving-ca/ca-bundle.crt</ind:filepath>
+      <ind:filepath operation="pattern match">^/etc/kubernetes/static-pod-resources/etcd-certs/configmaps/etcd-(serving-ca|all-bundles)/(server-)?ca-bundle.crt$</ind:filepath>
       <ind:hash_type>SHA-256</ind:hash_type>
     </ind:filehash58_object>
 


### PR DESCRIPTION

#### Description:

- Make the `filepath` for the CA bundle certs a regular expression matching the path for OCP <= 4.16 and OCP >= 4.17.

#### Rationale:

- In OCP 4.17 the ca bundle certs were relocated, lets update the bundle filepath to match it as well.
  This keeps the rule compatible with all supported OCP versions without need to add a new rule, or object and test.

- Fixes [OCPBUGS-35854](https://issues.redhat.com/browse/OCPBUGS-35854)
