### PR TITLE
Fix typo in assertion for `kubelet-configure-tls-cipher-suites-ingresscontroller`

### DIFF
--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.12.yml
@@ -230,7 +230,7 @@ rule_results:
  e2e-pci-dss-4-0-kubelet-configure-tls-cert:
    default_result: PASS
    result_after_remediation: PASS
- e2e-pci-dss-4-0-kubelet-configure-tls-cipher-suites-ingress-controller:
+ e2e-pci-dss-4-0-kubelet-configure-tls-cipher-suites-ingresscontroller:
    default_result: FAIL
    result_after_remediation: PASS
  e2e-pci-dss-4-0-kubelet-configure-tls-key:

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.13.yml
@@ -230,7 +230,7 @@ rule_results:
  e2e-pci-dss-4-0-kubelet-configure-tls-cert:
    default_result: PASS
    result_after_remediation: PASS
- e2e-pci-dss-4-0-kubelet-configure-tls-cipher-suites-ingress-controller:
+ e2e-pci-dss-4-0-kubelet-configure-tls-cipher-suites-ingresscontroller:
    default_result: FAIL
    result_after_remediation: PASS
  e2e-pci-dss-4-0-kubelet-configure-tls-key:

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.14.yml
@@ -230,7 +230,7 @@ rule_results:
  e2e-pci-dss-4-0-kubelet-configure-tls-cert:
    default_result: PASS
    result_after_remediation: PASS
- e2e-pci-dss-4-0-kubelet-configure-tls-cipher-suites-ingress-controller:
+ e2e-pci-dss-4-0-kubelet-configure-tls-cipher-suites-ingresscontroller:
    default_result: FAIL
    result_after_remediation: PASS
  e2e-pci-dss-4-0-kubelet-configure-tls-key:

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.15.yml
@@ -230,7 +230,7 @@ rule_results:
  e2e-pci-dss-4-0-kubelet-configure-tls-cert:
    default_result: PASS
    result_after_remediation: PASS
- e3e-pci-dss-4-0-kubelet-configure-tls-cipher-suites-ingress-controller:
+ e3e-pci-dss-4-0-kubelet-configure-tls-cipher-suites-ingresscontroller:
    default_result: FAIL
    result_after_remediation: PASS
  e2e-pci-dss-4-0-kubelet-configure-tls-key:

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.16.yml
@@ -230,7 +230,7 @@ rule_results:
  e2e-pci-dss-4-0-kubelet-configure-tls-cert:
    default_result: PASS
    result_after_remediation: PASS
- e2e-pci-dss-4-0-kubelet-configure-tls-cipher-suites-ingress-controller:
+ e2e-pci-dss-4-0-kubelet-configure-tls-cipher-suites-ingresscontroller:
    default_result: FAIL
    result_after_remediation: PASS
  e2e-pci-dss-4-0-kubelet-configure-tls-key:

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.17.yml
@@ -230,7 +230,7 @@ rule_results:
  e2e-pci-dss-4-0-kubelet-configure-tls-cert:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE
- e2e-pci-dss-4-0-kubelet-configure-tls-cipher-suites-ingress-controller:
+ e2e-pci-dss-4-0-kubelet-configure-tls-cipher-suites-ingresscontroller:
    default_result: FAIL
    result_after_remediation: PASS
  e2e-pci-dss-4-0-kubelet-configure-tls-key:


### PR DESCRIPTION


#### Description:

- Fix typo in rule assertion id.
- Follow up from: https://github.com/ComplianceAsCode/content/pull/12371

#### Rationale:

- Rule id is `kubelet-configure-tls-cipher-suites-ingresscontroller`