### PR TITLE
Adjust bootloader argument rules to work in bootable containers

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/group.yml
+++ b/linux_os/guide/system/bootloader-grub2/group.yml
@@ -15,4 +15,4 @@ description: |-
     with a password and ensure its configuration file's permissions
     are set properly.
 
-platform: grub2
+platform: grub2 and system_with_kernel

--- a/linux_os/guide/system/bootloader-grub2/grub2_disable_recovery/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_disable_recovery/rule.yml
@@ -41,5 +41,3 @@ fixtext: |-
     Then, run the following command:
 
     $ sudo {{{ grub_command("update") }}}
-
-platform: grub2

--- a/linux_os/guide/system/bootloader-grub2/grub2_enable_iommu_force/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_enable_iommu_force/rule.yml
@@ -20,7 +20,6 @@ identifiers:
     cce@sle12: CCE-91532-2
     cce@sle15: CCE-91217-0
 
-platform: system_with_kernel
 
 ocil_clause: 'I/OMMU is not activated'
 

--- a/linux_os/guide/system/bootloader-grub2/grub2_enable_iommu_force/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_enable_iommu_force/rule.yml
@@ -20,7 +20,7 @@ identifiers:
     cce@sle12: CCE-91532-2
     cce@sle15: CCE-91217-0
 
-platform: machine
+platform: system_with_kernel
 
 ocil_clause: 'I/OMMU is not activated'
 

--- a/linux_os/guide/system/bootloader-grub2/grub2_init_on_alloc_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_init_on_alloc_argument/rule.yml
@@ -24,7 +24,6 @@ ocil_clause: 'the kernel is not configured to zero out memory before allocation'
 ocil: |-
     {{{ ocil_grub2_argument("init_on_alloc=1") | indent(4) }}}
 
-platform: system_with_kernel
 
 template:
     name: grub2_bootloader_argument

--- a/linux_os/guide/system/bootloader-grub2/grub2_init_on_alloc_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_init_on_alloc_argument/rule.yml
@@ -24,7 +24,7 @@ ocil_clause: 'the kernel is not configured to zero out memory before allocation'
 ocil: |-
     {{{ ocil_grub2_argument("init_on_alloc=1") | indent(4) }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: grub2_bootloader_argument

--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/rule.yml
@@ -46,7 +46,7 @@ ocil: |-
     the kernel, check that the option is configured through boot parameter.
     {{{ ocil_grub2_argument("random.trust_cpu=on") | indent(4) }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: grub2_bootloader_argument

--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/rule.yml
@@ -46,7 +46,6 @@ ocil: |-
     the kernel, check that the option is configured through boot parameter.
     {{{ ocil_grub2_argument("random.trust_cpu=on") | indent(4) }}}
 
-platform: system_with_kernel
 
 template:
     name: grub2_bootloader_argument

--- a/linux_os/guide/system/bootloader-grub2/grub2_l1tf_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_l1tf_argument/rule.yml
@@ -36,7 +36,6 @@ ocil_clause: 'l1tf mitigations are not configured appropriately'
 ocil: |-
     {{{ ocil_grub2_argument("l1tf=" + xccdf_value("var_l1tf_options")) | indent(4) }}}
 
-platform: system_with_kernel
 
 template:
     name: grub2_bootloader_argument

--- a/linux_os/guide/system/bootloader-grub2/grub2_l1tf_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_l1tf_argument/rule.yml
@@ -36,7 +36,7 @@ ocil_clause: 'l1tf mitigations are not configured appropriately'
 ocil: |-
     {{{ ocil_grub2_argument("l1tf=" + xccdf_value("var_l1tf_options")) | indent(4) }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: grub2_bootloader_argument

--- a/linux_os/guide/system/bootloader-grub2/grub2_mce_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_mce_argument/rule.yml
@@ -29,7 +29,6 @@ ocil_clause: 'MCE tolerance is not set to zero'
 ocil: |-
     {{{ ocil_grub2_argument("mce=0") | indent(4) }}}
 
-platform: system_with_kernel
 
 template:
     name: grub2_bootloader_argument

--- a/linux_os/guide/system/bootloader-grub2/grub2_mce_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_mce_argument/rule.yml
@@ -29,7 +29,7 @@ ocil_clause: 'MCE tolerance is not set to zero'
 ocil: |-
     {{{ ocil_grub2_argument("mce=0") | indent(4) }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: grub2_bootloader_argument

--- a/linux_os/guide/system/bootloader-grub2/grub2_mds_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_mds_argument/rule.yml
@@ -47,7 +47,6 @@ ocil_clause: 'MDS mitigations are not configured appropriately'
 ocil: |-
     {{{ ocil_grub2_argument("mds=" + xccdf_value(var_mds_options)) | indent(4) }}}
 
-platform: system_with_kernel
 
 template:
     name: grub2_bootloader_argument

--- a/linux_os/guide/system/bootloader-grub2/grub2_mds_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_mds_argument/rule.yml
@@ -47,7 +47,7 @@ ocil_clause: 'MDS mitigations are not configured appropriately'
 ocil: |-
     {{{ ocil_grub2_argument("mds=" + xccdf_value(var_mds_options)) | indent(4) }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: grub2_bootloader_argument

--- a/linux_os/guide/system/bootloader-grub2/grub2_mitigation_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_mitigation_argument/rule.yml
@@ -24,7 +24,6 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-010424
 
-platform: system_with_kernel
 
 ocil_clause: 'mitigations is set to off'
 

--- a/linux_os/guide/system/bootloader-grub2/grub2_mitigation_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_mitigation_argument/rule.yml
@@ -9,6 +9,8 @@ description: |-
 
     The mitigations must not be set to "off".
 
+    {{{ describe_grub2_argument_absent("mitigations=off") | indent(4) }}}
+
 rationale: |-
     Hardware vulnerabilities allow programs to steal data that is currently processed on the
     computer. While programs are typically not permitted to read data from other programs, a

--- a/linux_os/guide/system/bootloader-grub2/grub2_mitigation_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_mitigation_argument/rule.yml
@@ -24,7 +24,7 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-010424
 
-platform: grub2
+platform: system_with_kernel
 
 ocil_clause: 'mitigations is set to off'
 

--- a/linux_os/guide/system/bootloader-grub2/grub2_nosmap_argument_absent/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_nosmap_argument_absent/rule.yml
@@ -34,7 +34,6 @@ ocil: |-
     <pre>grep -q nosmap /boot/config-`uname -r`</pre>
     If the command returns a line, it means that SMAP is being disabled.
 
-platform: system_with_kernel
 
 template:
     name: grub2_bootloader_argument_absent

--- a/linux_os/guide/system/bootloader-grub2/grub2_nosmap_argument_absent/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_nosmap_argument_absent/rule.yml
@@ -10,10 +10,7 @@ description: |-
     Ensure that Supervisor Mode Access Prevention (SMAP) is not disabled by
     the <tt>nosmap</tt> boot paramenter option.
 
-    Check that the line <pre>GRUB_CMDLINE_LINUX="..."</pre> within <tt>/etc/default/grub</tt>
-    doesn't contain the argument <tt>nosmap</tt>.
-    Run the following command to update command line for already installed kernels:
-    <pre># grubby --update-kernel=ALL --remove-args="nosmap"</pre>
+    {{{ describe_grub2_argument_absent("nosmap") | indent(4) }}}
 
 rationale: |-
     Disabling SMAP can facilitate exploitation of vulnerabilities caused by unintended access and

--- a/linux_os/guide/system/bootloader-grub2/grub2_nosmap_argument_absent/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_nosmap_argument_absent/rule.yml
@@ -34,7 +34,7 @@ ocil: |-
     <pre>grep -q nosmap /boot/config-`uname -r`</pre>
     If the command returns a line, it means that SMAP is being disabled.
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: grub2_bootloader_argument_absent

--- a/linux_os/guide/system/bootloader-grub2/grub2_nosmep_argument_absent/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_nosmep_argument_absent/rule.yml
@@ -10,10 +10,7 @@ description: |-
     Ensure that Supervisor Mode Execution Prevention (SMEP) is not disabled by
     the <tt>nosmep</tt> boot paramenter option.
 
-    Check that the line <pre>GRUB_CMDLINE_LINUX="..."</pre> within <tt>/etc/default/grub</tt>
-    doesn't contain the argument <tt>nosmep</tt>.
-    Run the following command to update command line for already installed kernels:
-    <pre># grubby --update-kernel=ALL --remove-args="nosmep"</pre>
+    {{{ describe_grub2_argument_absent("nosmep") | indent(4) }}}
 
 rationale: |-
     Disabling SMEP can facilitate exploitation of certain vulnerabilities because it allows

--- a/linux_os/guide/system/bootloader-grub2/grub2_nosmep_argument_absent/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_nosmep_argument_absent/rule.yml
@@ -34,7 +34,7 @@ ocil: |-
     <pre>grep -q nosmep /boot/config-`uname -r`</pre>
     If the command returns a line, it means that SMEP is being disabled.
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: grub2_bootloader_argument_absent

--- a/linux_os/guide/system/bootloader-grub2/grub2_nosmep_argument_absent/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_nosmep_argument_absent/rule.yml
@@ -34,7 +34,6 @@ ocil: |-
     <pre>grep -q nosmep /boot/config-`uname -r`</pre>
     If the command returns a line, it means that SMEP is being disabled.
 
-platform: system_with_kernel
 
 template:
     name: grub2_bootloader_argument_absent

--- a/linux_os/guide/system/bootloader-grub2/grub2_page_alloc_shuffle_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_page_alloc_shuffle_argument/rule.yml
@@ -31,7 +31,6 @@ ocil_clause: 'randomization of the page allocator is not enabled in the kernel'
 ocil: |-
     {{{ ocil_grub2_argument("page_alloc.shuffle=1") | indent(4) }}}
 
-platform: system_with_kernel
 
 template:
     name: grub2_bootloader_argument

--- a/linux_os/guide/system/bootloader-grub2/grub2_page_alloc_shuffle_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_page_alloc_shuffle_argument/rule.yml
@@ -31,7 +31,7 @@ ocil_clause: 'randomization of the page allocator is not enabled in the kernel'
 ocil: |-
     {{{ ocil_grub2_argument("page_alloc.shuffle=1") | indent(4) }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: grub2_bootloader_argument

--- a/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/rule.yml
@@ -34,7 +34,6 @@ ocil_clause: 'Kernel page-table isolation is not enabled'
 ocil: |-
     {{{ ocil_grub2_argument("pti=on") | indent(4) }}}
 
-platform: system_with_kernel
 
 template:
     name: grub2_bootloader_argument

--- a/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/rule.yml
@@ -34,7 +34,7 @@ ocil_clause: 'Kernel page-table isolation is not enabled'
 ocil: |-
     {{{ ocil_grub2_argument("pti=on") | indent(4) }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: grub2_bootloader_argument

--- a/linux_os/guide/system/bootloader-grub2/grub2_rng_core_default_quality_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_rng_core_default_quality_argument/rule.yml
@@ -37,7 +37,6 @@ ocil_clause: 'trust on hardware random number generator is not configured approp
 ocil: |-
     {{{ ocil_grub2_argument("rng_core.default_quality=" + xccdf_value("var_rng_core_default_quality")) | indent(4) }}}
 
-platform: system_with_kernel
 
 template:
     name: grub2_bootloader_argument

--- a/linux_os/guide/system/bootloader-grub2/grub2_rng_core_default_quality_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_rng_core_default_quality_argument/rule.yml
@@ -37,7 +37,7 @@ ocil_clause: 'trust on hardware random number generator is not configured approp
 ocil: |-
     {{{ ocil_grub2_argument("rng_core.default_quality=" + xccdf_value("var_rng_core_default_quality")) | indent(4) }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: grub2_bootloader_argument

--- a/linux_os/guide/system/bootloader-grub2/grub2_slab_nomerge_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_slab_nomerge_argument/rule.yml
@@ -35,7 +35,7 @@ ocil_clause: 'merging of slabs with similar size is enabled'
 ocil: |-
     {{{ ocil_grub2_argument("slab_nomerge=yes") | indent(4) }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: grub2_bootloader_argument

--- a/linux_os/guide/system/bootloader-grub2/grub2_slab_nomerge_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_slab_nomerge_argument/rule.yml
@@ -35,7 +35,6 @@ ocil_clause: 'merging of slabs with similar size is enabled'
 ocil: |-
     {{{ ocil_grub2_argument("slab_nomerge=yes") | indent(4) }}}
 
-platform: system_with_kernel
 
 template:
     name: grub2_bootloader_argument

--- a/linux_os/guide/system/bootloader-grub2/grub2_spec_store_bypass_disable_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_spec_store_bypass_disable_argument/rule.yml
@@ -39,7 +39,7 @@ ocil_clause: 'SSB is not configured appropriately'
 ocil: |-
     {{{ ocil_grub2_argument("spec_store_bypass_disable=" + xccdf_value("var_spec_store_bypass_disable_options")) | indent(4) }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: grub2_bootloader_argument

--- a/linux_os/guide/system/bootloader-grub2/grub2_spec_store_bypass_disable_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_spec_store_bypass_disable_argument/rule.yml
@@ -39,7 +39,6 @@ ocil_clause: 'SSB is not configured appropriately'
 ocil: |-
     {{{ ocil_grub2_argument("spec_store_bypass_disable=" + xccdf_value("var_spec_store_bypass_disable_options")) | indent(4) }}}
 
-platform: system_with_kernel
 
 template:
     name: grub2_bootloader_argument

--- a/linux_os/guide/system/bootloader-grub2/grub2_spectre_v2_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_spectre_v2_argument/rule.yml
@@ -32,7 +32,7 @@ ocil_clause: 'spectre_v2 mitigation is not enforced'
 ocil: |-
     {{{ ocil_grub2_argument("spectre_v2=on") | indent(4) }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: grub2_bootloader_argument

--- a/linux_os/guide/system/bootloader-grub2/grub2_spectre_v2_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_spectre_v2_argument/rule.yml
@@ -32,7 +32,6 @@ ocil_clause: 'spectre_v2 mitigation is not enforced'
 ocil: |-
     {{{ ocil_grub2_argument("spectre_v2=on") | indent(4) }}}
 
-platform: system_with_kernel
 
 template:
     name: grub2_bootloader_argument

--- a/linux_os/guide/system/bootloader-grub2/grub2_systemd_debug-shell_argument_absent/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_systemd_debug-shell_argument_absent/rule.yml
@@ -44,7 +44,7 @@ ocil: |-
 fixtext: |-
     {{{ fixtext_grub2_bootloader_argument_absent("debug-shell") | indent(4) }}}
 
-platform: machine
+platform: system_with_kernel
 
 template:
     name: grub2_bootloader_argument_absent

--- a/linux_os/guide/system/bootloader-grub2/grub2_systemd_debug-shell_argument_absent/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_systemd_debug-shell_argument_absent/rule.yml
@@ -13,12 +13,10 @@ description: |-
     By default, the <tt>debug-shell</tt> systemd service is already disabled.
 
     Ensure the debug-shell is not enabled by the <tt>systemd.debug-shel=1</tt>
-    boot paramenter option.
+    boot parameter option.
 
-    Check that the line <pre>GRUB_CMDLINE_LINUX="..."</pre> within <tt>/etc/default/grub</tt>
-    doesn't contain the argument <tt>systemd.debug-shell=1</tt>.
-    Run the following command to update command line for already installed kernels:
-    <pre># grubby --update-kernel=ALL --remove-args="systemd.debug-shell"</pre>
+    {{{ describe_grub2_argument_absent("systemd.debug-shell")  | indent(4) }}}
+
 
 rationale: |-
     This prevents attackers with physical access from trivially bypassing security

--- a/linux_os/guide/system/bootloader-grub2/grub2_systemd_debug-shell_argument_absent/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_systemd_debug-shell_argument_absent/rule.yml
@@ -44,7 +44,6 @@ ocil: |-
 fixtext: |-
     {{{ fixtext_grub2_bootloader_argument_absent("debug-shell") | indent(4) }}}
 
-platform: system_with_kernel
 
 template:
     name: grub2_bootloader_argument_absent

--- a/linux_os/guide/system/bootloader-grub2/grub2_vsyscall_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_vsyscall_argument/rule.yml
@@ -33,7 +33,7 @@ ocil_clause: 'vsyscalls are enabled'
 ocil: |-
     {{{ ocil_grub2_argument("vsyscall=none") | indent(4) }}}
 
-platform: system_with_kernel and x86_64_arch
+platform: x86_64_arch
 
 template:
     name: grub2_bootloader_argument

--- a/linux_os/guide/system/bootloader-grub2/grub2_vsyscall_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_vsyscall_argument/rule.yml
@@ -33,7 +33,7 @@ ocil_clause: 'vsyscalls are enabled'
 ocil: |-
     {{{ ocil_grub2_argument("vsyscall=none") | indent(4) }}}
 
-platform: machine and x86_64_arch
+platform: system_with_kernel and x86_64_arch
 
 template:
     name: grub2_bootloader_argument

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/rule.yml
@@ -50,7 +50,6 @@ fixtext: '{{{ fixtext_file_group_owner(grub2_boot_path ~ "/grub.cfg", "root") }}
 
 srg_requirement: '{{{ srg_requirement_file_group_owner(grub2_boot_path ~ "/grub.cfg", "root") }}}'
 
-platform: system_with_kernel
 
 template:
     name: file_groupowner

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_user_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_user_cfg/rule.yml
@@ -44,7 +44,6 @@ fixtext: '{{{ fixtext_file_group_owner(grub2_boot_path ~ "/user.cfg", "root") }}
 
 srg_requirement: '{{{ srg_requirement_file_group_owner(grub2_boot_path ~ "/user.cfg", "root") }}}'
 
-platform: machine
 
 template:
     name: file_groupowner

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/rule.yml
@@ -46,7 +46,6 @@ ocil_clause: '{{{ ocil_clause_file_owner(file=grub2_boot_path ~ "/grub.cfg", own
 ocil: |-
     {{{ ocil_file_owner(file=grub2_boot_path ~ "/grub.cfg", owner="root") }}}
 
-platform: system_with_kernel
 
 template:
     name: file_owner

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_user_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_user_cfg/rule.yml
@@ -39,7 +39,6 @@ ocil_clause: '{{{ ocil_clause_file_owner(file=grub2_boot_path ~ "/user.cfg", own
 ocil: |-
     {{{ ocil_file_owner(file=grub2_boot_path ~ "/user.cfg", owner="root") }}}
 
-platform: machine
 
 template:
     name: file_owner

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_grub2_cfg/rule.yml
@@ -46,7 +46,6 @@ ocil: |-
     If properly configured, the output should indicate the following
     permissions: <tt>-rw-------</tt>
 
-platform: system_with_kernel
 
 template:
     name: file_permissions

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_user_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_user_cfg/rule.yml
@@ -35,7 +35,6 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file=grub2_boot_path ~ "/user.cfg
 ocil: |-
     {{{ ocil_file_permissions(file=grub2_boot_path ~ "/user.cfg", perms="-rw-------") }}}
 
-platform: machine
 
 template:
     name: file_permissions

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_admin_username/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_admin_username/rule.yml
@@ -68,7 +68,6 @@ warnings:
         Also, do NOT manually add the superuser account and password to the
         <tt>grub.cfg</tt> file as the grub2-mkconfig command overwrites this file.
 
-platform: machine
 
 fixtext: |-
     Configure {{{ full_name }}} to have a unique username for the grub superuser account.

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_no_removeable_media/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_no_removeable_media/rule.yml
@@ -38,4 +38,3 @@ ocil: |-
     media which should not exist in the lines:
     <pre>set root='hd0,msdos1'</pre>
 
-platform: machine

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/rule.yml
@@ -92,7 +92,6 @@ warnings:
         Also, do NOT manually add the superuser account and password to the
         <tt>grub.cfg</tt> file as the grub2-mkconfig command overwrites this file.
 
-platform: machine
 
 fixtext: |-
     Configure {{{ full_name }}} to require a grub bootloader password for the grub superuser account.

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password_legacy/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password_legacy/rule.yml
@@ -51,4 +51,3 @@ warnings:
         Also, do NOT manually add the superuser account and password to the
         <tt>grub.cfg</tt> file as the grub2-mkconfig command overwrites this file.
 
-platform: system_with_kernel

--- a/linux_os/guide/system/bootloader-grub2/uefi/file_groupowner_efi_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/file_groupowner_efi_grub2_cfg/rule.yml
@@ -38,7 +38,6 @@ ocil_clause: '{{{ ocil_clause_file_group_owner(file=grub2_uefi_boot_path ~ "/gru
 ocil: |-
     {{{ ocil_file_group_owner(file=grub2_uefi_boot_path ~ "/grub.cfg", group="root") }}}
 
-platform: machine
 
 template:
     name: file_groupowner

--- a/linux_os/guide/system/bootloader-grub2/uefi/file_groupowner_efi_user_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/file_groupowner_efi_user_cfg/rule.yml
@@ -38,7 +38,6 @@ ocil_clause: '{{{ ocil_clause_file_group_owner(file=grub2_uefi_boot_path ~ "/use
 ocil: |-
     {{{ ocil_file_group_owner(file=grub2_uefi_boot_path ~ "/user.cfg", group="root") }}}
 
-platform: machine
 
 template:
     name: file_groupowner

--- a/linux_os/guide/system/bootloader-grub2/uefi/file_owner_efi_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/file_owner_efi_grub2_cfg/rule.yml
@@ -36,7 +36,6 @@ ocil_clause: '{{{ ocil_clause_file_owner(file=grub2_uefi_boot_path ~ "/grub.cfg"
 ocil: |-
     {{{ ocil_file_owner(file=grub2_uefi_boot_path ~ "/grub.cfg", owner="root") }}}
 
-platform: machine
 
 template:
     name: file_owner

--- a/linux_os/guide/system/bootloader-grub2/uefi/file_owner_efi_user_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/file_owner_efi_user_cfg/rule.yml
@@ -38,7 +38,6 @@ ocil_clause: '{{{ ocil_clause_file_owner(file=grub2_uefi_boot_path ~ "/user.cfg"
 ocil: |-
     {{{ ocil_file_owner(file=grub2_uefi_boot_path ~ "/user.cfg", owner="root") }}}
 
-platform: machine
 
 template:
     name: file_owner

--- a/linux_os/guide/system/bootloader-grub2/uefi/file_permissions_efi_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/file_permissions_efi_grub2_cfg/rule.yml
@@ -38,7 +38,6 @@ ocil: |-
     If properly configured, the output should indicate the following
     permissions: <tt>-rwx------</tt>
 
-platform: machine
 
 template:
     name: file_permissions

--- a/linux_os/guide/system/bootloader-grub2/uefi/file_permissions_efi_user_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/file_permissions_efi_user_cfg/rule.yml
@@ -35,7 +35,6 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file=grub2_uefi_boot_path ~ "/use
 ocil: |-
     {{{ ocil_file_permissions(file=grub2_uefi_boot_path ~ "/user.cfg", perms="-rw-------") }}}
 
-platform: machine
 
 template:
     name: file_permissions

--- a/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_admin_username/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_admin_username/rule.yml
@@ -69,7 +69,6 @@ warnings:
         Also, do NOT manually add the superuser account and password to the
         <tt>grub.cfg</tt> file as the grub2-mkconfig command overwrites this file.
 
-platform: machine
 
 fixtext: |-
     Configure {{{ full_name }}} to have a unique username for the grub superuser account.

--- a/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/rule.yml
@@ -93,7 +93,6 @@ warnings:
         Also, do NOT manually add the superuser account and password to the
         <tt>grub.cfg</tt> file as the grub2-mkconfig command overwrites this file.
 
-platform: system_with_kernel
 
 fixtext: |-
     Configure {{{ full_name }}} to use a secure UEFI boot loader password.

--- a/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password_legacy/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password_legacy/rule.yml
@@ -50,4 +50,3 @@ warnings:
         Also, do NOT manually add the superuser account and password to the
         <tt>grub.cfg</tt> file as the grub2-mkconfig command overwrites this file.
 
-platform: machine

--- a/linux_os/guide/system/bootloader-grub2/uefi/uefi_no_removeable_media/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/uefi_no_removeable_media/rule.yml
@@ -38,4 +38,3 @@ ocil: |-
     media which should not exist in the lines:
     <pre>set root='hd0,msdos1'</pre>
 
-platform: machine

--- a/products/rhel10/product.yml
+++ b/products/rhel10/product.yml
@@ -21,6 +21,7 @@ init_system: "systemd"
 # EFI and non-EFI configs are stored in same path, see https://fedoraproject.org/wiki/Changes/UnifyGrubConfig
 
 sshd_distributed_config: "true"
+bootable_containers_supported: "true"
 
 dconf_gdm_dir: "distro.d"
 

--- a/products/rhel9/product.yml
+++ b/products/rhel9/product.yml
@@ -25,6 +25,7 @@ groups:
     name: ssh_keys
 
 sshd_distributed_config: "true"
+bootable_containers_supported: "true"
 
 dconf_gdm_dir: "distro.d"
 

--- a/shared/checks/oval/bootc.xml
+++ b/shared/checks/oval/bootc.xml
@@ -1,0 +1,13 @@
+<def-group>
+  <definition class="inventory" id="bootc" version="1">
+    {{{ oval_metadata("Bootable container or bootc system", affected_platforms=["multi_platform_all"]) }}}
+    <criteria operator="AND">
+      <criterion comment="kernel is installed" test_ref="bootc_platform_test_kernel_installed" />
+      <criterion comment="rpm-ostree is installed" test_ref="bootc_platform_test_rpm_ostree_installed" />
+      <criterion comment="bootc is installed" test_ref="bootc_platform_test_bootc_installed" />
+    </criteria>
+  </definition>
+{{{ oval_test_package_installed(package="kernel", test_id="bootc_platform_test_kernel_installed") }}}
+{{{ oval_test_package_installed(package="rpm-ostree", test_id="bootc_platform_test_rpm_ostree_installed") }}}
+{{{ oval_test_package_installed(package="bootc", test_id="bootc_platform_test_bootc_installed") }}}
+</def-group>

--- a/shared/macros/01-general.jinja
+++ b/shared/macros/01-general.jinja
@@ -1069,8 +1069,34 @@ Run the following command to update command line for already installed kernels:
 Configure the default Grub2 kernel command line to contain {{{ arg_name_value }}} as follows:
 <pre># grub2-editenv - set "$(grub2-editenv - list | grep kernelopts) {{{ arg_name_value }}}"</pre>
 {{%- endif -%}}
+{{% if bootable_containers_supported == "true" %}}
+If the system is distributed as a bootable container image, GRUB2 can't be configured using the method described above, but the following method needs to be used instead.
+The kernel arguments should be set in <tt>/usr/lib/bootc/kargs.d</tt> in a TOML file that has the following form:
+<pre>
+# /usr/lib/bootc/kargs.d/10-example.toml
+kargs = ["{{{ arg_name_value }}}"]
+</pre>
+For more details on configuring kernel arguments in bootable container images, please refer to {{{ weblink(link="https://containers.github.io/bootc/building/kernel-arguments.html", text="Bootc documentation") }}}.
+{{%- endif -%}}
 {{%- endmacro -%}}
 
+{{#
+    Describe how to remove a kernel argument from Grub2 default kernel command line.
+
+:param arg_name: The kernel parameter name
+:type arg_name: str
+#}}
+{{%- macro describe_grub2_argument_absent(arg_name) -%}}
+Check that the line <pre>GRUB_CMDLINE_LINUX="..."</pre> within <tt>/etc/default/grub</tt>
+doesn't contain the argument <tt>{{{ arg_name }}}</tt>.
+Run the following command to update command line for already installed kernels:
+<pre># grubby --update-kernel=ALL --remove-args="{{{ arg_name }}}"</pre>
+{{% if bootable_containers_supported == "true" %}}
+If the system is distributed as a bootable container image, GRUB2 can't be configured using the method described above, but the kernel arguments should be configured using TOML files located in the <tt>/usr/lib/bootc/kargs.d</tt> directory.
+Remove all occurences of <tt>{{{ arg_name }}}</tt> from all files in <tt>/usr/lib/bootc/kargs.d</tt>.
+For more details on configuring kernel arguments in bootable container images, please refer to {{{ weblink(link="https://containers.github.io/bootc/building/kernel-arguments.html", text="Bootc documentation") }}}.
+{{%- endif -%}}
+{{%- endmacro -%}}
 
 {{#
     Describe how to check a kernel compile parameter

--- a/shared/templates/grub2_bootloader_argument/bash.template
+++ b/shared/templates/grub2_bootloader_argument/bash.template
@@ -3,9 +3,22 @@
    See the OVAL template for more comments.
    Product-specific categorization should be synced across all template content types
 -#}}
+
 {{%- if ARG_VARIABLE %}}
 {{{- bash_instantiate_variables(ARG_VARIABLE) }}}
 {{%- set ARG_NAME_VALUE= ARG_NAME ~ "=$" ~ ARG_VARIABLE %}}
-{{%- endif %}}
+expected_value="${{{ ARG_VARIABLE }}}"
+{{% else %}}
+expected_value="{{{ ARG_VALUE }}}"
+{{% endif %}}
 
-{{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}
+if {{{ bash_bootc_build() }}} ; then
+    KARGS_DIR="/usr/lib/bootc/kargs.d/"
+    if grep -q -E "{{{ ARG_NAME }}}" "$KARGS_DIR/*.toml" ; then
+        sed -i -E "s/^(\s*kargs\s*=\s*\[.*)\"{{{ ARG_NAME }}}=[^\"]*\"(.*]\s*)/\1\"{{{ ARG_NAME }}}=$expected_value\"\2/" "$KARGS_DIR/*.toml"
+    else
+        echo "kargs = [\"{{{ ARG_NAME }}}=$expected_value\"]" >> "$KARGS_DIR/10-{{{ SANITIZED_ARG_NAME }}}.toml"
+    fi
+else
+{{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) | indent(4) }}}
+fi

--- a/shared/templates/grub2_bootloader_argument/oval.template
+++ b/shared/templates/grub2_bootloader_argument/oval.template
@@ -324,23 +324,23 @@
   <ind:textfilecontent54_object id="object_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" version="1">
     <ind:path>/usr/lib/bootc/kargs.d/</ind:path>
     <ind:filename operation="pattern match">^.*\.toml$</ind:filename>
-    <ind:pattern operation="pattern match">^kargs = \["([^\"]+)"\]$</ind:pattern>
+    <ind:pattern operation="pattern match">^kargs = \[([^\]]+)\]$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 {{% if ARG_VALUE %}}
   <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" version="1">
-    <ind:subexpression operation="pattern match">^(?:.*\s)?{{{ ESCAPED_ARG_NAME_VALUE }}}(?:\s.*)?$</ind:subexpression>
+    <ind:subexpression operation="pattern match">^.*"{{{ ESCAPED_ARG_NAME_VALUE }}}".*$</ind:subexpression>
   </ind:textfilecontent54_state>
 {{% else %}}
   <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" version="1">
-    <ind:subexpression operation="pattern match" var_ref="local_var_regex_{{{ SANITIZED_ARG_NAME }}}_{{{ ARG_VARIABLE }}}" />
+    <ind:subexpression operation="pattern match" var_ref="local_var_regex_{{{ SANITIZED_ARG_NAME }}}_{{{ ARG_VARIABLE }}}_bootc_kargs" />
   </ind:textfilecontent54_state>
 
-  <local_variable id="local_var_regex_{{{ SANITIZED_ARG_NAME }}}_{{{ ARG_VARIABLE }}}"
+  <local_variable id="local_var_regex_{{{ SANITIZED_ARG_NAME }}}_{{{ ARG_VARIABLE }}}_bootc_kargs"
   comment="Regex that matches {{{ ARG_NAME }}} with value {{{ ARG_VARIABLE }}}"
   datatype="string" version="1">
     <concat>
-      <literal_component>^(?:.*\s)?{{{ ARG_NAME }}}=</literal_component>
+      <literal_component>^.*"{{{ ARG_NAME }}}=</literal_component>
       {{% if IS_SUBSTRING == "true" %}}
       <literal_component>\S*</literal_component>
       {{% endif %}}
@@ -348,7 +348,7 @@
       {{% if IS_SUBSTRING == "true" %}}
       <literal_component>\S*</literal_component>
       {{% endif %}}
-      <literal_component>(?:\s.*)?$</literal_component>
+      <literal_component>".*$</literal_component>
     </concat>
   </local_variable>
 

--- a/shared/templates/grub2_bootloader_argument/oval.template
+++ b/shared/templates/grub2_bootloader_argument/oval.template
@@ -12,7 +12,6 @@
 {{% set system_with_kernel_options_in_etc_default_grub_d = false -%}}
 {{% set system_with_expanded_kernel_options_in_grub_cfg = false -%}}
 {{% set system_with_bios_and_uefi_support = false -%}}
-{{% set bootable_containers_supported = false %}}
 
 {{% if product in ["fedora", "ol9", "rhel9", "rhel10"] -%}}
 {{% set system_with_expanded_kernel_options_in_loader_entries = true %}}
@@ -32,10 +31,6 @@
 
 {{% if grub2_uefi_boot_path and grub2_uefi_boot_path != grub2_boot_path -%}}
 {{% set system_with_bios_and_uefi_support = true %}}
-{{%- endif -%}}
-
-{{% if product in ["rhel9", "rhel10"] -%}}
-{{% set bootable_containers_supported = true %}}
 {{%- endif -%}}
 
 <def-group>
@@ -114,7 +109,7 @@
         </criteria>
       {{%- endif %}}
     </criteria>
-    {{% if bootable_containers_supported %}}
+    {{% if bootable_containers_supported == "true" %}}
       <criteria operator="AND">
         <extend_definition comment="The system is RHEL Image Mode"  definition_ref="bootc" />
         <criterion comment="The {{{ ARG_NAME_VALUE }}} is present in the /usr/lib/bootc/kargs.d/*.toml files"  test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" />
@@ -319,7 +314,7 @@
   <external_variable comment="Variable defining the value the argument should have" datatype="string" id="{{{ ARG_VARIABLE }}}" version="1" />
 {{% endif %}}
 
-{{% if bootable_containers_supported %}}
+{{% if bootable_containers_supported == "true" %}}
   <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d"
                               comment="check kernel command line parameters for {{{ ARG_NAME_VALUE }}} for all boot entries."
                               check="at least one" check_existence="at_least_one_exists" version="1">

--- a/shared/templates/grub2_bootloader_argument/oval.template
+++ b/shared/templates/grub2_bootloader_argument/oval.template
@@ -38,6 +38,9 @@
     {{{ oval_metadata("Ensure " + ARG_NAME_VALUE + " is configured in the kernel line in /etc/default/grub.") }}}
     <criteria operator="OR">
     <criteria operator="AND">
+      {{% if bootable_containers_supported == "true" %}}
+        <extend_definition comment="The system is RHEL Image Mode" definition_ref="bootc" negate="true" />
+      {{% endif %}}
       {{% if system_with_expanded_kernel_options_in_loader_entries_or_with_options_in_grubenv %}}
       <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_entries_expanded_or_referenced"
       comment="Check /boot/loader/entries/*.conf files if they contain direct reference to {{{ ARG_NAME_VALUE }}} or if they contain $kernelopts" />
@@ -111,7 +114,7 @@
     </criteria>
     {{% if bootable_containers_supported == "true" %}}
       <criteria operator="AND">
-        <extend_definition comment="The system is RHEL Image Mode"  definition_ref="bootc" />
+        <extend_definition comment="The system is RHEL Image Mode" definition_ref="bootc" />
         <criterion comment="The {{{ ARG_NAME_VALUE }}} is present in the /usr/lib/bootc/kargs.d/*.toml files"  test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" />
       </criteria>
     {{% endif %}}

--- a/shared/templates/grub2_bootloader_argument/oval.template
+++ b/shared/templates/grub2_bootloader_argument/oval.template
@@ -12,6 +12,7 @@
 {{% set system_with_kernel_options_in_etc_default_grub_d = false -%}}
 {{% set system_with_expanded_kernel_options_in_grub_cfg = false -%}}
 {{% set system_with_bios_and_uefi_support = false -%}}
+{{% set bootable_containers_supported = false %}}
 
 {{% if product in ["fedora", "ol9", "rhel9", "rhel10"] -%}}
 {{% set system_with_expanded_kernel_options_in_loader_entries = true %}}
@@ -33,10 +34,14 @@
 {{% set system_with_bios_and_uefi_support = true %}}
 {{%- endif -%}}
 
+{{% if product in ["rhel9", "rhel10"] -%}}
+{{% set bootable_containers_supported = true %}}
+{{%- endif -%}}
 
 <def-group>
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="2">
     {{{ oval_metadata("Ensure " + ARG_NAME_VALUE + " is configured in the kernel line in /etc/default/grub.") }}}
+    <criteria operator="OR">
     <criteria operator="AND">
       {{% if system_with_expanded_kernel_options_in_loader_entries_or_with_options_in_grubenv %}}
       <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_entries_expanded_or_referenced"
@@ -108,6 +113,13 @@
           </criteria>
         </criteria>
       {{%- endif %}}
+    </criteria>
+    {{% if bootable_containers_supported %}}
+      <criteria operator="AND">
+        <extend_definition comment="The system is RHEL Image Mode"  definition_ref="bootc" />
+        <criterion comment="The {{{ ARG_NAME_VALUE }}} is present in the /usr/lib/bootc/kargs.d/*.toml files"  test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" />
+      </criteria>
+    {{% endif %}}
     </criteria>
   </definition>
 
@@ -305,6 +317,48 @@
   </local_variable>
 
   <external_variable comment="Variable defining the value the argument should have" datatype="string" id="{{{ ARG_VARIABLE }}}" version="1" />
+{{% endif %}}
+
+{{% if bootable_containers_supported %}}
+  <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d"
+                              comment="check kernel command line parameters for {{{ ARG_NAME_VALUE }}} for all boot entries."
+                              check="at least one" check_existence="at_least_one_exists" version="1">
+    <ind:object object_ref="object_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" />
+    <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" version="1">
+    <ind:path>/usr/lib/bootc/kargs.d/</ind:path>
+    <ind:filename operation="pattern match">^.*\.toml$</ind:filename>
+    <ind:pattern operation="pattern match">^kargs = \["([^\"]+)"\]$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+{{% if ARG_VALUE %}}
+  <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" version="1">
+    <ind:subexpression operation="pattern match">^(?:.*\s)?{{{ ESCAPED_ARG_NAME_VALUE }}}(?:\s.*)?$</ind:subexpression>
+  </ind:textfilecontent54_state>
+{{% else %}}
+  <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d" version="1">
+    <ind:subexpression operation="pattern match" var_ref="local_var_regex_{{{ SANITIZED_ARG_NAME }}}_{{{ ARG_VARIABLE }}}" />
+  </ind:textfilecontent54_state>
+
+  <local_variable id="local_var_regex_{{{ SANITIZED_ARG_NAME }}}_{{{ ARG_VARIABLE }}}"
+  comment="Regex that matches {{{ ARG_NAME }}} with value {{{ ARG_VARIABLE }}}"
+  datatype="string" version="1">
+    <concat>
+      <literal_component>^(?:.*\s)?{{{ ARG_NAME }}}=</literal_component>
+      {{% if IS_SUBSTRING == "true" %}}
+      <literal_component>\S*</literal_component>
+      {{% endif %}}
+      <variable_component var_ref="{{{ ARG_VARIABLE }}}" />
+      {{% if IS_SUBSTRING == "true" %}}
+      <literal_component>\S*</literal_component>
+      {{% endif %}}
+      <literal_component>(?:\s.*)?$</literal_component>
+    </concat>
+  </local_variable>
+
+  <external_variable comment="Variable defining the value the argument should have" datatype="string" id="{{{ ARG_VARIABLE }}}" version="1" />
+{{% endif %}}
 {{% endif %}}
 
 </def-group>

--- a/shared/templates/grub2_bootloader_argument/template.py
+++ b/shared/templates/grub2_bootloader_argument/template.py
@@ -21,5 +21,6 @@ def preprocess(data, lang):
         data["escaped_arg_name_value"] = data["arg_name_value"].replace(".", "\\.")
         data["escaped_arg_name"] = data["arg_name"].replace(".", "\\.")
         # replace . with _, this is used in test / object / state ids
-        data["sanitized_arg_name"] = ssg.utils.escape_id(data["arg_name"])
+
+    data["sanitized_arg_name"] = ssg.utils.escape_id(data["arg_name"])
     return data

--- a/shared/templates/grub2_bootloader_argument_absent/bash.template
+++ b/shared/templates/grub2_bootloader_argument_absent/bash.template
@@ -4,8 +4,8 @@
    Product-specific categorization should be synced across all template content types
 -#}}
 if {{{ bash_bootc_build() }}} ; then
-    sed -i -E "/kargs\s*=\s*\[\s*\"{{{ ARG_NAME }}}=[^\"]*\"\s*]/d" "$KARGS_DIR/*.toml"
-    sed -i -E "s/^(\s*kargs\s*=\s*\[.*)\"{{{ ARG_NAME }}}=[^\"]*\"(.*]\s*)/\1\2/" "$KARGS_DIR/*.toml"
+    sed -i -E "/kargs\s*=\s*\[\s*\"{{{ ARG_NAME }}}=[^\"]*\"\s*]/{:a;N;/^\n$/ba;N;/match-architectures.*/d;}" "$KARGS_DIR/*.toml"
+    sed -i -E -e "s/^(\s*kargs\s*=\s*\[.*)\"{{{ ARG_NAME }}}=[^\"]*\"[,[:space:]]*(.*]\s*)/\1\2/" -e "s/^(\s*kargs.*),\s*\]$/\1\]/" "$KARGS_DIR/*.toml"
 else
 {{{ grub2_bootloader_argument_absent_remediation(ARG_NAME) }}}
 fi

--- a/shared/templates/grub2_bootloader_argument_absent/bash.template
+++ b/shared/templates/grub2_bootloader_argument_absent/bash.template
@@ -3,4 +3,9 @@
    See the OVAL template for more comments.
    Product-specific categorization should be synced across all template content types
 -#}}
+if {{{ bash_bootc_build() }}} ; then
+    sed -i -E "/kargs\s*=\s*\[\s*\"{{{ ARG_NAME }}}=[^\"]*\"\s*]/d" "$KARGS_DIR/*.toml"
+    sed -i -E "s/^(\s*kargs\s*=\s*\[.*)\"{{{ ARG_NAME }}}=[^\"]*\"(.*]\s*)/\1\2/" "$KARGS_DIR/*.toml"
+else
 {{{ grub2_bootloader_argument_absent_remediation(ARG_NAME) }}}
+fi

--- a/shared/templates/grub2_bootloader_argument_absent/oval.template
+++ b/shared/templates/grub2_bootloader_argument_absent/oval.template
@@ -34,6 +34,9 @@
     {{{ oval_metadata("Ensure " + ARG_NAME + " is not set in the kernel line in /etc/default/grub.") }}}
     <criteria operator="OR">
     <criteria operator="AND">
+      {{% if bootable_containers_supported == "true" %}}
+        <extend_definition comment="The system is RHEL Image Mode" definition_ref="bootc" negate="true" />
+      {{% endif %}}
       {{% if system_with_kernel_options_in_grubenv -%}}
       {{% if system_with_bios_and_uefi_support -%}}
       <criteria operator="OR">

--- a/shared/templates/grub2_bootloader_argument_absent/oval.template
+++ b/shared/templates/grub2_bootloader_argument_absent/oval.template
@@ -32,6 +32,7 @@
 <def-group>
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="2">
     {{{ oval_metadata("Ensure " + ARG_NAME + " is not set in the kernel line in /etc/default/grub.") }}}
+    <criteria operator="OR">
     <criteria operator="AND">
       {{% if system_with_kernel_options_in_grubenv -%}}
       {{% if system_with_bios_and_uefi_support -%}}
@@ -76,6 +77,13 @@
           </criteria>
         </criteria>
       {{%- endif %}}
+    </criteria>
+    {{% if bootable_containers_supported == "true" %}}
+      <criteria operator="AND">
+        <extend_definition comment="The system is RHEL Image Mode" definition_ref="bootc" />
+        <criterion comment="The {{{ ARG_NAME }}} is not present in the /usr/lib/bootc/kargs.d/*.toml files"  test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d_absent" />
+      </criteria>
+    {{% endif %}}
     </criteria>
   </definition>
 
@@ -174,4 +182,17 @@
 {{%- endif %}}
 {{%- endif %}}
 
+{{% if bootable_containers_supported == "true" %}}
+  <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d_absent"
+                              comment="check kernel command line parameters for {{{ ARG_NAME }}}"
+                              check="at least one" check_existence="none_exist" version="1">
+    <ind:object object_ref="object_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d_absent" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_grub2_{{{ SANITIZED_ARG_NAME }}}_usr_lib_bootc_kargs_d_absent" version="1">
+    <ind:path>/usr/lib/bootc/kargs.d/</ind:path>
+    <ind:filename operation="pattern match">^.*\.toml$</ind:filename>
+    <ind:pattern operation="pattern match">^kargs = \["{{{ ARG_NAME }}}.*"\]$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+{{% endif %}}
 </def-group>

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -457,6 +457,7 @@ DEFAULT_CHRONY_CONF_PATH = '/etc/chrony.conf'
 DEFAULT_CHRONY_D_PATH = '/etc/chrony.d/'
 DEFAULT_AUDISP_CONF_PATH = '/etc/audit'
 DEFAULT_SYSCTL_REMEDIATE_DROP_IN_FILE = 'false'
+DEFAULT_BOOTABLE_CONTAINERS_SUPPORTED = 'false'
 
 
 # Constants for OVAL object model

--- a/ssg/products.py
+++ b/ssg/products.py
@@ -20,6 +20,7 @@ from .constants import (DEFAULT_PRODUCT, product_directories,
                         DEFAULT_AUDISP_CONF_PATH,
                         DEFAULT_FAILLOCK_PATH,
                         DEFAULT_SYSCTL_REMEDIATE_DROP_IN_FILE,
+                        DEFAULT_BOOTABLE_CONTAINERS_SUPPORTED,
                         PKG_MANAGER_TO_SYSTEM,
                         PKG_MANAGER_TO_CONFIG_FILE,
                         XCCDF_PLATFORM_TO_PACKAGE,
@@ -114,6 +115,9 @@ def _get_implied_properties(existing_properties):
 
     if "sysctl_remediate_drop_in_file" not in existing_properties:
         result["sysctl_remediate_drop_in_file"] = DEFAULT_SYSCTL_REMEDIATE_DROP_IN_FILE
+
+    if "bootable_containers_supported" not in existing_properties:
+        result["bootable_containers_supported"] = DEFAULT_BOOTABLE_CONTAINERS_SUPPORTED
 
     return result
 

--- a/tests/data/product_stability/alinux2.yml
+++ b/tests/data/product_stability/alinux2.yml
@@ -7,6 +7,7 @@ auid: 1000
 basic_properties_derived: true
 benchmark_id: ALINUX-2
 benchmark_root: ../../linux_os/guide
+bootable_containers_supported: 'false'
 chrony_conf_path: /etc/chrony.conf
 chrony_d_path: /etc/chrony.d/
 cpes:

--- a/tests/data/product_stability/alinux3.yml
+++ b/tests/data/product_stability/alinux3.yml
@@ -7,6 +7,7 @@ auid: 1000
 basic_properties_derived: true
 benchmark_id: ALINUX-3
 benchmark_root: ../../linux_os/guide
+bootable_containers_supported: 'false'
 chrony_conf_path: /etc/chrony.conf
 chrony_d_path: /etc/chrony.d/
 cpes:

--- a/tests/data/product_stability/anolis23.yml
+++ b/tests/data/product_stability/anolis23.yml
@@ -7,6 +7,7 @@ auid: 1000
 basic_properties_derived: true
 benchmark_id: ANOLIS-23
 benchmark_root: ../../linux_os/guide
+bootable_containers_supported: 'false'
 chrony_conf_path: /etc/chrony.conf
 chrony_d_path: /etc/chrony.d/
 cpes:

--- a/tests/data/product_stability/anolis8.yml
+++ b/tests/data/product_stability/anolis8.yml
@@ -7,6 +7,7 @@ auid: 1000
 basic_properties_derived: true
 benchmark_id: ANOLIS-8
 benchmark_root: ../../linux_os/guide
+bootable_containers_supported: 'false'
 chrony_conf_path: /etc/chrony.conf
 chrony_d_path: /etc/chrony.d/
 cpes:

--- a/tests/data/product_stability/chromium.yml
+++ b/tests/data/product_stability/chromium.yml
@@ -7,6 +7,7 @@ auid: 1000
 basic_properties_derived: true
 benchmark_id: CHROMIUM
 benchmark_root: ./guide
+bootable_containers_supported: 'false'
 chrony_conf_path: /etc/chrony.conf
 chrony_d_path: /etc/chrony.d/
 cpes:

--- a/tests/data/product_stability/debian11.yml
+++ b/tests/data/product_stability/debian11.yml
@@ -7,6 +7,7 @@ auid: 1000
 basic_properties_derived: true
 benchmark_id: DEBIAN-11
 benchmark_root: ../../linux_os/guide
+bootable_containers_supported: 'false'
 chrony_conf_path: /etc/chrony.conf
 chrony_d_path: /etc/chrony.d/
 cpes:

--- a/tests/data/product_stability/debian12.yml
+++ b/tests/data/product_stability/debian12.yml
@@ -7,6 +7,7 @@ auid: 1000
 basic_properties_derived: true
 benchmark_id: DEBIAN-12
 benchmark_root: ../../linux_os/guide
+bootable_containers_supported: 'false'
 chrony_conf_path: /etc/chrony/chrony.conf
 chrony_d_path: /etc/chrony/chrony.d/
 cpes:

--- a/tests/data/product_stability/eks.yml
+++ b/tests/data/product_stability/eks.yml
@@ -7,6 +7,7 @@ auid: 1000
 basic_properties_derived: true
 benchmark_id: EKS
 benchmark_root: ../../applications
+bootable_containers_supported: 'false'
 chrony_conf_path: /etc/chrony.conf
 chrony_d_path: /etc/chrony.d/
 cpes:

--- a/tests/data/product_stability/example.yml
+++ b/tests/data/product_stability/example.yml
@@ -7,6 +7,7 @@ auid: 1000
 basic_properties_derived: true
 benchmark_id: EXAMPLE
 benchmark_root: ../../linux_os/guide
+bootable_containers_supported: 'false'
 chrony_conf_path: /etc/chrony.conf
 chrony_d_path: /etc/chrony.d/
 components_root: ../../components

--- a/tests/data/product_stability/fedora.yml
+++ b/tests/data/product_stability/fedora.yml
@@ -7,6 +7,7 @@ auid: 1000
 basic_properties_derived: true
 benchmark_id: FEDORA
 benchmark_root: ../../linux_os/guide
+bootable_containers_supported: 'false'
 chrony_conf_path: /etc/chrony.conf
 chrony_d_path: /etc/chrony.d/
 components_root: ../../components

--- a/tests/data/product_stability/firefox.yml
+++ b/tests/data/product_stability/firefox.yml
@@ -7,6 +7,7 @@ auid: 1000
 basic_properties_derived: true
 benchmark_id: FIREFOX
 benchmark_root: ./guide
+bootable_containers_supported: 'false'
 chrony_conf_path: /etc/chrony.conf
 chrony_d_path: /etc/chrony.d/
 cpes:

--- a/tests/data/product_stability/macos1015.yml
+++ b/tests/data/product_stability/macos1015.yml
@@ -7,6 +7,7 @@ auid: 1000
 basic_properties_derived: true
 benchmark_id: macOS-1015
 benchmark_root: ../../apple_os/
+bootable_containers_supported: 'false'
 chrony_conf_path: /etc/chrony.conf
 chrony_d_path: /etc/chrony.d/
 cpes:

--- a/tests/data/product_stability/ocp4.yml
+++ b/tests/data/product_stability/ocp4.yml
@@ -7,6 +7,7 @@ auid: 1000
 basic_properties_derived: true
 benchmark_id: OCP-4
 benchmark_root: ../../applications
+bootable_containers_supported: 'false'
 chrony_conf_path: /etc/chrony.conf
 chrony_d_path: /etc/chrony.d/
 cpes:

--- a/tests/data/product_stability/ol7.yml
+++ b/tests/data/product_stability/ol7.yml
@@ -7,6 +7,7 @@ auid: 1000
 basic_properties_derived: true
 benchmark_id: OL-7
 benchmark_root: ../../linux_os/guide
+bootable_containers_supported: 'false'
 chrony_conf_path: /etc/chrony.conf
 chrony_d_path: /etc/chrony.d/
 cpes:

--- a/tests/data/product_stability/ol8.yml
+++ b/tests/data/product_stability/ol8.yml
@@ -7,6 +7,7 @@ auid: 1000
 basic_properties_derived: true
 benchmark_id: OL-8
 benchmark_root: ../../linux_os/guide
+bootable_containers_supported: 'false'
 chrony_conf_path: /etc/chrony.conf
 chrony_d_path: /etc/chrony.d/
 cpes:

--- a/tests/data/product_stability/ol9.yml
+++ b/tests/data/product_stability/ol9.yml
@@ -10,6 +10,7 @@ auxiliary_key_fingerprint: 982231759C7467065D0CE9B2A7DD07088B4EFBE6
 basic_properties_derived: true
 benchmark_id: OL-9
 benchmark_root: ../../linux_os/guide
+bootable_containers_supported: 'false'
 chrony_conf_path: /etc/chrony.conf
 chrony_d_path: /etc/chrony.d/
 cpes:

--- a/tests/data/product_stability/openembedded.yml
+++ b/tests/data/product_stability/openembedded.yml
@@ -7,6 +7,7 @@ auid: 1000
 basic_properties_derived: true
 benchmark_id: OPENEMBEDDED
 benchmark_root: ../../linux_os/guide
+bootable_containers_supported: 'false'
 chrony_conf_path: /etc/chrony.conf
 chrony_d_path: /etc/chrony.d/
 cpes:

--- a/tests/data/product_stability/opensuse.yml
+++ b/tests/data/product_stability/opensuse.yml
@@ -7,6 +7,7 @@ auid: 1000
 basic_properties_derived: true
 benchmark_id: OPENSUSE
 benchmark_root: ../../linux_os/guide
+bootable_containers_supported: 'false'
 chrony_conf_path: /etc/chrony.conf
 chrony_d_path: /etc/chrony.d/
 cpes:

--- a/tests/data/product_stability/rhcos4.yml
+++ b/tests/data/product_stability/rhcos4.yml
@@ -7,6 +7,7 @@ auid: 1000
 basic_properties_derived: true
 benchmark_id: RHCOS-4
 benchmark_root: ../../linux_os/guide
+bootable_containers_supported: 'false'
 chrony_conf_path: /etc/chrony.conf
 chrony_d_path: /etc/chrony.d/
 cpes:

--- a/tests/data/product_stability/rhel8.yml
+++ b/tests/data/product_stability/rhel8.yml
@@ -10,6 +10,7 @@ auxiliary_key_fingerprint: 6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792
 basic_properties_derived: true
 benchmark_id: RHEL-8
 benchmark_root: ../../linux_os/guide
+bootable_containers_supported: 'false'
 centos_major_version: '8'
 centos_pkg_release: 5ccc5b19
 centos_pkg_version: 8483c65d

--- a/tests/data/product_stability/rhel9.yml
+++ b/tests/data/product_stability/rhel9.yml
@@ -10,6 +10,7 @@ auxiliary_key_fingerprint: 7E4624258C406535D56D6F135054E4A45A6340B3
 basic_properties_derived: true
 benchmark_id: RHEL-9
 benchmark_root: ../../linux_os/guide
+bootable_containers_supported: 'true'
 centos_major_version: '9'
 centos_pkg_release: 5ccc5b19
 centos_pkg_version: 8483c65d

--- a/tests/data/product_stability/rhv4.yml
+++ b/tests/data/product_stability/rhv4.yml
@@ -10,6 +10,7 @@ auxiliary_key_fingerprint: 6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792
 basic_properties_derived: true
 benchmark_id: RHV-4
 benchmark_root: ../../linux_os/guide
+bootable_containers_supported: 'false'
 chrony_conf_path: /etc/chrony.conf
 chrony_d_path: /etc/chrony.d/
 cpes:

--- a/tests/data/product_stability/sle12.yml
+++ b/tests/data/product_stability/sle12.yml
@@ -7,6 +7,7 @@ auid: 1000
 basic_properties_derived: true
 benchmark_id: SLE-12
 benchmark_root: ../../linux_os/guide
+bootable_containers_supported: 'false'
 chrony_conf_path: /etc/chrony.conf
 chrony_d_path: /etc/chrony.d/
 cpes:

--- a/tests/data/product_stability/sle15.yml
+++ b/tests/data/product_stability/sle15.yml
@@ -7,6 +7,7 @@ auid: 1000
 basic_properties_derived: true
 benchmark_id: SLE-15
 benchmark_root: ../../linux_os/guide
+bootable_containers_supported: 'false'
 chrony_conf_path: /etc/chrony.conf
 chrony_d_path: /etc/chrony.d/
 cpes:

--- a/tests/data/product_stability/ubuntu1604.yml
+++ b/tests/data/product_stability/ubuntu1604.yml
@@ -7,6 +7,7 @@ auid: 1000
 basic_properties_derived: true
 benchmark_id: UBUNTU-XENIAL
 benchmark_root: ../../linux_os/guide
+bootable_containers_supported: 'false'
 chrony_conf_path: /etc/chrony/chrony.conf
 chrony_d_path: /etc/chrony/conf.d/
 cpes:

--- a/tests/data/product_stability/ubuntu1804.yml
+++ b/tests/data/product_stability/ubuntu1804.yml
@@ -7,6 +7,7 @@ auid: 1000
 basic_properties_derived: true
 benchmark_id: UBUNTU-BIONIC
 benchmark_root: ../../linux_os/guide
+bootable_containers_supported: 'false'
 chrony_conf_path: /etc/chrony/chrony.conf
 chrony_d_path: /etc/chrony/conf.d/
 cpes:

--- a/tests/data/product_stability/ubuntu2004.yml
+++ b/tests/data/product_stability/ubuntu2004.yml
@@ -8,6 +8,7 @@ auid: 1000
 basic_properties_derived: true
 benchmark_id: UBUNTU_20-04
 benchmark_root: ../../linux_os/guide
+bootable_containers_supported: 'false'
 chrony_conf_path: /etc/chrony/chrony.conf
 chrony_d_path: /etc/chrony/conf.d/
 cpes:

--- a/tests/data/product_stability/ubuntu2204.yml
+++ b/tests/data/product_stability/ubuntu2204.yml
@@ -8,6 +8,7 @@ auid: 1000
 basic_properties_derived: true
 benchmark_id: UBUNTU_22-04
 benchmark_root: ../../linux_os/guide
+bootable_containers_supported: 'false'
 chrony_conf_path: /etc/chrony/chrony.conf
 chrony_d_path: /etc/chrony/conf.d/
 cpes:

--- a/tests/data/product_stability/ubuntu2404.yml
+++ b/tests/data/product_stability/ubuntu2404.yml
@@ -8,6 +8,7 @@ auid: 1000
 basic_properties_derived: true
 benchmark_id: UBUNTU_24-04
 benchmark_root: ../../linux_os/guide
+bootable_containers_supported: 'false'
 chrony_conf_path: /etc/chrony/chrony.conf
 chrony_d_path: /etc/chrony/conf.d/
 components_root: ../../components


### PR DESCRIPTION
This commit extends templates `grub2_bootloader_argument` and  `grub2_bootloader_argument_absent` for bootable containers.

The rules that use these templates will be marked with the `system_with_kernel` platform to extend their applicability also to bootable containers.

The bootable containers use a special mechanism for specifying the kernel arguments. In bootable containers, the kernel build arguments are specified in TOML files in special directory  `/usr/lib/bootc/kargs.d/`.  For more details, see:
https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/using_image_mode_for_rhel_to_build_deploy_and_manage_operating_systems/managing-kernel-arguments-in-bootc-systems#how-to-add-support-to-inject-kernel-arguments-with-bootc_managing-kernel-arguments-in-bootc-systems
Based on that, the OVAL will check the `/usr/lib/bootc/kargs.d/` and the remediation will remediate this directory if a bootable container image is built.

To support this effort, this PR introduces new product property `bootable_containers_supported`. By default, this variable is set to `"false"` and RHEL 9 and 10 products set this variable to `"true"`.
