### PR TITLE
Update assertions for 4.15 `file_permissions_cni_conf`

### DIFF
--- a/tests/assertions/ocp4/ocp4-cis-node-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-cis-node-4.14.yml
@@ -116,7 +116,7 @@ rule_results:
   e2e-cis-node-master-file-owner-worker-service:
     default_result: PASS
   e2e-cis-node-master-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-cis-node-master-file-permissions-controller-manager-kubeconfig:
     default_result: PASS
   e2e-cis-node-master-file-permissions-etcd-data-dir:
@@ -316,7 +316,7 @@ rule_results:
   e2e-cis-node-worker-file-owner-worker-service:
     default_result: PASS
   e2e-cis-node-worker-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-cis-node-worker-file-permissions-controller-manager-kubeconfig:
     default_result: NOT-APPLICABLE
   e2e-cis-node-worker-file-permissions-etcd-data-dir:

--- a/tests/assertions/ocp4/ocp4-cis-node-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-cis-node-4.15.yml
@@ -116,7 +116,7 @@ rule_results:
   e2e-cis-node-master-file-owner-worker-service:
     default_result: PASS
   e2e-cis-node-master-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-cis-node-master-file-permissions-controller-manager-kubeconfig:
     default_result: PASS
   e2e-cis-node-master-file-permissions-etcd-data-dir:
@@ -316,7 +316,7 @@ rule_results:
   e2e-cis-node-worker-file-owner-worker-service:
     default_result: PASS
   e2e-cis-node-worker-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-cis-node-worker-file-permissions-controller-manager-kubeconfig:
     default_result: NOT-APPLICABLE
   e2e-cis-node-worker-file-permissions-etcd-data-dir:

--- a/tests/assertions/ocp4/ocp4-high-node-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-high-node-4.14.yml
@@ -197,7 +197,7 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-high-node-master-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-high-node-master-file-permissions-controller-manager-kubeconfig:
     default_result: PASS
     result_after_remediation: PASS
@@ -548,7 +548,7 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-high-node-worker-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-high-node-worker-file-permissions-controller-manager-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-high-node-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-high-node-4.15.yml
@@ -197,7 +197,7 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-high-node-master-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-high-node-master-file-permissions-controller-manager-kubeconfig:
     default_result: PASS
     result_after_remediation: PASS
@@ -548,7 +548,7 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-high-node-worker-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-high-node-worker-file-permissions-controller-manager-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-moderate-node-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-node-4.14.yml
@@ -197,7 +197,7 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-moderate-node-master-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-moderate-node-master-file-permissions-controller-manager-kubeconfig:
     default_result: PASS
     result_after_remediation: PASS
@@ -548,7 +548,7 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-moderate-node-worker-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-moderate-node-worker-file-permissions-controller-manager-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-moderate-node-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-node-4.15.yml
@@ -197,7 +197,7 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-moderate-node-master-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-moderate-node-master-file-permissions-controller-manager-kubeconfig:
     default_result: PASS
     result_after_remediation: PASS
@@ -548,7 +548,7 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-moderate-node-worker-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-moderate-node-worker-file-permissions-controller-manager-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.14.yml
@@ -201,7 +201,7 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-pci-dss-node-4-0-master-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
     result_after_remediation: FAIL
   e2e-pci-dss-node-4-0-master-file-permissions-controller-manager-kubeconfig:
     default_result: PASS
@@ -543,7 +543,7 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-pci-dss-node-4-0-worker-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
     result_after_remediation: FAIL
   e2e-pci-dss-node-4-0-worker-file-permissions-controller-manager-kubeconfig:
     default_result: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.15.yml
@@ -201,7 +201,7 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-pci-dss-node-4-0-master-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
     result_after_remediation: FAIL
   e2e-pci-dss-node-4-0-master-file-permissions-controller-manager-kubeconfig:
     default_result: PASS
@@ -543,7 +543,7 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-pci-dss-node-4-0-worker-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
     result_after_remediation: FAIL
   e2e-pci-dss-node-4-0-worker-file-permissions-controller-manager-kubeconfig:
     default_result: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4.14.yml
@@ -128,7 +128,7 @@ rule_results:
   e2e-pci-dss-node-master-file-ownership-var-log-ocp-audit:
     default_result: PASS
   e2e-pci-dss-node-master-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-pci-dss-node-master-file-permissions-controller-manager-kubeconfig:
     default_result: PASS
   e2e-pci-dss-node-master-file-permissions-etcd-data-dir:
@@ -355,7 +355,7 @@ rule_results:
   e2e-pci-dss-node-worker-file-ownership-var-log-ocp-audit:
     default_result: NOT-APPLICABLE
   e2e-pci-dss-node-worker-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-pci-dss-node-worker-file-permissions-controller-manager-kubeconfig:
     default_result: NOT-APPLICABLE
   e2e-pci-dss-node-worker-file-permissions-etcd-data-dir:

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4.15.yml
@@ -128,7 +128,7 @@ rule_results:
   e2e-pci-dss-node-master-file-ownership-var-log-ocp-audit:
     default_result: PASS
   e2e-pci-dss-node-master-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-pci-dss-node-master-file-permissions-controller-manager-kubeconfig:
     default_result: PASS
   e2e-pci-dss-node-master-file-permissions-etcd-data-dir:
@@ -355,7 +355,7 @@ rule_results:
   e2e-pci-dss-node-worker-file-ownership-var-log-ocp-audit:
     default_result: NOT-APPLICABLE
   e2e-pci-dss-node-worker-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-pci-dss-node-worker-file-permissions-controller-manager-kubeconfig:
     default_result: NOT-APPLICABLE
   e2e-pci-dss-node-worker-file-permissions-etcd-data-dir:

--- a/tests/assertions/ocp4/ocp4-stig-node-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-stig-node-4.14.yml
@@ -173,7 +173,7 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-stig-node-master-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-stig-node-master-file-permissions-controller-manager-kubeconfig:
     default_result: PASS
     result_after_remediation: PASS
@@ -484,7 +484,7 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-stig-node-worker-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-stig-node-worker-file-permissions-controller-manager-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-stig-node-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-stig-node-4.15.yml
@@ -173,7 +173,7 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-stig-node-master-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-stig-node-master-file-permissions-controller-manager-kubeconfig:
     default_result: PASS
     result_after_remediation: PASS
@@ -484,7 +484,7 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-stig-node-worker-file-permissions-cni-conf:
-    default_result: FAIL
+    default_result: PASS
   e2e-stig-node-worker-file-permissions-controller-manager-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE


### PR DESCRIPTION


#### Description:

- Update 4.15 `file_permissions_cni_conf`
  - https://github.com/openshift/cluster-network-operator/pull/2324

#### Rationale:

- A change in file permissions landed in 4.15, requiring us to update assertions for `file-permissions-cni-conf`.
