### PR TITLE
Add Ism profile to OL9

### DIFF
--- a/controls/ism_o.yml
+++ b/controls/ism_o.yml
@@ -95,7 +95,15 @@ controls:
             - sshd_set_max_auth_tries
             - sssd_enable_smartcards
         status: automated
-
+    -   id: '0484'
+        title: 'SSH daemon configuration'
+        levels:
+            - base
+        rules:
+            - disable_host_auth
+            - sshd_enable_warning_banner
+            - sshd_disable_x11_forwarding
+        status: partial
     -   id: '0487'
         title: 'Passwordless SSH Connections Configuration'
         levels:
@@ -429,6 +437,7 @@ use of device access control software or by disabling external communication int
             - base
         rules:
             - sshd_allow_only_protocol2
+            - file_permissions_sshd_private_key
         status: partial
         notes: |-
             This needs more

--- a/products/ol9/profiles/ism_o.profile
+++ b/products/ol9/profiles/ism_o.profile
@@ -2,7 +2,7 @@ documentation_complete: true
 
 reference: https://www.cyber.gov.au/ism
 
-title: 'Australian Cyber Security Centre (ACSC) ISM Official - Top Secret'
+title: 'Australian Cyber Security Centre (ACSC) ISM Official'
 
 description: |-
     This profile contains configuration checks for Oracle Linux 9
@@ -21,37 +21,45 @@ extends: e8
 selections:
     - ism_o:all:top_secret
 
-    # Setting any nondefault, so it is safer to spot an issue
+    # Setting any nondefault, so a specific driver is expected
+    # using the same as in STIG
     - var_smartcard_drivers=cac
 
-    # Rule is for authconfig not used in OL9
+    # ISM 0418,1055,1402
+    # Rule is for authconfig not used in 
     - "!enable_ldap_client"
-
-    # Configuration not available in OL9
-    - "!force_opensc_card_drivers"
-
     # Not applicable to OL9 due to krb5-server version
     - "!kerberos_disable_no_keytab"
 
-    # Doesn't seem applicable to OL9 as per openssl man page
+    # ISM 1386
+    # Configuration not available in OL9
+    - "!force_opensc_card_drivers"
+
+    # ISM 1277,1552
+    # Not applicable to OL9 as per openssl man page
     - "!openssl_use_strong_entropy"     
 
+    # ISM 0988,1405
     # Always use chronyd
     - "!service_chronyd_or_ntpd_enabled"
 
-    # pam_tally2 not available in OL9
+    # ISM 0421,0422,0431,0974,1173,1401,1504,1505,1546,1557,1558,1559,1560,1561
+    # pam_tally2 is not available in OL9
     - "!accounts_passwords_pam_tally2_deny_root"
     - "!accounts_passwords_pam_tally2_unlock_time"
 
+    # ISM 0582,0846
     # This divition of rules is not implemented in OL9
     - "!audit_access_failed_aarch64"
     - "!audit_access_failed_ppc64le"
     - "!audit_access_success_aarch64"
     - "!audit_access_success_ppc64le"
 
-    # Doesn't seem to cover the expected requirement
+    # Doesn't cover the expected requirement 
+    # 1319 "Static addressing is not used..."
     - "!network_ipv6_static_address"
 
+    # ISM 1467,1483,1493
     # Packages not available in OL
     - "!package_libdnf-plugin-subscription-manager_installed"
     - "!package_subscription-manager_installed"

--- a/products/ol9/profiles/ism_o.profile
+++ b/products/ol9/profiles/ism_o.profile
@@ -1,0 +1,57 @@
+documentation_complete: true
+
+reference: https://www.cyber.gov.au/ism
+
+title: 'Australian Cyber Security Centre (ACSC) ISM Official - Top Secret'
+
+description: |-
+    This profile contains configuration checks for Oracle Linux 9
+    that align to the Australian Cyber Security Centre (ACSC) Information Security Manual (ISM).
+
+    The ISM uses a risk-based approach to cyber security. This profile provides a guide to aligning 
+    Oracle Linux security controls with the ISM, which can be used to select controls 
+    specific to an organisation's security posture and risk profile.
+
+    A copy of the ISM can be found at the ACSC website:
+
+    https://www.cyber.gov.au/ism
+
+extends: e8
+
+selections:
+    - ism_o:all:top_secret
+
+    # Setting any nondefault, so it is safer to spot an issue
+    - var_smartcard_drivers=cac
+
+    # Rule is for authconfig not used in OL9
+    - "!enable_ldap_client"
+
+    # Configuration not available in OL9
+    - "!force_opensc_card_drivers"
+
+    # Not applicable to OL9 due to krb5-server version
+    - "!kerberos_disable_no_keytab"
+
+    # Doesn't seem applicable to OL9 as per openssl man page
+    - "!openssl_use_strong_entropy"     
+
+    # Always use chronyd
+    - "!service_chronyd_or_ntpd_enabled"
+
+    # pam_tally2 not available in OL9
+    - "!accounts_passwords_pam_tally2_deny_root"
+    - "!accounts_passwords_pam_tally2_unlock_time"
+
+    # This divition of rules is not implemented in OL9
+    - "!audit_access_failed_aarch64"
+    - "!audit_access_failed_ppc64le"
+    - "!audit_access_success_aarch64"
+    - "!audit_access_success_ppc64le"
+
+    # Doesn't seem to cover the expected requirement
+    - "!network_ipv6_static_address"
+
+    # Packages not available in OL
+    - "!package_libdnf-plugin-subscription-manager_installed"
+    - "!package_subscription-manager_installed"


### PR DESCRIPTION
#### Description:

- Add ISM profile for OL9
- Update ism_o control with rules already present in RHEL9

#### Rationale:

- OL9 didn't have this profile

