### PR TITLE
Review and fix sssd rules in ANSSI control file

### DIFF
--- a/linux_os/guide/services/sssd/service_sssd_enabled/tests/common.sh
+++ b/linux_os/guide/services/sssd/service_sssd_enabled/tests/common.sh
@@ -7,7 +7,7 @@ services = nss, pam
 domains = example.com
 
 [domain/example.com]
-id_provider = files
+id_provider = ldap
 access_provider = simple
 simple_allow_users = user1, user2
 

--- a/linux_os/guide/services/sssd/service_sssd_enabled/tests/service_disabled.fail.sh
+++ b/linux_os/guide/services/sssd/service_sssd_enabled/tests/service_disabled.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = sssd
+# packages = sssd-common
 
 source common.sh
 

--- a/linux_os/guide/services/sssd/service_sssd_enabled/tests/service_enabled.pass.sh
+++ b/linux_os/guide/services/sssd/service_sssd_enabled/tests/service_enabled.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = sssd
+# packages = sssd-common
 
 source common.sh
 

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/ansible/shared.yml
@@ -4,14 +4,14 @@
 # complexity = low
 # disruption = medium
 
-- name: {{{ rule_title }}} - Find all the conf files inside the /etc/sssd/conf.d/ directory
+- name: {{{ rule_title }}} - Find all conf files inside the /etc/sssd/conf.d/ directory
   ansible.builtin.find:
     paths:
     - "/etc/sssd/conf.d/"
     patterns: "*.conf"
   register: sssd_conf_d_files
 
-- name: {{{ rule_title }}} - Modify lines in files in the /etc/sssd/conf.d/ directory
+- name: {{{ rule_title }}} - Modify lines in files found in the /etc/sssd/conf.d/ directory
   ansible.builtin.replace:
     path: "{{ item }}"
     regexp: '^(\s*\[sssd\].*(?:\n\s*[^[\s].*)*\n\s*services\s*=(?!.*\bpam\b).*)$'
@@ -20,7 +20,7 @@
   register: modify_lines_sssd_conf_d_files
   when: sssd_conf_d_files.matched is defined and sssd_conf_d_files.matched >= 1
 
-- name: {{{ rule_title }}} - Find /etc/sssd/sssd.conf
+- name: {{{ rule_title }}} - Check existence of /etc/sssd/sssd.conf
   ansible.builtin.stat:
     path: /etc/sssd/sssd.conf
   register: sssd_conf_file
@@ -33,17 +33,7 @@
   register: modify_lines_sssd_conf_file
   when: sssd_conf_file.stat.exists
 
-- name: {{{ rule_title }}} - Find services key in /etc/sssd/sssd.conf
-  ansible.builtin.replace:
-    path: "/etc/sssd/sssd.conf"
-    regexp: '^\s*\[sssd\][^\[\]]*?(?:\n(?!\[)[^\n]*?services\s*=)+'
-    replace: ''
-  changed_when: false
-  check_mode: true
-  register: sssd_conf_file_services
-  when: sssd_conf_file.stat.exists
-
-- name: {{{ rule_title }}} - Insert entry to /etc/sssd/sssd.conf
+- name: {{{ rule_title }}} - Ensure services entry in sssd section of /etc/sssd/sssd.conf
   ini_file:
     path: /etc/sssd/sssd.conf
     section: sssd
@@ -52,4 +42,4 @@
   when:
   - not modify_lines_sssd_conf_d_files.changed
   - not modify_lines_sssd_conf_file.changed
-  - (sssd_conf_file_services.msg is defined and "replacements" not in sssd_conf_file_services.msg) or not sssd_conf_file.stat.exists
+  - sssd_conf_file.stat.exists

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/bash/shared.sh
@@ -1,51 +1,39 @@
 # platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_ol
 
-
-
-# sssd configuration files must be created with 600 permissions if they don't exist
-# otherwise the sssd module fails to start
-OLD_UMASK=$(umask)
-umask u=rw,go=
-
 SSSD_CONF="/etc/sssd/sssd.conf"
 SSSD_CONF_DIR="/etc/sssd/conf.d/*.conf"
 
 if [ ! -f "$SSSD_CONF" ] && [ ! -f "$SSSD_CONF_DIR" ]; then
-    mkdir -p /etc/sssd
-    touch "$SSSD_CONF"
-fi
-
-# Flag to check if there is already services with pam
-service_already_exist=false
-for f in $SSSD_CONF $SSSD_CONF_DIR; do
-	if [ ! -e "$f" ]; then
-		continue
-	fi
-	# finds all services entries under [sssd] configuration category, get a unique list so it doesn't add redundant fix
-	services_list=$( awk '/^\s*\[/{f=0} /^\s*\[sssd\]/{f=1}f' $f | grep -P '^services[ \t]*=' | uniq )
-    if [ -z "$services_list" ]; then
-        continue
-    fi
-
-	while IFS= read -r services; do
-		if [[ ! $services =~ "pam" ]]; then
-			sed -i "s/$services$/&, pam/" $f
-		fi
-        # Either pam service was already there or got added now
-        service_already_exist=true
-	done <<< "$services_list"
-
-done
-
-# If there was no service in [sssd], add it to first config
-if [ "$service_already_exist" = false ]; then
+    echo "
+    sssd configuration files not found. Ensure a valid configuration is present.
+    Manual modification of configuration files may be necessary to align with site policies."
+else
+    # Flag to check if there is already services with pam
+    service_already_exist=false
     for f in $SSSD_CONF $SSSD_CONF_DIR; do
-        cat << EOF >> "$f"
+        if [ ! -e "$f" ]; then
+            continue
+        fi
+        # finds all services entries under [sssd] configuration category, get a unique list so it doesn't add redundant fix
+        services_list=$( awk '/^\s*\[/{f=0} /^\s*\[sssd\]/{f=1}f' $f | grep -P '^services[ \t]*=' | uniq )
+        if [ -z "$services_list" ]; then
+            continue
+        fi
+
+        while IFS= read -r services; do
+            if [[ ! $services =~ "pam" ]]; then
+                sed -i "s/$services$/&, pam/" $f
+            fi
+            # Either pam service was already there or got added now
+            service_already_exist=true
+        done <<< "$services_list"
+    done
+
+    # If there was no service in [sssd], add it to first config
+    if [ "$service_already_exist" = false ]; then
+        cat << EOF >> "$SSSD_CONF"
 [sssd]
 services = pam
 EOF
-        break
-    done
+    fi
 fi
-
-umask $OLD_UMASK

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/rule.yml
@@ -1,6 +1,5 @@
 documentation_complete: true
 
-
 title: 'Configure PAM in SSSD Services'
 
 description: |-
@@ -37,6 +36,8 @@ references:
     srg: SRG-OS-000375-GPOS-00160,SRG-OS-000376-GPOS-00161,SRG-OS-000377-GPOS-00162
     stigid@ol7: OL07-00-041002
 
+platform: sssd_conf_files_present
+
 ocil_clause: 'it does not exist or ''pam'' is not added to the ''services'' option under the ''sssd'' section'
 
 ocil: |-
@@ -44,3 +45,9 @@ ocil: |-
     <pre>$ sudo grep services /etc/sssd/sssd.conf</pre>
     If configured properly, output should be similar to
     <pre>services = pam</pre>
+
+warnings:
+    - general:
+        This rule will report as "notapplicable" if there is no SSSD configuration file present
+        in the system. The SSSD configuration might be different for each site and therefore a new
+        configuration file is not automatically created.

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/custom_conf_services_pam_missing.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/custom_conf_services_pam_missing.fail.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 # packages = sssd-common
 
-rm -rf /etc/sssd/conf.d/
-mkdir -p /etc/sssd/conf.d/
-SSSD_CONF="/etc/sssd/conf.d/sssd.conf"
+SSSD_CONF_FILE="/etc/sssd/sssd.conf"
+SSSD_CONF_DIR_FILE="/etc/sssd/conf.d/sssd.conf"
+SSSD_CONF_DIR_FILES="/etc/sssd/conf.d/*.conf"
 
-cp wrong_sssd.conf $SSSD_CONF
+rm -rf $SSSD_CONF_FILE $SSSD_CONF_DIR_FILES
 
-SSSD_CONF="/etc/sssd/sssd.conf"
-cp wrong_sssd.conf $SSSD_CONF
+for file in $SSSD_CONF_FILE $SSSD_CONF_DIR_FILE; do
+    cp wrong_sssd.conf $file
+done

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/custom_conf_services_pam_missing.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/custom_conf_services_pam_missing.fail.sh
@@ -1,7 +1,5 @@
-
-# packages = sssd
 #!/bin/bash
-#
+# packages = sssd-common
 
 rm -rf /etc/sssd/conf.d/
 mkdir -p /etc/sssd/conf.d/

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/missing_sections.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/missing_sections.fail.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 # packages = sssd-common
 
-rm /etc/sssd/sssd.conf
-rm -rf /etc/sssd/conf.d/
+SSSD_CONF_FILE="/etc/sssd/sssd.conf"
+SSSD_CONF_DIR_FILES="/etc/sssd/conf.d/*.conf"
+
+rm -rf $SSSD_CONF_FILE $SSSD_CONF_DIR_FILES
+
 # Only empty config without any section
-touch /etc/sssd/sssd.conf
+touch $SSSD_CONF_FILE

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/missing_sections.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/missing_sections.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = sssd
+# packages = sssd-common
 
 rm /etc/sssd/sssd.conf
 rm -rf /etc/sssd/conf.d/

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/multiple_wrong_entries.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/multiple_wrong_entries.fail.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 # packages = sssd-common
 
-rm -rf /etc/sssd/conf.d/
-mkdir -p /etc/sssd/conf.d/
-SSSD_CONF="/etc/sssd/conf.d/sssd.conf"
+SSSD_CONF_FILE="/etc/sssd/sssd.conf"
+SSSD_CONF_DIR_FILE="/etc/sssd/conf.d/sssd.conf"
+SSSD_CONF_DIR_FILES="/etc/sssd/conf.d/*.conf"
 
-cp wrong_sssd.conf $SSSD_CONF
+rm -rf $SSSD_CONF_FILE $SSSD_CONF_DIR_FILES
 
-SSSD_CONF="/etc/sssd/sssd.conf"
-cp wrong_sssd.conf $SSSD_CONF
+for file in $SSSD_CONF_FILE $SSSD_CONF_DIR_FILE; do
+    cp wrong_sssd.conf $file
+done
 
-SSSD_CONF="/etc/sssd/sssd_custom.conf"
-cat <<EOF > $SSSD_CONF
+cat <<EOF > "/etc/sssd/conf.d/sssd_custom.conf"
 [sssd]
 services = nss
 domains = shadowutils

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/multiple_wrong_entries.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/multiple_wrong_entries.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-# packages = sssd
-#
+# packages = sssd-common
 
 rm -rf /etc/sssd/conf.d/
 mkdir -p /etc/sssd/conf.d/
@@ -23,7 +22,7 @@ domains = shadowutils
 services = pam
 
 [domain/shadowutils]
-id_provider = files
+id_provider = ldap
 
 auth_provider = proxy
 proxy_pam_target = sssd-shadowutils

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/services_pam_missing.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/services_pam_missing.fail.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 # packages = sssd-common
-#
 
-SSSD_CONF="/etc/sssd/sssd.conf"
+SSSD_CONF_FILE="/etc/sssd/sssd.conf"
+SSSD_CONF_DIR_FILES="/etc/sssd/conf.d/*.conf"
 
-rm -rf /etc/sssd/conf.d/
-rm -f $SSSD_CONF
-cat <<EOF > $SSSD_CONF
+rm -rf $SSSD_CONF_FILE $SSSD_CONF_DIR_FILES
+
+cat <<EOF > $SSSD_CONF_FILE
 [sssd]
 section1 = key
 section2 = nss

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/services_pam_missing.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/services_pam_missing.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = sssd
+# packages = sssd-common
 #
 
 SSSD_CONF="/etc/sssd/sssd.conf"

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/services_pam_wrong_section.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/services_pam_wrong_section.fail.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # packages = sssd-common
 
-rm -rf /etc/sssd/conf.d/
-SSSD_CONF="/etc/sssd/sssd.conf"
-cp wrong_sssd.conf $SSSD_CONF
+SSSD_CONF_FILE="/etc/sssd/sssd.conf"
+SSSD_CONF_DIR_FILES="/etc/sssd/conf.d/*.conf"
+
+rm -rf $SSSD_CONF_FILE $SSSD_CONF_DIR_FILES
+cp wrong_sssd.conf $SSSD_CONF_FILE

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/services_pam_wrong_section.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/services_pam_wrong_section.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-# packages = sssd
-#
+# packages = sssd-common
 
 rm -rf /etc/sssd/conf.d/
 SSSD_CONF="/etc/sssd/sssd.conf"

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/sssd_config_missing.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/sssd_config_missing.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # packages = sssd-common
+# remediation = none
 
 rm /etc/sssd/sssd.conf
 rm -rf /etc/sssd/conf.d/

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/sssd_config_missing.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/sssd_config_missing.fail.sh
@@ -2,6 +2,9 @@
 # packages = sssd-common
 # remediation = none
 
+# SSSD configuration files are expected to be created manually since the configuration can
+# be different for each site. Therefore, if there is no configuration files previously created
+# in the system, this rule will report "not applicable".
 SSSD_CONF_FILE="/etc/sssd/sssd.conf"
 SSSD_CONF_DIR_FILES="/etc/sssd/conf.d/*.conf"
 

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/sssd_config_missing.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/sssd_config_missing.fail.sh
@@ -2,5 +2,7 @@
 # packages = sssd-common
 # remediation = none
 
-rm /etc/sssd/sssd.conf
-rm -rf /etc/sssd/conf.d/
+SSSD_CONF_FILE="/etc/sssd/sssd.conf"
+SSSD_CONF_DIR_FILES="/etc/sssd/conf.d/*.conf"
+
+rm -rf $SSSD_CONF_FILE $SSSD_CONF_DIR_FILES

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/sssd_config_missing.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/sssd_config_missing.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = sssd
+# packages = sssd-common
 
 rm /etc/sssd/sssd.conf
 rm -rf /etc/sssd/conf.d/

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/sssd_pam_services.pass.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/sssd_pam_services.pass.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 # packages = sssd-common
 
-SSSD_CONF="/etc/sssd/sssd.conf"
+SSSD_CONF_FILE="/etc/sssd/sssd.conf"
+SSSD_CONF_DIR_FILES="/etc/sssd/conf.d/*.conf"
 
-rm -rf /etc/sssd/conf.d/
-rm -f SSSD_CONF
-cat <<EOF > $SSSD_CONF
+rm -rf $SSSD_CONF_FILE $SSSD_CONF_DIR_FILES
+
+cat <<EOF > $SSSD_CONF_FILE
 [sssd]
 services = nss,pam
 [pam]

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/sssd_pam_services.pass.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/sssd_pam_services.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-# packages = sssd
-#
+# packages = sssd-common
 
 SSSD_CONF="/etc/sssd/sssd.conf"
 

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/sssd_pam_services_conf_d.pass.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/sssd_pam_services_conf_d.pass.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 # packages = sssd-common
 
-rm -rf "/etc/sssd/conf.d/"
-rm -f "/etc/sssd/sssd.conf"
-mkdir -p "/etc/sssd/conf.d/"
-cat <<EOF > "/etc/sssd/conf.d/sssd.conf"
+SSSD_CONF_FILE="/etc/sssd/sssd.conf"
+SSSD_CONF_DIR_FILE="/etc/sssd/conf.d/sssd.conf"
+SSSD_CONF_DIR_FILES="/etc/sssd/conf.d/*.conf"
+
+rm -rf $SSSD_CONF_FILE $SSSD_CONF_DIR_FILES
+
+cat <<EOF > $SSSD_CONF_DIR_FILE
 [sssd]
 services = nss,pam
 [pam]

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/sssd_pam_services_conf_d.pass.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/sssd_pam_services_conf_d.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = sssd
+# packages = sssd-common
 
 rm -rf "/etc/sssd/conf.d/"
 rm -f "/etc/sssd/sssd.conf"

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/wrong_sssd.conf
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/tests/wrong_sssd.conf
@@ -8,7 +8,7 @@ domains = shadowutils
 services = pam
 
 [domain/shadowutils]
-id_provider = files
+id_provider = ldap
 
 auth_provider = proxy
 proxy_pam_target = sssd-shadowutils

--- a/shared/applicability/oval/sssd_conf_files_present.xml
+++ b/shared/applicability/oval/sssd_conf_files_present.xml
@@ -1,0 +1,27 @@
+<def-group>
+  <definition class="inventory" id="sssd_conf_files_present" version="1">
+    <metadata>
+      <title>SSSD configuration files are present</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>/etc/sssd/sssd.conf is present or there are custom files within /etc/sssd/conf.d</description>
+      <reference ref_id="cpe:/a:sssd_conf_files_present" source="CPE" />
+    </metadata>
+    <criteria>
+      <criterion test_ref="test_sssd_conf_files_present"
+        comment="There are SSSD configuration files present in the system"/>
+    </criteria>
+  </definition>
+
+  <unix:file_test id="test_sssd_conf_files_present" version="1"
+    check="all" check_existence="at_least_one_exists"
+    comment="Verify existence of SSSD configuration files.">
+    <unix:object object_ref="object_conf_files_present"/>
+  </unix:file_test>
+
+  <unix:file_object id="object_conf_files_present" version="1"
+    comment="Matches /etc/sssd/sssd.conf or any .conf file within /etc/sssd/conf.d directory">
+    <unix:filepath operation="pattern match">^/etc/sssd/(sssd|conf\.d/.*)\.conf$</unix:filepath>
+  </unix:file_object>
+</def-group>

--- a/shared/applicability/sssd_conf_files_present.yml
+++ b/shared/applicability/sssd_conf_files_present.yml
@@ -1,0 +1,3 @@
+name: cpe:/a:sssd_conf_files_present
+title: SSSD configuration files are present
+check_id: sssd_conf_files_present


### PR DESCRIPTION
#### Description:

When reviewing #12351 I noticed some issues with `sssd` related rules.
This PR:
- Remove unnecessary steps in `sssd_enable_pam_services` bash remediation
- Updates the `id_provider` value and fix the sssd package name in some test scenarios
- Simplify and align the test scenarios logic
- Create applicability to check if SSSD configuration files are present
- Use the applicability in `sssd_enable_pam_services` for better reporting

#### Rationale:

Better test scenarios and remediation for sssd related rules used in ANSSI control file.

#### Review Hints:

```
./build_product rhel9
./tests/automatus.py rule --libvirt qemu:///session rhel9 --datastream build/ssg-rhel9-ds.xml --dontclean --remediate-using bash --debug service_sssd_enabled
./tests/automatus.py rule --libvirt qemu:///session rhel9 --datastream build/ssg-rhel9-ds.xml --dontclean --remediate-using bash --debug sssd_enable_pam_services
```
