### PR TITLE
Fix Audit related rules in RHEL 10

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/auditctl_syscalls_multiple_per_arg.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/auditctl_syscalls_multiple_per_arg.pass.sh
@@ -2,8 +2,7 @@
 # packages = audit
 # remediation = bash
 
-# Use auditctl, on RHEL7, default is to use augenrules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 rm -f /etc/audit/rules.d/*
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/auditctl_syscalls_one_per_arg.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/auditctl_syscalls_one_per_arg.pass.sh
@@ -2,8 +2,7 @@
 # packages = audit
 # remediation = bash
 
-# Use auditctl, on RHEL7, default is to use augenrules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 rm -f /etc/audit/rules.d/*
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/auditctl_syscalls_one_per_line.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/auditctl_syscalls_one_per_line.pass.sh
@@ -2,11 +2,9 @@
 # packages = audit
 # remediation = bash
 
-# Use auditctl, on RHEL7, default is to use augenrules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 rm -f /etc/audit/rules.d/*
 
 # Delete everything that is not between "one per line" and "multiple per arg"
 sed '/# one per line/,/# multiple per arg/!d' test_audit.rules > /etc/audit/audit.rules
-

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/augenrules_syscalls_multiple_per_arg.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/augenrules_syscalls_multiple_per_arg.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# packages = audit
+# remediation = bash
+
+rm -f /etc/audit/rules.d/*
+
+# Deletes everything up do "one per line"
+# Then deletes everything from "one per arg" until end of file
+sed '/# one per line/,/# multiple per arg/d;/# one per arg/,$d' test_audit.rules > /etc/audit/rules.d/audit.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/augenrules_syscalls_one_per_arg.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/augenrules_syscalls_one_per_arg.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# packages = audit
+# remediation = bash
+
+rm -f /etc/audit/rules.d/*
+
+# Delete everything that is between "one per line" and "one per arg"
+sed '/# one per line/,/# one per arg/d' test_audit.rules > /etc/audit/rules.d/audit.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/augenrules_syscalls_one_per_line.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/augenrules_syscalls_one_per_line.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# packages = audit
+# remediation = bash
+
+rm -f /etc/audit/rules.d/*
+
+# Delete everything that is not between "one per line" and "multiple per arg"
+sed '/# one per line/,/# multiple per arg/!d' test_audit.rules > /etc/audit/rules.d/audit.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_multiple_per_arg.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_multiple_per_arg.pass.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 # packages = audit
 
-
-# Use auditctl, on RHEL7, default is to use augenrules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 rm -f /etc/audit/rules.d/*
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_arg.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_arg.pass.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 # packages = audit
 
-
-# Use auditctl, on RHEL7, default is to use augenrules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 rm -f /etc/audit/rules.d/*
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_line.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_line.pass.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 # packages = audit
 
-
-# Use auditctl, on RHEL7, default is to use augenrules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 rm -f /etc/audit/rules.d/*
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_line_one_missing.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_line_one_missing.fail.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 # packages = audit
 
-
-# Use auditctl, on RHEL7, default is to use augenrules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 rm -f /etc/audit/rules.d/*
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct.pass.sh
@@ -2,5 +2,7 @@
 # packages = audit
 # platform = multi_platform_all
 
+{{{ setup_auditctl_environment() }}}
+
 path="/var/log/faillock"
 . $SHARED/audit_rules_login_events/auditctl_correct.pass.sh

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct_cis.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct_cis.pass.sh
@@ -3,5 +3,7 @@
 # platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
 # profiles = xccdf_org.ssgproject.content_profile_cis
 
+{{{ setup_auditctl_environment() }}}
+
 path="/var/run/faillock"
 . $SHARED/audit_rules_login_events/auditctl_correct.pass.sh

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct_extra_permission.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct_extra_permission.pass.sh
@@ -2,5 +2,7 @@
 # packages = audit
 # platform = multi_platform_all
 
+{{{ setup_auditctl_environment() }}}
+
 path="/var/log/faillock"
 . $SHARED/audit_rules_login_events/auditctl_correct_extra_permission.pass.sh

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct_extra_permission_cis.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct_extra_permission_cis.pass.sh
@@ -3,5 +3,7 @@
 # platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
 # profiles = xccdf_org.ssgproject.content_profile_cis
 
+{{{ setup_auditctl_environment() }}}
+
 path="/var/run/faillock"
 . $SHARED/audit_rules_login_events/auditctl_correct_extra_permission.pass.sh

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct_without_key.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct_without_key.pass.sh
@@ -2,5 +2,7 @@
 # packages = audit
 # platform = multi_platform_all
 
+{{{ setup_auditctl_environment() }}}
+
 path="/var/log/faillock"
 . $SHARED/audit_rules_login_events/auditctl_correct_without_key.pass.sh

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct_without_key_cis.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_correct_without_key_cis.pass.sh
@@ -3,5 +3,7 @@
 # platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
 # profiles = xccdf_org.ssgproject.content_profile_cis
 
+{{{ setup_auditctl_environment() }}}
+
 path="/var/run/faillock"
 . $SHARED/audit_rules_login_events/auditctl_correct_without_key.pass.sh

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_remove_all_rules.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_remove_all_rules.fail.sh
@@ -2,4 +2,6 @@
 # packages = audit
 # platform = multi_platform_all
 
+{{{ setup_auditctl_environment() }}}
+
 . $SHARED/audit_rules_login_events/auditctl_remove_all_rules.fail.sh

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_remove_all_rules_cis.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_remove_all_rules_cis.fail.sh
@@ -3,5 +3,7 @@
 # platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
 # profiles = xccdf_org.ssgproject.content_profile_cis
 
+{{{ setup_auditctl_environment() }}}
+
 path="/var/run/faillock"
 . $SHARED/audit_rules_login_events/auditctl_remove_all_rules.fail.sh

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_wrong_rule.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_wrong_rule.fail.sh
@@ -2,5 +2,7 @@
 # packages = audit
 # platform = multi_platform_all
 
+{{{ setup_auditctl_environment() }}}
+
 path="/var/log/faillock"
 . $SHARED/audit_rules_login_events/auditctl_wrong_rule.fail.sh

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_wrong_rule_cis.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_wrong_rule_cis.fail.sh
@@ -3,5 +3,7 @@
 # platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
 # profiles = xccdf_org.ssgproject.content_profile_cis
 
+{{{ setup_auditctl_environment() }}}
+
 path="/var/run/faillock"
 . $SHARED/audit_rules_login_events/auditctl_wrong_rule.fail.sh

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_wrong_rule_without_key.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_wrong_rule_without_key.fail.sh
@@ -2,5 +2,7 @@
 # packages = audit
 # platform = multi_platform_all
 
+{{{ setup_auditctl_environment() }}}
+
 path="/var/log/faillock"
 . $SHARED/audit_rules_login_events/auditctl_wrong_rule_without_key.fail.sh

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_wrong_rule_without_key_cis.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/tests/auditctl_wrong_rule_without_key_cis.fail.sh
@@ -3,5 +3,7 @@
 # platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
 # profiles = xccdf_org.ssgproject.content_profile_cis
 
+{{{ setup_auditctl_environment() }}}
+
 path="/var/run/faillock"
 . $SHARED/audit_rules_login_events/auditctl_wrong_rule_without_key.fail.sh

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_default.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_default.fail.sh
@@ -2,4 +2,4 @@
 # packages = audit
 # platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_missing_rule.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_missing_rule.fail.sh
@@ -2,6 +2,7 @@
 # packages = audit
 # platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
+{{{ setup_auditctl_environment() }}}
+
 ./generate_privileged_commands_rule.sh {{{ uid_min }}} privileged /etc/audit/audit.rules
 sed -i '/newgrp/d' /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_one_rule.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_one_rule.fail.sh
@@ -2,5 +2,6 @@
 # packages = audit
 # platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
+{{{ setup_auditctl_environment() }}}
+
 echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -k privileged" >> /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_rules_configured.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_rules_configured.pass.sh
@@ -2,5 +2,6 @@
 # packages = audit
 # platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
+{{{ setup_auditctl_environment() }}}
+
 ./generate_privileged_commands_rule.sh {{{ uid_min }}} privileged /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_rules_without_perm_x.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_rules_without_perm_x.pass.sh
@@ -2,6 +2,7 @@
 # packages = audit
 # platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
+{{{ setup_auditctl_environment() }}}
+
 ./generate_privileged_commands_rule.sh {{{ uid_min }}} privileged /etc/audit/audit.rules
 sed -i -E 's/^(.*path=[[:graph:]]+) -F perm=x(.*$)/\1\2/' /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/auditclt_modprobe_correct_without_key.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/auditclt_modprobe_correct_without_key.pass.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-# packages = audit
-
-echo "-w /sbin/modprobe -p x" >> /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/auditctl_modprobe_correct.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/auditctl_modprobe_correct.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # packages = audit
 
+{{{ setup_auditctl_environment() }}}
+
 echo "-w /sbin/modprobe -p x -k modules" >> /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/auditctl_modprobe_correct_without_key.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/auditctl_modprobe_correct_without_key.pass.sh
@@ -3,4 +3,4 @@
 
 {{{ setup_auditctl_environment() }}}
 
-rm -f /etc/audit/audit.rules
+echo "-w /sbin/modprobe -p x" >> /etc/audit/audit.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/auditctl_modprobe_wrong_rule.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/auditctl_modprobe_wrong_rule.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # packages = audit
 
+{{{ setup_auditctl_environment() }}}
+
 echo "-w /sbin/something -p x -k modules" >> /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_immutable/tests/auditctl_correct.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_immutable/tests/auditctl_correct.pass.sh
@@ -2,6 +2,6 @@
 # packages = audit
 
 # use auditctl
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 echo "-e 2" > /etc/audit/audit.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_immutable/tests/auditctl_missing.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_immutable/tests/auditctl_missing.fail.sh
@@ -2,6 +2,6 @@
 # packages = audit
 
 # use auditctl
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 echo "some value" > /etc/audit/audit.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_immutable/tests/auditctl_wrong_value.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_immutable/tests/auditctl_wrong_value.fail.sh
@@ -2,7 +2,7 @@
 # packages = audit
 
 # use auditctl
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 echo "-e 1" > /etc/audit/audit.rules
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification/tests/auditctl_correct.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification/tests/auditctl_correct.pass.sh
@@ -2,6 +2,6 @@
 # packages = audit
 
 # use auditctl
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 echo "-w /etc/selinux/ -p wa -k MAC-policy" > /etc/audit/audit.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification/tests/auditctl_correct_without_key.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification/tests/auditctl_correct_without_key.pass.sh
@@ -2,6 +2,6 @@
 # packages = audit
 
 # use auditctl
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 echo "-w /etc/selinux/ -p wa" > /etc/audit/audit.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification/tests/auditctl_missing.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification/tests/auditctl_missing.fail.sh
@@ -2,6 +2,6 @@
 # packages = audit
 
 # use auditctl
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 echo "some value" > /etc/audit/audit.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification/tests/auditctl_wrong_value.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification/tests/auditctl_wrong_value.fail.sh
@@ -2,7 +2,7 @@
 # packages = audit
 
 # use auditctl
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 echo "-w /etc/passwd -p w -k MAC-policy" > /etc/audit/audit.rules
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification_usr_share/tests/auditctl_correct.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification_usr_share/tests/auditctl_correct.pass.sh
@@ -2,6 +2,6 @@
 # packages = audit
 
 # use auditctl
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 echo "-w /usr/share/selinux/ -p wa -k MAC-policy" > /etc/audit/audit.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification_usr_share/tests/auditctl_correct_without_key.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification_usr_share/tests/auditctl_correct_without_key.pass.sh
@@ -2,6 +2,6 @@
 # packages = audit
 
 # use auditctl
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 echo "-w /usr/share/selinux/ -p wa" > /etc/audit/audit.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification_usr_share/tests/auditctl_missing.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification_usr_share/tests/auditctl_missing.fail.sh
@@ -2,6 +2,6 @@
 # packages = audit
 
 # use auditctl
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 echo "some value" > /etc/audit/audit.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification_usr_share/tests/auditctl_wrong_value.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification_usr_share/tests/auditctl_wrong_value.fail.sh
@@ -2,7 +2,7 @@
 # packages = audit
 
 # use auditctl
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 echo "-w /etc/passwd -p w -k MAC-policy" > /etc/audit/audit.rules
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/auditctl_correct_rules.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/auditctl_correct_rules.pass.sh
@@ -3,7 +3,7 @@
 
 
 # use auditctl
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 
 rm -rf /etc/audit/rules.d/*

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/auditctl_correct_rules_watch_rules_without_key.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/auditctl_correct_rules_watch_rules_without_key.pass.sh
@@ -3,7 +3,7 @@
 
 
 # use auditctl
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 
 rm -rf /etc/audit/rules.d/*

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_session_events/tests/auditctl_correct.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_session_events/tests/auditctl_correct.pass.sh
@@ -2,7 +2,7 @@
 # packages = audit
 
 # use auditctl
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 rm -rf /etc/audit/rules.d/*
 rm /etc/audit/audit.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_session_events/tests/auditctl_correct_without_key.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_session_events/tests/auditctl_correct_without_key.pass.sh
@@ -2,7 +2,7 @@
 # packages = audit
 
 # use auditctl
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 rm -rf /etc/audit/rules.d/*
 rm /etc/audit/audit.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_session_events/tests/auditctl_rules_missing.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_session_events/tests/auditctl_rules_missing.fail.sh
@@ -2,7 +2,7 @@
 # packages = audit
 
 # use auditctl
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_usergroup_modification/tests/auditctl_correct.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_usergroup_modification/tests/auditctl_correct.pass.sh
@@ -2,7 +2,7 @@
 # packages = audit
 
 # use auditctl
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 echo "-w /etc/group -p wa -k audit_rules_usergroup_modification" >> /etc/audit/audit.rules
 echo "-w /etc/passwd -p wa -k audit_rules_usergroup_modification" >> /etc/audit/audit.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_usergroup_modification/tests/auditctl_correct_without_key.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_usergroup_modification/tests/auditctl_correct_without_key.pass.sh
@@ -2,7 +2,7 @@
 # packages = audit
 
 # use auditctl
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 echo "-w /etc/group -p wa" >> /etc/audit/audit.rules
 echo "-w /etc/passwd -p wa" >> /etc/audit/audit.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_usergroup_modification/tests/auditctl_missing.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_usergroup_modification/tests/auditctl_missing.fail.sh
@@ -2,6 +2,6 @@
 # packages = audit
 
 # use auditctl
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 echo "some value" > /etc/audit/audit.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_usergroup_modification/tests/auditctl_wrong_value.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_usergroup_modification/tests/auditctl_wrong_value.fail.sh
@@ -2,7 +2,7 @@
 # packages = audit
 
 # use auditctl
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 echo "-w /etc/group -p w -k audit_rules_usergroup_modification" >> /etc/audit/audit.rules
 echo "-w /etc/passwd -p w -k audit_rules_usergroup_modification" >> /etc/audit/audit.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/auditctl_correct_rule.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/auditctl_correct_rule.pass.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 # packages = audit
 
-
-# Use auditctl in RHEL7
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 echo "-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>={{{ uid_min }}} -F auid!=unset -F key=access-audit-trail" >> /etc/audit/audit.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/auditctl_wrong_dir.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/auditctl_wrong_dir.fail.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 # packages = audit
 
-
-# Use auditctl in RHEL7
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 echo "-a always,exit -F dir=/var/log/auditd/ -F perm=r -F auid>={{{ uid_min }}} -F auid!=unset -F key=access-audit-trail" >> /etc/audit/audit.rules

--- a/linux_os/guide/auditing/group.yml
+++ b/linux_os/guide/auditing/group.yml
@@ -1,5 +1,15 @@
 documentation_complete: true
 
+{{% if product == 'rhel10' %}}
+{{% set audit_loading_systemd_directive="ExecStart" %}}
+{{% set audit_loading_systemd_directive_suffix="=" %}}
+{{% set audit_loading_service_file="audit-rules.service" %}}
+{{% else %}}
+{{% set audit_loading_systemd_directive="ExecStartPost" %}}
+{{% set audit_loading_service_file="auditd.service" %}}
+{{% set audit_loading_systemd_directive_suffix="=-" %}}
+{{% endif %}}
+
 title: 'System Accounting with auditd'
 
 description: |-
@@ -19,17 +29,17 @@ description: |-
     daemon can use the <tt>auditctl</tt> utility to read audit rules from the
     <tt>/etc/audit/audit.rules</tt> configuration file during daemon startup,
     and load them into the kernel. The expected behavior is configured via the
-    appropriate <tt>ExecStartPost</tt> directive setting in the
-    <tt>/usr/lib/systemd/system/auditd.service</tt> configuration file.
+    appropriate <tt>{{{ audit_loading_systemd_directive }}}</tt> directive setting in the
+    <tt>/usr/lib/systemd/system/{{{ audit_loading_service_file }}}</tt> configuration file.
     To instruct the <tt>auditd</tt> daemon to use the <tt>augenrules</tt> program
     to read audit rules (default configuration), use the following setting:
-    <br /> <pre>ExecStartPost=-/sbin/augenrules --load</pre>
-    in the <tt>/usr/lib/systemd/system/auditd.service</tt> configuration file.
+    <br /> <pre>{{{ audit_loading_systemd_directive ~ audit_loading_systemd_directive_suffix }}}/sbin/augenrules --load</pre>
+    in the <tt>/usr/lib/systemd/system/{{{ audit_loading_service_file }}}</tt> configuration file.
     In order to instruct the <tt>auditd</tt> daemon to use the <tt>auditctl</tt>
     utility to read audit rules, use the following setting:
-    <br /> <pre>ExecStartPost=-/sbin/auditctl -R /etc/audit/audit.rules</pre>
-    in the <tt>/usr/lib/systemd/system/auditd.service</tt> configuration file.
-    Refer to <tt>[Service]</tt> section of the <tt>/usr/lib/systemd/system/auditd.service</tt>
+    <br /> <pre>{{{ audit_loading_systemd_directive ~ audit_loading_systemd_directive_suffix }}}/sbin/auditctl -R /etc/audit/audit.rules</pre>
+    in the <tt>/usr/lib/systemd/system/{{{ audit_loading_service_file }}}</tt> configuration file.
+    Refer to <tt>[Service]</tt> section of the <tt>/usr/lib/systemd/system/{{{ audit_loading_service_file }}}</tt>
     configuration file for further details.
     <br /><br />
     Government networks often have substantial auditing

--- a/shared/checks/oval/audit_rules_auditctl.xml
+++ b/shared/checks/oval/audit_rules_auditctl.xml
@@ -18,8 +18,13 @@
     <ind:object object_ref="object_audit_rules_auditctl" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_audit_rules_auditctl" version="1">
+{{% if product == 'rhel10' %}}
+    <ind:filepath>/usr/lib/systemd/system/audit-rules.service</ind:filepath>
+    <ind:pattern operation="pattern match">^ExecStart=\/sbin\/auditctl.*$</ind:pattern>
+  {{% else %}}
     <ind:filepath>/usr/lib/systemd/system/auditd.service</ind:filepath>
     <ind:pattern operation="pattern match">^ExecStartPost=\-\/sbin\/auditctl.*$</ind:pattern>
+{{% endif %}}
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/shared/checks/oval/audit_rules_augenrules.xml
+++ b/shared/checks/oval/audit_rules_augenrules.xml
@@ -18,8 +18,13 @@
     <ind:object object_ref="object_audit_rules_augenrules" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_audit_rules_augenrules" version="1">
+  {{% if product == 'rhel10' %}}
+    <ind:filepath>/usr/lib/systemd/system/audit-rules.service</ind:filepath>
+    <ind:pattern operation="pattern match">^ExecStart=\/sbin\/augenrules.*$</ind:pattern>
+  {{% else %}}
     <ind:filepath>/usr/lib/systemd/system/auditd.service</ind:filepath>
     <ind:pattern operation="pattern match">^(ExecStartPost=\-\/sbin\/augenrules.*$|Requires=augenrules.service)</ind:pattern>
+{{% endif %}}
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/shared/macros/20-test-scenarios.jinja
+++ b/shared/macros/20-test-scenarios.jinja
@@ -1,0 +1,12 @@
+{{#
+This macro changes the configuration of the audit service so that it looks like auditctl is used to load rules.
+#}}
+
+{{%- macro setup_auditctl_environment () -%}}
+  {{% if product == "rhel10" %}}
+  sed -i "s%^ExecStart=.*%ExecStart=/sbin/auditctl%" /usr/lib/systemd/system/audit-rules.service
+  {{% else %}}
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+  {{% endif %}}
+{{%- endmacro -%}}
+

--- a/shared/templates/audit_rules_login_events/tests/auditctl_correct.pass.sh
+++ b/shared/templates/audit_rules_login_events/tests/auditctl_correct.pass.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # packages = audit
 
+{{{ setup_auditctl_environment() }}}
+
 path={{{ PATH }}}
 . $SHARED/audit_rules_login_events/auditctl_correct.pass.sh

--- a/shared/templates/audit_rules_login_events/tests/auditctl_correct_extra_permission.pass.sh
+++ b/shared/templates/audit_rules_login_events/tests/auditctl_correct_extra_permission.pass.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # packages = audit
 
+{{{ setup_auditctl_environment() }}}
+
 path={{{ PATH }}}
 . $SHARED/audit_rules_login_events/auditctl_correct_extra_permission.pass.sh

--- a/shared/templates/audit_rules_login_events/tests/auditctl_correct_without_key.pass.sh
+++ b/shared/templates/audit_rules_login_events/tests/auditctl_correct_without_key.pass.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # packages = audit
 
+{{{ setup_auditctl_environment() }}}
+
 path={{{ PATH }}}
 . $SHARED/audit_rules_login_events/auditctl_correct_without_key.pass.sh

--- a/shared/templates/audit_rules_login_events/tests/auditctl_remove_all_rules.fail.sh
+++ b/shared/templates/audit_rules_login_events/tests/auditctl_remove_all_rules.fail.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # packages = audit
 
+{{{ setup_auditctl_environment() }}}
+
 path={{{ PATH }}}
 . $SHARED/audit_rules_login_events/auditctl_remove_all_rules.fail.sh

--- a/shared/templates/audit_rules_login_events/tests/auditctl_wrong_rule.fail.sh
+++ b/shared/templates/audit_rules_login_events/tests/auditctl_wrong_rule.fail.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # packages = audit
 
+{{{ setup_auditctl_environment() }}}
+
 path={{{ PATH }}}
 . $SHARED/audit_rules_login_events/auditctl_wrong_rule.fail.sh

--- a/shared/templates/audit_rules_login_events/tests/auditctl_wrong_rule_without_key.fail.sh
+++ b/shared/templates/audit_rules_login_events/tests/auditctl_wrong_rule_without_key.fail.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # packages = audit
 
+{{{ setup_auditctl_environment() }}}
+
 path={{{ PATH }}}
 . $SHARED/audit_rules_login_events/auditctl_wrong_rule_without_key.fail.sh

--- a/shared/templates/audit_rules_privileged_commands/tests/auditctl_comented_value.fail.sh
+++ b/shared/templates/audit_rules_privileged_commands/tests/auditctl_comented_value.fail.sh
@@ -2,7 +2,7 @@
 # packages = audit
 source common.sh
 
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 echo \
 "# -a always,exit -F path={{{ PATH }}} ${perm_x} -F auid>={{{ auid }}} -F auid!=unset -k test_key" \

--- a/shared/templates/audit_rules_privileged_commands/tests/auditctl_correct_value.pass.sh
+++ b/shared/templates/audit_rules_privileged_commands/tests/auditctl_correct_value.pass.sh
@@ -2,7 +2,7 @@
 # packages = audit
 source common.sh
 
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 echo \
 "-a always,exit -F path={{{ PATH }}} ${perm_x} -F auid>={{{ auid }}} -F auid!=unset -k test_key" \

--- a/shared/templates/audit_rules_privileged_commands/tests/auditctl_missing_auid.fail.sh
+++ b/shared/templates/audit_rules_privileged_commands/tests/auditctl_missing_auid.fail.sh
@@ -2,6 +2,6 @@
 # packages = audit
 source common.sh
 
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 echo "-a always,exit -F path={{{ PATH }}} ${perm_x} -k test_key" >> /etc/audit/audit.rules

--- a/shared/templates/audit_rules_privileged_commands/tests/auditctl_missing_perm_x.fail.sh
+++ b/shared/templates/audit_rules_privileged_commands/tests/auditctl_missing_perm_x.fail.sh
@@ -4,7 +4,7 @@
 
 source common.sh
 
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 echo "-a always,exit -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -k test_key" \
 >> /etc/audit/audit.rules

--- a/shared/templates/audit_rules_privileged_commands/tests/augenrules_comented_value.fail.sh
+++ b/shared/templates/audit_rules_privileged_commands/tests/augenrules_comented_value.fail.sh
@@ -2,8 +2,6 @@
 
 source common.sh
 
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/augenrules%" /usr/lib/systemd/system/auditd.service
-
 echo \
 "# -a always,exit -F path={{{ PATH }}} ${perm_x} -F auid>={{{ auid }}} -F auid!=unset -k test_key" \
 >> /etc/audit/rules.d/test_key.rules

--- a/shared/templates/audit_rules_privileged_commands/tests/augenrules_correct_value.pass.sh
+++ b/shared/templates/audit_rules_privileged_commands/tests/augenrules_correct_value.pass.sh
@@ -2,8 +2,6 @@
 
 source common.sh
 
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/augenrules%" /usr/lib/systemd/system/auditd.service
-
 echo \
 "-a always,exit -F path={{{ PATH }}} ${perm_x} -F auid>={{{ auid }}} -F auid!=unset -k test_key" \
 >> /etc/audit/rules.d/test_key.rules

--- a/shared/templates/audit_rules_privileged_commands/tests/augenrules_missing_auid.fail.sh
+++ b/shared/templates/audit_rules_privileged_commands/tests/augenrules_missing_auid.fail.sh
@@ -2,6 +2,4 @@
 
 source common.sh
 
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/augenrules%" /usr/lib/systemd/system/auditd.service
-
 echo "-a always,exit -F path={{{ PATH }}} ${perm_x} -k test_key" >> /etc/audit/rules.d/test_key.rules

--- a/shared/templates/audit_rules_privileged_commands/tests/augenrules_missing_perm_x.fail.sh
+++ b/shared/templates/audit_rules_privileged_commands/tests/augenrules_missing_perm_x.fail.sh
@@ -3,7 +3,5 @@
 
 source common.sh
 
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/augenrules%" /usr/lib/systemd/system/auditd.service
-
 echo "-a always,exit -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -k test_key" \
 >> /etc/audit/rules.d/test_key.rules

--- a/shared/templates/audit_rules_privileged_commands/tests/common.sh
+++ b/shared/templates/audit_rules_privileged_commands/tests/common.sh
@@ -1,6 +1,8 @@
+
 {{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] %}}
 perm_x="-F perm=x"
 {{%- endif %}}
+
 
 rm -f /etc/audit/rules.d/*.rules
 truncate -s 0 /etc/audit/audit.rules

--- a/shared/templates/audit_rules_usergroup_modification/tests/auditctl_correct.pass.sh
+++ b/shared/templates/audit_rules_usergroup_modification/tests/auditctl_correct.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # packages = audit
 
+{{{ setup_auditctl_environment() }}}
+
 echo "-w {{{ PATH }}} -p wa -k audit_rules_usergroup_modification" >> /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/shared/templates/audit_rules_usergroup_modification/tests/auditctl_correct_extra_permission.pass.sh
+++ b/shared/templates/audit_rules_usergroup_modification/tests/auditctl_correct_extra_permission.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # packages = audit
 
+{{{ setup_auditctl_environment() }}}
+
 echo "-w {{{ PATH }}} -p wra -k audit_rules_usergroup_modification" >> /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/shared/templates/audit_rules_usergroup_modification/tests/auditctl_correct_without_key.pass.sh
+++ b/shared/templates/audit_rules_usergroup_modification/tests/auditctl_correct_without_key.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # packages = audit
 
+{{{ setup_auditctl_environment() }}}
+
 echo "-w {{{ PATH }}} -p wa" >> /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/shared/templates/audit_rules_usergroup_modification/tests/auditctl_remove_all_rules.fail.sh
+++ b/shared/templates/audit_rules_usergroup_modification/tests/auditctl_remove_all_rules.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # packages = audit
 
+{{{ setup_auditctl_environment() }}}
+
 rm -f /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/shared/templates/audit_rules_usergroup_modification/tests/auditctl_wrong_rule.fail.sh
+++ b/shared/templates/audit_rules_usergroup_modification/tests/auditctl_wrong_rule.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # packages = audit
 
+{{{ setup_auditctl_environment() }}}
+
 echo "-w {{{ PATH }}} -p w -k audit_rules_usergroup_modification" >> /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/shared/templates/audit_rules_usergroup_modification/tests/auditctl_wrong_rule_without_key.fail.sh
+++ b/shared/templates/audit_rules_usergroup_modification/tests/auditctl_wrong_rule_without_key.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # packages = audit
 
+{{{ setup_auditctl_environment() }}}
+
 echo "-w {{{ PATH }}} -p w" >> /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/shared/templates/audit_rules_watch/tests/auditctl_correct_rules.pass.sh
+++ b/shared/templates/audit_rules_watch/tests/auditctl_correct_rules.pass.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 # packages = audit
 
-# use auditctl
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
-
+{{{ setup_auditctl_environment() }}}
 
 rm -rf /etc/audit/rules.d/*
 rm /etc/audit/audit.rules

--- a/shared/templates/audit_rules_watch/tests/auditctl_correct_rules_watch_rules_without_key.pass.sh
+++ b/shared/templates/audit_rules_watch/tests/auditctl_correct_rules_watch_rules_without_key.pass.sh
@@ -2,8 +2,7 @@
 # packages = audit
 
 
-# use auditctl
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
+{{{ setup_auditctl_environment() }}}
 
 rm -rf /etc/audit/rules.d/*
 rm /etc/audit/audit.rules

--- a/tests/shared/audit_rules_login_events/auditctl_correct.pass.sh
+++ b/tests/shared/audit_rules_login_events/auditctl_correct.pass.sh
@@ -2,4 +2,3 @@
 # packages = audit
 
 echo "-w $path -p wa -k logins" >> /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/tests/shared/audit_rules_login_events/auditctl_correct_extra_permission.pass.sh
+++ b/tests/shared/audit_rules_login_events/auditctl_correct_extra_permission.pass.sh
@@ -2,4 +2,3 @@
 # packages = audit
 
 echo "-w $path -p wra -k logins" >> /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/tests/shared/audit_rules_login_events/auditctl_correct_without_key.pass.sh
+++ b/tests/shared/audit_rules_login_events/auditctl_correct_without_key.pass.sh
@@ -2,4 +2,3 @@
 # packages = audit
 
 echo "-w $path -p wa" >> /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/tests/shared/audit_rules_login_events/auditctl_remove_all_rules.fail.sh
+++ b/tests/shared/audit_rules_login_events/auditctl_remove_all_rules.fail.sh
@@ -2,4 +2,3 @@
 # packages = audit
 
 rm -f /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/tests/shared/audit_rules_login_events/auditctl_wrong_rule.fail.sh
+++ b/tests/shared/audit_rules_login_events/auditctl_wrong_rule.fail.sh
@@ -2,4 +2,3 @@
 # packages = audit
 
 echo "-w $path -p w -k logins" >> /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/tests/shared/audit_rules_login_events/auditctl_wrong_rule_without_key.fail.sh
+++ b/tests/shared/audit_rules_login_events/auditctl_wrong_rule_without_key.fail.sh
@@ -2,4 +2,3 @@
 # packages = audit
 
 echo "-w $path -p w" >> /etc/audit/audit.rules
-sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service


### PR DESCRIPTION
#### Description:

- modify OVAL checks which decide if we use augenrules or auditctl to load rules. Point them to the new file audit-rules.service in case we are on rhel10 product
- modify test scenarios of all templates where this scenario occurs
- modify test scenarios of all rules which are in rhel10 product

#### Rationale:

In RHEL 10, there is a special Systemd service file which loads rules.
Previously, this was done through ExecStartPost directive in auditd.service.
In RHEL 10, there is a new file audit-rules.service which achieves the same but through ExecStart directive.

#### Review Hints:

1. review CI results
2. CI might not be able to test all rules so in case of failures, please retest locally through Automatus.