### PR TITLE
OCPBUGS-304: Fix jq filters for resource request limits

### DIFF
--- a/applications/openshift/general/resource_requests_limits_in_deployment/rule.yml
+++ b/applications/openshift/general/resource_requests_limits_in_deployment/rule.yml
@@ -26,7 +26,7 @@ identifiers: {}
 references:
   nist: SC-6
 
-{{% set jqfilter = '[ .items[] | select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not) | select(.metadata.namespace != "rhacs-operator" and ({{if ne .var_deployment_limit_namespaces_exempt_regex "None"}}.metadata.namespace | test("{{.var_deployment_limit_namespaces_exempt_regex}}") | select( .spec.template.spec.containers[].resources.requests.cpu == null  or  .spec.template.spec.containers[].resources.requests.memory == null or .spec.template.spec.containers[].resources.limits.cpu == null  or  .spec.template.spec.containers[].resources.limits.memory == null )  | .metadata.name ]' %}}
+{{% set jqfilter = '[ .items[] | select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not) | select(.metadata.namespace != "rhacs-operator" and ({{if ne .var_deployment_limit_namespaces_exempt_regex "None"}}.metadata.namespace | test("{{.var_deployment_limit_namespaces_exempt_regex}}") | not{{else}}true{{end}})) | select( .spec.template.spec.containers[].resources.requests.cpu == null  or  .spec.template.spec.containers[].resources.requests.memory == null or .spec.template.spec.containers[].resources.limits.cpu == null  or  .spec.template.spec.containers[].resources.limits.memory == null )  | .metadata.name ]' %}}
 
 ocil_clause: 'Resource requests and limits is not set'
 

--- a/applications/openshift/general/resource_requests_limits_in_statefulset/rule.yml
+++ b/applications/openshift/general/resource_requests_limits_in_statefulset/rule.yml
@@ -26,7 +26,7 @@ identifiers: {}
 references:
   nist: SC-6
 
-{{% set jqfilter = '[ .items[] | select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not) | select(.metadata.namespace != "rhacs-operator" and ({{if ne .var_statefulset_limit_namespaces_exempt_regex "None"}}.metadata.namespace | test("{{.var_statefulset_limit_namespaces_exempt_regex}}") | select( .spec.template.spec.containers[].resources.requests.cpu == null  or  .spec.template.spec.containers[].resources.requests.memory == null or .spec.template.spec.containers[].resources.limits.cpu == null  or  .spec.template.spec.containers[].resources.limits.memory == null )  | .metadata.name ]' %}}
+{{% set jqfilter = '[ .items[] | select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not) | select(.metadata.namespace != "rhacs-operator" and ({{if ne .var_statefulset_limit_namespaces_exempt_regex "None"}}.metadata.namespace | test("{{.var_statefulset_limit_namespaces_exempt_regex}}") | not{{else}}true{{end}})) | select( .spec.template.spec.containers[].resources.requests.cpu == null  or  .spec.template.spec.containers[].resources.requests.memory == null or .spec.template.spec.containers[].resources.limits.cpu == null  or  .spec.template.spec.containers[].resources.limits.memory == null )  | .metadata.name ]' %}}
 
 ocil_clause: 'Resource requests and limits is not set'
 


### PR DESCRIPTION


#### Description:

- Fix jq filters in:
  - `resource_requests_limits_in_deployment`
  - `resource_requests_limits_in_statefulset`
  - Similar to [resource_requests_limits_in_daemonset](https://github.com/yuumasato/scap-security-guide/blob/0f99444698dc37754bc103baaa81585ec5209f89/applications/openshift/general/resource_requests_limits_in_daemonset/rule.yml#L28)

#### Rationale:

- These changes were probably lost during PR rebase fix in https://github.com/ComplianceAsCode/content/pull/12307