### PR TITLE
Update Regex for sudoers_explicit_command_args

### DIFF
--- a/linux_os/guide/system/software/sudo/sudoers_explicit_command_args/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudoers_explicit_command_args/oval/shared.xml
@@ -19,7 +19,7 @@
            - ',' is a command delimiter, while
          The last capturing group holds the offending command without args.
     -->
-    <ind:pattern operation="pattern match">^(?:\s*[^#=]+)=(?:\s*(?:\([^\)]+\))?\s*(?!\s*\()[^,\s]+(?:[ \t]+[^,\s]+)+[ \t]*,)*(\s*(?:\([^\)]+\))?\s*(?!\s*\()[^,\s]+[ \t]*(?:,|$))</ind:pattern>
+    <ind:pattern operation="pattern match">^(?!\s*Defaults)(?:\s*[^#=]+)=(?:\s*(?:\([^\)]+\))?\s*(?!\s*\()[^,\s]+(?:[ \t]+[^,\s]+)+[ \t]*,)*(\s*(?:\([^\)]+\))?\s*(?!\s*\()[^,\s]+[ \t]*(?:,|$))</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/software/sudo/sudoers_explicit_command_args/tests/defaults_entries.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_explicit_command_args/tests/defaults_entries.pass.sh
@@ -1,0 +1,6 @@
+# platform = multi_platform_all
+# remediation = none
+# packages = sudo
+
+echo 'Defaults  secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin:/usr/local/go/bin"' > /etc/sudoers
+echo 'root    ALL=(root) /bin/bash -c test' >> /etc/sudoers


### PR DESCRIPTION
#### Description:

#### Rationale:

- "Defaults" entries in sudoers were picked by the regex used for this rule. Adding exclusion for lines beginning with "Defaults" solves that.

- Fixes #12349 

#### Review Hints:
