### PR TITLE
Update Account Home Folder Rules

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/ansible/shared.yml
@@ -24,6 +24,7 @@
   when:
     - item.value[1]|int >= {{{ uid_min }}}
     - item.value[1]|int != {{{ nobody_uid }}}
+    - item.value[4] != "/"
 
 - name: Ensure interactive local users are the owners of their respective home directories
   ansible.builtin.file:

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/bash/shared.sh
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = low
 
-for user in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) print $1 }' /etc/passwd); do
+for user in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}} && $6 != "/") print $1 }' /etc/passwd); do
     home_dir=$(getent passwd $user | cut -d: -f6)
     group=$(getent passwd $user | cut -d: -f4)
     # Only update the group-ownership when necessary. This will avoid changing the inode timestamp

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/tests/root_fs_home.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/tests/root_fs_home.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# remediation = none
+
+USER="cac_user"
+
+useradd -d"/" -M $USER

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/ansible/shared.yml
@@ -24,6 +24,7 @@
   when:
     - item.value[1]|int >= {{{ uid_min }}}
     - item.value[1]|int != {{{ nobody_uid }}}
+    - item.value[4] != "/"
 
 - name: Ensure interactive local users are the owners of their respective home directories
   ansible.builtin.file:

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/bash/shared.sh
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = low
 
-for user in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) print $1 }' /etc/passwd); do
+for user in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}} && $6 != "/") print $1 }' /etc/passwd); do
     home_dir=$(getent passwd $user | cut -d: -f6)
     # Only update the ownership when necessary. This will avoid changing the inode timestamp
     # when the owner is already defined as expected, therefore not impacting in possible integrity

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/tests/root_fs_home.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/tests/root_fs_home.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# remediation = none
+
+USER="cac_user"
+
+useradd -d"/" -M $USER

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1372,6 +1372,7 @@ Part of the grub2_bootloader_argument_absent template.
   when:
     - item.value[1]|int >= {{{ uid_min }}}
     - item.value[1]|int != {{{ nobody_uid }}}
+    - item.value[4] != "/"
 
 - name: Ensure interactive local users have proper permissions on their respective home directories
   ansible.builtin.file:

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1427,7 +1427,7 @@ fi
 
 #}}
 {{%- macro bash_restrict_permissions_home_directories(recursive=false) -%}}
-for home_dir in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) print $6 }' /etc/passwd); do
+for home_dir in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}} && "/" $6 != "/") print $6 }' /etc/passwd); do
     # Only update the permissions when necessary. This will avoid changing the inode timestamp when
     # the permission is already defined as expected, therefore not impacting in possible integrity
     # check systems that also check inodes timestamps.

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1427,7 +1427,7 @@ fi
 
 #}}
 {{%- macro bash_restrict_permissions_home_directories(recursive=false) -%}}
-for home_dir in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}} && "/" $6 != "/") print $6 }' /etc/passwd); do
+for home_dir in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}} && $6 != "/") print $6 }' /etc/passwd); do
     # Only update the permissions when necessary. This will avoid changing the inode timestamp when
     # the permission is already defined as expected, therefore not impacting in possible integrity
     # check systems that also check inodes timestamps.


### PR DESCRIPTION
#### Description:



The following now skip users with home folders defined as `/`.
* Macros 
    * `bash_restrict_permissions_home_directories`  
    * `ansible_restrict_permissions_home_directories`
* Rules
  * accounts_users_home_files_groupownership
  * accounts_users_home_files_ownership 

#### Rationale:
Ensuring the scripts complete successfully with a user doesn't a proper home folder defined.