### PR TITLE
Fix display_login_attempts

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/bash/shared.sh
@@ -13,7 +13,7 @@
 {{%- elif "sle" in product %}}
 {{%- set control = "optional" %}}
 {{%- else %}}
-{{%- set control = "\[default=1\]" %}}
+{{%- set control = "[default=1]" %}}
 {{%- endif %}}
 
 {{{ bash_pam_lastlog_enable_showfailed(pam_lastlog_path, control, after_match) }}}


### PR DESCRIPTION
Due to the change in Bash Jinja macros introduced by https://github.com/ComplianceAsCode/content/pull/12600 the regular expressions in Bash remediation in rule `display_login_attempts` have been broken. The escaping of the `control` parameter is now done inside `bash_ensure_pam_module_option` and therefore the bash remediation should pass the `control` parameter without escaping.
