### PR TITLE
Remove redundant sshd oval macro

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/oval/shared.xml
@@ -1,1 +1,1 @@
-{{{ oval_sshd_config(parameter="Ciphers", value="((aes128-ctr|aes192-ctr|aes256-ctr|chacha20-poly1305@openssh\.com|aes256-gcm@openssh\.com|aes128-gcm@openssh\.com),?)+") }}}
+{{{ sshd_oval_check(parameter="Ciphers", value="((aes128-ctr|aes192-ctr|aes256-ctr|chacha20-poly1305@openssh\.com|aes256-gcm@openssh\.com|aes128-gcm@openssh\.com),?)+", missing_parameter_pass=false, config_is_distributed=false, datatype=string) }}}

--- a/shared/macros/10-oval.jinja
+++ b/shared/macros/10-oval.jinja
@@ -546,28 +546,6 @@ datatype="{{{ datatype }}}" version="1">
 </def-group>
 {{%- endmacro -%}}
 
-
-{{#
-  High level macro to check if a particular combination of parameter and value in the ssh daemon configuration file is set.
-  A case insensitive comparison is used in the prefix because sshd_config has case-insensitive parameters (but case-sensitive values).
-
-:param parameter: The parameter to be checked in the configuration file.
-:type parameter: str
-:param value: The value to be checked. This can also be a regular expression (e.g: value1|value2 can match both values).
-:type value: str
-:param missing_parameter_pass: If set, the check will also pass if the parameter is not present in the configuration file (default is applied).
-:type missing_parameter_pass: bool
-:param multi_value: If set, it means that the parameter can accept multiple values and the expected value must be present in the current list of values.
-:type multi_value: bool
-:param missing_config_file_fail: If set, the check will fail if the configuration file doesn't exist in the system.
-:type missing_config_file_fail: bool
-
-#}}
-{{%- macro oval_sshd_config(parameter='', value='', missing_parameter_pass=false, multi_value=false, missing_config_file_fail=false) %}}
-{{{ oval_check_config_file("/etc/ssh/sshd_config", prefix_regex="^[ \\t]*(?i)", parameter=parameter, separator_regex='(?-i)[ \\t]+', value=value, missing_parameter_pass=missing_parameter_pass, application="sshd", multi_value=multi_value, missing_config_file_fail=missing_config_file_fail) }}}
-{{%- endmacro %}}
-
-
 {{#
   High level macro to check if a particular shell variable is set.
 


### PR DESCRIPTION
#### Description:

- remove the oval_sshd_config macro
- replace its usage with sshd_oval_check macro

#### Rationale:

- there were two macros for  checking of sshd config, this might cause confusion. Moreover, the removed macro was less powerful and effectively a subset of the sshd_oval_check macro.

#### Review Hints:

- run automatus on sshd_use_storng_ciphers rule
