### PR TITLE
Hide CJIS profile for OL8

### DIFF
--- a/products/ol8/profiles/cjis.profile
+++ b/products/ol8/profiles/cjis.profile
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+hidden: true
+
 reference: https://www.fbi.gov/services/cjis/cjis-security-policy-resource-center
 
 title: 'Criminal Justice Information Services (CJIS) Security Policy'


### PR DESCRIPTION
#### Description:

- Hide CJIS profile for OL8

#### Rationale:

- This profile is no longer expected in OL8