### PR TITLE
Add SCE check to socket_disabled template

### DIFF
--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -795,7 +795,7 @@ When the remediation is applied duplicate occurrences of `key` are removed.
         package name is provided, socketname is used. Currently, the package name
         is used when running Automatus test scenarios.
 
-- languages: Ansible, Bash, OVAL
+- languages: Ansible, Bash, OVAL, SCE
 
 #### sshd_lineinfile
 -   Checks SSH server configuration items in `/etc/ssh/sshd_config` or

--- a/shared/templates/socket_disabled/sce-bash.template
+++ b/shared/templates/socket_disabled/sce-bash.template
@@ -1,0 +1,6 @@
+#!/bin/bash
+# check-import = stdout
+if [[ $(systemctl is-enabled {{{ SOCKETNAME }}}.socket) == "masked" ]] ; then
+    exit "$XCCDF_RESULT_PASS"
+fi
+exit "$XCCDF_RESULT_FAIL"

--- a/shared/templates/socket_disabled/template.yml
+++ b/shared/templates/socket_disabled/template.yml
@@ -2,3 +2,4 @@ supported_languages:
   - ansible
   - bash
   - oval
+  - sce-bash


### PR DESCRIPTION
During the build of bootable container images we can't use OVAL check in rules from the socket_disabled template because the OVAL tests depend on dbus which isn't available in that environment. Therefore we will use SCE checks for that environment. The SCE check is similar to the already existing SCE check for the service_disabled template.

