### PR TITLE
Proposed solution for RHEL8 and RHEL9 in system detection to avoid false positives

### DIFF
--- a/shared/checks/oval/installed_OS_is_rhel8.xml
+++ b/shared/checks/oval/installed_OS_is_rhel8.xml
@@ -15,7 +15,11 @@
       <criterion comment="Installed operating system is part of the unix family"
       test_ref="test_rhel8_unix_family" />
       <criteria operator="OR">
-        <criterion comment="RHEL 8 is installed" test_ref="test_rhel8" />
+        <criteria operator="AND" comment="RHEL 8 is installed">
+          <criterion comment="RHEL 8 is installed" test_ref="test_rhel8" />
+          <!-- This prevent false positive RHEL8 in OL8 because OL8 has redhat-release package present-->
+          <extend_definition comment="Installed OS is not OL8" definition_ref="installed_OS_is_ol8" negate="true"/>
+        </criteria>
         <criteria operator="AND" comment="Red Hat Enterprise Virtualization Host is installed">
           <criterion comment="Red Hat Virtualization Host (RHVH)" test_ref="test_rhvh4_version" />
           <criterion comment="Red Hat Enterprise Virtualization Host is based on RHEL 8" test_ref="test_rhevh_rhel8_version" />

--- a/shared/checks/oval/installed_OS_is_rhel9.xml
+++ b/shared/checks/oval/installed_OS_is_rhel9.xml
@@ -15,7 +15,11 @@
       <criterion comment="Installed operating system is part of the unix family"
       test_ref="test_rhel9_unix_family" />
       <criteria operator="OR">
-        <criterion comment="RHEL 9 is installed" test_ref="test_rhel9" />
+        <criteria operator="AND" comment="RHEL 9 is installed">
+          <criterion comment="RHEL 9 is installed" test_ref="test_rhel9" />
+          <!-- This prevent false positive RHEL9 in OL9 because OL9 has redhat-release package present -->
+          <extend_definition comment="Installed OS is not OL9" definition_ref="installed_OS_is_ol9" negate="true"/>
+        </criteria>
         <criteria operator="AND" comment="Red Hat Enterprise Virtualization Host is installed">
           <criterion comment="Red Hat Virtualization Host (RHVH)" test_ref="test_rhvh4_version" />
           <criterion comment="Red Hat Enterprise Virtualization Host is based on RHEL 9" test_ref="test_rhevh_rhel9_version" />

--- a/ssg/build_derivatives.py
+++ b/ssg/build_derivatives.py
@@ -76,7 +76,8 @@ def add_element_to(oval_root, tag_name, component_element):
     if xml_el is None:
         xml_el = ElementTree.Element("{%s}%s" % (oval_namespace, tag_name))
         oval_root.append(xml_el)
-    xml_el.append(component_element)
+    if xml_el.find("%s[@id='%s']" % (component_element.tag, component_element.get("id"))) is None:
+        xml_el.append(component_element)
 
 
 def add_oval_components_to_oval_xml(oval_root, tag_name, component_dict):


### PR DESCRIPTION
#### Description:

Updated

installed_OS_is_rhel9
installed_OS_is_rhel8

#### Rationale:

We have a false positive from RHEL9 to OL9, we also have a false positive from RHEL8 to OL8, this is because OL9 and OL8 have `redhat-release` package present.

When we check the rule `installed_OS_is_vendor_supported` we have the following oval results:
OL9
```
<definition definition_id="oval:ssg-installed_OS_is_vendor_supported:def:1" result="true" version="1">
                  <criteria operator="OR" result="true">
                    <extend_definition definition_ref="oval:ssg-installed_OS_is_rhel8:def:1" version="1" result="false"/>
                    <extend_definition definition_ref="oval:ssg-installed_OS_is_rhel9:def:1" version="1" result="true"/>
                    <extend_definition definition_ref="oval:ssg-installed_OS_is_ol7:def:1" version="1" result="false"/>
                    <extend_definition definition_ref="oval:ssg-installed_OS_is_ol8:def:1" version="1" result="false"/>
                    <extend_definition definition_ref="oval:ssg-installed_OS_is_ol9:def:1" version="1" result="true"/>
                    <extend_definition definition_ref="oval:ssg-installed_OS_is_sle12:def:1" version="1" result="false"/>
                    <extend_definition definition_ref="oval:ssg-installed_OS_is_sle15:def:1" version="1" result="false"/>
                    <extend_definition definition_ref="oval:ssg-installed_OS_is_slmicro5:def:1" version="1" result="false"/>
                  </criteria>
                </definition>
```
OL8
```
<definition definition_id="oval:ssg-installed_OS_is_vendor_supported:def:1" result="true" version="1">
                  <criteria operator="OR" result="true">
                    <extend_definition definition_ref="oval:ssg-installed_OS_is_rhel8:def:1" version="1" result="true"/>
                    <extend_definition definition_ref="oval:ssg-installed_OS_is_rhel9:def:1" version="1" result="false"/>
                    <extend_definition definition_ref="oval:ssg-installed_OS_is_ol7:def:1" version="1" result="false"/>
                    <extend_definition definition_ref="oval:ssg-installed_OS_is_ol8:def:1" version="1" result="true"/>
                    <extend_definition definition_ref="oval:ssg-installed_OS_is_ol9:def:1" version="1" result="false"/>
                    <extend_definition definition_ref="oval:ssg-installed_OS_is_sle12:def:1" version="1" result="false"/>
                    <extend_definition definition_ref="oval:ssg-installed_OS_is_sle15:def:1" version="1" result="false"/>
                    <extend_definition definition_ref="oval:ssg-installed_OS_is_slmicro5:def:1" version="1" result="false"/>
                  </criteria>
                </definition>
```