### PR TITLE
Add setuptools to ocp4 build

### DIFF
--- a/.github/workflows/automatus-sanity.yaml
+++ b/.github/workflows/automatus-sanity.yaml
@@ -15,7 +15,7 @@ jobs:
       image: fedora:latest
     steps:
       - name: Install Deps
-        run: dnf install -y cmake make openscap-utils python3-pyyaml python3-jinja2 git python3-pip
+        run: dnf install -y cmake make openscap-utils python3-pyyaml python3-jinja2 git python3-pip python3-setuptools
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:

--- a/Dockerfiles/ocp4_content
+++ b/Dockerfiles/ocp4_content
@@ -2,7 +2,7 @@ FROM registry.fedoraproject.org/fedora-minimal:latest as builder
 
 WORKDIR /content
 
-RUN microdnf -y install cmake make git /usr/bin/python3 python3-pyyaml python3-jinja2 openscap-utils
+RUN microdnf -y install cmake make git /usr/bin/python3 python3-pyyaml python3-jinja2 openscap-utils python3-setuptools
 
 COPY . .
 

--- a/docs/manual/developer/02_building_complianceascode.md
+++ b/docs/manual/developer/02_building_complianceascode.md
@@ -33,7 +33,7 @@ less ~/OpenSCAP/STARTGUIDE.md
 On *Red Hat Enterprise Linux 8* and *Fedora* the package list but must also include python3:
 
 ```bash
-dnf install cmake make openscap-utils openscap-scanner python3
+dnf install cmake make openscap-utils openscap-scanner python3 python3-setuptools
 ```
 
 On *Ubuntu* and *Debian*, make sure the packages `libopenscap8`,


### PR DESCRIPTION
#### Description:

Ensure to setuptools is installed when building OCP4 content.

#### Rationale:
Make the content build.
