### PR TITLE
Add hipaa reference to `sshd_use_directory_configuration`

### DIFF
--- a/controls/hipaa.yml
+++ b/controls/hipaa.yml
@@ -1116,6 +1116,7 @@ controls:
             - selinux_confinement_of_daemons
             - selinux_policytype
             - selinux_state
+            - sshd_use_directory_configuration
         status: automated
 
     -   id: 164.312(a)(1)

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_directory_configuration/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_directory_configuration/rule.yml
@@ -18,6 +18,9 @@ identifiers:
     cce@rhel9: CCE-87681-3
     cce@rhel10: CCE-87449-5
 
+references:
+    hipaa: 164.312(a)
+
 ocil_clause: "you don't include other configuration files from the main configuration file"
 
 ocil: |-


### PR DESCRIPTION


#### Description:

Add hipaa reference to `sshd_use_directory_configuration`

#### Rationale:

Closes #12426

#### Review Hints:


