### PR TITLE
Update RHEL 8 STIG due to rule removal

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_tmux/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_tmux/rule.yml
@@ -27,7 +27,6 @@ references:
     disa: CCI-000060,CCI-000056
     srg: SRG-OS-000031-GPOS-00012,SRG-OS-000028-GPOS-00009,SRG-OS-000030-GPOS-00011
     stigid@ol8: OL08-00-020041
-    stigid@rhel8: RHEL-08-020041
 
 platform: package[tmux]
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/rule.yml
@@ -25,7 +25,6 @@ references:
     ospp: FMT_SMF_EXT.1,FMT_MOF_EXT.1,FTA_SSL.1
     srg: SRG-OS-000029-GPOS-00010,SRG-OS-000031-GPOS-00012
     stigid@ol8: OL08-00-020070
-    stigid@rhel8: RHEL-08-020070
 
 platform: package[tmux]
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/rule.yml
@@ -30,7 +30,6 @@ references:
     ospp: FMT_SMF_EXT.1,FMT_MOF_EXT.1,FTA_SSL.1
     srg: SRG-OS-000028-GPOS-00009,SRG-OS-000030-GPOS-00011
     stigid@ol8: OL08-00-020040
-    stigid@rhel8: RHEL-08-020040
 
 platform: package[tmux]
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/rule.yml
@@ -27,7 +27,6 @@ references:
     disa: CCI-000056
     srg: SRG-OS-000028-GPOS-00009,SRG-OS-000030-GPOS-00011
     stigid@ol8: OL08-00-020040
-    stigid@rhel8: RHEL-08-020040
 
 platform: package[tmux]
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/no_tmux_in_shells/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/no_tmux_in_shells/rule.yml
@@ -26,7 +26,6 @@ references:
     ospp: FMT_SMF_EXT.1,FMT_MOF_EXT.1,FTA_SSL.1
     srg: SRG-OS-000324-GPOS-00125,SRG-OS-000028-GPOS-00009,SRG-OS-000030-GPOS-00011
     stigid@ol8: OL08-00-020042
-    stigid@rhel8: RHEL-08-020042
 
 ocil_clause: 'tmux is listed in /etc/shells'
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/package_tmux_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/package_tmux_installed/rule.yml
@@ -43,7 +43,6 @@ references:
     ospp: FMT_SMF_EXT.1,FMT_MOF_EXT.1,FTA_SSL.1
     srg: SRG-OS-000030-GPOS-00011,SRG-OS-000028-GPOS-00009
     stigid@ol8: OL08-00-020039
-    stigid@rhel8: RHEL-08-020039
 
 ocil_clause: 'the package is not installed'
 

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_endpoint_security_software/agent_mfetpd_running/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_endpoint_security_software/agent_mfetpd_running/rule.yml
@@ -24,7 +24,6 @@ references:
     disa: CCI-001263,CCI-000366
     nist: SI-2(2)
     srg: SRG-OS-000191-GPOS-00080
-    stigid@rhel8: RHEL-08-010001
     stigid@sle12: SLES-12-010599
 
 ocil_clause: 'virus scanning software is not running'

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -92,10 +92,6 @@ selections:
     # RHEL-08-010000
     - installed_OS_is_vendor_supported
 
-    # RHEL-08-010001
-    - package_mcafeetp_installed
-    - agent_mfetpd_running
-
     # RHEL-08-010010
     - security_patches_up_to_date
 
@@ -549,27 +545,11 @@ selections:
     - logind_session_timeout
     - var_logind_session_timeout=10_minutes
 
-    # RHEL-08-020039
-    - package_tmux_installed
-
-    # RHEL-08-020040
-    - configure_tmux_lock_command
-    - configure_tmux_lock_keybinding
-
-    # RHEL-08-020041
-    - configure_bashrc_tmux
-
-    # RHEL-08-020042
-    - no_tmux_in_shells
-
     # RHEL-08-020050
     - dconf_gnome_lock_screen_on_smartcard_removal
 
     # RHEL-08-020060
     - dconf_gnome_screensaver_idle_delay
-
-    # RHEL-08-020070
-    - configure_tmux_lock_after_time
 
     # RHEL-08-020080
     - dconf_gnome_screensaver_user_locks

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -79,7 +79,6 @@ selections:
 - accounts_user_interactive_home_directory_exists
 - accounts_users_home_files_groupownership
 - accounts_users_home_files_permissions
-- agent_mfetpd_running
 - aide_build_database
 - aide_check_audit_tools
 - aide_scan_notification
@@ -169,7 +168,6 @@ selections:
 - chronyd_server_directive
 - chronyd_specify_remote_server
 - clean_components_post_updating
-- configure_bashrc_tmux
 - configure_bind_crypto_policy
 - configure_crypto_policy
 - configure_firewalld_ports
@@ -179,9 +177,6 @@ selections:
 - configure_openssl_crypto_policy
 - configure_openssl_tls_crypto_policy
 - configure_ssh_crypto_policy
-- configure_tmux_lock_after_time
-- configure_tmux_lock_command
-- configure_tmux_lock_keybinding
 - configure_usbguard_auditbackend
 - configured_firewalld_default_deny
 - coredump_disable_backtraces
@@ -306,7 +301,6 @@ selections:
 - no_empty_passwords_etc_shadow
 - no_files_unowned_by_user
 - no_host_based_files
-- no_tmux_in_shells
 - no_user_host_based_files
 - package_abrt-addon-ccpp_removed
 - package_abrt-addon-kerneloops_removed
@@ -324,7 +318,6 @@ selections:
 - package_libreport-plugin-logger_removed
 - package_libreport-plugin-rhtsupport_removed
 - package_mailx_installed
-- package_mcafeetp_installed
 - package_opensc_installed
 - package_openssh-server_installed
 - package_policycoreutils_installed
@@ -337,7 +330,6 @@ selections:
 - package_sendmail_removed
 - package_telnet-server_removed
 - package_tftp-server_removed
-- package_tmux_installed
 - package_tuned_removed
 - package_usbguard_installed
 - package_vsftpd_removed

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -90,7 +90,6 @@ selections:
 - accounts_user_interactive_home_directory_exists
 - accounts_users_home_files_groupownership
 - accounts_users_home_files_permissions
-- agent_mfetpd_running
 - aide_build_database
 - aide_check_audit_tools
 - aide_scan_notification
@@ -180,7 +179,6 @@ selections:
 - chronyd_server_directive
 - chronyd_specify_remote_server
 - clean_components_post_updating
-- configure_bashrc_tmux
 - configure_bind_crypto_policy
 - configure_crypto_policy
 - configure_firewalld_ports
@@ -190,9 +188,6 @@ selections:
 - configure_openssl_crypto_policy
 - configure_openssl_tls_crypto_policy
 - configure_ssh_crypto_policy
-- configure_tmux_lock_after_time
-- configure_tmux_lock_command
-- configure_tmux_lock_keybinding
 - configure_usbguard_auditbackend
 - configured_firewalld_default_deny
 - coredump_disable_backtraces
@@ -316,7 +311,6 @@ selections:
 - no_empty_passwords_etc_shadow
 - no_files_unowned_by_user
 - no_host_based_files
-- no_tmux_in_shells
 - no_user_host_based_files
 - package_abrt-addon-ccpp_removed
 - package_abrt-addon-kerneloops_removed
@@ -333,7 +327,6 @@ selections:
 - package_krb5-workstation_removed
 - package_libreport-plugin-logger_removed
 - package_mailx_installed
-- package_mcafeetp_installed
 - package_opensc_installed
 - package_openssh-server_installed
 - package_policycoreutils_installed
@@ -346,7 +339,6 @@ selections:
 - package_sendmail_removed
 - package_telnet-server_removed
 - package_tftp-server_removed
-- package_tmux_installed
 - package_tuned_removed
 - package_usbguard_installed
 - package_vsftpd_removed


### PR DESCRIPTION
#### Description:

Remove rules from the RHEL 8 STIG profile that no longer in the STIG

#### Rationale:

Keep RHEL 8 STIG up to date.