### PR TITLE
Add SCE check to timer_enabled template

### DIFF
--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -983,7 +983,7 @@ The selected value can be changed in the profile (consult the actual variable fo
         provided it is assumed that the name of the RPM package is the
         same as the name of the SystemD timer unit.
 
--   Languages: Ansible, Bash, OVAL
+-   Languages: Ansible, Bash, OVAL, SCE
 
 #### yamlfile_value
 -   Check if value(s) of certain type is (are) present in a YAML (or

--- a/shared/templates/timer_enabled/sce-bash.template
+++ b/shared/templates/timer_enabled/sce-bash.template
@@ -1,0 +1,6 @@
+#!/bin/bash
+# check-import = stdout
+if [[ $(systemctl is-enabled {{{ TIMERNAME }}}.timer) == "enabled" ]] ; then
+    exit "$XCCDF_RESULT_PASS"
+fi
+exit "$XCCDF_RESULT_FAIL"

--- a/shared/templates/timer_enabled/template.yml
+++ b/shared/templates/timer_enabled/template.yml
@@ -2,3 +2,4 @@ supported_languages:
   - ansible
   - bash
   - oval
+  - sce-bash


### PR DESCRIPTION
During the build of bootable container images we can't use OVAL check in rules from the timer_enabled template because the OVAL tests depend on dbus which isn't available in that environment. Therefore we will use SCE checks for that environment. The SCE check is similar to the already existing SCE check for the service_enabled template.
