### PR TITLE
Two CIS RHEL 9 enhancements

### DIFF
--- a/controls/cis_rhel9.yml
+++ b/controls/cis_rhel9.yml
@@ -602,7 +602,10 @@ controls:
       - l1_server
       - l1_workstation
     status: manual
-
+    notes: |-        
+        User should manually ensure that CVE-2023-48795 is addressed.
+        This is not automated and it might be difficult to automate actually.
+        Therefore, keeping this control as manual.
   - id: 1.6.7
     title: Ensure system wide crypto policy disables EtM for ssh (Automated)
     levels:
@@ -1067,7 +1070,7 @@ controls:
       - l1_server
       - l1_workstation
     status: automated
-    related_rules:
+    rules:
       - package_chrony_installed
 
   - id: 2.3.2

--- a/tests/data/profile_stability/rhel9/cis.profile
+++ b/tests/data/profile_stability/rhel9/cis.profile
@@ -285,6 +285,7 @@ selections:
 - package_audit-libs_installed
 - package_audit_installed
 - package_bind_removed
+- package_chrony_installed
 - package_cyrus-imapd_removed
 - package_dhcp_removed
 - package_dnsmasq_removed

--- a/tests/data/profile_stability/rhel9/cis_server_l1.profile
+++ b/tests/data/profile_stability/rhel9/cis_server_l1.profile
@@ -201,6 +201,7 @@ selections:
 - no_shelllogin_for_systemaccounts
 - package_aide_installed
 - package_bind_removed
+- package_chrony_installed
 - package_cyrus-imapd_removed
 - package_dhcp_removed
 - package_dnsmasq_removed

--- a/tests/data/profile_stability/rhel9/cis_workstation_l1.profile
+++ b/tests/data/profile_stability/rhel9/cis_workstation_l1.profile
@@ -198,6 +198,7 @@ selections:
 - no_shelllogin_for_systemaccounts
 - package_aide_installed
 - package_bind_removed
+- package_chrony_installed
 - package_cyrus-imapd_removed
 - package_dhcp_removed
 - package_dnsmasq_removed

--- a/tests/data/profile_stability/rhel9/cis_workstation_l2.profile
+++ b/tests/data/profile_stability/rhel9/cis_workstation_l2.profile
@@ -285,6 +285,7 @@ selections:
 - package_audit-libs_installed
 - package_audit_installed
 - package_bind_removed
+- package_chrony_installed
 - package_cyrus-imapd_removed
 - package_dhcp_removed
 - package_dnsmasq_removed


### PR DESCRIPTION
#### Description:

- control 2.3.1 - switch the rule package_chrony_installed from related rules to rules
- control 1.6.6 - add a note explaining why the control is manual

#### Rationale:

- fixes based on input in https://issues.redhat.com/browse/RHEL-60005


#### Review Hints:

- build the content and check the profile contents. Eventually, run Automatus in profile mode.