### PR TITLE
Move package_rear_installed to related rules in e8

### DIFF
--- a/controls/e8.yml
+++ b/controls/e8.yml
@@ -74,9 +74,9 @@ controls:
         levels:
             - base
         title: 'Regular backups'
-        rules:
+        related_rules:
             - package_rear_installed
-        status: partial
+        status: manual
 
     -   id: 'hardening'
         levels:


### PR DESCRIPTION

#### Description:

Move package_rear_installed to related rules in e8.

#### Rationale:

More configuration is needed for backups, the check should be manual.
