### PR TITLE
Add `agent_mfetpd_running` and `package_mcafeetp_installed` back to RHEL9 benchmark

### DIFF
--- a/products/rhel9/profiles/default.profile
+++ b/products/rhel9/profiles/default.profile
@@ -559,3 +559,5 @@ selections:
     - set_nftables_table
     - sshd_use_approved_ciphers
     - configure_bashrc_exec_tmux
+    - agent_mfetpd_running
+    - package_mcafeetp_installed


### PR DESCRIPTION
#### Description:
Both rules got removed from benchmark in 0485740a3aa28569263223598cf598edcf34667d.
Introduce them back.

#### Rationale:
No rule removals from RHEL9 benchmark.

#### Review Hints:
Build content and see these 2 rules are there.