### PR TITLE
Remove rule disable_ctrlaltdel_burstaction from Ubuntu STIG profiles

### DIFF
--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -596,7 +596,6 @@ selections:
 
     # UBTU-20-010460 The Ubuntu operating system must disable the x86 Ctrl-Alt-Delete key sequence.
     - disable_ctrlaltdel_reboot
-    - disable_ctrlaltdel_burstaction
 
     # UBTU-20-010461 The Ubuntu operating system must disable automatic mounting of Universal Serial Bus (USB) mass storage driver.
     - kernel_module_usb-storage_disabled

--- a/products/ubuntu2204/profiles/stig.profile
+++ b/products/ubuntu2204/profiles/stig.profile
@@ -559,7 +559,6 @@ selections:
 
     # UBTU-22-211015 The Ubuntu operating system must disable the x86 Ctrl-Alt-Delete key sequence.
     - disable_ctrlaltdel_reboot
-    - disable_ctrlaltdel_burstaction
 
     # UBTU-22-291010 The Ubuntu operating system must disable automatic mounting of Universal Serial Bus (USB) mass storage driver.
     - kernel_module_usb-storage_disabled


### PR DESCRIPTION
#### Description:

- Remove `disable_ctrlaltdel_burstaction` from Ubuntu 20.04 and 22.04 STIG profiles

#### Rationale:

- Not a requirement for Ubuntu STIGs
- Fixes https://github.com/ComplianceAsCode/content/issues/12556