### PR TITLE
Add Missing CPEs for RHEL10

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fremovexattr/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fremovexattr/rule.yml
@@ -11,13 +11,13 @@ description: |-
     startup (the default), add the following line to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
     <pre>-a always,exit -F arch=b32 -S fremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
+{{%- if product in ["ol8", "ol9"] or 'rhel' in product or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b32 -S fremovexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     <br /><br />
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S fremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
+{{%- if product in ["ol8", "ol9"] or 'rhel' in product or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b64 -S fremovexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     <br /><br />
@@ -25,13 +25,13 @@ description: |-
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
     <pre>-a always,exit -F arch=b32 -S fremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
+{{%- if product in ["ol8", "ol9"] or 'rhel' in product or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b32 -S fremovexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     <br /><br />
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S fremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
+{{%- if product in ["ol8", "ol9"] or 'rhel' in product or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b64 -S fremovexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fsetxattr/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fsetxattr/rule.yml
@@ -9,24 +9,24 @@ description: |-
     startup (the default), add the following line to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
     <pre>-a always,exit -F arch=b32 -S fsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
+{{%- if product in ["ol8", "ol9"] or 'rhel' in product or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b32 -S fsetxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S fsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
+{{%- if product in ["ol8", "ol9"] or 'rhel' in product or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b64 -S fsetxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
     <pre>-a always,exit -F arch=b32 -S fsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
+{{%- if product in ["ol8", "ol9"] or 'rhel' in product or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b32 -S fsetxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S fsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
+{{%- if product in ["ol8", "ol9"] or 'rhel' in product or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b64 -S fsetxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lremovexattr/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lremovexattr/rule.yml
@@ -11,13 +11,13 @@ description: |-
     startup (the default), add the following line to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
     <pre>-a always,exit -F arch=b32 -S lremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
+{{%- if product in ["ol8", "ol9"] or 'rhel' in product or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b32 -S lremovexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     <br /><br />
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S lremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
+{{%- if product in ["ol8", "ol9"] or 'rhel' in product or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b64 -S lremovexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     <br /><br />
@@ -25,13 +25,13 @@ description: |-
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
     <pre>-a always,exit -F arch=b32 -S lremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
+{{%- if product in ["ol8", "ol9"] or 'rhel' in product or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b32 -S lremovexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     <br /><br />
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S lremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
+{{%- if product in ["ol8", "ol9"] or 'rhel' in product or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b64 -S lremovexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lsetxattr/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lsetxattr/rule.yml
@@ -9,24 +9,24 @@ description: |-
     startup (the default), add the following line to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
     <pre>-a always,exit -F arch=b32 -S lsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
+{{%- if product in ["ol8", "ol9"] or 'rhel' in product or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b32 -S lsetxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S lsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
+{{%- if product in ["ol8", "ol9"] or 'rhel' in product or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b64 -S lsetxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
     <pre>-a always,exit -F arch=b32 -S lsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
+{{%- if product in ["ol8", "ol9"] or 'rhel' in product or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b32 -S lsetxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S lsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
+{{%- if product in ["ol8", "ol9"] or 'rhel' in product or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b64 -S lsetxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_removexattr/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_removexattr/rule.yml
@@ -10,13 +10,13 @@ description: |-
     program to read audit rules during daemon startup (the default), add the
     following line to a file with suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
     <pre>-a always,exit -F arch=b32 -S removexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
+{{%- if product in ["ol8", "ol9"] or 'rhel' in product or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b32 -S removexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     <br /><br />
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S removexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
+{{%- if product in ["ol8", "ol9"] or 'rhel' in product or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b64 -S removexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     <br /><br />
@@ -24,13 +24,13 @@ description: |-
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
     <pre>-a always,exit -F arch=b32 -S removexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
+{{%- if product in ["ol8", "ol9"] or 'rhel' in product or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b32 -S removexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     <br /><br />
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S removexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
+{{%- if product in ["ol8", "ol9"] or 'rhel' in product or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b64 -S removexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_setxattr/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_setxattr/rule.yml
@@ -9,24 +9,24 @@ description: |-
     startup (the default), add the following line to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
     <pre>-a always,exit -F arch=b32 -S setxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
+{{%- if product in ["ol8", "ol9"] or 'rhel' in product or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b32 -S setxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S setxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
+{{%- if product in ["ol8", "ol9"] or 'rhel' in product or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b64 -S setxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
     <pre>-a always,exit -F arch=b32 -S setxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
+{{%- if product in ["ol8", "ol9"] or 'rhel' in product or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b32 -S setxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S setxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["ol8", "ol9", "rhel8", "rhel9"] or 'ubuntu' in product %}}
+{{%- if product in ["ol8", "ol9"] or 'rhel' in product or 'ubuntu' in product %}}
     <pre>-a always,exit -F arch=b64 -S setxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_chcon/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_chcon/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_restorecon/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_restorecon/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol8", "ol9", "rhel8", "rhel9", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] %}}
+{{%- if product in ["fedora", "ol8", "ol9", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_semanage/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_semanage/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setfiles/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setfiles/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setsebool/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setsebool/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_seunshare/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_seunshare/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol8", "ol9", "rhel8", "rhel9", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] %}}
+{{%- if product in ["fedora", "ol8", "ol9", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_at/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_at/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol8", "ol9", "rhel8", "rhel9", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] %}}
+{{%- if product in ["fedora", "ol8", "ol9", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in products %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chage/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chage/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chsh/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chsh/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_crontab/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_crontab/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_dbus_daemon_launch_helper/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_dbus_daemon_launch_helper/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4",  "rhel8", "rhel9", "rhel10", "sle12", "sle15", "ubuntu2004", "ubuntu2204"]%}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fusermount/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fusermount/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4",  "rhel8", "rhel9", "rhel10", "sle12", "sle15", "ubuntu2004", "ubuntu2204"]%}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fusermount3/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fusermount3/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4",  "rhel8", "rhel9", "rhel10", "sle12", "sle15", "ubuntu2004", "ubuntu2204"]%}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_gpasswd/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_gpasswd/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4",  "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5" ,"ubuntu2004", "ubuntu2204"]%}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "slmicro5" ,"ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_grub2_set_bootflag/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_grub2_set_bootflag/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4",  "rhel8", "rhel9", "rhel10", "sle12", "sle15", "ubuntu2004", "ubuntu2204"]%}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_mount/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_mount/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4",  "rhel8", "rhel9", "rhel10", "sle12", "sle15", "ubuntu2004", "ubuntu2204"]%}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_mount_nfs/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_mount_nfs/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4",  "rhel8", "rhel9", "rhel10", "sle12", "sle15", "ubuntu2004", "ubuntu2204"]%}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgidmap/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgidmap/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol8", "ol9", "rhel8", "rhel9", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] %}}
+{{%- if product in ["fedora", "ol8", "ol9",  "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgrp/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgrp/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4",  "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"]%}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newuidmap/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newuidmap/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol8", "ol9", "rhel8", "rhel9", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] %}}
+ {{%- if product in ["fedora", "ol8", "ol9", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pam_timestamp_check/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pam_timestamp_check/rule.yml
@@ -1,5 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4",  "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"]%}}
-  {{%- set perm_x="-F perm=x " %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}  {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 
 {{% if product in ["sle12", "sle15", "slmicro5"] %}}
@@ -66,7 +65,7 @@ references:
     stigid@ol8: OL08-00-030340
     stigid@rhel8: RHEL-08-030340
     stigid@sle12: SLES-12-020720
-    stigid@sle15: SLES-15-030510    
+    stigid@sle15: SLES-15-030510
     stigid@ubuntu2004: UBTU-20-010178
     stigid@ubuntu2204: UBTU-22-654075
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passwd/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passwd/rule.yml
@@ -1,5 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4",  "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"]%}}
-  {{%- set perm_x="-F perm=x " %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}  {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 
 documentation_complete: true

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pkexec/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pkexec/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4",  "rhel8", "rhel9", "rhel10", "sle12", "sle15", "ubuntu2004", "ubuntu2204"]%}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_polkit_helper/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_polkit_helper/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4",  "rhel8", "rhel9", "rhel10", "sle12", "sle15", "ubuntu2004", "ubuntu2204"]%}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postdrop/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postdrop/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postqueue/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postqueue/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pt_chown/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pt_chown/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol8", "ol9", "rhel8", "rhel9", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] %}}
+ {{%- if product in ["fedora", "ol8", "ol9", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sssd_krb5_child/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sssd_krb5_child/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4",  "rhel8", "rhel9", "rhel10", "sle12", "sle15", "ubuntu2004", "ubuntu2204"]%}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sssd_ldap_child/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sssd_ldap_child/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4",  "rhel8", "rhel9", "rhel10", "sle12", "sle15", "ubuntu2004", "ubuntu2204"]%}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sssd_proxy_child/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sssd_proxy_child/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4",  "rhel8", "rhel9", "rhel10", "sle12", "sle15", "ubuntu2004", "ubuntu2204"]%}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sssd_selinux_child/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sssd_selinux_child/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4",  "rhel8", "rhel9", "rhel10", "sle12", "sle15", "ubuntu2004", "ubuntu2204"]%}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_su/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_su/rule.yml
@@ -1,5 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4",  "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"]%}}
-  {{%- set perm_x="-F perm=x " %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}  {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 
 documentation_complete: true

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudoedit/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudoedit/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol8", "ol9", "rhel8", "rhel9", "sle12", "sle15", "slmicro5" ,"ubuntu2004", "ubuntu2204"] %}}
+{{%- if product in ["fedora", "ol8", "ol9", "sle12", "sle15", "slmicro5" ,"ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4",  "rhel8", "rhel9", "rhel10", "sle12", "sle15", "ubuntu2004", "ubuntu2204"]%}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/rule.yml
@@ -1,5 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4",  "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"]%}}
-  {{%- set perm_x="-F perm=x " %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}  {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 
 documentation_complete: true

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_userhelper/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_userhelper/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_usernetctl/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_usernetctl/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol8", "ol9", "rhel8", "rhel9", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] %}}
+ {{%- if product in ["fedora", "ol8", "ol9", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_utempter/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_utempter/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4",  "rhel8", "rhel9", "rhel10", "sle12", "sle15", "ubuntu2004", "ubuntu2204"]%}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_write/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_write/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4",  "rhel8", "rhel9", "rhel10", "sle12", "sle15", "ubuntu2004", "ubuntu2204"]%}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/rule.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/rule.yml
@@ -55,7 +55,7 @@ ocil: |-
 
 fixtext: |-
     Configure {{{ full_name }}} to encrypt audit records sent with audispd plugin.
-{{% if product in ["rhel8", "rhel9", "fedora", "ol8", "rhv4"] %}}
+{{% if product in ["fedora", "ol8", "rhv4"] or "rhel" in product %}}
     Set the "transport" option in "{{{ audisp_conf_path }}}/audisp-remote.conf" to "KRB5".
 {{% else %}}
     Uncomment the "enable_krb5" option in "{{{ audisp_conf_path }}}/audisp-remote.conf",

--- a/linux_os/guide/auditing/policy_rules/audit_access_failed/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_access_failed/rule.yml
@@ -26,7 +26,7 @@ rationale: |-
 
 severity: medium
 
-# on RHEL9 there are rules which cover particular hardware architectures
+# on RHEL9+ there are rules which cover particular hardware architectures
 # so do not apply this rule but apply the specific one instead
 {{% if product in ["rhel9", "rhel10"] %}}
 platforms:

--- a/linux_os/guide/auditing/policy_rules/audit_access_failed/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_access_failed/rule.yml
@@ -28,7 +28,7 @@ severity: medium
 
 # on RHEL9 there are rules which cover particular hardware architectures
 # so do not apply this rule but apply the specific one instead
-{{% if product == "rhel9" %}}
+{{% if product in ["rhel9", "rhel10"] %}}
 platforms:
     - not aarch64_arch and not ppc64le_arch
 {{% endif %}}

--- a/linux_os/guide/auditing/policy_rules/audit_access_success/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_access_success/rule.yml
@@ -27,7 +27,7 @@ severity: medium
 
 # on RHEL9 there are rules which cover particular hardware architectures
 # so do not apply this rule but apply the specific one instead
-{{% if product == "rhel9" %}}
+{{% if product in ["rhel9", "rhel10"] %}}
 platforms:
     - not aarch64_arch and not ppc64le_arch
 {{% endif %}}

--- a/linux_os/guide/auditing/policy_rules/audit_create_failed/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_create_failed/rule.yml
@@ -34,9 +34,9 @@ rationale: |-
 
 severity: medium
 
-# on RHEL9 there are rules which cover particular hardware architectures
+# on RHEL9+ there are rules which cover particular hardware architectures
 # so do not apply this rule but apply the specific one instead
-{{% if product == "rhel9" %}}
+{{% if product in ["rhel9", "rhel10"] %}}
 platforms:
     - not aarch64_arch and not ppc64le_arch
 {{% endif %}}

--- a/linux_os/guide/auditing/policy_rules/audit_create_success/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_create_success/rule.yml
@@ -28,9 +28,9 @@ rationale: |-
 
 severity: medium
 
-# on RHEL9 there are rules which cover particular hardware architectures
+# on RHEL9+ there are rules which cover particular hardware architectures
 # so do not apply this rule but apply the specific one instead
-{{% if product == "rhel9" %}}
+{{% if product in ["rhel9", "rhel10"] %}}
 platforms:
     - not aarch64_arch and not ppc64le_arch
 {{% endif %}}

--- a/linux_os/guide/auditing/policy_rules/audit_delete_failed/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_delete_failed/rule.yml
@@ -26,9 +26,9 @@ rationale: |-
 
 severity: medium
 
-# on RHEL9 there are rules which cover particular hardware architectures
+# on RHEL9+ there are rules which cover particular hardware architectures
 # so do not apply this rule but apply the specific one instead
-{{% if product == "rhel9" %}}
+{{% if product in ["rhel9", "rhel10"] %}}
 platforms:
     - not aarch64_arch and not ppc64le_arch
 {{% endif %}}

--- a/linux_os/guide/auditing/policy_rules/audit_delete_success/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_delete_success/rule.yml
@@ -24,9 +24,9 @@ rationale: |-
 
 severity: medium
 
-# on RHEL9 there are rules which cover particular hardware architectures
+# on RHEL9+ there are rules which cover particular hardware architectures
 # so do not apply this rule but apply the specific one instead
-{{% if product == "rhel9" %}}
+{{% if product in ["rhel9", "rhel10"] %}}
 platforms:
     - not aarch64_arch and not ppc64le_arch
 {{% endif %}}

--- a/linux_os/guide/auditing/policy_rules/audit_modify_failed/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_modify_failed/rule.yml
@@ -34,9 +34,9 @@ rationale: |-
 
 severity: medium
 
-# on RHEL9 there are rules which cover particular hardware architectures
+# on RHEL9+ there are rules which cover particular hardware architectures
 # so do not apply this rule but apply the specific one instead
-{{% if product == "rhel9" %}}
+{{% if product in ["rhel9", "rhel10"] %}}
 platforms:
     - not aarch64_arch and not ppc64le_arch
 {{% endif %}}

--- a/linux_os/guide/auditing/policy_rules/audit_modify_success/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_modify_success/rule.yml
@@ -29,9 +29,9 @@ rationale: |-
 
 severity: medium
 
-# on RHEL9 there are rules which cover particular hardware architectures
+# on RHEL9+ there are rules which cover particular hardware architectures
 # so do not apply this rule but apply the specific one instead
-{{% if product == "rhel9" %}}
+{{% if product in ["rhel9", "rhel10"] %}}
 platforms:
     - not aarch64_arch and not ppc64le_arch
 {{% endif %}}

--- a/linux_os/guide/auditing/policy_rules/audit_module_load/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_module_load/rule.yml
@@ -25,9 +25,9 @@ rationale: |-
 
 severity: medium
 
-# on RHEL9 there are rules which cover particular hardware architectures
+# on RHEL9+ there are rules which cover particular hardware architectures
 # so do not apply this rule but apply the specific one instead
-{{% if product == "rhel9" %}}
+{{% if product in ["rhel9", "rhel10"] %}}
 platforms:
     - not ppc64le_arch
 {{% endif %}}

--- a/linux_os/guide/auditing/policy_rules/audit_ospp_general/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_ospp_general/rule.yml
@@ -113,9 +113,9 @@ rationale: |-
 
 severity: medium
 
-# on RHEL9 there are rules which cover particular hardware architectures
+# on RHEL9+ there are rules which cover particular hardware architectures
 # so do not apply this rule but apply the specific one instead
-{{% if product == "rhel9" %}}
+{{% if product in ["rhel9", "rhel10"] %}}
 platforms:
     - not aarch64_arch and not ppc64le_arch
 {{% endif %}}

--- a/linux_os/guide/auditing/policy_rules/audit_owner_change_failed/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_owner_change_failed/rule.yml
@@ -26,9 +26,9 @@ rationale: |-
 
 severity: medium
 
-# on RHEL9 there are rules which cover particular hardware architectures
+# on RHEL9+ there are rules which cover particular hardware architectures
 # so do not apply this rule but apply the specific one instead
-{{% if product == "rhel9" %}}
+{{% if product in ["rhel9", "rhel10"] %}}
 platforms:
     - not aarch64_arch and not ppc64le_arch
 {{% endif %}}

--- a/linux_os/guide/auditing/policy_rules/audit_owner_change_success/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_owner_change_success/rule.yml
@@ -24,9 +24,9 @@ rationale: |-
 
 severity: medium
 
-# on RHEL9 there are rules which cover particular hardware architectures
+# on RHEL9+ there are rules which cover particular hardware architectures
 # so do not apply this rule but apply the specific one instead
-{{% if product == "rhel9" %}}
+{{% if product in ["rhel9", "rhel10"] %}}
 platforms:
     - not aarch64_arch and not ppc64le_arch
 {{% endif %}}

--- a/linux_os/guide/auditing/policy_rules/audit_perm_change_failed/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_perm_change_failed/rule.yml
@@ -26,9 +26,9 @@ rationale: |-
 
 severity: medium
 
-# on RHEL9 there are rules which cover particular hardware architectures
+# on RHEL9+ there are rules which cover particular hardware architectures
 # so do not apply this rule but apply the specific one instead
-{{% if product == "rhel9" %}}
+{{% if product in ["rhel9", "rhel10"] %}}
 platforms:
     - not aarch64_arch and not ppc64le_arch
 {{% endif %}}

--- a/linux_os/guide/auditing/policy_rules/audit_perm_change_success/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_perm_change_success/rule.yml
@@ -24,9 +24,9 @@ rationale: |-
 
 severity: medium
 
-# on RHEL9 there are rules which cover particular hardware architectures
+# on RHEL9+ there are rules which cover particular hardware architectures
 # so do not apply this rule but apply the specific one instead
-{{% if product == "rhel9" %}}
+{{% if product in ["rhel9", "rhel10"] %}}
 platforms:
     - not aarch64_arch and not ppc64le_arch
 {{% endif %}}

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern/rule.yml
@@ -12,7 +12,7 @@ rationale: |-
 
 severity: medium
 
-{{% if product in ["rhel9"] %}}
+{{% if product in ["rhel9", "rhel10"] %}}
 conflicts:
     - sysctl_kernel_core_pattern_empty_string
 {{% endif %}}


### PR DESCRIPTION
#### Description:

* Add missing CPEs (#12404)
* Add conflicts for sysctl_kernel_core_pattern on RHEL10

#### Rationale:

* Keep the conflicts for RHEL10
* Fixes #12404 

#### Review Hints:

