### PR TITLE
[DO NOT MERGE] Adapt sysctl template for use in oscap-bootc

### DIFF
--- a/shared/checks/oval/oscap_bootc_env_var.xml
+++ b/shared/checks/oval/oscap_bootc_env_var.xml
@@ -1,0 +1,33 @@
+<def-group>
+  <definition class="inventory" id="oscap_bootc_env_var" version="2">
+    <metadata>
+      <title>Check if the environment is execution of the oscap-bootc build tool in the podman build environment</title>
+       <affected family="unix">
+        <platform>multi_platform_all</platform>
+       </affected>
+      <description>Check the value of environment variable OSCAP_BOOTC_BUILD.</description>
+      <reference ref_id="cpe:/a:osbuild" source="CPE" />
+    </metadata>
+    <criteria>
+      <criterion comment="Check the value of OSCAP_BOOTC_BUILD variable" test_ref="test_oscap_bootc_env_var" />
+    </criteria>
+  </definition>
+
+  <ind:environmentvariable58_test check="all" check_existence="all_exist"
+    comment="environment variable OSCAP_BOOTC_BUILD is set to bwrap-osbuild"
+    id="test_oscap_bootc_env_var" version="1">
+    <ind:object object_ref="object_oscap_bootc_env_var" />
+    <ind:state state_ref="state_oscap_bootc_env_var" />
+  </ind:environmentvariable58_test>
+
+  <ind:environmentvariable58_object 
+    id="object_oscap_bootc_env_var" version="1">
+    <ind:pid xsi:nil="true" datatype="int" />
+    <ind:name>OSCAP_BOOTC_BUILD</ind:name>
+  </ind:environmentvariable58_object>
+
+  <ind:environmentvariable58_state
+    id="state_oscap_bootc_env_var" version="1">
+    <ind:value>YES</ind:value>
+  </ind:environmentvariable58_state>
+</def-group>

--- a/shared/templates/sysctl/bash.template
+++ b/shared/templates/sysctl/bash.template
@@ -38,10 +38,12 @@ SYSCONFIG_FILE="/etc/sysctl.conf"
 {{%- if SYSCTLVAL == "" or SYSCTLVAL is not string %}}
 {{{ bash_instantiate_variables("sysctl_" ~ SYSCTLID ~ "_value") }}}
 
+if [[ "$OSCAP_BOOTC_BUILD" != "YES" ]] ; then
 #
 # Set runtime for {{{ SYSCTLVAR }}}
 #
 /sbin/sysctl -q -n -w {{{ SYSCTLVAR }}}="$sysctl_{{{ SYSCTLID }}}_value"
+fi
 
 #
 # If {{{ SYSCTLVAR }}} present in /etc/sysctl.conf, change value to appropriate value
@@ -54,10 +56,12 @@ sed -i "/^$SYSCONFIG_VAR/d" /etc/sysctl.conf
 
 {{%- else %}}
 
+if [[ "$OSCAP_BOOTC_BUILD" != "YES" ]] ; then
 #
 # Set runtime for {{{ SYSCTLVAR }}}
 #
 /sbin/sysctl -q -n -w {{{ SYSCTLVAR }}}="{{{ SYSCTLVAL }}}"
+fi
 
 #
 # If {{{ SYSCTLVAR }}} present in /etc/sysctl.conf, change value to "{{{ SYSCTLVAL }}}"

--- a/shared/templates/sysctl/oval.template
+++ b/shared/templates/sysctl/oval.template
@@ -29,8 +29,12 @@
       <extend_definition comment="{{{ SYSCTLVAR }}} configuration setting check"
                          definition_ref="{{{ rule_id }}}_static"/>
 {{% if CHECK_RUNTIME == "true" %}}
-      <extend_definition comment="{{{ SYSCTLVAR }}} runtime setting check"
-                         definition_ref="{{{ rule_id }}}_runtime"/>
+      <criteria operator="OR">
+        <extend_definition comment="we are building bootable container image"
+                          definition_ref="oscap_bootc_env_var"/>
+        <extend_definition comment="{{{ SYSCTLVAR }}} runtime setting check"
+                          definition_ref="{{{ rule_id }}}_runtime"/>
+      </criteria>
 {{%- endif %}}
     </criteria>
   </definition>
@@ -53,8 +57,12 @@
         <extend_definition comment="{{{ SYSCTLVAR }}} configuration setting check"
                            definition_ref="{{{ rule_id }}}_static"/>
 {{% if CHECK_RUNTIME == "true" %}}
-        <extend_definition comment="{{{ SYSCTLVAR }}} runtime setting check"
-                           definition_ref="{{{ rule_id }}}_runtime"/>
+        <criteria operator="OR">
+          <extend_definition comment="we are building bootable container image"
+                            definition_ref="oscap_bootc_env_var"/>
+          <extend_definition comment="{{{ SYSCTLVAR }}} runtime setting check"
+                            definition_ref="{{{ rule_id }}}_runtime"/>
+        </criteria>
 {{%- endif %}}
       </criteria>
     </criteria>


### PR DESCRIPTION
OVAL check in sysctl template consists of 2 parts where the first part checks configuration and second checks the runtime status of the sysctl option. But, when building a bootable container image we face a problem that the runtime status doesn't make sense to check and can't be changed by the remediation. That causes the check after remediation fails and the rule result is error. Therefore, we need to suppress then runtime part of the check when building a bootable container image. Also, we shouldn't attempt to change runtime while building a bootable container image.

#### Description:

- _Description here. Replace this text. Don't use the italics format!_

#### Rationale:

- _Rationale here. Replace this text. Don't use the italics format!_

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._

#### Review Hints:

- _Review hints here. Replace this text. Don't use the italics format!_

- _Use this optional section to give any relevant information which could help the reviewer to more quickly and assertively understand and test the changes._

- _Good examples are useful commands, if it is better to review all commits together or in a suggested sequence, any relevant discussion in other PRs or issues, etc._
