### PR TITLE
Update ubuntu2404 control 2.3.3.1 

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -960,8 +960,15 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented. Analogous to ubuntu2204/2.1.2.1.
+    rules:
+      - var_multiple_time_servers=ubuntu
+      - var_multiple_time_pools=ubuntu
+      - chronyd_configure_pool_and_server
+    status: partial
+    notes: |
+      Rule does not check or remediate config files included via
+      confdir and sourcedir directives.
+
 
   - id: 2.3.3.2
     title: Ensure chrony is running as user _chrony (Automated)

--- a/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/correct_chrony_configuration.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/correct_chrony_configuration.pass.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 # packages = chrony
+# variables = var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
+# variables = var_multiple_time_pools=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
 
-
-{{{ bash_instantiate_variables("var_multiple_time_servers") }}}
-{{{ bash_instantiate_variables("var_multiple_time_pools") }}}
+var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
+var_multiple_time_pools=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
 
 config_file="{{{ chrony_conf_path }}}"
 

--- a/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/file_empty.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/file_empty.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # packages = chrony
-
+# variables = var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
+# variables = var_multiple_time_pools=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
 
 echo "" > {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/file_missing.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/file_missing.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # packages = chrony
-
+# variables = var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
+# variables = var_multiple_time_pools=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
 
 rm -f {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/incorrect_line1.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/incorrect_line1.fail.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # packages = chrony
-
+# variables = var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
+# variables = var_multiple_time_pools=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
 
 echo "" > {{{ chrony_conf_path }}}
 echo "server0.suse.pool.ntp.org" >> {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/incorrect_line2.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/incorrect_line2.fail.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # packages = chrony
-
+# variables = var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
+# variables = var_multiple_time_pools=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
 
 echo "" > {{{ chrony_conf_path }}}
 echo "server   0.suse.pool.ntp.org" >> {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/incorrect_line3.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/incorrect_line3.fail.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # packages = chrony
-
+# variables = var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
+# variables = var_multiple_time_pools=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
 
 echo "" > {{{ chrony_conf_path }}}
 echo " server   0.suse.pool.ntp.org" >> {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/incorrect_line4.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/incorrect_line4.fail.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # packages = chrony
-
+# variables = var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
+# variables = var_multiple_time_pools=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
 
 echo "" > {{{ chrony_conf_path }}}
 echo " server 0.suse.pool.ntp.org" >> {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/multiple_servers.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/multiple_servers.pass.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # packages = chrony
-
+# variables = var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
+# variables = var_multiple_time_pools=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
 
 echo "" > {{{ chrony_conf_path }}}
 echo "server 0.suse.pool.ntp.org" >> {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/var_multiple_time_pools.var
+++ b/linux_os/guide/services/ntp/var_multiple_time_pools.var
@@ -16,3 +16,4 @@ options:
     suse: "0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org"
     alinux: "0.ntp.cloud.aliyuncs.com,1.ntp.aliyun.com,2.ntp1.aliyun.com,3.ntp1.cloud.aliyuncs.com"
     amazon: "0.rhel.pool.ntp.org,1.rhel.pool.ntp.org,2.rhel.pool.ntp.org,3.rhel.pool.ntp.org"
+    ubuntu: "0.ubuntu.pool.ntp.org,1.ubuntu.pool.ntp.org,2.ubuntu.pool.ntp.org,3.ubuntu.pool.ntp.org"

--- a/linux_os/guide/services/ntp/var_multiple_time_servers.var
+++ b/linux_os/guide/services/ntp/var_multiple_time_servers.var
@@ -18,3 +18,4 @@ options:
     suse: "0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org"
     alinux: "0.ntp.cloud.aliyuncs.com,1.ntp.aliyun.com,2.ntp1.aliyun.com,3.ntp1.cloud.aliyuncs.com"
     amazon: "0.rhel.pool.ntp.org,1.rhel.pool.ntp.org,2.rhel.pool.ntp.org,3.rhel.pool.ntp.org"
+    ubuntu: "0.ubuntu.pool.ntp.org,1.ubuntu.pool.ntp.org,2.ubuntu.pool.ntp.org,3.ubuntu.pool.ntp.org"


### PR DESCRIPTION
#### Description:

- Added rule and vars for Ubuntu 2404 CIS control 2.3.3.1 - "Ensure chrony is configured with authorized timeserver"
- Marked as a partial implementation since the rule does not check configs included via confdir and sourcedir directives
- Fixed the tests