### PR TITLE
Change rule platforms - Part 2: Groups of system

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/group.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/group.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 title: 'Protect Physical Console Access'
 
-platform: machine
+platform: system_with_kernel
 
 description: |-
     It is impossible to fully protect a system from an

--- a/linux_os/guide/system/kernel_build_config/gcc_plugin/group.yml
+++ b/linux_os/guide/system/kernel_build_config/gcc_plugin/group.yml
@@ -3,5 +3,3 @@ documentation_complete: true
 title: 'Kernel GCC plugin configuration'
 
 description: 'Contains rules that check the configuration of GCC plugins used by the compiler'
-
-platform: machine

--- a/linux_os/guide/system/kernel_build_config/group.yml
+++ b/linux_os/guide/system/kernel_build_config/group.yml
@@ -4,4 +4,4 @@ title: 'Kernel Configuration'
 
 description: 'Contains rules that check the kernel configuration that was used to build it.'
 
-platform: machine
+platform: system_with_kernel

--- a/linux_os/guide/system/logging/group.yml
+++ b/linux_os/guide/system/logging/group.yml
@@ -20,4 +20,4 @@ description: |-
     best effect, and how to use tools provided with the system to maintain and
     monitor logs.
 
-platform: machine
+platform: system_with_kernel

--- a/linux_os/guide/system/logging/journald/service_systemd-journald_enabled/rule.yml
+++ b/linux_os/guide/system/logging/journald/service_systemd-journald_enabled/rule.yml
@@ -33,8 +33,6 @@ fixtext: |-
 
 srg_requirement: '{{{ srg_requirement_service_enabled("systemd-journald") }}}'
 
-platform: machine
-
 template:
     name: service_enabled
     vars:

--- a/linux_os/guide/system/network/network-firewalld/firewalld_deactivation/service_firewalld_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_deactivation/service_firewalld_disabled/rule.yml
@@ -36,8 +36,6 @@ fixtext: '{{{ fixtext_service_disabled("firewalld") }}}'
 
 srg_requirement: '{{{ srg_requirement_service_disabled("firewalld") }}}'
 
-platform: machine
-
 template:
     name: service_disabled
     vars:

--- a/linux_os/guide/system/network/network-firewalld/group.yml
+++ b/linux_os/guide/system/network/network-firewalld/group.yml
@@ -21,4 +21,4 @@ description: |-
     unintended disruption of existing network connections occurs as no part of
     the firewall has to be reloaded.
 
-platform: machine
+platform: system_with_kernel

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/group.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/group.yml
@@ -7,4 +7,4 @@ description: |-
     acting as either hosts or routers to improve the system's ability defend
     against certain types of IPv4 protocol attacks.
 
-platform: machine
+platform: system_with_kernel

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/group.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/group.yml
@@ -7,4 +7,4 @@ description: |-
     kernel parameters ensure that the host will not perform routing
     of network traffic.
 
-platform: machine
+platform: system_with_kernel

--- a/linux_os/guide/system/network/network-uncommon/group.yml
+++ b/linux_os/guide/system/network/network-uncommon/group.yml
@@ -14,4 +14,4 @@ warnings:
         in your network environment by ensuring they are not needed
         prior to disabling them.
 
-platform: machine
+platform: system_with_kernel

--- a/linux_os/guide/system/selinux/group.yml
+++ b/linux_os/guide/system/selinux/group.yml
@@ -30,4 +30,4 @@ description: |-
     For more information on SELinux, see <b>{{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/selinux/") }}}</b>.
     {{% endif %}}
 
-platform: machine
+platform: system_with_kernel

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_endpoint_security_software/group.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_endpoint_security_software/group.yml
@@ -6,4 +6,4 @@ description: |-
     McAfee Endpoint Security for Linux (ENSL) is a suite of software applications
     used to monitor, detect, and defend computer networks and systems.
 
-platform: machine
+platform: system_with_kernel

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/rule.yml
@@ -32,8 +32,6 @@ rationale: |-
 
 severity: high
 
-platform: machine  # The check uses syscyl_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhcos4: CCE-82540-6
     cce@rhel8: CCE-80942-6

--- a/linux_os/guide/system/software/integrity/fips/group.yml
+++ b/linux_os/guide/system/software/integrity/fips/group.yml
@@ -15,4 +15,4 @@ description: |-
     <br /><br />
     See <b>{{{ weblink(link="http://csrc.nist.gov/publications/PubsFIPS.html") }}}</b> for more information.
 
-platform: machine and not osbuild
+platform: system_with_kernel and not osbuild

--- a/linux_os/guide/system/software/integrity/fips/package_dracut-fips-aesni_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/package_dracut-fips-aesni_installed/rule.yml
@@ -55,5 +55,3 @@ warnings:
         party review by an accredited lab. While open source software is
         capable of meeting this, it does not meet FIPS-140 unless the vendor
         submits to this process.
-
-platform: machine

--- a/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/rule.yml
@@ -53,8 +53,6 @@ warnings:
         capable of meeting this, it does not meet FIPS-140 unless the vendor
         submits to this process.
 
-platform: machine
-
 template:
     name: package_installed
     vars:

--- a/linux_os/guide/system/software/integrity/fips/sysctl_crypto_fips_enabled/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/sysctl_crypto_fips_enabled/rule.yml
@@ -21,8 +21,6 @@ rationale: |-
 
 severity: high
 
-platform: machine  # The oscap sysctl probe doesn't support offline mode
-
 identifiers:
     cce@rhel8: CCE-84027-2
     cce@rhel9: CCE-83441-6

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/group.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/group.yml
@@ -9,4 +9,4 @@ description: |-
     software update.  AIDE is highly configurable, with further configuration
     information located in <tt>/usr/share/doc/aide-<i>VERSION</i></tt>.
 
-platform: machine
+platform: system_with_kernel


### PR DESCRIPTION
Many rules currently marked with the `machine` platform should be applicable also to bootable containers. The reason is that often these rules check configuration that should be applied if the bootable container is deployed and booted on a real system. The applicability of these rules needs to be extended by marking them with the `system_with_kernel` platform instead.

We change the platforms carefully, we don't perform a blind mass platform replacement because not every rule that is currently marked as `machine` should be applicable to bootable containers, for example partition rules should be evaluated as "not applicable" when scanning a bootable container.

For more details, please read commit messages of all commits.

### Review hints

For normal (non-bootable) containers, run a scan and verify that the rules affected by this change are still evaluated as notapplicable as they were before this change. For example: `sudo oscap-podman centos:stream9 xccdf eval --profile stig --report /tmp/report.html build/ssg-cs9-ds.xml`

