### PR TITLE
Build SCE content by default in rhel9 and rhel10 products

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -95,7 +95,7 @@ jobs:
         run: pip3 install -r requirements.txt -r test-requirements.txt
       - name: Build
         env:
-          ADDITIONAL_CMAKE_OPTIONS: "-DSSG_SCE_ENABLED:BOOL=ON -DSSG_OVAL_SCHEMATRON_VALIDATION_ENABLED=OFF"
+          ADDITIONAL_CMAKE_OPTIONS: "-DSSG_OVAL_SCHEMATRON_VALIDATION_ENABLED=OFF"
         run: |-
           ./build_product ubuntu1604 ubuntu1804 ubuntu2004
       - name: Test
@@ -114,7 +114,7 @@ jobs:
         run: pip3 install -r requirements.txt -r test-requirements.txt
       - name: Build
         env:
-          ADDITIONAL_CMAKE_OPTIONS: "-DSSG_SCE_ENABLED:BOOL=ON -DSSG_OVAL_SCHEMATRON_VALIDATION_ENABLED=OFF"
+          ADDITIONAL_CMAKE_OPTIONS: "-DSSG_OVAL_SCHEMATRON_VALIDATION_ENABLED=OFF"
         run: |-
           ./build_product ubuntu2204
       - name: Test

--- a/build_product
+++ b/build_product
@@ -337,6 +337,13 @@ set_no_derivatives_options() {
 	fi
 }
 
+set_sce_options() {
+	grep -q "SSG_SCE_ENABLED" <<< "$ADDITIONAL_CMAKE_OPTIONS" && return
+	if grep -q 'rhel9\|rhel10' <<< "${_arg_product[*]}"; then
+		CMAKE_OPTIONS+=("-DSSG_SCE_ENABLED:BOOL=ON")
+	fi
+}
+
 set_explict_build_targets() {
 	if test "$_arg_datastream_only" = on || test "$_arg_thin_datastream" = on || test "$_arg_rule_id" != off ; then
 		for chosen_product in "${_arg_product[@]}"; do
@@ -429,6 +436,7 @@ done
 
 CMAKE_OPTIONS=(${ADDITIONAL_CMAKE_OPTIONS} "${build_type_option}" "${oval_major_version_option}" "${oval_minor_version_option}" '-DSSG_PRODUCT_DEFAULT=OFF' "${cmake_enable_args[@]}" -G "$cmake_generator")
 set_no_derivatives_options
+set_sce_options
 if [ "$_arg_ansible_playbooks" = off ] ; then
 	CMAKE_OPTIONS+=("-DSSG_ANSIBLE_PLAYBOOKS_ENABLED:BOOL=OFF")
 fi

--- a/build_product
+++ b/build_product
@@ -339,7 +339,8 @@ set_no_derivatives_options() {
 
 set_sce_options() {
 	grep -q "SSG_SCE_ENABLED" <<< "$ADDITIONAL_CMAKE_OPTIONS" && return
-	if grep -q 'rhel9\|rhel10' <<< "${_arg_product[*]}"; then
+	# These products will build SCE by default
+	if grep -q -E 'rhel9|rhel10|ubuntu2004|ubuntu2204' <<< "${_arg_product[*]}"; then
 		CMAKE_OPTIONS+=("-DSSG_SCE_ENABLED:BOOL=ON")
 	fi
 }

--- a/scap-security-guide.spec
+++ b/scap-security-guide.spec
@@ -58,7 +58,11 @@ present in %{name} package.
 %define centos_8_specific %{nil}
 
 %if 0%{?_rhel_like}
+%if 0%{?_rhel_like} == 7 || 0%{?_rhel_like} == 8
 %define cmake_defines_specific -DSSG_PRODUCT_DEFAULT:BOOLEAN=FALSE -DSSG_PRODUCT_RHEL%{_rhel_like}:BOOLEAN=TRUE -DSSG_CENTOS_DERIVATIVES_ENABLED:BOOL=ON
+%else
+%define cmake_defines_specific -DSSG_PRODUCT_DEFAULT:BOOLEAN=FALSE -DSSG_PRODUCT_RHEL%{_rhel_like}:BOOLEAN=TRUE -DSSG_CENTOS_DERIVATIVES_ENABLED:BOOL=ON -DSSG_SCE_ENABLED:BOOL=ON
+%endif
 %endif
 %if 0%{?fedora}
 %define cmake_defines_specific -DSSG_PRODUCT_DEFAULT:BOOLEAN=FALSE -DSSG_PRODUCT_FEDORA:BOOLEAN=TRUE


### PR DESCRIPTION
#### Description:

Build SCE checks into RHEL 9 and RHEL 10 data streams by default.

#### Rationale:

This change supports building bootable container images based on RHEL 9 and 10 (and CentOS Stream 9 and 10).

SCE checks will be used during the image build for the rules for which the classic OVAL check don't work in a container build environment (mainly service enabled/disabled rules).

#### Review Hints:

Build the RHEL 10 and RHEL 9 products and verify visually that SCE extended components are present in the built data stream.

Then, you can download the built scap-security-guide RPMs EL9 from Packit from COPR and verify visually that SCE extended components are present in the shipped data stream.

```
wget .....
rpm2cpio $rpm | cpio -ivdm
vim ./usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml
```
