### PR TITLE
Fix timestamps for data-stream composition

### DIFF
--- a/build-scripts/compose_ds.py
+++ b/build-scripts/compose_ds.py
@@ -10,7 +10,7 @@ import xml.etree.ElementTree as ET
 from ssg.build_sce import collect_sce_checks
 from ssg.constants import (
     cat_namespace, datastream_namespace, oval_namespace, sce_namespace,
-    XCCDF12_NS, xlink_namespace)
+    timestamp, XCCDF12_NS, xlink_namespace)
 import ssg.xml
 
 try:
@@ -47,7 +47,7 @@ def embed_sce_checks_in_datastream(datastreamtree, checklists, checks, build_dir
             datastreamtree, '{%s}extended-component' % datastream_namespace,
             attrib={
                 'id': component_id,
-                'timestamp': get_timestamp(path)
+                'timestamp': timestamp
             })
         # Append the file content
         script_data = ET.SubElement(component, '{%s}script' % sce_namespace)
@@ -190,16 +190,6 @@ def parse_args():
     return parser.parse_args()
 
 
-def get_timestamp(file_name):
-    source_date_epoch = os.getenv("SOURCE_DATE_EPOCH")
-    if source_date_epoch:
-        time_sec = float(source_date_epoch)
-    else:
-        time_sec = os.path.getmtime(file_name)
-    timestamp = time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime(time_sec))
-    return timestamp
-
-
 def add_component(
         ds_collection, component_ref_parent, component_file_name,
         dependencies=None):
@@ -210,7 +200,7 @@ def add_component(
     component = ET.SubElement(
         ds_collection, "{%s}component" % datastream_namespace)
     component.set("id", component_id)
-    component.set("timestamp", get_timestamp(component_file_name))
+    component.set("timestamp", timestamp)
     component_ref = ET.SubElement(
         component_ref_parent, "{%s}component-ref" % datastream_namespace)
     component_ref_id = "scap_%s_cref_%s" % (
@@ -247,6 +237,7 @@ def compose_ds(
     ds.set("id", "scap_%s_datastream_%s" % (ID_NS, name))
     ds.set("scap-version", "1.3")
     ds.set("use-case", "OTHER")
+    ds.set("timestamp", timestamp)
     dictionaries = ET.SubElement(ds, "{%s}dictionaries" % datastream_namespace)
     checklists = ET.SubElement(ds, "{%s}checklists" % datastream_namespace)
     checks = ET.SubElement(ds, "{%s}checks" % datastream_namespace)

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -742,10 +742,7 @@ class Benchmark(XCCDFEntity):
         root.set('xml:lang', 'en-US')
 
         status = ET.SubElement(root, '{%s}status' % XCCDF12_NS)
-        status.set(
-            'date',
-            time.strftime("%Y-%m-%d",
-                          time.gmtime(int(os.environ.get('SOURCE_DATE_EPOCH', time.time())))))
+        status.set('date', timestamp)
         status.text = self.status
 
         add_sub_element(root, "title", XCCDF12_NS, self.title)

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -34,6 +34,7 @@ from .constants import (XCCDF12_NS,
                         xhtml_namespace,
                         xsi_namespace,
                         timestamp,
+                        timestamp_yyyy_mm_dd,
                         SSG_BENCHMARK_LATEST_URI,
                         SSG_PROJECT_NAME,
                         SSG_REF_URIS,
@@ -742,7 +743,7 @@ class Benchmark(XCCDFEntity):
         root.set('xml:lang', 'en-US')
 
         status = ET.SubElement(root, '{%s}status' % XCCDF12_NS)
-        status.set('date', timestamp)
+        status.set('date', timestamp_yyyy_mm_dd)
         status.text = self.status
 
         add_sub_element(root, "title", XCCDF12_NS, self.title)

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -183,9 +183,16 @@ oval_header = (
         {0}#linux linux-definitions-schema.xsd">"""
     .format(oval_namespace))
 
+_timestamp = time.gmtime(int(os.environ.get('SOURCE_DATE_EPOCH', time.time())))
+
 timestamp = time.strftime(
     "%Y-%m-%dT%H:%M:%S",
-    time.gmtime(int(os.environ.get('SOURCE_DATE_EPOCH', time.time())))
+    _timestamp
+)
+
+timestamp_yyyy_mm_dd = time.strftime(
+    "%Y-%m-%d",
+    _timestamp
 )
 
 PKG_MANAGER_TO_SYSTEM = {


### PR DESCRIPTION


#### Description:
- Unify and use the constant timestamp across the whole code.

- Previously oscap info command would print null for such cases. Stream: scap_org.open-scap_datastream_from_xccdf_ssg-fedora-xccdf.xml Generated: (null)


#### Review Hints:

- oscap info "ds.file"

Previous:
~ 0 $ oscap info "/usr/share/xml/scap/ssg/content/ssg-fedora-ds.xml"
Document type: Source Data Stream
Imported: 2024-08-12T02:00:00

Stream: scap_org.open-scap_datastream_from_xccdf_ssg-fedora-xccdf.xml
Generated: (null)
Version: 1.3
Checklists:


Current:
oscap info build/ssg-rhel9-ds.xml
Document type: Source Data Stream
Imported: 2024-11-21T14:20:20

Stream: scap_org.open-scap_datastream_from_xccdf_ssg-rhel9-xccdf.xml
Generated: 2024-11-21T13:20:19
Version: 1.3
Checklists:

