### PR TITLE
Remove zipl_vsyscall_argument from OSPP control file.

### DIFF
--- a/controls/ospp.yml
+++ b/controls/ospp.yml
@@ -435,7 +435,6 @@ controls:
             - base
         rules:
             - grub2_vsyscall_argument
-            - zipl_vsyscall_argument
         status: automated
 
     -   id: FPT_TUD_EXT.1


### PR DESCRIPTION


#### Description:

- Remove zipl_vsyscall_argument from OSPP control file.

#### Rationale:

- vsyscalls (as vDSO) are on all architectures, but vsyscall emulation (what this option controls) is only on x86, see
CONFIG_X86_VSYSCALL_EMULATION.
