### PR TITLE
Add rule sysctl_kernel_yama_ptrace_scope to Ubuntu 24.04 CIS

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -440,8 +440,10 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    rules:
+      - sysctl_kernel_yama_ptrace_scope_value=1
+      - sysctl_kernel_yama_ptrace_scope
+    status: automated
 
   - id: 1.5.3
     title: Ensure core dumps are restricted (Automated)

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_yama_ptrace_scope/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_yama_ptrace_scope/rule.yml
@@ -42,5 +42,13 @@ template:
     name: sysctl
     vars:
         sysctlvar: kernel.yama.ptrace_scope
+        {{% if product in ['ubuntu2404'] %}}
+        sysctlval:
+          - '1'
+          - '2'
+          - '3'
+        wrong_sysctlval_for_testing: '0'
+        {{% else %}}
         sysctlval: '1'
+        {{% endif %}}
         datatype: int

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_yama_ptrace_scope_value.var
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_yama_ptrace_scope_value.var
@@ -1,0 +1,20 @@
+documentation_complete: true
+
+title: kernel.yama.ptrace_scope
+
+description: |-
+    The setting yama.ptrace_scope restricts the ability of a process
+    to observe and control the execution of another process via ptrace.
+    See https://www.kernel.org/doc/Documentation/security/Yama.txt
+
+type: number
+
+operator: equals
+
+interactive: false
+
+options:
+    default: 1
+    1: 1
+    2: 2
+    3: 3


### PR DESCRIPTION
#### Description:

- Added rule `sysctl_kernel_yama_ptrace_scope` to Ubuntu 24.04 CIS
- Created a new variable `sysctl_kernel_yama_ptrace_scope_value` to allow the audit to pass on multiple values (1,2,3), whilst remediating to a single user-defined value.

Draft until issues with `oval_feed_url` are resolved (https://github.com/ComplianceAsCode/content/pull/12617)