### PR TITLE
PCI-DSS-4-0: Add cipher suite ingress controller assertion

### DIFF
--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.12.yml
@@ -230,6 +230,9 @@ rule_results:
  e2e-pci-dss-4-0-kubelet-configure-tls-cert:
    default_result: PASS
    result_after_remediation: PASS
+ e2e-pci-dss-4-0-kubelet-configure-tls-cipher-suites-ingress-controller:
+   default_result: FAIL
+   result_after_remediation: PASS
  e2e-pci-dss-4-0-kubelet-configure-tls-key:
    default_result: PASS
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.13.yml
@@ -230,6 +230,9 @@ rule_results:
  e2e-pci-dss-4-0-kubelet-configure-tls-cert:
    default_result: PASS
    result_after_remediation: PASS
+ e2e-pci-dss-4-0-kubelet-configure-tls-cipher-suites-ingress-controller:
+   default_result: FAIL
+   result_after_remediation: PASS
  e2e-pci-dss-4-0-kubelet-configure-tls-key:
    default_result: PASS
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.14.yml
@@ -230,6 +230,9 @@ rule_results:
  e2e-pci-dss-4-0-kubelet-configure-tls-cert:
    default_result: PASS
    result_after_remediation: PASS
+ e2e-pci-dss-4-0-kubelet-configure-tls-cipher-suites-ingress-controller:
+   default_result: FAIL
+   result_after_remediation: PASS
  e2e-pci-dss-4-0-kubelet-configure-tls-key:
    default_result: PASS
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.15.yml
@@ -230,6 +230,9 @@ rule_results:
  e2e-pci-dss-4-0-kubelet-configure-tls-cert:
    default_result: PASS
    result_after_remediation: PASS
+ e3e-pci-dss-4-0-kubelet-configure-tls-cipher-suites-ingress-controller:
+   default_result: FAIL
+   result_after_remediation: PASS
  e2e-pci-dss-4-0-kubelet-configure-tls-key:
    default_result: PASS
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.16.yml
@@ -230,6 +230,9 @@ rule_results:
  e2e-pci-dss-4-0-kubelet-configure-tls-cert:
    default_result: PASS
    result_after_remediation: PASS
+ e2e-pci-dss-4-0-kubelet-configure-tls-cipher-suites-ingress-controller:
+   default_result: FAIL
+   result_after_remediation: PASS
  e2e-pci-dss-4-0-kubelet-configure-tls-key:
    default_result: PASS
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.17.yml
@@ -230,6 +230,9 @@ rule_results:
  e2e-pci-dss-4-0-kubelet-configure-tls-cert:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE
+ e2e-pci-dss-4-0-kubelet-configure-tls-cipher-suites-ingress-controller:
+   default_result: FAIL
+   result_after_remediation: PASS
  e2e-pci-dss-4-0-kubelet-configure-tls-key:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE


### PR DESCRIPTION


#### Description:

- Add assertion of `kubelet-configure-tls-cipher-suites-ingress-controller` in pci-dss-4-0-4.XX files.
  See for example: [4.17-e2e-aws-ocp4-pci-dss-4-weekly](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-ComplianceAsCode-content-master-4.17-e2e-aws-ocp4-pci-dss-4-weekly/1832546982153949184)

#### Rationale:

- Follow up from https://github.com/ComplianceAsCode/content/pull/12361