### PR TITLE
Remove `sshd_enable_warning_banner_net` from HIPAA control file

### DIFF
--- a/controls/hipaa.yml
+++ b/controls/hipaa.yml
@@ -368,7 +368,6 @@ controls:
             - sshd_do_not_permit_user_env
             - sshd_enable_strictmodes
             - sshd_enable_warning_banner
-            - sshd_enable_warning_banner_net
             - sshd_set_keepalive
             - sshd_set_keepalive_0
             - sshd_use_priv_separation
@@ -639,7 +638,6 @@ controls:
             - sshd_do_not_permit_user_env
             - sshd_enable_strictmodes
             - sshd_enable_warning_banner
-            - sshd_enable_warning_banner_net
             - sshd_set_keepalive
             - var_sshd_set_keepalive=1
             - sshd_use_approved_ciphers
@@ -708,7 +706,6 @@ controls:
             - sshd_do_not_permit_user_env
             - sshd_enable_strictmodes
             - sshd_enable_warning_banner
-            - sshd_enable_warning_banner_net
             - sshd_set_keepalive
             - sshd_set_keepalive_0
             - sshd_use_priv_separation
@@ -906,7 +903,6 @@ controls:
             - sshd_do_not_permit_user_env
             - sshd_enable_strictmodes
             - sshd_enable_warning_banner
-            - sshd_enable_warning_banner_net
             - sshd_set_keepalive
             - sshd_set_keepalive_0
             - sshd_use_priv_separation
@@ -1675,7 +1671,6 @@ controls:
             - sshd_do_not_permit_user_env
             - sshd_enable_strictmodes
             - sshd_enable_warning_banner
-            - sshd_enable_warning_banner_net
             - sshd_set_keepalive
             - sshd_set_keepalive_0
             - sshd_use_approved_ciphers
@@ -1749,7 +1744,6 @@ controls:
             - sshd_do_not_permit_user_env
             - sshd_enable_strictmodes
             - sshd_enable_warning_banner
-            - sshd_enable_warning_banner_net
             - sshd_set_keepalive
             - sshd_set_keepalive_0
             - sshd_use_approved_ciphers

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/rule.yml
@@ -61,6 +61,9 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} must display the Standard Mandatory DoD Notice and Consent Banner before granting local or remote access to the system via a ssh logon.'
 
+conflicts:
+    - sshd_enable_warning_banner_net
+
 template:
     name: sshd_lineinfile
     vars:

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner_net/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner_net/rule.yml
@@ -46,6 +46,9 @@ references:
 
 {{{ complete_ocil_entry_sshd_option(default="no", option="Banner", value="/etc/issue.net") }}}
 
+conflicts:
+    - sshd_enable_warning_banner
+
 template:
     name: sshd_lineinfile
     vars:


### PR DESCRIPTION
#### Description:

- Remove `sshd_enable_warning_banner_net` from HIPAA control file

#### Rationale:

- The rule conflicts with already selected `sshd_enable_warning_banner`.