### PR TITLE
Adjust zipl_bls_entries_option template remedation to allow RHEL 10

### DIFF
--- a/shared/templates/zipl_bls_entries_option/ansible.template
+++ b/shared/templates/zipl_bls_entries_option/ansible.template
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+# platform = multi_platform_rhel
 # reboot = true
 # strategy = configure
 # complexity = medium

--- a/shared/templates/zipl_bls_entries_option/bash.template
+++ b/shared/templates/zipl_bls_entries_option/bash.template
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+# platform = multi_platform_rhel
 
 # Correct BLS option using grubby, which is a thin wrapper around BLS operations
 grubby --update-kernel=ALL --args="{{{ ARG_NAME }}}={{{ ARG_VALUE }}}"


### PR DESCRIPTION
#### Description:

Adjust the platforms for the `zipl_bls_entries_option` template

#### Rationale:
Fixes #12403


