### PR TITLE
Update ansible remediation to harden_sshd_ciphers_openssh_conf_crypto_policy rule 

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,multi_platform_fedora
 # reboot = true
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_correct.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_correct.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_stig
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,multi_platform_fedora
+# variables = sshd_approved_ciphers=aes256-ctr,aes192-ctr,aes128-ctr
 
 sshd_approved_ciphers=aes256-ctr,aes192-ctr,aes128-ctr
 configfile=/etc/crypto-policies/back-ends/openssh.config

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_correct_commented.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_correct_commented.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_stig
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,multi_platform_fedora
+# variables = sshd_approved_ciphers=aes256-ctr,aes192-ctr,aes128-ctr
 
 sshd_approved_ciphers=aes256-ctr,aes192-ctr,aes128-ctr
 configfile=/etc/crypto-policies/back-ends/openssh.config

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_correct_followed_by_incorrect_commented.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_correct_followed_by_incorrect_commented.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_stig
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,multi_platform_fedora
+# variables = sshd_approved_ciphers=aes256-ctr,aes192-ctr,aes128-ctr
 
 sshd_approved_ciphers=aes256-ctr,aes192-ctr,aes128-ctr
 configfile=/etc/crypto-policies/back-ends/openssh.config

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_empty_file.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_empty_file.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_stig
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,multi_platform_fedora
+# variables = sshd_approved_ciphers=aes256-ctr,aes192-ctr,aes128-ctr
 
 configfile=/etc/crypto-policies/back-ends/openssh.config
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_empty_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_empty_policy.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_stig
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,multi_platform_fedora
+# variables = sshd_approved_ciphers=aes256-ctr,aes192-ctr,aes128-ctr
 
 configfile=/etc/crypto-policies/back-ends/openssh.config
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_incorrect_followed_by_correct_commented.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_incorrect_followed_by_correct_commented.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_stig
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,multi_platform_fedora
+# variables = sshd_approved_ciphers=aes256-ctr,aes192-ctr,aes128-ctr
 
 sshd_approved_ciphers=aes256-ctr,aes192-ctr,aes128-ctr
 incorrect_sshd_approved_ciphers=aes256-gcm@openssh.com,chacha20-poly1305@openssh.com,aes256-ctr

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_incorrect_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_incorrect_policy.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_stig
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,multi_platform_fedora
+# variables = sshd_approved_ciphers=aes256-ctr,aes192-ctr,aes128-ctr
 
 incorrect_sshd_approved_ciphers=aes256-gcm@openssh.com,chacha20-poly1305@openssh.com,aes256-ctr,aes256-cbc
 configfile=/etc/crypto-policies/back-ends/openssh.config

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_missing_file.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_missing_file.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
-# profiles = xccdf_org.ssgproject.content_profile_stig
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,multi_platform_fedora
+# variables = sshd_approved_ciphers=aes256-ctr,aes192-ctr,aes128-ctr
 
 configfile=/etc/crypto-policies/back-ends/openssh.config
 


### PR DESCRIPTION
#### Description:

Updated
Ansible remediation

Add 'variables' clause and OL9 platform in header of the following tests
stig_correct.pass.sh
stig_correct_commented.fail.sh
stig_correct_followed_by_incorrect_commented.pass.sh
stig_empty_file.fail.sh
stig_empty_policy.fail.sh
stig_incorrect_followed_by_correct_commented.fail.sh
stig_incorrect_policy.fail.sh
stig_missing_file.fail.sh

#### Rationale:

In the task filling gaps in OL9 automation, the rule `harden_sshd_ciphers_openssh_conf_crypto_policy` has a remediation deficit with ansible. The Ansible remediation already existed; it just needed OL9 added to the "platform" clause. The test update is to align the test with best practices, since the profile can generate inconsistencies in the test because the variable may have a different value in the profile than the one used in the test, this can cause the test to fail.
