### PR TITLE
Remove package_talk-server_removed from RHEL 10 ANSSI

### DIFF
--- a/products/rhel10/profiles/anssi_bp28_enhanced.profile
+++ b/products/rhel10/profiles/anssi_bp28_enhanced.profile
@@ -65,6 +65,7 @@ selections:
     - '!package_rsh-server_removed'
     - '!package_sendmail_removed'
     - '!package_talk_removed'
+    - '!package_talk-server_removed'
     - '!package_xinetd_removed'
     - '!package_ypserv_removed'
     # these rules are failing when they are remediated with Ansible, removing them temporarily until they are fixed

--- a/products/rhel10/profiles/anssi_bp28_high.profile
+++ b/products/rhel10/profiles/anssi_bp28_high.profile
@@ -69,6 +69,7 @@ selections:
     - '!package_rsh-server_removed'
     - '!package_sendmail_removed'
     - '!package_talk_removed'
+    - '!package_talk-server_removed'
     - '!package_xinetd_removed'
     - '!package_ypserv_removed'
     # these rules are failing when they are remediated with Ansible, removing them temporarily until they are fixed

--- a/products/rhel10/profiles/anssi_bp28_intermediary.profile
+++ b/products/rhel10/profiles/anssi_bp28_intermediary.profile
@@ -45,6 +45,7 @@ selections:
     - '!package_rsh-server_removed'
     - '!package_sendmail_removed'
     - '!package_talk_removed'
+    - '!package_talk-server_removed'
     - '!package_xinetd_removed'
     - '!package_ypserv_removed'
     # these rules are failing when they are remediated with Ansible, removing them temporarily until they are fixed

--- a/products/rhel10/profiles/anssi_bp28_minimal.profile
+++ b/products/rhel10/profiles/anssi_bp28_minimal.profile
@@ -43,6 +43,7 @@ selections:
     - '!package_rsh-server_removed'
     - '!package_sendmail_removed'
     - '!package_talk_removed'
+    - '!package_talk-server_removed'
     - '!package_xinetd_removed'
     - '!package_ypserv_removed'
     # these rules are failing when they are remediated with Ansible, removing then temporarily until they are fixed


### PR DESCRIPTION


#### Description:

Remove package_talk-server_removed from RHEL 10 ANSSI

#### Rationale:

Package isn't in RHEL 10.
