### PR TITLE
Load all the profile if not loaded for Ubuntu

### DIFF
--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/rule.yml
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/rule.yml
@@ -34,4 +34,4 @@ references:
     cis@ubuntu2004: 1.7.1.4
     cis@ubuntu2204: 1.6.1.4
 
-platform: package[apparmor]
+platform: machine

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/rule.yml
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/rule.yml
@@ -34,4 +34,4 @@ references:
     cis@ubuntu2004: 1.7.1.4
     cis@ubuntu2204: 1.6.1.4
 
-platform: machine
+platform: machine and package[apparmor]

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/sce/shared.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/sce/shared.sh
@@ -5,7 +5,7 @@
 # If apparmor or apparmor-utils are not installed, then this test fails.
 {{{ bash_package_installed("apparmor") }}}
 if [ $? -ne 0 ]; then
-        exit ${XCCDF_RESULT_FAIL}
+    exit ${XCCDF_RESULT_FAIL}
 fi
 
 # if number of apparmor profiles loaded not the same as enforced profiles, then it fails.

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/correct_apparmor_profiles_enforced.pass.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/correct_apparmor_profiles_enforced.pass.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# platform = multi_platform_rhel,multi_platform_ubuntu
+# packages = apparmor-utils
 
 #Replace apparmor definitions
 apparmor_parser -q -r /etc/apparmor.d/

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/correct_apparmor_profiles_enforced.pass.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/correct_apparmor_profiles_enforced.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# platform = multi_platform_sle
 # packages = apparmor-utils
 
 #Replace apparmor definitions

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/correct_apparmor_profiles_enforced.pass.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/correct_apparmor_profiles_enforced.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_rhel,multi_platform_ubuntu
+# platform = multi_platform_sle,multi_platform_ubuntu
 # packages = apparmor-utils
 
 #Replace apparmor definitions

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/correct_apparmor_profiles_enforced.pass.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/correct_apparmor_profiles_enforced.pass.sh
@@ -5,3 +5,9 @@
 apparmor_parser -q -r /etc/apparmor.d/
 #Set all profiles in enforce mode
 aa-enforce /etc/apparmor.d/*
+
+# rsyslogd apparmor profile is disabled in focal and jammy.
+# Reloading the profile results in an unconfined process
+# which fails the SCE, so we need to restart the process manually.
+systemctl restart rsyslog
+

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/correct_apparmor_profiles_enforced.pass.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/correct_apparmor_profiles_enforced.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_sle
 # packages = apparmor-utils
 
 #Replace apparmor definitions

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/incorrect_apparmor_profiles.fail.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/incorrect_apparmor_profiles.fail.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# platform = multi_platform_rhel,multi_platform_ubuntu
+# packages = apparmor
 
 #Configure the OS to unload all AppArmor profiles
 aa-teardown

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/incorrect_apparmor_profiles.fail.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/incorrect_apparmor_profiles.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# platform = multi_platform_sle
 # packages = apparmor
 
 #Configure the OS to unload all AppArmor profiles

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/incorrect_apparmor_profiles.fail.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/incorrect_apparmor_profiles.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_sle
 # packages = apparmor
 
 #Configure the OS to unload all AppArmor profiles

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/incorrect_apparmor_profiles.fail.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/incorrect_apparmor_profiles.fail.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-# packages = apparmor
-
-#Configure the OS to unload all AppArmor profiles
-aa-teardown

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/incorrect_apparmor_profiles.fail.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/incorrect_apparmor_profiles.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_rhel,multi_platform_ubuntu
+# platform = multi_platform_sle,multi_platform_ubuntu
 # packages = apparmor
 
 #Configure the OS to unload all AppArmor profiles

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/incorrect_apparmor_profiles_enforced.fail.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/incorrect_apparmor_profiles_enforced.fail.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# platform = multi_platform_rhel,multi_platform_ubuntu
+# packages = apparmor
 
 #Replace apparmor definitions and force profiles into compliant mode
 apparmor_parser -C -q -r  /etc/apparmor.d/ 

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/incorrect_apparmor_profiles_enforced.fail.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/incorrect_apparmor_profiles_enforced.fail.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
-# packages = apparmor
+# packages = apparmor-utils
 
 #Replace apparmor definitions and force profiles into compliant mode
-apparmor_parser -C -q -r  /etc/apparmor.d/ 
+apparmor_parser -q -r  /etc/apparmor.d/ 
+#Set all profiles in complain mode
+aa-complain /etc/apparmor.d/*
+
+# rsyslogd apparmor profile is disabled in focal and jammy.
+# Reloading the profile results in an unconfined process
+# which fails the SCE, so we need to restart the process manually.
+systemctl restart rsyslog

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/incorrect_apparmor_profiles_enforced.fail.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/incorrect_apparmor_profiles_enforced.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_sle
 # packages = apparmor
 
 #Replace apparmor definitions and force profiles into compliant mode

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/incorrect_apparmor_profiles_enforced.fail.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/incorrect_apparmor_profiles_enforced.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_rhel,multi_platform_ubuntu
+# platform = multi_platform_sle,multi_platform_ubuntu
 # packages = apparmor
 
 #Replace apparmor definitions and force profiles into compliant mode

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/incorrect_apparmor_profiles_enforced.fail.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/incorrect_apparmor_profiles_enforced.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# platform = multi_platform_sle
 # packages = apparmor
 
 #Replace apparmor definitions and force profiles into compliant mode

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/bash/shared.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/bash/shared.sh
@@ -19,8 +19,14 @@ fi
 
 if [ "$APPARMOR_MODE" = "complain" ]
 then
+  {{% if 'ubuntu' in product %}}
+  # Load all not-loaded profiles into complain mode
+  apparmor_parser -a --Complain /etc/apparmor.d/
+  echo "***WARNING***: This remediation will not downgrade any existing AppArmor profiles."
+  {{% else %}}
   # Set all profiles to complain mode
   aa-complain /etc/apparmor.d/*
+  {{% endif %}}
 fi
 
 {{% if 'ubuntu' in product %}}

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/bash/shared.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/bash/shared.sh
@@ -13,8 +13,13 @@ APPARMOR_MODE="$var_apparmor_mode"
 
 if [ "$APPARMOR_MODE" = "enforce" ]
 then
+  {{% if 'ubuntu' in product %}}
+  # Set all profiles to enforce mode except disabled profiles
+  find /etc/apparmor.d -maxdepth 1 ! -type d -exec bash -c '[[ -e "/etc/apparmor.d/disable/$(basename "{}")" ]] || aa-enforce "{}"' \;
+  {{% else %}}
   # Set all profiles to enforce mode
   aa-enforce /etc/apparmor.d/*
+  {{% endif %}}
 fi
 
 if [ "$APPARMOR_MODE" = "complain" ]

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/bash/shared.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/bash/shared.sh
@@ -15,7 +15,7 @@ if [ "$APPARMOR_MODE" = "enforce" ]
 then
   {{% if 'ubuntu' in product %}}
   # Set all profiles to enforce mode except disabled profiles
-  find /etc/apparmor.d -maxdepth 1 ! -type d -exec bash -c '[[ -e "/etc/apparmor.d/disable/$(basename "{}")" ]] || aa-enforce "{}"' \;
+  find /etc/apparmor.d -maxdepth 1 ! -type d -exec bash -c '[[ -e "/etc/apparmor.d/disable/$(basename "$1")" ]] || aa-enforce "$1"' _ {} \;
   {{% else %}}
   # Set all profiles to enforce mode
   aa-enforce /etc/apparmor.d/*

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/rule.yml
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/rule.yml
@@ -37,4 +37,4 @@ references:
     cis@ubuntu2004: 1.7.1.3
     cis@ubuntu2204: 1.6.1.3
 
-platform: package[apparmor]
+platform: machine

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/rule.yml
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/rule.yml
@@ -37,4 +37,4 @@ references:
     cis@ubuntu2004: 1.7.1.3
     cis@ubuntu2204: 1.6.1.3
 
-platform: machine
+platform: machine and package[apparmor]

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/correct_all_apparmor_profiles_in_complain.pass.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/correct_all_apparmor_profiles_in_complain.pass.sh
@@ -3,5 +3,11 @@
 
 #Replace apparmor definitions
 apparmor_parser -q -r /etc/apparmor.d/
+{{% if 'ubuntu' in product %}}
+# Set all profiles to complain mode except disabled profiles
+find /etc/apparmor.d -maxdepth 1 ! -type d -exec bash -c '[[ -e "/etc/apparmor.d/disable/$(basename "{}")" ]] || aa-complain "{}"' \;
+{{% else %}}
 #Set all profiles in complain mode
 aa-complain /etc/apparmor.d/*
+{{% endif %}}
+

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/correct_all_apparmor_profiles_in_complain.pass.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/correct_all_apparmor_profiles_in_complain.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_sle,multi_platform_ubuntu
 # packages = apparmor-utils
 
 #Replace apparmor definitions

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/correct_all_apparmor_profiles_in_complain.pass.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/correct_all_apparmor_profiles_in_complain.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# platform = multi_platform_sle
 # packages = apparmor-utils
 
 #Replace apparmor definitions

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/correct_all_apparmor_profiles_in_complain.pass.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/correct_all_apparmor_profiles_in_complain.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_sle
 # packages = apparmor-utils
 
 #Replace apparmor definitions

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/correct_all_apparmor_profiles_in_enforce.pass.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/correct_all_apparmor_profiles_in_enforce.pass.sh
@@ -3,5 +3,11 @@
 
 #Replace apparmor definitions
 apparmor_parser -q -r /etc/apparmor.d/
+{{% if 'ubuntu' in product %}}
+# Set all profiles to complain mode except disabled profiles
+find /etc/apparmor.d -maxdepth 1 ! -type d -exec bash -c '[[ -e "/etc/apparmor.d/disable/$(basename "{}")" ]] || aa-enforce "{}"' \;
+{{% else %}}
 #Set all profiles in enforce mode
 aa-enforce /etc/apparmor.d/*
+{{% endif %}}
+

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/correct_all_apparmor_profiles_in_enforce.pass.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/correct_all_apparmor_profiles_in_enforce.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_sle,multi_platform_ubuntu
 # packages = apparmor-utils
 
 #Replace apparmor definitions

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/correct_all_apparmor_profiles_in_enforce.pass.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/correct_all_apparmor_profiles_in_enforce.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# platform = multi_platform_sle
 # packages = apparmor-utils
 
 #Replace apparmor definitions

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/correct_all_apparmor_profiles_in_enforce.pass.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/correct_all_apparmor_profiles_in_enforce.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_sle
 # packages = apparmor-utils
 
 #Replace apparmor definitions

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/incorrect_all_apparmor_profiles.fail.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/incorrect_all_apparmor_profiles.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# packages = apparmor-utils
+# platform = multi_platform_sle,multi_platform_ubuntu
+# packages = apparmor
 
 #Configure the OS to unload all AppArmor profiles
 aa-teardown

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/incorrect_all_apparmor_profiles.fail.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/incorrect_all_apparmor_profiles.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# platform = multi_platform_sle
 # packages = apparmor
 
 #Configure the OS to unload all AppArmor profiles

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/incorrect_all_apparmor_profiles.fail.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/incorrect_all_apparmor_profiles.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_sle
 # packages = apparmor
 
 #Configure the OS to unload all AppArmor profiles

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/incorrect_all_apparmor_profiles.fail.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/tests/incorrect_all_apparmor_profiles.fail.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-# packages = apparmor
-
-#Configure the OS to unload all AppArmor profiles
-aa-teardown


### PR DESCRIPTION
#### Description:

- Load all the profile if not loaded for Ubuntu without change the mode of loaded profiles

#### Rationale:

- We change the default mode to enforce for Ubuntu so if the var_apparmor_mode has been changed it means the customs tailored the benchmark and don't want to enforce all existing profiles. In order to preserve the modes of loaded profiles and still to be compliant, we should only load the not loaded profiles into complain mode.