### PR TITLE
modify test scenarios of grub2_argument template to handle variables

### DIFF
--- a/shared/templates/grub2_bootloader_argument/tests/arg_not_in_entries.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/arg_not_in_entries.fail.sh
@@ -5,6 +5,11 @@
 
 source common.sh
 
+{{%- if ARG_VARIABLE %}}
+# variables = {{{ ARG_VARIABLE }}}=correct_value
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+{{%- endif %}}
+
 {{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}
 
 # Removes argument from kernel command line in /boot/loader/entries/*.conf

--- a/shared/templates/grub2_bootloader_argument/tests/arg_not_in_etcdefaultgrub.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/arg_not_in_etcdefaultgrub.fail.sh
@@ -4,6 +4,11 @@
 
 source common.sh
 
+{{%- if ARG_VARIABLE %}}
+# variables = {{{ ARG_VARIABLE }}}=correct_value
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+{{%- endif %}}
+
 {{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}
 
 # Removes argument from kernel command line in /etc/default/grub

--- a/shared/templates/grub2_bootloader_argument/tests/arg_not_in_etcdefaultgrub_recovery_disabled.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/arg_not_in_etcdefaultgrub_recovery_disabled.fail.sh
@@ -4,6 +4,12 @@
 
 source common.sh
 
+{{%- if ARG_VARIABLE %}}
+# variables = {{{ ARG_VARIABLE }}}=correct_value
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+{{%- endif %}}
+
+
 {{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}
 
 # Removes the argument from kernel command line in /etc/default/grub

--- a/shared/templates/grub2_bootloader_argument/tests/arg_not_in_grubenv_but_referenced.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/arg_not_in_grubenv_but_referenced.fail.sh
@@ -5,6 +5,11 @@
 
 source common.sh
 
+{{%- if ARG_VARIABLE %}}
+# variables = {{{ ARG_VARIABLE }}}=correct_value
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+{{%- endif %}}
+
 for entry in /boot/loader/entries/*.conf; do
   if ! grep -q '\$kernelopts' "$entry"; then
     sed -i 's/^\(options.*\)$/\1 \$kernelopts/' "$entry"

--- a/shared/templates/grub2_bootloader_argument/tests/correct_recovery_disabled.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_recovery_disabled.pass.sh
@@ -9,6 +9,11 @@
 
 source common.sh
 
+{{%- if ARG_VARIABLE %}}
+# variables = {{{ ARG_VARIABLE }}}=correct_value
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+{{%- endif %}}
+
 {{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}
 
 # Correct the form of default kernel command line in GRUB /etc/default/grub and applies value through Grubby

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_grubenv_only.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_grubenv_only.pass.sh
@@ -3,13 +3,12 @@
 # platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 # packages = grub2,grubby
 
+source common.sh
+
 {{%- if ARG_VARIABLE %}}
 # variables = {{{ ARG_VARIABLE }}}=correct_value
 {{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
 {{%- endif %}}
-
-
-source common.sh
 
 # adds argument from kernel command line into /etc/default/grub
 file="/etc/default/grub"

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_mix_entries_and_grubenv.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_mix_entries_and_grubenv.pass.sh
@@ -3,13 +3,12 @@
 # platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 # packages = grub2,grubby
 
+source common.sh
+
 {{%- if ARG_VARIABLE %}}
 # variables = {{{ ARG_VARIABLE }}}=correct_value
 {{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
 {{%- endif %}}
-
-
-source common.sh
 
 # adds argument from kernel command line into /etc/default/grub
 file="/etc/default/grub"

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_noupdate.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_noupdate.fail.sh
@@ -3,12 +3,12 @@
 # platform = multi_platform_all
 # packages = grub2
 
+source common.sh
+
 {{%- if ARG_VARIABLE %}}
 # variables = {{{ ARG_VARIABLE }}}=correct_value
 {{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
 {{%- endif %}}
-
-source common.sh
 
 # Clean up
 rm -f /etc/default/grub.d/*

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_remediated.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_remediated.pass.sh
@@ -7,11 +7,11 @@
 # packages = grub2,grubby
 {{%- endif %}}
 
+source common.sh
+
 {{%- if ARG_VARIABLE %}}
 # variables = {{{ ARG_VARIABLE }}}=correct_value
 {{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
 {{%- endif %}}
-
-source common.sh
 
 {{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}

--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value_entries.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value_entries.fail.sh
@@ -5,16 +5,24 @@
 
 source common.sh
 
+{{%- if ARG_VARIABLE %}}
+# variables = {{{ ARG_VARIABLE }}}=correct_value
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+{{%- set ARG_NAME_VALUE_WRONG= ARG_NAME ~ "=wrong_value" %}}
+{{%- else %}}
+{{%- set ARG_NAME_VALUE_WRONG= "wrong_variable" %}}
+{{%- endif %}}
+
 {{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}
 
 # Breaks argument from kernel command line in /boot/loader/entries/*.conf
 for file in /boot/loader/entries/*.conf ; do
   if grep -q '^.*{{{ ESCAPED_ARG_NAME }}}=.*'  "$file" ; then
       # modify the GRUB command-line if an ={{{ARG_NAME}}} arg already exists
-	    sed -i 's/\(^.*\){{{ARG_NAME}}}=[^[:space:]]*\(.*\)/\1 {{{ARG_NAME}}}=wrong \2/'  "$file"
+	    sed -i 's/\(^.*\){{{ ARG_NAME }}}=[^[:space:]]*\(.*\)/\1 {{{ ARG_NAME_VALUE_WRONG }}} \2/'  "$file"
     else
 	    # no {{{ARG_NAME}}}=arg is present, append it
-	    sed -i 's/\(^.*\(vmlinuz\|kernelopts\).*\)/\1 {{{ARG_NAME}}}=wrong/'  "$file"
+	    sed -i 's/\(^.*\(vmlinuz\|kernelopts\).*\)/\1 {{{ ARG_NAME_VALUE_WRONG }}}/'  "$file"
   fi
 # ensure that grubenv is not referenced
   if  grep -q '\$kernelopts' "$file"; then

--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value_etcdefault.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value_etcdefault.fail.sh
@@ -11,9 +11,8 @@
 {{%- if ARG_VARIABLE %}}
 # variables = {{{ ARG_VARIABLE }}}=correct_value
 {{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
-{{%- set ARG_NAME_VALUE_WRONG= ARG_NAME ~ "=correct_value" %}}
+{{%- set ARG_NAME_VALUE_WRONG= ARG_NAME ~ "=wrong_value" %}}
 {{%- else %}}
-{{%- set ARG_NAME_VALUE= ARG_NAME %}}
 {{%- set ARG_NAME_VALUE_WRONG= "wrong_variable" %}}
 {{%- endif %}}
 
@@ -25,4 +24,4 @@ echo "GRUB_CMDLINE_LINUX=\"{{{ ARG_NAME_VALUE }}}\"" > /etc/default/grub
 {{{ grub_command("update") }}}
 
 # Set to wrong var/value
-echo "GRUB_CMDLINE_LINUX=\"{{{ ARG_NAME }}}=wrong_value\"" > /etc/default/grub
+echo "GRUB_CMDLINE_LINUX=\"{{{ ARG_NAME_VALUE_WRONG }}}=\"" > /etc/default/grub

--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value_etcdefaultgrub_recovery_disabled.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value_etcdefaultgrub_recovery_disabled.fail.sh
@@ -6,9 +6,8 @@ source common.sh
 {{%- if ARG_VARIABLE %}}
 # variables = {{{ ARG_VARIABLE }}}=correct_value
 {{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
-{{%- set ARG_NAME_VALUE_WRONG= ARG_NAME ~ "=correct_value" %}}
+{{%- set ARG_NAME_VALUE_WRONG= ARG_NAME ~ "=wrong_value" %}}
 {{%- else %}}
-{{%- set ARG_NAME_VALUE= ARG_NAME %}}
 {{%- set ARG_NAME_VALUE_WRONG= "wrong_variable" %}}
 {{%- endif %}}
 
@@ -18,10 +17,10 @@ rm -f /etc/default/grub.d/*
 # Correct the form of default kernel command line in GRUB /etc/default/grub and applies value through Grubby
 if grep -q '^GRUB_CMDLINE_LINUX_DEFAULT=.*{{{ ESCAPED_ARG_NAME }}}=.*"'  '/etc/default/grub' ; then
 	# modify the GRUB command-line if an arg=value already exists
-	sed -i 's/\(^GRUB_CMDLINE_LINUX_DEFAULT=".*\){{{ ARG_NAME }}}=[^[:space:]]*\(.*"\)/\1 {{{ ARG_NAME }}}={{{ ARG_NAME_VALUE_WRONG }}} \2/'  '/etc/default/grub'
+	sed -i 's/\(^GRUB_CMDLINE_LINUX_DEFAULT=".*\){{{ ARG_NAME }}}=[^[:space:]]*\(.*"\)/\1{{{ ARG_NAME_VALUE_WRONG }}} \2/'  '/etc/default/grub'
 else
 	# no arg is present, append it
-	sed -i 's/\(^GRUB_CMDLINE_LINUX_DEFAULT=".*\)"/\1 {{{ ARG_NAME }}}={{{ ARG_NAME_VALUE_WRONG }}}"/'  '/etc/default/grub'
+	sed -i 's/\(^GRUB_CMDLINE_LINUX_DEFAULT=".*\)"/\1{{{ ARG_NAME_VALUE_WRONG }}}"/'  '/etc/default/grub'
 fi
 
 # removing the parameter from the no recovery kernel parameters as well

--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value_grubenv.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value_grubenv.fail.sh
@@ -5,16 +5,24 @@
 
 source common.sh
 
+{{%- if ARG_VARIABLE %}}
+# variables = {{{ ARG_VARIABLE }}}=correct_value
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+{{%- set ARG_NAME_VALUE_WRONG= ARG_NAME ~ "=wrong_value" %}}
+{{%- else %}}
+{{%- set ARG_NAME_VALUE_WRONG= "wrong_variable" %}}
+{{%- endif %}}
+
 {{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}
 
 # Break the argument in kernel command line in /boot/grub2/grubenv
 file="/boot/grub2/grubenv"
 if grep -q '^.*{{{ARG_NAME}}}=.*'  "$file" ; then
 	# modify the GRUB command-line if the arg already exists
-	sed -i 's/\(^.*\){{{ARG_NAME}}}=[^[:space:]]*\(.*\)/\1 {{{ARG_NAME}}}=wrong \2/'  "$file"
+	sed -i 's/\(^.*\){{{ ARG_NAME }}}=[^[:space:]]*\(.*\)/\1 {{{ ARG_NAME_VALUE_WRONG }}}=wrong \2/'  "$file"
 else
 	# no arg is present, append it
-	sed -i 's/\(^.*\(vmlinuz\|kernelopts\).*\)/\1 {{{ARG_NAME}}}=wrong/'  "$file"
+	sed -i 's/\(^.*\(vmlinuz\|kernelopts\).*\)/\1 {{{ ARG_NAME_VALUE_WRONG }}}=wrong/'  "$file"
 fi
 
 # Ensure that grubenv is referenced through $kernelopts


### PR DESCRIPTION
#### Description:

- ensure that all test scenarios can handle case when the rule uses XCCDF variable and not

#### Rationale:

- test scenarios in such cases were not behaving correctly, it did not affect the rule it self


#### Review Hints:

Build content for rhel8 and rhel9 product.
Then pick two rules templated with grub2_argument template so that one uses xccdf variable (grub2_l1tf_argument) and another does not (grub2_audit_argument).
Run automatus for those rules.