### PR TITLE
Update select rules for RHEL not to modify systemd units in /usr

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/ansible/shared.yml
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = low
 
-{{% if 'sle' in product %}}
+{{% if 'sle' in product or 'rhel' in product %}}
 - name: Require emergency mode password
   ansible.builtin.blockinfile:
       create: yes

--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/ansible/shared.yml
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = low
 
-{{% if 'sle' in product or 'rhel' in product %}}
+{{% if 'sle' in product or 'rhel' in product or product == 'fedora' %}}
 - name: Require emergency mode password
   ansible.builtin.blockinfile:
       create: yes
@@ -18,7 +18,7 @@
       create: yes
       dest: /usr/lib/systemd/system/emergency.service
       regexp: "^#?ExecStart="
-      {{% if product in ["fedora", "ol8", "ol9", "rhel8", "rhel9"] -%}}
+      {{% if product in ["ol8", "ol9"] -%}}
       line: "ExecStart=-/usr/lib/systemd/systemd-sulogin-shell emergency"
       {{%- else -%}}
       line: 'ExecStart=-/bin/sh -c "/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"'

--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/bash/shared.sh
@@ -1,19 +1,19 @@
 # platform = multi_platform_all
 
-{{% if 'sle' in product or 'rhel' in product %}}
+{{% if 'sle' in product or 'rhel' in product or product == 'fedora' %}}
 service_dropin_cfg_dir="/etc/systemd/system/emergency.service.d"
 service_dropin_file="${service_dropin_cfg_dir}/10-oscap.conf"
 {{% else %}}
 service_file="/usr/lib/systemd/system/emergency.service"
 {{% endif %}}
 
-{{% if product in ["fedora", "ol8", "ol9", "rhel8", "rhel9", "sle12", "sle15"] -%}}
+{{% if product in ["fedora", "ol8", "ol9", "sle12", "sle15"] or 'rhel' in product -%}}
 sulogin="/usr/lib/systemd/systemd-sulogin-shell emergency"
 {{%- else -%}}
 sulogin='/bin/sh -c "/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"'
 {{%- endif %}}
 
-{{% if 'sle' in product or 'rhel' in product %}}
+{{% if 'sle' in product or 'rhel' in product or product == 'fedora' %}}
 mkdir -p "${service_dropin_cfg_dir}"
 echo "[Service]" >> "${service_dropin_file}"
 echo "ExecStart=-$sulogin" >> "${service_dropin_file}"

--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/bash/shared.sh
@@ -1,6 +1,6 @@
 # platform = multi_platform_all
 
-{{% if 'sle' in product %}}
+{{% if 'sle' in product or 'rhel' in product %}}
 service_dropin_cfg_dir="/etc/systemd/system/emergency.service.d"
 service_dropin_file="${service_dropin_cfg_dir}/10-oscap.conf"
 {{% else %}}
@@ -13,7 +13,7 @@ sulogin="/usr/lib/systemd/systemd-sulogin-shell emergency"
 sulogin='/bin/sh -c "/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"'
 {{%- endif %}}
 
-{{% if 'sle' in product %}}
+{{% if 'sle' in product or 'rhel' in product %}}
 mkdir -p "${service_dropin_cfg_dir}"
 echo "[Service]" >> "${service_dropin_file}"
 echo "ExecStart=-$sulogin" >> "${service_dropin_file}"

--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/oval/shared.xml
@@ -2,7 +2,7 @@
   <definition class="compliance" id="require_emergency_target_auth" version="1">
     {{{ oval_metadata("The requirement for a password to boot into emergency mode
       should be configured correctly.") }}}
-{{% if 'sle' in product %}}
+{{% if 'sle' in product or 'rhel' in product %}}
     <criteria operator="OR">
 {{% endif %}}
       <criteria operator="AND">
@@ -12,7 +12,7 @@
         <criterion test_ref="test_no_custom_emergency_target" negate="true"/>
         <criterion test_ref="test_no_custom_emergency_service" negate="true"/>
       </criteria>
-{{% if 'sle' in product %}}
+{{% if 'sle' in product or 'rhel' in product %}}
       <criteria operator="OR">
         <criterion comment="Check /usr/lib/* configuration"
           test_ref="test_require_emergency_service" />
@@ -44,7 +44,7 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-{{% if 'sle' in product %}}
+{{% if 'sle' in product or 'rhel' in product %}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
     comment="Tests that
     /usr/lib/systemd/systemd-sulogin-shell

--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/oval/shared.xml
@@ -2,7 +2,7 @@
   <definition class="compliance" id="require_emergency_target_auth" version="1">
     {{{ oval_metadata("The requirement for a password to boot into emergency mode
       should be configured correctly.") }}}
-{{% if 'sle' in product or 'rhel' in product %}}
+{{% if 'sle' in product or 'rhel' in product or product == 'fedora' %}}
     <criteria operator="OR">
 {{% endif %}}
       <criteria operator="AND">
@@ -11,20 +11,19 @@
         <criterion test_ref="test_require_emergency_service_emergency_target" />
         <criterion test_ref="test_no_custom_emergency_target" negate="true"/>
         <criterion test_ref="test_no_custom_emergency_service" negate="true"/>
+        <criterion test_ref="test_{{{ rule_id }}}_drop_in_config_exist" negate="true"/>
       </criteria>
-{{% if 'sle' in product or 'rhel' in product %}}
-      <criteria operator="OR">
-        <criterion comment="Check /usr/lib/* configuration"
-          test_ref="test_require_emergency_service" />
+{{% if 'sle' in product or 'rhel' in product or product == 'fedora' %}}
+      <criteria operator="ONE">
         <criterion comment="Check drop-in configuration"
-          test_ref="test_require_emergency_service_dropin" />
+          test_ref="test_require_emergency_service_drop_in" />
       </criteria>
     </criteria>
 {{% endif %}}
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
     comment="Tests that
-    {{% if product in ["fedora", "ol8", "ol9", "rhel8", "rhel9", "sle12", "sle15"] -%}}
+    {{% if product in ["fedora", "ol8", "ol9", "sle12", "sle15"] or 'rhel' in product -%}}
     /usr/lib/systemd/systemd-sulogin-shell
     {{%- else -%}}
     /sbin/sulogin
@@ -36,7 +35,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_require_emergency_service" version="1">
     <ind:filepath>/usr/lib/systemd/system/emergency.service</ind:filepath>
-    {{%- if product in ["fedora", "ol8", "ol9", "kylinserver10", "openeuler2203", "rhel8", "rhel9", "sle12", "sle15"] -%}}
+    {{%- if product in ["fedora", "ol8", "ol9", "kylinserver10", "openeuler2203", "sle12", "sle15"] or 'rhel' in product -%}}
     <ind:pattern operation="pattern match">^ExecStart=\-/usr/lib/systemd/systemd-sulogin-shell[\s]+emergency</ind:pattern>
     {{%- else -%}}
     <ind:pattern operation="pattern match">^ExecStart=\-/bin/sh[\s]+-c[\s]+\"(/usr)?/sbin/sulogin;[\s]+/usr/bin/systemctl[\s]+--fail[\s]+--no-block[\s]+default\"</ind:pattern>
@@ -44,16 +43,16 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-{{% if 'sle' in product or 'rhel' in product %}}
+{{% if 'sle' in product or 'rhel' in product or product == 'fedora' %}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
     comment="Tests that
     /usr/lib/systemd/systemd-sulogin-shell
     was not removed from the default systemd emergency.service to ensure that a
     password must be entered to access single user mode"
-    id="test_require_emergency_service_dropin" version="1">
-    <ind:object object_ref="obj_require_emergency_service_dropin" />
+    id="test_require_emergency_service_drop_in" version="1">
+    <ind:object object_ref="obj_require_emergency_service_drop_in" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="obj_require_emergency_service_dropin" version="1">
+  <ind:textfilecontent54_object id="obj_require_emergency_service_drop_in" version="1">
     <ind:path>/etc/systemd/system/emergency.service.d</ind:path>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
     <ind:pattern operation="pattern match">^ExecStart=\-/usr/lib/systemd/systemd-sulogin-shell[\s]+emergency</ind:pattern>
@@ -95,4 +94,20 @@
     <unix:path operation="equals">/etc/systemd/system</unix:path>
     <unix:filename operation="pattern match">^emergency.target$</unix:filename>
   </unix:file_object>
+
+  <unix:file_test id="test_{{{ rule_id }}}_drop_in_config_exist"
+                  comment="Look for drop in config files for emergency.service"
+                  version="1"
+                  check="all"
+                  check_existence="at_least_one_exists">
+     <unix:object object_ref="object_{{{ rule_id }}}_drop_in_config_exist" />
+  </unix:file_test>
+
+<unix:file_object id="object_{{{ rule_id }}}_drop_in_config_exist"
+                  comment="Look for drop in config files for emergency.service"
+                  version="1">
+    <unix:path operation="equals">/etc/systemd/system/emergency.service.d</unix:path>
+    <unix:filename operation="pattern match">^.*\.conf$</unix:filename>
+</unix:file_object>
+
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/tests/correct_value_dropin.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/tests/correct_value_dropin.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platform = multi_platform_fedora,multi_platform_rhel,multi_platform_sle
+rm -f /etc/systemd/system/emergency.service
+mkdir -p /etc/systemd/system/emergency.service.d/
+cat << EOF > /etc/systemd/system/emergency.service.d/10-automatus.conf
+[Service]
+ExecStart=-/usr/lib/systemd/systemd-sulogin-shell emergency
+EOF

--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/tests/wrong_value_dropin.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/tests/wrong_value_dropin.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platform = multi_platform_fedora,multi_platform_rhel,multi_platform_sle
+rm -f /etc/systemd/system/emergency.service
+mkdir -p /etc/systemd/system/emergency.service.d/
+cat << EOF > /etc/systemd/system/emergency.service.d/10-automatus.conf
+[Service]
+ExecStart=-/usr/lib/systemd/systemd-sulogin-shell emergency
+EOF

--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/tests/wrong_value_dropin.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/tests/wrong_value_dropin.fail.sh
@@ -2,7 +2,7 @@
 # platform = multi_platform_fedora,multi_platform_rhel,multi_platform_sle
 rm -f /etc/systemd/system/emergency.service
 mkdir -p /etc/systemd/system/emergency.service.d/
-cat << EOF > /etc/systemd/system/emergency.service.d/10-automatus.conf
+cat << EOF > /etc/systemd/system/emergency.service.d/10-oscap.conf
 [Service]
-ExecStart=-/usr/lib/systemd/systemd-sulogin-shell emergency
+ExecStart=/bin/bash
 EOF

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/ansible/shared.yml
@@ -4,19 +4,19 @@
 # complexity = low
 # disruption = low
 
-{{% if 'rhel' not in product %}}
+{{% if 'rhel' not in product and product != 'fedora' %}}
 - name: Require single user mode password
   lineinfile:
       create: yes
       dest: /usr/lib/systemd/system/rescue.service
       regexp: "^#?ExecStart="
-      {{% if product in ["fedora", "ol8", "ol9", "sle12", "sle15"] -%}}
+      {{% if product in ["ol8", "ol9", "sle12", "sle15"]-%}}
       line: "ExecStart=-/usr/lib/systemd/systemd-sulogin-shell rescue"
       {{%- else -%}}
       line: 'ExecStart=-/bin/sh -c "/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"'
       {{%- endif %}}
 {{% else %}}
-- name: "{{{ rule_title }}} - Require single user mode password"
+- name: "{{{ rule_title }}} - Require emergency user mode password"
   community.general.ini_file:
     path: "/etc/systemd/system/rescue.service.d/10-oscap.conf"
     section: "Service"

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/ansible/shared.yml
@@ -4,13 +4,22 @@
 # complexity = low
 # disruption = low
 
+{{% if 'rhel' not in product %}}
 - name: Require single user mode password
   lineinfile:
       create: yes
       dest: /usr/lib/systemd/system/rescue.service
       regexp: "^#?ExecStart="
-      {{% if product in ["fedora", "ol8", "ol9", "rhel8", "rhel9", "sle12", "sle15"] -%}}
+      {{% if product in ["fedora", "ol8", "ol9", "sle12", "sle15"] -%}}
       line: "ExecStart=-/usr/lib/systemd/systemd-sulogin-shell rescue"
       {{%- else -%}}
       line: 'ExecStart=-/bin/sh -c "/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"'
       {{%- endif %}}
+{{% else %}}
+- name: "{{{ rule_title }}} - Require single user mode password"
+  community.general.ini_file:
+    path: "/etc/systemd/system/rescue.service.d/10-oscap.conf"
+    section: "Service"
+    option: "ExecStart"
+    value: "-/usr/lib/systemd/systemd-sulogin-shell rescue"
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/bash/shared.sh
@@ -1,15 +1,9 @@
 # platform = multi_platform_all
 
-service_file="/usr/lib/systemd/system/rescue.service"
-
 {{% if product in ["fedora", "ol8", "ol9", "sle12", "sle15",] or 'rhel' in product -%}}
-sulogin="/usr/lib/systemd/systemd-sulogin-shell rescue"
+{{% set sulogin="/usr/lib/systemd/systemd-sulogin-shell rescue" %}}
 {{%- else -%}}
-sulogin='/bin/sh -c "/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"'
+{{% set sulogin='/bin/sh -c "/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"'  %}}
 {{%- endif %}}
 
-if grep "^ExecStart=.*" "$service_file" ; then
-    sed -i "s%^ExecStart=.*%ExecStart=-$sulogin%" "$service_file"
-else
-    echo "ExecStart=-$sulogin" >> "$service_file"
-fi
+{{{ bash_ensure_ini_config("/etc/systemd/system/rescue.service.d/10-oscap.conf", "Service", "ExecStart", sulogin) }}}

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/bash/shared.sh
@@ -1,9 +1,9 @@
 # platform = multi_platform_all
 
 {{% if product in ["fedora", "ol8", "ol9", "sle12", "sle15",] or 'rhel' in product -%}}
-{{% set sulogin="/usr/lib/systemd/systemd-sulogin-shell rescue" %}}
+{{% set sulogin="-/usr/lib/systemd/systemd-sulogin-shell rescue" %}}
 {{%- else -%}}
-{{% set sulogin='/bin/sh -c "/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"'  %}}
+{{% set sulogin='-/bin/sh -c "/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"'  %}}
 {{%- endif %}}
 
 {{{ bash_ensure_ini_config("/etc/systemd/system/rescue.service.d/10-oscap.conf", "Service", "ExecStart", sulogin) }}}

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
@@ -8,7 +8,7 @@
       {{%- if product not in ["ol8"] and 'rhel' not in product  -%}}
       <criterion test_ref="test_require_rescue_service_runlevel1" />
       <criterion test_ref="test_no_custom_runlevel1_target" negate="true"/>
-            <criterion test_ref="test_no_custom_rescue_service" negate="true"/>
+      <criterion test_ref="test_no_custom_rescue_service" negate="true"/>
       {{%- endif -%}}
     </criteria>
   </definition>
@@ -25,7 +25,7 @@
     <ind:object object_ref="obj_require_rescue_service" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_require_rescue_service" version="1">
-    {{%- if 'rhel' in product -%}}
+    {{%- if 'rhel' in product or product == 'fedora' -%}}
     <ind:path>/etc/systemd/system/rescue.service.d</ind:path>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
     {{%- else -%}}

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
@@ -5,7 +5,7 @@
     <criteria operator="AND">
       <criterion comment="Conditions are satisfied"
       test_ref="test_require_rescue_service" />
-      {{%- if product not in ["ol8"] and 'rhel' not in product  -%}}
+      {{%- if product not in ["ol8"] and 'rhel' not in product and "fedora" != product-%}}
       <criterion test_ref="test_require_rescue_service_runlevel1" />
       <criterion test_ref="test_no_custom_runlevel1_target" negate="true"/>
       <criterion test_ref="test_no_custom_rescue_service" negate="true"/>
@@ -32,9 +32,9 @@
     <ind:filepath>/usr/lib/systemd/system/rescue.service</ind:filepath>
     {{%- endif -%}}
     {{%- if product in ["fedora", "ol8", "ol9", "rhcos4", "sle12", "sle15"] or 'rhel' in product -%}}
-    <ind:pattern operation="pattern match">^ExecStart=\-.*/usr/lib/systemd/systemd-sulogin-shell[ ]+rescue</ind:pattern>
+    <ind:pattern operation="pattern match">^ExecStart\s?=\s?\-.*/usr/lib/systemd/systemd-sulogin-shell[ ]+rescue</ind:pattern>
     {{%- else -%}}
-    <ind:pattern operation="pattern match">^ExecStart=\-/bin/sh[\s]+-c[\s]+\"(/usr)?/sbin/sulogin;[\s]+/usr/bin/systemctl[\s]+--fail[\s]+--no-block[\s]+default\"</ind:pattern>
+    <ind:pattern operation="pattern match">^ExecStart\s?=\s?\-/bin/sh[\s]+-c[\s]+\"(/usr)?/sbin/sulogin;[\s]+/usr/bin/systemctl[\s]+--fail[\s]+--no-block[\s]+default\"</ind:pattern>
     {{%- endif -%}}
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
@@ -5,16 +5,16 @@
     <criteria operator="AND">
       <criterion comment="Conditions are satisfied"
       test_ref="test_require_rescue_service" />
-      {{%- if product not in ["ol8", "rhel8"] -%}}
+      {{%- if product not in ["ol8"] and 'rhel' not in product  -%}}
       <criterion test_ref="test_require_rescue_service_runlevel1" />
       <criterion test_ref="test_no_custom_runlevel1_target" negate="true"/>
-      <criterion test_ref="test_no_custom_rescue_service" negate="true"/>
+            <criterion test_ref="test_no_custom_rescue_service" negate="true"/>
       {{%- endif -%}}
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
     comment="Tests that
-    {{% if product in ["fedora", "ol8", "ol9", "rhel8", "rhel9", "rhcos4", "sle12", "sle15"] -%}}
+    {{% if product in ["fedora", "ol8", "ol9", "rhcos4", "sle12", "sle15"] or 'rhel' in product -%}}
     /usr/lib/systemd/systemd-sulogin-shell
     {{%- else -%}}
     /sbin/sulogin
@@ -25,8 +25,13 @@
     <ind:object object_ref="obj_require_rescue_service" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_require_rescue_service" version="1">
+    {{%- if 'rhel' in product -%}}
+    <ind:path>/etc/systemd/system/rescue.service.d</ind:path>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    {{%- else -%}}
     <ind:filepath>/usr/lib/systemd/system/rescue.service</ind:filepath>
-    {{%- if product in ["fedora", "ol8", "ol9", "rhel8", "rhel9", "rhcos4", "sle12", "sle15"] -%}}
+    {{%- endif -%}}
+    {{%- if product in ["fedora", "ol8", "ol9", "rhcos4", "sle12", "sle15"] or 'rhel' in product -%}}
     <ind:pattern operation="pattern match">^ExecStart=\-.*/usr/lib/systemd/systemd-sulogin-shell[ ]+rescue</ind:pattern>
     {{%- else -%}}
     <ind:pattern operation="pattern match">^ExecStart=\-/bin/sh[\s]+-c[\s]+\"(/usr)?/sbin/sulogin;[\s]+/usr/bin/systemctl[\s]+--fail[\s]+--no-block[\s]+default\"</ind:pattern>
@@ -34,7 +39,7 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  {{%- if product not in ["ol8", "rhel8"] -%}}
+  {{%- if product not in ["ol8"] and 'rhel' not in product -%}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
     comment="Tests that the systemd rescue.service is in the runlevel1.target"
     id="test_require_rescue_service_runlevel1" version="1">

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/rule.yml
@@ -54,7 +54,7 @@ ocil: |-
     To check if authentication is required for single-user mode, run the following command:
     <pre>$ grep sulogin /usr/lib/systemd/system/rescue.service</pre>
     The output should be similar to the following, and the line must begin with
-    {{% if product in ["fedora", "ol8", "ol9", "rhel8", "rhel9", "rhcos4"] -%}}
+    {{% if product in ["fedora", "ol8", "ol9", "rhcos4"] or 'rhel' in product -%}}
         ExecStart and /usr/lib/systemd/systemd-sulogin-shell.
         <pre>ExecStart=-/usr/lib/systemd/systemd-sulogin-shell rescue</pre>
     {{%- else -%}}
@@ -84,7 +84,7 @@ fixtext: |-
     Configure {{{ full_name }}} to require authentication in single user mode.
 
     Add or update the following line in "/usr/lib/systemd/system/rescue.service":
-    {{% if product in ["fedora", "ol8", "ol9", "rhel8", "rhel9", "sle12", "sle15"] -%}}
+    {{% if product in ["fedora", "ol8", "ol9", "sle12", "sle15"] or 'rhel' in product -%}}
     ExecStart=-/usr/lib/systemd/systemd-sulogin-shell rescue
     {{%- else -%}}
     ExecStart=-/bin/sh -c "/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/tests/correct_dropin.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/tests/correct_dropin.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platform = multi_platform_fedora,multi_platform_rhel
+
+mkdir -p /etc/systemd/system/rescue.service.d
+cat << EOF > /etc/systemd/system/rescue.service.d/10-automatus.conf
+[Service]
+ExecStart=-/usr/lib/systemd/systemd-sulogin-shell rescue
+EOF

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/tests/correct_dropin.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/tests/correct_dropin.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # platform = multi_platform_fedora,multi_platform_rhel
-
+rm -rf /etc/systemd/system/rescue.service.d
 mkdir -p /etc/systemd/system/rescue.service.d
 cat << EOF > /etc/systemd/system/rescue.service.d/10-automatus.conf
 [Service]

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/tests/correct_value.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Oracle Linux 8,Oracle Linux 9,multi_platform_fedora,multi_platform_rhel
+# platform = Oracle Linux 8,Oracle Linux 9
 
 service_file="/usr/lib/systemd/system/rescue.service"
 sulogin="/usr/lib/systemd/systemd-sulogin-shell"

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/tests/correct_value.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Oracle Linux 9,multi_platform_fedora,multi_platform_rhel
 
 service_file="/usr/lib/systemd/system/rescue.service"
 sulogin="/usr/lib/systemd/systemd-sulogin-shell"

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/tests/wrong_dropin.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/tests/wrong_dropin.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platform = multi_platform_fedora,multi_platform_rhel
+
+mkdir -p /etc/systemd/system/rescue.service.d
+cat << EOF > /etc/systemd/system/rescue.service.d/10-automatus.conf
+[Service]
+ExecStart=-/usr/lib/systemd/systemd-sulogin-shell rescue
+EOF

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/tests/wrong_dropin.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/tests/wrong_dropin.fail.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # platform = multi_platform_fedora,multi_platform_rhel
-
+rm -rf /etc/systemd/system/rescue.service.d
 mkdir -p /etc/systemd/system/rescue.service.d
 cat << EOF > /etc/systemd/system/rescue.service.d/10-automatus.conf
 [Service]
-ExecStart=-/usr/lib/systemd/systemd-sulogin-shell rescue
+ExecStart=/bin/bash
 EOF


### PR DESCRIPTION
#### Description:

* Update `require_singleuser_auth` to use drop in files
* Update `require_emergency_target_auth` to use drop in files

#### Rationale:

Help with RPM verify pass.