### PR TITLE
Remove sendmail from RHEL 10 profiles

### DIFF
--- a/controls/srg_gpos/SRG-OS-000095-GPOS-00049.yml
+++ b/controls/srg_gpos/SRG-OS-000095-GPOS-00049.yml
@@ -5,7 +5,6 @@ controls:
         title: {{{ full_name }}} must be configured to disable non-essential capabilities.
         rules:
             - package_vsftpd_removed
-            - package_sendmail_removed
             - package_nfs-utils_removed
             - chronyd_client_only
             - chronyd_no_chronyc_network

--- a/controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml
+++ b/controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml
@@ -84,7 +84,6 @@ controls:
 
             # package removed
             - package_vsftpd_removed
-            - package_sendmail_removed
             - package_tftp-server_removed
             - package_quagga_removed
             - package_gssproxy_removed


### PR DESCRIPTION


#### Description:

Remove sendmail from RHEL 10 profiles

#### Rationale:
Package is not in RHEL 10.

