### PR TITLE
Add ansible remediation for aide_use_fips_hashes rule 

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/ansible/shared.yml
@@ -1,0 +1,36 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = enable
+# complexity = low
+# disruption = low
+
+-   name: "{{{ rule_title }}} - Ensure aide is installed"
+    ansible.builtin.package:
+        name: aide
+        state: present
+
+-   name: "{{{ rule_title }}} - Set-fact aide config file and forbidden hashes"
+    ansible.builtin.set_fact:
+        aide_conf: "/etc/aide.conf"
+        forbidden_hashes:
+            - sha1
+            - rmd160
+            - sha256
+            - whirlpool
+            - tiger
+            - haval
+            - gost
+            - crc32
+
+-   name: "{{{ rule_title }}} - Remove forbidden hashes"
+    ansible.builtin.replace:
+        path: "{{ aide_conf }}"
+        regexp: '(^\s*[A-Z][A-Za-z_]*\s*=.*?)({{ item }}\+|\+?{{ item }})(.*)'
+        replace: '\1\3'
+    loop: "{{ forbidden_hashes }}"
+
+-   name: "{{{ rule_title }}} - Set sha512"
+    ansible.builtin.replace:
+        path: "{{ aide_conf }}"
+        regexp: '(^\s*[A-Z][A-Za-z_]*\s*=)((?:(?!\+?sha512).)*)\s*$'
+        replace: '\1\2+sha512'


### PR DESCRIPTION
#### Description:

Added
Ansible remediation

#### Rationale:

In the task filling gaps in OL9 automation, the rule `aide_use_fips_hashes` has a remediation deficit with ansible. The remediation logic was adapted from bash remediation, the residual `+` verification steps was reduced in the regex to remove forbidden hashes and also the approach prioritize the use of the regex before the loops handled in bash remediation.

In addition to the test of automatus tool, the following scenario was tested to ensure the correct remediation behavior.

```
All = p+i+n+u+g+sha1+s+m+S+acl+xattrs+selinux
option = yes
Group = sha1+selinux+sha256
```
With the following result:

```
All = p+i+n+u+g+s+m+S+acl+xattrs+selinux+sha512
option = yes
Group = selinux+sha512
```
