### PR TITLE
Add ansible remediation to mount_option_home template 

### DIFF
--- a/shared/templates/mount_option_home/ansible.template
+++ b/shared/templates/mount_option_home/ansible.template
@@ -1,0 +1,64 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = high
+
+-   name: "Initialize variables"
+    ansible.builtin.set_fact:
+        non_allowed_partitions: ["/", "/lib", "/opt", "/usr", "/bin", "/sbin", "/boot", "/dev", "/proc"]
+        home_directories: []
+        allowed_mount_point: []
+        fstab_mount_point_info: []
+
+-   name: "Get home directories from passwd"
+    ansible.builtin.getent:
+        database: passwd
+
+-   name: "Filter home directories based on UID range"
+    ansible.builtin.set_fact:
+        home_directories: "{{ home_directories + [item.data[4]] }}"
+    when:
+        - item.data[4] is defined
+        - item.data[2]|int >= {{{ uid_min }}}
+        - item.data[2]|int != {{{ nobody_uid }}}
+        - item.data[4] not in non_allowed_partitions
+    with_items: "{{ ansible_facts.getent_passwd | dict2items(key_name='user', value_name='data')}}"
+
+-   name: "Gather mount points"
+    ansible.builtin.setup:
+        filter: ansible_mounts
+
+-   name: "Ensure mount options for home directories"
+    block:
+
+    -   name: "Obtain mount point using df and shell"
+        ansible.builtin.shell: |
+            df {{ item }} | awk '/^\/dev/ {print $6}'
+        register: df_output
+        with_items: "{{ home_directories }}"
+
+    -   name: "Set mount point for each home directory"
+        ansible.builtin.set_fact:
+            allowed_mount_point: "{{ allowed_mount_point + [item.stdout_lines[0]] }}"
+        with_items: "{{ df_output.results }}"
+        when: item.stdout_lines[0] != ""
+
+    -   name: "Obtain full mount information for allowed mount point"
+        ansible.builtin.set_fact:
+            fstab_mount_point_info: "{{ fstab_mount_point_info + [ ansible_mounts | selectattr('mount', 'equalto', item) | first ]}}"
+        with_items: "{{ allowed_mount_point }}"
+        when: allowed_mount_point is defined
+
+    -   name: "Ensure mount option {{{ MOUNTOPTION }}} is in fstab for allowed mount point"
+        ansible.builtin.mount:
+            path: "{{ item.mount }}"
+            src: "{{ item.device }}"
+            opts: "{{ item.options }},{{{ MOUNTOPTION }}}"
+            state: mounted
+            fstype: "{{ item.fstype }}"
+        with_items: "{{ fstab_mount_point_info }}"
+        when:
+            - allowed_mount_point is defined
+            - item.mount not in non_allowed_partitions
+            - "'{{{ MOUNTOPTION }}}' not in item.options"

--- a/shared/templates/mount_option_home/ansible.template
+++ b/shared/templates/mount_option_home/ansible.template
@@ -4,18 +4,18 @@
 # complexity = low
 # disruption = high
 
--   name: "Initialize variables"
+-   name: "{{{ rule_title }}} - Initialize variables"
     ansible.builtin.set_fact:
         non_allowed_partitions: ["/", "/lib", "/opt", "/usr", "/bin", "/sbin", "/boot", "/dev", "/proc"]
         home_directories: []
         allowed_mount_point: []
         fstab_mount_point_info: []
 
--   name: "Get home directories from passwd"
+-   name: "{{{ rule_title }}} - Get home directories from passwd"
     ansible.builtin.getent:
         database: passwd
 
--   name: "Filter home directories based on UID range"
+-   name: "{{{ rule_title }}} - Filter home directories based on UID range"
     ansible.builtin.set_fact:
         home_directories: "{{ home_directories + [item.data[4]] }}"
     when:
@@ -25,32 +25,35 @@
         - item.data[4] not in non_allowed_partitions
     with_items: "{{ ansible_facts.getent_passwd | dict2items(key_name='user', value_name='data')}}"
 
--   name: "Gather mount points"
+-   name: "{{{ rule_title }}} - Gather mount points"
     ansible.builtin.setup:
         filter: ansible_mounts
 
--   name: "Ensure mount options for home directories"
+-   name: "{{{ rule_title }}} - Ensure mount options for home directories"
     block:
 
-    -   name: "Obtain mount point using df and shell"
+    -   name: " {{{ rule_title }}} - Obtain mount point using df and shell"
         ansible.builtin.shell: |
             df {{ item }} | awk '/^\/dev/ {print $6}'
         register: df_output
         with_items: "{{ home_directories }}"
 
-    -   name: "Set mount point for each home directory"
+    -   name: "{{{ rule_title }}} - Set mount point for each home directory"
         ansible.builtin.set_fact:
             allowed_mount_point: "{{ allowed_mount_point + [item.stdout_lines[0]] }}"
         with_items: "{{ df_output.results }}"
-        when: item.stdout_lines[0] != ""
+        when: 
+            - item.stdout_lines is defined
+            - item.stdout_lines | length > 0
+            - item.stdout_lines[0] != ""
 
-    -   name: "Obtain full mount information for allowed mount point"
+    -   name: "{{{ rule_title }}} - Obtain full mount information for allowed mount point"
         ansible.builtin.set_fact:
             fstab_mount_point_info: "{{ fstab_mount_point_info + [ ansible_mounts | selectattr('mount', 'equalto', item) | first ]}}"
         with_items: "{{ allowed_mount_point }}"
         when: allowed_mount_point is defined
 
-    -   name: "Ensure mount option {{{ MOUNTOPTION }}} is in fstab for allowed mount point"
+    -   name: "{{{ rule_title }}} - Ensure mount option {{{ MOUNTOPTION }}} is in fstab for allowed mount point"
         ansible.builtin.mount:
             path: "{{ item.mount }}"
             src: "{{ item.device }}"

--- a/shared/templates/mount_option_home/template.yml
+++ b/shared/templates/mount_option_home/template.yml
@@ -1,3 +1,4 @@
 supported_languages:
   - bash
   - oval
+  - ansible

--- a/shared/templates/mount_option_home/tests/fstab_multiple_users_template.fail.sh
+++ b/shared/templates/mount_option_home/tests/fstab_multiple_users_template.fail.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+. $SHARED/partition.sh
+
+mkdir -p /srv/home
+awk -F':' '{if ($3>={{{ uid_min }}} && $3!= {{{ nobody_uid }}}) print $1}' /etc/passwd \
+        | xargs -I{} userdel -r {}
+
+umount /srv || true  # no problem if not mounted
+
+clean_up_partition /srv
+
+create_partition
+
+{{% if MOUNTOPTION != "nodev" %}}
+make_fstab_given_partition_line /srv ext2 nodev
+{{% else %}}
+make_fstab_given_partition_line /srv ext2 noexec
+{{% endif %}}
+
+mount_partition /srv
+
+mkdir -p /srv/home
+useradd -m -d /srv/home/testUser1 testUser1
+
+useradd -m -d /home/testUser2 testUser2


### PR DESCRIPTION
#### Description:

Added

- ansible.template
- fstab_multiple_users_template.fail.sh

Updated

- template.yml

#### Rationale:

This change introduces ansible remediation in the mount_option_home template, which is used by the mount_option_home_noexec and mount_option_home_nosuid rules; the logic was taken from bash remediation.
