### PR TITLE
Ubuntu 24.04 5.4.1.5 account_disable_post_pw_expiration 45 days

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2083,11 +2083,11 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    related_rules:
-      - var_account_disable_post_pw_expiration=30
+    rules:
+      - var_account_disable_post_pw_expiration=45
       - account_disable_post_pw_expiration
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/5.5.1.4.
+    status: automated
+    notes: CIS setting now 45 days.
 
   - id: 5.4.1.6
     title: Ensure all users last password change date is in the past (Automated)


### PR DESCRIPTION
#### Description:

- Ubuntu 24.04 5.4.1.5 account_disable_post_pw_expiration 45 days

#### Rationale:

- Update for CIS Ubuntu 24.04, issue 5.4.1.5, set post pw expiration to 45 days

