### PR TITLE
chronyd_or_ntpd_specify_remote_server: update assertion results

### DIFF
--- a/tests/assertions/ocp4/rhcos4-high-4.17.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.17.yml
@@ -400,7 +400,7 @@ rule_results:
    result_after_remediation: PASS
  e2e-high-master-chronyd-or-ntpd-specify-remote-server:
    default_result: PASS
-   result_after_remediation: FAIL
+   result_after_remediation: PASS
  e2e-high-master-configure-crypto-policy:
    default_result: PASS
    result_after_remediation: PASS
@@ -1126,7 +1126,7 @@ rule_results:
    result_after_remediation: PASS
  e2e-high-worker-chronyd-or-ntpd-specify-remote-server:
    default_result: PASS
-   result_after_remediation: FAIL
+   result_after_remediation: PASS
  e2e-high-worker-configure-crypto-policy:
    default_result: PASS
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-moderate-4.17.yml
+++ b/tests/assertions/ocp4/rhcos4-moderate-4.17.yml
@@ -400,7 +400,7 @@ rule_results:
    result_after_remediation: PASS
  e2e-moderate-master-chronyd-or-ntpd-specify-remote-server:
    default_result: PASS
-   result_after_remediation: FAIL
+   result_after_remediation: PASS
  e2e-moderate-master-configure-crypto-policy:
    default_result: PASS
    result_after_remediation: PASS
@@ -1123,7 +1123,7 @@ rule_results:
    result_after_remediation: PASS
  e2e-moderate-worker-chronyd-or-ntpd-specify-remote-server:
    default_result: PASS
-   result_after_remediation: FAIL
+   result_after_remediation: PASS
  e2e-moderate-worker-configure-crypto-policy:
    default_result: PASS
    result_after_remediation: PASS


### PR DESCRIPTION

#### Description:

- This updates `chronyd_or_ntpd_specify_remote_server` assertion results to PASS, they were not updated after a fix landed upstream.

#### Rationale:

- Follow up from #12312