### PR TITLE
Add special conditions for bootable containers

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/bash/shared.sh
@@ -1,5 +1,5 @@
 # platform = multi_platform_all
-if {{{ bootc_build() }}} ; then
+if {{{ bash_bootc_build() }}} ; then
     systemctl disable ctrl-alt-del.target
     systemctl mask ctrl-alt-del.target
 else

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/bash/shared.sh
@@ -1,3 +1,8 @@
 # platform = multi_platform_all
-systemctl disable --now ctrl-alt-del.target
-systemctl mask --now ctrl-alt-del.target
+if {{{ bootc_build() }}} ; then
+    systemctl disable ctrl-alt-del.target
+    systemctl mask ctrl-alt-del.target
+else
+    systemctl disable --now ctrl-alt-del.target
+    systemctl mask --now ctrl-alt-del.target
+fi

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -2517,3 +2517,19 @@ mkdir -p /etc/dconf/db/{{{ database }}}.d
 chmod -R u=rwX,go=rX /etc/dconf/profile
 (umask 0022 && dconf update)
 {{%- endmacro -%}}
+
+{{#
+This macro defines a conditional expression that is evaluated as true
+if the remediation is performed during a build of a bootable container image.
+#}}
+{{%- macro bootc_build() -%}}
+[[ "$OSCAP_BOOTC_BUILD" == "YES" ]]
+{{%- endmacro -%}}
+
+{{#
+This macro defines a conditional expression that is evaluated as true
+if the remediation is not performed during a build of a bootable container image.
+#}}
+{{%- macro not_bootc_build() -%}}
+[[ "$OSCAP_BOOTC_BUILD" != "YES" ]]
+{{%- endmacro -%}}

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -2522,7 +2522,7 @@ chmod -R u=rwX,go=rX /etc/dconf/profile
 This macro defines a conditional expression that is evaluated as true
 if the remediation is performed during a build of a bootable container image.
 #}}
-{{%- macro bootc_build() -%}}
+{{%- macro bash_bootc_build() -%}}
 [[ "$OSCAP_BOOTC_BUILD" == "YES" ]]
 {{%- endmacro -%}}
 
@@ -2530,6 +2530,6 @@ if the remediation is performed during a build of a bootable container image.
 This macro defines a conditional expression that is evaluated as true
 if the remediation is not performed during a build of a bootable container image.
 #}}
-{{%- macro not_bootc_build() -%}}
+{{%- macro bash_not_bootc_build() -%}}
 [[ "$OSCAP_BOOTC_BUILD" != "YES" ]]
 {{%- endmacro -%}}


### PR DESCRIPTION
This commit adds 2 new Jinja macros: `bootc_build` and `not_bootc_build`.  These macros define Bash conditional expressions that are evaluated as true or false if the remediation is performed during a build of a bootable container image or not performed during a build of a bootable container image. These macros can be used in Bash remediation code.  They can be used to control the remediation behavior in the bootable container build environment.

The code relies on new OpenSCAP feature implemented in https://github.com/OpenSCAP/openscap/pull/2170.

This commit changes the Bash remediation in rule
`disable_ctrlaltdel_reboot` to demonstrate usefulness of the new macros.
