### PR TITLE
Bring bash version in-sync with Ansible

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/bash/shared.sh
@@ -9,7 +9,7 @@
 {{% endif %}}
 
 grep -q "^[^#]*\bumask" {{{ etc_bash_rc }}} && \
-  sed -i -E -e "s/^([^#]*\bumask).*/\1 $var_accounts_user_umask/g" {{{ etc_bash_rc }}}
+  sed -i -E -e "s/^([^#]*\bumask)[[:space:]]+[[:digit:]]+/\1 $var_accounts_user_umask/g" {{{ etc_bash_rc }}}
 if ! [ $? -eq 0 ]; then
     echo "umask $var_accounts_user_umask" >> {{{ etc_bash_rc }}}
 fi


### PR DESCRIPTION
#### Description:

- Currently ash script for adjusting umask in /etc/bashrc is breaking existing /etc/bashrc

#### Rationale:

Ansible script uses much more reasonable regexp to replace *only* umask value whereas bash script replaces value and anything that follows.

#### Review Hints:
