### PR TITLE
Update networkmanager_dns_mode for bootable containers

### DIFF
--- a/linux_os/guide/system/network/networkmanager/networkmanager_dns_mode/bash/shared.sh
+++ b/linux_os/guide/system/network/networkmanager/networkmanager_dns_mode/bash/shared.sh
@@ -8,4 +8,6 @@
 
 {{{ bash_ini_file_set("/etc/NetworkManager/NetworkManager.conf", "main", "dns", "$var_networkmanager_dns_mode") }}}
 
-systemctl reload NetworkManager
+if {{{ bash_not_bootc_build() }}} ; then
+    systemctl reload NetworkManager
+fi


### PR DESCRIPTION
Remediation of the rule `networkmanager_dns_mode` calls `systemctl reload` which doesn't work in the bootable container build environment and so we use the `bash_not_bootc_build` macro to not run it there.