### PR TITLE
Update sebool template for bootable containers

### DIFF
--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -699,7 +699,7 @@ When the remediation is applied duplicate occurrences of `key` are removed.
         `var_selinuxuser_execheap` to turn on or off the SELinux
         boolean.
 
--   Languages: Ansible, Bash, OVAL
+-   Languages: Ansible, Bash, OVAL, SCE
 
 #### service_disabled
 -   Checks if a service is disabled. Uses either systemd or SysV init

--- a/shared/templates/sebool/bash.template
+++ b/shared/templates/sebool/bash.template
@@ -16,7 +16,7 @@
 {{{ bash_package_install("libsemanage-python") }}}
 {{% endif %}}
 
-if selinuxenabled; then
+if selinuxenabled || {{{ bash_bootc_build() }}} ; then
 {{% if SEBOOL_BOOL %}}
     setsebool -P {{{ SEBOOLID }}} {{{ SEBOOL_BOOL }}}
 {{% else %}}

--- a/shared/templates/sebool/sce-bash.template
+++ b/shared/templates/sebool/sce-bash.template
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# check-import = stdout
+{{% if not SEBOOL_BOOL %}}
+# check-export = var_{{{ SEBOOLID }}}=var_{{{ SEBOOLID }}}
+{{% endif %}}
+
+function check_sebool_value()
+{
+    local seboolid="$1"
+    local exp_value="$2"
+
+    if seinfo -xb "$seboolid" | grep -q "$seboolid[[:space:]]\+$exp_value;" ; then
+        return $XCCDF_RESULT_PASS
+    else
+        return $XCCDF_RESULT_FAIL
+    fi
+}
+
+{{% if SEBOOL_BOOL -%}}
+expected_value="{{{ SEBOOL_BOOL }}}"
+{{%- else -%}}
+expected_value="$XCCDF_VALUE_var_{{{ SEBOOLID }}}"
+{{%- endif %}}
+
+check_sebool_value {{{ SEBOOLID }}} "$expected_value"
+exit $?

--- a/shared/templates/sebool/template.yml
+++ b/shared/templates/sebool/template.yml
@@ -2,3 +2,4 @@ supported_languages:
   - ansible
   - bash
   - oval
+  - sce-bash

--- a/tests/test_xccdf_values_in_ds.sh
+++ b/tests/test_xccdf_values_in_ds.sh
@@ -5,7 +5,7 @@ if grep -iq "dangling reference to" "$DS" ; then
     printf "Found dangling reference in %s, ensure correct usage of the xccdf_value Jinja macro!" "$DS" >&2
     exit 1
 fi
-if grep -iq "xccdf_value" "$DS" ; then
+if grep -iq "[^$]xccdf_value" "$DS" ; then
     printf "Found obtrusive xccdf_value in %s, ensure correct usage of the xccdf_value Jinja macro!" "$DS" >&2
     exit 1
 fi


### PR DESCRIPTION
Add an SCE check to the sebool template for bootable containers. OVAL can't be used in this case because `selinuxboolean` probe as currently [implemented](https://github.com/OpenSCAP/openscap/blob/eda9881e08f0398d1481f133fbb56c0080cfe9f3/src/OVAL/probes/unix/linux/selinuxboolean_probe.c#L198) won't work inside a container as it uses `security_get_boolean_names` from libselinux which checks runtime status and that is not possible in a container build environment. The new SCE check uses `seinfo` binary (from `setools-console` RPM) which checks static configuration (`/etc/selinux/targeted/policy/policy.33` policy file) to obtain SELinux booleans values which will be used once a container is booted.

Related PR in openscap - https://github.com/OpenSCAP/openscap/pull/2171