### PR TITLE
Update install_smartcard_packages for RHEL10

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/rule.yml
@@ -6,6 +6,8 @@
 {{% set smartcard_packages = ['pam_pkcs11'] %}}
 {{% elif 'ubuntu' in product %}}
 {{% set smartcard_packages = ['libpam-pkcs11'] %}}
+{{% elif product in ['rhel10'] %}}
+{{% set smartcard_package = ['pkcs11-provider'] %}}
 {{% else %}}
 {{% set smartcard_packages = ['openssl-pkcs11'] %}}
 {{% endif %}}
@@ -73,6 +75,7 @@ template:
     vars:
         pkgname: openssl-pkcs11
         pkgname@ol7: pam_pkcs11
+        pkgname@rhel10: pkcs11-provider
         pkgname@ubuntu1604: libpam-pkcs11
         pkgname@ubuntu1804: libpam-pkcs11
         pkgname@ubuntu2004: libpam-pkcs11


### PR DESCRIPTION

#### Description:
Update install_smartcard_packages for RHEL10

#### Rationale:

The pkcs11-provider is the correct name for RHEL 10.

