### PR TITLE
Update assertions for PCI-DSS profile

### DIFF
--- a/tests/assertions/ocp4/ocp4-pci-dss-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.13.yml
@@ -334,3 +334,36 @@ rule_results:
   e2e-pci-dss-tls-version-check-router:
     default_result: PASS
     result_after_remediation: PASS
+  e2e-pci-dss-acs-sensor-exists:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-alert-receiver-configured:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-pci-dss-api-server-tls-security-profile:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-audit-error-alert-exists:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-container-security-operator-exists:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-ingress-controller-certificate:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-ingress-controller-tls-security-profile:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-kubelet-configure-tls-cipher-suites-ingresscontroller:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-oauth-or-oauthclient-inactivity-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-ocp-idp-no-htpasswd:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-security-profiles-operator-exists:
+    default_result: FAIL
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.14.yml
@@ -334,3 +334,36 @@ rule_results:
   e2e-pci-dss-tls-version-check-router:
     default_result: PASS
     result_after_remediation: PASS
+  e2e-pci-dss-acs-sensor-exists:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-alert-receiver-configured:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-pci-dss-api-server-tls-security-profile:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-audit-error-alert-exists:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-container-security-operator-exists:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-ingress-controller-certificate:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-ingress-controller-tls-security-profile:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-kubelet-configure-tls-cipher-suites-ingresscontroller:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-oauth-or-oauthclient-inactivity-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-ocp-idp-no-htpasswd:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-security-profiles-operator-exists:
+    default_result: FAIL
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.15.yml
@@ -334,3 +334,36 @@ rule_results:
   e2e-pci-dss-tls-version-check-router:
     default_result: PASS
     result_after_remediation: PASS
+  e2e-pci-dss-acs-sensor-exists:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-alert-receiver-configured:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-pci-dss-api-server-tls-security-profile:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-audit-error-alert-exists:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-container-security-operator-exists:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-ingress-controller-certificate:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-ingress-controller-tls-security-profile:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-kubelet-configure-tls-cipher-suites-ingresscontroller:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-oauth-or-oauthclient-inactivity-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-ocp-idp-no-htpasswd:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-security-profiles-operator-exists:
+    default_result: FAIL
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.16.yml
@@ -334,3 +334,36 @@ rule_results:
   e2e-pci-dss-tls-version-check-router:
     default_result: PASS
     result_after_remediation: PASS
+  e2e-pci-dss-acs-sensor-exists:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-alert-receiver-configured:
+    default_result: MANUAL
+    result_after_remediation: MANUAL
+  e2e-pci-dss-api-server-tls-security-profile:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-audit-error-alert-exists:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-container-security-operator-exists:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-ingress-controller-certificate:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-ingress-controller-tls-security-profile:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-kubelet-configure-tls-cipher-suites-ingresscontroller:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-oauth-or-oauthclient-inactivity-timeout:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-ocp-idp-no-htpasswd:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-security-profiles-operator-exists:
+    default_result: FAIL
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.17.yml
@@ -78,14 +78,14 @@ rule_results:
    default_result: PASS
    result_after_remediation: PASS
  e2e-pci-dss-api-server-kubelet-client-cert:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: PASS
+   result_after_remediation: PASS
  e2e-pci-dss-api-server-kubelet-client-cert-pre-4-9:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE
  e2e-pci-dss-api-server-kubelet-client-key:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: PASS
+   result_after_remediation: PASS
  e2e-pci-dss-api-server-kubelet-client-key-pre-4-9:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.17.yml
@@ -335,3 +335,36 @@ rule_results:
  e2e-pci-dss-tls-version-check-router:
    default_result: PASS
    result_after_remediation: PASS
+ e2e-pci-dss-acs-sensor-exists:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-alert-receiver-configured:
+   default_result: MANUAL
+   result_after_remediation: MANUAL
+ e2e-pci-dss-api-server-tls-security-profile:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-audit-error-alert-exists:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-container-security-operator-exists:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-ingress-controller-certificate:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-ingress-controller-tls-security-profile:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-kubelet-configure-tls-cipher-suites-ingresscontroller:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-oauth-or-oauthclient-inactivity-timeout:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-ocp-idp-no-htpasswd:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-security-profiles-operator-exists:
+   default_result: FAIL
+   result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4.13.yml
@@ -452,3 +452,27 @@ rule_results:
     default_result: MANUAL
   e2e-pci-dss-node-worker-tls-version-check-masters-workers:
     default_result: PASS
+  e2e-pci-dss-node-master-directory-access-var-log-kube-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-node-master-directory-access-var-log-oauth-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-node-master-directory-access-var-log-ocp-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-node-master-kubelet-configure-tls-min-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-worker-directory-access-var-log-kube-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-directory-access-var-log-oauth-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-directory-access-var-log-ocp-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-kubelet-configure-tls-min-version:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4.14.yml
@@ -452,3 +452,27 @@ rule_results:
     default_result: MANUAL
   e2e-pci-dss-node-worker-tls-version-check-masters-workers:
     default_result: PASS
+  e2e-pci-dss-node-master-directory-access-var-log-kube-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-node-master-directory-access-var-log-oauth-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-node-master-directory-access-var-log-ocp-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-node-master-kubelet-configure-tls-min-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-worker-directory-access-var-log-kube-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-directory-access-var-log-oauth-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-directory-access-var-log-ocp-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-kubelet-configure-tls-min-version:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4.15.yml
@@ -452,3 +452,27 @@ rule_results:
     default_result: MANUAL
   e2e-pci-dss-node-worker-tls-version-check-masters-workers:
     default_result: PASS
+  e2e-pci-dss-node-master-directory-access-var-log-kube-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-node-master-directory-access-var-log-oauth-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-node-master-directory-access-var-log-ocp-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-node-master-kubelet-configure-tls-min-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-worker-directory-access-var-log-kube-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-directory-access-var-log-oauth-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-directory-access-var-log-ocp-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-kubelet-configure-tls-min-version:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4.16.yml
@@ -452,3 +452,27 @@ rule_results:
     default_result: MANUAL
   e2e-pci-dss-node-worker-tls-version-check-masters-workers:
     default_result: PASS
+  e2e-pci-dss-node-master-directory-access-var-log-kube-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-node-master-directory-access-var-log-oauth-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-node-master-directory-access-var-log-ocp-audit:
+    default_result: FAIL
+    result_after_remediation: PASS
+  e2e-pci-dss-node-master-kubelet-configure-tls-min-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-node-worker-directory-access-var-log-kube-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-directory-access-var-log-oauth-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-directory-access-var-log-ocp-audit:
+    default_result: NOT-APPLICABLE
+    result_after_remediation: NOT-APPLICABLE
+  e2e-pci-dss-node-worker-kubelet-configure-tls-min-version:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4.17.yml
@@ -451,3 +451,27 @@ rule_results:
    default_result: MANUAL
  e2e-pci-dss-node-worker-tls-version-check-masters-workers:
    default_result: PASS
+ e2e-pci-dss-node-master-directory-access-var-log-kube-audit:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-node-master-directory-access-var-log-oauth-audit:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-node-master-directory-access-var-log-ocp-audit:
+   default_result: FAIL
+   result_after_remediation: PASS
+ e2e-pci-dss-node-master-kubelet-configure-tls-min-version:
+   default_result: PASS
+   result_after_remediation: PASS
+ e2e-pci-dss-node-worker-directory-access-var-log-kube-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-worker-directory-access-var-log-oauth-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-worker-directory-access-var-log-ocp-audit:
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-node-worker-kubelet-configure-tls-min-version:
+   default_result: PASS
+   result_after_remediation: PASS


### PR DESCRIPTION
We recently updated the PCI-DSS profile to use 4.0 by default, but
didn't update the default assertions. This commit updates the assertions
so that the versionless profile name includes assertions for rules in
the v4.0 profile.
