### PR TITLE
Improve error message

### DIFF
--- a/ssg/oval_object_model/general.py
+++ b/ssg/oval_object_model/general.py
@@ -11,7 +11,7 @@ def required_attribute(_xml_el, _key):
     if _key in _xml_el.attrib:
         return _xml_el.get(_key)
     raise ValueError(
-        "%s is required but was not found in:\n%s" % (_key, repr(_xml_el.attrib))
+        "%s attribute is required but was not found in %s element:\n%s" % (_key, _xml_el.tag, repr(_xml_el.attrib))
     )
 
 


### PR DESCRIPTION
This makes the error more clear in situations that the missing attribute name is ambiguous. For example, if the attribute name is `check`, the message was `check is required` which some people understood as the whole OVAL file wasn't there.
