### PR TITLE
Explicitly state FindOpenSCAP cmake so it loads before it's used.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 set(CMAKE_INSTALL_LIBDIR "/nowhere")
 include(GNUInstallDirs)
 include(CMakeDependentOption)
+include(FindOpenSCAP)
 include(FindPythonModule)
 include(SSGCommon)
 


### PR DESCRIPTION


#### Description:

- Sometimes it could happen that the OSCAP_VERSION was being used without being defined first. This makes sure that whenever the variables are attempted to be used, they are defined.

Fix a problem where cmake would define --schematron option even if the OSCAP would be greater or equal than 1.3.5.

#### Review Hints:

- Since this seems to be a "race condition" type of problem, it's not that trivial to reproduce it. We'll be seeing this getting fixed in some productization runs.
