### PR TITLE
Update assertions for kubelet-client-cert|key rules

### DIFF
--- a/tests/assertions/ocp4/ocp4-cis-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.17.yml
@@ -78,14 +78,14 @@ rule_results:
    default_result: PASS
    result_after_remediation: PASS
  e2e-cis-api-server-kubelet-client-cert:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: PASS
+   result_after_remediation: PASS
  e2e-cis-api-server-kubelet-client-cert-pre-4-9:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE
  e2e-cis-api-server-kubelet-client-key:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: PASS
+   result_after_remediation: PASS
  e2e-cis-api-server-kubelet-client-key-pre-4-9:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE
@@ -207,11 +207,11 @@ rule_results:
    default_result: FAIL
    result_after_remediation: FAIL
  e2e-cis-kubelet-configure-tls-cert:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: PASS
+   result_after_remediation: PASS
  e2e-cis-kubelet-configure-tls-key:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: PASS
+   result_after_remediation: PASS
  e2e-cis-kubelet-disable-readonly-port:
    default_result: PASS
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.17.yml
@@ -90,14 +90,14 @@ rule_results:
    default_result: PASS
    result_after_remediation: PASS
  e2e-high-api-server-kubelet-client-cert:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: PASS
+   result_after_remediation: PASS
  e2e-high-api-server-kubelet-client-cert-pre-4-9:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE
  e2e-high-api-server-kubelet-client-key:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: PASS
+   result_after_remediation: PASS
  e2e-high-api-server-kubelet-client-key-pre-4-9:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE
@@ -276,14 +276,14 @@ rule_results:
    default_result: FAIL
    result_after_remediation: FAIL
  e2e-high-kubelet-configure-tls-cert:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: PASS
+   result_after_remediation: PASS
  e2e-high-kubelet-configure-tls-cert-pre-4-9:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE
  e2e-high-kubelet-configure-tls-key:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: PASS
+   result_after_remediation: PASS
  e2e-high-kubelet-disable-readonly-port:
    default_result: PASS
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.17.yml
@@ -87,14 +87,14 @@ rule_results:
    default_result: PASS
    result_after_remediation: PASS
  e2e-moderate-api-server-kubelet-client-cert:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: PASS
+   result_after_remediation: PASS
  e2e-moderate-api-server-kubelet-client-cert-pre-4-9:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE
  e2e-moderate-api-server-kubelet-client-key:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: PASS
+   result_after_remediation: PASS
  e2e-moderate-api-server-kubelet-client-key-pre-4-9:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE
@@ -267,14 +267,14 @@ rule_results:
    default_result: FAIL
    result_after_remediation: FAIL
  e2e-moderate-kubelet-configure-tls-cert:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: PASS
+   result_after_remediation: PASS
  e2e-moderate-kubelet-configure-tls-cert-pre-4-9:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE
  e2e-moderate-kubelet-configure-tls-key:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: PASS
+   result_after_remediation: PASS
  e2e-moderate-kubelet-disable-readonly-port:
    default_result: PASS
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.17.yml
@@ -78,14 +78,14 @@ rule_results:
    default_result: PASS
    result_after_remediation: PASS
  e2e-pci-dss-4-0-api-server-kubelet-client-cert:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: PASS
+   result_after_remediation: PASS
  e2e-pci-dss-4-0-api-server-kubelet-client-cert-pre-4-9:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE
  e2e-pci-dss-4-0-api-server-kubelet-client-key:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: PASS
+   result_after_remediation: PASS
  e2e-pci-dss-4-0-api-server-kubelet-client-key-pre-4-9:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.17.yml
@@ -216,14 +216,14 @@ rule_results:
    default_result: FAIL
    result_after_remediation: FAIL
  e2e-pci-dss-kubelet-configure-tls-cert:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: PASS
+   result_after_remediation: PASS
  e2e-pci-dss-kubelet-configure-tls-cert-pre-4-9:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE
  e2e-pci-dss-kubelet-configure-tls-key:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: PASS
+   result_after_remediation: PASS
  e2e-pci-dss-kubelet-configure-tls-key-pre-4-9:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE


### PR DESCRIPTION
We recently enabled these rules for 4.17, but didn't update the 4.17
assertion files for STIG, FedRAMP High, FedRAMP Moderate, or CIS. This
commit does that so that so the tests assert the correct behavior on
4.17.

  https://github.com/ComplianceAsCode/content/pull/12311
