### PR TITLE
DO NOT MERGE: trying to fix Automatus sanity check

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/ansible/shared.yml
@@ -21,5 +21,5 @@
   loop: '{{ local_users }}'
   when:
     - item.value[2]|int >= {{{ uid_min }}}
-    - item.value[2]|int != {{{ nobody_uid }}}
+    - item.value[2]|int != 65535
     - not item.value[4] | regex_search('^\/\w*\/\w{1,}')


### PR DESCRIPTION
Automatus sanity check is sometimes failing. The reason is that the rule file_owner_etc_issue_net is being scanned and it fails.
The fail might be legitimate, but the peculiar thing is that when testing locally on Fedora, the rule does not get picked by the last test run.
The particular test run tests the template feature of Automatus and it uses slice 1 of 15 for file_owner template.