### PR TITLE
Remove sshd_allow_only_protocol2 from RHEL 10

### DIFF
--- a/controls/ism_o.yml
+++ b/controls/ism_o.yml
@@ -436,7 +436,6 @@ use of device access control software or by disabling external communication int
         levels:
             - base
         rules:
-            - sshd_allow_only_protocol2
             - file_permissions_sshd_private_key
         status: partial
         notes: |-
@@ -540,11 +539,11 @@ use of device access control software or by disabling external communication int
         title: 'The use of SSH version 1 is disabled for SSH connections.'
         levels:
             - base
-        rules:
+        related_rules:
             - sshd_allow_only_protocol2
-        status: partial
+        status: inherently met
         notes: |-
-            This should be reviewed.
+            As of OpenSSH 7.6, OpenSSH only supports SSH 2.
 
     -   id: '1546'
         title: 'Users are authenticated before they are granted access to a system and its resources'

--- a/products/rhel10/profiles/hipaa.profile
+++ b/products/rhel10/profiles/hipaa.profile
@@ -11,7 +11,7 @@ title: 'DRAFT - Health Insurance Portability and Accountability Act (HIPAA)'
 description: |-
     This is a draft profile for experimental purposes.
 
-    The HIPAA Security Rule establishes U.S. national standards to protect individuals’
+    The HIPAA Security Rule establishes U.S. national standards to protect individuals's
     electronic personal health information that is created, received, used, or
     maintained by a covered entity. The Security Rule requires appropriate
     administrative, physical and technical safeguards to ensure the


### PR DESCRIPTION
#### Description:
Remove sshd_allow_only_protocol2 from RHEL 10

#### Rationale:
As of OpenSSH 7.6 (released in 2017), OpenSSH only supports SSH 2.