### PR TITLE
Fix inventory_test_kernel_installed for SLE

### DIFF
--- a/shared/applicability/oval/system_with_kernel.xml
+++ b/shared/applicability/oval/system_with_kernel.xml
@@ -5,5 +5,9 @@
       <criterion comment="kernel is installed" test_ref="inventory_test_kernel_installed" />
     </criteria>
   </definition>
+{{% if 'sle' in product or 'slmicro' in product %}}
+{{{ oval_test_package_installed(package="kernel-default", test_id="inventory_test_kernel_installed") }}}
+{{% else %}}
 {{{ oval_test_package_installed(package="kernel", test_id="inventory_test_kernel_installed") }}}
+{{% endif %}}
 </def-group>


### PR DESCRIPTION
#### Description:

- _Fix inventory_test_kernel_installed for SLE_

#### Rationale:

- _The SLE package is kernel-default_
