### PR TITLE
Remove package_quagga_removed from RHEL 10 profiles

### DIFF
--- a/controls/e8.yml
+++ b/controls/e8.yml
@@ -19,7 +19,6 @@ controls:
             - package_telnet-server_removed
             - package_rsh_removed
             - package_rsh-server_removed
-            - package_quagga_removed
             - service_avahi-daemon_disabled
             - package_squid_removed
             - service_squid_disabled

--- a/controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml
+++ b/controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml
@@ -84,7 +84,6 @@ controls:
             # package removed
             - package_vsftpd_removed
             - package_tftp-server_removed
-            - package_quagga_removed
             - package_gssproxy_removed
             - package_iprutils_removed
             - package_tuned_removed


### PR DESCRIPTION
#### Description:
Remove package_quagga_removed from RHEL 10 profiles

#### Rationale:
No longer in RHEL 10.
