### PR TITLE
Add rsyslog package applicability to ensure_rsyslog_log_file_configuration group

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/group.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/group.yml
@@ -22,3 +22,5 @@ description: |-
     some log processing programs may not understand. If this occurs,
     edit the file <tt>/etc/rsyslog.conf</tt> and add or edit the following line:</i>
     <pre>$ ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat</pre>
+
+platform: package[rsyslog]

--- a/shared/applicability/package.yml
+++ b/shared/applicability/package.yml
@@ -134,3 +134,5 @@ args:
     pkgname: zypper
   apt_get:
     pkgname: apt
+  rsyslog:
+    pkgname: rsyslog


### PR DESCRIPTION
Add `rsyslog` to templated package applicability platforms and use it in the `ensure_rsyslog_log_file_configuration` group to make all the rules in the group applicable only in case `rsyslog` package is installed.