### PR TITLE
Adapt sysctl template for bootable containers

### DIFF
--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -934,7 +934,7 @@ The selected value can be changed in the profile (consult the actual variable fo
     the remediation scripts will set the variable with correct value to a drop-in file in
     `/etc/sysctl.d/var_name.conf` file.
 
--   Languages: Ansible, Bash, OVAL
+-   Languages: Ansible, Bash, OVAL, SCE
 
 #### systemd_dropin_configuration
 - checks if a Systemd-style configuration exists either in the main file or in any file within specified dropin directory.

--- a/shared/templates/sysctl/bash.template
+++ b/shared/templates/sysctl/bash.template
@@ -41,7 +41,9 @@ SYSCONFIG_FILE="/etc/sysctl.conf"
 #
 # Set runtime for {{{ SYSCTLVAR }}}
 #
-/sbin/sysctl -q -n -w {{{ SYSCTLVAR }}}="$sysctl_{{{ SYSCTLID }}}_value"
+if {{{ bash_not_bootc_build() }}} ; then
+    /sbin/sysctl -q -n -w {{{ SYSCTLVAR }}}="$sysctl_{{{ SYSCTLID }}}_value"
+fi
 
 #
 # If {{{ SYSCTLVAR }}} present in /etc/sysctl.conf, change value to appropriate value
@@ -57,7 +59,9 @@ sed -i "/^$SYSCONFIG_VAR/d" /etc/sysctl.conf
 #
 # Set runtime for {{{ SYSCTLVAR }}}
 #
-/sbin/sysctl -q -n -w {{{ SYSCTLVAR }}}="{{{ SYSCTLVAL }}}"
+if {{{ bash_not_bootc_build() }}} ; then
+    /sbin/sysctl -q -n -w {{{ SYSCTLVAR }}}="{{{ SYSCTLVAL }}}"
+fi
 
 #
 # If {{{ SYSCTLVAR }}} present in /etc/sysctl.conf, change value to "{{{ SYSCTLVAL }}}"

--- a/shared/templates/sysctl/oval.template
+++ b/shared/templates/sysctl/oval.template
@@ -20,7 +20,7 @@
     <ind:pattern operation="pattern match">^[\s]*{{{ SYSCTLVAR }}}[\s]*=[\s]*(.*\S)[\s]*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
 {{%- endmacro -%}}
-{{%- if "P" in FLAGS -%}}
+{{%- if IPV6 == "false" -%}}
 
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="3">
@@ -36,7 +36,7 @@
   </definition>
 </def-group>
 
-{{%- elif "I" in FLAGS -%}}
+{{%- else -%}}
 
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="4">

--- a/shared/templates/sysctl/oval.template
+++ b/shared/templates/sysctl/oval.template
@@ -62,7 +62,6 @@
 </def-group>
 
 {{%- endif %}}
-{{%- if "R" in FLAGS -%}}
 
 {{% if CHECK_RUNTIME == "true" %}}
 <def-group>
@@ -121,8 +120,6 @@
 </def-group>
 {{% endif %}}
 
-{{%- endif -%}}
-{{%- if "S" in FLAGS -%}}
 
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}_static" version="3">
@@ -269,4 +266,3 @@
 {{% endfor %}}
 {{% endif %}}
 </def-group>
-{{%- endif -%}}

--- a/shared/templates/sysctl/sce-bash.template
+++ b/shared/templates/sysctl/sce-bash.template
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# check-import = stdout
+{{% if SYSCTLVAL == "" %}}
+# check-export = sysctl_{{{ SYSCTLID }}}_value=sysctl_{{{ SYSCTLID }}}_value
+{{% endif %}}
+
+{{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel8", "rhel9", "rhel10", "ubuntu2004", "ubuntu2204"] %}}
+FILES_NOT_MANAGED_BY_PACKAGES=("/etc/sysctl.conf" "/etc/sysctl.d/*.conf" "/lib/sysctl.d/*.conf" "/usr/local/lib/sysctl.d/*.conf" "/run/sysctl.d/*.conf")
+{{% else %}}
+FILES_NOT_MANAGED_BY_PACKAGES=("/etc/sysctl.conf" "/etc/sysctl.d/*.conf" "/usr/local/lib/sysctl.d/*.conf" "/run/sysctl.d/*.conf")
+{{% endif %}}
+FILES_MANAGED_BY_PACKAGES=("/usr/lib/sysctl.d/*.conf")
+
+function check_sysctl_configuration()
+{
+    local sysctlvar="$1"
+    local expected_value="$2"
+
+    regex="^\s*$sysctlvar\s*=\s*(.*)\s*"
+
+    # kernel static parameter $sysctlvar set to $sysctlvar in sysctl files not managed by packages
+    found=0
+    for files in ${FILES_NOT_MANAGED_BY_PACKAGES[@]} ; do
+        [[ -e "$files" ]] || continue
+        found_value=$(grep -P "$regex" $files | sed -E "s/$regex/\1/")
+        if [[ -n "$found_value" ]] ; then
+            if [[ "$found_value" == "$expected_value" ]] ; then
+                found=1
+            else
+                return $XCCDF_RESULT_FAIL
+            fi
+        fi
+    done
+    if [[ $found != 0 ]] ; then
+        return $XCCDF_RESULT_PASS
+    fi
+
+    # kernel static parameter $sysctlvar missing in sysctl files not managed by packages
+    for files in ${FILES_NOT_MANAGED_BY_PACKAGES[@]} ; do
+        [[ -e "$files" ]] || continue
+        if grep -P "$regex"  $files ; then
+            return $XCCDF_RESULT_FAIL
+        fi
+    done
+
+    # kernel static parameter $sysctlvar set to $sysctlval in sysctl files managed by packages
+    found=0
+    for files in ${FILES_MANAGED_BY_PACKAGES[@]} ; do
+        [[ -e "$files" ]] || continue
+        if [[ -n "$found_value" ]] ; then
+            if [[ "$found_value" == "$expected_value" ]] ; then
+                found=1
+            else
+                return $XCCDF_RESULT_FAIL
+            fi
+        fi
+    done
+    if [[ $found != 0 ]] ; then
+        return $XCCDF_RESULT_PASS
+    fi
+
+    return $XCCDF_RESULT_FAIL
+}
+
+{{% if "I" in FLAGS -%}}
+# pass if IPv6 is disabled
+check_sysctl_configuration "net.ipv6.conf.all.disable_ipv6" "1"
+if [[ $? == $XCCDF_RESULT_PASS ]] ; then
+    exit $XCCDF_RESULT_PASS
+fi
+{{% endif %}}
+
+{{% if SYSCTLVAL == "" -%}}
+expected_value="$XCCDF_VALUE_sysctl_{{{ SYSCTLID }}}_value"
+{{%- else -%}}
+expected_value="{{{ SYSCTLVAL }}}"
+{{%- endif %}}
+check_sysctl_configuration "{{{ SYSCTLVAR }}}" "$expected_value"
+exit $?

--- a/shared/templates/sysctl/sce-bash.template
+++ b/shared/templates/sysctl/sce-bash.template
@@ -4,12 +4,43 @@
 # check-export = sysctl_{{{ SYSCTLID }}}_value=sysctl_{{{ SYSCTLID }}}_value
 {{% endif %}}
 
-{{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel8", "rhel9", "rhel10", "ubuntu2004", "ubuntu2204"] %}}
-FILES_NOT_MANAGED_BY_PACKAGES=("/etc/sysctl.conf" "/etc/sysctl.d/*.conf" "/lib/sysctl.d/*.conf" "/usr/local/lib/sysctl.d/*.conf" "/run/sysctl.d/*.conf")
-{{% else %}}
+{{% if product in [ "ol7", "ol8", "ol9", "rhcos4", "rhel8", "rhel9", "rhel10", "ubuntu2004", "ubuntu2204"] %}}
 FILES_NOT_MANAGED_BY_PACKAGES=("/etc/sysctl.conf" "/etc/sysctl.d/*.conf" "/usr/local/lib/sysctl.d/*.conf" "/run/sysctl.d/*.conf")
+{{% else %}}
+FILES_NOT_MANAGED_BY_PACKAGES=("/etc/sysctl.conf" "/etc/sysctl.d/*.conf" "/lib/sysctl.d/*.conf" "/usr/local/lib/sysctl.d/*.conf" "/run/sysctl.d/*.conf")
 {{% endif %}}
 FILES_MANAGED_BY_PACKAGES=("/usr/lib/sysctl.d/*.conf")
+
+function pass_if_set_correctly()
+{
+    local filelist="$1"
+    local regex="$2"
+    local expected_value="$3"
+    local found=0
+    for files in $filelist ; do
+        [[ -e "$files" ]] || continue
+        found_value=$(grep -P "$regex" $files | sed -E "s/$regex/\1/")
+        if [[ -n "$found_value" ]] ; then
+            if [[ "$found_value" == "$expected_value" ]] ; then
+                return 0
+            fi
+        fi
+    done
+    return 1
+}
+
+function pass_if_missing()
+{
+    local filelist="$1"
+    local regex="$2"
+    for files in $filelist ; do
+        [[ -e "$files" ]] || continue
+        if grep -P "$regex"  $files ; then
+            return 1
+        fi
+    done
+    return 0
+}
 
 function check_sysctl_configuration()
 {
@@ -19,53 +50,27 @@ function check_sysctl_configuration()
     regex="^\s*$sysctlvar\s*=\s*(.*)\s*"
 
     # kernel static parameter $sysctlvar set to $sysctlvar in sysctl files not managed by packages
-    found=0
-    for files in ${FILES_NOT_MANAGED_BY_PACKAGES[@]} ; do
-        [[ -e "$files" ]] || continue
-        found_value=$(grep -P "$regex" $files | sed -E "s/$regex/\1/")
-        if [[ -n "$found_value" ]] ; then
-            if [[ "$found_value" == "$expected_value" ]] ; then
-                found=1
-            else
-                return $XCCDF_RESULT_FAIL
-            fi
-        fi
-    done
-    if [[ $found != 0 ]] ; then
-        return $XCCDF_RESULT_PASS
-    fi
+    pass_if_set_correctly "${FILES_NOT_MANAGED_BY_PACKAGES[*]}" "$regex" "$expected_value"
+    set_correctly_in_not_managed="$?"
 
     # kernel static parameter $sysctlvar missing in sysctl files not managed by packages
-    for files in ${FILES_NOT_MANAGED_BY_PACKAGES[@]} ; do
-        [[ -e "$files" ]] || continue
-        if grep -P "$regex"  $files ; then
-            return $XCCDF_RESULT_FAIL
-        fi
-    done
+    pass_if_missing "${FILES_NOT_MANAGED_BY_PACKAGES[*]}" "$regex"
+    missing_in_not_managed="$?"
 
     # kernel static parameter $sysctlvar set to $sysctlval in sysctl files managed by packages
-    found=0
-    for files in ${FILES_MANAGED_BY_PACKAGES[@]} ; do
-        [[ -e "$files" ]] || continue
-        if [[ -n "$found_value" ]] ; then
-            if [[ "$found_value" == "$expected_value" ]] ; then
-                found=1
-            else
-                return $XCCDF_RESULT_FAIL
-            fi
-        fi
-    done
-    if [[ $found != 0 ]] ; then
-        return $XCCDF_RESULT_PASS
-    fi
+    pass_if_set_correctly "${FILES_MANAGED_BY_PACKAGES[*]}" "$regex" "$expected_value"
+    set_correctly_in_managed="$?"
 
-    return $XCCDF_RESULT_FAIL
+    if [[ "$set_correctly_in_not_managed" == 0 || ( "$missing_in_not_managed" == 0 && "$set_correctly_in_managed" == 0 ) ]] ; then
+        return 0
+    fi
+    return 1
 }
 
 {{% if IPV6 == "true" -%}}
 # pass if IPv6 is disabled
 check_sysctl_configuration "net.ipv6.conf.all.disable_ipv6" "1"
-if [[ $? == $XCCDF_RESULT_PASS ]] ; then
+if [[ $? == 0 ]] ; then
     exit $XCCDF_RESULT_PASS
 fi
 {{% endif %}}
@@ -76,4 +81,7 @@ expected_value="$XCCDF_VALUE_sysctl_{{{ SYSCTLID }}}_value"
 expected_value="{{{ SYSCTLVAL }}}"
 {{%- endif %}}
 check_sysctl_configuration "{{{ SYSCTLVAR }}}" "$expected_value"
-exit $?
+if [[ $? == 0 ]] ; then
+    exit $XCCDF_RESULT_PASS
+fi
+exit $XCCDF_RESULT_FAIL

--- a/shared/templates/sysctl/sce-bash.template
+++ b/shared/templates/sysctl/sce-bash.template
@@ -62,7 +62,7 @@ function check_sysctl_configuration()
     return $XCCDF_RESULT_FAIL
 }
 
-{{% if "I" in FLAGS -%}}
+{{% if IPV6 == "true" -%}}
 # pass if IPv6 is disabled
 check_sysctl_configuration "net.ipv6.conf.all.disable_ipv6" "1"
 if [[ $? == $XCCDF_RESULT_PASS ]] ; then

--- a/shared/templates/sysctl/sce-bash.template
+++ b/shared/templates/sysctl/sce-bash.template
@@ -75,6 +75,7 @@ if [[ $? == 0 ]] ; then
 fi
 {{% endif %}}
 
+{{% if SYSCTLVAL is string %}}
 {{% if SYSCTLVAL == "" -%}}
 expected_value="$XCCDF_VALUE_sysctl_{{{ SYSCTLID }}}_value"
 {{%- else -%}}
@@ -84,4 +85,12 @@ check_sysctl_configuration "{{{ SYSCTLVAR }}}" "$expected_value"
 if [[ $? == 0 ]] ; then
     exit $XCCDF_RESULT_PASS
 fi
+{{% elif SYSCTLVAL is sequence %}}
+{{% for x in SYSCTLVAL %}}
+check_sysctl_configuration "{{{ SYSCTLVAR }}}" "{{{ x }}}"
+if [[ $? == 0 ]] ; then
+    exit $XCCDF_RESULT_PASS
+fi
+{{% endfor %}}
+{{% endif %}}
 exit $XCCDF_RESULT_FAIL

--- a/shared/templates/sysctl/sce-bash.template
+++ b/shared/templates/sysctl/sce-bash.template
@@ -22,10 +22,15 @@ function pass_if_set_correctly()
         found_value=$(grep -P "$regex" $files | sed -E "s/$regex/\1/")
         if [[ -n "$found_value" ]] ; then
             if [[ "$found_value" == "$expected_value" ]] ; then
-                return 0
+                found=1
+            else
+                return 1
             fi
         fi
     done
+    if [[ $found == 1 ]] ; then
+        return 0
+    fi
     return 1
 }
 

--- a/shared/templates/sysctl/template.py
+++ b/shared/templates/sysctl/template.py
@@ -8,7 +8,7 @@ def preprocess(data, lang):
     ipv6_flag = "P"
     if data["sysctlid"].find("ipv6") >= 0:
         ipv6_flag = "I"
-    data["flags"] = "SR" + ipv6_flag
+    data["flags"] = ipv6_flag
     if "operation" not in data:
         data["operation"] = "equals"
     if isinstance(data["sysctlval"], list) and len(data["sysctlval"]) == 0:

--- a/shared/templates/sysctl/template.py
+++ b/shared/templates/sysctl/template.py
@@ -5,10 +5,10 @@ def preprocess(data, lang):
     data["sysctlid"] = ssg.utils.escape_id(data["sysctlvar"])
     if not data.get("sysctlval"):
         data["sysctlval"] = ""
-    ipv6_flag = "P"
     if data["sysctlid"].find("ipv6") >= 0:
-        ipv6_flag = "I"
-    data["flags"] = ipv6_flag
+        data["ipv6"] = "true"
+    else:
+        data["ipv6"] = "false"
     if "operation" not in data:
         data["operation"] = "equals"
     if isinstance(data["sysctlval"], list) and len(data["sysctlval"]) == 0:

--- a/shared/templates/sysctl/template.yml
+++ b/shared/templates/sysctl/template.yml
@@ -2,3 +2,4 @@ supported_languages:
   - ansible
   - bash
   - oval
+  - sce-bash


### PR DESCRIPTION
Add an SCE check to the sysctl template special for bootable containers. We don't want to use  OVAL check in this template because the OVAL check checks runtime status using OpenSCAP sysctl probe. The probe doesn't return meaningful results during podman build process and also it doesn't make sense to check runtime during the build. We need to check only the static configuration. Moreover, we update the Bash remediation to not set the runtime status during podman build process.
