### PR TITLE
Fix/debian20241107

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/bash/shared.sh
@@ -10,5 +10,5 @@ for user in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}
     # Only update the group-ownership when necessary. This will avoid changing the inode timestamp
     # when the group is already defined as expected, therefore not impacting in possible integrity
     # check systems that also check inodes timestamps.
-    find $home_dir -not -group $group -exec chgrp -f $group {} \;
+    find $home_dir -not -group $group -exec chgrp -f --no-dereference $group {} \;
 done

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/bash/shared.sh
@@ -9,5 +9,5 @@ for user in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}
     # Only update the ownership when necessary. This will avoid changing the inode timestamp
     # when the owner is already defined as expected, therefore not impacting in possible integrity
     # check systems that also check inodes timestamps.
-    find $home_dir -not -user $user -exec chown -f $user {} \;
+    find $home_dir -not -user $user -exec chown -f --no-dereference $user {} \;
 done

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_permissions/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_permissions/oval/shared.xml
@@ -24,11 +24,15 @@
     <unix:path var_ref="var_accounts_users_home_files_permissions_dirs" var_check="at least one"/>
     <unix:filename xsi:nil="true" />
   </unix:file_object>
+  <unix:file_state id="state_accounts_users_home_files_permissions_is_symlink" version="1">
+    <unix:type operation="equals">symbolic link</unix:type>
+  </unix:file_state>
   <unix:file_object id="object_accounts_users_home_files_permissions_files" version="1">
     <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1"
                     recurse_file_system="local"/>
     <unix:path var_ref="var_accounts_users_home_files_permissions_dirs" var_check="at least one"/>
     <unix:filename operation="pattern match">^[^\.].*</unix:filename>
+    <filter action="exclude">state_accounts_users_home_files_permissions_is_symlink</filter>
   </unix:file_object>
   <!-- #### creation of state #### -->
   <unix:file_state id="state_accounts_users_home_files_permissions_dirs" version="1" operator='AND'>

--- a/shared/applicability/oval/system_with_kernel.xml
+++ b/shared/applicability/oval/system_with_kernel.xml
@@ -5,7 +5,9 @@
       <criterion comment="kernel is installed" test_ref="inventory_test_kernel_installed" />
     </criteria>
   </definition>
-{{% if 'sle' in product or 'slmicro' in product %}}
+{{% if 'debian' in product or 'ubuntu' in product %}}
+{{{ oval_test_package_installed(package="linux-base", test_id="inventory_test_kernel_installed") }}}
+{{% elif 'sle' in product or 'slmicro' in product %}}
 {{{ oval_test_package_installed(package="kernel-default", test_id="inventory_test_kernel_installed") }}}
 {{% else %}}
 {{{ oval_test_package_installed(package="kernel", test_id="inventory_test_kernel_installed") }}}

--- a/shared/applicability/system_with_kernel.yml
+++ b/shared/applicability/system_with_kernel.yml
@@ -22,9 +22,15 @@ bash_conditional: "rpm --quiet -q kernel-default"
 bash_conditional: "rpm --quiet -q kernel"
 {{% endif %}}
 {{% else %}}
-bash_conditional: "dpkg-query --show --showformat='${db:Status-Status}\n' 'kernel' 2>/dev/null | grep -q installed"
+{{% if "debian" in product or "ubuntu" in product %}}
+bash_conditional: "dpkg-query --show --showformat='${db:Status-Status}\n' 'linux-base' 2>/dev/null | grep -q ^installed"
+{{% else %}}
+bash_conditional: "dpkg-query --show --showformat='${db:Status-Status}\n' 'kernel' 2>/dev/null | grep -q ^installed"
 {{% endif %}}
-{{% if "sle" in product or "slmicro" in product %}}
+{{% endif %}}
+{{% if "debian" in product or "ubuntu" in product %}}
+ansible_conditional: '"linux-base" in ansible_facts.packages'
+{{% elif "sle" in product or "slmicro" in product %}}
 ansible_conditional: '"kernel-default" in ansible_facts.packages'
 {{% else %}}
 ansible_conditional: '"kernel" in ansible_facts.packages'

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1432,9 +1432,9 @@ for home_dir in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid
     # the permission is already defined as expected, therefore not impacting in possible integrity
     # check systems that also check inodes timestamps.
     {{%- if recursive %}}
-    find "$home_dir" -perm /7027 -exec chmod u-s,g-w-s,o=- {} \;
+    find "$home_dir" -perm /7027 \! -type l -exec chmod u-s,g-w-s,o=- {} \;
     {{%- else %}}
-    find "$home_dir" -maxdepth 0 -perm /7027 -exec chmod u-s,g-w-s,o=- {} \;
+    find "$home_dir" -maxdepth 0 -perm /7027 \! -type l -exec chmod u-s,g-w-s,o=- {} \;
     {{%- endif %}}
 done
 {{%- endmacro -%}}


### PR DESCRIPTION
#### Description:

- fix system_with_kernel applicability for debian derived operating systems
- fix accounts_users_home_files_groupownership bash remediation to handle symlinks properly
- fix accounts_users_home_files_ownership bash remediation to handle symlinks properly

edit: similar issue fixed in accounts_users_home_files_permissions

#### system_with_kernel

debian/ubuntu packages have different names than in the redhat world. We now check against the correct packages.

There was an error in the grep expression that would match both "installed" and "not-installed", so any system would be identified as having a kernel.

#### accounts_users_home_files_...

Add a --no-dereference option in bash remediation so that the remediation applies to the symlink and not to the linked file (if relevant, this last file is already handled as a regular file).
