### PR TITLE
Change rule platforms - Part 4: Individual rules in the "system" group

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/rule.yml
@@ -124,7 +124,7 @@ references:
     stigid@sle12: SLES-12-010030
     stigid@sle15: SLES-15-010020
 
-platform: machine
+platform: system_with_kernel
 
 ocil_clause: 'it does not display the required banner'
 

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_cis/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_cis/rule.yml
@@ -32,7 +32,7 @@ identifiers:
 
 {{{ ocil_cis_banner("/etc/issue") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: cis_banner

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/rule.yml
@@ -70,4 +70,4 @@ ocil: |-
     To check if the system login banner is compliant, run the following command:
     <pre>$ cat /etc/issue.net</pre>
 
-platform: machine
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net_cis/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net_cis/rule.yml
@@ -32,7 +32,7 @@ identifiers:
 
 {{{ ocil_cis_banner("/etc/issue.net") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: cis_banner

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/rule.yml
@@ -67,4 +67,4 @@ ocil: |-
     run the following command:
     <pre>$ cat /etc/motd</pre>
 
-platform: machine
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd_cis/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd_cis/rule.yml
@@ -31,7 +31,7 @@ identifiers:
 
 {{{ ocil_cis_banner("/etc/motd") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: cis_banner

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/bash/shared.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 # platform = multi_platform_all
 
 FAILLOCK_CONF_FILES="/etc/security/faillock.conf /etc/pam.d/system-auth /etc/pam.d/password-auth"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/rule.yml
@@ -25,7 +25,7 @@ references:
     stigid@ol8: OL08-00-020027,OL08-00-020028
     stigid@rhel8: RHEL-08-020027,RHEL-08-020028
 
-platform: machine
+platform: system_with_kernel
 
 ocil_clause: 'the security context type of the non-default tally directory is not "faillog_t"'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_file_selinux/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_file_selinux/bash/shared.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 # platform = multi_platform_slmicro5
 
 if ! semanage fcontext -a -t faillog_t "/var/log/tallylog"; then

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_unique_id/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_unique_id/rule.yml
@@ -32,7 +32,7 @@ references:
     stigid@sle15: SLES-15-010230
 
 # The rule check uses password probe, which doesn't support offline mode
-platform: machine
+platform: system_with_kernel
 
 ocil_clause: 'output is produced and the accounts listed are interactive user accounts'
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/rule.yml
@@ -39,7 +39,7 @@ references:
     pcidss: Req-8.2.1
 
 # The rule check uses password probe, which doesn't support offline mode
-platform: machine
+platform: system_with_kernel
 
 ocil_clause: 'any stored hashes are found in /etc/passwd'
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_last_change_is_in_past/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_last_change_is_in_past/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
 
 severity: medium
 
-platform: machine
+platform: system_with_kernel
 
 identifiers:
     cce@rhel8: CCE-86525-3

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/rule.yml
@@ -21,7 +21,7 @@ rationale: |-
 
 severity: high
 
-platform: machine
+platform: system_with_kernel
 
 identifiers:
     cce@rhel8: CCE-85953-8

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_root_password_configured/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_root_password_configured/rule.yml
@@ -19,7 +19,7 @@ identifiers:
     cce@rhel9: CCE-87101-2
     cce@rhel10: CCE-89334-7
 
-platform: machine
+platform: system_with_kernel
 
 references:
     cis@ubuntu2004: 1.5.3

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/rule.yml
@@ -56,7 +56,7 @@ ocil: |-
     <pre>cat /etc/securetty</pre>
     If any output is returned, this is a finding.
 
-platform: machine
+platform: system_with_kernel
 
 warnings:
     - general: |-

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
@@ -86,7 +86,7 @@ ocil: |-
     export TMOUT
     {{% endif %}}
 
-platform: machine
+platform: system_with_kernel
 
 fixtext: |-
     Configure {{{ full_name }}} to terminate user sessions after {{{ xccdf_value("var_accounts_tmout") }}} seconds of inactivity.

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/service_ip6tables_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/service_ip6tables_enabled/rule.yml
@@ -27,7 +27,7 @@ references:
     nist: AC-4,CM-7(b),CA-3(5),SC-7(21),CM-6(a)
     nist-csf: DE.AE-1,ID.AM-3,PR.AC-5,PR.DS-5,PR.IP-1,PR.PT-3,PR.PT-4
 
-platform: machine
+platform: system_with_kernel
 
 ocil: |-
     If IPv6 is disabled, this is not applicable.

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/service_iptables_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/service_iptables_enabled/rule.yml
@@ -29,7 +29,7 @@ references:
     nist: AC-4,CM-7(b),CA-3(5),SC-7(21),CM-6(a)
     nist-csf: DE.AE-1,ID.AM-3,PR.AC-5,PR.DS-5,PR.IP-1,PR.PT-3,PR.PT-4
 
-platform: machine and package[iptables] and service_disabled[firewalld]
+platform: system_with_kernel and package[iptables] and service_disabled[firewalld]
 
 ocil: |-
     {{{ ocil_service_enabled(service="iptables") }}}

--- a/linux_os/guide/system/network/network-iptables/package_iptables_installed/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/package_iptables_installed/rule.yml
@@ -1,7 +1,7 @@
 documentation_complete: true
 
 
-platform: machine and not rhcos4-rhel9 and service_disabled[nftables] and service_disabled[ufw]
+platform: system_with_kernel and not rhcos4-rhel9 and service_disabled[nftables] and service_disabled[ufw]
 
 title: 'Install iptables Package'
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra/rule.yml
@@ -43,7 +43,7 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} must not accept router advertisements on all IPv6 interfaces.'
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra_defrtr/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra_defrtr/rule.yml
@@ -18,7 +18,7 @@ identifiers:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv6.conf.all.accept_ra_defrtr", value="0") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra_pinfo/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra_pinfo/rule.yml
@@ -18,7 +18,7 @@ identifiers:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv6.conf.all.accept_ra_pinfo", value="0") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra_rtr_pref/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra_rtr_pref/rule.yml
@@ -18,7 +18,7 @@ identifiers:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv6.conf.all.accept_ra_rtr_pref", value="0") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_redirects/rule.yml
@@ -46,7 +46,7 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} must ignore IPv6 Internet Control Message Protocol (ICMP) redirect messages.'
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_source_route/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_source_route/rule.yml
@@ -55,7 +55,7 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} must not forward IPv6 source-routed packets.'
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_autoconf/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_autoconf/rule.yml
@@ -18,7 +18,7 @@ identifiers:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv6.conf.all.autoconf", value="0") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_forwarding/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_forwarding/rule.yml
@@ -51,7 +51,7 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} must not perform packet forwarding unless the system is a router.'
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_max_addresses/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_max_addresses/rule.yml
@@ -20,7 +20,7 @@ identifiers:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv6.conf.all.max_addresses", value="1") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_router_solicitations/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_router_solicitations/rule.yml
@@ -18,7 +18,7 @@ identifiers:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv6.conf.all.router_solicitations", value="0") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra/rule.yml
@@ -43,7 +43,7 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} must not accept router advertisements on all IPv6 interfaces by default.'
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra_defrtr/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra_defrtr/rule.yml
@@ -18,7 +18,7 @@ identifiers:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv6.conf.default.accept_ra_defrtr", value="0") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra_pinfo/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra_pinfo/rule.yml
@@ -18,7 +18,7 @@ identifiers:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv6.conf.default.accept_ra_pinfo", value="0") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra_rtr_pref/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra_rtr_pref/rule.yml
@@ -18,7 +18,7 @@ identifiers:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv6.conf.default.accept_ra_rtr_pref", value="0") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_redirects/rule.yml
@@ -49,7 +49,7 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} must prevent IPv6 Internet Control Message Protocol (ICMP) redirect messages from being accepted.'
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_source_route/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_source_route/rule.yml
@@ -55,7 +55,7 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} must not forward IPv6 source-routed packets by default.'
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_autoconf/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_autoconf/rule.yml
@@ -18,7 +18,7 @@ identifiers:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv6.conf.default.autoconf", value="0") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_forwarding/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_forwarding/rule.yml
@@ -30,7 +30,7 @@ ocil: |-
     {{{ ocil_sysctl_option_value(sysctl="net.ipv6.conf.default.forwarding", value="0") }}}
     The ability to forward packets is only appropriate for routers.
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_max_addresses/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_max_addresses/rule.yml
@@ -20,7 +20,7 @@ identifiers:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv6.conf.default.max_addresses", value="1") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_router_solicitations/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_router_solicitations/rule.yml
@@ -18,7 +18,7 @@ identifiers:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv6.conf.default.router_solicitations", value="0") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/kernel_module_ipv6_option_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/kernel_module_ipv6_option_disabled/rule.yml
@@ -47,4 +47,4 @@ ocil: |-
     <tt>/etc/modprobe.conf</tt>:
     <pre xml:space="preserve">$ grep -r ipv6 /etc/modprobe.conf /etc/modprobe.d</pre>
 
-platform: machine
+platform: system_with_kernel

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/sysctl_net_ipv6_conf_all_disable_ipv6/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/sysctl_net_ipv6_conf_all_disable_ipv6/rule.yml
@@ -49,7 +49,7 @@ ocil: |-
     files in <tt>/etc/sysctl.d</tt>:
     <pre>$ grep -r ipv6 /etc/sysctl.d</pre>
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/sysctl_net_ipv6_conf_default_disable_ipv6/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/sysctl_net_ipv6_conf_default_disable_ipv6/rule.yml
@@ -45,7 +45,7 @@ ocil: |-
     files in <tt>/etc/sysctl.d</tt>:
     <pre>$ grep -r ipv6 /etc/sysctl.d</pre>
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_forwarding/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_forwarding/rule.yml
@@ -36,7 +36,7 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} must not perform packet forwarding unless the system is a router.'
 
-platform: machine
+platform: system_with_kernel
 
 
 warnings:

--- a/linux_os/guide/system/network/network-nftables/package_nftables_installed/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/package_nftables_installed/rule.yml
@@ -32,7 +32,7 @@ ocil_clause: 'the package is not installed'
 
 ocil: '{{{ ocil_package(package="nftables") }}}'
 
-platform: machine and service_disabled[iptables] and service_disabled[ufw]
+platform: system_with_kernel and service_disabled[iptables] and service_disabled[ufw]
 
 template:
     name: package_installed

--- a/linux_os/guide/system/network/network-nftables/service_nftables_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/service_nftables_disabled/rule.yml
@@ -34,7 +34,7 @@ ocil: |-
 
 fixtext: '{{{ fixtext_service_disabled("nftables") }}}'
 
-platform: machine and package[nftables] and package[firewalld]
+platform: system_with_kernel and package[nftables] and package[firewalld]
 
 template:
     name: service_disabled

--- a/linux_os/guide/system/network/network-nftables/service_nftables_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/service_nftables_enabled/rule.yml
@@ -32,7 +32,7 @@ ocil: |-
 fixtext: |-
     {{{ fixtext_service_enabled("nftables") }}}
 
-platform: machine and package[nftables] and service_disabled[firewalld]
+platform: system_with_kernel and package[nftables] and service_disabled[firewalld]
 
 template:
     name: service_enabled

--- a/linux_os/guide/system/network/network-ufw/check_ufw_active/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/check_ufw_active/rule.yml
@@ -29,4 +29,4 @@ fixtext: |-
     Enable the ufw by using the following command:  
     <pre>$ sudo ufw enable</pre>
 
-platform: machine and package[ufw]
+platform: system_with_kernel and package[ufw]

--- a/linux_os/guide/system/network/network-ufw/group.yml
+++ b/linux_os/guide/system/network/network-ufw/group.yml
@@ -23,4 +23,4 @@ description: |-
     administrator who knows what he or she is doing. ufw is an upstream
     for other distributions and graphical frontends.
 
-platform: machine
+platform: system_with_kernel

--- a/linux_os/guide/system/network/network-ufw/service_ufw_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/service_ufw_enabled/rule.yml
@@ -28,4 +28,4 @@ template:
     vars:
         servicename: ufw
 
-platform: machine and package[ufw]
+platform: system_with_kernel and package[ufw]

--- a/linux_os/guide/system/network/network-wireless/wireless_software/kernel_module_bluetooth_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/kernel_module_bluetooth_disabled/rule.yml
@@ -51,7 +51,7 @@ fixtext: |-
 
 srg_requirement: '{{{ srg_requirement_kernel_module_disable('bluetooth') }}}'
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: kernel_module_disabled

--- a/linux_os/guide/system/network/network-wireless/wireless_software/kernel_module_cfg80211_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/kernel_module_cfg80211_disabled/rule.yml
@@ -21,7 +21,7 @@ references:
 
 {{{ complete_ocil_entry_module_disable(module="cfg80211") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: kernel_module_disabled

--- a/linux_os/guide/system/network/network-wireless/wireless_software/kernel_module_iwlmvm_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/kernel_module_iwlmvm_disabled/rule.yml
@@ -21,7 +21,7 @@ references:
 
 {{{ complete_ocil_entry_module_disable(module="iwlmvm") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: kernel_module_disabled

--- a/linux_os/guide/system/network/network-wireless/wireless_software/kernel_module_iwlwifi_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/kernel_module_iwlwifi_disabled/rule.yml
@@ -21,7 +21,7 @@ references:
 
 {{{ complete_ocil_entry_module_disable(module="iwlwifi") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: kernel_module_disabled

--- a/linux_os/guide/system/network/network-wireless/wireless_software/kernel_module_mac80211_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/kernel_module_mac80211_disabled/rule.yml
@@ -21,7 +21,7 @@ references:
 
 {{{ complete_ocil_entry_module_disable(module="mac80211") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: kernel_module_disabled

--- a/linux_os/guide/system/network/network-wireless/wireless_software/service_bluetooth_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/service_bluetooth_disabled/rule.yml
@@ -37,7 +37,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="bluetooth") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_disabled

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_in_bios/rule.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_in_bios/rule.yml
@@ -29,4 +29,4 @@ references:
     nist: AC-18(a),AC-18(3),CM-7(a),CM-7(b),CM-6(a),MP-7
     nist-csf: PR.AC-3,PR.IP-1,PR.PT-3,PR.PT-4
 
-platform: machine
+platform: system_with_kernel

--- a/linux_os/guide/system/permissions/files/no_files_unowned_by_user/rule.yml
+++ b/linux_os/guide/system/permissions/files/no_files_unowned_by_user/rule.yml
@@ -52,7 +52,7 @@ references:
     stigid@sle15: SLES-15-040400
 
 # The rule check uses password probe, which doesn't support offline mode
-platform: machine
+platform: system_with_kernel
 
 ocil_clause: 'files exist that are not owned by a valid user'
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/directory_groupowner_etc_sysctld/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/directory_groupowner_etc_sysctld/rule.yml
@@ -26,7 +26,7 @@ fixtext: '{{{ fixtext_file_group_owner(file="/etc/sysctl.d", group="root") }}}'
 
 srg_requirement: '{{{ srg_requirement_file_group_owner(file="/etc/sysctl.d", group="root") }}}'
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: file_groupowner

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/directory_owner_etc_sysctld/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/directory_owner_etc_sysctld/rule.yml
@@ -26,7 +26,7 @@ fixtext: '{{{ fixtext_file_owner(file="/etc/sysctl.d", owner="root") }}}'
 
 srg_requirement: '{{{ srg_requirement_file_owner(file="/etc/sysctl.d", owner="root") }}}'
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: file_owner

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/directory_permissions_etc_sysctld/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/directory_permissions_etc_sysctld/rule.yml
@@ -26,7 +26,7 @@ fixtext: '{{{ fixtext_file_permissions(file="/etc/sysctl.d", mode="0755") }}}'
 
 srg_requirement: '{{{ srg_requirement_file_permission(file="/etc/sysctl.d", mode="0755") }}}'
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: file_permissions

--- a/linux_os/guide/system/permissions/files/sysctl_fs_protected_fifos/rule.yml
+++ b/linux_os/guide/system/permissions/files/sysctl_fs_protected_fifos/rule.yml
@@ -28,4 +28,4 @@ template:
         sysctlval: '2'
         datatype: int
 
-platform: machine
+platform: system_with_kernel

--- a/linux_os/guide/system/permissions/files/sysctl_fs_protected_hardlinks/rule.yml
+++ b/linux_os/guide/system/permissions/files/sysctl_fs_protected_hardlinks/rule.yml
@@ -43,4 +43,4 @@ template:
         sysctlval: '1'
         datatype: int
 
-platform: machine
+platform: system_with_kernel

--- a/linux_os/guide/system/permissions/files/sysctl_fs_protected_regular/rule.yml
+++ b/linux_os/guide/system/permissions/files/sysctl_fs_protected_regular/rule.yml
@@ -29,4 +29,4 @@ template:
         sysctlval: '2'
         datatype: int
 
-platform: machine
+platform: system_with_kernel

--- a/linux_os/guide/system/permissions/files/sysctl_fs_protected_symlinks/rule.yml
+++ b/linux_os/guide/system/permissions/files/sysctl_fs_protected_symlinks/rule.yml
@@ -45,4 +45,4 @@ template:
         sysctlval: '1'
         datatype: int
 
-platform: machine
+platform: system_with_kernel

--- a/linux_os/guide/system/permissions/mounting/bios_assign_password/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/bios_assign_password/rule.yml
@@ -18,4 +18,4 @@ rationale: |-
 
 severity: unknown
 
-platform: machine
+platform: system_with_kernel

--- a/linux_os/guide/system/permissions/mounting/bios_disable_usb_boot/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/bios_disable_usb_boot/rule.yml
@@ -27,4 +27,4 @@ references:
     nist: MP-7,CM-7(b),CM-6(a)
     nist-csf: PR.AC-3,PR.AC-6
 
-platform: machine
+platform: system_with_kernel

--- a/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/rule.yml
@@ -18,7 +18,7 @@ rationale: |-
 
 severity: low
 
-platform: machine
+platform: system_with_kernel
 
 identifiers:
     cce@rhcos4: CCE-82514-1

--- a/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/rule.yml
@@ -30,7 +30,7 @@ references:
     nist: CM-7(a),CM-7(b),CM-6(a)
     nist-csf: PR.IP-1,PR.PT-3
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: kernel_module_disabled

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfs_disabled/rule.yml
@@ -31,7 +31,7 @@ references:
     nist: CM-7(a),CM-7(b),CM-6(a)
     nist-csf: PR.IP-1,PR.PT-3
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: kernel_module_disabled

--- a/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_hfsplus_disabled/rule.yml
@@ -31,7 +31,7 @@ references:
     nist: CM-7(a),CM-7(b),CM-6(a)
     nist-csf: PR.IP-1,PR.PT-3
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: kernel_module_disabled

--- a/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/rule.yml
@@ -30,7 +30,7 @@ references:
     nist: CM-7(a),CM-7(b),CM-6(a)
     nist-csf: PR.IP-1,PR.PT-3
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: kernel_module_disabled

--- a/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/rule.yml
@@ -18,7 +18,7 @@ rationale: |-
 
 severity: low
 
-platform: machine
+platform: system_with_kernel
 
 identifiers:
     cce@rhcos4: CCE-82717-0

--- a/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/rule.yml
@@ -19,7 +19,7 @@ rationale: |-
 
 severity: low
 
-platform: machine
+platform: system_with_kernel
 
 identifiers:
     cce@rhcos4: CCE-82718-8

--- a/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/rule.yml
@@ -52,7 +52,7 @@ references:
 
 {{{ complete_ocil_entry_module_disable(module="usb-storage") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: kernel_module_disabled

--- a/linux_os/guide/system/permissions/mounting/kernel_module_vfat_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_vfat_disabled/rule.yml
@@ -18,7 +18,7 @@ rationale: |-
 
 severity: low
 
-platform: machine
+platform: system_with_kernel
 
 identifiers:
     cce@rhcos4: CCE-82720-4

--- a/linux_os/guide/system/permissions/mounting/service_autofs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/service_autofs_disabled/rule.yml
@@ -61,7 +61,7 @@ ocil_clause: |-
 ocil: |-
     {{{ ocil_service_disabled(service="autofs") }}}
 
-platform: machine and package[autofs]
+platform: system_with_kernel and package[autofs]
 
 template:
     name: service_disabled

--- a/linux_os/guide/system/permissions/restrictions/coredumps/service_systemd-coredump_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/service_systemd-coredump_disabled/rule.yml
@@ -15,7 +15,7 @@ rationale: |-
 
 severity: medium
 
-platform: machine
+platform: system_with_kernel
 
 identifiers:
     cce@rhcos4: CCE-82530-7

--- a/linux_os/guide/system/permissions/restrictions/coredumps/sysctl_fs_suid_dumpable/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/sysctl_fs_suid_dumpable/rule.yml
@@ -30,7 +30,7 @@ references:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="fs.suid_dumpable", value="0") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/rule.yml
@@ -25,7 +25,7 @@ rationale: |-
 
 severity: medium
 
-platform: machine  # The oscap sysctl probe doesn't support offline mode
+platform: system_with_kernel  # The oscap sysctl probe doesn't support offline mode
 
 identifiers:
     cce@rhel8: CCE-80914-5

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/rule.yml
@@ -63,7 +63,7 @@ ocil_clause: "the kernel.kptr_restrict is not set to 1 or 2 or is configured to 
 
 srg_requirement: '{{{ full_name }}} must restrict exposed kernel pointer addresses access.'
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_randomize_va_space/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_randomize_va_space/rule.yml
@@ -47,7 +47,7 @@ references:
 
 srg_requirement: '{{{ full_name }}} must implement address space layout randomization (ASLR) to protect its memory from unauthorized code execution.'
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/permissions/restrictions/enable_nx/bios_enable_execution_restrictions/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_nx/bios_enable_execution_restrictions/rule.yml
@@ -43,7 +43,7 @@ references:
 
 # In aarch64 cpus the bit is XN and it is not disableable
 # In ppc64le cpus the bit is not applicable
-platform: machine and not aarch64_arch and not ppc64le_arch
+platform: system_with_kernel and not aarch64_arch and not ppc64le_arch
 
 ocil: |-
     Verify the NX (no-execution) bit flag is set on the system.

--- a/linux_os/guide/system/permissions/restrictions/enable_nx/install_PAE_kernel_on_x86-32/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_nx/install_PAE_kernel_on_x86-32/rule.yml
@@ -44,4 +44,4 @@ warnings:
         installed on older systems that do not support the XD or NX bit, as
         8this may prevent them from booting.8
 
-platform: machine
+platform: system_with_kernel

--- a/linux_os/guide/system/permissions/restrictions/kernel_module_uvcvideo_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/kernel_module_uvcvideo_disabled/rule.yml
@@ -22,7 +22,7 @@ references:
     stigid@ol8: OL08-00-040020
     stigid@rhel8: RHEL-08-040020
 
-platform: machine
+platform: system_with_kernel
 
 ocil_clause: 'the command does not return any output, or the line is commented out, and the collaborative computing device has not been authorized for use'
 

--- a/linux_os/guide/system/permissions/restrictions/poisoning/group.yml
+++ b/linux_os/guide/system/permissions/restrictions/poisoning/group.yml
@@ -7,4 +7,4 @@ description: |-
     Poisoning can be used as a mechanism to prevent leak of information and detection of
     corrupted memory.
 
-platform: machine
+platform: system_with_kernel

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern/rule.yml
@@ -44,7 +44,7 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} must disable the kernel.core_pattern.'
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/rule.yml
@@ -42,4 +42,4 @@ ocil: |
     <pre>$ sysctl kernel.core_pattern | cat -A</pre>
     <code>kernel.core_pattern = $</code>
 
-platform: machine
+platform: system_with_kernel

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_uses_pid/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_uses_pid/rule.yml
@@ -29,7 +29,7 @@ ocil_clause: 'the returned line does not have a value of 0'
 ocil: |-
     {{{ ocil_sysctl_option_value(sysctl="kernel.core_uses_pid", value=0) }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict/rule.yml
@@ -42,7 +42,7 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} must restrict access to the kernel message buffer.'
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_kexec_load_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_kexec_load_disabled/rule.yml
@@ -31,7 +31,7 @@ srg_requirement: '{{{ full_name }}} must prevent the loading of a new kernel for
 {{% if product == "ol8" %}}
 platform: machine and not (secure_boot and kernel_uek)
 {{% else %}}
-platform: machine
+platform: system_with_kernel
 {{% endif %}}
 
 template:

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_modules_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_modules_disabled/rule.yml
@@ -23,7 +23,7 @@ identifiers:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="kernel.modules_disabled", value="1") }}}
 
-platform: machine
+platform: system_with_kernel
 
 warnings:
   - general:

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_panic_on_oops/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_panic_on_oops/rule.yml
@@ -22,7 +22,7 @@ identifiers:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="kernel.panic_on_oops", value="1") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_cpu_time_max_percent/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_cpu_time_max_percent/rule.yml
@@ -21,7 +21,7 @@ identifiers:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="kernel.perf_cpu_time_max_percent", value="1") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_max_sample_rate/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_max_sample_rate/rule.yml
@@ -22,7 +22,7 @@ identifiers:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="kernel.perf_event_max_sample_rate", value="1") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_paranoid/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_paranoid/rule.yml
@@ -34,7 +34,7 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} must prevent kernel profiling by unprivileged users.'
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_pid_max/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_pid_max/rule.yml
@@ -22,7 +22,7 @@ identifiers:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="kernel.pid_max", value="65536") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_sysrq/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_sysrq/rule.yml
@@ -22,7 +22,7 @@ identifiers:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="kernel.sysrq", value="0") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_unprivileged_bpf_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_unprivileged_bpf_disabled/rule.yml
@@ -31,7 +31,7 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} must disable access to network bpf syscall from unprivileged processes.'
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_unprivileged_bpf_disabled_accept_default/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_unprivileged_bpf_disabled_accept_default/rule.yml
@@ -68,7 +68,7 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} must disable access to network bpf syscall from unprivileged processes.'
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_yama_ptrace_scope/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_yama_ptrace_scope/rule.yml
@@ -36,7 +36,7 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} must restrict usage of ptrace to descendant processes.'
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/permissions/restrictions/sysctl_net_core_bpf_jit_harden/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_net_core_bpf_jit_harden/rule.yml
@@ -33,7 +33,7 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} must enable hardening for the Berkeley Packet Filter Just-in-time compiler.'
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/permissions/restrictions/sysctl_user_max_user_namespaces/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_user_max_user_namespaces/rule.yml
@@ -55,7 +55,7 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} must disable the use of user namespaces.'
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/permissions/restrictions/sysctl_vm_mmap_min_addr/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_vm_mmap_min_addr/rule.yml
@@ -22,7 +22,7 @@ identifiers:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="vm.mmap_min_addr", value="65536") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: sysctl

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/install_antivirus/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/install_antivirus/rule.yml
@@ -42,4 +42,4 @@ ocil: |-
     Verify an anti-virus solution is installed on the system. The anti-virus solution may be
     bundled with an approved host-based security solution.
 
-platform: machine
+platform: system_with_kernel

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/install_hids/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/install_hids/rule.yml
@@ -50,5 +50,5 @@ warnings:
         clarification be required, DISA contact information is published publicly at
         https://public.cyber.mil/stigs/
 
-platform: machine
+platform: system_with_kernel
 

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/install_mcafee_antivirus/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/install_mcafee_antivirus/rule.yml
@@ -42,4 +42,4 @@ warnings:
         Due to McAfee HIPS being 3rd party software, automated
         remediation is not available for this configuration check.
 
-platform: machine
+platform: system_with_kernel

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_antivirus_definitions_updated/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_antivirus_definitions_updated/rule.yml
@@ -29,4 +29,4 @@ ocil: |-
     <pre>$ sudo cd /opt/NAI/LinuxShield/engine/dat
     $ sudo ls -la avvscan.dat avvnames.dat avvclean.dat</pre>
 
-platform: machine
+platform: system_with_kernel

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/service_nails_enabled/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/service_nails_enabled/rule.yml
@@ -28,7 +28,7 @@ references:
 ocil: |-
     {{{ ocil_service_enabled(service="nails") }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: service_enabled

--- a/linux_os/guide/system/software/sudo/package_sudo_installed/rule.yml
+++ b/linux_os/guide/system/software/sudo/package_sudo_installed/rule.yml
@@ -47,4 +47,4 @@ template:
     vars:
         pkgname: sudo
 
-platform: machine
+platform: system_with_kernel

--- a/linux_os/guide/system/software/system-tools/package_rng-tools_installed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_rng-tools_installed/rule.yml
@@ -31,7 +31,7 @@ fixtext: '{{{ fixtext_package_installed("rng-tools") }}}'
 
 srg_requirement: '{{{ srg_requirement_package_installed("rng-tools") }}}'
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: package_installed


### PR DESCRIPTION
Many rules currently marked with the `machine` platform should be applicable also to bootable containers. The reason is that often these rules check configuration that should be applied if the bootable container is deployed and booted on a real system. The applicability of these rules needs to be extended by marking them with the `system_with_kernel` platform instead.

We change the platforms carefully, we don't perform a blind mass platform replacement because not every rule that is currently marked as `machine` should be applicable to bootable containers, for example partition rules should be evaluated as "not applicable" when scanning a bootable container.

For more details, please read commit messages of all commits.

### Review hints

For normal (non-bootable) containers, run a scan and verify that the rules affected by this change are still evaluated as notapplicable as they were before this change. For example: `sudo oscap-podman centos:stream9 xccdf eval --profile stig --report /tmp/report.html build/ssg-cs9-ds.xml`

