### PR TITLE
Change platform in xwindows_runlevel_target

### DIFF
--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/rule.yml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/rule.yml
@@ -53,4 +53,4 @@ fixtext: |-
 
 srg_requirement: 'The graphical display manager must not be the default target on {{{ full_name }}} unless approved.'
 
-platform: machine
+platform: system_with_kernel


### PR DESCRIPTION
The rule xwindows_runlevel_target should be applicable during bootable container image build. The built image should contain a correct systemd default target because once the image is booted this target will be applied. Therefore we are extending the rule applicability also to bootable containers.
