### PR TITLE
Change rule platforms 

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_insmod/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_insmod/rule.yml
@@ -53,4 +53,3 @@ ocil: |-
     If the system is configured to audit the execution of the module management program "insmod",
     the command will return a line.
 
-platform: machine

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/rule.yml
@@ -54,7 +54,6 @@ references:
 
 {{{ ocil_fix_srg_privileged_command("kmod") }}}
 
-platform: machine
 
 template:
     name: audit_rules_privileged_commands

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/rule.yml
@@ -59,4 +59,3 @@ ocil: |-
     </pre>
     It should return a relevant line in the audit rules.
 
-platform: machine

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_rmmod/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_rmmod/rule.yml
@@ -53,4 +53,3 @@ ocil: |-
     If the system is configured to audit the execution of the module management program "rmmod",
     the command will return a line.
 
-platform: machine

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_auid_privilege_function/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_auid_privilege_function/rule.yml
@@ -68,6 +68,5 @@ fixtext: |-
 
     The audit daemon must be restarted for the changes to take effect.
 
-platform: machine
 
 srg_requirement: '{{{ full_name }}} must audit execution as another user.'

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/rule.yml
@@ -109,6 +109,5 @@ fixtext: |-
 
     The audit daemon must be restarted for the changes to take effect.
 
-platform: machine
 
 srg_requirement: '{{{ full_name }}} must audit the execution of privileged functions.'

--- a/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/rule.yml
@@ -39,4 +39,3 @@ ocil: |-
     <pre space="preserve">$ sudo grep "dir=/var/log/audit" /etc/audit/audit.rules</pre>
     If the system is configured to audit this activity, it will return a line.
 
-platform: machine

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_sufficiently_large_partition/rule.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_sufficiently_large_partition/rule.yml
@@ -85,6 +85,5 @@ fixtext: |-
 
     If audit records are not stored on a partition made specifically for audit records, a new partition with sufficient space will need be to be created.
 
-platform: machine
 
 srg_requirement: '{{{ full_name }}} must allocate enough storage capacity for at least one week of audit records.'

--- a/linux_os/guide/auditing/group.yml
+++ b/linux_os/guide/auditing/group.yml
@@ -112,5 +112,5 @@ description: |-
     </li></ul>
     </li></ul>
 
-platform: machine
+platform: system_with_kernel
 

--- a/linux_os/guide/auditing/policy_rules/group.yml
+++ b/linux_os/guide/auditing/policy_rules/group.yml
@@ -8,5 +8,4 @@ description: |-
     configuration settings for specific policies or use cases.
     The rules in this section make use of rules defined in <tt>/usr/share/doc/audit-VERSION/rules</tt>.
 
-platform: machine
 


### PR DESCRIPTION
Many rules currently marked with the `machine` platform should be applicable also to bootable containers. The reason is that often these rules check configuration that should be applied if the bootable container is deployed and booted on a real system. The applicability of these rules needs to be extended by marking them with the `system_with_kernel` platform instead.

We change the platforms carefully, we don't perform a blind mass platform replacement because not every rule that is currently marked as `machine` should be applicable to bootable containers, for example partition rules should be evaluated as "not applicable" when scanning a bootable container.

For more details, please read commit messages of all commits.
