### PR TITLE
Adjust rule assertions 11.11

### DIFF
--- a/tests/assertions/ocp4/ocp4-moderate-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.17.yml
@@ -342,7 +342,7 @@ rule_results:
    default_result: PASS
    result_after_remediation: PASS
  e2e-moderate-resource-requests-quota:
-   default_result: FAIL
+   default_result: PASS
    result_after_remediation: PASS
  e2e-moderate-route-ip-whitelist:
    default_result: PASS

--- a/tests/assertions/ocp4/rhcos4-high-4.16.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.16.yml
@@ -572,9 +572,9 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-partition-for-var-log:
-    default_result: MANUAL
+    default_result: NOT-APPLICABLE
   e2e-high-master-partition-for-var-log-audit:
-    default_result: MANUAL
+    default_result: NOT-APPLICABLE
   e2e-high-master-require-singleuser-auth:
     default_result: PASS
     result_after_remediation: PASS
@@ -1292,9 +1292,9 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-partition-for-var-log:
-    default_result: MANUAL
+    default_result: NOT-APPLICABLE
   e2e-high-worker-partition-for-var-log-audit:
-    default_result: MANUAL
+    default_result: NOT-APPLICABLE
   e2e-high-worker-require-singleuser-auth:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-high-4.17.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.17.yml
@@ -573,11 +573,11 @@ rule_results:
    default_result: FAIL
    result_after_remediation: PASS
  e2e-high-master-partition-for-var-log:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
  e2e-high-master-partition-for-var-log-audit:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
  e2e-high-master-require-singleuser-auth:
    default_result: PASS
    result_after_remediation: PASS
@@ -1299,11 +1299,11 @@ rule_results:
    default_result: FAIL
    result_after_remediation: PASS
  e2e-high-worker-partition-for-var-log:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
  e2e-high-worker-partition-for-var-log-audit:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
  e2e-high-worker-require-singleuser-auth:
    default_result: PASS
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-moderate-4.16.yml
+++ b/tests/assertions/ocp4/rhcos4-moderate-4.16.yml
@@ -572,9 +572,9 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-partition-for-var-log:
-    default_result: MANUAL
+    default_result: NOT-APPLICABLE
   e2e-moderate-master-partition-for-var-log-audit:
-    default_result: MANUAL
+    default_result: NOT-APPLICABLE
   e2e-moderate-master-require-singleuser-auth:
     default_result: PASS
     result_after_remediation: PASS
@@ -1289,9 +1289,9 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-partition-for-var-log:
-    default_result: MANUAL
+    default_result: NOT-APPLICABLE
   e2e-moderate-worker-partition-for-var-log-audit:
-    default_result: MANUAL
+    default_result: NOT-APPLICABLE
   e2e-moderate-worker-require-singleuser-auth:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-moderate-4.17.yml
+++ b/tests/assertions/ocp4/rhcos4-moderate-4.17.yml
@@ -573,11 +573,11 @@ rule_results:
    default_result: FAIL
    result_after_remediation: PASS
  e2e-moderate-master-partition-for-var-log:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
  e2e-moderate-master-partition-for-var-log-audit:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
  e2e-moderate-master-require-singleuser-auth:
    default_result: PASS
    result_after_remediation: PASS
@@ -1296,11 +1296,11 @@ rule_results:
    default_result: FAIL
    result_after_remediation: PASS
  e2e-moderate-worker-partition-for-var-log:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
  e2e-moderate-worker-partition-for-var-log-audit:
-   default_result: MANUAL
-   result_after_remediation: MANUAL
+   default_result: NOT-APPLICABLE
+   result_after_remediation: NOT-APPLICABLE
  e2e-moderate-worker-require-singleuser-auth:
    default_result: PASS
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-stig-4.16.yml
+++ b/tests/assertions/ocp4/rhcos4-stig-4.16.yml
@@ -324,7 +324,7 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-partition-for-var-log-audit:
-    default_result: MANUAL
+    default_result: NOT-APPLICABLE
   e2e-stig-master-selinux-policytype:
     default_result: PASS
     result_after_remediation: PASS
@@ -680,7 +680,7 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-partition-for-var-log-audit:
-    default_result: MANUAL
+    default_result: NOT-APPLICABLE
   e2e-stig-worker-selinux-policytype:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-stig-4.17.yml
+++ b/tests/assertions/ocp4/rhcos4-stig-4.17.yml
@@ -324,7 +324,7 @@ rule_results:
    default_result: FAIL
    result_after_remediation: PASS
  e2e-stig-master-partition-for-var-log-audit:
-   default_result: MANUAL
+   default_result: NOT-APPLICABLE
    result_after_remediation: MANUAL
  e2e-stig-master-selinux-policytype:
    default_result: PASS
@@ -681,7 +681,7 @@ rule_results:
    default_result: FAIL
    result_after_remediation: PASS
  e2e-stig-worker-partition-for-var-log-audit:
-   default_result: MANUAL
+   default_result: NOT-APPLICABLE
    result_after_remediation: MANUAL
  e2e-stig-worker-selinux-policytype:
    default_result: PASS

--- a/tests/assertions/ocp4/rhcos4-stig-4.17.yml
+++ b/tests/assertions/ocp4/rhcos4-stig-4.17.yml
@@ -325,7 +325,7 @@ rule_results:
    result_after_remediation: PASS
  e2e-stig-master-partition-for-var-log-audit:
    default_result: NOT-APPLICABLE
-   result_after_remediation: MANUAL
+   result_after_remediation: NOT-APPLICABLE
  e2e-stig-master-selinux-policytype:
    default_result: PASS
    result_after_remediation: PASS
@@ -682,7 +682,7 @@ rule_results:
    result_after_remediation: PASS
  e2e-stig-worker-partition-for-var-log-audit:
    default_result: NOT-APPLICABLE
-   result_after_remediation: MANUAL
+   result_after_remediation: NOT-APPLICABLE
  e2e-stig-worker-selinux-policytype:
    default_result: PASS
    result_after_remediation: PASS


### PR DESCRIPTION
#### Description:

- Adjust assertions for:
  - RHCOS4
    - 4.17 and 4.16
    - `stig`, `moderate` and `high` profiles
  - OCP4
    - 4.17
      - `moderate`

#### Rationale:

- Based on the latest failures:
 - [4.16](https://sippy.dptools.openshift.org/sippy-ng/jobs/4.16/runs?filters=%257B%2522items%2522%253A%255B%257B%2522columnField%2522%253A%2522timestamp%2522%252C%2522operatorValue%2522%253A%2522%253E%253D%2522%252C%2522value%2522%253A%25221731178800000%2522%257D%252C%257B%2522columnField%2522%253A%2522job%2522%252C%2522operatorValue%2522%253A%2522contains%2522%252C%2522value%2522%253A%2522ComplianceAsCode-content%2522%257D%252C%257B%2522columnField%2522%253A%2522overall_result%2522%252C%2522not%2522%253Atrue%252C%2522operatorValue%2522%253A%2522equals%2522%252C%2522value%2522%253A%2522S%2522%257D%255D%252C%2522linkOperator%2522%253A%2522and%2522%257D&sortField=timestamp)
 - [4.17](https://sippy.dptools.openshift.org/sippy-ng/jobs/4.17/runs?filters=%257B%2522items%2522%253A%255B%257B%2522columnField%2522%253A%2522timestamp%2522%252C%2522operatorValue%2522%253A%2522%253E%253D%2522%252C%2522value%2522%253A%25221731178800000%2522%257D%252C%257B%2522columnField%2522%253A%2522job%2522%252C%2522operatorValue%2522%253A%2522contains%2522%252C%2522value%2522%253A%2522ComplianceAsCode-content%2522%257D%252C%257B%2522columnField%2522%253A%2522overall_result%2522%252C%2522not%2522%253Atrue%252C%2522operatorValue%2522%253A%2522equals%2522%252C%2522value%2522%253A%2522S%2522%257D%255D%252C%2522linkOperator%2522%253A%2522and%2522%257D&sortField=timestamp)

#### Review Hints:

- Check if CI is green after these assertion adjustments.