### PR TITLE
Update file_permissions_etc_chrony_keys

### DIFF
--- a/linux_os/guide/services/ntp/file_permissions_etc_chrony_keys/rule.yml
+++ b/linux_os/guide/services/ntp/file_permissions_etc_chrony_keys/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 title: Verify Permissions On /etc/chrony.keys File
 
-description: '{{{ describe_file_permissions(file="/etc/chrony.keys", perms="0600") }}}'
+description: '{{{ describe_file_permissions(file="/etc/chrony.keys", perms="0644") }}}'
 
 rationale: |-
     Setting correct permissions on the /etc/chrony.keys file is important
@@ -17,17 +17,17 @@ identifiers:
     cce@rhel9: CCE-86384-5
     cce@rhel10: CCE-88155-7
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/chrony.keys", perms="0600") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/chrony.keys", perms="0644") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/etc/chrony.keys", perms="0600") }}}
+    {{{ ocil_file_permissions(file="/etc/chrony.keys", perms="0644") }}}
 
-fixtext: '{{{ fixtext_file_permissions(file="/etc/chrony.keys", mode="0600") }}}'
+fixtext: '{{{ fixtext_file_permissions(file="/etc/chrony.keys", mode="0644") }}}'
 
-srg_requirement: '{{{ srg_requirement_file_permission(file="/etc/chrony.keys", mode="0600") }}}'
+srg_requirement: '{{{ srg_requirement_file_permission(file="/etc/chrony.keys", mode="0644") }}}'
 
 template:
     name: file_permissions
     vars:
         filepath: /etc/chrony.keys
-        filemode: '0600'
+        filemode: '0644'


### PR DESCRIPTION


#### Description:

file_permissions_etc_chrony_keys to 644

#### Rationale:

Make it so that chrony can still read it once it drops root

