### PR TITLE
etcd_unique_ca: updated assertion results on OCP 4.17

### DIFF
--- a/tests/assertions/ocp4/ocp4-cis-node-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-cis-node-4.17.yml
@@ -1,6 +1,6 @@
 rule_results:
  e2e-cis-node-master-etcd-unique-ca:
-   default_result: FAIL
+   default_result: PASS
  e2e-cis-node-master-file-groupowner-cni-conf:
    default_result: PASS
  e2e-cis-node-master-file-groupowner-controller-manager-kubeconfig:

--- a/tests/assertions/ocp4/ocp4-high-node-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-high-node-4.17.yml
@@ -18,8 +18,8 @@ rule_results:
    default_result: PASS
    result_after_remediation: PASS
  e2e-high-node-master-etcd-unique-ca:
-   default_result: FAIL
-   result_after_remediation: FAIL
+   default_result: PASS
+   result_after_remediation: PASS
  e2e-high-node-master-file-groupowner-cni-conf:
    default_result: PASS
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-node-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-node-4.17.yml
@@ -18,8 +18,8 @@ rule_results:
    default_result: PASS
    result_after_remediation: PASS
  e2e-moderate-node-master-etcd-unique-ca:
-   default_result: FAIL
-   result_after_remediation: FAIL
+   default_result: PASS
+   result_after_remediation: PASS
  e2e-moderate-node-master-file-groupowner-cni-conf:
    default_result: PASS
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4.17.yml
@@ -6,7 +6,7 @@ rule_results:
  e2e-pci-dss-node-master-directory-permissions-var-log-ocp-audit:
    default_result: PASS
  e2e-pci-dss-node-master-etcd-unique-ca:
-   default_result: FAIL
+   default_result: PASS
  e2e-pci-dss-node-master-file-groupowner-cni-conf:
    default_result: PASS
  e2e-pci-dss-node-master-file-groupowner-controller-manager-kubeconfig:

--- a/tests/assertions/ocp4/ocp4-stig-node-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-stig-node-4.17.yml
@@ -1,7 +1,7 @@
 rule_results:
  e2e-stig-node-master-etcd-unique-ca:
-   default_result: FAIL
-   result_after_remediation: FAIL
+   default_result: PASS
+   result_after_remediation: PASS
  e2e-stig-node-master-file-groupowner-cni-conf:
    default_result: PASS
    result_after_remediation: PASS


### PR DESCRIPTION


#### Description:

- This updates `etcd_unique_ca assertion` results to PASS, since the rule was updated to work on OCP 4.17.

#### Rationale:

- Follow up from #12320