### PR TITLE
Review sshd_set_maxstartups rule

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/ansible/shared.yml
@@ -1,8 +1,0 @@
-# platform = multi_platform_all
-# reboot = false
-# strategy = restrict
-# complexity = low
-# disruption = low
-- (xccdf-var var_sshd_set_maxstartups)
-
-{{{ ansible_sshd_set(parameter="MaxStartups", value="{{ var_sshd_set_maxstartups }}") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/bash/shared.sh
@@ -1,9 +1,0 @@
-# platform = multi_platform_all
-# reboot = false
-# strategy = restrict
-# complexity = low
-# disruption = low
-
-{{{ bash_instantiate_variables("var_sshd_set_maxstartups") }}}
-
-{{{ bash_sshd_config_set(parameter="MaxStartups", value="$var_sshd_set_maxstartups") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/oval/shared.xml
@@ -21,18 +21,21 @@
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_object id="obj_sshd_config_maxstartups_first_parameter" version="1">
-    <ind:filepath operation="equals">/etc/ssh/sshd_config</ind:filepath>
+  <ind:textfilecontent54_object id="obj_sshd_config_maxstartups_first_parameter" version="2">
+    <ind:path operation="pattern match">/etc/(ssh|ssh/sshd_config.d)</ind:path>
+    <ind:filename operation="pattern match">(sshd_config|.*\.conf)$</ind:filename>
     <ind:pattern operation="pattern match" datatype="string">(?i)^\s*MaxStartups\s+(\d+):\d+:\d+\s*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-  <ind:textfilecontent54_object id="obj_sshd_config_maxstartups_second_parameter" version="1">
-    <ind:filepath operation="equals">/etc/ssh/sshd_config</ind:filepath>
+  <ind:textfilecontent54_object id="obj_sshd_config_maxstartups_second_parameter" version="2">
+    <ind:path operation="pattern match">/etc/(ssh|ssh/sshd_config.d)</ind:path>
+    <ind:filename operation="pattern match">(sshd_config|.*\.conf)$</ind:filename>
     <ind:pattern operation="pattern match" datatype="string">(?i)^\s*MaxStartups\s+\d+:(\d+):\d+\s*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-  <ind:textfilecontent54_object id="obj_sshd_config_maxstartups_third_parameter" version="1">
-    <ind:filepath operation="equals">/etc/ssh/sshd_config</ind:filepath>
+  <ind:textfilecontent54_object id="obj_sshd_config_maxstartups_third_parameter" version="2">
+    <ind:path operation="pattern match">/etc/(ssh|ssh/sshd_config.d)</ind:path>
+    <ind:filename operation="pattern match">(sshd_config|.*\.conf)$</ind:filename>
     <ind:pattern operation="pattern match" datatype="string">(?i)^\s*MaxStartups\s+\d+:\d+:(\d+)\s*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/oval/shared.xml
@@ -75,21 +75,21 @@
       var_ref="var_sshd_set_maxstartups_third"/>
   </ind:textfilecontent54_state>
 
-  <ind:textfilecontent54_test id="tst_maxstartups_start_parameter" version="1"
-    check="all" check_existence="only_one_exists"
-    comment="SSH MaxStartups start parameter is less than or equal to 10">
+  <ind:textfilecontent54_test id="tst_maxstartups_start_parameter" version="2"
+    check="all" check_existence="at_least_one_exists"
+    comment="SSH MaxStartups start parameter is less than or equal to the expected value">
     <ind:object object_ref="obj_sshd_config_maxstartups_first_parameter"/>
     <ind:state state_ref="ste_sshd_config_start_parameter_valid"/>
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_test id="tst_maxstartups_rate_parameter" version="1"
-    check="all" check_existence="only_one_exists"
-    comment="SSH MaxStartups rate parameter is greater than or equal to 30">
+  <ind:textfilecontent54_test id="tst_maxstartups_rate_parameter" version="2"
+    check="all" check_existence="at_least_one_exists"
+    comment="SSH MaxStartups rate parameter is greater than or equal to the expected value">
     <ind:object object_ref="obj_sshd_config_maxstartups_second_parameter"/>
     <ind:state state_ref="ste_sshd_config_rate_parameter_valid"/>
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_test id="tst_maxstartups_full_parameter" version="1"
-    check="all" check_existence="only_one_exists"
-    comment="SSH MaxStartups full parameter is less than or equal to 100">
+  <ind:textfilecontent54_test id="tst_maxstartups_full_parameter" version="2"
+    check="all" check_existence="at_least_one_exists"
+    comment="SSH MaxStartups full parameter is less than or equal to the expected value">
     <ind:object object_ref="obj_sshd_config_maxstartups_third_parameter"/>
     <ind:state state_ref="ste_sshd_config_full_parameter_valid"/>
   </ind:textfilecontent54_test>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/oval/shared.xml
@@ -1,23 +1,22 @@
 <def-group>
-  <definition class="compliance" id="sshd_set_maxstartups" version="1">
-    {{{ oval_metadata("Ensure 'MaxStartups' is configured in
-      '/etc/ssh/sshd_config'") }}}
-    <criteria comment="sshd is configured correctly or is not installed" operator="OR">
-      <criteria comment="sshd is not installed" operator="AND">
-        <extend_definition comment="sshd is not required or requirement is unset"
-        definition_ref="sshd_not_required_or_unset" />
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("Ensure 'MaxStartups' is properly configured in SSH configuration files.") }}}
+    <criteria operator="OR" comment="sshd MaxStartups parameter is properly configured if sshd is installed">
+      <criteria operator="AND" comment="sshd is not installed">
+        <extend_definition definition_ref="sshd_not_required_or_unset"
+          comment="sshd is not required or requirement is unset"/>
         {{% if product in ['opensuse', 'sle12', 'sle15'] %}}
-        <extend_definition comment="rpm package openssh removed"
-        definition_ref="package_openssh_removed" />
+        <extend_definition definition_ref="package_openssh_removed"
+          comment="rpm package openssh is removed"/>
         {{% else %}}
-        <extend_definition comment="rpm package openssh-server removed"
-        definition_ref="package_openssh-server_removed" />
+        <extend_definition definition_ref="package_openssh-server_removed"
+          comment="rpm package openssh-server is removed"/>
         {{% endif %}}
       </criteria>
       <criteria operator="AND">
-        <criterion test_ref="tst_maxstartups_start_parameter" comment="SSH MaxStartups start parameter is less than or equal to 10" />
-        <criterion test_ref="tst_maxstartups_rate_parameter" comment="SSH MaxStartups rate parameter is greater than or equal to 30" />
-        <criterion test_ref="tst_maxstartups_full_parameter" comment="SSH MaxStartups full parameter is less than or equal to 100" />
+        <criterion test_ref="tst_maxstartups_start_parameter" comment="SSH MaxStartups start parameter is less than or equal to 10"/>
+        <criterion test_ref="tst_maxstartups_rate_parameter" comment="SSH MaxStartups rate parameter is greater than or equal to 30"/>
+        <criterion test_ref="tst_maxstartups_full_parameter" comment="SSH MaxStartups full parameter is less than or equal to 100"/>
       </criteria>
     </criteria>
   </definition>
@@ -48,16 +47,22 @@
     <ind:subexpression datatype="int" operation="less than or equal">100</ind:subexpression>
   </ind:textfilecontent54_state>
 
-  <ind:textfilecontent54_test check="all" check_existence="only_one_exists" id="tst_maxstartups_start_parameter" version="1" comment="SSH MaxStartups start parameter is less than or equal to 10">
-    <ind:object object_ref="obj_sshd_config_maxstartups_first_parameter" />
-    <ind:state state_ref="ste_sshd_config_start_parameter_valid" />
+  <ind:textfilecontent54_test id="tst_maxstartups_start_parameter" version="1"
+    check="all" check_existence="only_one_exists"
+    comment="SSH MaxStartups start parameter is less than or equal to 10">
+    <ind:object object_ref="obj_sshd_config_maxstartups_first_parameter"/>
+    <ind:state state_ref="ste_sshd_config_start_parameter_valid"/>
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_test check="all" check_existence="only_one_exists" id="tst_maxstartups_rate_parameter" version="1" comment="SSH MaxStartups rate parameter is greater than or equal to 30">
-    <ind:object object_ref="obj_sshd_config_maxstartups_second_parameter" />
-    <ind:state state_ref="ste_sshd_config_rate_parameter_valid" />
+  <ind:textfilecontent54_test id="tst_maxstartups_rate_parameter" version="1"
+    check="all" check_existence="only_one_exists"
+    comment="SSH MaxStartups rate parameter is greater than or equal to 30">
+    <ind:object object_ref="obj_sshd_config_maxstartups_second_parameter"/>
+    <ind:state state_ref="ste_sshd_config_rate_parameter_valid"/>
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_test check="all" check_existence="only_one_exists" id="tst_maxstartups_full_parameter" version="1" comment="SSH MaxStartups full parameter is less than or equal to 100">
-    <ind:object object_ref="obj_sshd_config_maxstartups_third_parameter" />
-    <ind:state state_ref="ste_sshd_config_full_parameter_valid" />
+  <ind:textfilecontent54_test id="tst_maxstartups_full_parameter" version="1"
+    check="all" check_existence="only_one_exists"
+    comment="SSH MaxStartups full parameter is less than or equal to 100">
+    <ind:object object_ref="obj_sshd_config_maxstartups_third_parameter"/>
+    <ind:state state_ref="ste_sshd_config_full_parameter_valid"/>
   </ind:textfilecontent54_test>
 </def-group>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/oval/shared.xml
@@ -50,13 +50,13 @@
     </regex_capture>
   </local_variable>
   <local_variable id="var_sshd_set_maxstartups_second" version="1" datatype="int"
-    comment="First number from MaxStartup parameter value.">
+    comment="Second number from MaxStartup parameter value.">
     <regex_capture pattern="\d+:(\d+):\d+">
       <variable_component var_ref="var_sshd_set_maxstartups"/>
     </regex_capture>
   </local_variable>
   <local_variable id="var_sshd_set_maxstartups_third" version="1" datatype="int"
-    comment="First number from MaxStartup parameter value.">
+    comment="Third number from MaxStartup parameter value.">
     <regex_capture pattern="\d+:\d+:(\d+)">
       <variable_component var_ref="var_sshd_set_maxstartups" />
     </regex_capture>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/oval/shared.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+  <definition class="compliance" id="{{{ rule_id }}}" version="2">
     {{{ oval_metadata("Ensure 'MaxStartups' is properly configured in SSH configuration files.") }}}
     <criteria operator="OR" comment="sshd MaxStartups parameter is properly configured if sshd is installed">
       <criteria operator="AND" comment="sshd is not installed">
@@ -40,14 +40,39 @@
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_state id="ste_sshd_config_start_parameter_valid" version="1">
-    <ind:subexpression datatype="int" operation="less than or equal">10</ind:subexpression>
+  <external_variable id="var_sshd_set_maxstartups" version="1"
+    datatype="string" comment="Expected value for MaxStartups parameter"/>
+
+  <local_variable id="var_sshd_set_maxstartups_first" version="1" datatype="int"
+    comment="First number from MaxStartup parameter value.">
+    <regex_capture pattern="(\d+):\d+:\d+">
+      <variable_component var_ref="var_sshd_set_maxstartups"/>
+    </regex_capture>
+  </local_variable>
+  <local_variable id="var_sshd_set_maxstartups_second" version="1" datatype="int"
+    comment="First number from MaxStartup parameter value.">
+    <regex_capture pattern="\d+:(\d+):\d+">
+      <variable_component var_ref="var_sshd_set_maxstartups"/>
+    </regex_capture>
+  </local_variable>
+  <local_variable id="var_sshd_set_maxstartups_third" version="1" datatype="int"
+    comment="First number from MaxStartup parameter value.">
+    <regex_capture pattern="\d+:\d+:(\d+)">
+      <variable_component var_ref="var_sshd_set_maxstartups" />
+    </regex_capture>
+  </local_variable>
+
+  <ind:textfilecontent54_state id="ste_sshd_config_start_parameter_valid" version="2">
+    <ind:subexpression datatype="int" operation="less than or equal"
+      var_ref="var_sshd_set_maxstartups_first"/>
   </ind:textfilecontent54_state>
-  <ind:textfilecontent54_state id="ste_sshd_config_rate_parameter_valid" version="1">
-    <ind:subexpression datatype="int" operation="greater than or equal">30</ind:subexpression>
+  <ind:textfilecontent54_state id="ste_sshd_config_rate_parameter_valid" version="2">
+    <ind:subexpression datatype="int" operation="greater than or equal"
+      var_ref="var_sshd_set_maxstartups_second"/>
   </ind:textfilecontent54_state>
-  <ind:textfilecontent54_state id="ste_sshd_config_full_parameter_valid" version="1">
-    <ind:subexpression datatype="int" operation="less than or equal">100</ind:subexpression>
+  <ind:textfilecontent54_state id="ste_sshd_config_full_parameter_valid" version="2">
+    <ind:subexpression datatype="int" operation="less than or equal"
+      var_ref="var_sshd_set_maxstartups_third"/>
   </ind:textfilecontent54_state>
 
   <ind:textfilecontent54_test id="tst_maxstartups_start_parameter" version="1"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/rule.yml
@@ -35,3 +35,12 @@ ocil: |-
     To check if MaxStartups is configured, run the following command:
     <pre>$ sudo grep -r ^[\s]*MaxStartups /etc/ssh/sshd_config*</pre>
     If configured, this command should output the configuration.
+
+template:
+    name: sshd_lineinfile
+    vars:
+        parameter: MaxStartups
+        xccdf_variable: var_sshd_set_maxstartups
+        datatype: string
+        backends:
+            oval: "off"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/rule.yml
@@ -3,20 +3,16 @@ documentation_complete: true
 title: 'Ensure SSH MaxStartups is configured'
 
 description: |-
-    The MaxStartups parameter specifies the maximum number of concurrent
-    unauthenticated connections to the SSH daemon. Additional connections will be
-    dropped until authentication succeeds or the LoginGraceTime expires for a
-    connection. To confgure MaxStartups, you should add or correct the following
-    line in the
-    <tt>/etc/ssh/sshd_config</tt> file:
+    The MaxStartups parameter specifies the maximum number of concurrent unauthenticated
+    connections to the SSH daemon. Additional connections will be dropped until authentication
+    succeeds or the LoginGraceTime expires for a connection. To configure MaxStartups, you should
+    add or edit the following line in the <tt>/etc/ssh/sshd_config</tt> file:
     <pre>MaxStartups {{{ xccdf_value("var_sshd_set_maxstartups") }}}</pre>
-    CIS recommends a MaxStartups value of '10:30:60', or more restrictive where
-    dictated by site policy.
 
 rationale: |-
-    To protect a system from denial of service due to a large number of pending
-    authentication connection attempts, use the rate limiting function of MaxStartups
-    to protect availability of sshd logins and prevent overwhelming the daemon.
+    To protect a system from denial of service due to a large number of pending authentication
+    connection attempts, use the rate limiting function of MaxStartups to protect availability of
+    sshd logins and prevent overwhelming the daemon.
 
 severity: medium
 
@@ -37,5 +33,5 @@ ocil_clause: 'maxstartups is not configured'
 
 ocil: |-
     To check if MaxStartups is configured, run the following command:
-    <pre>$ sudo grep MaxStartups /etc/ssh/sshd_config</pre>
+    <pre>$ sudo grep -r ^[\s]*MaxStartups /etc/ssh/sshd_config*</pre>
     If configured, this command should output the configuration.

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/tests/comment.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/tests/comment.fail.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-# variables = var_sshd_set_maxstartups=10:30:60
-
-if grep -q "^MaxStartups" /etc/ssh/sshd_config; then
-	sed -i "s/^MaxStartups.*/# MaxStartups 10:30:60/" /etc/ssh/sshd_config
-else
-	echo "# MaxStartups 10:30:60" >> /etc/ssh/sshd_config
-fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/tests/comment.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/tests/comment.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-#
-# profiles = xccdf_org.ssgproject.content_profile_cis
+# variables = var_sshd_set_maxstartups=10:30:60
 
 if grep -q "^MaxStartups" /etc/ssh/sshd_config; then
 	sed -i "s/^MaxStartups.*/# MaxStartups 10:30:60/" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/tests/correct_value.pass.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-# variables = var_sshd_set_maxstartups=10:30:60
-
-if grep -q "^MaxStartups" /etc/ssh/sshd_config; then
-	sed -i "s/^MaxStartups.*/MaxStartups 10:30:60/" /etc/ssh/sshd_config
-else
-	echo "MaxStartups 10:30:60" >> /etc/ssh/sshd_config
-fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/tests/lenient_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/tests/lenient_value.fail.sh
@@ -4,5 +4,5 @@
 if grep -q "^MaxStartups" /etc/ssh/sshd_config; then
 	sed -i "s/^MaxStartups.*/MaxStartups 10:30:60/" /etc/ssh/sshd_config
 else
-	echo "MaxStartups 10:30:60" >> /etc/ssh/sshd_config
+	echo "MaxStartups 20:40:60" >> /etc/ssh/sshd_config
 fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/tests/line_not_there.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/tests/line_not_there.fail.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-# variables = var_sshd_set_maxstartups=10:30:60
-
-sed -i "/^MaxStartups.*/d" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/tests/line_not_there.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/tests/line_not_there.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#
-# profiles = xccdf_org.ssgproject.content_profile_cis
+# variables = var_sshd_set_maxstartups=10:30:60
 
 sed -i "/^MaxStartups.*/d" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/tests/nothing.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/tests/nothing.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#
-# profiles = xccdf_org.ssgproject.content_profile_cis
+# variables = var_sshd_set_maxstartups=10:30:60
 
 true

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/tests/nothing.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/tests/nothing.fail.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-# variables = var_sshd_set_maxstartups=10:30:60
-
-true

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/tests/stricter_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/tests/stricter_value.pass.sh
@@ -4,5 +4,5 @@
 if grep -q "^MaxStartups" /etc/ssh/sshd_config; then
 	sed -i "s/^MaxStartups.*/MaxStartups 10:30:60/" /etc/ssh/sshd_config
 else
-	echo "MaxStartups 10:30:60" >> /etc/ssh/sshd_config
+	echo "MaxStartups 5:60:30" >> /etc/ssh/sshd_config
 fi

--- a/shared/templates/sshd_lineinfile/template.py
+++ b/shared/templates/sshd_lineinfile/template.py
@@ -13,8 +13,12 @@ def set_variables_for_test_scenarios(data):
     elif data["datatype"] == "string":
         if not data.get("value"):
             # this implies XCCDF variable is used
-            data["wrong_value"] = "wrong_value"
-            data["correct_value"] = "correct_value"
+            if data['xccdf_variable'] == 'var_sshd_set_maxstartups':
+                data["wrong_value"] = "30:10:110"
+                data["correct_value"] = "10:30:60"
+            else:
+                data["wrong_value"] = "wrong_value"
+                data["correct_value"] = "correct_value"
         else:
             data["wrong_value"] = "wrong_value"
             data["correct_value"] = str(data["value"])


### PR DESCRIPTION
#### Description:

The template `sshd_lineinfile` was recently improved (https://github.com/ComplianceAsCode/content/pull/12251) to use variables. The rule `sshd_set_maxstartups` is used in different profiles and could benefit from this template, but the SSH `MaxStartups` parameter has some particularities in its OVAL.

During the review, I concluded that is better to keep a specific OVAL for `sshd_set_maxstartups` since there is no other rules using a similar parameter or even similar parameters in SSH configuration. So it would bring an unnecessary complexity to the templated OVAL. But the bash, Ansible and test scenarios could be nicely used to keep a better consistency among SSH rules.

This PR:

- Refactor the `sshd_set_maxstartups` OVAL logic
  - Remove incorrect assumptions about parameter duplication
  - Remove hard-coded values and use variable values instead, giving more flexibility to the rule.
- Use the `sshd_lineinfile` template for remediation and tests.
- Increase coverage of test scenarios.

#### Rationale:

- Better alignment among SSH related rules
- Less complexity and more robustness for the rule
- Fixes https://issues.redhat.com/browse/RHEL-38206

#### Review Hints:

```
./build_product rhel9
./tests/automatus.py rule --libvirt qemu:///session rhel9 --datastream build/ssg-rhel9-ds.xml --dontclean --remediate-using bash sshd_set_maxstartups
```

Other CI tests will help us to test the changes in a context of a profile. But I expect everything to be green.
