### PR TITLE
Update Fedora in `install_vm.py` to F41

### DIFF
--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -19,7 +19,7 @@ KNOWN_DISTROS = [
 
 DISTRO_URL = {
     "fedora":
-        "https://download.fedoraproject.org/pub/fedora/linux/releases/39/Everything/x86_64/os",
+        "https://download.fedoraproject.org/pub/fedora/linux/releases/41/Everything/x86_64/os",
     "centos8": "http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/",
     "centos9": "http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/",
 }


### PR DESCRIPTION

#### Description:
Update Fedora in `install_vm.py` to F41

#### Rationale:
F39 is going EOL soon
