### PR TITLE
RHEL 10 ISM_O: add back enable_fips_mode rule

### DIFF
--- a/products/rhel10/profiles/ism_o.profile
+++ b/products/rhel10/profiles/ism_o.profile
@@ -32,7 +32,6 @@ selections:
     - '!enable_dracut_fips_module'
     - '!firewalld_sshd_port_enabled'
     - '!require_singleuser_auth'
-    - '!enable_fips_mode'
     # tally2 is deprecated, replaced by faillock
     - '!accounts_passwords_pam_tally2_deny_root'
     - '!accounts_passwords_pam_tally2_unlock_time'

--- a/products/rhel10/profiles/ism_o_secret.profile
+++ b/products/rhel10/profiles/ism_o_secret.profile
@@ -34,7 +34,6 @@ selections:
     - '!enable_dracut_fips_module'
     - '!firewalld_sshd_port_enabled'
     - '!require_singleuser_auth'
-    - '!enable_fips_mode'
     # tally2 is deprecated, replaced by faillock
     - '!accounts_passwords_pam_tally2_deny_root'
     - '!accounts_passwords_pam_tally2_unlock_time'

--- a/products/rhel10/profiles/ism_o_top_secret.profile
+++ b/products/rhel10/profiles/ism_o_top_secret.profile
@@ -32,7 +32,6 @@ selections:
     - '!enable_dracut_fips_module'
     - '!firewalld_sshd_port_enabled'
     - '!require_singleuser_auth'
-    - '!enable_fips_mode'
     # tally2 is deprecated, replaced by faillock
     - '!accounts_passwords_pam_tally2_deny_root'
     - '!accounts_passwords_pam_tally2_unlock_time'


### PR DESCRIPTION
#### Description:

- add back enable_fips_mode rule to all ISM_O profiles in RHEL 10

#### Rationale:

- the rule was broken when the profile was being reviewed, but now it is working again.
- Also, the cryptopolicy is configured to FIPS, so it is natural to have the enable_fips_mode rule there.



#### Review Hints:

- build the product and check the profile content
- use Automatus in profile mode