### PR TITLE
Add new rule service_dnsmasq_disabled

### DIFF
--- a/components/bind.yml
+++ b/components/bind.yml
@@ -18,3 +18,4 @@ rules:
 - package_bind_removed
 - package_dnsmasq_removed
 - service_named_disabled
+- service_dnsmasq_disabled

--- a/components/dnsmasq.yml
+++ b/components/dnsmasq.yml
@@ -3,3 +3,4 @@ packages:
 - dnsmasq
 rules:
 - package_dnsmasq_removed
+- service_dnsmasq_disabled

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -682,8 +682,10 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    rules:
+      - package_dnsmasq_removed
+      - service_dnsmasq_disabled
+    status: automated
 
   - id: 2.1.6
     title: Ensure ftp server services are not in use (Automated)

--- a/linux_os/guide/services/dns/service_dnsmasq_disabled/rule.yml
+++ b/linux_os/guide/services/dns/service_dnsmasq_disabled/rule.yml
@@ -1,0 +1,20 @@
+documentation_complete: true
+
+title: 'Disable dnsmasq Service'
+
+description: |-
+    {{{ describe_service_disable(service="dnsmasq") }}}
+
+rationale: |-
+    Unless a system is specifically designated to act as a DNS
+    caching, DNS forwarding and/or DHCP server, it is recommended
+    that the package be removed to reduce the potential attack surface.
+
+severity: medium
+
+platform: system_with_kernel
+
+template:
+    name: service_disabled
+    vars:
+        servicename: dnsmasq


### PR DESCRIPTION
#### Description:

- Add new rule `service_dnsmasq_disabled`
- Update control 2.1.5 in Ubuntu2404 CIS profile (Ensure dnsmasq services are not in use)
