### PR TITLE
MULTIARCH-4655: add support for DISA-STIG on Power

### DIFF
--- a/Dockerfiles/ocp4_content
+++ b/Dockerfiles/ocp4_content
@@ -6,7 +6,6 @@ RUN microdnf -y install cmake make git /usr/bin/python3 python3-pyyaml python3-j
 
 COPY . .
 
-
 # Enable only certain profiles on ppc64le and s390x
 RUN if [ "$(uname -m)" == "x86_64" ]; then \
     echo "Building OpenShift and RHCOS content for x86_64"; \
@@ -30,6 +29,11 @@ RUN if [ "$(uname -m)" == "x86_64" ]; then \
         products/ocp4/profiles/moderate.profile \
         products/ocp4/profiles/moderate-node-rev-4.profile \
         products/ocp4/profiles/moderate-rev-4.profile && \
+        # Adds DISA-STIG for ppc64le
+        if [ "$(uname -m)" = "ppc64le" ]; then \
+            find products/rhcos4 -name "*stig*.profile" | xargs sed -i 's/\(documentation_complete: \).*/\1true/' && \
+            find products/ocp4 -name "*stig*.profile" | xargs sed -i 's/\(documentation_complete: \).*/\1true/' ; \
+        fi && \
         # OCPBUGS-32794: Ensure stability of rules shipped
         # Before building the content we re-enable all profiles as hidden, this will include any rule selected
         # by these profiles in the data stream without creating a profile for them.


### PR DESCRIPTION
#### Description:

Enables the DISA-STIG on Power

#### Rationale:
- Adding DISA STIG to the content image.

MULTIARCH-4655 is an OCP4 ticket.

#### Review Hints:
Adds ppc64le build 