### PR TITLE
Add Ubuntu Maintainers as CODEOWNERS for 24.04 CIS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,3 +18,4 @@
 /controls/cis_rhel9.yml @ComplianceAsCode/red-hatters
 /controls/cis_sle12.yml @ComplianceAsCode/suse-maintainers
 /controls/cis_sle15.yml @ComplianceAsCode/suse-maintainers
+/controls/cis_ubuntu2404.yml @ComplianceAsCode/ubuntu-maintainers


### PR DESCRIPTION
#### Description:

Add Ubuntu Maintainers as CODEOWNERS for 24.04 CIS

#### Rationale:

To be consistent between the distros. 