### PR TITLE
Add the system_with_kernel CPE platform

### DIFF
--- a/.github/workflows/automatus-cs9.yaml
+++ b/.github/workflows/automatus-cs9.yaml
@@ -136,7 +136,7 @@ jobs:
           name: ${{ env.DATASTREAM }}
       - name: Run tests in a container - Bash
         if: ${{steps.bash.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        run: tests/test_rule_in_container.sh --no-remove-machine-only --dontclean --logdir logs_bash --remediate-using bash --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
+        run: tests/test_rule_in_container.sh --no-make-applicable-in-containers --dontclean --logdir logs_bash --remediate-using bash --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
         env:
           ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --remove-fips-certified --product rhel9"
       - name: Check for ERROR in logs
@@ -157,7 +157,7 @@ jobs:
           path: logs_bash/
       - name: Run tests in a container - Ansible
         if: ${{ steps.ansible.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        run: tests/test_rule_in_container.sh --no-remove-machine-only --dontclean --logdir logs_ansible --remediate-using ansible --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
+        run: tests/test_rule_in_container.sh --no-make-applicable-in-containers --dontclean --logdir logs_ansible --remediate-using ansible --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
         env:
           ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --remove-fips-certified --product rhel9"
       - name: Check for ERROR in logs

--- a/.github/workflows/automatus-debian12.yaml
+++ b/.github/workflows/automatus-debian12.yaml
@@ -152,7 +152,7 @@ jobs:
           name: ${{ env.DATASTREAM }}
       - name: Run tests in a container - Bash
         if: ${{steps.bash.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        run: tests/test_rule_in_container.sh --no-remove-machine-only --dontclean --logdir logs_bash --remediate-using bash --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
+        run: tests/test_rule_in_container.sh --no-make-applicable-in-containers --dontclean --logdir logs_bash --remediate-using bash --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
         env:
           ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --remove-fips-certified"
       - name: Check for ERROR in logs
@@ -173,7 +173,7 @@ jobs:
           path: logs_bash/
       - name: Run tests in a container - Ansible
         if: ${{ steps.ansible.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        run: tests/test_rule_in_container.sh --no-remove-machine-only --dontclean --logdir logs_ansible --remediate-using ansible --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
+        run: tests/test_rule_in_container.sh --no-make-applicable-in-containers --dontclean --logdir logs_ansible --remediate-using ansible --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
         env:
           ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --remove-fips-certified --product debian12"
       - name: Check for ERROR in logs

--- a/.github/workflows/automatus-sanity.yaml
+++ b/.github/workflows/automatus-sanity.yaml
@@ -53,13 +53,13 @@ jobs:
         with:
           name: ${{ env.DATASTREAM }}
       - name: Check One Rule
-        run: ./tests/automatus.py rule --remove-platforms --remove-machine-only --logdir log_rule --datastream ssg-fedora-ds.xml --container ssg_test_suite package_sudo_installed
+        run: ./tests/automatus.py rule --remove-platforms --make-applicable-in-containers --logdir log_rule --datastream ssg-fedora-ds.xml --container ssg_test_suite package_sudo_installed
       - name: Check One Rule - Ansible
-        run: ./tests/automatus.py rule --remove-platforms --remove-machine-only --logdir log_rule_ansible --remediate-using ansible --datastream ssg-fedora-ds.xml --container ssg_test_suite package_sudo_installed
+        run: ./tests/automatus.py rule --remove-platforms --make-applicable-in-containers --logdir log_rule_ansible --remediate-using ansible --datastream ssg-fedora-ds.xml --container ssg_test_suite package_sudo_installed
       - name: Check Profile Mode
-        run: ./tests/automatus.py profile --remove-platforms --remove-machine-only --logdir log_profile --datastream ssg-fedora-ds.xml --container ssg_test_suite test
+        run: ./tests/automatus.py profile --remove-platforms --make-applicable-in-containers --logdir log_profile --datastream ssg-fedora-ds.xml --container ssg_test_suite test
       - name: Check Combined Mode
-        run: ./tests/automatus.py combined --remove-platforms --remove-machine-only --logdir log_combined --datastream ssg-fedora-ds.xml --container ssg_test_suite test
+        run: ./tests/automatus.py combined --remove-platforms --make-applicable-in-containers --logdir log_combined --datastream ssg-fedora-ds.xml --container ssg_test_suite test
       - name: Check Template Mode
         run: ./tests/automatus.py template --logdir log_template --datastream ssg-fedora-ds.xml --container ssg_test_suite --slice 1 15 file_owner
       - name: Check for ERROR in logs

--- a/.github/workflows/automatus-sle15.yaml
+++ b/.github/workflows/automatus-sle15.yaml
@@ -144,7 +144,7 @@ jobs:
           name: ${{ env.DATASTREAM }}
       - name: Run tests in a container - Bash
         if: ${{steps.bash.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        run: tests/test_rule_in_container.sh --no-remove-machine-only --dontclean --logdir logs_bash --remediate-using bash --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
+        run: tests/test_rule_in_container.sh --no-make-applicable-in-containers --dontclean --logdir logs_bash --remediate-using bash --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
         env:
           ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --remove-fips-certified --product sle15"
       - name: Check for ERROR in logs
@@ -165,7 +165,7 @@ jobs:
           path: logs_bash/
       - name: Run tests in a container - Ansible
         if: ${{ steps.ansible.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        run: tests/test_rule_in_container.sh --no-remove-machine-only --dontclean --logdir logs_ansible --remediate-using ansible --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
+        run: tests/test_rule_in_container.sh --no-make-applicable-in-containers --dontclean --logdir logs_ansible --remediate-using ansible --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
         env:
           ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --remove-fips-certified --product sle15"
       - name: Check for ERROR in logs

--- a/.github/workflows/automatus-ubi8.yaml
+++ b/.github/workflows/automatus-ubi8.yaml
@@ -136,7 +136,7 @@ jobs:
           name: ${{ env.DATASTREAM }}
       - name: Run tests in a container - Bash
         if: ${{steps.bash.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        run: tests/test_rule_in_container.sh --no-remove-machine-only --dontclean --logdir logs_bash --remediate-using bash --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
+        run: tests/test_rule_in_container.sh --no-make-applicable-in-containers --dontclean --logdir logs_bash --remediate-using bash --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
         env:
           ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --remove-fips-certified --product rhel8"
       - name: Check for ERROR in logs
@@ -157,7 +157,7 @@ jobs:
           path: logs_bash/
       - name: Run tests in a container - Ansible
         if: ${{ steps.ansible.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        run: tests/test_rule_in_container.sh --no-remove-machine-only --dontclean --logdir logs_ansible --remediate-using ansible --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
+        run: tests/test_rule_in_container.sh --no-make-applicable-in-containers --dontclean --logdir logs_ansible --remediate-using ansible --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
         env:
           ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --remove-fips-certified --product rhel8"
       - name: Check for ERROR in logs

--- a/.github/workflows/automatus-ubuntu2204.yaml
+++ b/.github/workflows/automatus-ubuntu2204.yaml
@@ -152,7 +152,7 @@ jobs:
           name: ${{ env.DATASTREAM }}
       - name: Run tests in a container - Bash
         if: ${{steps.bash.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        run: tests/test_rule_in_container.sh --no-remove-machine-only --dontclean --logdir logs_bash --remediate-using bash --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
+        run: tests/test_rule_in_container.sh --no-make-applicable-in-containers --dontclean --logdir logs_bash --remediate-using bash --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
         env:
           ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --remove-fips-certified"
       - name: Check for ERROR in logs
@@ -173,7 +173,7 @@ jobs:
           path: logs_bash/
       - name: Run tests in a container - Ansible
         if: ${{ steps.ansible.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        run: tests/test_rule_in_container.sh --no-remove-machine-only --dontclean --logdir logs_ansible --remediate-using ansible --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
+        run: tests/test_rule_in_container.sh --no-make-applicable-in-containers --dontclean --logdir logs_ansible --remediate-using ansible --name ssg_test_suite --datastream $DATASTREAM ${{join(fromJSON(steps.rules.outputs.prop))}}
         env:
           ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --remove-fips-certified --product ubuntu2204"
       - name: Check for ERROR in logs

--- a/.github/workflows/automatus.yaml
+++ b/.github/workflows/automatus.yaml
@@ -134,7 +134,7 @@ jobs:
           name: ssg-${{steps.product.outputs.prop}}-ds.xml
       - name: Run tests in a container - Bash
         if: ${{steps.bash.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        run: tests/test_rule_in_container.sh --no-remove-machine-only --dontclean --logdir logs_bash --remediate-using bash --name ssg_test_suite --datastream ssg-${{steps.product.outputs.prop}}-ds.xml ${{join(fromJSON(steps.rules.outputs.prop))}}
+        run: tests/test_rule_in_container.sh --no-make-applicable-in-containers --dontclean --logdir logs_bash --remediate-using bash --name ssg_test_suite --datastream ssg-${{steps.product.outputs.prop}}-ds.xml ${{join(fromJSON(steps.rules.outputs.prop))}}
         env:
           ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --remove-fips-certified"
       - name: Check for ERROR in logs
@@ -155,7 +155,7 @@ jobs:
           path: logs_bash/
       - name: Run tests in a container - Ansible
         if: ${{ steps.ansible.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        run: tests/test_rule_in_container.sh --no-remove-machine-only --dontclean --logdir logs_ansible --remediate-using ansible --name ssg_test_suite --datastream ssg-${{steps.product.outputs.prop}}-ds.xml ${{join(fromJSON(steps.rules.outputs.prop))}}
+        run: tests/test_rule_in_container.sh --no-make-applicable-in-containers --dontclean --logdir logs_ansible --remediate-using ansible --name ssg_test_suite --datastream ssg-${{steps.product.outputs.prop}}-ds.xml ${{join(fromJSON(steps.rules.outputs.prop))}}
         env:
           ADDITIONAL_TEST_OPTIONS: "--duplicate-templates --remove-fips-certified"
       - name: Check for ERROR in logs

--- a/.gitpod.launch.json
+++ b/.gitpod.launch.json
@@ -57,7 +57,7 @@
           "${workspaceFolder}/build/ssg-${input:pickProductName}-ds.xml",
           "--remediate-using",
           "${input:pickRemediationType}",
-          "--remove-machine-only",
+          "--make-applicable-in-containers",
           "--remove-ocp4-only",
           "--remove-fips-certified",
           "--remove-platforms",

--- a/docs/workshop/lab3_profiles.adoc
+++ b/docs/workshop/lab3_profiles.adoc
@@ -645,7 +645,7 @@ You also add arguments to turn on full reporting, which generates XML and HTML r
             --docker {container_name} \
             --datastream build/ssg-rhel8-ds.xml \
             --remediate-using bash \
-            --remove-machine-only \
+            --make-applicable-in-containers \
             --remove-platforms \
             --logdir profile-log \
             travel

--- a/docs/workshop/lab5_oval.adoc
+++ b/docs/workshop/lab5_oval.adoc
@@ -275,7 +275,7 @@ With that in mind, execute the test suite:
             --docker {container_name} \
             --datastream build/ssg-rhel8-ds.xml \
             --remediate-using bash \
-            --remove-machine-only \
+            --make-applicable-in-containers \
             --remove-platforms \
             accounts_tmout
 ----
@@ -431,7 +431,7 @@ TIP: You can use the `Up` arrow key to browse the command history so you do not 
             --docker {container_name} \
             --datastream build/ssg-rhel8-ds.xml \
             --remediate-using bash \
-            --remove-machine-only \
+            --make-applicable-in-containers \
             --remove-platforms \
             accounts_tmout
 ----
@@ -571,7 +571,7 @@ This way, you do not have to worry about possibly introducing those link:https:/
 [... ]$ SSH_ADDITIONAL_OPTIONS="-o IdentityFile=/workspace/content/.ssh/id_rsa" tests/automatus.py rule \
             --docker {container_name} \
             --remediate-using bash \
-            --remove-machine-only \
+            --make-applicable-in-containers \
             --remove-platforms \
             accounts_tmout
 ----
@@ -654,7 +654,7 @@ fi
 [... ]$ SSH_ADDITIONAL_OPTIONS="-o IdentityFile=/workspace/content/.ssh/id_rsa" tests/automatus.py rule \
             --docker {container_name} \
             --remediate-using bash \
-            --remove-machine-only \
+            --make-applicable-in-containers \
             --remove-platforms \
             accounts_tmout
 ----
@@ -703,7 +703,7 @@ This time, when rebuilt and executed again, the tests pass:
 [... ]$ SSH_ADDITIONAL_OPTIONS="-o IdentityFile=/workspace/content/.ssh/id_rsa" tests/automatus.py rule \
             --docker {container_name} \
             --remediate-using bash \
-            --remove-machine-only \
+            --make-applicable-in-containers \
             --remove-platforms \
             accounts_tmout
 ----
@@ -755,7 +755,7 @@ Execute the test suite again and expect the `ERROR - Script correct_value.pass.s
 [... ]$ SSH_ADDITIONAL_OPTIONS="-o IdentityFile=/workspace/content/.ssh/id_rsa" tests/automatus.py rule \
             --docker {container_name} \
             --remediate-using bash \
-            --remove-machine-only \
+            --make-applicable-in-containers \
             --remove-platforms \
             accounts_tmout
 ----
@@ -802,7 +802,7 @@ The non-capturing group that consists of `export` followed by at least one white
 [... ]$ SSH_ADDITIONAL_OPTIONS="-o IdentityFile=/workspace/content/.ssh/id_rsa" tests/automatus.py rule \
             --docker {container_name} \
             --remediate-using bash \
-            --remove-machine-only \
+            --make-applicable-in-containers \
             --remove-platforms \
             accounts_tmout
 ----

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/rule.yml
@@ -24,7 +24,7 @@ rationale: |-
 
 severity: high
 
-platform: machine
+platform: system_with_kernel
 
 identifiers:
     cce@rhcos4: CCE-82553-9

--- a/shared/applicability/oval/system_with_kernel.xml
+++ b/shared/applicability/oval/system_with_kernel.xml
@@ -1,0 +1,9 @@
+<def-group>
+  <definition class="inventory" id="system_with_kernel" version="1">
+    {{{ oval_metadata("The kernel is installed", affected_platforms=["multi_platform_all"]) }}}
+    <criteria operator="AND">
+      <criterion comment="kernel is installed" test_ref="inventory_test_kernel_installed" />
+    </criteria>
+  </definition>
+{{{ oval_test_package_installed(package="kernel", test_id="inventory_test_kernel_installed") }}}
+</def-group>

--- a/shared/applicability/system_with_kernel.yml
+++ b/shared/applicability/system_with_kernel.yml
@@ -1,0 +1,23 @@
+name: cpe:/a:system_with_kernel
+title: Bare-metal systems, virtual machines, bootc container images, running bootc systems
+# Common platform for all systems that aren't containers
+# Matches:
+# - normal bare-metal systems or VMs
+# - running bootc (RHEL Image Mode) systems
+# - bootc (RHEL Image Mode) containers and container images
+# Does not match:
+# - classic containers and container images
+#
+# The matching platforms and non-matching platforms can be easily distinguished
+# by checking for presence of the kernel RPM package. All matching platforms
+# have in common that they contain kernel.
+#
+# In most cases, this platform is assigned to rules where the "machine" platform
+# was set in past.
+check_id: system_with_kernel
+{{% if pkg_system == "rpm" %}}
+bash_conditional: "rpm --quiet -q kernel"
+{{% else %}}
+bash_conditional: "dpkg-query --show --showformat='${db:Status-Status}\n' 'kernel' 2>/dev/null | grep -q installed"
+{{% endif %}}
+ansible_conditional: '"kernel" in ansible_facts.packages'

--- a/tests/README.md
+++ b/tests/README.md
@@ -406,7 +406,7 @@ Using Podman:
 ```
 
 or just call the `test_rule_in_container.sh` script that passes the backend options for you
-in addition to `--remove-machine-only` and `--remove-platforms`
+in addition to `--make-applicable-in-containers` and `--remove-platforms`
 that remove some testing limitations of the container backend.
 
 Using Docker:

--- a/tests/automatus.py
+++ b/tests/automatus.py
@@ -92,10 +92,10 @@ def parse_args():
             "Although more low level platforms such as packages or container/machine "
             "CPE are still applicable.")
     common_parser.add_argument(
-            "--remove-machine-only",
+            "--make-applicable-in-containers",
             default=False,
             action="store_true",
-            help="Removes machine-only platform constraint from rules "
+            help="Removes platform constraints from rules "
             "to enable testing these rules on container backends.")
     common_parser.add_argument(
             "--remove-ocp4-only",
@@ -501,9 +501,8 @@ def main():
         with xml_operations.datastream_root(stashed_datastream, stashed_datastream) as root:
             if options.remove_platforms:
                 xml_operations.remove_platforms(root)
-            if options.remove_machine_only:
-                xml_operations.remove_machine_platform(root)
-                xml_operations.remove_machine_remediation_condition(root)
+            if options.make_applicable_in_containers:
+                xml_operations.make_applicable_in_containers(root)
             if options.remove_ocp4_only:
                 xml_operations.remove_ocp4_platforms(root)
             if options.add_platform:

--- a/tests/ssg_test_suite/xml_operations.py
+++ b/tests/ssg_test_suite/xml_operations.py
@@ -107,6 +107,11 @@ def instance_in_platforms(inst, platforms):
         (hasattr(platforms, "__iter__") and inst.get("idref") in platforms)
 
 
+def make_applicable_in_containers(root):
+    remove_machine_platform(root)
+    remove_machine_remediation_condition(root)
+
+
 def remove_machine_platform(root):
     remove_platforms_from_element(root, "xccdf-1.2:Rule", "cpe:/a:machine")
     remove_platforms_from_element(root, "xccdf-1.2:Group", "cpe:/a:machine")

--- a/tests/ssg_test_suite/xml_operations.py
+++ b/tests/ssg_test_suite/xml_operations.py
@@ -112,6 +112,8 @@ def remove_machine_platform(root):
     remove_platforms_from_element(root, "xccdf-1.2:Group", "cpe:/a:machine")
     remove_platforms_from_element(root, "xccdf-1.2:Rule", "#machine")
     remove_platforms_from_element(root, "xccdf-1.2:Group", "#machine")
+    remove_platforms_from_element(root, "xccdf-1.2:Rule", "#system_with_kernel")
+    remove_platforms_from_element(root, "xccdf-1.2:Group", "#system_with_kernel")
 
 
 def remove_platforms(root):
@@ -141,6 +143,7 @@ def remove_bash_machine_remediation_condition(root):
     system = "urn:xccdf:fix:script:sh"
     considered_machine_platform_checks = [
         r"\[\s+!\s+-f\s+/\.dockerenv\s+\]\s+&&\s+\[\s+!\s+-f\s+/run/\.containerenv\s+\]",
+        r"rpm\s+--quiet\s+-q\s+kernel"
     ]
     repl = "true"
     _replace_in_fix(root, system, considered_machine_platform_checks, repl)
@@ -150,6 +153,7 @@ def remove_ansible_machine_remediation_condition(root):
     system = "urn:xccdf:fix:script:ansible"
     considered_machine_platform_checks = [
         r"\bansible_virtualization_type\s+not\s+in.*docker.*",
+        r"\"kernel\"\s+in\s+ansible_facts.packages"
     ]
     repl = "True"
     _replace_in_fix(root, system, considered_machine_platform_checks, repl)

--- a/tests/test_rule_in_container.sh
+++ b/tests/test_rule_in_container.sh
@@ -7,7 +7,7 @@
 # ARG_OPTIONAL_SINGLE([remediate-using],[r],[What to remediate with],[oscap])
 # ARG_OPTIONAL_SINGLE([logdir],[l],[Directory where logs will be stored])
 # ARG_OPTIONAL_BOOLEAN([dontclean],[],[Don't remove HTML reports from the log directory.])
-# ARG_OPTIONAL_BOOLEAN([remove-machine-only],[],[Don't remove machine platforms.],[on])
+# ARG_OPTIONAL_BOOLEAN([make-applicable-in-containers],[],[Remove some platforms to make the rule applicable in containers.],[on])
 # ARG_OPTIONAL_BOOLEAN([dry-run],[],[Just print the test suite command-line.])
 # ARG_OPTIONAL_BOOLEAN([docker],[],[Use Docker instead of Podman as container backend.])
 # ARG_USE_ENV([ADDITIONAL_SSGTS_OPTIONS],[],[Deprecated, use ADDITIONAL_TEST_OPTIONS])
@@ -65,7 +65,7 @@ _arg_datastream=
 _arg_remediate_using="oscap"
 _arg_logdir=
 _arg_dontclean="off"
-_arg_remove_machine_only="on"
+_arg_make_applicable_in_containers="on"
 _arg_dry_run="off"
 _arg_docker="off"
 
@@ -73,7 +73,7 @@ _arg_docker="off"
 print_help()
 {
 	printf '%s\n' "Test a rule using the container backend."
-	printf 'Usage: %s [-n|--name <arg>] [-s|--scenarios <arg>] [-d|--datastream <arg>] [-r|--remediate-using <REMEDIATION>] [-l|--logdir <arg>] [--(no-)dontclean] [--(no-)remove-machine-only] [--(no-)dry-run] [--(no-)docker] [-h|--help] <rule-1> [<rule-2>] ... [<rule-n>] ...\n' "$0"
+	printf 'Usage: %s [-n|--name <arg>] [-s|--scenarios <arg>] [-d|--datastream <arg>] [-r|--remediate-using <REMEDIATION>] [-l|--logdir <arg>] [--(no-)dontclean] [--(no-)make-applicable-in-containers] [--(no-)dry-run] [--(no-)docker] [-h|--help] <rule-1> [<rule-2>] ... [<rule-n>] ...\n' "$0"
 	printf '\t%s\n' "<rule>: The short rule ID. Wildcards are supported."
 	printf '\t%s\n' "-n, --name: Name of the test image (default: 'ssg_test_suite')"
 	printf '\t%s\n' "-s, --scenarios: Regex to reduce selection of tested scenarios (no default)"
@@ -81,7 +81,7 @@ print_help()
 	printf '\t%s\n' "-r, --remediate-using: What to remediate with. Can be one of: 'oscap', 'bash' and 'ansible' (default: 'oscap')"
 	printf '\t%s\n' "-l, --logdir: Directory where logs will be stored (no default)"
 	printf '\t%s\n' "--dontclean, --no-dontclean: Don't remove HTML reports from the log directory. (off by default)"
-	printf '\t%s\n' "--remove-machine-only, --no-remove-machine-only: Remove machine platforms. (on by default)"
+	printf '\t%s\n' "--make-applicable-in-containers, --no-make-applicable-in-containers: Remove some platforms to make the rule applicable in containers. (on by default)"
 	printf '\t%s\n' "--dry-run, --no-dry-run: Just print the test suite command-line. (off by default)"
 	printf '\t%s\n' "--docker, --no-docker: Use Docker instead of Podman as container backend. (off by default)"
 	printf '\t%s\n' "-h, --help: Prints help"
@@ -158,9 +158,9 @@ parse_commandline()
 				_arg_dontclean="on"
 				test "${1:0:5}" = "--no-" && _arg_dontclean="off"
 				;;
-			--no-remove-machine-only|--remove-machine-only)
-				_arg_remove_machine_only="on"
-				test "${1:0:5}" = "--no-" && _arg_remove_machine_only="off"
+			--no-make-applicable-in-containers|--make-applicable-in-containers)
+				_arg_make_applicable_in_containers="on"
+				test "${1:0:5}" = "--no-" && _arg_make_applicable_in_containers="off"
 				;;
 			--no-dry-run|--dry-run)
 				_arg_dry_run="on"
@@ -237,7 +237,7 @@ $CONTAINER_BACKEND images | grep -q "$_arg_name" || die "Couldn't find the $CONT
 
 additional_args=()
 test "$_arg_dontclean" = on && additional_args+=(--dontclean)
-test "$_arg_remove_machine_only" = on && additional_args+=(--remove-machine-only)
+test "$_arg_make_applicable_in_containers" = on && additional_args+=(--make-applicable-in-containers)
 
 # Don't act on the default value.
 test -n "$_arg_scenarios" && additional_args+=(--scenario "$_arg_scenarios")


### PR DESCRIPTION
### Description:

The system_with_kernel CPE platform will be a common platform matching all systems that aren't containers.

Matches:
- normal bare-metal systems or VMs
- running bootc (RHEL Image Mode) systems
- bootc (RHEL Image Mode) containers and container images

Does not match:
- classic containers and container images

The matching platforms and non-matching platforms can be easily distinguished by checking for presence of the kernel RPM package. All matching platforms have in common that they contain kernel.

Conceptually this platform is an alias of the `package[kernel]` platform but unfortunately we don't have a way of creating aliases for CPE platforms, therefore we create a new platform.

For more details, please read commit messages of all commits.

#### Automatus changes

The introduction of the platform causes a need for changes in Automatus which are also done in this PR. The option `--remove-machine-only` is renamed to `--make-applicable-in-containers`. The `--make-applicable-in-containers` will remove the `machine` and `system_with_kernel` platforms from the tested rules in order to make the rules applicable in containers.

### Rationale:

This new platform will be assigned to many rules instead of machine platform to make these rules applicable also during the bootc container image build.

This PR supports RHEL Image Mode effort.


