### PR TITLE
Introduce new CPE platform for bootable containers

### DIFF
--- a/shared/applicability/bootc.yml
+++ b/shared/applicability/bootc.yml
@@ -1,0 +1,18 @@
+name: cpe:/a:bootc
+title: Bootable containers
+# Matches:
+# - bootc (RHEL Image Mode) containers and container images
+# - running bootc (RHEL Image Mode) systems
+# Does not match:
+# - classic containers and container images
+# - normal bare-metal systems or VMs
+#
+# The matching platforms and non-matching platforms can be easily distinguished
+# by checking for presence of the kernel and rpm-ostree RPM packages.
+# Bootable containers and running bootc systems both contain both these packages.
+# Normal bare-metal systems usually don't have the rpm-ostree, normal
+# containers don't contain kernel.
+#
+check_id: bootc
+bash_conditional: "{ rpm --quiet -q kernel } && { rpm --quiet -q rpm-ostree }"
+ansible_conditional: '"kernel" in ansible_facts.packages and "rpm-ostree" in ansible_facts.packages'

--- a/shared/applicability/oval/bootc.xml
+++ b/shared/applicability/oval/bootc.xml
@@ -1,0 +1,11 @@
+<def-group>
+  <definition class="inventory" id="bootc" version="1">
+    {{{ oval_metadata("Bootable container or bootc system", affected_platforms=["multi_platform_all"]) }}}
+    <criteria operator="AND">
+      <criterion comment="kernel is installed" test_ref="inventory_test_kernel_installed" />
+      <criterion comment="rpm-ostree is installed" test_ref="inventory_test_rpm_ostree_installed" />
+    </criteria>
+  </definition>
+{{{ oval_test_package_installed(package="kernel", test_id="inventory_test_kernel_installed") }}}
+{{{ oval_test_package_installed(package="rpm-ostree", test_id="inventory_test_rpm_ostree_installed") }}}
+</def-group>


### PR DESCRIPTION
This commit adds a new CPE platform `bootc`.

Matches:
- bootc (RHEL Image Mode) containers and container images
- running bootc (RHEL Image Mode) systems

Does not match:
- classic containers and container images
- normal bare-metal systems or VMs

The matching platforms and non-matching platforms can be easily distinguished by checking for presence of the kernel and rpm-ostree RPM packages. Bootable containers and running bootc systems both contain both these packages. Normal bare-metal systems usually don't have the rpm-ostree, normal containers don't contain kernel.

