### PR TITLE
Update several controls and variables for Ubuntu 24.04 CIS

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -780,10 +780,10 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    related_rules:
+    rules:
       - package_net-snmp_removed
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/2.2.13.
+      - service_snmpd_disabled
+    status: automated
 
   - id: 2.1.16
     title: Ensure tftp server services are not in use (Automated)

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -830,10 +830,9 @@ controls:
     title: Ensure X window server services are not in use (Automated)
     levels:
       - l2_server
-    related_rules:
+    rules:
       - package_xorg-x11-server-common_removed
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/2.2.1.
+    status: automated
 
   - id: 2.1.21
     title: Ensure mail transfer agent is configured for local-only mode (Automated)

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -709,11 +709,10 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    related_rules:
-      - package_cyrus-imapd_removed
+    rules:
       - package_dovecot_removed
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/2.2.10.
+      - service_dovecot_disabled
+    status: automated
 
   - id: 2.1.9
     title: Ensure network file system services are not in use (Automated)

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -699,10 +699,10 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    related_rules:
+    rules:
       - package_openldap-servers_removed
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/2.2.5.
+      - service_slapd_disabled
+    status: automated
 
   - id: 2.1.8
     title: Ensure message access server services are not in use (Automated)

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -750,10 +750,10 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    related_rules:
+    rules:
       - package_rpcbind_removed
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/2.3.6.
+      - service_rpcbind_disabled
+    status: automated
 
   - id: 2.1.13
     title: Ensure rsync services are not in use (Automated)

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -730,10 +730,10 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    related_rules:
-      - package_nis_removed
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/2.2.14.
+    rules:
+      - package_ypserv_removed
+      - service_ypserv_disabled
+    status: automated
 
   - id: 2.1.11
     title: Ensure print server services are not in use (Automated)

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -770,10 +770,10 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    related_rules:
+    rules:
       - package_samba_removed
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/2.2.11.
+      - service_smb_disabled
+    status: automated
 
   - id: 2.1.15
     title: Ensure snmp services are not in use (Automated)

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -721,8 +721,8 @@ controls:
       - l1_workstation
     related_rules:
       - package_nfs-kernel-server_removed
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/2.2.6.
+      - service_nfs_disabled
+    status: automated
 
   - id: 2.1.10
     title: Ensure nis server services are not in use (Automated)

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -740,11 +740,10 @@ controls:
     levels:
       - l1_server
       - l2_workstation
-    related_rules:
+    rules:
       - package_cups_removed
       - service_cups_disabled
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/2.2.3.
+    status: automated
 
   - id: 2.1.12
     title: Ensure rpcbind services are not in use (Automated)

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -671,10 +671,10 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    related_rules:
+    rules:
       - package_bind_removed
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/2.2.7.
+      - service_named_disabled
+    status: automated
 
   - id: 2.1.5
     title: Ensure dnsmasq services are not in use (Automated)

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -651,11 +651,10 @@ controls:
     levels:
       - l1_server
       - l2_workstation
-    related_rules:
+    rules:
       - package_avahi_removed
       - service_avahi-daemon_disabled
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/2.2.2.
+    status: automated
 
   - id: 2.1.3
     title: Ensure dhcp server services are not in use (Automated)

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -800,10 +800,10 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    related_rules:
+    rules:
       - package_squid_removed
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/2.2.12.
+      - service_squid_disabled
+    status: automated
 
   - id: 2.1.18
     title: Ensure web server services are not in use (Automated)

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -689,10 +689,10 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    related_rules:
+    rules:
       - package_vsftpd_removed
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/2.2.8.
+      - service_vsftpd_disabled
+    status: automated
 
   - id: 2.1.7
     title: Ensure ldap server services are not in use (Automated)

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -821,8 +821,10 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    rules:
+      - package_xinetd_removed
+      - service_xinetd_disabled
+    status: automated
 
   - id: 2.1.20
     title: Ensure X window server services are not in use (Automated)

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -760,10 +760,10 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    related_rules:
+    rules:
       - package_rsync_removed
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/2.2.16.
+      - service_rsyncd_disabled
+    status: automated
 
   - id: 2.1.14
     title: Ensure samba file server services are not in use (Automated)

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -790,8 +790,10 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    rules:
+      - package_tftp-server_removed
+      - service_tftp_disabled
+    status: automated
 
   - id: 2.1.17
     title: Ensure web proxy server services are not in use (Automated)

--- a/linux_os/guide/services/avahi/disable_avahi_group/package_avahi_removed/rule.yml
+++ b/linux_os/guide/services/avahi/disable_avahi_group/package_avahi_removed/rule.yml
@@ -45,3 +45,4 @@ template:
         pkgname: avahi
         pkgname@ubuntu2004: avahi-daemon
         pkgname@ubuntu2204: avahi-daemon
+        pkgname@ubuntu2404: avahi-daemon

--- a/linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/rule.yml
+++ b/linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/rule.yml
@@ -52,3 +52,4 @@ template:
         packagename@ubuntu1804: avahi-daemon
         packagename@ubuntu2004: avahi-daemon
         packagename@ubuntu2204: avahi-daemon
+        packagename@ubuntu2404: avahi-daemon

--- a/linux_os/guide/services/dns/disabling_dns_server/package_bind_removed/rule.yml
+++ b/linux_os/guide/services/dns/disabling_dns_server/package_bind_removed/rule.yml
@@ -1,6 +1,5 @@
 documentation_complete: true
 
-
 title: 'Uninstall bind Package'
 
 description: |-
@@ -44,3 +43,4 @@ template:
         pkgname@ubuntu1804: bind9
         pkgname@ubuntu2004: bind9
         pkgname@ubuntu2204: bind9
+        pkgname@ubuntu2404: bind9

--- a/linux_os/guide/services/dns/disabling_dns_server/service_named_disabled/rule.yml
+++ b/linux_os/guide/services/dns/disabling_dns_server/service_named_disabled/rule.yml
@@ -1,6 +1,5 @@
 documentation_complete: true
 
-
 title: 'Disable named Service'
 
 description: |-
@@ -43,3 +42,4 @@ template:
     vars:
         servicename: named
         packagename: bind
+        packagename@ubuntu2404: bind9

--- a/linux_os/guide/services/imap/disabling_dovecot/package_dovecot_removed/rule.yml
+++ b/linux_os/guide/services/imap/disabling_dovecot/package_dovecot_removed/rule.yml
@@ -1,6 +1,5 @@
 documentation_complete: true
 
-
 title: 'Uninstall dovecot Package'
 
 description: |-
@@ -43,3 +42,4 @@ template:
         pkgname@ubuntu1804: dovecot-core
         pkgname@ubuntu2004: dovecot-core
         pkgname@ubuntu2204: dovecot-core
+        pkgname@ubuntu2404: dovecot-core

--- a/linux_os/guide/services/imap/disabling_dovecot/service_dovecot_disabled/rule.yml
+++ b/linux_os/guide/services/imap/disabling_dovecot/service_dovecot_disabled/rule.yml
@@ -1,6 +1,5 @@
 documentation_complete: true
 
-
 title: 'Disable Dovecot Service'
 
 description: |-
@@ -34,3 +33,4 @@ template:
     name: service_disabled
     vars:
         servicename: dovecot
+        packagename@ubuntu2404: dovecot-core

--- a/linux_os/guide/services/ldap/openldap_server/package_openldap-servers_removed/rule.yml
+++ b/linux_os/guide/services/ldap/openldap_server/package_openldap-servers_removed/rule.yml
@@ -11,7 +11,6 @@
 
 documentation_complete: true
 
-
 title: 'Uninstall openldap-servers Package'
 
 description: |-
@@ -65,3 +64,4 @@ template:
         pkgname@ubuntu1804: slapd
         pkgname@ubuntu2004: slapd
         pkgname@ubuntu2204: slapd
+        pkgname@ubuntu2404: slapd

--- a/linux_os/guide/services/ldap/openldap_server/service_slapd_disabled/rule.yml
+++ b/linux_os/guide/services/ldap/openldap_server/service_slapd_disabled/rule.yml
@@ -1,14 +1,14 @@
 documentation_complete: true
 
-
 title: 'Disable LDAP Server (slapd)'
 
 description: |-
-    The Lightweight Directory Access Protocol (LDAP) is a service that provides a method for looking up information from a central database.
+    The Lightweight Directory Access Protocol (LDAP) is a service that
+    provides a method for looking up information from a central database.
 
 rationale: |-
-    If the system will not need to act as an LDAP server, it is recommended that the software be
-    disabled to reduce the potential attack surface.
+    If the system will not need to act as an LDAP server, it is recommended
+    that the software be disabled to reduce the potential attack surface.
 
 severity: medium
 
@@ -29,3 +29,4 @@ template:
     vars:
         servicename: slapd
         packagename: openldap-servers
+        packagename@ubuntu2404: slapd

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/disabling_nfsd/service_nfs_disabled/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/disabling_nfsd/service_nfs_disabled/rule.yml
@@ -1,6 +1,5 @@
 documentation_complete: true
 
-
 title: 'Disable Network File System (nfs)'
 
 description: |-
@@ -44,3 +43,4 @@ template:
     vars:
         servicename: nfs-server
         packagename: nfs-utils
+        packagename@ubuntu2404: nfs-kernel-server

--- a/linux_os/guide/services/obsolete/service_rsyncd_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/service_rsyncd_disabled/rule.yml
@@ -40,4 +40,5 @@ template:
         packagename@sle12: rsync
         packagename@sle15: rsync
         packagename@openeuler2203: rsync
-        packagename@kylinserver10: rsync
+        servicename@ubuntu2404: rsync
+        packagename@ubuntu2404: rsync

--- a/linux_os/guide/services/obsolete/tftp/package_tftp-server_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/tftp/package_tftp-server_removed/rule.yml
@@ -1,12 +1,17 @@
 documentation_complete: true
 
+{{% if product in ['ubuntu2404'] %}}
+{{% set package_name = "tftpd-hpa" %}}
+{{% else %}}
+{{% set package_name = "tftp-server" %}}
+{{% endif %}}
 
-title: 'Uninstall tftp-server Package'
+title: 'Uninstall {{{ package_name }}} Package'
 
-description: '{{{ describe_package_remove(package="tftp-server") }}}'
+description: '{{{ describe_package_remove(package=package_name) }}}'
 
 rationale: |-
-    Removing the <tt>tftp-server</tt> package decreases the risk of the accidental
+    Removing the <tt>{{{ package_name }}}</tt> package decreases the risk of the accidental
     (or intentional) activation of tftp services.
     <br /><br />
     If TFTP is required for operational support (such as transmission of router
@@ -37,13 +42,13 @@ references:
     stigid@ol8: OL08-00-040190
     stigid@rhel8: RHEL-08-040190
 
-{{{ complete_ocil_entry_package(package="tftp-server") }}}
+{{{ complete_ocil_entry_package(package=package_name) }}}
 
-fixtext: '{{{ fixtext_package_removed("tftp-server") }}}'
+fixtext: '{{{ fixtext_package_removed(package_name) }}}'
 
 srg_requirement: 'The Trivial File Transfer Protocol (TFTP) server package must not be installed if not required for {{{ full_name }}} operational support.'
 
 template:
     name: package_removed
     vars:
-        pkgname: tftp-server
+        pkgname: {{{ package_name }}}

--- a/linux_os/guide/services/obsolete/tftp/service_tftp_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/tftp/service_tftp_disabled/rule.yml
@@ -1,14 +1,21 @@
 documentation_complete: true
 
+{{% if product in ['ubuntu2404'] %}}
+{{% set service_name = "tftpd-hpa" %}}
+{{% set package_name = "tftpd-hpa" %}}
+{{% else %}}
+{{% set service_name = "tftp" %}}
+{{% set package_name = "tftp-server" %}}
+{{% endif %}}
 
-title: 'Disable tftp Service'
+title: 'Disable {{{ service_name }}} Service'
 
 description: |-
-    The <tt>tftp</tt> service should be disabled.
-    {{{ describe_service_disable(service="tftp") }}}
+    The <tt>{{{ service_name }}}</tt> service should be disabled.
+    {{{ describe_service_disable(service=service_name) }}}
 
 rationale: |-
-    Disabling the <tt>tftp</tt> service ensures the system is not acting
+    Disabling the <tt>{{{ service_name }}}</tt> service ensures the system is not acting
     as a TFTP server, which does not provide encryption or authentication.
 
 severity: high
@@ -28,15 +35,15 @@ references:
     nist-csf: PR.AC-3,PR.IP-1,PR.PT-3,PR.PT-4
 
 ocil_clause: |-
-    {{{ ocil_clause_service_disabled(service="tftp") }}}
+    {{{ ocil_clause_service_disabled(service=service_name) }}}
 
 ocil: |-
-    {{{ ocil_service_disabled(service="tftp") }}}
+    {{{ ocil_service_disabled(service=service_name) }}}
 
 platform: system_with_kernel
 
 template:
     name: service_disabled
     vars:
-        servicename: tftp
-        packagename: tftp-server
+        servicename: {{{ service_name }}}
+        packagename: {{{ package_name }}}

--- a/linux_os/guide/services/smb/disabling_samba/service_smb_disabled/rule.yml
+++ b/linux_os/guide/services/smb/disabling_samba/service_smb_disabled/rule.yml
@@ -35,4 +35,5 @@ template:
     name: service_disabled
     vars:
         servicename: smb
+        servicename@ubuntu2404: smbd
         packagename: samba

--- a/linux_os/guide/services/snmp/disabling_snmp_service/package_net-snmp_removed/rule.yml
+++ b/linux_os/guide/services/snmp/disabling_snmp_service/package_net-snmp_removed/rule.yml
@@ -47,3 +47,4 @@ template:
         pkgname@ubuntu1804: snmp
         pkgname@ubuntu2004: snmp
         pkgname@ubuntu2204: snmp
+        pkgname@ubuntu2404: snmpd

--- a/linux_os/guide/services/snmp/disabling_snmp_service/service_snmpd_disabled/rule.yml
+++ b/linux_os/guide/services/snmp/disabling_snmp_service/service_snmpd_disabled/rule.yml
@@ -38,4 +38,5 @@ template:
         servicename: snmpd
         packagename@debian11: snmpd
         packagename@debian12: snmpd
+        packagename@ubuntu2404: snmpd
         packagename: net-snmp

--- a/linux_os/guide/services/xwindows/disabling_xwindows/package_xorg-x11-server-common_removed/rule.yml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/package_xorg-x11-server-common_removed/rule.yml
@@ -67,3 +67,4 @@ template:
         pkgname@ubuntu1804: xserver-xorg
         pkgname@ubuntu2004: xserver-xorg
         pkgname@ubuntu2204: xserver-xorg
+        pkgname@ubuntu2404: xserver-common


### PR DESCRIPTION
#### Description:

Update several controls for Ubuntu 24.04 CIS, adding missing rules and fixing variable overrides:
- 2.1.2  - Ensure avahi daemon services are not in use
- 2.1.4  - Ensure dns server services are not in use
- 2.1.6  - Ensure ftp server services are not in use
- 2.1.7  - Ensure ldap server services are not in use
- 2.1.8  - Ensure message access server services are not in use
- 2.1.9  - Ensure network file system services are not in use
- 2.1.10 - Ensure nis server services are not in use
- 2.1.11 - Ensure print server services are not in use
- 2.1.12 - Ensure rpcbind services are not in use
- 2.1.13 - Ensure rsync services are not in use
- 2.1.14 - Ensure samba file server services are not in use
- 2.1.15 - Ensure snmp services are not in use 
- 2.1.16 - Ensure tftp server services are not in use
- 2.1.17 - Ensure web proxy server services are not in use
- 2.1.19 - Ensure xinetd services are not in use
- 2.1.20 - Ensure X window server services are not in use
