### PR TITLE
Skip users with ID above UID MAX on accounts_user_interactive_home_directory_defined

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/ansible/shared.yml
@@ -22,4 +22,5 @@
   when:
     - item.value[2]|int >= {{{ uid_min }}}
     - item.value[2]|int != {{{ nobody_uid }}}
+    - item.value[2]|int < {{{ dynamic_uid_min }}} or item.value[2]|int > {{{ dynamic_uid_min }}}
     - not item.value[4] | regex_search('^\/\w*\/\w{1,}')

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/ansible/shared.yml
@@ -22,5 +22,5 @@
   when:
     - item.value[2]|int >= {{{ uid_min }}}
     - item.value[2]|int != {{{ nobody_uid }}}
-    - item.value[2]|int < {{{ dynamic_uid_min }}} or item.value[2]|int > {{{ dynamic_uid_min }}}
+    - item.value[2]|int < {{{ dynamic_uid_min }}} or item.value[2]|int > {{{ dynamic_uid_max }}}
     - not item.value[4] | regex_search('^\/\w*\/\w{1,}')

--- a/product_properties/10-ids.yml
+++ b/product_properties/10-ids.yml
@@ -5,3 +5,5 @@ default:
   nobody_gid: 65534
   nobody_uid: 65534
   auid: 1000
+  dynamic_uid_min: 61184
+  dynamic_uid_max: 65519

--- a/tests/data/product_stability/alinux2.yml
+++ b/tests/data/product_stability/alinux2.yml
@@ -16,6 +16,8 @@ cpes:
     title: Alibaba Cloud Linux 2
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
 faillock_path: /var/run/faillock
 full_name: Alibaba Cloud Linux 2
 gid_min: 1000

--- a/tests/data/product_stability/alinux3.yml
+++ b/tests/data/product_stability/alinux3.yml
@@ -16,6 +16,8 @@ cpes:
     title: Alibaba Cloud Linux 3
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
 faillock_path: /var/run/faillock
 full_name: Alibaba Cloud Linux 3
 gid_min: 1000

--- a/tests/data/product_stability/anolis23.yml
+++ b/tests/data/product_stability/anolis23.yml
@@ -16,6 +16,8 @@ cpes:
     title: Anolis OS 23
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
 faillock_path: /var/run/faillock
 full_name: Anolis OS 23
 gid_min: 1000

--- a/tests/data/product_stability/anolis8.yml
+++ b/tests/data/product_stability/anolis8.yml
@@ -16,6 +16,8 @@ cpes:
     title: Anolis OS 8
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
 faillock_path: /var/run/faillock
 full_name: Anolis OS 8
 gid_min: 1000

--- a/tests/data/product_stability/chromium.yml
+++ b/tests/data/product_stability/chromium.yml
@@ -16,6 +16,8 @@ cpes:
     title: Google Chromium Browser
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
 faillock_path: /var/run/faillock
 full_name: Chromium
 gid_min: 1000

--- a/tests/data/product_stability/debian11.yml
+++ b/tests/data/product_stability/debian11.yml
@@ -16,6 +16,8 @@ cpes:
     title: Debian Linux 11
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
 faillock_path: /var/run/faillock
 families:
 - debian

--- a/tests/data/product_stability/debian12.yml
+++ b/tests/data/product_stability/debian12.yml
@@ -16,6 +16,8 @@ cpes:
     title: Debian Linux 12
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
 faillock_path: /var/run/faillock
 families:
 - debian

--- a/tests/data/product_stability/eks.yml
+++ b/tests/data/product_stability/eks.yml
@@ -24,6 +24,8 @@ cpes:
     title: Amazon Elastic Kubernetes Service 1.21
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
 faillock_path: /var/run/faillock
 full_name: Amazon Elastic Kubernetes Service
 gid_min: 1000

--- a/tests/data/product_stability/example.yml
+++ b/tests/data/product_stability/example.yml
@@ -17,6 +17,8 @@ cpes:
     title: Example
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
 faillock_path: /var/run/faillock
 full_name: Example
 gid_min: 1000

--- a/tests/data/product_stability/fedora.yml
+++ b/tests/data/product_stability/fedora.yml
@@ -41,6 +41,8 @@ cpes:
     title: Fedora 39
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: distro.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
 faillock_path: /var/run/faillock
 full_name: Fedora
 future_pkg_release: 62f2920f

--- a/tests/data/product_stability/firefox.yml
+++ b/tests/data/product_stability/firefox.yml
@@ -16,6 +16,8 @@ cpes:
     title: Mozilla Firefox
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
 faillock_path: /var/run/faillock
 full_name: Firefox
 gid_min: 1000

--- a/tests/data/product_stability/macos1015.yml
+++ b/tests/data/product_stability/macos1015.yml
@@ -16,6 +16,8 @@ cpes:
     title: Apple macOS 10.15
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
 faillock_path: /var/run/faillock
 full_name: Apple macOS 10.15
 gid_min: 1000

--- a/tests/data/product_stability/ocp4.yml
+++ b/tests/data/product_stability/ocp4.yml
@@ -100,6 +100,8 @@ cpes:
     title: Red Hat OpenShift Container Platform 4 on SDN
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
 faillock_path: /var/run/faillock
 full_name: Red Hat OpenShift Container Platform 4
 gid_min: 1000

--- a/tests/data/product_stability/ol7.yml
+++ b/tests/data/product_stability/ol7.yml
@@ -16,6 +16,8 @@ cpes:
     title: Oracle Linux 7
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: local.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
 faillock_path: /var/run/faillock
 families:
 - rhel-like

--- a/tests/data/product_stability/ol8.yml
+++ b/tests/data/product_stability/ol8.yml
@@ -16,6 +16,8 @@ cpes:
     title: Oracle Linux 8
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: local.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
 faillock_path: /var/log/faillock
 families:
 - rhel-like

--- a/tests/data/product_stability/ol9.yml
+++ b/tests/data/product_stability/ol9.yml
@@ -19,6 +19,8 @@ cpes:
     title: Oracle Linux 9
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: local.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
 faillock_path: /var/log/faillock
 families:
 - rhel-like

--- a/tests/data/product_stability/openembedded.yml
+++ b/tests/data/product_stability/openembedded.yml
@@ -28,6 +28,8 @@ cpes:
     title: OpenEmbedded Harden distribution
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
 faillock_path: /var/run/faillock
 full_name: OpenEmbedded
 gid_min: 1000

--- a/tests/data/product_stability/opensuse.yml
+++ b/tests/data/product_stability/opensuse.yml
@@ -28,6 +28,8 @@ cpes:
     title: openSUSE Leap 15.0
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
 faillock_path: /var/run/faillock
 full_name: openSUSE
 gid_min: 1000

--- a/tests/data/product_stability/rhcos4.yml
+++ b/tests/data/product_stability/rhcos4.yml
@@ -16,6 +16,8 @@ cpes:
     title: Red Hat Enterprise Linux CoreOS 4
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
 faillock_path: /var/run/faillock
 full_name: Red Hat Enterprise Linux CoreOS 4
 gid_min: 1000

--- a/tests/data/product_stability/rhel8.yml
+++ b/tests/data/product_stability/rhel8.yml
@@ -67,6 +67,8 @@ cpes:
     title: Red Hat Enterprise Linux 8.10
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
 faillock_path: /var/log/faillock
 families:
 - rhel

--- a/tests/data/product_stability/rhel9.yml
+++ b/tests/data/product_stability/rhel9.yml
@@ -23,6 +23,8 @@ cpes:
     title: Red Hat Enterprise Linux 9
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: distro.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
 faillock_path: /var/log/faillock
 families:
 - rhel

--- a/tests/data/product_stability/rhv4.yml
+++ b/tests/data/product_stability/rhv4.yml
@@ -23,6 +23,8 @@ cpes:
     title: Red Hat Virtualization 4 Manager
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
 faillock_path: /var/run/faillock
 full_name: Red Hat Virtualization 4
 gid_min: 1000

--- a/tests/data/product_stability/sle12.yml
+++ b/tests/data/product_stability/sle12.yml
@@ -20,6 +20,8 @@ cpes:
     title: SUSE Linux Enterprise Desktop 12
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
 faillock_path: /var/run/faillock
 families:
 - suse

--- a/tests/data/product_stability/sle15.yml
+++ b/tests/data/product_stability/sle15.yml
@@ -20,6 +20,8 @@ cpes:
     title: SUSE Linux Enterprise Desktop 15
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
 faillock_path: /var/run/faillock
 families:
 - suse

--- a/tests/data/product_stability/ubuntu1604.yml
+++ b/tests/data/product_stability/ubuntu1604.yml
@@ -16,6 +16,8 @@ cpes:
     title: Ubuntu release 16.04 (Xenial)
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
 faillock_path: /var/run/faillock
 families:
 - debian-like

--- a/tests/data/product_stability/ubuntu1804.yml
+++ b/tests/data/product_stability/ubuntu1804.yml
@@ -16,6 +16,8 @@ cpes:
     title: Ubuntu release 18.04 (Bionic Beaver)
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
 faillock_path: /var/run/faillock
 families:
 - debian-like

--- a/tests/data/product_stability/ubuntu2004.yml
+++ b/tests/data/product_stability/ubuntu2004.yml
@@ -17,6 +17,8 @@ cpes:
     title: Ubuntu release 20.04 (Focal Fossa)
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
 faillock_path: /var/run/faillock
 families:
 - debian-like

--- a/tests/data/product_stability/ubuntu2204.yml
+++ b/tests/data/product_stability/ubuntu2204.yml
@@ -17,6 +17,8 @@ cpes:
     title: Ubuntu release 22.04 (Jammy Jellyfish)
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
+dynamic_uid_max: 65519
+dynamic_uid_min: 61184
 faillock_path: /var/run/faillock
 families:
 - debian-like


### PR DESCRIPTION


#### Description:
To skip systemd dynamic users.
Since accounts_user_interactive_home_directory_defined only works on local users this should be fine.

Since bash remediation accesses `/etc/passwd` directly and the systemd dynamic users do not show up in that file, the bash remediation was not updated.

#### Rationale:
Fix Ansible playbook failures.
