### PR TITLE
Add OL9 into installed_OS_is_vendor_supported 

### DIFF
--- a/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_vendor_supported/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_vendor_supported/oval/shared.xml
@@ -8,6 +8,7 @@
       <extend_definition comment="Installed OS is RHEL9" definition_ref="installed_OS_is_rhel9" />
       <extend_definition comment="Installed OS is OL7" definition_ref="installed_OS_is_ol7" />
       <extend_definition comment="Installed OS is OL8" definition_ref="installed_OS_is_ol8" />
+      <extend_definition comment="Installed OS is OL9" definition_ref="installed_OS_is_ol9" />
       <extend_definition comment="Installed OS is SLE12" definition_ref="installed_OS_is_sle12" />
       <extend_definition comment="Installed OS is SLE15" definition_ref="installed_OS_is_sle15" />
       <extend_definition comment="Installed OS is SLE Micro 5" definition_ref="installed_OS_is_slmicro5" />


### PR DESCRIPTION
#### Description:

Updated

Oval rule file

#### Rationale:

In the OL9 automation gap filling task, the installed_OS_is_vendor_supported rule does not include OL9 in the supported operating systems.