### PR TITLE
Update ubuntu2404 CIS control 2.3.2.1

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -939,8 +939,10 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented. Analogous to ubuntu2204/2.1.3.1.
+    status: automated
+    rules:
+      - var_multiple_time_servers=ubuntu
+      - service_timesyncd_configured
 
   - id: 2.3.2.2
     title: Ensure systemd-timesyncd is enabled and running (Automated)

--- a/linux_os/guide/services/ntp/service_timesyncd_configured/tests/dropin_config.pass.sh
+++ b/linux_os/guide/services/ntp/service_timesyncd_configured/tests/dropin_config.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # packages = systemd
+# variables = var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
 
 source common.sh
 

--- a/linux_os/guide/services/ntp/service_timesyncd_configured/tests/empty_config.fail.sh
+++ b/linux_os/guide/services/ntp/service_timesyncd_configured/tests/empty_config.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 # packages = systemd
+# variables = var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
 
 source common.sh

--- a/linux_os/guide/services/ntp/service_timesyncd_configured/tests/no_fallback.fail.sh
+++ b/linux_os/guide/services/ntp/service_timesyncd_configured/tests/no_fallback.fail.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-# packages = systemd
-
-source common.sh
-
-cat <<EOF >/etc/systemd/timesyncd.d/oscap-remedy.conf
-NTP=0.suse.pool.ntp.org,1.suse.pool.ntp.org
-EOF

--- a/linux_os/guide/services/ntp/service_timesyncd_configured/tests/timesyncd_config.pass.sh
+++ b/linux_os/guide/services/ntp/service_timesyncd_configured/tests/timesyncd_config.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # packages = systemd
+# variables = var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
 
 source common.sh
 

--- a/linux_os/guide/services/ntp/var_multiple_time_pools.var
+++ b/linux_os/guide/services/ntp/var_multiple_time_pools.var
@@ -16,3 +16,4 @@ options:
     suse: "0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org"
     alinux: "0.ntp.cloud.aliyuncs.com,1.ntp.aliyun.com,2.ntp1.aliyun.com,3.ntp1.cloud.aliyuncs.com"
     amazon: "0.rhel.pool.ntp.org,1.rhel.pool.ntp.org,2.rhel.pool.ntp.org,3.rhel.pool.ntp.org"
+    ubuntu: "0.ubuntu.pool.ntp.org,1.ubuntu.pool.ntp.org,2.ubuntu.pool.ntp.org,3.ubuntu.pool.ntp.org"

--- a/linux_os/guide/services/ntp/var_multiple_time_servers.var
+++ b/linux_os/guide/services/ntp/var_multiple_time_servers.var
@@ -18,3 +18,4 @@ options:
     suse: "0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org"
     alinux: "0.ntp.cloud.aliyuncs.com,1.ntp.aliyun.com,2.ntp1.aliyun.com,3.ntp1.cloud.aliyuncs.com"
     amazon: "0.rhel.pool.ntp.org,1.rhel.pool.ntp.org,2.rhel.pool.ntp.org,3.rhel.pool.ntp.org"
+    ubuntu: "0.ubuntu.pool.ntp.org,1.ubuntu.pool.ntp.org,2.ubuntu.pool.ntp.org,3.ubuntu.pool.ntp.org"


### PR DESCRIPTION
#### Description:

- Add rules and vars for ubuntu2404 CIS control 2.3.2.1 - "Ensure systemd-timesyncd configured with authorized timeserver"
- Add ubuntu ntp servers to `var_multiple_time_servers` and `var_multiple_time_pools`
- Fix tests for rule service-timesyncd_configured (see commit message for more info)
