### PR TITLE
Updated 6 rules 2 for sle micro

### DIFF
--- a/controls/stig_slmicro5.yml
+++ b/controls/stig_slmicro5.yml
@@ -802,8 +802,9 @@ controls:
       title:
           All SLEM 5 local interactive user accounts, upon creation, must be assigned
           a home directory.
-      rules: []
-      status: pending
+      rules: 
+          - accounts_have_homedir_login_defs
+      status: automated
     
     - id: SLEM-05-411015
       levels:
@@ -1154,15 +1155,16 @@ controls:
           - high
       title: SLEM 5 must not be configured to allow blank or null passwords.
       rules:
-          - sshd_disable_empty_passwords
+          - no_empty_passwords
       status: automated
     
     - id: SLEM-05-611060
       levels:
           - high
       title: SLEM 5 must not have accounts configured with blank or null passwords.
-      rules: []
-      status: pending
+      rules: 
+          - no_empty_passwords_etc_shadow
+      status: automated
     
     - id: SLEM-05-611065
       levels:
@@ -1449,15 +1451,17 @@ controls:
       title:
           SLEM 5 must offload audit records onto a different system or media from the
           system being audited.
-      rules: []
-      status: pending
+      rules: 
+          - auditd_audispd_network_failure_action
+      status: automated
     
     - id: SLEM-05-653045
       levels:
           - medium
       title: Audispd must take appropriate action when SLEM 5 audit storage is full.
-      rules: []
-      status: pending
+      rules: 
+          - auditd_audispd_disk_full_action
+      status: automated
     
     - id: SLEM-05-653050
       levels:
@@ -1944,8 +1948,9 @@ controls:
       levels:
           - medium
       title: SLEM 5 must not disable syscall auditing.
-      rules: []
-      status: pending
+      rules: 
+          - audit_rules_enable_syscall_auditing
+      status: automated
     
     - id: SLEM-05-671010
       levels:

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_enable_syscall_auditing/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_enable_syscall_auditing/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_sle,multi_platform_slmicro
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_enable_syscall_auditing/bash/shared.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_enable_syscall_auditing/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_sle,multi_platform_slmicro
 
 if [ -f "/usr/lib/systemd/system/auditd.service" ] ; then
     IS_AUGENRULES=$(grep -E "^(ExecStartPost=|Requires=augenrules\.service)" /usr/lib/systemd/system/auditd.service)

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_enable_syscall_auditing/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_enable_syscall_auditing/rule.yml
@@ -20,6 +20,7 @@ severity: medium
 identifiers:
     cce@sle12: CCE-83119-8
     cce@sle15: CCE-85706-0
+    cce@slmicro5: CCE-93739-1
 
 references:
     disa: CCI-000366

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_disk_full_action/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_disk_full_action/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicro
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_disk_full_action/bash/shared.sh
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_disk_full_action/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicro,multi_platform_ubuntu
 
 {{{ bash_instantiate_variables("var_audispd_disk_full_action") }}}
 

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_disk_full_action/rule.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_disk_full_action/rule.yml
@@ -24,6 +24,7 @@ identifiers:
     cce@rhel9: CCE-88477-5
     cce@sle12: CCE-83116-4
     cce@sle15: CCE-85617-9
+    cce@slmicro5: CCE-93728-4
 
 references:
     disa: CCI-001851

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicro
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/bash/shared.sh
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicro,multi_platform_ubuntu
 
 {{{ bash_instantiate_variables("var_audispd_network_failure_action") }}}
 

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/rule.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/rule.yml
@@ -25,6 +25,7 @@ identifiers:
     cce@rhel9: CCE-90187-6
     cce@sle12: CCE-83115-6
     cce@sle15: CCE-85705-2
+    cce@slmicro5: CCE-93727-6
 
 references:
     disa: CCI-001851

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/tests/audisp_network_failure_action_absent.fail.sh
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/tests/audisp_network_failure_action_absent.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicro
 
 . $SHARED/auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/tests/audisp_network_failure_action_set.pass.sh
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/tests/audisp_network_failure_action_set.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicro
 
 . $SHARED/auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/ansible/slmicro5.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/ansible/slmicro5.yml
@@ -1,0 +1,17 @@
+# platform = multi_platform_slmicro
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = medium
+- name: Find files in /etc/pam.d/ with password auth
+  find:
+    paths: /etc/pam.d
+    contains: ".*pam_unix\\.so.*nullok.*"
+    recurse: yes
+  register: find_pam_conf_files_result
+
+- name: Prevent Log In to Accounts with Empty Password
+  replace:
+    dest: "{{ item.path }}"
+    regexp: nullok
+  with_items: "{{ find_pam_conf_files_result.files }}"

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/bash/shared.sh
@@ -1,10 +1,10 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle,multi_platform_slmicro,multi_platform_ubuntu
 # reboot = false
 # strategy = configure
 # complexity = low
 # disruption = medium
 
-{{% if 'sle' in product %}}
+{{% if 'sle' or 'slmicro' in product %}}
 PAM_PATH="/etc/pam.d/"
 NULLOK_FILES=$(grep -rl ".*pam_unix\\.so.*nullok.*" ${PAM_PATH})
 for FILE in ${NULLOK_FILES}; do

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/bash/shared.sh
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = medium
 
-{{% if 'sle' or 'slmicro' in product %}}
+{{% if 'sle' in product or 'slmicro' in product %}}
 PAM_PATH="/etc/pam.d/"
 NULLOK_FILES=$(grep -rl ".*pam_unix\\.so.*nullok.*" ${PAM_PATH})
 for FILE in ${NULLOK_FILES}; do

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/oval/shared.xml
@@ -12,7 +12,7 @@
     <ind:object object_ref="object_no_empty_passwords" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_no_empty_passwords" version="1">
-{{% if product in ['sle12', 'sle15'] %}}
+{{% if product in ["sle12", "sle15", "slmicro5"] %}}
     <ind:filepath operation="pattern match">^/etc/pam.d/.*$</ind:filepath>
 {{% elif 'ubuntu' in product %}}
     <ind:filepath operation="pattern match">^/etc/pam.d/common-password</ind:filepath>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/rule.yml
@@ -7,7 +7,7 @@ description: |-
     but does not have an assigned password, it may be possible to log
     into the account without authentication. Remove any instances of the
     <tt>nullok</tt> in
-    {{% if product in ["sle12", "sle15"] %}}
+    {{% if product in ["sle12", "sle15", "slmicro5"] %}}
     password authentication configurations in <tt>/etc/pam.d/</tt>
     {{% elif 'ubuntu' in product %}}
     <tt>/etc/pam.d/common-password</tt>
@@ -33,6 +33,7 @@ identifiers:
     cce@rhel10: CCE-86640-0
     cce@sle12: CCE-83039-8
     cce@sle15: CCE-85576-7
+    cce@slmicro5: CCE-93738-3
 
 references:
     cis-csc: 1,12,13,14,15,16,18,3,5
@@ -62,7 +63,7 @@ ocil_clause: 'NULL passwords can be used'
 
 ocil: |-
     To verify that null passwords cannot be used, run the following command:
-    {{% if product in ["sle12", "sle15"] %}}
+    {{% if product in ["sle12", "sle15", "slmicro5"] %}}
     <pre>$ grep pam_unix.so /etc/pam.d/* | grep nullok</pre>
     {{% elif 'ubuntu' in product %}}
     <pre>grep nullok /etc/pam.d/common-password</pre>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/rule.yml
@@ -29,6 +29,7 @@ identifiers:
     cce@rhel10: CCE-90491-2
     cce@sle12: CCE-83249-3
     cce@sle15: CCE-91155-2
+    cce@slmicro5: CCE-93737-5
 
 references:
     cis@ubuntu2204: 6.2.2

--- a/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/rule.yml
@@ -23,6 +23,7 @@ identifiers:
     cce@rhel10: CCE-88604-4
     cce@sle12: CCE-83053-9
     cce@sle15: CCE-85562-7
+    cce@slmicro5: CCE-93736-7
 
 references:
     disa: CCI-000366


### PR DESCRIPTION
#### Description:

- _The PR includes updates of 6 rules to support new SUSE product sle micro according to DISA STIG_

#### Rationale:

- The list of the rules is 
auditd_audispd_network_failure_action
auditd_audispd_disk_full_action 
accounts_have_homedir_login_defs 
no_empty_passwords_etc_shadow 
no_empty_passwords 
audit_rules_enable_syscall_auditing 
