### PR TITLE
Improve rule file_permissions_ungroupowned for use in bootable containers

### DIFF
--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/oval/shared.xml
@@ -1,9 +1,19 @@
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="2">
     {{{ oval_metadata("All files should be owned by a group") }}}
-    <criteria>
-      <criterion test_ref="test_file_permissions_ungroupowned"
-        comment="Check all local files and make sure they are owned by a group"/>
+    <criteria operator="OR">
+      <criteria operator="AND">
+        <criterion test_ref="test_file_permissions_ungroupowned_nsswitch_uses_altfiles" negate="true"
+          comment="The /etc/nsswitch.conf does not use nss-altfiles"/>
+        <criterion test_ref="test_file_permissions_ungroupowned"
+          comment="Check all local files and make sure they are owned by a group"/>
+      </criteria>
+      <criteria operator="AND">
+        <criterion test_ref="test_file_permissions_ungroupowned_nsswitch_uses_altfiles"
+          comment="The /etc/nsswitch.conf uses nss-altfiles"/>
+        <criterion test_ref="test_file_permissions_ungroupowned_with_usrlib"
+          comment="Check all local files and make sure they are owned by a group"/>
+      </criteria>
     </criteria>
   </definition>
 
@@ -20,7 +30,7 @@
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_object id="object_all_gids" version="1">
+  <ind:textfilecontent54_object id="object_all_gids_with_usrlib" version="1">
     <set>
       <object_reference>object_etc_group</object_reference>
       <object_reference>object_usr_lib_group</object_reference>
@@ -29,12 +39,22 @@
 
   <local_variable id="var_all_local_gids" version="1"
     datatype="int" comment="all GIDs extracted from /etc/group on the target system">
-    <object_component object_ref="object_all_gids" item_field="subexpression"/>
+    <object_component object_ref="object_etc_group" item_field="subexpression"/>
+  </local_variable>
+
+  <local_variable id="var_all_local_gids_with_usrlib" version="1"
+    datatype="int" comment="all GIDs extracted from /etc/group on the target system">
+    <object_component object_ref="object_all_gids_with_usrlib" item_field="subexpression"/>
   </local_variable>
 
   <unix:file_state id="state_file_permissions_ungroupowned_local_group_owner" version="1"
     comment="Used to filter out all files group-owned by a group defined in /etc/group">
     <unix:group_id datatype="int" var_check="at least one" var_ref="var_all_local_gids"/>
+  </unix:file_state>
+
+  <unix:file_state id="state_file_permissions_ungroupowned_local_group_owner_with_usrlib" version="1"
+    comment="Used to filter out all files group-owned by a group defined in /etc/group">
+    <unix:group_id datatype="int" var_check="at least one" var_ref="var_all_local_gids_with_usrlib"/>
   </unix:file_state>
 
   <unix:file_state id="state_file_permissions_ungroupowned_sysroot" version="1"
@@ -61,9 +81,43 @@
     <filter action="exclude">state_file_permissions_ungroupowned_sysroot</filter>
   </unix:file_object>
 
+  <unix:file_object id="object_file_permissions_ungroupowned_with_usrlib" version="2"
+    comment="all local files without a known group owner">
+    <unix:behaviors recurse="directories" recurse_direction="down"
+      recurse_file_system="defined" max_depth="-1"/>
+    <unix:path operation="equals" var_check="at least one"
+      var_ref="{{{ var_local_mount_points }}}"/>
+    <unix:filename operation="pattern match">.*</unix:filename>
+    <filter action="exclude">state_file_permissions_ungroupowned_local_group_owner_with_usrlib</filter>
+    <filter action="exclude">state_file_permissions_ungroupowned_sysroot</filter>
+  </unix:file_object>
+
+  <ind:textfilecontent54_test id="test_file_permissions_ungroupowned_nsswitch_uses_altfiles" version="1"
+    check="all" check_existence="at_least_one_exists"
+    comment="Test if /etc/nssswitch.conf contains 'altfiles' in 'group' key">
+    <ind:object object_ref="object_file_permissions_ungroupowned_nsswitch_uses_altfiles"/>
+    <ind:state state_ref="state_file_permissions_ungroupowned_nsswitch_uses_altfiles"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_file_permissions_ungroupowned_nsswitch_uses_altfiles" version="1">
+    <ind:filepath>/etc/nsswitch.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*group:\s+(.*)$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_file_permissions_ungroupowned_nsswitch_uses_altfiles" version="1">
+    <ind:subexpression operation="pattern match">altfiles</ind:subexpression>
+  </ind:textfilecontent54_state>
+
   <unix:file_test id="test_file_permissions_ungroupowned" version="1"
     check="all" check_existence="none_exist"
     comment="there are no files with group owner different than local groups">
     <unix:object object_ref="object_file_permissions_ungroupowned"/>
+  </unix:file_test>
+
+  <unix:file_test id="test_file_permissions_ungroupowned_with_usrlib" version="1"
+    check="all" check_existence="none_exist"
+    comment="there are no files with group owner different than local groups">
+    <unix:object object_ref="object_file_permissions_ungroupowned_with_usrlib"/>
   </unix:file_test>
 </def-group>

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/oval/shared.xml
@@ -8,15 +8,28 @@
   </definition>
 
   <!-- Create a file_state to filter out files group-owned by known groups. -->
-  <ind:textfilecontent54_object id="etc_group_objects" version="1">
+  <ind:textfilecontent54_object id="object_etc_group" version="1">
     <ind:filepath>/etc/group</ind:filepath>
     <ind:pattern operation="pattern match">^[^:]+:[^:]*:([\d]+):[^:]*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
+  <ind:textfilecontent54_object id="object_usr_lib_group" version="1">
+    <ind:filepath>/usr/lib/group</ind:filepath>
+    <ind:pattern operation="pattern match">^[^:]+:[^:]*:([\d]+):[^:]*$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="object_all_gids" version="1">
+    <set>
+      <object_reference>object_etc_group</object_reference>
+      <object_reference>object_usr_lib_group</object_reference>
+    </set>
+  </ind:textfilecontent54_object>
+
   <local_variable id="var_all_local_gids" version="1"
     datatype="int" comment="all GIDs extracted from /etc/group on the target system">
-    <object_component object_ref="etc_group_objects" item_field="subexpression"/>
+    <object_component object_ref="object_all_gids" item_field="subexpression"/>
   </local_variable>
 
   <unix:file_state id="state_file_permissions_ungroupowned_local_group_owner" version="1"

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/oval/shared.xml
@@ -24,6 +24,11 @@
     <unix:group_id datatype="int" var_check="at least one" var_ref="var_all_local_gids"/>
   </unix:file_state>
 
+  <unix:file_state id="state_file_permissions_ungroupowned_sysroot" version="1"
+    comment="Used to filter out all files in the /sysroot directory">
+    <unix:filepath operation="pattern match">^/sysroot/.*$</unix:filepath>
+  </unix:file_state>
+
   {{%- set var_local_mount_points = "var_" ~ rule_id ~ "_local_mountpoints" -%}}
   {{{ create_local_mount_points_list(var_local_mount_points) }}}
 
@@ -40,6 +45,7 @@
       var_ref="{{{ var_local_mount_points }}}"/>
     <unix:filename operation="pattern match">.*</unix:filename>
     <filter action="exclude">state_file_permissions_ungroupowned_local_group_owner</filter>
+    <filter action="exclude">state_file_permissions_ungroupowned_sysroot</filter>
   </unix:file_object>
 
   <unix:file_test id="test_file_permissions_ungroupowned" version="1"

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/rule.yml
@@ -4,9 +4,11 @@ documentation_complete: true
 title: 'Ensure All Files Are Owned by a Group'
 
 description: |-
-    If any file is not group-owned by a group present in /etc/group, the cause of the lack of
+    If any file is not group-owned by a valid defined group, the cause of the lack of
     group-ownership must be investigated. Following this, those files should be deleted or
-    assigned to an appropriate group.
+    assigned to an appropriate group. The groups need to be defined in <tt>/etc/group</tt>
+    or in <tt>/usr/lib/group</tt> if <tt>nss-altfiles</tt> are configured to be used
+    in <tt>/etc/nsswitch.conf</tt>.
 
     Locate the mount points related to local devices by the following command:
     <pre>$ findmnt -n -l -k -it $(awk '/nodev/ { print $2 }' /proc/filesystems | paste -sd,)</pre>
@@ -75,7 +77,7 @@ srg_requirement: 'All {{{ full_name }}} local files and directories must have a 
 warnings:
     - general: |-
         This rule only considers local groups as valid groups.
-        If you have your groups defined outside <code>/etc/group</code>, the rule won't consider those.
+        If you have your groups defined outside <code>/etc/group</code> or <code>/usr/lib/group</code>, the rule won't consider those.
     - general: |-
         This rule can take a long time to perform the check and might consume a considerable
         amount of resources depending on the number of files present on the system. It is not a

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/tests/group_in_usr_lib.pass.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/tests/group_in_usr_lib.pass.sh
@@ -6,6 +6,7 @@ IFS=$"\n"
 for f in $UNOWNED_FILES; do
 	rm -f "$f"
 done
+sed -i  's/group:\s\+\(.*\)/group: altfiles \1/' /etc/nsswitch.conf
 
 touch /root/test
 chown 9999:9999 /root/test

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/tests/group_in_usr_lib.pass.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/tests/group_in_usr_lib.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+UNOWNED_FILES=$(df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nogroup)
+
+IFS=$"\n"
+for f in $UNOWNED_FILES; do
+	rm -f "$f"
+done
+
+touch /root/test
+chown 9999:9999 /root/test
+echo "testgroup:x:9999:" >> /usr/lib/group

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/tests/unowned_in_sysroot.pass.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/tests/unowned_in_sysroot.pass.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# remediation = none
+
+UNOWNED_FILES=$(df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nogroup)
+
+IFS=$"\n"
+for f in $UNOWNED_FILES; do
+	rm -f "$f"
+done
+
+mkdir /sysroot
+touch /sysroot/test
+chown 9999:9999 /sysroot/test


### PR DESCRIPTION
#### Description:
- Exclude `/sysroot` from scanning
- Get additional group data from `/usr/lib/group`
- Add test scenarios

For more details, please read commit messages of all commits.

#### Rationale:
In systems based on bootable container images the `/sysroot` directory contains the filesystem of the image which should be excluded from the scanned files check.

If the `nss-altfiles` are installed and `/etc/nsswitch.conf` is configured to use `nss-altfiles`, the users group can be defined
also in `/usr/lib/group` next to `/etc/group`. The `/usr/lib/group` is a valid source of group definitions and therefore needs to be consulted during the check if nsswitch is configured to use this file. The `nss-altfiles` is often used in bootable containers base images.

#### Review Hints:

Build CS9 data stream and apply STIG profile in podman build of an image based on quay.io/centos-bootc/centos-bootc:stream9.
