### PR TITLE
remove sshd_use_priv_separation from hipaa control file

### DIFF
--- a/controls/hipaa.yml
+++ b/controls/hipaa.yml
@@ -370,7 +370,6 @@ controls:
             - sshd_enable_warning_banner
             - sshd_set_keepalive
             - sshd_set_keepalive_0
-            - sshd_use_priv_separation
             - libreswan_approved_tunnels
             - dconf_gnome_remote_access_credential_prompt
             - dconf_gnome_remote_access_encryption


### PR DESCRIPTION
#### Rationale:

This ssh option is deprecated since openssh 7.4.
https://www.openssh.com/txt/release-7.4

#### Review Hints:

review the hipaa control file