### PR TITLE
Improve Benchmark detection in Automatus

### DIFF
--- a/tests/ssg_test_suite/xml_operations.py
+++ b/tests/ssg_test_suite/xml_operations.py
@@ -42,9 +42,14 @@ def get_all_xccdf_ids_in_datastream(datastream):
         logging.error(
             "Checklists not found within data stream")
 
-    all_checklist_components = checklists_node.findall('ds:component-ref',
-                                                       PREFIX_TO_NS)
-    xccdf_ids = [component.get("id") for component in all_checklist_components]
+    xccdf_ids = []
+    for cref in checklists_node.findall("ds:component-ref", PREFIX_TO_NS):
+        href = cref.get('{%s}href' % PREFIX_TO_NS["xlink"])
+        comp_id = href.lstrip("#")
+        query = ".//ds:component[@id='%s']/xccdf-1.2:Benchmark" % (comp_id)
+        benchmark_node = root.find(query, PREFIX_TO_NS)
+        if benchmark_node is not None:
+            xccdf_ids.append(cref.get("id"))
     return xccdf_ids
 
 


### PR DESCRIPTION
The SCE checks are inserted to SCAP source data stream in a form of `extended-component` element, each SCE check as a separate `extended-component` element. We shouldn't treat these extended component as XCCDF Benchmarks. Instead, when resolving a component reference we should check if the reference really points to an XCCDF Benchmark.

This fix will remove these annoying messages from automatus output:

```
INFO - The data stream contains 132 Benchmarks
INFO - 0 - scap_org.open-scap_cref_ssg-rhel9-xccdf.xml
INFO - 1 - scap_org.open-scap_cref_rhel9-checks-sce-timer_dnf-automatic_enabled.sh
INFO - 2 - scap_org.open-scap_cref_rhel9-checks-sce-service_debug-shell_disabled.sh
INFO - 3 - scap_org.open-scap_cref_rhel9-checks-sce-service_pcscd_enabled.sh
...
```


#### Review Hints:
1. Build a product using `build_product` of a product where SCE checks are now enabled by default, eg. `rhel9`.
2. Run `automatus` tests of your favourite rule.
3. Compare `automatus` output with and without this patch.
