### PR TITLE
Add ubuntu2404 to GitHub Actions

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -97,7 +97,7 @@ jobs:
         env:
           ADDITIONAL_CMAKE_OPTIONS: "-DSSG_OVAL_SCHEMATRON_VALIDATION_ENABLED=OFF"
         run: |-
-          ./build_product ubuntu1604 ubuntu1804 ubuntu2004
+          ./build_product ubuntu1604 ubuntu1804 ubuntu2004 ubuntu2404
       - name: Test
         run: ctest -j2 --output-on-failure -E unique-stigids
         working-directory: ./build


### PR DESCRIPTION
#### Description:

Add ubuntu2404 to GitHub Actions

#### Rationale:

Catch issues in CI.
