### PR TITLE
Update firewalld rules for bootable containers

### DIFF
--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_restricted/bash/shared.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_restricted/bash/shared.sh
@@ -9,7 +9,7 @@
 ipv4_rule='rule family=ipv4 source address="127.0.0.1" destination not address="127.0.0.1" drop'
 ipv6_rule='rule family=ipv6 source address="::1" destination not address="::1" drop'
 
-if {{{ in_chrooted_environment }}}; then
+if {{{ in_chrooted_environment }}} || {{{ bash_bootc_build() }}}; then
     firewall-offline-cmd --zone=trusted --add-rich-rule="${ipv4_rule}"
     firewall-offline-cmd --zone=trusted --add-rich-rule="${ipv6_rule}"
 elif systemctl is-active firewalld; then

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_trusted/bash/shared.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_trusted/bash/shared.sh
@@ -6,7 +6,7 @@
 
 {{{ bash_package_install("firewalld") }}}
 
-if {{{ in_chrooted_environment }}}; then
+if {{{ in_chrooted_environment }}} || {{{ bash_bootc_build() }}}; then
     firewall-offline-cmd --zone=trusted --add-interface=lo
 elif systemctl is-active firewalld; then
     firewall-cmd --permanent --zone=trusted --add-interface=lo


### PR DESCRIPTION
The rules `firewalld_loopback_traffic_restricted`, `firewalld_loopback_traffic_trusted` and `configure_firewalld_rate_limiting` have been updated for bootable containers (only their remediations needed an update).