### PR TITLE
Don't autoremove packages on dnf package uninstall

### DIFF
--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -483,7 +483,12 @@ if rpm -q --quiet "{{{ package }}}" ; then
 {{% if SSG_TEST_SUITE_ENV %}}
     rpm -e --nodeps "{{{ package }}}"
 {{% else %}}
-    {{{ pkg_manager }}} remove -y "{{{ package }}}"
+    {{%- if pkg_manager == "dnf" -%}}
+        dnf remove -y --noautoremove "{{{ package }}}"
+    {{%- else -%}}
+        {{{ pkg_manager }}} remove -y "{{{ package }}}"
+    {{%- endif -%}}
+
 {{% endif %}}
 fi
 {{%- elif pkg_manager == "apt_get" -%}}


### PR DESCRIPTION
#### Description:
Ensure add `--noautoremove` for dnf uninstall.
#### Rationale:

Closes #12388
