### PR TITLE
CMP-2400: exclusion of the namespace for `resource-requests-quota-per-project`

### DIFF
--- a/applications/openshift/general/resource_requests_quota_per_project/oval/shared.xml
+++ b/applications/openshift/general/resource_requests_quota_per_project/oval/shared.xml
@@ -1,8 +1,8 @@
 <def-group>
 {{% set resourcequota_api_path = '/api/v1/resourcequotas' %}}
 {{% set namespaces_api_path = '/api/v1/namespaces' %}}
-{{% set resourcequota_for_non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.namespace | startswith("openshift") | not) and (.metadata.namespace | startswith("kube-") | not) and .metadata.namespace != "default") | .metadata.namespace] | unique' %}}
-{{% set non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default")]' %}}
+{{% set resourcequota_for_non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.namespace | startswith("openshift") | not) and (.metadata.namespace | startswith("kube-") | not) and .metadata.namespace != "default" and .metadata.namespace != "rhacs-operator" and ({{if ne .var_resource_requests_quota_per_project_exempt_regex "None"}}.metadata.namespace | test("{{.var_resource_requests_quota_per_project_exempt_regex}}") | not{{else}}true{{end}})) | .metadata.namespace] | unique' %}}
+{{% set non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default" and .metadata.name != "rhacs-operator" and ({{if ne .var_resource_requests_quota_per_project_exempt_regex "None"}}.metadata.name | test("{{.var_resource_requests_quota_per_project_exempt_regex}}") | not{{else}}true{{end}}))]' %}}
   <definition class="compliance" id="resource_requests_quota_per_project" version="1">
     {{{ oval_metadata("Ensure that application Namespaces have Network Policies defined") }}}
     <criteria>
@@ -10,8 +10,16 @@
                  test_ref="test_file_for_resource_requests_quota_per_project"/>
       <criterion comment="Make sure that the file '{{{ openshift_filtered_path(namespaces_api_path, non_ctlplane_namespaces_filter) }}}' exists."
                  test_ref="test_file_for_resource_requests_quotas_filtered_namespaces"/>
-      <criterion comment="Make sure that all target elements exists "
-                 test_ref="test_elements_count_for_resource_requests_quota_per_project"/>
+      <criteria operator="OR">
+        <criterion comment="Make sure that all target elements exist"
+                   test_ref="test_elements_count_for_resource_requests_quota_per_project"/>
+        <criteria operator="AND">
+          <criterion comment="Make sure there are no resource quotas in non-ctlplane namespaces"
+                     test_ref="test_resource_requests_quota_per_project"/>
+          <criterion comment="Make sure there are no namespaces in non-ctlplane namespaces"
+                     test_ref="test_resource_requests_quotas_filtered_namespaces"/>
+        </criteria>
+      </criteria>
     </criteria>
   </definition>
 
@@ -50,6 +58,19 @@
   <unix:file_object id="object_file_for_resource_requests_quotas_filtered_namespaces" version="1">
     <unix:filepath var_ref="resource_requests_quotas_filtered_namespaces_file_location"/>
   </unix:file_object>
+
+  <!-- Check if the number of elements at the two paths are both zero -->
+  <ind:yamlfilecontent_test id="test_resource_requests_quota_per_project" version="1" check="all" 
+                            comment="Make sure there are no resource quotas in non-ctlplane namespaces" 
+                            check_existence="none_exist" state_operator="AND">
+    <ind:object object_ref="object_resource_requests_quota_per_project"/>
+  </ind:yamlfilecontent_test>
+
+  <ind:yamlfilecontent_test id="test_resource_requests_quotas_filtered_namespaces" version="1" check="all" 
+                            comment="Make sure there are no namespaces in non-ctlplane namespaces" 
+                            check_existence="none_exist" state_operator="AND">
+    <ind:object object_ref="object_resource_requests_quotas_filtered_namespaces"/>
+  </ind:yamlfilecontent_test>
 
   <!-- Object gathering --> 
   <ind:yamlfilecontent_object id="object_resource_requests_quota_per_project" version="1">

--- a/applications/openshift/general/resource_requests_quota_per_project/rule.yml
+++ b/applications/openshift/general/resource_requests_quota_per_project/rule.yml
@@ -48,13 +48,13 @@ references:
 
 {{% set resourcequotas_api_path = '/api/v1/resourcequotas' %}}
 {{% set namespaces_api_path = '/api/v1/namespaces' %}}
-{{% set resourcequotas_for_non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.namespace | startswith("openshift") | not) and (.metadata.namespace | startswith("kube-") | not) and .metadata.namespace != "default") | .metadata.namespace] | unique' %}}
-{{% set non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default")]' %}}
+{{% set resourcequotas_for_non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.namespace | startswith("openshift") | not) and (.metadata.namespace | startswith("kube-") | not) and .metadata.namespace != "default" and .metadata.namespace != "rhacs-operator" and ({{if ne .var_resource_requests_quota_per_project_exempt_regex "None"}}.metadata.namespace | test("{{.var_resource_requests_quota_per_project_exempt_regex}}") | not{{else}}true{{end}})) | .metadata.namespace] | unique' %}}
+{{% set non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default" and .metadata.name != "rhacs-operator" and ({{if ne .var_resource_requests_quota_per_project_exempt_regex "None"}}.metadata.name | test("{{.var_resource_requests_quota_per_project_exempt_regex}}") | not{{else}}true{{end}}))]' %}}
 
 ocil_clause: 'Resource requests and limits is not set per project'
 
 # same as above except filters the names only. Used in OCIL only, not in the 'warnings attribute'
-{{% set non_ctlplane_namespaces_filter_names = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default") | .metadata.name ]' %}}
+{{% set non_ctlplane_namespaces_filter_names = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default" and .metadata.name != "rhacs-operator" and ({{if ne .var_resource_requests_quota_per_project_exempt_regex "None"}}.metadata.name | test("{{.var_resource_requests_quota_per_project_exempt_regex}}") | not{{else}}true{{end}})) | .metadata.name]' %}}
 
 ocil: |-
     Verify that the every non-control plane namespace has an appropriate ResourceQuota.

--- a/applications/openshift/general/resource_requests_quota_per_project/tests/ocp4/e2e-remediation.sh
+++ b/applications/openshift/general/resource_requests_quota_per_project/tests/ocp4/e2e-remediation.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+
+
+# Deploy a resource quota for e2e-test namespace, this namespace is created by the e2e-remediation.sh script
+# under the applications/openshift/networking/configure_network_policies_namespaces/tests/ocp4/e2e-remediation.sh
+# let's create a new project anyway because this could run before the other script
+cat << EOF | oc apply -f -
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: e2e-test
+EOF
+
+cat << EOF | oc apply -n e2e-test -f -
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: e2e-test-namespace-quotas
+spec:
+  hard:
+    count/daemonsets.apps: "0"
+    count/deployments.apps: "0"
+    limits.cpu: "0"
+    limits.memory: "0"
+    pods: "0"
+EOF

--- a/applications/openshift/general/var_resource_requests_quota_per_project_exempt_regex.var
+++ b/applications/openshift/general/var_resource_requests_quota_per_project_exempt_regex.var
@@ -1,0 +1,18 @@
+documentation_complete: true
+
+title: 'Namespaces exempt of Resource Requests Quota per Project checks'
+
+description: |-
+    Namespaces regular expression explicitly allowed
+    through deployment resource filters, e.g. setting value to
+    "namespace1|namespace2" will exempt namespace
+    "namespace1" and "namespace2" for deployment resource limit checks.
+
+type: string
+
+operator: equals
+
+interactive: true
+
+options:
+  default: "None"

--- a/applications/openshift/networking/configure_network_policies_namespaces/tests/ocp4/e2e-remediation.sh
+++ b/applications/openshift/networking/configure_network_policies_namespaces/tests/ocp4/e2e-remediation.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
-oc adm new-project e2e-test
+cat << EOF | oc apply -f -
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: e2e-test
+EOF
 sleep 10
 # Deploy a single NetworkPolicy per non control plane namespace
 for NS in $(oc get namespaces -o json | jq -r '.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default") | .metadata.name'); do

--- a/tests/assertions/ocp4/ocp4-stig-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.12.yml
@@ -318,8 +318,7 @@ rule_results:
     default_result: MANUAL
     result_after_remediation: MANUAL
   e2e-stig-resource-requests-quota-per-project:
-    default_result: FAIL
-    result_after_remediation: FAIL
+    default_result: PASS
   e2e-stig-routes-rate-limit:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-stig-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.13.yml
@@ -317,8 +317,7 @@ rule_results:
     default_result: MANUAL
     result_after_remediation: MANUAL
   e2e-stig-resource-requests-quota-per-project:
-    default_result: FAIL
-    result_after_remediation: FAIL
+    default_result: PASS
   e2e-stig-routes-rate-limit:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-stig-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.14.yml
@@ -317,8 +317,7 @@ rule_results:
     default_result: MANUAL
     result_after_remediation: MANUAL
   e2e-stig-resource-requests-quota-per-project:
-    default_result: FAIL
-    result_after_remediation: FAIL
+    default_result: PASS
   e2e-stig-routes-rate-limit:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-stig-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.15.yml
@@ -317,8 +317,7 @@ rule_results:
     default_result: MANUAL
     result_after_remediation: MANUAL
   e2e-stig-resource-requests-quota-per-project:
-    default_result: FAIL
-    result_after_remediation: FAIL
+    default_result: PASS
   e2e-stig-routes-rate-limit:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-stig-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.16.yml
@@ -317,8 +317,7 @@ rule_results:
     default_result: MANUAL
     result_after_remediation: MANUAL
   e2e-stig-resource-requests-quota-per-project:
-    default_result: FAIL
-    result_after_remediation: FAIL
+    default_result: PASS
   e2e-stig-routes-rate-limit:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-stig-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.17.yml
@@ -1,370 +1,369 @@
 rule_results:
- e2e-stig-accounts-restrict-service-account-tokens:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
- e2e-stig-accounts-unique-service-account:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
- e2e-stig-api-server-admission-control-plugin-alwaysadmit:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-admission-control-plugin-alwayspullimages:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-admission-control-plugin-namespacelifecycle:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-admission-control-plugin-noderestriction:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-admission-control-plugin-scc:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-admission-control-plugin-securitycontextdeny:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-admission-control-plugin-service-account:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-anonymous-auth:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-api-priority-flowschema-catch-all:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-api-priority-gate-enabled:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
- e2e-stig-api-server-audit-log-maxbackup:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-audit-log-maxsize:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-audit-log-path:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-auth-mode-no-aa:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-auth-mode-node:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-auth-mode-rbac:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-basic-auth:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-bind-address:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-encryption-provider-cipher:
-   default_result: FAIL
-   result_after_remediation: PASS
- e2e-stig-api-server-etcd-cert:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-etcd-key:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-https-for-kubelet-conn:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-insecure-bind-address:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-insecure-port:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
- e2e-stig-api-server-kubelet-certificate-authority:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-kubelet-client-cert:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
- e2e-stig-api-server-kubelet-client-cert-pre-4-9:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
- e2e-stig-api-server-kubelet-client-key:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
- e2e-stig-api-server-kubelet-client-key-pre-4-9:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
- e2e-stig-api-server-no-adm-ctrl-plugins-disabled:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-oauth-https-serving-cert:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-openshift-https-serving-cert:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-profiling-protected-by-rbac:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-request-timeout:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-service-account-lookup:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-service-account-public-key:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-tls-cipher-suites:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-tls-security-profile:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-api-server-token-auth:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-audit-error-alert-exists:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-audit-log-forwarding-enabled:
-   default_result: FAIL
-   result_after_remediation: PASS
- e2e-stig-audit-log-forwarding-uses-tls:
-   default_result: FAIL
-   result_after_remediation: PASS
- e2e-stig-audit-profile-set:
-   default_result: FAIL
-   result_after_remediation: PASS
- e2e-stig-classification-banner:
-   default_result: FAIL
-   result_after_remediation: PASS
- e2e-stig-cluster-logging-operator-exist:
-   default_result: FAIL
-   result_after_remediation: PASS
- e2e-stig-cluster-version-operator-exists:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-cluster-version-operator-verify-integrity:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-configure-network-policies:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-configure-network-policies-namespaces:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-container-security-operator-exists:
-   default_result: FAIL
-   result_after_remediation: PASS
- e2e-stig-controller-insecure-port-disabled:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-controller-rotate-kubelet-server-certs:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
- e2e-stig-controller-secure-port:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-controller-service-account-ca:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-controller-service-account-private-key:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-controller-use-service-account:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-etcd-auto-tls:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-etcd-cert-file:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-etcd-client-cert-auth:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-etcd-key-file:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-etcd-peer-auto-tls:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-etcd-peer-client-cert-auth:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-file-groupowner-proxy-kubeconfig:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
- e2e-stig-file-integrity-exists:
-   default_result: FAIL
-   result_after_remediation: PASS
- e2e-stig-file-owner-proxy-kubeconfig:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
- e2e-stig-file-permissions-proxy-kubeconfig:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
- e2e-stig-fips-mode-enabled-on-all-nodes:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-general-apply-scc:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
- e2e-stig-general-configure-imagepolicywebhook:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
- e2e-stig-general-default-namespace-use:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
- e2e-stig-general-default-seccomp-profile:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
- e2e-stig-general-namespaces-in-use:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
- e2e-stig-idp-is-configured:
-   default_result: FAIL
-   result_after_remediation: PASS
- e2e-stig-image-pruner-active:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-imagestream-sets-schedule:
-   default_result: FAIL
-   result_after_remediation: FAIL
- e2e-stig-ingress-controller-tls-security-profile:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-kubeadmin-removed:
-   default_result: FAIL
-   result_after_remediation: FAIL
- e2e-stig-kubelet-disable-readonly-port:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-oauth-login-template-set:
-   default_result: FAIL
-   result_after_remediation: PASS
- e2e-stig-oauth-logout-url-set:
-   default_result: FAIL
-   result_after_remediation: PASS
- e2e-stig-oauth-or-oauthclient-inactivity-timeout:
-   default_result: FAIL
-   result_after_remediation: PASS
- e2e-stig-oauth-or-oauthclient-token-maxage:
-   default_result: FAIL
-   result_after_remediation: PASS
- e2e-stig-oauth-provider-selection-set:
-   default_result: FAIL
-   result_after_remediation: PASS
- e2e-stig-ocp-allowed-registries:
-   default_result: FAIL
-   result_after_remediation: FAIL
- e2e-stig-ocp-allowed-registries-for-import:
-   default_result: FAIL
-   result_after_remediation: FAIL
- e2e-stig-ocp-api-server-audit-log-maxbackup:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-ocp-api-server-audit-log-maxsize:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-ocp-idp-no-htpasswd:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-ocp-insecure-allowed-registries-for-import:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-ocp-insecure-registries:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-ocp-no-ldap-insecure:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-openshift-api-server-audit-log-path:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-openshift-motd-exists:
-   default_result: FAIL
-   result_after_remediation: PASS
- e2e-stig-project-config-and-template-network-policy:
-   default_result: FAIL
-   result_after_remediation: PASS
- e2e-stig-project-config-and-template-resource-quota:
-   default_result: FAIL
-   result_after_remediation: PASS
- e2e-stig-rbac-debug-role-protects-pprof:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-rbac-least-privilege:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
- e2e-stig-rbac-limit-cluster-admin:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
- e2e-stig-rbac-limit-secrets-access:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
- e2e-stig-rbac-logging-del:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
- e2e-stig-rbac-logging-mod:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
- e2e-stig-rbac-logging-view:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
- e2e-stig-rbac-pod-creation-access:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
- e2e-stig-rbac-wildcard-use:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
- e2e-stig-resource-requests-quota-per-project:
-   default_result: FAIL
-   result_after_remediation: FAIL
- e2e-stig-routes-rate-limit:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-scansettingbinding-exists:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-scansettings-have-schedule:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-scc-drop-container-capabilities:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
- e2e-stig-scc-limit-container-allowed-capabilities:
-   default_result: PASS
-   result_after_remediation: PASS
- e2e-stig-scc-limit-host-dir-volume-plugin:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
- e2e-stig-scc-limit-host-ports:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
- e2e-stig-scc-limit-ipc-namespace:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
- e2e-stig-scc-limit-net-raw-capability:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
- e2e-stig-scc-limit-network-namespace:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
- e2e-stig-scc-limit-privilege-escalation:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
- e2e-stig-scc-limit-privileged-containers:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
- e2e-stig-scc-limit-process-id-namespace:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
- e2e-stig-scc-limit-root-containers:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
- e2e-stig-secrets-consider-external-storage:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
- e2e-stig-secrets-no-environment-variables:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
+  e2e-stig-accounts-restrict-service-account-tokens:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-accounts-unique-service-account:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-api-server-admission-control-plugin-alwaysadmit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-admission-control-plugin-alwayspullimages:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-admission-control-plugin-namespacelifecycle:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-admission-control-plugin-noderestriction:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-admission-control-plugin-scc:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-admission-control-plugin-securitycontextdeny:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-admission-control-plugin-service-account:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-anonymous-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-api-priority-flowschema-catch-all:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-api-priority-gate-enabled:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-api-server-audit-log-maxbackup:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-audit-log-maxsize:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-audit-log-path:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-auth-mode-no-aa:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-auth-mode-node:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-auth-mode-rbac:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-basic-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-bind-address:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-encryption-provider-cipher:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-api-server-etcd-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-etcd-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-https-for-kubelet-conn:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-insecure-bind-address:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-insecure-port:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-api-server-kubelet-certificate-authority:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-kubelet-client-cert:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-api-server-kubelet-client-cert-pre-4-9:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-api-server-kubelet-client-key:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-api-server-kubelet-client-key-pre-4-9:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-api-server-no-adm-ctrl-plugins-disabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-oauth-https-serving-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-openshift-https-serving-cert:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-profiling-protected-by-rbac:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-request-timeout:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-service-account-lookup:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-service-account-public-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-tls-cipher-suites:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-tls-security-profile:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-api-server-token-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-audit-error-alert-exists:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-audit-log-forwarding-enabled:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-audit-log-forwarding-uses-tls:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-audit-profile-set:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-classification-banner:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-cluster-logging-operator-exist:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-cluster-version-operator-exists:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-cluster-version-operator-verify-integrity:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-configure-network-policies:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-configure-network-policies-namespaces:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-container-security-operator-exists:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-controller-insecure-port-disabled:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-controller-rotate-kubelet-server-certs:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-controller-secure-port:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-controller-service-account-ca:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-controller-service-account-private-key:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-controller-use-service-account:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-etcd-auto-tls:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-etcd-cert-file:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-etcd-client-cert-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-etcd-key-file:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-etcd-peer-auto-tls:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-etcd-peer-client-cert-auth:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-file-groupowner-proxy-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-file-integrity-exists:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-file-owner-proxy-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-file-permissions-proxy-kubeconfig:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-stig-fips-mode-enabled-on-all-nodes:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-general-apply-scc:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-general-configure-imagepolicywebhook:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-general-default-namespace-use:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-general-default-seccomp-profile:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-general-namespaces-in-use:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-idp-is-configured:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-image-pruner-active:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-imagestream-sets-schedule:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-stig-ingress-controller-tls-security-profile:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-kubeadmin-removed:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-stig-kubelet-disable-readonly-port:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-oauth-login-template-set:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-oauth-logout-url-set:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-oauth-or-oauthclient-inactivity-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-oauth-or-oauthclient-token-maxage:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-oauth-provider-selection-set:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-ocp-allowed-registries:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-stig-ocp-allowed-registries-for-import:
+    default_result: FAIL
+    result_after_remediation: FAIL
+  e2e-stig-ocp-api-server-audit-log-maxbackup:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-ocp-api-server-audit-log-maxsize:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-ocp-idp-no-htpasswd:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-ocp-insecure-allowed-registries-for-import:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-ocp-insecure-registries:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-ocp-no-ldap-insecure:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-openshift-api-server-audit-log-path:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-openshift-motd-exists:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-project-config-and-template-network-policy:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-project-config-and-template-resource-quota:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-stig-rbac-debug-role-protects-pprof:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-rbac-least-privilege:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-rbac-limit-cluster-admin:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-rbac-limit-secrets-access:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-rbac-logging-del:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-rbac-logging-mod:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-rbac-logging-view:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-rbac-pod-creation-access:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-rbac-wildcard-use:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-resource-requests-quota-per-project:
+    default_result: PASS
+  e2e-stig-routes-rate-limit:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-scansettingbinding-exists:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-scansettings-have-schedule:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-scc-drop-container-capabilities:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-scc-limit-container-allowed-capabilities:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-stig-scc-limit-host-dir-volume-plugin:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-scc-limit-host-ports:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-scc-limit-ipc-namespace:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-scc-limit-net-raw-capability:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-scc-limit-network-namespace:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-scc-limit-privilege-escalation:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-scc-limit-privileged-containers:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-scc-limit-process-id-namespace:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-scc-limit-root-containers:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-secrets-consider-external-storage:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-stig-secrets-no-environment-variables:
+    default_result: MANUAL
+    result_after_remediation: MANUAL


### PR DESCRIPTION
We have excluded RHACS from the default namespace check. We don't want to relax our rule too much for the optional operators, as it might increase security risk, instead, the user should use a `tailoredprofile` to set the exclusion regex.

Added a new variable `var_resource_requests_quota_per_project_exempt_regex`

[CMP-2400](https://issues.redhat.com/browse/CMP-2400)