### PR TITLE
RHEL 9 STIG: change remediated Networkmanager DNS mode

### DIFF
--- a/controls/stig_rhel9.yml
+++ b/controls/stig_rhel9.yml
@@ -1512,7 +1512,7 @@ controls:
         title: RHEL 9 must configure a DNS processing mode set be Network Manager.
         rules:
             - networkmanager_dns_mode
-            - var_networkmanager_dns_mode=none
+            - var_networkmanager_dns_mode=explicit_default
         status: automated
 
     -   id: RHEL-09-252045

--- a/linux_os/guide/system/network/networkmanager/var_networkmanager_dns_mode.var
+++ b/linux_os/guide/system/network/networkmanager/var_networkmanager_dns_mode.var
@@ -17,3 +17,4 @@ operator: 'equals'
 options:
     none: none
     default: default
+    explicit_default: default

--- a/tests/data/profile_stability/rhel9/stig.profile
+++ b/tests/data/profile_stability/rhel9/stig.profile
@@ -567,7 +567,7 @@ selections:
 - var_rekey_limit_size=1G
 - var_rekey_limit_time=1hour
 - sshd_approved_ciphers=stig_rhel9
-- var_networkmanager_dns_mode=none
+- var_networkmanager_dns_mode=explicit_default
 - var_multiple_time_servers=stig
 - var_time_service_set_maxpoll=18_hours
 - var_user_initialization_files_regex=all_dotfiles

--- a/tests/data/profile_stability/rhel9/stig_gui.profile
+++ b/tests/data/profile_stability/rhel9/stig_gui.profile
@@ -574,7 +574,7 @@ selections:
 - var_rekey_limit_size=1G
 - var_rekey_limit_time=1hour
 - sshd_approved_ciphers=stig_rhel9
-- var_networkmanager_dns_mode=none
+- var_networkmanager_dns_mode=explicit_default
 - var_multiple_time_servers=stig
 - var_time_service_set_maxpoll=18_hours
 - var_user_initialization_files_regex=all_dotfiles


### PR DESCRIPTION
#### Description:

- change the mode used in remediation from "none" to "default"
- also modify profile stability data

#### Rationale:

- fixes https://issues.redhat.com/browse/RHEL-53426
- relevant STIG prose: https://stigaview.com/products/rhel9/v2r1/RHEL-09-252040/


#### Review Hints:

- build the rhel9 product and review the resulting profile