### PR TITLE
Add platform_package_overrides

### DIFF
--- a/products/ubuntu2004/product.yml
+++ b/products/ubuntu2004/product.yml
@@ -37,6 +37,8 @@ cpes:
 
 platform_package_overrides:
   audit: auditd
+  avahi: avahi-daemon
+  dconf: dconf-editor
   gdm: gdm3
   grub2: grub2-common
   net-snmp: snmp

--- a/tests/data/product_stability/ubuntu2004.yml
+++ b/tests/data/product_stability/ubuntu2004.yml
@@ -38,6 +38,8 @@ pkg_system: dpkg
 platform_package_overrides:
   aarch64_arch: null
   audit: auditd
+  avahi: avahi-daemon
+  dconf: dconf-editor
   gdm: gdm3
   grub2: grub2-common
   login_defs: login


### PR DESCRIPTION
#### Description:

- Add platform_package_overrides for dconf and avahi in both products/product.yml and tests/product_stability/ubuntu2004.yml
 
#### Rationale:

- The Ubuntu focal is in lack of correct platform_package_overrides variables for dconf and avahi