### PR TITLE
Check whether all the profiles already parsed and loaded into the kernel

### DIFF
--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/sce/shared.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/sce/shared.sh
@@ -3,7 +3,7 @@
 # check-import = stdout
 
 # If apparmor or apparmor-utils are not installed, then this test fails.
-{{{ bash_package_installed("apparmor") }}} && {{{ bash_package_installed("apparmor-utils") }}}
+{{{ bash_package_installed("apparmor") }}}
 if [ $? -ne 0 ]; then
         exit ${XCCDF_RESULT_FAIL}
 fi

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/sce/shared.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/sce/shared.sh
@@ -8,6 +8,12 @@ if [ $? -ne 0 ]; then
         exit ${XCCDF_RESULT_FAIL}
 fi
 
+# Check whether all the profiles already parsed and loaded into the kernel
+comm -13 <(cat /sys/kernel/security/apparmor/profiles| cut -d' ' -f1| sort) <(apparmor_parser -NQ /etc/apparmor.d/| sort)
+if [ $? -ne 0 ]; then
+        exit ${XCCDF_RESULT_FAIL}
+fi
+
 # if number of apparmor profiles loaded not the same as enforced profiles, then it fails.
 loaded_profiles=$(/usr/sbin/aa-status --profiled)
 enforced_profiles=$(/usr/sbin/aa-status --enforced)
@@ -15,6 +21,7 @@ if [ ${loaded_profiles} -ne ${enforced_profiles} ]; then
     exit $XCCDF_RESULT_FAIL
 fi
 
+# This check will fail without reboot after remediation during automatic test
 unconfined=$(/usr/sbin/aa-status | grep "processes are unconfined" | awk '{print $1;}')
 if [ $unconfined -ne 0 ]; then
     exit $XCCDF_RESULT_FAIL

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/sce/shared.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/sce/shared.sh
@@ -3,7 +3,7 @@
 # check-import = stdout
 
 # If apparmor or apparmor-utils are not installed, then this test fails.
-{{{ bash_package_installed("apparmor") }}} && {{{ bash_package_installed("apparmor-utils") }}}
+{{{ bash_package_installed("apparmor") }}}
 if [ $? -ne 0 ]; then
         exit ${XCCDF_RESULT_FAIL}
 fi


### PR DESCRIPTION
#### Description:

- Check whether all the profiles already parsed and loaded into the kernel

#### Rationale:

- Make sure the apparmor is aware of all the profiles under /etc/apparmor.d/ folder without actually load them
- The automatic test is expected to fail for the "processes are unconfined" check logic since some processes already confined by existing profiles which will be replaced by remediation will need reboot to take effects 