### PR TITLE
Minor update to default CIS banner

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/login_banner_text.var
+++ b/linux_os/guide/system/accounts/accounts-banners/login_banner_text.var
@@ -14,7 +14,7 @@ interactive: false
 
 {{% set var_dod_default="You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only. By using this IS (which includes any device attached to this IS), you consent to the following conditions:\n-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.\n-At any time, the USG may inspect and seize data stored on this IS.\n-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.\n-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy.\n-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details." %}}
 {{% set var_dod_short = "I've read & consent to terms in IS user agreem't." %}}
-{{% set var_cis_default = "Authorized uses only. All activity may be monitored and reported." %}}
+{{% set var_cis_default = "Authorized users only. All activity may be monitored and reported." %}}
 {{% set var_cis_regex = "^(?!.*(\\\\|fedora|rhel|sle|ubuntu)).*" %}}
 
 options:


### PR DESCRIPTION
#### Description:

In the past was used `Authorized uses only` but now the policy recommends `Authorized users only`.

#### Rationale:

Better CIS alignment.
