### PR TITLE
[ubuntu] Set the default behaviour of AppArmor to enforce

### DIFF
--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -162,7 +162,7 @@ selections:
     - grub2_enable_apparmor
 
     #### 1.7.1.3 Ensure all AppArmor Profiles are in enforce or complain mode (Automated)
-    - var_apparmor_mode=complain
+    - var_apparmor_mode=enforce
     - all_apparmor_profiles_in_enforce_complain_mode
 
     #### 1.7.1.4 Ensure all AppArmor Profiles are enforcing (Automated)

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -157,7 +157,7 @@ selections:
     - grub2_enable_apparmor
 
     #### 1.6.1.3 Ensure all AppArmor Profiles are in enforce or complain mode (Automated)
-    - var_apparmor_mode=complain
+    - var_apparmor_mode=enforce
     - all_apparmor_profiles_in_enforce_complain_mode
 
     #### 1.6.1.4 Ensure all AppArmor Profiles are enforcing (Automated)


### PR DESCRIPTION
#### Description:

- Set the default behavior of AppArmor to enforce in CIS Level1 profile in Ubuntu

#### Rationale:

- Change the current default mode "complain" in cis level1 to enforce mode.