### PR TITLE
Add OL into jinja conditionals

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -1362,9 +1362,9 @@ controls:
       When authentication takes place through a remote application (network),
       the authentication protocol used by PAM must be secure (flow encryption,
       remote server authentication, anti-replay mechanisms, ...).
-    {{% if "rhel" in product %}}
+    {{% if "rhel" in product or "ol" in families %}}
     notes: |-
-      In RHEL systems, remote authentication is handled through sssd service.
+      In {{{ full_name }}} systems, remote authentication is handled through sssd service.
       PAM delegates requests for remote authentication to this service through a
       local Unix socket. The sssd service can use IPA, AD or LDAP as a remote
       database containing information required for authentication. In case IPA or  AD is configured through a documented way, the connection is secured by default. In case LDAP is configured manually, there are several configuration options which should be chedked.
@@ -1379,7 +1379,7 @@ controls:
       - sssd_enable_pam_services
       - sssd_ldap_configure_tls_reqcert
       - sssd_ldap_start_tls
-      {{% if product in ["rhel8"] %}}
+      {{% if product in ["rhel8","ol8"] %}}
       - ldap_client_start_tls
       - ldap_client_tls_cacertpath
       {{% endif %}}
@@ -1418,14 +1418,14 @@ controls:
       When the user databases are stored on a remote network service, NSS must
       be configured to establish a secure link that allows, at minimum, to
       authenticate the server and protect the communication channel.
-    {{% if "rhel" in product %}}
+    {{% if "rhel" in product or "ol" in families %}}
     notes: |-
       A nsswitch service connecting to remote database is provided by sssd. This is checked in requirement R67.
       Another such service is winbind which is by default configured to connect
       securely to Samba domains.
       Other relevant services are NIS and Hesiod. These should not be used.
     status: automated
-    {{% if product in ["rhel8"] %}}
+    {{% if product in ["rhel8","ol8"] %}}
     rules:
       - no_nis_in_nsswitch
     {{% endif %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["ol7"] or 'rhel' in product %}}
+{{%- if 'ol' in families or 'rhel' in product %}}
     {{%- set kmod_audit="-a always,exit -F path=/usr/bin/kmod -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=privileged" %}}
 {{%- else %}}
     {{%- set kmod_audit="-w /usr/bin/kmod -p x -k modules" %}}

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/rule.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/rule.yml
@@ -55,7 +55,7 @@ ocil: |-
 
 fixtext: |-
     Configure {{{ full_name }}} to encrypt audit records sent with audispd plugin.
-{{% if product in ["fedora", "ol8", "rhv4"] or "rhel" in product %}}
+{{% if product in ["fedora", "ol8", "ol9", "rhv4"] or "rhel" in product %}}
     Set the "transport" option in "{{{ audisp_conf_path }}}/audisp-remote.conf" to "KRB5".
 {{% else %}}
     Uncomment the "enable_krb5" option in "{{{ audisp_conf_path }}}/audisp-remote.conf",

--- a/linux_os/guide/services/obsolete/package_rsync_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/package_rsync_removed/rule.yml
@@ -1,4 +1,4 @@
-{{% if product in ['rhel8', 'rhel9'] -%}}
+{{% if product in ['rhel8', 'rhel9','ol8','ol9'] -%}}
 {{% set pkg='rsync-daemon' %}}
 {{% else %}}
 {{% set pkg='rsync' %}}

--- a/linux_os/guide/services/rng/service_rngd_enabled/rule.yml
+++ b/linux_os/guide/services/rng/service_rngd_enabled/rule.yml
@@ -47,7 +47,7 @@ warnings:
       Consequently, the rngd service can't be started in FIPS mode.
 {{% endif %}}
 
-{{% if product == "rhel9" or product == "rhel10" %}}
+{{% if product == "rhel9" or product == "rhel10" or product == "ol9" or product == "ol10" %}}
 platform: not runtime_kernel_fips_enabled
 warnings:
   - general: |-

--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/oval/shared.xml
@@ -29,7 +29,7 @@
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  {{% if product in ['rhel9'] %}}
+  {{% if product in ['rhel9','ol9'] %}}
   <ind:textfilecontent54_test id="test_trust_cpu_rng_boot_param_off"
                               comment="check kernel command line parameters for the argument for all boot entries."
                               check="all" check_existence="all_exist" version="1">

--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/oval/shared.xml
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/oval/shared.xml
@@ -11,7 +11,7 @@
       test_ref="test_logrotate_conf_no_other_keyword" />
       <criteria comment="Check if either logrotate timer or cron job is enabled" operator="OR">
         <criterion comment="Check if /etc/cron.daily/logrotate file exists (and calls logrotate)" test_ref="test_cron_daily_logrotate_existence" />
-{{% if product in ["rhcos4", "rhel9", "sle12", "sle15"] %}}
+{{% if product in ["rhcos4", "rhel9", "sle12", "sle15","ol9"] %}}
         <extend_definition comment="Check if logrotate timer is being enabled" definition_ref="timer_logrotate_enabled" />
 {{% endif %}}
       </criteria>

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/ansible/shared.yml
@@ -5,7 +5,7 @@
 # disruption = low
 
 {{# products that are available also in a 32 bits form #}}
-{{% if "rhel" not in product and product != "fedora" %}}
+{{% if "rhel" not in product and product != "fedora" and "ol" not in families %}}
 
 # What architecture are we on?
 # By default, set 32bit

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/bash/shared.sh
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/bash/shared.sh
@@ -5,7 +5,7 @@
 # disruption = low
 
 {{# products that are available also in a 32 bits form #}}
-{{% if "rhel" not in product and product != "fedora" %}}
+{{% if "rhel" not in product and product != "fedora" and "ol" not in families %}}
 if [ "$(getconf LONG_BIT)" = "32" ] ; then
   #
   # Set runtime for kernel.exec-shield

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/oval/shared.xml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/oval/shared.xml
@@ -3,7 +3,7 @@
     {{{ oval_metadata("The kernel runtime parameter 'kernel.exec-shield' should not be disabled and set to 1 on 32-bit systems.") }}}
     <criteria operator="OR">
       {{# products that are available also in a 32 bits form #}}
-      {{% if "rhel" not in product and product != "fedora" %}}
+      {{% if "rhel" not in product and product != "fedora" and "ol" not in families %}}
       <criteria operator="AND">
         <extend_definition comment="32-bit system" definition_ref="system_info_architecture_x86" />
         <criterion comment="kernel runtime parameter kernel.exec-shield set to 1" test_ref="test_runtime_sysctl_kernel_exec_shield" />

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/rule.yml
@@ -9,7 +9,7 @@ description: |-
     ExecShield or is disabled in <tt>/etc/default/grub</tt>.
 
     {{# products that are available also in a 32 bits form #}}
-    {{% if "rhel" not in product and product != "fedora" %}}
+    {{% if "rhel" not in product and product != "fedora" and "ol" not in families %}}
     For {{{ full_name }}}  32-bit systems, <tt>sysctl</tt> can be used to enable
     ExecShield.
     {{% endif %}}
@@ -56,7 +56,7 @@ ocil: |-
     {{{ ocil_grub2_argument("noexec=off") | indent(4) }}}
 
     {{# products that are available also in a 32 bits form #}}
-    {{% if "rhel" not in product and product != "fedora" %}}
+    {{% if "rhel" not in product and product != "fedora" and "ol" not in families %}}
     For 32-bit {{{ full_name }}} systems, run the following command:
     <pre>$ sysctl kernel.exec-shield</pre>
     The output should be:
@@ -65,7 +65,7 @@ ocil: |-
 
 fixtext: |-
     {{# products that are available also in a 32 bits form #}}
-    {{%- if "rhel" not in product and product != "fedora" -%}}
+    {{%- if "rhel" not in product and product != "fedora" and "ol" not in families -%}}
     On a 64-bit {{{ full_name }}} system update the GRUB bootloader configuration.
 
     {{{ fixtext_grub2_bootloader_argument_absent("noexec") | indent(4) }}}

--- a/linux_os/guide/system/software/sudo/sudo_add_env_reset/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_add_env_reset/rule.yml
@@ -6,7 +6,7 @@ title: 'Ensure sudo Runs In A Minimal Environment - sudo env_reset'
 description: |-
     The sudo <tt>env_reset</tt> tag, when specified, will run the command in a minimal environment,
     containing the TERM, PATH, HOME, MAIL, SHELL, LOGNAME, USER and SUDO_* variables.
-{{%- if 'rhel' in product %}}
+{{%- if 'rhel' in product or 'ol' in families %}}
     On {{{ full_name }}}, <tt>env_reset</tt> is enabled by default
 {{%- endif %}}
     This should be enabled by making sure that the <tt>env_reset</tt> tag exists in

--- a/linux_os/guide/system/software/sudo/sudo_add_ignore_dot/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_add_ignore_dot/rule.yml
@@ -6,8 +6,8 @@ title: 'Ensure sudo Ignores Commands In Current Dir - sudo ignore_dot'
 description: |-
     The sudo <tt>ignore_dot</tt> tag, when specified, will ignore the current directory
     in the PATH environment variable.
-{{%- if 'rhel' in product %}}
-    On {{{ full_name }}}, <tt>env_reset</tt> is enabled by default
+{{%- if 'rhel' in product or 'ol' in families %}}
+    On {{{ full_name }}}, <tt>ignore_dot</tt> is enabled by default
 {{%- endif %}}
     This should be enabled by making sure that the <tt>ignore_dot</tt> tag exists in
     <tt>/etc/sudoers</tt> configuration file or any sudo configuration snippets

--- a/linux_os/guide/system/software/sudo/sudo_add_passwd_timeout/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_add_passwd_timeout/rule.yml
@@ -5,7 +5,7 @@ title: 'Ensure sudo passwd_timeout is appropriate - sudo passwd_timeout'
 
 description: |-
     The sudo <tt>passwd_timeout</tt> tag sets the amount of time sudo password prompt waits.
-{{%- if 'rhel' in product %}}
+{{%- if 'rhel' in product or 'ol' in families %}}
     On {{{ full_name }}}, the default <tt>passwd_timeout</tt> value is 5 minutes.
 {{% endif %}}
     The passwd_timeout should be configured by making sure that the

--- a/linux_os/guide/system/software/sudo/sudo_add_umask/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_add_umask/rule.yml
@@ -6,7 +6,7 @@ title: 'Ensure sudo umask is appropriate - sudo umask'
 description: |-
     The sudo <tt>umask</tt> tag, when specified, will be added the to the user's umask in the
     command environment.
-{{%- if 'rhel' in product %}}
+{{%- if 'rhel' in product or 'ol' in families %}}
     On {{{ full_name }}}, the default <tt>umask</tt> value is 0022.
 {{% endif %}}
     The umask should be configured by making sure that the <tt>umask={{{ xccdf_value("var_sudo_umask") }}}</tt> tag exists in

--- a/products/ol9/profiles/default.profile
+++ b/products/ol9/profiles/default.profile
@@ -67,7 +67,6 @@ selections:
     - harden_sshd_ciphers_opensshserver_conf_crypto_policy
     - package_cron_installed
     - sshd_enable_gssapi_auth
-    - package_audit-audispd-plugins_installed
     - partition_for_dev_shm
     - ftp_configure_firewall
     - auditd_data_disk_error_action


### PR DESCRIPTION
#### Description:

Add OL into jinja conditionals in the following files:

controls/anssi.yml
auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/rule.yml auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/rule.yml services/obsolete/package_rsync_removed/rule.yml
services/rng/service_rngd_enabled/rule.yml
system/bootloader-grub2/grub2_kernel_trust_cpu_rng/oval/shared.xml system/logging/log_rotation/ensure_logrotate_activated/oval/shared.xml system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/ansible/shared.yml system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/bash/shared.sh system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/oval/shared.xml system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/rule.yml system/software/sudo/sudo_add_env_reset/rule.yml
system/software/sudo/sudo_add_ignore_dot/rule.yml
system/software/sudo/sudo_add_passwd_timeout/rule.yml system/software/sudo/sudo_add_umask/rule.yml

Remove package_audit-audispd-plugins_installed rule, the package is not available in OL products/ol9/profiles/default.profile

Fix word error in sudo_add_ignore_dot rule

#### Rationale:

Filling OL gaps in jinja conditionals