### PR TITLE
Add new rule service_dhcpd6_disabled

### DIFF
--- a/components/dhcp.yml
+++ b/components/dhcp.yml
@@ -19,5 +19,6 @@ rules:
 - package_dhcp_client_removed
 - package_dhcp_removed
 - service_dhcpd_disabled
+- service_dhcpd6_disabled
 - sysconfig_networking_bootproto_ifcfg
 - package_kea_removed

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -662,10 +662,11 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    related_rules:
+    rules:
       - package_dhcp_removed
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/2.2.4.
+      - service_dhcpd_disabled
+      - service_dhcpd6_disabled
+    status: automated
 
   - id: 2.1.4
     title: Ensure dns server services are not in use (Automated)

--- a/linux_os/guide/services/dhcp/disabling_dhcp_server/package_dhcp_removed/rule.yml
+++ b/linux_os/guide/services/dhcp/disabling_dhcp_server/package_dhcp_removed/rule.yml
@@ -1,6 +1,5 @@
 documentation_complete: true
 
-
 title: 'Uninstall DHCP Server Package'
 
 description: |-
@@ -59,5 +58,6 @@ template:
         pkgname@ubuntu1804: isc-dhcp-server
         pkgname@ubuntu2004: isc-dhcp-server
         pkgname@ubuntu2204: isc-dhcp-server
+        pkgname@ubuntu2404: isc-dhcp-server
         pkgname@sle12: dhcp-server
         pkgname@sle15: dhcp-server

--- a/linux_os/guide/services/dhcp/disabling_dhcp_server/service_dhcpd6_disabled/rule.yml
+++ b/linux_os/guide/services/dhcp/disabling_dhcp_server/service_dhcpd6_disabled/rule.yml
@@ -1,0 +1,31 @@
+documentation_complete: true
+
+title: 'Disable DHCPD6 Service'
+
+description: |-
+    The <tt>dhcp6</tt> service should be disabled on
+    any system that does not need to act as a DHCP server.
+    {{% if product in ['ubuntu2404'] %}}
+    {{{ describe_service_disable(service="isc-dhcp-server6") }}}
+    {{% else %}}
+    {{{ describe_service_disable(service="dhcpd6") }}}
+    {{% endif %}}
+
+rationale: |-
+    Unmanaged or unintentionally activated DHCP servers may provide faulty information
+    to clients, interfering with the operation of a legitimate site
+    DHCP server if there is one.
+
+severity: medium
+
+platform: system_with_kernel
+
+template:
+    name: service_disabled
+    vars:
+        servicename: dhcpd6
+        servicename@ubuntu2404: isc-dhcp-server6
+        packagename: dhcp
+        packagename@rhel8: dhcp-server
+        packagename@rhel9: dhcp-server
+        packagename@ubuntu2404: isc-dhcp-server

--- a/linux_os/guide/services/dhcp/disabling_dhcp_server/service_dhcpd_disabled/rule.yml
+++ b/linux_os/guide/services/dhcp/disabling_dhcp_server/service_dhcpd_disabled/rule.yml
@@ -1,12 +1,15 @@
 documentation_complete: true
 
-
 title: 'Disable DHCP Service'
 
 description: |-
     The <tt>dhcpd</tt> service should be disabled on
     any system that does not need to act as a DHCP server.
+    {{% if product in ['ubuntu2404'] %}}
+    {{{ describe_service_disable(service="isc-dhcp-server") }}}
+    {{% else %}}
     {{{ describe_service_disable(service="dhcpd") }}}
+    {{% endif %}}
 
 rationale: |-
     Unmanaged or unintentionally activated DHCP servers may provide faulty information
@@ -45,6 +48,8 @@ template:
     name: service_disabled
     vars:
         servicename: dhcpd
+        servicename@ubuntu2404: isc-dhcp-server
         packagename: dhcp
         packagename@rhel8: dhcp-server
         packagename@rhel9: dhcp-server
+        packagename@ubuntu2404: isc-dhcp-server


### PR DESCRIPTION
#### Description:

- Add new rule `service_dhcpd6_disabled` based on `service_dhcpd_disabled`
- Update control 2.1.5 in ubuntu2404 CIS profile (Ensure dhcp server services are not in use)
- Define variable overrides for pkgname and servicename on ubuntu2404
 