### PR TITLE
Fix file_permissions_unauthorized_sgid

### DIFF
--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_sgid/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_sgid/oval/shared.xml
@@ -12,6 +12,11 @@
         <unix:sgid datatype="boolean">true</unix:sgid>
     </unix:file_state>
 
+    <unix:file_state id="state_file_permissions_unauthorized_sgid_sysroot" version="1"
+        comment="Used to filter out all files in the /sysroot directory">
+        <unix:filepath operation="pattern match">^/sysroot/.*$</unix:filepath>
+    </unix:file_state>
+
     {{%- set var_local_mount_points = "var_" ~ rule_id ~ "_local_mountpoints" -%}}
     {{{ create_local_mount_points_list(var_local_mount_points) }}}
 
@@ -28,6 +33,7 @@
                 var_ref="{{{ var_local_mount_points }}}"/>
         <unix:filename operation="pattern match">^.*$</unix:filename>
         <filter action="include">state_file_permissions_unauthorized_sgid_set</filter>
+        <filter action="exclude">state_file_permissions_unauthorized_sgid_sysroot</filter>
     </unix:file_object>
 
     <local_variable id="var_file_permissions_unauthorized_sgid_all_sgid_files" version="1"


### PR DESCRIPTION
Fix rule file_permissions_unauthorized_sgid for bootable containers. We will filter out the /sysroot directory from our scan because it contains only the physical root and not the real file system.

See:
https://containers.github.io/bootc/filesystem-sysroot.html#sysroot-mount

