### PR TITLE
Change variable name from mount_has_to_exist to fstab_entry_is_optional

### DIFF
--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -521,7 +521,7 @@ The only way to remediate is to recompile and reinstall the kernel, so no remedi
 
     -   **type** - filesystem type. Used only in Bash remediation.
 
-    -   **mount_has_to_exist** - Specifies if the **mountpoint**
+    -   **fstab_entry_is_optional** - Specifies if the **mountpoint**
         entry has to exist in `/etc/fstab` before the remediation is
         executed. If set to `true` and the **mountpoint** entry is not
         present in `/etc/fstab` the Bash remediation terminates. If set
@@ -544,7 +544,7 @@ The only way to remediate is to recompile and reinstall the kernel, so no remedi
         new entry in `/etc/fstab`), eg. `tmpfs`. Used only in Bash
         remediation.
 
-    -   **mount_has_to_exist** - Used only in Bash remediation.
+    -   **fstab_entry_is_optional** - Used only in Bash remediation.
         Specifies if the **mountpoint** entry has to exist in
         `/etc/fstab` before the remediation is executed. If set to `yes`
         and the **mountpoint** entry is not present in `/etc/fstab` the

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/rule.yml
@@ -40,7 +40,7 @@ ocil: |-
 template:
     name: mount_option_remote_filesystems
     vars:
-        mount_has_to_exist: 'yes'
+        fstab_entry_is_optional: 'yes'
         mountoption: sec=krb5:krb5i:krb5p
         mountpoint: remote_filesystems
 

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_nodev_remote_filesystems/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_nodev_remote_filesystems/rule.yml
@@ -45,7 +45,7 @@ srg_requirement: '{{{ full_name }}} must prevent special devices on file systems
 template:
     name: mount_option_remote_filesystems
     vars:
-        mount_has_to_exist: 'yes'
+        fstab_entry_is_optional: 'yes'
         mountoption: nodev
         mountpoint: remote_filesystems
 

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_noexec_remote_filesystems/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_noexec_remote_filesystems/rule.yml
@@ -53,7 +53,7 @@ srg_requirement: '{{{ full_name }}} must prevent code from being executed on fil
 template:
     name: mount_option_remote_filesystems
     vars:
-        mount_has_to_exist: 'yes'
+        fstab_entry_is_optional: 'yes'
         mountoption: noexec
         mountpoint: remote_filesystems
 

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_nosuid_remote_filesystems/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_nosuid_remote_filesystems/rule.yml
@@ -51,7 +51,7 @@ srg_requirement: '{{{ full_name }}} must prevent files with the setuid and setgi
 template:
     name: mount_option_remote_filesystems
     vars:
-        mount_has_to_exist: 'yes'
+        fstab_entry_is_optional: 'yes'
         mountoption: nosuid
         mountpoint: remote_filesystems
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nodev/rule.yml
@@ -50,10 +50,10 @@ template:
     vars:
         mountpoint: /dev/shm
         mountoption: nodev
-        mount_has_to_exist: false
+        fstab_entry_is_optional: false
         filesystem: tmpfs
         type: tmpfs
-        mount_has_to_exist@sle12: true
+        fstab_entry_is_optional@sle12: true
         filesystem@sle12: ''
         type@sle12: ''
     backends:

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/rule.yml
@@ -57,10 +57,10 @@ template:
     vars:
         mountpoint: /dev/shm
         mountoption: noexec
-        mount_has_to_exist: false
+        fstab_entry_is_optional: false
         filesystem: tmpfs
         type: tmpfs
-        mount_has_to_exist@sle12: true
+        fstab_entry_is_optional@sle12: true
         filesystem@sle12: ''
         type@sle12: ''
     backends:

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nosuid/rule.yml
@@ -50,10 +50,10 @@ template:
     vars:
         mountpoint: /dev/shm
         mountoption: nosuid
-        mount_has_to_exist: false
+        fstab_entry_is_optional: false
         filesystem: tmpfs
         type: tmpfs
-        mount_has_to_exist@sle12: true
+        fstab_entry_is_optional@sle12: true
         filesystem@sle12: ''
         type@sle12: ''
     backends:

--- a/linux_os/guide/system/permissions/partitions/mount_option_proc_hidepid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_proc_hidepid/rule.yml
@@ -46,7 +46,7 @@ template:
         mountpoint: /proc
         mountoption: hidepid
         mountoption_arg_var: var_mount_option_proc_hidepid
-        mount_has_to_exist: false
+        fstab_entry_is_optional: false
         filesystem: proc
         type: proc
     backends:

--- a/shared/templates/mount_option/ansible.template
+++ b/shared/templates/mount_option/ansible.template
@@ -8,7 +8,7 @@
 {{{ ansible_instantiate_variables(MOUNTOPTION_ARG_VAR) }}}
 {{% endif %}}
 
-{{% if not MOUNT_HAS_TO_EXIST %}}
+{{% if not FSTAB_ENTRY_IS_OPTIONAL %}}
    {{% set TABFILE='' %}}
 {{% else %}}
    {{% set TABFILE='--fstab' %}}

--- a/shared/templates/mount_option/bash.template
+++ b/shared/templates/mount_option/bash.template
@@ -2,7 +2,7 @@
 # reboot = false
 
 function perform_remediation {
-    {{% if MOUNT_HAS_TO_EXIST %}}
+    {{% if FSTAB_ENTRY_IS_OPTIONAL %}}
         # the mount point {{{ MOUNTPOINT }}} has to be defined in /etc/fstab
         # before this remediation can be executed. In case it is not defined, the
         # remediation aborts and no changes regarding the mount point are done.

--- a/shared/templates/mount_option/oval.template
+++ b/shared/templates/mount_option/oval.template
@@ -1,11 +1,9 @@
 <def-group>
-  {{%- set local_id = POINTID ~ "_partition_" ~ MOUNTOPTIONID ~ "_" ~ ("optional" if MOUNT_HAS_TO_EXIST else "expected") -%}}
+  {{%- set local_id = POINTID ~ "_partition_" ~ MOUNTOPTIONID ~ "_" ~ ("optional" if FSTAB_ENTRY_IS_OPTIONAL else "expected") -%}}
   <!-- The test will check if correct option is present in both active (/proc/mounts) and
        configured (/etc/fstab) mount points. It won't fail if the mount point is not currently
        active, but will consider absence of the mount point configuration as a failure unless
-       MOUNT_HAS_TO_EXIST is set to `true` (the name is a bit controversial: it means that
-       the mount point has to exist in the configuration file to be checked, and we don't care
-       about it if it is not configured). -->
+       FSTAB_ENTRY_IS_OPTIONAL is set to `true` -->
 
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="2">
     {{{ oval_metadata(MOUNTPOINT ~ " should be mounted with mount option " ~ MOUNTOPTION ~ ".") }}}
@@ -20,7 +18,7 @@
       <criteria operator="OR">
          <criterion comment="{{{ MOUNTOPTION }}} on {{{ MOUNTPOINT }}} in /etc/fstab"
            test_ref="test_{{{ local_id }}}_in_fstab"/>
-    {{% if MOUNT_HAS_TO_EXIST %}}
+    {{% if FSTAB_ENTRY_IS_OPTIONAL %}}
          <criterion comment="{{{ MOUNTPOINT }}} does not exist in /etc/fstab"
            test_ref="test_{{{ local_id }}}_exist_in_fstab"
            negate="true" />
@@ -100,7 +98,7 @@
     <linux:object object_ref="object_{{{ local_id }}}"/>
   </linux:partition_test>
 
-{{% if MOUNT_HAS_TO_EXIST %}}
+{{% if FSTAB_ENTRY_IS_OPTIONAL %}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist" version="1"
     comment="{{{ MOUNTPOINT }}} exists in /etc/fstab"
     id="test_{{{ local_id }}}_exist_in_fstab">

--- a/shared/templates/mount_option/template.py
+++ b/shared/templates/mount_option/template.py
@@ -14,8 +14,8 @@ def _mount_option(data, lang):
 
 
 def preprocess(data, lang):
-    data["mount_has_to_exist"] = parse_template_boolean_value(data,
-                                                              parameter="mount_has_to_exist",
+    data["fstab_entry_is_optional"] = parse_template_boolean_value(data,
+                                                              parameter="fstab_entry_is_optional",
                                                               default_value=True)
     if lang == "oval":
         data["mountoptionid"] = data["mountoption"].split()[0]


### PR DESCRIPTION
#### Description:

Change variable name in `mount_option` template and associated rules from `mount_has_to_exist` to `fstab_entry_is_optional`.

### Rationale
The current name `mount_has_to_exist` is confusing because it implies that the check will pass only when the mount is defined in fstab.

This is opposite to the logic in OVAL, where:
- `mount_has_to_exist == True`: pass when mount is not defined in fstab
- `mount_has_to_exist == False`: fail when mount is not defined in fstab

