### PR TITLE
Remove unnecessary apparmor-utils pkg

### DIFF
--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/sce/shared.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/sce/shared.sh
@@ -3,7 +3,7 @@
 # check-import = stdout
 
 # If apparmor or apparmor-utils are not installed, then this test fails.
-{{{ bash_package_installed("apparmor") }}} && {{{ bash_package_installed("apparmor-utils") }}}
+{{{ bash_package_installed("apparmor") }}}
 if [ $? -ne 0 ]; then
         exit ${XCCDF_RESULT_FAIL}
 fi

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/sce/shared.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/sce/shared.sh
@@ -3,7 +3,7 @@
 # check-import = stdout
 
 # If apparmor or apparmor-utils are not installed, then this test fails.
-{{{ bash_package_installed("apparmor") }}} && {{{ bash_package_installed("apparmor-utils") }}}
+{{{ bash_package_installed("apparmor") }}}
 if [ $? -ne 0 ]; then
         exit ${XCCDF_RESULT_FAIL}
 fi


### PR DESCRIPTION
#### Description:

- Remove unnecessary apparmor-utils dependency

#### Rationale:

- The sce check script only use aa-status which is provided by apparmor pkg alone according to [package search](https://packages.ubuntu.com/jammy/amd64/apparmor/filelist). So the apparmor-utils can be removed