### PR TITLE
Change rule platforms - Part 3: Individual rules in the "services" group

### DIFF
--- a/linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/rule.yml
+++ b/linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/rule.yml
@@ -41,7 +41,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="avahi-daemon") }}}
 
-platform: machine and package[avahi]
+platform: system_with_kernel and package[avahi]
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/base/service_abrtd_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_abrtd_disabled/rule.yml
@@ -37,7 +37,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="abrtd") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/base/service_acpid_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_acpid_disabled/rule.yml
@@ -35,7 +35,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="acpid") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/base/service_certmonger_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_certmonger_disabled/rule.yml
@@ -35,7 +35,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="certmonger") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/base/service_cockpit_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_cockpit_disabled/rule.yml
@@ -13,7 +13,7 @@ rationale: |-
 
 severity: medium
 
-platform: machine
+platform: system_with_kernel
 
 ocil_clause: |-
     {{{ ocil_clause_service_disabled(service="cockpit") }}}

--- a/linux_os/guide/services/base/service_cpupower_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_cpupower_disabled/rule.yml
@@ -34,7 +34,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="cpupower") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/base/service_kdump_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_kdump_disabled/rule.yml
@@ -61,7 +61,7 @@ fixtext: '{{{ fixtext_service_disabled(kdump_service) }}}'
 
 srg_requirement: '{{{ srg_requirement_service_disabled(kdump_service) }}}'
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/base/service_mdmonitor_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_mdmonitor_disabled/rule.yml
@@ -32,7 +32,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="mdmonitor") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/base/service_netconsole_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_netconsole_disabled/rule.yml
@@ -35,7 +35,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="netconsole") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/base/service_ntpdate_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_ntpdate_disabled/rule.yml
@@ -39,7 +39,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="ntpdate") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/base/service_oddjobd_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_oddjobd_disabled/rule.yml
@@ -38,7 +38,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="oddjobd") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/base/service_portreserve_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_portreserve_disabled/rule.yml
@@ -34,7 +34,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="portreserve") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/base/service_psacct_enabled/rule.yml
+++ b/linux_os/guide/services/base/service_psacct_enabled/rule.yml
@@ -35,7 +35,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="psacct") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_enabled

--- a/linux_os/guide/services/base/service_qpidd_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_qpidd_disabled/rule.yml
@@ -40,7 +40,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="qpidd") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/base/service_quota_nld_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_quota_nld_disabled/rule.yml
@@ -38,7 +38,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="quota_nld") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/base/service_rdisc_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_rdisc_disabled/rule.yml
@@ -38,7 +38,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="rdisc") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/base/service_rhnsd_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_rhnsd_disabled/rule.yml
@@ -38,7 +38,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="rhnsd") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/base/service_rhsmcertd_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_rhsmcertd_disabled/rule.yml
@@ -36,7 +36,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="rhsmcertd") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/base/service_saslauthd_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_saslauthd_disabled/rule.yml
@@ -37,7 +37,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="saslauthd") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/base/service_sysstat_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_sysstat_disabled/rule.yml
@@ -36,7 +36,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="sysstat") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/dhcp/disabling_dhcp_server/service_dhcpd_disabled/rule.yml
+++ b/linux_os/guide/services/dhcp/disabling_dhcp_server/service_dhcpd_disabled/rule.yml
@@ -39,7 +39,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="dhcpd") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/dns/disabling_dns_server/service_named_disabled/rule.yml
+++ b/linux_os/guide/services/dns/disabling_dns_server/service_named_disabled/rule.yml
@@ -36,7 +36,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="named") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/ftp/disabling_vsftpd/service_vsftpd_disabled/rule.yml
+++ b/linux_os/guide/services/ftp/disabling_vsftpd/service_vsftpd_disabled/rule.yml
@@ -38,7 +38,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="vsftpd") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/http/disabling_httpd/service_httpd_disabled/rule.yml
+++ b/linux_os/guide/services/http/disabling_httpd/service_httpd_disabled/rule.yml
@@ -35,7 +35,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="httpd") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/imap/disabling_dovecot/service_dovecot_disabled/rule.yml
+++ b/linux_os/guide/services/imap/disabling_dovecot/service_dovecot_disabled/rule.yml
@@ -28,7 +28,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="dovecot") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/ldap/openldap_server/service_slapd_disabled/rule.yml
+++ b/linux_os/guide/services/ldap/openldap_server/service_slapd_disabled/rule.yml
@@ -22,7 +22,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="slapd") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/disabling_nfsd/service_nfs_disabled/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/disabling_nfsd/service_nfs_disabled/rule.yml
@@ -37,7 +37,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="nfs-server") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/disabling_nfsd/service_rpcsvcgssd_disabled/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/disabling_nfsd/service_rpcsvcgssd_disabled/rule.yml
@@ -20,7 +20,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="rpcsvcgssd") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/obsolete/nis/service_ypbind_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/nis/service_ypbind_disabled/rule.yml
@@ -36,7 +36,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="ypbind") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/obsolete/nis/service_ypserv_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/nis/service_ypserv_disabled/rule.yml
@@ -26,7 +26,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="ypserv") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/obsolete/r_services/service_rexec_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/service_rexec_disabled/rule.yml
@@ -37,7 +37,7 @@ references:
 
 {{{ complete_ocil_entry_socket_and_service_disabled("rexec") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/obsolete/r_services/service_rlogin_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/service_rlogin_disabled/rule.yml
@@ -39,7 +39,7 @@ references:
 
 {{{ complete_ocil_entry_socket_and_service_disabled("rlogin") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/obsolete/r_services/service_rsh_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/service_rsh_disabled/rule.yml
@@ -36,7 +36,7 @@ references:
 
 {{{ complete_ocil_entry_socket_and_service_disabled("rsh") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/obsolete/service_rsyncd_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/service_rsyncd_disabled/rule.yml
@@ -12,7 +12,7 @@ rationale: |-
 
 severity: medium
 
-platform: machine
+platform: system_with_kernel
 
 identifiers:
     cce@rhel8: CCE-83335-0

--- a/linux_os/guide/services/obsolete/telnet/service_telnet_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/telnet/service_telnet_disabled/rule.yml
@@ -34,7 +34,7 @@ references:
 
 {{{ complete_ocil_entry_socket_and_service_disabled("telnet") }}}
 
-platform: machine and package[telnet-server]
+platform: system_with_kernel and package[telnet-server]
 
 warnings:
     - general: |-

--- a/linux_os/guide/services/obsolete/tftp/service_tftp_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/tftp/service_tftp_disabled/rule.yml
@@ -33,7 +33,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="tftp") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/printing/service_cups_disabled/rule.yml
+++ b/linux_os/guide/services/printing/service_cups_disabled/rule.yml
@@ -36,7 +36,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="cups") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/proxy/disabling_squid/service_squid_disabled/rule.yml
+++ b/linux_os/guide/services/proxy/disabling_squid/service_squid_disabled/rule.yml
@@ -29,7 +29,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="squid") }}}
 
-platform: machine and package[squid]
+platform: system_with_kernel and package[squid]
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/routing/disabling_quagga/service_zebra_disabled/rule.yml
+++ b/linux_os/guide/services/routing/disabling_quagga/service_zebra_disabled/rule.yml
@@ -36,7 +36,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="zebra") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/smb/disabling_samba/service_smb_disabled/rule.yml
+++ b/linux_os/guide/services/smb/disabling_samba/service_smb_disabled/rule.yml
@@ -29,7 +29,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="smb") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/snmp/disabling_snmp_service/service_snmpd_disabled/rule.yml
+++ b/linux_os/guide/services/snmp/disabling_snmp_service/service_snmpd_disabled/rule.yml
@@ -30,7 +30,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="snmpd") }}}
 
-platform: machine and package[snmpd]
+platform: system_with_kernel and package[snmpd]
 
 template:
     name: service_disabled

--- a/linux_os/guide/services/sssd/service_sssd_enabled/rule.yml
+++ b/linux_os/guide/services/sssd/service_sssd_enabled/rule.yml
@@ -16,7 +16,7 @@ identifiers:
     cce@rhel9: CCE-86088-2
     cce@rhel10: CCE-87447-9
 
-platform: machine
+platform: system_with_kernel
 
 references:
     cis-csc: 1,12,15,16,5

--- a/linux_os/guide/services/sssd/sssd-ldap/group.yml
+++ b/linux_os/guide/services/sssd/sssd-ldap/group.yml
@@ -12,4 +12,4 @@ description: |-
     SSSD can support many backends including LDAP. The <tt>sssd-ldap</tt> backend
     allows SSSD to fetch identity information from an LDAP server.
 
-platform: machine
+platform: system_with_kernel

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/rule.yml
@@ -35,8 +35,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel8: CCE-80909-5
     cce@rhel9: CCE-89155-6

--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/rule.yml
@@ -21,8 +21,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel8: CCE-80910-3
     cce@sle12: CCE-83040-6

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/rule.yml
@@ -26,8 +26,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel8: CCE-82460-7
     cce@rhel9: CCE-87996-5

--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/rule.yml
@@ -19,8 +19,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
-
 identifiers:
     cce@rhel8: CCE-82442-5
 


### PR DESCRIPTION
Many rules currently marked with the `machine` platform should be applicable also to bootable containers. The reason is that often these rules check configuration that should be applied if the bootable container is deployed and booted on a real system. The applicability of these rules needs to be extended by marking them with the `system_with_kernel` platform instead.

We change the platforms carefully, we don't perform a blind mass platform replacement because not every rule that is currently marked as `machine` should be applicable to bootable containers, for example partition rules should be evaluated as "not applicable" when scanning a bootable container.

For more details, please read commit messages of all commits.

### Review hints

For normal (non-bootable) containers, run a scan and verify that the rules affected by this change are still evaluated as notapplicable as they were before this change. For example: `sudo oscap-podman centos:stream9 xccdf eval --profile stig --report /tmp/report.html build/ssg-cs9-ds.xml`

