### PR TITLE
Fix RH references for OL

### DIFF
--- a/linux_os/guide/services/fapolicyd/fapolicy_default_deny/ansible/shared.yml
+++ b/linux_os/guide/services/fapolicyd/fapolicy_default_deny/ansible/shared.yml
@@ -7,7 +7,9 @@
 - name: {{{ rule_title }}} - Ensure a Final Rule Denying Everything
   ansible.builtin.copy:
     content: |
+      {{%- if 'ol' not in families %}}
       # Red Hat KCS 7003854 (https://access.redhat.com/solutions/7003854)
+      {{%- endif %}}
       deny perm=any all : all
     dest: /etc/fapolicyd/rules.d/99-deny-everything.rules
     owner: root

--- a/linux_os/guide/services/fapolicyd/fapolicy_default_deny/bash/shared.sh
+++ b/linux_os/guide/services/fapolicyd/fapolicy_default_deny/bash/shared.sh
@@ -5,7 +5,9 @@
 # disruption = low
 
 cat > /etc/fapolicyd/rules.d/99-deny-everything.rules << EOF
+{{%- if 'ol' not in families %}}
 # Red Hat KCS 7003854 (https://access.redhat.com/solutions/7003854)
+{{%- endif %}}
 deny perm=any all : all
 EOF
 

--- a/linux_os/guide/system/software/system-tools/package_libreport-plugin-logger_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_libreport-plugin-logger_removed/rule.yml
@@ -8,7 +8,11 @@ description: |-
 
 rationale: |-
     <tt>libreport-plugin-logger</tt> is a ABRT plugin to report bugs into the
+    {{%- if 'ol' in families %}}
+    Oracle Linux Support system.
+    {{%- else %}}
     Red Hat Support system.
+    {{%- endif %}}
 
 severity: low
 


### PR DESCRIPTION
#### Description:

- Update fapolicy_default_deny ansible and bash remediations
- Update package_libreport-plugin-logger_removed rule

#### Rationale:

Fix references for OL