### PR TITLE
Remove enable_dracut_fips_module from RHEL 10 profiles

### DIFF
--- a/products/rhel10/profiles/ism_o.profile
+++ b/products/rhel10/profiles/ism_o.profile
@@ -42,3 +42,5 @@ selections:
     - '!rpm_verify_hashes'
     # this rule should not be needed anymore on RHEL 10, but investigation is recommended
     - '!openssl_use_strong_entropy'
+    # Currently not working RHEL 10, changes are being made to FIPS mode. Investigation is recommended.
+    - '!enable_dracut_fips_module'

--- a/products/rhel10/profiles/ism_o_secret.profile
+++ b/products/rhel10/profiles/ism_o_secret.profile
@@ -44,3 +44,5 @@ selections:
     - '!rpm_verify_hashes'
     # this rule should not be needed anymore on RHEL 10, but investigation is recommended
     - '!openssl_use_strong_entropy'
+    # Currently not working RHEL 10, changes are being made to FIPS mode. Investigation is recommended.
+    - '!enable_dracut_fips_module'

--- a/products/rhel10/profiles/ism_o_top_secret.profile
+++ b/products/rhel10/profiles/ism_o_top_secret.profile
@@ -42,3 +42,5 @@ selections:
     - '!rpm_verify_hashes'
     # this rule should not be needed anymore on RHEL 10, but investigation is recommended
     - '!openssl_use_strong_entropy'
+    # Currently not working RHEL 10, changes are being made to FIPS mode. Investigation is recommended.
+    - '!enable_dracut_fips_module'

--- a/products/rhel10/profiles/ospp.profile
+++ b/products/rhel10/profiles/ospp.profile
@@ -22,3 +22,5 @@ selections:
     - ospp:all
     - '!package_screen_installed'
     - '!package_dnf-plugin-subscription-manager_installed'
+    # Currently not working RHEL 10, changes are being made to FIPS mode. Investigation is recommended.
+    - '!enable_dracut_fips_module'

--- a/products/rhel10/profiles/stig.profile
+++ b/products/rhel10/profiles/stig.profile
@@ -20,3 +20,5 @@ description: |-
 
 selections:
     - srg_gpos:all
+    # Currently not working RHEL 10, changes are being made to FIPS mode. Investigation is recommended.
+    - '!enable_dracut_fips_module'

--- a/products/rhel10/profiles/stig_gui.profile
+++ b/products/rhel10/profiles/stig_gui.profile
@@ -32,3 +32,5 @@ selections:
     - '!sysctl_user_max_user_namespaces'
     # locking of idle sessions is handled by screensaver when GUI is present, the following rule is therefore redundant
     - '!logind_session_timeout'
+    # Currently not working RHEL 10, changes are being made to FIPS mode. Investigation is recommended.
+    - '!enable_dracut_fips_module'


### PR DESCRIPTION

#### Description:

Remove enable_dracut_fips_module from RHEL 10 profiles 

#### Rationale:

Due to changes being in FIPS mode in RHEL 10 is rule is being removed for now.

#### Review Hints:
1. `$ ./build_product rhel10 `
2.  `grep 'enable_dracut_fips_module' build/ssg-rhel10-ds.xml`
3. Observe the rule is no longer in the data stream.
