### PR TITLE
Adjust 4.12 pci-dss-node assertion

### DIFF
--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.12.yml
@@ -273,7 +273,8 @@ rule_results:
    default_result: PASS
    result_after_remediation: PASS
  e2e-pci-dss-node-4-0-master-file-permissions-var-log-kube-audit:
-   default_result: INCONSISTENT
+   # nodes get INCONSISTENT because of https://bugzilla.redhat.com/show_bug.cgi?id=2001442
+   default_result: PASS or INCONSISTENT
    result_after_remediation: PASS
  e2e-pci-dss-node-4-0-master-file-permissions-var-log-oauth-audit:
    default_result: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.13.yml
@@ -273,7 +273,8 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-pci-dss-node-4-0-master-file-permissions-var-log-kube-audit:
-    default_result: INCONSISTENT
+    # nodes get INCONSISTENT because of https://bugzilla.redhat.com/show_bug.cgi?id=2001442
+    default_result: PASS or INCONSISTENT
     result_after_remediation: PASS
   e2e-pci-dss-node-4-0-master-file-permissions-var-log-oauth-audit:
     default_result: PASS


### PR DESCRIPTION
#### Description:

- Adjust 4.12 pci-dss-node master node assertion for rule `file-permissions-var-log-kube-audit`

#### Rationale:

- https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-ComplianceAsCode-content-master-4.12-e2e-aws-ocp4-pci-dss-node-4-weekly/1860398099151720448