### PR TITLE
Fix incorrect file mode

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_permissions_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_permissions_library_dirs/rule.yml
@@ -80,4 +80,4 @@ template:
             - /usr/lib/
             - /usr/lib64/
         recursive: 'true'
-        filemode: '7755'
+        filemode: '0755'

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/rule.yml
@@ -68,7 +68,7 @@ template:
             - /usr/lib64/
         recursive: 'true'
         file_regex: ^.*$
-        filemode: '7755'
+        filemode: '0755'
 
 fixtext: |-
     Configure the library files to be protected from unauthorized access. Run the following command, replacing "[FILE]" with any library file with a mode more permissive than 755.


### PR DESCRIPTION
#### Description:

- Fix incorrect file mode for dir_permissions_library_dirs and file_permissions_library_dirs

#### Rationale:

- The 7 as special mode is incorrect for those file and path
