### PR TITLE
Update chronyd rules for bootable containers

### DIFF
--- a/components/chrony.yml
+++ b/components/chrony.yml
@@ -13,3 +13,7 @@ rules:
 - package_chrony_installed
 - service_chronyd_enabled
 - chrony_set_nts
+- chronyd_client_only
+- chronyd_no_chronyc_network
+- chronyd_or_ntpd_specify_multiple_servers
+- chronyd_sync_clock

--- a/linux_os/guide/services/ntp/chronyd_client_only/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_client_only/oval/shared.xml
@@ -2,8 +2,7 @@
   <definition class="compliance" id="chronyd_client_only" version="1">
     {{{ oval_metadata("Configure the port setting in " ~ chrony_conf_path ~ " to disable
       server operation.") }}}
-    <criteria operator="AND">
-      <extend_definition definition_ref="service_chronyd_enabled" comment="service chronyd enabled" />
+    <criteria>
       <criterion test_ref="test_chronyd_client_only" comment="check if port is 0 in {{{ chrony_conf_path }}}" />
     </criteria>
   </definition>

--- a/linux_os/guide/services/ntp/chronyd_client_only/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_client_only/rule.yml
@@ -15,6 +15,7 @@ rationale: |-
 
 severity: low
 
+platform: package[chrony]
 
 identifiers:
     cce@rhcos4: CCE-82465-6

--- a/linux_os/guide/services/ntp/chronyd_no_chronyc_network/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_no_chronyc_network/oval/shared.xml
@@ -2,8 +2,7 @@
   <definition class="compliance" id="chronyd_no_chronyc_network" version="1">
     {{{ oval_metadata("Configure the cmdport setting in " ~ chrony_conf_path ~ " to disable
       chronyc management connections over network.") }}}
-    <criteria operator="AND">
-      <extend_definition definition_ref="service_chronyd_enabled" comment="service chronyd enabled" />
+    <criteria>
       <criterion test_ref="test_chronyd_no_chronyc_network" comment="check if cmdport is 0 in {{{ chrony_conf_path }}}" />
     </criteria>
   </definition>

--- a/linux_os/guide/services/ntp/chronyd_no_chronyc_network/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_no_chronyc_network/rule.yml
@@ -14,6 +14,7 @@ rationale: |-
 
 severity: low
 
+platform: package[chrony]
 
 identifiers:
     cce@rhcos4: CCE-82466-4

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/bash/shared.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_sle
+# platform = multi_platform_rhel,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_sle
 
 {{{ bash_instantiate_variables("var_multiple_time_servers") }}}
 

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/oval/shared.xml
@@ -3,14 +3,8 @@
     {{{ oval_metadata("Multiple remote chronyd or ntpd NTP Servers for time synchronization should be specified (and dependencies are met)") }}}
 
     <criteria operator="OR">
-      <criteria comment="chronyd enabled and multiple remote servers specified" operator="AND">
-        <extend_definition comment="service chronyd enabled" definition_ref="service_chronyd_enabled" />
-        <extend_definition comment="multiple chronyd remote servers specified" definition_ref="chronyd_specify_multiple_servers" />
-      </criteria>
-      <criteria comment="ntpd enabled and multile remote servers specified" operator="AND">
-        <extend_definition comment="service ntpd enabled" definition_ref="service_ntpd_enabled" />
-        <extend_definition comment="multiple ntpd remote servers specified" definition_ref="ntpd_specify_multiple_servers" />
-      </criteria>
+      <extend_definition comment="multiple chronyd remote servers specified" definition_ref="chronyd_specify_multiple_servers" />
+      <extend_definition comment="multiple ntpd remote servers specified" definition_ref="ntpd_specify_multiple_servers" />
     </criteria>
 
   </definition>

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/rule.yml
@@ -86,6 +86,7 @@ rationale: |-
 
 severity: medium
 
+platform: package[chrony] or package[ntp]
 
 identifiers:
     cce@rhcos4: CCE-82685-9

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/oval/shared.xml
@@ -3,14 +3,8 @@
     {{{ oval_metadata("A remote chronyd or ntpd NTP Server for time synchronization should be specified (and dependencies are met)") }}}
 
     <criteria operator="OR">
-      <criteria comment="chronyd enabled and remote server specified" operator="AND">
-        <extend_definition comment="service chronyd enabled" definition_ref="service_chronyd_enabled" />
-        <extend_definition comment="chronyd remote server specified" definition_ref="chronyd_specify_remote_server" />
-      </criteria>
-      <criteria comment="ntpd enabled and remote server specified" operator="AND">
-        <extend_definition comment="service ntpd enabled" definition_ref="service_ntpd_enabled" />
-        <extend_definition comment="ntpd remote server specified" definition_ref="ntpd_specify_remote_server" />
-      </criteria>
+      <extend_definition comment="chronyd remote server specified" definition_ref="chronyd_specify_remote_server" />
+      <extend_definition comment="ntpd remote server specified" definition_ref="ntpd_specify_remote_server" />
     </criteria>
 
   </definition>

--- a/linux_os/guide/services/ntp/chronyd_sync_clock/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_sync_clock/rule.yml
@@ -21,6 +21,8 @@ rationale: |-
 
 severity: medium
 
+platform: package[chrony]
+
 references:
     disa: CCI-002046,CCI-004926
     srg: SRG-OS-000356-GPOS-00144


### PR DESCRIPTION
The rules used `service_chronyd_enabled` or `service_ntpd_enabled`
in their OVALs to not only check the services configuration but to
also check if the services are enabled.

This approach is unnecessary and it won't work in the bootable
container build environment where systemd services don't run.

Therefore, we update OVALs of these rules and remove the mentioned
service enabled checks and we rather use CPE platforms to make the
rules applicable only in cases when `chrony` or `ntp` packages are
installed. This shouldn't be a big change as if `chrony` or `ntp`
packages are installed their service config files should exist and
in case `chronyd` or `ntpd` services are enabled later they will
already run with the expected configuration.