### PR TITLE
Add ubuntu2404 product to conditional statements

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_chcon/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_chcon/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_restorecon/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_restorecon/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol8", "ol9", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol8", "ol9", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_semanage/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_semanage/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setfiles/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setfiles/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setsebool/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setsebool/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_seunshare/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_seunshare/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol8", "ol9", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol8", "ol9", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_at/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_at/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol8", "ol9", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in products %}}
+{{%- if product in ["fedora", "ol8", "ol9", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in products %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chage/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chage/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chsh/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chsh/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_crontab/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_crontab/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_dbus_daemon_launch_helper/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_dbus_daemon_launch_helper/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fusermount/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fusermount/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fusermount3/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fusermount3/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_gpasswd/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_gpasswd/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "slmicro5" ,"ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "slmicro5" ,"ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_grub2_set_bootflag/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_grub2_set_bootflag/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_mount/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_mount/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_mount_nfs/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_mount_nfs/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgidmap/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgidmap/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol8", "ol9",  "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol8", "ol9",  "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgrp/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgrp/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newuidmap/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newuidmap/rule.yml
@@ -1,4 +1,4 @@
- {{%- if product in ["fedora", "ol8", "ol9", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+ {{%- if product in ["fedora", "ol8", "ol9", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pam_timestamp_check/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pam_timestamp_check/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}  {{%- set perm_x="-F perm=x " %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}  {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 
 {{% if product in ["sle12", "sle15", "slmicro5"] %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passwd/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passwd/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}  {{%- set perm_x="-F perm=x " %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}  {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 
 documentation_complete: true

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pkexec/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pkexec/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_polkit_helper/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_polkit_helper/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postdrop/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postdrop/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postqueue/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postqueue/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pt_chown/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pt_chown/rule.yml
@@ -1,4 +1,4 @@
- {{%- if product in ["fedora", "ol8", "ol9", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+ {{%- if product in ["fedora", "ol8", "ol9", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sssd_krb5_child/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sssd_krb5_child/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sssd_ldap_child/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sssd_ldap_child/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sssd_proxy_child/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sssd_proxy_child/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sssd_selinux_child/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sssd_selinux_child/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_su/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_su/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}  {{%- set perm_x="-F perm=x " %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}  {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 
 documentation_complete: true

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "debian12"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404", "debian12"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudoedit/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudoedit/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol8", "ol9", "sle12", "sle15", "slmicro5" ,"ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol8", "ol9", "sle12", "sle15", "slmicro5" ,"ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}  {{%- set perm_x="-F perm=x " %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}  {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 
 documentation_complete: true

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_userhelper/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_userhelper/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_usernetctl/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_usernetctl/rule.yml
@@ -1,4 +1,4 @@
- {{%- if product in ["fedora", "ol8", "ol9", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+ {{%- if product in ["fedora", "ol8", "ol9", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_utempter/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_utempter/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_write/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_write/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_sufficiently_large_partition/oval/shared.xml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_sufficiently_large_partition/oval/shared.xml
@@ -1,4 +1,4 @@
-{{% if product not in ['ubuntu2204'] %}}
+{{% if product not in ['ubuntu2204', 'ubuntu2404'] %}}
 {{% if target_oval_version >= [5, 11.2] %}}
 <def-group oval_version="5.11.2">
   <definition class="compliance" id="{{{ rule_id }}}" version="1">

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_sufficiently_large_partition/rule.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_configure_sufficiently_large_partition/rule.yml
@@ -11,7 +11,7 @@ description: |-
     The partition size needed to capture a week's worth of audit records is
     based on the activity level of the system and the total storage capacity
     available.
-    {{% if product not in ['ubuntu2204'] %}}
+    {{% if product not in ['ubuntu2204', 'ubuntu2404'] %}}
     In normal circumstances, 10.0 GB of storage space for audit
     records will be sufficient.
     {{% endif %}}

--- a/linux_os/guide/services/ntp/chronyd_sync_clock/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_sync_clock/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-{{% if product == 'ubuntu2204' -%}}
+{{% if product in ['ubuntu2204', 'ubuntu2404'] -%}}
 {{% set step_value = '1 1' -%}}
 {{% else -%}}
 {{% set step_value = '1 -1' -%}}

--- a/linux_os/guide/services/ntp/chronyd_sync_clock/tests/commented.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_sync_clock/tests/commented.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = chrony
 
-{{% if product == 'ubuntu2204' -%}}
+{{% if product in ['ubuntu2204', 'ubuntu2404'] -%}}
 echo "# makestep 1 1" >> {{{ chrony_conf_path }}}
 {{% else -%}}
 echo "# makestep 1 -1" >> {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_sync_clock/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_sync_clock/tests/correct_value.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = chrony
 
-{{% if product == 'ubuntu2204' -%}}
+{{% if product in ['ubuntu2204', 'ubuntu2404'] -%}}
 echo "makestep 1 1" > {{{ chrony_conf_path }}}
 {{% else -%}}
 echo "makestep 1 -1" > {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/tests/comment.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/tests/comment.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-{{% if product == "ubuntu2204" %}}
+{{% if product == "ubuntu2204", "ubuntu2404" %}}
 sshd_approved_ciphers="aes256-ctr,aes256-gcm@openssh.com,aes192-ctr,aes128-ctr,aes128-gcm@openssh.com"
 {{% else %}}
 sshd_approved_ciphers="aes256-ctr,aes192-ctr,aes128-ctr"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/tests/correct_value.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-{{% if product == "ubuntu2204" %}}
+{{% if product == "ubuntu2204", "ubuntu2404" %}}
 sshd_approved_ciphers="aes256-ctr,aes256-gcm@openssh.com,aes192-ctr,aes128-ctr,aes128-gcm@openssh.com"
 {{% else %}}
 sshd_approved_ciphers="aes256-ctr,aes192-ctr,aes128-ctr"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/rule.yml
@@ -8,7 +8,7 @@
 {{% set path='/etc/ssh/sshd_config' %}}
 {{% set conf="KexAlgorithms ecdh-sha1-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521" ~
              ",diffie-hellman-group-exchange-sha256"  %}}
-{{% elif product in ['sle12', 'sle15', 'slmicro5', 'ubuntu2004', 'ubuntu2204'] %}}
+{{% elif product in ['sle12', 'sle15', 'slmicro5', 'ubuntu2004', 'ubuntu2204', 'ubuntu2404'] %}}
 {{% set path='/etc/ssh/sshd_config' %}}
 {{% set conf="KexAlgorithms ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521" ~
              ",diffie-hellman-group-exchange-sha256"  %}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/common.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/common.sh
@@ -5,7 +5,7 @@ CONF_PREFIX="CRYPTO_POLICY='-oKexAlgorithms="
 KEX_ALGOS="ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512"
 CONF_SUFIX="'"
 CONF_PREFIX_REGEX="^\s*CRYPTO_POLICY"
-{{% elif product in ['ol7', 'sle12', 'sle15', 'slmicro5', 'ubuntu2004', 'ubuntu2204'] %}}
+{{% elif product in ['ol7', 'sle12', 'sle15', 'slmicro5', 'ubuntu2004', 'ubuntu2204', 'ubuntu2404'] %}}
 FILE_PATH='/etc/ssh/sshd_config'
 FILE_PATH_CONFIGDIR='/etc/ssh/sshd_config.d'
 CONF_PREFIX="KexAlgorithms "

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/tests/comment.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/tests/comment.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-{{% if product == "ubuntu2204" %}}
+{{% if product == "ubuntu2204", "ubuntu2404" %}}
 sshd_approved_macs="hmac-sha2-512,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-256-etm@openssh.com"
 {{% else %}}
 sshd_approved_macs="hmac-sha2-512,hmac-sha2-256"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/tests/correct_value.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-{{% if product == "ubuntu2204" %}}
+{{% if product == "ubuntu2204", "ubuntu2404" %}}
 sshd_approved_macs="hmac-sha2-512,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-256-etm@openssh.com"
 {{% else %}}
 sshd_approved_macs="hmac-sha2-512,hmac-sha2-256"

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/rule.yml
@@ -90,7 +90,7 @@ ocil: |-
 platform: package[pam]
 
 fixtext: |-
-    {{% if product in ['ol9', 'rhel9', 'ubuntu2204'] -%}}
+    {{% if product in ['ol9', 'rhel9', 'ubuntu2204', 'ubuntu2404'] -%}}
     Configure {{{ full_name }}} to use a FIPS 140-3 approved cryptographic hashing algorithm for system authentication.
     {{% else %}}
     Configure {{{ full_name }}} to use a FIPS 140-2 approved cryptographic hashing algorithm for system authentication.

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/rule.yml
@@ -92,7 +92,7 @@ fixtext: |-
 
 srg_requirement: 'The systemd Ctrl-Alt-Delete burst key sequence in {{{ full_name }}} must be disabled.'
 
-{{% if product not in ["ubuntu2004", "ubuntu2204"] %}}
+{{% if product not in ["ubuntu2004", "ubuntu2204", "ubuntu2404"] %}}
 warnings:
     - functionality: |-
         Disabling the <tt>Ctrl-Alt-Del</tt> key sequence

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
@@ -82,7 +82,7 @@ ocil: |-
     {{% endif %}}
     The output should return the following:
     <pre>TMOUT={{{ xccdf_value("var_accounts_tmout") }}}</pre>
-    {{% if product in ["sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] %}}
+    {{% if product in ["sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] %}}
     readonly TMOUT
     export TMOUT
     {{% endif %}}

--- a/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/rule.yml
@@ -9,14 +9,14 @@ description: |-
     <br /><br />
     Since plaintext passwords are a security risk, generate a hash for the password
     by running the following command:
-    {{% if product in ["sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] %}}
+    {{% if product in ["sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404", "ubuntu2404"] %}}
     <pre># grub2-mkpasswd-pbkdf2</pre>
     {{% else %}}
     <pre># grub2-setpassword</pre>
     {{% endif %}}
     When prompted, enter the password that was selected.
     <br /><br />
-    {{% if product in ["sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] %}}
+    {{% if product in ["sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404", "ubuntu2404"] %}}
     Using the hash from the output, modify the <tt>/etc/grub.d/40_custom</tt>
     file with the following content:
     <pre>set superusers="boot"

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/rule.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/rule.yml
@@ -5,7 +5,7 @@ title: 'Ensure Log Files Are Owned By Appropriate User'
 description: |-
     The owner of all log files written by
     <tt>rsyslog</tt> should be
-    {{% if product in ['ubuntu2204','ubuntu2004'] %}}
+    {{% if product in ['ubuntu2404', 'ubuntu2204','ubuntu2004'] %}}
     <tt>syslog</tt>.
     {{% elif 'debian' in product or 'ubuntu' in product %}}
     <tt>adm</tt>.
@@ -18,7 +18,7 @@ description: |-
     run the following command to inspect the file's owner:
     <pre>$ ls -l <i>LOGFILE</i></pre>
     If the owner is not
-    {{% if product in ['ubuntu2204','ubuntu2004'] %}}
+    {{% if product in ['ubuntu2404', 'ubuntu2204','ubuntu2004'] %}}
     <tt>syslog</tt>,
     {{% elif 'debian' in product or 'ubuntu' in product %}}
     <tt>adm</tt>,
@@ -27,7 +27,7 @@ description: |-
     {{% endif %}}
     run the following command to
     correct this:
-    {{% if product in ['ubuntu2204','ubuntu2004'] %}}
+    {{% if product in ['ubuntu2404', 'ubuntu2204','ubuntu2004'] %}}
     <pre>$ sudo chown syslog <i>LOGFILE</i></pre>
     {{% elif 'debian' in product or 'ubuntu' in product %}}
     <pre>$ sudo chown adm <i>LOGFILE</i></pre>
@@ -68,7 +68,7 @@ ocil_clause: 'the owner is not correct'
 
 ocil: |-
     The owner of all log files written by <tt>rsyslog</tt> should be
-    {{% if product in ['ubuntu2204','ubuntu2004'] %}}
+    {{% if product in ['ubuntu2404', 'ubuntu2204','ubuntu2004'] %}}
     <tt>syslog</tt>.
     {{% elif 'debian' in product or 'ubuntu' in product %}}
     <tt>adm</tt>.

--- a/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/rule.yml
@@ -13,7 +13,7 @@ description: |-
     option is selected the system will prompt for a passphrase to use in
     decrypting the partition. The passphrase will subsequently need to be entered manually
     every time the system boots.
-    {{% if product not in ["sle12", "sle15", "slmicro5",  "ubuntu2004", "ubuntu2204"] %}}
+    {{% if product not in ["sle12", "sle15", "slmicro5",  "ubuntu2004", "ubuntu2204", "ubuntu2404"] %}}
     <br /><br />
     For automated/unattended installations, it is possible to use Kickstart by adding
     the <tt>--encrypted</tt> and <tt>--passphrase=</tt> options to the definition of each partition to be

--- a/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_FIPS_certified/rule.yml
+++ b/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_FIPS_certified/rule.yml
@@ -11,7 +11,7 @@ description: |-
     SUSE Enterprise Linux is supported by SUSE Software Solutions Germany GmbH. As the SUSE Enterprise
     Linux vendor, SUSE Software Solutions Germany GmbH is responsible for maintaining government
     certifications and standards.
-{{% elif product in ["ubuntu1604", "ubuntu1804", "ubuntu2004", "ubuntu2204"] %}}
+{{% elif product in ["ubuntu1604", "ubuntu1804", "ubuntu2004", "ubuntu2204", "ubuntu2404"] %}}
     Ubuntu Linux is supported by Canonical Ltd. As the Ubuntu Linux Vendor, Canonical Ltd. is
     responsible for government certifications and standards.
 
@@ -75,7 +75,7 @@ ocil: |-
     <pre>$ grep -i "oracle" /etc/oracle-release</pre>
 {{% elif product in ["sle12", "sle15"] %}}
     <pre>$ grep -i "suse" /etc/os-release</pre>
-{{% elif product in ["ubuntu1604", "ubuntu1804", "ubuntu2004", "ubuntu2204"] %}}
+{{% elif product in ["ubuntu1604", "ubuntu1804", "ubuntu2004", "ubuntu2204", "ubuntu2404"] %}}
     <pre>$ grep -i "ubuntu" /etc/os-release</pre>
 {{% endif %}}
     The output should contain something similar to:

--- a/shared/templates/audit_rules_privileged_commands/ansible.template
+++ b/shared/templates/audit_rules_privileged_commands/ansible.template
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] %}}
   {{%- set perm_x=" -F perm=x" %}}
 {{%- endif %}}
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle,multi_platform_slmicro,multi_platform_ubuntu

--- a/shared/templates/audit_rules_privileged_commands/bash.template
+++ b/shared/templates/audit_rules_privileged_commands/bash.template
@@ -1,4 +1,4 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "debian12"] %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404", "debian12"] %}}
   {{%- set perm_x=" -F perm=x" %}}
 {{%- endif %}}
 # platform = multi_platform_all

--- a/shared/templates/audit_rules_privileged_commands/oval.template
+++ b/shared/templates/audit_rules_privileged_commands/oval.template
@@ -1,4 +1,4 @@
-{{%- if product in [ "debian12", "fedora", "ol7", "ol8", "ol9", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] %}}
+{{%- if product in [ "debian12", "fedora", "ol7", "ol8", "ol9", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] %}}
   {{%- set perm_x="(?:[\s]+-F[\s]+perm=x)" %}}
 {{%- endif %}}
 <def-group>

--- a/shared/templates/audit_rules_privileged_commands/tests/common.sh
+++ b/shared/templates/audit_rules_privileged_commands/tests/common.sh
@@ -1,5 +1,5 @@
 
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] %}}
+{{%- if product in ["fedora", "ol7", "ol8", "ol9", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] %}}
 perm_x="-F perm=x"
 {{%- endif %}}
 

--- a/shared/templates/sysctl/ansible.template
+++ b/shared/templates/sysctl/ansible.template
@@ -19,7 +19,7 @@
       - "/run/sysctl.d/"
       - "/usr/local/lib/sysctl.d/"
 {{% endif %}}
-{{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204"] %}}
+{{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] %}}
       - "/usr/lib/sysctl.d/"
 {{% endif %}}
     contains: '^[\s]*{{{ SYSCTLVAR }}}.*$'

--- a/shared/templates/sysctl/bash.template
+++ b/shared/templates/sysctl/bash.template
@@ -7,7 +7,7 @@
 # Comment out any occurrences of {{{ SYSCTLVAR }}} from /etc/sysctl.d/*.conf files
 {{% if product in [ "sle12", "sle15", "slmicro5"] %}}
 for f in /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf; do
-{{% elif product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel8", "rhel9", "rhel10", "ubuntu2004", "ubuntu2204"] %}}
+{{% elif product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel8", "rhel9", "rhel10", "ubuntu2004", "ubuntu2204", "ubuntu2404"] %}}
 for f in /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf; do
 {{% else %}}
 for f in /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf; do

--- a/shared/templates/sysctl/oval.template
+++ b/shared/templates/sysctl/oval.template
@@ -185,7 +185,7 @@
   <ind:textfilecontent54_object id="object_static_etc_lib_sysctls_{{{ rule_id }}}" version="1">
     <set>
       <object_reference>object_static_etc_sysctls_{{{ rule_id }}}</object_reference>
-{{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel8", "rhel9", "rhel10", "ubuntu2004", "ubuntu2204"] %}}
+{{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel8", "rhel9", "rhel10", "ubuntu2004", "ubuntu2204", "ubuntu2404"] %}}
       <object_reference>object_static_lib_sysctld_{{{ rule_id }}}</object_reference>
 {{% endif %}}
     </set>
@@ -232,7 +232,7 @@
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
     {{{ sysctl_match() }}}
   </ind:textfilecontent54_object>
-{{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "ubuntu2004", "ubuntu2204"] or 'rhel' in product %}}
+{{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'rhel' in product %}}
   <ind:textfilecontent54_object id="object_static_lib_sysctld_{{{ rule_id }}}" version="1">
     <ind:path>/lib/sysctl.d</ind:path>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>

--- a/shared/templates/sysctl/sce-bash.template
+++ b/shared/templates/sysctl/sce-bash.template
@@ -4,7 +4,7 @@
 # check-export = sysctl_{{{ SYSCTLID }}}_value=sysctl_{{{ SYSCTLID }}}_value
 {{% endif %}}
 
-{{% if product in [ "ol7", "ol8", "ol9", "rhcos4", "rhel8", "rhel9", "rhel10", "ubuntu2004", "ubuntu2204"] %}}
+{{% if product in [ "ol7", "ol8", "ol9", "rhcos4", "rhel8", "rhel9", "rhel10", "ubuntu2004", "ubuntu2204", "ubuntu2404"] %}}
 FILES_NOT_MANAGED_BY_PACKAGES=("/etc/sysctl.conf" "/etc/sysctl.d/*.conf" "/usr/local/lib/sysctl.d/*.conf" "/run/sysctl.d/*.conf")
 {{% else %}}
 FILES_NOT_MANAGED_BY_PACKAGES=("/etc/sysctl.conf" "/etc/sysctl.d/*.conf" "/lib/sysctl.d/*.conf" "/usr/local/lib/sysctl.d/*.conf" "/run/sysctl.d/*.conf")


### PR DESCRIPTION
#### Description:

Add `ubuntu2404` product to conditional statements in rules and templates which already contain conditionals for `ubuntu2204`. There likely exist some discrepancies between the two systems, but it is more probable that the two systems behave similarly in most conditionals, thus this is a better starting point for the Ubuntu 24.04 product.

Draft until https://github.com/ComplianceAsCode/content/pull/12611 is merged.