### PR TITLE
Introduce bootc remediation type

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -673,7 +673,7 @@ macro(ssg_build_product PRODUCT)
     add_custom_target(${PRODUCT}-content)
 
     if(NOT DEFINED PRODUCT_REMEDIATION_LANGUAGES)
-        set(PRODUCT_REMEDIATION_LANGUAGES "bash;ansible;puppet;anaconda;ignition;kubernetes;blueprint;kickstart")
+        set(PRODUCT_REMEDIATION_LANGUAGES "bash;ansible;puppet;anaconda;ignition;kubernetes;blueprint;kickstart;bootc")
     endif()
     # Define variables for each language to facilitate assesment of specific remediation languages
     foreach(LANGUAGE ${PRODUCT_REMEDIATION_LANGUAGES})

--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -518,6 +518,8 @@ then contain the following subdirectories:
 
 - `kickstart` - For Kickstart remediation content, ending in `.cfg`
 
+- `bootc` - for remediation content used in the `oscap-bootc` tool internally, ending in `.bo`
+
 In each of these subdirectories, a file named `shared.ext` will apply to
 all products and be included in all builds, but `{{{ product }}}.ext`
 will only get included in the build for `{{{ product }}}` (e.g.,

--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -582,7 +582,7 @@ The only way to remediate is to recompile and reinstall the kernel, so no remedi
         state uses operation "greater than or equal" to compare the
         collected package version with the version in the OVAL state.
 
--   Languages: Anaconda, Ansible, Bash, OVAL, Puppet, Blueprint, Kickstart
+-   Languages: Anaconda, Ansible, Bash, OVAL, Puppet, Blueprint, Kickstart, Bootc
 
 #### package_removed
 -   Checks if the given package is not installed.
@@ -591,7 +591,7 @@ The only way to remediate is to recompile and reinstall the kernel, so no remedi
 
     -   **pkgname** - name of the RPM or DEB package, eg. `tmux`
 
--   Languages: Anaconda, Ansible, Bash, OVAL, Puppet, Kickstart
+-   Languages: Anaconda, Ansible, Bash, OVAL, Puppet, Kickstart, Bootc
 
 #### key_value_pair_in_file
 Checks if a given key and value are configured in a file.

--- a/shared/templates/package_installed/bootc.template
+++ b/shared/templates/package_installed/bootc.template
@@ -1,0 +1,7 @@
+# platform = multi_platform_rhel,multi_platform_fedora
+# reboot = false
+# strategy = enable
+# complexity = low
+# disruption = low
+
+package install {{{ PKGNAME }}}

--- a/shared/templates/package_installed/bootc.template
+++ b/shared/templates/package_installed/bootc.template
@@ -4,4 +4,4 @@
 # complexity = low
 # disruption = low
 
-package install {{{ PKGNAME }}}
+dnf install {{{ PKGNAME }}}

--- a/shared/templates/package_installed/template.yml
+++ b/shared/templates/package_installed/template.yml
@@ -6,3 +6,4 @@ supported_languages:
   - puppet
   - blueprint
   - kickstart
+  - bootc

--- a/shared/templates/package_removed/bootc.template
+++ b/shared/templates/package_removed/bootc.template
@@ -1,0 +1,7 @@
+# platform = multi_platform_rhel,multi_platform_fedora
+# reboot = false
+# strategy = disable
+# complexity = low
+# disruption = low
+
+package remove {{{ PKGNAME }}}

--- a/shared/templates/package_removed/bootc.template
+++ b/shared/templates/package_removed/bootc.template
@@ -4,4 +4,4 @@
 # complexity = low
 # disruption = low
 
-package remove {{{ PKGNAME }}}
+dnf remove {{{ PKGNAME }}}

--- a/shared/templates/package_removed/template.yml
+++ b/shared/templates/package_removed/template.yml
@@ -5,3 +5,4 @@ supported_languages:
   - oval
   - puppet
   - kickstart
+  - bootc

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -26,7 +26,8 @@ REMEDIATION_TO_EXT_MAP = {
     'ignition': '.yml',
     'kubernetes': '.yml',
     'blueprint': '.toml',
-    'kickstart': '.cfg'
+    'kickstart': '.cfg',
+    'bootc': '.bo'
 }
 
 
@@ -467,6 +468,14 @@ class KickstartRemediation(Remediation):
         super(KickstartRemediation, self).__init__(
             file_path, "kickstart")
 
+class BootcRemediation(Remediation):
+    """
+    This provides class for Bootc remediations
+    """
+    def __init__(self, file_path):
+        super(BootcRemediation, self).__init__(
+            file_path, "bootc")
+
 
 REMEDIATION_TO_CLASS = {
     'anaconda': AnacondaRemediation,
@@ -477,6 +486,7 @@ REMEDIATION_TO_CLASS = {
     'kubernetes': KubernetesRemediation,
     'blueprint': BlueprintRemediation,
     'kickstart': KickstartRemediation,
+    'bootc': BootcRemediation,
 }
 
 
@@ -616,6 +626,8 @@ def expand_xccdf_subs(fix, remediation_type):
         pattern = r'\(bash-populate\s*(\S+)\)'
     elif remediation_type == "kickstart":
         pattern = r'\(kickstart-populate\s*(\S+)\)'
+    elif remediation_type == "bootc":
+        pattern = r'\(bootc-populate\s*(\S+)\)'
     else:
         sys.stderr.write("Unknown remediation type '%s'\n" % (remediation_type))
         sys.exit(1)

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -468,6 +468,7 @@ class KickstartRemediation(Remediation):
         super(KickstartRemediation, self).__init__(
             file_path, "kickstart")
 
+
 class BootcRemediation(Remediation):
     """
     This provides class for Bootc remediations

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -89,6 +89,7 @@ blueprint_system = "urn:redhat:osbuild:blueprint"
 puppet_system = "urn:xccdf:fix:script:puppet"
 anaconda_system = "urn:redhat:anaconda:pre"
 kickstart_system = "urn:xccdf:fix:script:kickstart"
+bootc_system = "urn:xccdf:fix:script:bootc"
 cce_uri = "https://ncp.nist.gov/cce"
 stig_ns = "https://public.cyber.mil/stigs/srg-stig-tools/"
 ccn_ns = "https://www.ccn-cert.cni.es/pdf/guias/series-ccn-stic/guias-de-acceso-publico-ccn-stic/6768-ccn-stic-610a22-perfilado-de-seguridad-red-hat-enterprise-linux-9-0/file.html"
@@ -156,6 +157,7 @@ FIX_TYPE_TO_SYSTEM = {
     "puppet": puppet_system,
     "anaconda": anaconda_system,
     "kickstart": kickstart_system,
+    "bootc": bootc_system,
 }
 
 for prefix, url_part in OVAL_SUB_NS.items():

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -25,13 +25,14 @@ LANGUAGES = {
     "ansible": TemplatingLang("ansible", ".yml",        TemplateType.REMEDIATION, "ansible"),
     "bash": TemplatingLang("bash", ".sh",               TemplateType.REMEDIATION, "bash"),
     "blueprint": TemplatingLang("blueprint", ".toml",   TemplateType.REMEDIATION, "blueprint"),
-    "cpe-oval": TemplatingLang("cpe-oval", ".xml",      TemplateType.CHECK, "cpe-oval"),
+    "cpe-oval": TemplatingLang("cpe-oval", ".xml",      TemplateType.CHECK,       "cpe-oval"),
     "ignition": TemplatingLang("ignition", ".yml",      TemplateType.REMEDIATION, "ignition"),
     "kubernetes": TemplatingLang("kubernetes", ".yml",  TemplateType.REMEDIATION, "kubernetes"),
     "oval": TemplatingLang("oval", ".xml",              TemplateType.CHECK,       "oval"),
     "puppet": TemplatingLang("puppet", ".pp",           TemplateType.REMEDIATION, "puppet"),
     "sce-bash": TemplatingLang("sce-bash", ".sh",       TemplateType.CHECK,       "sce"),
-    "kickstart": TemplatingLang("kickstart", ".cfg",    TemplateType.REMEDIATION, "kickstart")
+    "kickstart": TemplatingLang("kickstart", ".cfg",    TemplateType.REMEDIATION, "kickstart"),
+    "bootc": TemplatingLang("bootc", ".bo",             TemplateType.REMEDIATION, "bootc")
 }
 
 PREPROCESSING_FILE_NAME = "template.py"


### PR DESCRIPTION
This PR introduces support for new remediation type "bootc".

Remediations of this type will be generated only internally by the future  `oscap-bootc` script. They aren't supposed to be generated by any user.

The format of this remediation will be similar to "kickstart" remediation. However, only package installation and removal will be supported and different keywords will be used. Currently supported commands:
- dnf install package_name
- dnf remove package_name

Having a new remediation type instead of reusing "kickstart" will help us create SCAP content specific for the needs of bootable containers.

This PR is strongly connected to this PR: https://github.com/OpenSCAP/openscap/pull/2166
