### PR TITLE
Update oval_feed_url for Ubuntu

### DIFF
--- a/build-scripts/verify_references.py
+++ b/build-scripts/verify_references.py
@@ -135,7 +135,7 @@ def is_remote_feed(href):
             href.startswith("security-data-oval-v2-") or \
             href.startswith("security-data-oval-com.redhat.rhsa-") or \
             href.startswith("security-oval-com.oracle") or \
-            href.startswith("-ubuntu-security-oval-com.ubuntu") or \
+            href.startswith("oval-com.ubuntu") or \
             href.startswith("pub-projects-security-oval-suse") or \
             href.startswith('security-oval-oval-definitions-bookworm')
 

--- a/products/ubuntu1604/product.yml
+++ b/products/ubuntu1604/product.yml
@@ -17,7 +17,7 @@ pkg_manager: "apt_get"
 pkg_manager_config_file: "/etc/apt/apt.conf"
 
 init_system: "systemd"
-oval_feed_url: "https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.xenial.cve.oval.xml"
+oval_feed_url: "https://security-metadata.canonical.com/oval/com.ubuntu.xenial.usn.oval.xml.bz2"
 
 
 chrony_conf_path: "/etc/chrony/chrony.conf"

--- a/products/ubuntu1804/product.yml
+++ b/products/ubuntu1804/product.yml
@@ -17,6 +17,7 @@ pkg_manager: "apt_get"
 pkg_manager_config_file: "/etc/apt/apt.conf"
 
 init_system: "systemd"
+oval_feed_url: "https://security-metadata.canonical.com/oval/com.ubuntu.bionic.usn.oval.xml.bz2"
 
 
 chrony_conf_path: "/etc/chrony/chrony.conf"

--- a/products/ubuntu2004/product.yml
+++ b/products/ubuntu2004/product.yml
@@ -17,7 +17,7 @@ pkg_manager: "apt_get"
 pkg_manager_config_file: "/etc/apt/apt.conf"
 
 init_system: "systemd"
-oval_feed_url: "https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.focal.cve.oval.xml"
+oval_feed_url: "https://security-metadata.canonical.com/oval/com.ubuntu.focal.usn.oval.xml.bz2"
 
 sshd_distributed_config: "true"
 

--- a/products/ubuntu2204/product.yml
+++ b/products/ubuntu2204/product.yml
@@ -17,7 +17,7 @@ pkg_manager: "apt_get"
 pkg_manager_config_file: "/etc/apt/apt.conf"
 
 init_system: "systemd"
-oval_feed_url: "https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.jammy.cve.oval.xml"
+oval_feed_url: "https://security-metadata.canonical.com/oval/com.ubuntu.jammy.usn.oval.xml.bz2"
 
 sshd_distributed_config: "true"
 

--- a/products/ubuntu2404/product.yml
+++ b/products/ubuntu2404/product.yml
@@ -18,7 +18,7 @@ pkg_manager: "apt_get"
 pkg_manager_config_file: "/etc/apt/apt.conf"
 
 init_system: "systemd"
-oval_feed_url: "https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.jammy.cve.oval.xml"
+oval_feed_url: "https://security-metadata.canonical.com/oval/com.ubuntu.noble.usn.oval.xml.bz2"
 
 sshd_distributed_config: "true"
 

--- a/tests/data/product_stability/ubuntu1604.yml
+++ b/tests/data/product_stability/ubuntu1604.yml
@@ -32,7 +32,7 @@ init_system: systemd
 major_version_ordinal: 1604
 nobody_gid: 65534
 nobody_uid: 65534
-oval_feed_url: https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.xenial.cve.oval.xml
+oval_feed_url: https://security-metadata.canonical.com/oval/com.ubuntu.xenial.usn.oval.xml.bz2
 pkg_manager: apt_get
 pkg_manager_config_file: /etc/apt/apt.conf
 pkg_system: dpkg

--- a/tests/data/product_stability/ubuntu1804.yml
+++ b/tests/data/product_stability/ubuntu1804.yml
@@ -32,6 +32,7 @@ init_system: systemd
 major_version_ordinal: 1804
 nobody_gid: 65534
 nobody_uid: 65534
+oval_feed_url: https://security-metadata.canonical.com/oval/com.ubuntu.bionic.usn.oval.xml.bz2
 pkg_manager: apt_get
 pkg_manager_config_file: /etc/apt/apt.conf
 pkg_system: dpkg

--- a/tests/data/product_stability/ubuntu2004.yml
+++ b/tests/data/product_stability/ubuntu2004.yml
@@ -33,7 +33,7 @@ init_system: systemd
 major_version_ordinal: 2004
 nobody_gid: 65534
 nobody_uid: 65534
-oval_feed_url: https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.focal.cve.oval.xml
+oval_feed_url: https://security-metadata.canonical.com/oval/com.ubuntu.focal.usn.oval.xml.bz2
 pkg_manager: apt_get
 pkg_manager_config_file: /etc/apt/apt.conf
 pkg_system: dpkg

--- a/tests/data/product_stability/ubuntu2204.yml
+++ b/tests/data/product_stability/ubuntu2204.yml
@@ -33,7 +33,7 @@ init_system: systemd
 major_version_ordinal: 2204
 nobody_gid: 65534
 nobody_uid: 65534
-oval_feed_url: https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.jammy.cve.oval.xml
+oval_feed_url: https://security-metadata.canonical.com/oval/com.ubuntu.jammy.usn.oval.xml.bz2
 pkg_manager: apt_get
 pkg_manager_config_file: /etc/apt/apt.conf
 pkg_system: dpkg

--- a/tests/data/product_stability/ubuntu2404.yml
+++ b/tests/data/product_stability/ubuntu2404.yml
@@ -10,6 +10,7 @@ benchmark_id: UBUNTU_24-04
 benchmark_root: ../../linux_os/guide
 chrony_conf_path: /etc/chrony/chrony.conf
 chrony_d_path: /etc/chrony/conf.d/
+components_root: ../../components
 cpes:
 - ubuntu2404:
     check_id: installed_OS_is_ubuntu2404
@@ -33,7 +34,7 @@ init_system: systemd
 major_version_ordinal: 2404
 nobody_gid: 65534
 nobody_uid: 65534
-oval_feed_url: https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.noble.cve.oval.xml
+oval_feed_url: https://security-metadata.canonical.com/oval/com.ubuntu.noble.usn.oval.xml.bz2
 pkg_manager: apt_get
 pkg_manager_config_file: /etc/apt/apt.conf
 pkg_system: dpkg


### PR DESCRIPTION
#### Description:

- Replace outdated broken links with current USN feeds from https://security-metadata.canonical.com/oval/
- Also address wrong release name (https://github.com/ComplianceAsCode/content/pull/12611#discussion_r1844254677)
- Also fix a failing ctest by changing the hardcoded value in `verify_references.py`
