### PR TITLE
update ism_o profiles for RHEL 10

### DIFF
--- a/linux_os/guide/system/network/network_nmcli_permissions/ansible/shared.yml
+++ b/linux_os/guide/system/network/network_nmcli_permissions/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 8,multi_platform_ol,multi_platform_rhv,multi_platform_fedora
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 10,multi_platform_ol,multi_platform_rhv,multi_platform_fedora
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/products/rhel10/profiles/ism_o.profile
+++ b/products/rhel10/profiles/ism_o.profile
@@ -28,3 +28,18 @@ extends: e8
 
 selections:
     - ism_o:all:base
+    # these rules do not work properly on RHEL 10 for now
+    - '!enable_dracut_fips_module'
+    - '!firewalld_sshd_port_enabled'
+    - '!require_singleuser_auth'
+    - '!enable_fips_mode'
+    # tally2 is deprecated, replaced by faillock
+    - '!accounts_passwords_pam_tally2_deny_root'
+    - '!accounts_passwords_pam_tally2_unlock_time'
+    - '!audit_rules_login_events_tallylog'
+    # lastlog is not used in RHEL 10
+    - '!audit_rules_login_events_lastlog'
+    # this rule is currently failing on some systemd services, probably because of require_emergency_target_auth and require_singleuser_auth rules
+    - '!rpm_verify_hashes'
+    # this rule should not be needed anymore on RHEL 10, but investigation is recommended
+    - '!openssl_use_strong_entropy'

--- a/products/rhel10/profiles/ism_o_secret.profile
+++ b/products/rhel10/profiles/ism_o_secret.profile
@@ -30,3 +30,18 @@ extends: e8
 
 selections:
     - ism_o:all:secret
+    # these rules do not work properly on RHEL 10 for now
+    - '!enable_dracut_fips_module'
+    - '!firewalld_sshd_port_enabled'
+    - '!require_singleuser_auth'
+    - '!enable_fips_mode'
+    # tally2 is deprecated, replaced by faillock
+    - '!accounts_passwords_pam_tally2_deny_root'
+    - '!accounts_passwords_pam_tally2_unlock_time'
+    - '!audit_rules_login_events_tallylog'
+    # lastlog is not used in RHEL 10
+    - '!audit_rules_login_events_lastlog'
+    # this rule is currently failing on some systemd services, probably because of require_emergency_target_auth and require_singleuser_auth rules
+    - '!rpm_verify_hashes'
+    # this rule should not be needed anymore on RHEL 10, but investigation is recommended
+    - '!openssl_use_strong_entropy'

--- a/products/rhel10/profiles/ism_o_top_secret.profile
+++ b/products/rhel10/profiles/ism_o_top_secret.profile
@@ -28,3 +28,18 @@ extends: e8
 
 selections:
     - ism_o:all:top_secret
+    # these rules do not work properly on RHEL 10 for now
+    - '!enable_dracut_fips_module'
+    - '!firewalld_sshd_port_enabled'
+    - '!require_singleuser_auth'
+    - '!enable_fips_mode'
+    # tally2 is deprecated, replaced by faillock
+    - '!accounts_passwords_pam_tally2_deny_root'
+    - '!accounts_passwords_pam_tally2_unlock_time'
+    - '!audit_rules_login_events_tallylog'
+    # lastlog is not used in RHEL 10
+    - '!audit_rules_login_events_lastlog'
+    # this rule is currently failing on some systemd services, probably because of require_emergency_target_auth and require_singleuser_auth rules
+    - '!rpm_verify_hashes'
+    # this rule should not be needed anymore on RHEL 10, but investigation is recommended
+    - '!openssl_use_strong_entropy'


### PR DESCRIPTION
#### Description:

- enable Ansible remediation for network_nmcli_permissions
- exclude some problematic rules, see comments in the file. Here are some explanations of rules which are not excluded but they are shown as failing:
    - enable_ldap_client - no remediation, but the rule seems quite valid, I consider it as remediated manually
    - audit_rules_unsuccessful_file_modification - no Ansible remediation
    - audit_rules_login_events - no Ansible remediation
    - rsyslog_remote_tls_cacert - no remediation, should be remediated manually
    - network_ipv6_static_address - should be remediated manually

#### Rationale:

- update of profiles for RHEL 10

#### Review Hints:

- run automatus in profile mode against RHEL 10 machine