### PR TITLE
Disable `sysctl_kernel_modules_disabled` Ansible remediation

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_modules_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_modules_disabled/rule.yml
@@ -27,7 +27,7 @@ platform: machine
 
 warnings:
   - general:
-      This rule doesn't come with Bash remediation.
+      This rule doesn't come with remediation.
       Remediating this rule during the installation process disrupts the install and boot process.
 
 template:
@@ -39,3 +39,4 @@ template:
     backends:
         # Automated remediation of this rule during installations disrupts the first boot
         bash: 'off'
+        ansible: 'off'


### PR DESCRIPTION
#### Description:
Disable Ansible remediation for `sysctl_kernel_modules_disabled`.

#### Rationale:
The remediation causes boot failure for UEFI systems.
The rule already had disabled Bash remediation (#6586) because of the same reason as #12508 .

Fixes #12508 

#### Review Hints:
Run Contest `/hardening/ansible/anssi_bp28_high` to see if machine boots successfully after ANSSI hardening.