### PR TITLE
Fix issue with ambiguity of control product

### DIFF
--- a/docs/manual/developer/03_creating_content.md
+++ b/docs/manual/developer/03_creating_content.md
@@ -977,7 +977,7 @@ original_title: used as a reference for policies not yet available in English
 source: a link to the original policy, eg. a URL of a PDF document
 controls_dir: a directory containing files representing controls that will be imported into this policy
 reference_type: Reference type represented by control IDs in this policy.
-product: product ID, set if the policy is specific to a single product.
+product: list of product IDs, set if the policy is specific to a single or number of products.
 levels: a list of levels, the first one is default
   - id: level ID (required key)
     inherits_from: a list of IDs of levels inheriting from

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -352,7 +352,7 @@ class Policy(ssg.entities.common.XCCDFEntity):
         yaml_product = yaml_contents.get("product", None)
         if type(yaml_product) is list:
             self.product = yaml_product
-        else:
+        elif yaml_product is not None:
             self.product = [yaml_product]
 
         default_level_dict = {"id": "default"}

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -350,7 +350,7 @@ class Policy(ssg.entities.common.XCCDFEntity):
         self.source = yaml_contents.get("source", "")
         self.reference_type = yaml_contents.get("reference_type", None)
         yaml_product = yaml_contents.get("product", None)
-        if type(yaml_product) is list:
+        if isinstance(yaml_product, list):
             self.product = yaml_product
         elif yaml_product is not None:
             self.product = [yaml_product]

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -349,7 +349,11 @@ class Policy(ssg.entities.common.XCCDFEntity):
         self.title = ssg.utils.required_key(yaml_contents, "title")
         self.source = yaml_contents.get("source", "")
         self.reference_type = yaml_contents.get("reference_type", None)
-        self.product = yaml_contents.get("product", None)
+        yaml_product = yaml_contents.get("product", None)
+        if type(yaml_product) is list:
+            self.product = yaml_product
+        else:
+            self.product = [yaml_product]
 
         default_level_dict = {"id": "default"}
         level_list = yaml_contents.get("levels", [default_level_dict])


### PR DESCRIPTION


#### Description:

-  Fix issue with ambiguity of control product and partial match of product names vs product specific controls

#### Rationale:

 - When product member is initialized during loading of yaml file it could be ambiguously created as a string, when control is specific for only one product or list when multiple products are specified in the yaml. The problem with partial match of product names comes later in the add_references method, where the current product of the build is matched vs the control product, and the condition used is `product not in self.product`.
- In case of list this condition will check if any of the members of the list is exact match to the product.
- In case of string though, which is the more common case it will check if the string of the product name, for which we are building is partially matched (contained) in the self.product. 

#### Fixes:
- The issue was found while analyzing complaint from a contributor Joel Njanga(@barbarello), while he was trying to add support for al2 platform and it was conflicting with existing platform al2023. The discussion can be seen in the gitter/matrix discussion channel
