### PR TITLE
Adjust OVAL for directory_permissions_var_log_audit

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/directory_permissions_var_log_audit/oval/shared.xml
+++ b/linux_os/guide/auditing/auditd_configure_rules/directory_permissions_var_log_audit/oval/shared.xml
@@ -2,7 +2,7 @@
   <definition class="compliance" id="directory_permissions_var_log_audit" version="1">
     {{{ oval_metadata("Checks for correct permissions for audit logs.") }}}
     <criteria operator="OR">
-      {{% if product not in ["ol8", "rhel8"] %}}
+      {{% if product not in ["ol8"] and 'rhel' not in product %}}
       <criteria operator="AND" comment="log_file set">
         <extend_definition comment="log_file set in auditd.conf" definition_ref="auditd_conf_log_file_not_set" negate="true" />
         <criteria operator="AND" comment="log_group in auditd.conf is not root">
@@ -16,7 +16,7 @@
       <criteria operator="AND" comment="log_group in auditd.conf is not root">
         <extend_definition comment="log_group in auditd.conf is not root"
         definition_ref="auditd_conf_log_group_not_root" />
-        <criterion test_ref="test_dir_permissions_var_log_audit-non_root" negate="true" /> 
+        <criterion test_ref="test_dir_permissions_var_log_audit-non_root" negate="true" />
       </criteria>
       {{% else %}}
       <criteria operator="AND" comment="log_file set">


### PR DESCRIPTION
#### Description:

Adjust OVAL for directory_permissions_var_log_audit

#### Rationale:
Fix automatus tests.

#### Review Hints:

Running the Automatus tests for `directory_permissions_var_log_audit` should be enough.
