### PR TITLE
Add ansible remediation to ensure_oracle_gpgkey_installed rule

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_oracle_gpgkey_installed/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_oracle_gpgkey_installed/ansible/shared.yml
@@ -1,0 +1,43 @@
+# platform = multi_platform_ol
+# reboot = false
+# strategy = restrict
+# complexity = medium
+# disruption = medium
+
+-   name: "{{{ rule_title }}} - Read GPG key directory permission"
+    ansible.builtin.stat:
+        path: /etc/pki/rpm-gpg/
+    register: gpg_key_directory_permission
+    check_mode: no
+
+# It should fail if it doesn't find any fingerprints in file - maybe file was not parsed well.
+
+-   name: "{{{ rule_title }}} - Retrieve GPG key fingerprints information"
+    # According to /usr/share/doc/gnupg2/DETAILS fingerprints are in "fpr" record in field 10
+    {{% if product in ['ol8', 'ol9'] -%}}
+    ansible.builtin.command: gpg --show-keys --with-fingerprint --with-colons "/etc/pki/rpm-gpg/RPM-GPG-KEY-oracle"
+    {{%- else -%}}
+    ansible.builtin.command: gpg --with-fingerprint --with-colons "/etc/pki/rpm-gpg/RPM-GPG-KEY-oracle"
+    {{%- endif %}}
+    changed_when: False
+    register: gpg_fingerprints
+    check_mode: no
+
+-   name: "{{{ rule_title }}} - Set fact for installed fingerprints"
+    ansible.builtin.set_fact:
+        gpg_installed_fingerprints: "{{ gpg_fingerprints.stdout | regex_findall('^pub.*\n(?:^fpr[:]*)([0-9A-Fa-f]*)', '\\1') | list }}"
+
+-   name: "{{{ rule_title }}} - Set fact for valid fingerprints"
+    ansible.builtin.set_fact:
+        gpg_valid_fingerprints:
+        - "{{{ release_key_fingerprint }}}"
+        - "{{{ auxiliary_key_fingerprint }}}"
+
+-   name: "{{{ rule_title }}} - Import Oracle GPG key securely"
+    ansible.builtin.rpm_key:
+        state: present
+        key: /etc/pki/rpm-gpg/RPM-GPG-KEY-oracle
+    when:
+    - gpg_key_directory_permission.stat.mode <= '0755'
+    - (gpg_installed_fingerprints | difference(gpg_valid_fingerprints)) | length == 0
+    - gpg_installed_fingerprints | length > 0

--- a/linux_os/guide/system/software/updating/ensure_oracle_gpgkey_installed/tests/key_installed.pass.sh
+++ b/linux_os/guide/system/software/updating/ensure_oracle_gpgkey_installed/tests/key_installed.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+#
+# platform = multi_platform_ol
+
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-oracle

--- a/linux_os/guide/system/software/updating/ensure_oracle_gpgkey_installed/tests/missing_key.fail.sh
+++ b/linux_os/guide/system/software/updating/ensure_oracle_gpgkey_installed/tests/missing_key.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+
+# remove all available keys
+
+KEYS=$(rpm -q gpg-pubkey --qf '%{NAME}-%{VERSION}-%{RELEASE}\n')
+
+if [ $? = 0 ]; then
+    for KEY in $KEYS; do
+    rpm -e $KEY
+    done
+fi


### PR DESCRIPTION
#### Description:

Added

- Ansible remediation
- Tests

#### Rationale:

In the task filling gaps in OL9 automation, the rule `ensure_oracle_gpgkey_installed` has a remediation deficit with ansible. I adapted the `ensure_redhat_gpgkey_installed` remediation and tests for Oracle.
