### PR TITLE
Update rsyslog_cron_logging for bootable containers

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/bash/shared.sh
@@ -5,4 +5,6 @@ if ! grep -s "^\s*cron\.\*\s*/var/log/cron$" /etc/rsyslog.conf /etc/rsyslog.d/*.
 	echo "cron.*	/var/log/cron" >> /etc/rsyslog.d/cron.conf
 fi
 
-systemctl restart rsyslog.service
+if {{{ bash_not_bootc_build() }}} ; then
+    systemctl restart rsyslog.service
+fi


### PR DESCRIPTION
Remediation of the rule `rsyslog_cron_logging` calls `systemctl reload` which doesn't work in the bootable container build environment and so we use the `bash_not_bootc_build` macro to not run it there.