### PR TITLE
Add ansible remediaton for rsyslog_cron_logging rule 

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/ansible/shared.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/ansible/shared.yml
@@ -1,0 +1,27 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+
+-   name: "{{{ rule_title }}} - Search if cron configuration exists"
+    ansible.builtin.command: 'grep -s "^\s*cron\.\*\s*/var/log/cron$" /etc/rsyslog.conf /etc/rsyslog.d/*.conf'
+    register: cron_log_config_exists
+    failed_when: false
+
+-   name: "{{{ rule_title }}} - Ensure the /etc/rsyslog.d directory exists"
+    ansible.builtin.file:
+        path: /etc/rsyslog.d
+        state: directory
+
+-   name: "{{{ rule_title }}} - Add cron log configuration line"
+    ansible.builtin.lineinfile:
+        path: /etc/rsyslog.d/cron.conf
+        line: "cron.*  /var/log/cron"
+        create: true
+    when: cron_log_config_exists.stdout_lines | length == 0
+
+-   name: "{{{ rule_title }}} - Restart the rsyslog service now"
+    ansible.builtin.service:
+        name: rsyslog
+        state: restarted

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/oval/shared.xml
@@ -11,7 +11,7 @@
       test_ref="test_cron_logging_rsyslog_dir" />
       <criterion comment="cron is configured in /etc/rsyslog.d using RainerScript"
       test_ref="test_cron_logging_rsyslog_dir_rainer" />
-      {{% if product == "ol8" %}}
+      {{% if "ol" in product %}}
       <criterion comment="rsyslog is configured in /etc/rsyslog.conf to log to all facilities"
       test_ref="test_cron_logging_rsyslog_logging_all_facilities" />
       <criterion comment="rsyslog is configured in /etc/rsyslog.d to log to all facilities"
@@ -70,7 +70,7 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  {{% if product == "ol8" %}}
+  {{% if "ol" in product %}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
   comment="rsyslog is configured in /etc/rsyslog.conf to log to all facilities"
   id="test_cron_logging_rsyslog_logging_all_facilities" version="1">


### PR DESCRIPTION
#### Description:

Added
Ansible remediation

Updated
Update oval file to include OL7 and OL9 into a condition to test the scenarios `all_facilities_set_rsyslog_conf.pass` and `all_facilities_set_rsyslog_d.pass`

#### Rationale:

In the task filling gaps in OL9 automation, the rule `rsyslog_cron_logging` has a remediation deficit with ansible. The logic of the remediation was taken of bash remediation