### PR TITLE
Add rules removed from RHEL8/RHEL9 profiles back to datastream

### DIFF
--- a/products/rhel8/profiles/default.profile
+++ b/products/rhel8/profiles/default.profile
@@ -712,3 +712,7 @@ selections:
     - dovecot_configure_ssl_key
     - banner_etc_motd
     - banner_etc_issue_net
+    - agent_mfetpd_running
+    - configure_bashrc_tmux
+    - configure_tmux_lock_keybinding
+    - package_mcafeetp_installed

--- a/products/rhel9/profiles/default.profile
+++ b/products/rhel9/profiles/default.profile
@@ -561,3 +561,13 @@ selections:
     - configure_bashrc_exec_tmux
     - agent_mfetpd_running
     - package_mcafeetp_installed
+    - configure_bashrc_tmux
+    - configure_tmux_lock_after_time
+    - configure_tmux_lock_command
+    - configure_tmux_lock_keybinding
+    - mount_option_krb_sec_remote_filesystems
+    - no_tmux_in_shells
+    - package_tmux_installed
+    - set_password_hashing_min_rounds_logindefs
+    - sshd_use_priv_separation
+    - tftpd_uses_secure_mode


### PR DESCRIPTION
#### Description:
Add back rules that were identifier by our daily productization that they got removed from datastream.

#### Rationale:
#12559 removed several rules from RHEL8 STIG profile. However, few of them were used only in STIG profile and thus the change removed them from datastream.

#12551 removed several rules from RHEL9 STIG profile. Similarly as RHEL8, these rules were only part of STIG profile.

#### Review Hints:
Check the rules are back in datastream.