### PR TITLE
Remove Outdated GNOME Rules in RHEL 10

### DIFF
--- a/controls/cis_rhel10.yml
+++ b/controls/cis_rhel10.yml
@@ -766,11 +766,15 @@ controls:
 
   - id: 1.8.10
     title: Ensure XDMCP is not enabled (Automated)
+    notes: |-
+        This was inherited from the RHEL 9 profile.
+        However, it was reported that XDMCP is no
+        longer in RHEL 10.
     levels:
       - l1_server
       - l1_workstation
     status: automated
-    rules:
+    related_rules:
       - gnome_gdm_disable_xdmcp
 
   - id: 2.1.1

--- a/products/rhel10/profiles/hipaa.profile
+++ b/products/rhel10/profiles/hipaa.profile
@@ -28,6 +28,8 @@ selections:
     - '!coreos_audit_option'
     - '!coreos_nousb_kernel_argument'
     - '!coreos_enable_selinux_kernel_argument'
+    - '!dconf_gnome_remote_access_credential_prompt'
+    - '!dconf_gnome_remote_access_encryption'
     - '!ensure_suse_gpgkey_installed'
     - '!ensure_fedora_gpgkey_installed'
     - '!grub2_uefi_admin_username'


### PR DESCRIPTION
#### Description:
Remove Outdated GNOME RHEL 10 Rules
#### Rationale:
Updates for RHEL 10.
