### PR TITLE
Update rule set_ip6tables_default_rule

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -1491,10 +1491,9 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    related_rules:
+    rules:
       - set_ip6tables_default_rule
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/3.5.3.3.1.
+    status: automated
 
   - id: 4.4.3.2
     title: Ensure ip6tables loopback traffic is configured (Automated)

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/bash/shared.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/bash/shared.sh
@@ -1,2 +1,8 @@
 # platform = multi_platform_all
+{{% if 'ubuntu' in product %}}
+{{{ bash_package_install("iptables-persistent") }}}
+sed -i 's/^:INPUT ACCEPT.*/:INPUT DROP [0:0]/g' /etc/iptables/rules.v6
+{{% else %}}
 sed -i 's/^:INPUT ACCEPT.*/:INPUT DROP [0:0]/g' /etc/sysconfig/ip6tables
+{{% endif %}}
+

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/rule.yml
@@ -6,7 +6,11 @@ description: |-
     To set the default policy to DROP (instead of ACCEPT) for
     the built-in INPUT chain which processes incoming packets,
     add or correct the following line in
+    {{% if 'ubuntu' in product %}}
+    <tt>/etc/iptables/rules.v6</tt>:
+    {{% else %}}
     <tt>/etc/sysconfig/ip6tables</tt>:
+    {{% endif %}}
     <pre>:INPUT DROP [0:0]</pre>
     If changes were required, reload the ip6tables rules:
     <pre>$ sudo service ip6tables reload</pre>

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/sce/shared.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/sce/shared.sh
@@ -12,8 +12,8 @@ if [ -z "${output}" ]; then
 fi
 
 while read -r line; do
-    chain=$(echo "$line" | awk '{print $1, $2}')
-    policy=$(echo "$line" | awk '{print $4}' | tr -d ")")
+    chain=$(echo "$line" | cut -f1-2 -d' ')
+    policy=$(echo "$line" | cut -f4 -d' ' | tr -d ')')
     if [ "$chain" = "Chain INPUT" ] || [ "$chain" = "Chain FORWARD" ] ||
        [ "$chain" = "Chain OUTPUT" ]; then
         if [ "$policy" != "DROP" ] && [ "$policy" != "REJECT" ]; then

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/tests/correct.pass.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/tests/correct.pass.sh
@@ -1,0 +1,8 @@
+# platform = multi_platform_ubuntu
+# packages = iptables,iptables-persistent
+
+apt purge -y nftables ufw
+
+ip6tables -P INPUT DROP
+ip6tables -P FORWARD DROP
+ip6tables -P OUTPUT DROP

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/tests/ipv6_disabled.pass.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/tests/ipv6_disabled.pass.sh
@@ -1,0 +1,7 @@
+# platform = multi_platform_ubuntu
+# packages = iptables,iptables-persistent
+
+apt purge -y nftables ufw
+
+ip6tables -P INPUT ACCEPT
+sysctl net.ipv6.conf.all.disable_ipv6=1

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/tests/wrong.fail.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/tests/wrong.fail.sh
@@ -1,0 +1,9 @@
+# platform = multi_platform_ubuntu
+# remediation = none
+# packages = iptables,iptables-persistent
+
+apt purge -y nftables ufw
+
+ip6tables -P INPUT ACCEPT
+ip6tables -P FORWARD DROP
+ip6tables -P OUTPUT DROP


### PR DESCRIPTION
#### Description:

- update ubuntu2404 CIS control 4.4.3.1 (Ensure ip6tables default deny firewall policy)
- fixed path for ip6tables persistent rules in `set_ip6tables_default_rule`
- move away from using awk in SCE
- defined few tests for ubuntu
