### PR TITLE
Change platform in dnf-automatic rules

### DIFF
--- a/linux_os/guide/system/software/updating/dnf-automatic_apply_updates/rule.yml
+++ b/linux_os/guide/system/software/updating/dnf-automatic_apply_updates/rule.yml
@@ -30,6 +30,8 @@ references:
     ospp: FMT_SMF_EXT.1
     srg: SRG-OS-000805-GPOS-00260
 
+platform: not bootc
+
 ocil_clause: 'apply_updates is not set to yes'
 
 ocil: |-

--- a/linux_os/guide/system/software/updating/dnf-automatic_security_updates_only/rule.yml
+++ b/linux_os/guide/system/software/updating/dnf-automatic_security_updates_only/rule.yml
@@ -26,6 +26,8 @@ references:
     nist: SI-2(5),CM-6(a),SI-2(c)
     srg: SRG-OS-000191-GPOS-00080
 
+platform: not bootc
+
 ocil_clause: 'the upgrade_type is not set to security'
 
 ocil: |-

--- a/linux_os/guide/system/software/updating/package_dnf-automatic_installed/rule.yml
+++ b/linux_os/guide/system/software/updating/package_dnf-automatic_installed/rule.yml
@@ -26,6 +26,8 @@ ocil_clause: 'the package is not installed'
 
 ocil: '{{{ ocil_package(package="dnf-automatic") }}}'
 
+platform: not bootc
+
 template:
     name: package_installed
     vars:

--- a/linux_os/guide/system/software/updating/timer_dnf-automatic_enabled/rule.yml
+++ b/linux_os/guide/system/software/updating/timer_dnf-automatic_enabled/rule.yml
@@ -28,6 +28,8 @@ ocil_clause: 'the dnf-automatic.timer is not enabled'
 
 ocil: "{{{ ocil_timer_enabled(timer='dnf-automatic') }}}"
 
+platform: not bootc
+
 template:
     name: timer_enabled
     vars:


### PR DESCRIPTION
In RHEL Image Mode the automatic updates can't be performed using dnf-automatic but instead the automatic updates are done by updating to a new container image version. The automatic updates are handled by the bootc-fetch-apply-updates.timer and corresponding bootc-fetch-apply-updates.service. Therefore, the dnf-automatic rules don't make sense in this environment and we will make them not applicable there.
