### PR TITLE
Update assertions for ingress controller TLS check

### DIFF
--- a/tests/assertions/ocp4/ocp4-cis-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.17.yml
@@ -293,3 +293,6 @@ rule_results:
  e2e-cis-secrets-no-environment-variables:
    default_result: MANUAL
    result_after_remediation: MANUAL
+ e2e-cis-kubelet-configure-tls-cipher-suites-ingresscontroller:
+   default_result: FAIL
+   result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.13.yml
@@ -376,3 +376,6 @@ rule_results:
     default_result: MANUAL
   e2e-high-secrets-no-environment-variables:
     default_result: MANUAL
+  e2e-high-kubelet-configure-tls-cipher-suites-ingresscontroller:
+    default_result: FAIL
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.14.yml
@@ -376,3 +376,6 @@ rule_results:
     default_result: MANUAL
   e2e-high-secrets-no-environment-variables:
     default_result: MANUAL
+  e2e-high-kubelet-configure-tls-cipher-suites-ingresscontroller:
+    default_result: FAIL
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.15.yml
@@ -403,3 +403,6 @@ rule_results:
   e2e-high-secrets-no-environment-variables:
     default_result: MANUAL
     result_after_remediation: MANUAL
+  e2e-high-kubelet-configure-tls-cipher-suites-ingresscontroller:
+    default_result: FAIL
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.16.yml
@@ -403,3 +403,6 @@ rule_results:
   e2e-high-secrets-no-environment-variables:
     default_result: MANUAL
     result_after_remediation: MANUAL
+  e2e-high-kubelet-configure-tls-cipher-suites-ingresscontroller:
+    default_result: FAIL
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.17.yml
@@ -404,3 +404,6 @@ rule_results:
  e2e-high-secrets-no-environment-variables:
    default_result: MANUAL
    result_after_remediation: MANUAL
+ e2e-high-kubelet-configure-tls-cipher-suites-ingresscontroller:
+   default_result: FAIL
+   result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.13.yml
@@ -394,3 +394,6 @@ rule_results:
   e2e-moderate-secrets-no-environment-variables:
     default_result: MANUAL
     result_after_remediation: MANUAL
+  e2e-moderate-kubelet-configure-tls-cipher-suites-ingresscontroller:
+    default_result: FAIL
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.14.yml
@@ -394,3 +394,6 @@ rule_results:
   e2e-moderate-secrets-no-environment-variables:
     default_result: MANUAL
     result_after_remediation: MANUAL
+  e2e-moderate-kubelet-configure-tls-cipher-suites-ingresscontroller:
+    default_result: FAIL
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.15.yml
@@ -368,3 +368,6 @@ rule_results:
     default_result: MANUAL
   e2e-moderate-secrets-no-environment-variables:
     default_result: MANUAL
+  e2e-moderate-kubelet-configure-tls-cipher-suites-ingresscontroller:
+    default_result: FAIL
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.16.yml
@@ -394,3 +394,6 @@ rule_results:
   e2e-moderate-secrets-no-environment-variables:
     default_result: MANUAL
     result_after_remediation: MANUAL
+  e2e-moderate-kubelet-configure-tls-cipher-suites-ingresscontroller:
+    default_result: FAIL
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.17.yml
@@ -395,3 +395,6 @@ rule_results:
  e2e-moderate-secrets-no-environment-variables:
    default_result: MANUAL
    result_after_remediation: MANUAL
+ e2e-moderate-kubelet-configure-tls-cipher-suites-ingresscontroller:
+   default_result: FAIL
+   result_after_remediation: PASS


### PR DESCRIPTION
We recently incorporated a new rule into the CIS profile that checks
ingress controller TLS configs:

  https://github.com/ComplianceAsCode/content/pull/12220

We added it to the CIS profile, but didn't update the assertions in the
moderate or high profiles, which is causing periodic CI to fail. This
commit adds the assertion to the moderate and high test files so we're
checking it in subsequent CI runs.
