### PR TITLE
Change flag cleanup

### DIFF
--- a/shared/templates/file_groupowner/bash.template
+++ b/shared/templates/file_groupowner/bash.template
@@ -19,6 +19,6 @@ find {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -group {{{ GID_OR_NAME }}}
 find -H {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type d -exec chgrp -L {{{ GID_OR_NAME }}} {} \;
 {{%- endif %}}
 {{%- else %}}
-chgrp -L {{{ GID_OR_NAME }}} {{{ path }}}
+chgrp {{{ GID_OR_NAME }}} {{{ path }}}
 {{%- endif %}}
 {{%- endfor %}}

--- a/shared/templates/file_owner/bash.template
+++ b/shared/templates/file_owner/bash.template
@@ -21,6 +21,6 @@ find {{{ FIND_RECURSE_ARGS_SYM }}} {{{ path }}} {{{ FIND_RECURSE_ARGS_DEP }}} -t
 find -H {{{ path }}} {{{ FIND_RECURSE_ARGS_DEP }}} -type d -exec chown -L {{{ FILEUID }}} {} \;
 {{%- endif %}}
 {{%- else %}}
-chown -L {{{ FILEUID }}} {{{ path }}}
+chown {{{ FILEUID }}} {{{ path }}}
 {{%- endif %}}
 {{%- endfor %}}


### PR DESCRIPTION
#### Description:

- Remove ineffective flag "-L" for chgrp and chown
 
#### Rationale:

- According to the https://www.gnu.org/software/coreutils/manual/html_node/Traversing-symlinks.html and https://www.ibm.com/docs/en/i/7.5?topic=directories-chgrp. The "-L" only take effects when combined with "-R"