### PR TITLE
Change platform for rules related to partitions

### DIFF
--- a/linux_os/guide/system/permissions/partitions/group.yml
+++ b/linux_os/guide/system/permissions/partitions/group.yml
@@ -7,3 +7,5 @@ description: |-
     that limit what files on those partitions can do. These options
     are set in the <tt>/etc/fstab</tt> configuration file, and can be
     used to make certain types of malicious behavior more difficult.
+
+platform: not container and not bootc

--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/rule.yml
@@ -28,7 +28,7 @@ references:
     stigid@ol8: OL08-00-010572
     stigid@rhel8: RHEL-08-010572
 
-platform: machine and uefi
+platform: not container and not bootc and uefi
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/rule.yml
@@ -28,7 +28,7 @@ references:
     stigid@ol8: OL08-00-010572
     stigid@rhel8: RHEL-08-010572
 
-platform: not container and not bootc and uefi
+platform: uefi
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_noauto/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_noauto/rule.yml
@@ -22,7 +22,7 @@ identifiers:
     cce@rhel8: CCE-83345-9
 
 
-platform: machine
+platform: not container and not bootc
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_noauto/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_noauto/rule.yml
@@ -22,7 +22,6 @@ identifiers:
     cce@rhel8: CCE-83345-9
 
 
-platform: not container and not bootc
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_nodev/rule.yml
@@ -31,7 +31,6 @@ references:
     nist-csf: PR.IP-1,PR.PT-2,PR.PT-3
     srg: SRG-OS-000368-GPOS-00154
 
-platform: not container and not bootc
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_nodev/rule.yml
@@ -31,7 +31,7 @@ references:
     nist-csf: PR.IP-1,PR.PT-2,PR.PT-3
     srg: SRG-OS-000368-GPOS-00154
 
-platform: machine
+platform: not container and not bootc
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_noexec/rule.yml
@@ -24,7 +24,6 @@ identifiers:
     cce@sle12: CCE-91541-3
     cce@sle15: CCE-91234-5
 
-platform: not container and not bootc
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_noexec/rule.yml
@@ -24,7 +24,7 @@ identifiers:
     cce@sle12: CCE-91541-3
     cce@sle15: CCE-91234-5
 
-platform: machine
+platform: not container and not bootc
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_nosuid/rule.yml
@@ -33,7 +33,6 @@ references:
     stigid@ol8: OL08-00-010571
     stigid@rhel8: RHEL-08-010571
 
-platform: not container and not bootc
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_nosuid/rule.yml
@@ -33,7 +33,7 @@ references:
     stigid@ol8: OL08-00-010571
     stigid@rhel8: RHEL-08-010571
 
-platform: machine
+platform: not container and not bootc
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nodev/rule.yml
@@ -44,7 +44,6 @@ references:
     stigid@ol8: OL08-00-040120
     stigid@rhel8: RHEL-08-040120
 
-platform: not container and not bootc
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nodev/rule.yml
@@ -44,7 +44,7 @@ references:
     stigid@ol8: OL08-00-040120
     stigid@rhel8: RHEL-08-040120
 
-platform: machine
+platform: not container and not bootc
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/rule.yml
@@ -46,7 +46,7 @@ references:
     stigid@ol8: OL08-00-040122
     stigid@rhel8: RHEL-08-040122
 
-platform: machine
+platform: not container and not bootc
 
 fixtext: |-
     {{{ fixtext_mount_option("/dev/shm", "noexec") }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/rule.yml
@@ -46,7 +46,6 @@ references:
     stigid@ol8: OL08-00-040122
     stigid@rhel8: RHEL-08-040122
 
-platform: not container and not bootc
 
 fixtext: |-
     {{{ fixtext_mount_option("/dev/shm", "noexec") }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nosuid/rule.yml
@@ -44,7 +44,6 @@ references:
     stigid@ol8: OL08-00-040121
     stigid@rhel8: RHEL-08-040121
 
-platform: not container and not bootc
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nosuid/rule.yml
@@ -44,7 +44,7 @@ references:
     stigid@ol8: OL08-00-040121
     stigid@rhel8: RHEL-08-040121
 
-platform: machine
+platform: not container and not bootc
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_grpquota/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_grpquota/rule.yml
@@ -48,13 +48,13 @@ warnings:
 {{% endif %}}
 
 {{% if "ol" in product %}}
-platform: machine
+platform: not container and not bootc
 template:
     name: mount_option_home
     vars:
         mountoption: grpquota
 {{% else %}}
-platform: machine and mount[home]
+platform: not container and not bootc and mount[home]
 template:
     name: mount_option
     vars:

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_grpquota/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_grpquota/rule.yml
@@ -48,13 +48,12 @@ warnings:
 {{% endif %}}
 
 {{% if "ol" in product %}}
-platform: not container and not bootc
 template:
     name: mount_option_home
     vars:
         mountoption: grpquota
 {{% else %}}
-platform: not container and not bootc and mount[home]
+platform: mount[home]
 template:
     name: mount_option
     vars:

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_nodev/rule.yml
@@ -36,7 +36,7 @@ references:
     disa: CCI-001764
     srg: SRG-OS-000368-GPOS-00154
 
-platform: machine and mount[home]
+platform: not container and not bootc and mount[home]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_nodev/rule.yml
@@ -36,7 +36,7 @@ references:
     disa: CCI-001764
     srg: SRG-OS-000368-GPOS-00154
 
-platform: not container and not bootc and mount[home]
+platform: mount[home]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_noexec/rule.yml
@@ -29,7 +29,7 @@ references:
     stigid@ol8: OL08-00-010590
     stigid@rhel8: RHEL-08-010590
 
-platform: machine
+platform: not container and not bootc
 
 {{{ complete_ocil_entry_mount_option("/home", "noexec") }}}
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_noexec/rule.yml
@@ -29,7 +29,6 @@ references:
     stigid@ol8: OL08-00-010590
     stigid@rhel8: RHEL-08-010590
 
-platform: not container and not bootc
 
 {{{ complete_ocil_entry_mount_option("/home", "noexec") }}}
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/rule.yml
@@ -49,14 +49,13 @@ fixtext: |-
 srg_requirement: '{{{ srg_requirement_mount_option("/home", "nosuid") }}}'
 
 {{% if "ol" not in product %}}
-platform: not container and not bootc and mount[home]
+platform: mount[home]
 template:
     name: mount_option
     vars:
         mountpoint: /home
         mountoption: nosuid
 {{% else %}}
-platform: not container and not bootc
 warnings:
     - functionality: |-
         OVAL looks for partitions whose mount point is a substring of any interactive user's home

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/rule.yml
@@ -49,14 +49,14 @@ fixtext: |-
 srg_requirement: '{{{ srg_requirement_mount_option("/home", "nosuid") }}}'
 
 {{% if "ol" not in product %}}
-platform: machine and mount[home]
+platform: not container and not bootc and mount[home]
 template:
     name: mount_option
     vars:
         mountpoint: /home
         mountoption: nosuid
 {{% else %}}
-platform: machine
+platform: not container and not bootc
 warnings:
     - functionality: |-
         OVAL looks for partitions whose mount point is a substring of any interactive user's home

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_usrquota/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_usrquota/rule.yml
@@ -48,13 +48,13 @@ warnings:
 {{% endif %}}
 
 {{% if "ol" in product %}}
-platform: machine
+platform: not container and not bootc
 template:
     name: mount_option_home
     vars:
         mountoption: usrquota
 {{% else %}}
-platform: machine and mount[home]
+platform: not container and not bootc and mount[home]
 template:
     name: mount_option
     vars:

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_usrquota/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_usrquota/rule.yml
@@ -48,13 +48,12 @@ warnings:
 {{% endif %}}
 
 {{% if "ol" in product %}}
-platform: not container and not bootc
 template:
     name: mount_option_home
     vars:
         mountoption: usrquota
 {{% else %}}
-platform: not container and not bootc and mount[home]
+platform: mount[home]
 template:
     name: mount_option
     vars:

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/rule.yml
@@ -47,7 +47,6 @@ references:
     stigid@ol8: OL08-00-010580
     stigid@rhel8: RHEL-08-010580
 
-platform: not container and not bootc
 
 fixtext: |-
     Configure the "/etc/fstab" to use the "nodev" option on all non-root local partitions.

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/rule.yml
@@ -47,7 +47,7 @@ references:
     stigid@ol8: OL08-00-010580
     stigid@rhel8: RHEL-08-010580
 
-platform: machine
+platform: not container and not bootc
 
 fixtext: |-
     Configure the "/etc/fstab" to use the "nodev" option on all non-root local partitions.

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/rule.yml
@@ -44,7 +44,7 @@ references:
     stigid@ol8: OL08-00-010600
     stigid@rhel8: RHEL-08-010600
 
-platform: machine
+platform: not container and not bootc
 
 ocil_clause: 'a file system found in "/etc/fstab" refers to removable media and it does not have the "nodev" option set'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/rule.yml
@@ -44,7 +44,6 @@ references:
     stigid@ol8: OL08-00-010600
     stigid@rhel8: RHEL-08-010600
 
-platform: not container and not bootc
 
 ocil_clause: 'a file system found in "/etc/fstab" refers to removable media and it does not have the "nodev" option set'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/rule.yml
@@ -54,7 +54,6 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} must prevent code from being executed on file systems that are used with removable media.'
 
-platform: not container and not bootc
 
 template:
     name: mount_option_removable_partitions

--- a/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/rule.yml
@@ -54,7 +54,7 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} must prevent code from being executed on file systems that are used with removable media.'
 
-platform: machine
+platform: not container and not bootc
 
 template:
     name: mount_option_removable_partitions

--- a/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/rule.yml
@@ -47,7 +47,7 @@ references:
     stigid@sle12: SLES-12-010800
     stigid@sle15: SLES-15-040150
 
-platform: machine
+platform: not container and not bootc
 
 ocil_clause: 'file system found in "/etc/fstab" refers to removable media and it does not have the "nosuid" option set'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/rule.yml
@@ -47,7 +47,6 @@ references:
     stigid@sle12: SLES-12-010800
     stigid@sle15: SLES-15-040150
 
-platform: not container and not bootc
 
 ocil_clause: 'file system found in "/etc/fstab" refers to removable media and it does not have the "nosuid" option set'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_opt_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_opt_nosuid/rule.yml
@@ -25,7 +25,7 @@ identifiers:
     cce@sle12: CCE-91584-3
     cce@sle15: CCE-91270-9
 
-platform: not container and not bootc and mount[opt]
+platform: mount[opt]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_opt_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_opt_nosuid/rule.yml
@@ -25,7 +25,7 @@ identifiers:
     cce@sle12: CCE-91584-3
     cce@sle15: CCE-91270-9
 
-platform: machine and mount[opt]
+platform: not container and not bootc and mount[opt]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_proc_hidepid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_proc_hidepid/rule.yml
@@ -39,7 +39,7 @@ identifiers:
     cce@rhel9: CCE-85883-7
 
 
-platform: machine
+platform: not container and not bootc
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_proc_hidepid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_proc_hidepid/rule.yml
@@ -39,7 +39,6 @@ identifiers:
     cce@rhel9: CCE-85883-7
 
 
-platform: not container and not bootc
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_srv_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_srv_nosuid/rule.yml
@@ -25,7 +25,7 @@ identifiers:
     cce@sle12: CCE-91585-0
     cce@sle15: CCE-91271-7
 
-platform: not container and not bootc and mount[srv]
+platform: mount[srv]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_srv_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_srv_nosuid/rule.yml
@@ -25,7 +25,7 @@ identifiers:
     cce@sle12: CCE-91585-0
     cce@sle15: CCE-91271-7
 
-platform: machine and mount[srv]
+platform: not container and not bootc and mount[srv]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_nodev/rule.yml
@@ -43,7 +43,7 @@ references:
     stigid@ol8: OL08-00-040123
     stigid@rhel8: RHEL-08-040123
 
-platform: machine and mount[tmp]
+platform: not container and not bootc and mount[tmp]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_nodev/rule.yml
@@ -43,7 +43,7 @@ references:
     stigid@ol8: OL08-00-040123
     stigid@rhel8: RHEL-08-040123
 
-platform: not container and not bootc and mount[tmp]
+platform: mount[tmp]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/rule.yml
@@ -42,7 +42,7 @@ references:
     stigid@ol8: OL08-00-040125
     stigid@rhel8: RHEL-08-040125
 
-platform: not container and not bootc and mount[tmp]
+platform: mount[tmp]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/rule.yml
@@ -42,7 +42,7 @@ references:
     stigid@ol8: OL08-00-040125
     stigid@rhel8: RHEL-08-040125
 
-platform: machine and mount[tmp]
+platform: not container and not bootc and mount[tmp]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_nosuid/rule.yml
@@ -43,7 +43,7 @@ references:
     stigid@ol8: OL08-00-040124
     stigid@rhel8: RHEL-08-040124
 
-platform: machine and mount[tmp]
+platform: not container and not bootc and mount[tmp]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_nosuid/rule.yml
@@ -43,7 +43,7 @@ references:
     stigid@ol8: OL08-00-040124
     stigid@rhel8: RHEL-08-040124
 
-platform: not container and not bootc and mount[tmp]
+platform: mount[tmp]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_nodev/rule.yml
@@ -34,7 +34,7 @@ references:
     stigid@ol8: OL08-00-040129
     stigid@rhel8: RHEL-08-040129
 
-platform: not container and not bootc and mount[var-log-audit]
+platform: mount[var-log-audit]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_nodev/rule.yml
@@ -34,7 +34,7 @@ references:
     stigid@ol8: OL08-00-040129
     stigid@rhel8: RHEL-08-040129
 
-platform: machine and mount[var-log-audit]
+platform: not container and not bootc and mount[var-log-audit]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_noexec/rule.yml
@@ -32,7 +32,7 @@ references:
     stigid@ol8: OL08-00-040131
     stigid@rhel8: RHEL-08-040131
 
-platform: machine and mount[var-log-audit]
+platform: not container and not bootc and mount[var-log-audit]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_noexec/rule.yml
@@ -32,7 +32,7 @@ references:
     stigid@ol8: OL08-00-040131
     stigid@rhel8: RHEL-08-040131
 
-platform: not container and not bootc and mount[var-log-audit]
+platform: mount[var-log-audit]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_nosuid/rule.yml
@@ -33,7 +33,7 @@ references:
     stigid@ol8: OL08-00-040130
     stigid@rhel8: RHEL-08-040130
 
-platform: not container and not bootc and mount[var-log-audit]
+platform: mount[var-log-audit]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_nosuid/rule.yml
@@ -33,7 +33,7 @@ references:
     stigid@ol8: OL08-00-040130
     stigid@rhel8: RHEL-08-040130
 
-platform: machine and mount[var-log-audit]
+platform: not container and not bootc and mount[var-log-audit]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_nodev/rule.yml
@@ -34,7 +34,7 @@ references:
     stigid@ol8: OL08-00-040126
     stigid@rhel8: RHEL-08-040126
 
-platform: machine and mount[var-log]
+platform: not container and not bootc and mount[var-log]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_nodev/rule.yml
@@ -34,7 +34,7 @@ references:
     stigid@ol8: OL08-00-040126
     stigid@rhel8: RHEL-08-040126
 
-platform: not container and not bootc and mount[var-log]
+platform: mount[var-log]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_noexec/rule.yml
@@ -34,7 +34,7 @@ references:
     stigid@ol8: OL08-00-040128
     stigid@rhel8: RHEL-08-040128
 
-platform: machine and mount[var-log]
+platform: not container and not bootc and mount[var-log]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_noexec/rule.yml
@@ -34,7 +34,7 @@ references:
     stigid@ol8: OL08-00-040128
     stigid@rhel8: RHEL-08-040128
 
-platform: not container and not bootc and mount[var-log]
+platform: mount[var-log]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_nosuid/rule.yml
@@ -35,7 +35,7 @@ references:
     stigid@ol8: OL08-00-040127
     stigid@rhel8: RHEL-08-040127
 
-platform: machine and mount[var-log]
+platform: not container and not bootc and mount[var-log]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_nosuid/rule.yml
@@ -35,7 +35,7 @@ references:
     stigid@ol8: OL08-00-040127
     stigid@rhel8: RHEL-08-040127
 
-platform: not container and not bootc and mount[var-log]
+platform: mount[var-log]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_nodev/rule.yml
@@ -32,7 +32,7 @@ references:
     nist-csf: PR.IP-1,PR.PT-2,PR.PT-3
     srg: SRG-OS-000368-GPOS-00154
 
-platform: not container and not bootc and mount[var]
+platform: mount[var]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_nodev/rule.yml
@@ -32,7 +32,7 @@ references:
     nist-csf: PR.IP-1,PR.PT-2,PR.PT-3
     srg: SRG-OS-000368-GPOS-00154
 
-platform: machine and mount[var]
+platform: not container and not bootc and mount[var]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_noexec/rule.yml
@@ -23,7 +23,7 @@ identifiers:
     cce@sle12: CCE-91590-0
     cce@sle15: CCE-91276-6
 
-platform: machine and mount[var]
+platform: not container and not bootc and mount[var]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_noexec/rule.yml
@@ -23,7 +23,7 @@ identifiers:
     cce@sle12: CCE-91590-0
     cce@sle15: CCE-91276-6
 
-platform: not container and not bootc and mount[var]
+platform: mount[var]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_nosuid/rule.yml
@@ -26,7 +26,7 @@ references:
 
 severity: medium
 
-platform: machine and mount[var]
+platform: not container and not bootc and mount[var]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_nosuid/rule.yml
@@ -26,7 +26,7 @@ references:
 
 severity: medium
 
-platform: not container and not bootc and mount[var]
+platform: mount[var]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_bind/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_bind/rule.yml
@@ -27,4 +27,4 @@ references:
     nist: CM-7(a),CM-7(b),CM-6(a),AC-6,AC-6(1),MP-7
     nist-csf: PR.IP-1,PR.PT-3
 
-platform: machine and mount[var-tmp]
+platform: not container and not bootc and mount[var-tmp]

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_bind/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_bind/rule.yml
@@ -27,4 +27,4 @@ references:
     nist: CM-7(a),CM-7(b),CM-6(a),AC-6,AC-6(1),MP-7
     nist-csf: PR.IP-1,PR.PT-3
 
-platform: not container and not bootc and mount[var-tmp]
+platform: mount[var-tmp]

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nodev/rule.yml
@@ -36,8 +36,7 @@ references:
     stigid@ol8: OL08-00-040132
     stigid@rhel8: RHEL-08-040132
 
-platforms:
-  - machine and mount[var-tmp]
+platform: not container and not bootc and mount[var-tmp]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nodev/rule.yml
@@ -36,7 +36,7 @@ references:
     stigid@ol8: OL08-00-040132
     stigid@rhel8: RHEL-08-040132
 
-platform: not container and not bootc and mount[var-tmp]
+platform: mount[var-tmp]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_noexec/rule.yml
@@ -36,7 +36,7 @@ references:
     stigid@ol8: OL08-00-040134
     stigid@rhel8: RHEL-08-040134
 
-platform: not container and not bootc and mount[var-tmp]
+platform: mount[var-tmp]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_noexec/rule.yml
@@ -36,7 +36,7 @@ references:
     stigid@ol8: OL08-00-040134
     stigid@rhel8: RHEL-08-040134
 
-platform: machine and mount[var-tmp]
+platform: not container and not bootc and mount[var-tmp]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nosuid/rule.yml
@@ -36,7 +36,7 @@ references:
     stigid@ol8: OL08-00-040133
     stigid@rhel8: RHEL-08-040133
 
-platform: machine and mount[var-tmp]
+platform: not container and not bootc and mount[var-tmp]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nosuid/rule.yml
@@ -36,7 +36,7 @@ references:
     stigid@ol8: OL08-00-040133
     stigid@rhel8: RHEL-08-040133
 
-platform: not container and not bootc and mount[var-tmp]
+platform: mount[var-tmp]
 
 template:
     name: mount_option

--- a/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/rule.yml
@@ -101,7 +101,6 @@ ocil: |-
     The boot partition and pseudo-file systems, such as /proc, /sys, and tmpfs,
     are not required to use disk encryption and are not a finding.
 
-platform: not container and not bootc
 
 fixtext: |-
     Configure {{{ full_name }}} to prevent unauthorized modification of all information at rest by using disk encryption.

--- a/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/rule.yml
@@ -101,7 +101,7 @@ ocil: |-
     The boot partition and pseudo-file systems, such as /proc, /sys, and tmpfs,
     are not required to use disk encryption and are not a finding.
 
-platform: machine
+platform: not container and not bootc
 
 fixtext: |-
     Configure {{{ full_name }}} to prevent unauthorized modification of all information at rest by using disk encryption.

--- a/linux_os/guide/system/software/disk_partitioning/group.yml
+++ b/linux_os/guide/system/software/disk_partitioning/group.yml
@@ -25,3 +25,5 @@ description: |-
     scheme was used, it is possible but nontrivial to
     modify it to create separate logical volumes for the directories
     listed above. The Logical Volume Manager (LVM) makes this possible.
+
+platform: not container and not bootc

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_boot/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_boot/rule.yml
@@ -16,7 +16,6 @@ rationale: |-
 
 severity: medium
 
-platform: not container and not bootc
 
 identifiers:
     cce@rhel8: CCE-83336-8

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_boot/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_boot/rule.yml
@@ -16,7 +16,7 @@ rationale: |-
 
 severity: medium
 
-platform: machine
+platform: not container and not bootc
 
 identifiers:
     cce@rhel8: CCE-83336-8

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_dev_shm/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_dev_shm/rule.yml
@@ -35,7 +35,6 @@ references:
 
 fixtext: '{{{ fixtext_separate_partition(part="/dev/shm") }}}'
 
-platform: not container and not bootc
 
 warnings:
 - general: |-

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_dev_shm/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_dev_shm/rule.yml
@@ -35,7 +35,7 @@ references:
 
 fixtext: '{{{ fixtext_separate_partition(part="/dev/shm") }}}'
 
-platform: machine
+platform: not container and not bootc
 
 warnings:
 - general: |-

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_home/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_home/rule.yml
@@ -52,7 +52,6 @@ fixtext: |-
 
 srg_requirement: 'A separate {{{ full_name }}} filesystem must be used for user home directories (such as /home or an equivalent).'
 
-platform: not container and not bootc
 
 template:
     name: mount

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_home/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_home/rule.yml
@@ -52,7 +52,7 @@ fixtext: |-
 
 srg_requirement: 'A separate {{{ full_name }}} filesystem must be used for user home directories (such as /home or an equivalent).'
 
-platform: machine
+platform: not container and not bootc
 
 template:
     name: mount

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_opt/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_opt/rule.yml
@@ -15,7 +15,7 @@ rationale: |-
 
 severity: medium
 
-platform: machine
+platform: not container and not bootc
 
 identifiers:
     cce@rhel8: CCE-83340-0

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_opt/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_opt/rule.yml
@@ -15,7 +15,6 @@ rationale: |-
 
 severity: medium
 
-platform: not container and not bootc
 
 identifiers:
     cce@rhel8: CCE-83340-0

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_srv/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_srv/rule.yml
@@ -17,7 +17,6 @@ rationale: |-
 
 severity: unknown
 
-platform: not container and not bootc
 
 
 identifiers:

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_srv/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_srv/rule.yml
@@ -17,7 +17,7 @@ rationale: |-
 
 severity: unknown
 
-platform: machine
+platform: not container and not bootc
 
 
 identifiers:

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_tmp/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_tmp/rule.yml
@@ -45,7 +45,6 @@ fixtext: '{{{ fixtext_separate_partition(part="/tmp") }}}'
 
 srg_requirement: '{{{ srg_requirement_separate_partition("/tmp") }}}'
 
-platform: not container and not bootc
 
 template:
     name: mount

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_tmp/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_tmp/rule.yml
@@ -45,7 +45,7 @@ fixtext: '{{{ fixtext_separate_partition(part="/tmp") }}}'
 
 srg_requirement: '{{{ srg_requirement_separate_partition("/tmp") }}}'
 
-platform: machine
+platform: not container and not bootc
 
 template:
     name: mount

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_usr/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_usr/rule.yml
@@ -14,7 +14,7 @@ rationale: |-
 
 severity: medium
 
-platform: machine
+platform: not container and not bootc
 
 identifiers:
     cce@rhel8: CCE-83343-4

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_usr/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_usr/rule.yml
@@ -14,7 +14,6 @@ rationale: |-
 
 severity: medium
 
-platform: not container and not bootc
 
 identifiers:
     cce@rhel8: CCE-83343-4

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var/rule.yml
@@ -50,7 +50,7 @@ fixtext: '{{{ fixtext_separate_partition(part="/var") }}}'
 
 srg_requirement: '{{{ srg_requirement_separate_partition("/var") }}}'
 
-platform: machine
+platform: not container and not bootc
 
 template:
     name: mount

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var/rule.yml
@@ -50,7 +50,6 @@ fixtext: '{{{ fixtext_separate_partition(part="/var") }}}'
 
 srg_requirement: '{{{ srg_requirement_separate_partition("/var") }}}'
 
-platform: not container and not bootc
 
 template:
     name: mount

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_log/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_log/rule.yml
@@ -46,7 +46,7 @@ fixtext: '{{{ fixtext_separate_partition(part="/var/log") }}}'
 
 srg_requirement: '{{{ srg_requirement_separate_partition("/var/log") }}}'
 
-platform: machine
+platform: not container and not bootc
 
 # (jhrozek): at the moment, the mount probe checks the /proc filesystem
 # even if openscap looks at a chroot, which doesn't allow to check for

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_log/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_log/rule.yml
@@ -46,7 +46,6 @@ fixtext: '{{{ fixtext_separate_partition(part="/var/log") }}}'
 
 srg_requirement: '{{{ srg_requirement_separate_partition("/var/log") }}}'
 
-platform: not container and not bootc
 
 # (jhrozek): at the moment, the mount probe checks the /proc filesystem
 # even if openscap looks at a chroot, which doesn't allow to check for

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_log_audit/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_log_audit/rule.yml
@@ -58,7 +58,6 @@ fixtext: |-
 srg_requirement: |-
     {{{ full_name }}} must use a separate file system for the system audit data path.
 
-platform: not container and not bootc
 
 # (jhrozek): at the moment, the mount probe checks the /proc filesystem
 # even if openscap looks at a chroot, which doesn't allow to check for

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_log_audit/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_log_audit/rule.yml
@@ -58,7 +58,7 @@ fixtext: |-
 srg_requirement: |-
     {{{ full_name }}} must use a separate file system for the system audit data path.
 
-platform: machine
+platform: not container and not bootc
 
 # (jhrozek): at the moment, the mount probe checks the /proc filesystem
 # even if openscap looks at a chroot, which doesn't allow to check for

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_tmp/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_tmp/rule.yml
@@ -40,7 +40,7 @@ fixtext: '{{{ fixtext_separate_partition(part="/var/tmp") }}}'
 
 srg_requirement: '{{{ srg_requirement_separate_partition("/var/tmp") }}}'
 
-platform: machine
+platform: not container and not bootc
 
 template:
     name: mount

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_tmp/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_tmp/rule.yml
@@ -40,7 +40,6 @@ fixtext: '{{{ fixtext_separate_partition(part="/var/tmp") }}}'
 
 srg_requirement: '{{{ srg_requirement_separate_partition("/var/tmp") }}}'
 
-platform: not container and not bootc
 
 template:
     name: mount

--- a/linux_os/guide/system/software/disk_partitioning/systemd_tmp_mount_enabled/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/systemd_tmp_mount_enabled/rule.yml
@@ -26,7 +26,7 @@ ocil: |-
 
 ocil_clause: "the tmp.mount unit is masked or disabled"
 
-platform: machine
+platform: not container and not bootc
 
 template:
     name: systemd_mount_enabled

--- a/linux_os/guide/system/software/disk_partitioning/systemd_tmp_mount_enabled/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/systemd_tmp_mount_enabled/rule.yml
@@ -26,7 +26,6 @@ ocil: |-
 
 ocil_clause: "the tmp.mount unit is masked or disabled"
 
-platform: not container and not bootc
 
 template:
     name: systemd_mount_enabled

--- a/shared/applicability/bootc.yml
+++ b/shared/applicability/bootc.yml
@@ -15,5 +15,5 @@ title: Bootable containers
 # containers don't contain kernel.
 #
 check_id: bootc
-bash_conditional: "{ rpm --quiet -q kernel } && { rpm --quiet -q rpm-ostree } && { rpm --quiet -q bootc }"
+bash_conditional: "{ rpm --quiet -q kernel ;} && { rpm --quiet -q rpm-ostree ;} && { rpm --quiet -q bootc ;}"
 ansible_conditional: '"kernel" in ansible_facts.packages and "rpm-ostree" in ansible_facts.packages and "bootc" in ansible_facts.packages'


### PR DESCRIPTION
Change platforms for rules in disk_partitioning and partitions group. These rules check mount options or existence of separate partitions. These rules should not be applicable when building bootable containers and also should be applicable on a running image mode system. Bootable containers and immutable systems have a different filesystem layout where many paths are read-only.

