### PR TITLE
Ubuntu enable unix

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/bash/shared.sh
@@ -2,16 +2,28 @@
 
 {{{ bash_instantiate_variables("var_password_pam_unix_remember") }}}
 
-{{% if "debian" in product or "ubuntu" in product or "sle12" in product %}}
+{{% if "debian" in product or "sle12" in product %}}
 {{%- set accounts_password_pam_unix_remember_file = '/etc/pam.d/common-password' -%}}
+{{% elif "ubuntu" in product %}}
+{{%- set accounts_password_pam_unix_remember_file = '/usr/share/pam-configs/unix' -%}}
 {{% else %}}
 {{%- set accounts_password_pam_unix_remember_file = '/etc/pam.d/system-auth' -%}}
 {{% endif %}}
 
-{{% if "debian" in product or "ubuntu" in product %}}
+{{% if "debian" in product %}}
 
 {{{ bash_ensure_pam_module_options(accounts_password_pam_unix_remember_file, 'password', '\[success=[[:alnum:]].*\]', 'pam_unix.so', 'remember', "$var_password_pam_unix_remember", "$var_password_pam_unix_remember") }}}
 
+{{% elif "ubuntu" in product %}}
+{{{ bash_pam_unix_enable() }}}
+sed -i -E '/^Password:/,/^[^[:space:]]/ {
+    /pam_unix\.so/ {
+        s/\s*remember=[^[:space:]]*//g
+        s/$/ remember='"$var_password_pam_unix_remember"'/g
+    }
+}' "$accounts_password_pam_unix_remember_file"
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update
 {{% else %}}
 
 {{{ bash_pam_pwhistory_enable(accounts_password_pam_unix_remember_file,

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/bash/shared.sh
@@ -5,7 +5,7 @@
 {{% if "debian" in product or "sle12" in product %}}
 {{%- set accounts_password_pam_unix_remember_file = '/etc/pam.d/common-password' -%}}
 {{% elif "ubuntu" in product %}}
-{{%- set accounts_password_pam_unix_remember_file = '/usr/share/pam-configs/cac_unix' -%}}
+config_file="/usr/share/pam-configs/cac_unix"
 {{% else %}}
 {{%- set accounts_password_pam_unix_remember_file = '/etc/pam.d/system-auth' -%}}
 {{% endif %}}
@@ -21,7 +21,14 @@ sed -i -E '/^Password:/,/^[^[:space:]]/ {
         s/\s*remember=[^[:space:]]*//g
         s/$/ remember='"$var_password_pam_unix_remember"'/g
     }
-}' "$accounts_password_pam_unix_remember_file"
+}' "$config_file"
+
+sed -i -E '/^Password-Initial:/,/^[^[:space:]]/ {
+    /pam_unix\.so/ {
+        s/\s*remember=[^[:space:]]*//g
+        s/$/ remember='"$var_password_pam_unix_remember"'/g
+    }
+}' "$config_file"
 
 DEBIAN_FRONTEND=noninteractive pam-auth-update
 {{% else %}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/bash/shared.sh
@@ -5,7 +5,7 @@
 {{% if "debian" in product or "sle12" in product %}}
 {{%- set accounts_password_pam_unix_remember_file = '/etc/pam.d/common-password' -%}}
 {{% elif "ubuntu" in product %}}
-{{%- set accounts_password_pam_unix_remember_file = '/usr/share/pam-configs/unix' -%}}
+{{%- set accounts_password_pam_unix_remember_file = '/usr/share/pam-configs/cac_unix' -%}}
 {{% else %}}
 {{%- set accounts_password_pam_unix_remember_file = '/etc/pam.d/system-auth' -%}}
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/ubuntu_arg_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/ubuntu_arg_missing.fail.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 
-cat << EOF > /usr/share/pam-configs/unix
+config_file=/usr/share/pam-configs/tmpunix
+cat << EOF > "$config_file"
 Name: Unix authentication
 Default: yes
 Priority: 256
@@ -28,3 +29,4 @@ Password-Initial:
 EOF
 
 DEBIAN_FRONTEND=noninteractive pam-auth-update
+rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/ubuntu_arg_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/ubuntu_arg_missing.fail.sh
@@ -1,7 +1,30 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 
-config_file=/etc/pam.d/common-password
-if grep -q "pam_unix\.so.*remember=" "${config_file}" ; then
-    sed -i "/pam_unix\.so/ s/\bremember=\S*//" "${config_file}"
-fi
+cat << EOF > /usr/share/pam-configs/unix
+Name: Unix authentication
+Default: yes
+Priority: 256
+Auth-Type: Primary
+Auth:
+        [success=end default=ignore]    pam_unix.so try_first_pass
+Auth-Initial:
+        [success=end default=ignore]    pam_unix.so
+Account-Type: Primary
+Account:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Account-Initial:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Session-Type: Additional
+Session:
+        required        pam_unix.so
+Session-Initial:
+        required        pam_unix.so
+Password-Type: Primary
+Password:
+        [success=end default=ignore]    pam_unix.so obscure use_authtok try_first_pass yescrypt
+Password-Initial:
+        [success=end default=ignore]    pam_unix.so obscure yescrypt
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/ubuntu_correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/ubuntu_correct_value.pass.sh
@@ -2,6 +2,22 @@
 # platform = multi_platform_ubuntu
 # variables = var_password_pam_unix_remember=5
 
-config_file=/etc/pam.d/common-password
+config_file=/usr/share/pam-configs/cac_unix
 remember_cnt=5
-sed -i "s/password.*pam_unix.so.*/password [success=1 default=ignore] pam_unix.so obscure sha512 shadow remember=${remember_cnt} rounds=5000/" "${config_file}"
+
+{{{ bash_pam_unix_enable() }}}
+sed -i -E '/^Password:/,/^[^[:space:]]/ {
+    /pam_unix\.so/ {
+        s/\s*remember=[^[:space:]]*//g
+        s/$/ remember='"$remember_cnt"'/g
+    }
+}' "$config_file"
+
+sed -i -E '/^Password-Initial:/,/^[^[:space:]]/ {
+    /pam_unix\.so/ {
+        s/\s*remember=[^[:space:]]*//g
+        s/$/ remember='"$remember_cnt"'/g
+    }
+}' "$config_file"
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/ubuntu_correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/ubuntu_correct_value.pass.sh
@@ -2,22 +2,34 @@
 # platform = multi_platform_ubuntu
 # variables = var_password_pam_unix_remember=5
 
-config_file=/usr/share/pam-configs/cac_unix
+config_file=/usr/share/pam-configs/tmpunix
 remember_cnt=5
 
-{{{ bash_pam_unix_enable() }}}
-sed -i -E '/^Password:/,/^[^[:space:]]/ {
-    /pam_unix\.so/ {
-        s/\s*remember=[^[:space:]]*//g
-        s/$/ remember='"$remember_cnt"'/g
-    }
-}' "$config_file"
-
-sed -i -E '/^Password-Initial:/,/^[^[:space:]]/ {
-    /pam_unix\.so/ {
-        s/\s*remember=[^[:space:]]*//g
-        s/$/ remember='"$remember_cnt"'/g
-    }
-}' "$config_file"
+cat << EOF > "$config_file"
+Name: Unix authentication
+Default: yes
+Priority: 256
+Auth-Type: Primary
+Auth:
+        [success=end default=ignore]    pam_unix.so try_first_pass
+Auth-Initial:
+        [success=end default=ignore]    pam_unix.so
+Account-Type: Primary
+Account:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Account-Initial:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Session-Type: Additional
+Session:
+        required        pam_unix.so
+Session-Initial:
+        required        pam_unix.so
+Password-Type: Primary
+Password:
+        [success=end default=ignore]    pam_unix.so obscure use_authtok try_first_pass yescrypt remember=$remember_cnt
+Password-Initial:
+        [success=end default=ignore]    pam_unix.so obscure yescrypt remember=$remember_cnt
+EOF
 
 DEBIAN_FRONTEND=noninteractive pam-auth-update
+rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/ubuntu_wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/ubuntu_wrong_value.fail.sh
@@ -2,7 +2,33 @@
 # platform = multi_platform_ubuntu
 # variables = var_password_pam_unix_remember=5
 
-config_file=/etc/pam.d/common-password
+config_file=/usr/share/pam-configs/unix
 remember_cnt=3
-sed -i "s/password.*pam_unix.so.*/password [success=1 default=ignore] pam_unix.so obscure sha512 shadow remember=${remember_cnt} rounds=5000/" "${config_file}"
 
+cat << EOF > "$config_file"
+Name: Unix authentication
+Default: yes
+Priority: 256
+Auth-Type: Primary
+Auth:
+        [success=end default=ignore]    pam_unix.so try_first_pass
+Auth-Initial:
+        [success=end default=ignore]    pam_unix.so
+Account-Type: Primary
+Account:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Account-Initial:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Session-Type: Additional
+Session:
+        required        pam_unix.so
+Session-Initial:
+        required        pam_unix.so
+Password-Type: Primary
+Password:
+        [success=end default=ignore]    pam_unix.so obscure use_authtok try_first_pass yescrypt remember=$remember_cnt
+Password-Initial:
+        [success=end default=ignore]    pam_unix.so obscure yescrypt remember=$remember_cnt
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/ubuntu_wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/ubuntu_wrong_value.fail.sh
@@ -2,7 +2,7 @@
 # platform = multi_platform_ubuntu
 # variables = var_password_pam_unix_remember=5
 
-config_file=/usr/share/pam-configs/unix
+config_file=/usr/share/pam-configs/tmpunix
 remember_cnt=3
 
 cat << EOF > "$config_file"
@@ -32,3 +32,4 @@ Password-Initial:
 EOF
 
 DEBIAN_FRONTEND=noninteractive pam-auth-update
+rm $config_file

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/bash/shared.sh
@@ -6,18 +6,30 @@
 PAM_FILE_PATH="/etc/pam.d/common-password"
 CONTROL="required"
 {{%- elif 'ubuntu' in product -%}}
-PAM_FILE_PATH="/etc/pam.d/common-password"
+{{{ bash_pam_unix_enable() }}}
+PAM_FILE_PATH=/usr/share/pam-configs/cac_unix
 {{%- else -%}}
 PAM_FILE_PATH="/etc/pam.d/system-auth"
 CONTROL="sufficient"
 {{%- endif %}}
 
 {{% if 'ubuntu' in product -%}}
-# Can't use macro bash_ensure_pam_module_configuration because the control
-# contains special characters and is not static ([success=N default=ignore)
-if ! grep -qP "^\s*password\s+.*\s+pam_unix.so\s+.*\b$var_password_hashing_algorithm_pam\b" "$PAM_FILE_PATH"; then
-  sed -i -E --follow-symlinks "/\s*password\s+.*\s+pam_unix.so.*/ s/$/ $var_password_hashing_algorithm_pam/" "$PAM_FILE_PATH"
+if ! grep -qzP "Password:\s*\n\s+.*\s+pam_unix.so\s+.*\b$var_password_hashing_algorithm_pam\b" "$PAM_FILE_PATH"; then
+  sed -i -E '/^Password:/,/^[^[:space:]]/ {
+    /pam_unix\.so/ {
+        s/$/ '"$var_password_hashing_algorithm_pam"'/g
+    }
+}' "$PAM_FILE_PATH"
 fi
+
+if ! grep -qzP "Password-Initial:\s*\n\s+.*\s+pam_unix.so\s+.*\b$var_password_hashing_algorithm_pam\b" "$PAM_FILE_PATH"; then
+  sed -i -E '/^Password-Initial:/,/^[^[:space:]]/ {
+    /pam_unix\.so/ {
+        s/$/ '"$var_password_hashing_algorithm_pam"'/g
+    }
+}' "$PAM_FILE_PATH"
+fi
+
 {{%- else -%}}
 {{{ bash_ensure_pam_module_configuration("$PAM_FILE_PATH", 'password', "$CONTROL", 'pam_unix.so', "$var_password_hashing_algorithm_pam", '', '') }}}
 {{%- endif %}}
@@ -27,8 +39,22 @@ declare -a HASHING_ALGORITHMS_OPTIONS=("sha512" "yescrypt" "gost_yescrypt" "blow
 
 for hash_option in "${HASHING_ALGORITHMS_OPTIONS[@]}"; do
   if [ "$hash_option" != "$var_password_hashing_algorithm_pam" ]; then
+    {{% if 'ubuntu' in product -%}}
+      sed -i -E '/^Password:/,/^[^[:space:]]/ {
+      /pam_unix\.so/ {
+        s/\s*'"$hash_option"'//g
+      }
+      }' "$PAM_FILE_PATH"
+      sed -i -E '/^Password-Initial:/,/^[^[:space:]]/ {
+      /pam_unix\.so/ {
+        s/\s*'"$hash_option"'//g
+      }
+      }' "$PAM_FILE_PATH"
+      DEBIAN_FRONTEND=noninteractive pam-auth-update
+    {{%- else -%}}
     if grep -qP "^\s*password\s+.*\s+pam_unix.so\s+.*\b$hash_option\b" "$PAM_FILE_PATH"; then
       {{{ bash_remove_pam_module_option_configuration("$PAM_FILE_PATH", 'password', ".*", 'pam_unix.so', "$hash_option") }}}
     fi
+    {{%- endif %}}
   fi
 done

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/oval/shared.xml
@@ -1,21 +1,21 @@
+{{% if product in ['sle12', 'sle15', 'slmicro5'] %}}
+  {{% set pam_file = "/etc/pam.d/common-password" %}}
+  {{% set line_pattern = "^[\s]*password[\s]+(?:(?:required))[\s]+pam_unix\.so[\s]+" %}}
+{{% elif 'ubuntu' in product %}}
+  {{% set pam_file = "/etc/pam.d/common-password" %}}
+  {{% set line_pattern = "^[\s]*password[\s]+(?:\[success=\d+\s+default=ignore\])[\s]+pam_unix\.so[\s]+" %}}
+{{% else %}}
+  {{% set pam_file = "/etc/pam.d/system-auth" %}}
+  {{% set line_pattern = "^[\s]*password[\s]+(?:(?:required)|(?:sufficient))[\s]+pam_unix\.so[\s]+" %}}
+{{% endif %}}
+
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="2">
-    {{{ oval_metadata("The password hashing algorithm should be set correctly in /etc/pam.d/system-auth.") }}}
+    {{{ oval_metadata("The password hashing algorithm should be set correctly in {{{ pam_file }}}.") }}}
     <criteria operator="AND">
       <criterion test_ref="test_pam_unix_hashing_algorithm_systemauth" />
     </criteria>
   </definition>
-
-  {{% if product in ['sle12', 'sle15', 'slmicro5'] %}}
-    {{% set pam_file = "/etc/pam.d/common-password" %}}
-    {{% set line_pattern = "^[\s]*password[\s]+(?:(?:required))[\s]+pam_unix\.so[\s]+" %}}
-  {{% elif 'ubuntu' in product %}}
-    {{% set pam_file = "/etc/pam.d/common-password" %}}
-    {{% set line_pattern = "^[\s]*password[\s]+(?:\[success=\d+\s+default=ignore\])[\s]+pam_unix\.so[\s]+" %}}
-  {{% else %}}
-    {{% set pam_file = "/etc/pam.d/system-auth" %}}
-    {{% set line_pattern = "^[\s]*password[\s]+(?:(?:required)|(?:sufficient))[\s]+pam_unix\.so[\s]+" %}}
-  {{% endif %}}
 
   {{% set pam_unix_algorithms = "\\b(sha512|yescrypt|gost_yescrypt|blowfish|sha256|md5|bigcrypt)\\b" %}}
   {{% set hashing_pattern = line_pattern + "(?!.*" + pam_unix_algorithms + "[^#]*" + pam_unix_algorithms + ")[^#]*" + pam_unix_algorithms + ".*$" %}}
@@ -37,13 +37,13 @@
 
   <ind:textfilecontent54_test id="test_pam_unix_hashing_algorithm_systemauth" version="2"
     check="all" check_existence="at_least_one_exists"
-    comment="check if pam_unix.so hashing algorithm option is correct and specified only once in /etc/pam.d/system-auth">
+    comment="check if pam_unix.so hashing algorithm option is correct and specified only once in {{{ pam_file }}}">
     <ind:object object_ref="object_pam_unix_hashing_algorithm_systemauth"/>
     <ind:state state_ref="state_pam_unix_hashing_algorithm_systemauth"/>
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_pam_unix_hashing_algorithm_systemauth" version="1"
-    comment="only one hashing algorithm option for pam_unix.so is found in /etc/pam.d/system-auth">
+    comment="only one hashing algorithm option for pam_unix.so is found in {{{ pam_file }}}">
     <ind:filepath>{{{ pam_file }}}</ind:filepath>
     <ind:pattern operation="pattern match">{{{ hashing_pattern }}}</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/oval/shared.xml
@@ -18,7 +18,7 @@
   {{% endif %}}
 
   {{% set pam_unix_algorithms = "(sha512|yescrypt|gost_yescrypt|blowfish|sha256|md5|bigcrypt)" %}}
-  {{% set hashing_pattern = line_pattern + "(?!.*" + pam_unix_algorithms + ".*" + pam_unix_algorithms + ").*" + pam_unix_algorithms + ".*$" %}}
+  {{% set hashing_pattern = line_pattern + "(?!.*" + pam_unix_algorithms + "[^#]*" + pam_unix_algorithms + ").*" + pam_unix_algorithms + ".*$" %}}
 
   <!--
     In addition to the pam file, what usually differ between products are the controls in the

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/oval/shared.xml
@@ -17,8 +17,8 @@
     {{% set line_pattern = "^[\s]*password[\s]+(?:(?:required)|(?:sufficient))[\s]+pam_unix\.so[\s]+" %}}
   {{% endif %}}
 
-  {{% set pam_unix_algorithms = "(sha512|yescrypt|gost_yescrypt|blowfish|sha256|md5|bigcrypt)" %}}
-  {{% set hashing_pattern = line_pattern + "(?!.*" + pam_unix_algorithms + "[^#]*" + pam_unix_algorithms + ").*" + pam_unix_algorithms + ".*$" %}}
+  {{% set pam_unix_algorithms = "\\b(sha512|yescrypt|gost_yescrypt|blowfish|sha256|md5|bigcrypt)\\b" %}}
+  {{% set hashing_pattern = line_pattern + "(?!.*" + pam_unix_algorithms + "[^#]*" + pam_unix_algorithms + ")[^#]*" + pam_unix_algorithms + ".*$" %}}
 
   <!--
     In addition to the pam file, what usually differ between products are the controls in the

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/commented_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/commented_value.fail.sh
@@ -3,7 +3,8 @@
 # variables = var_password_hashing_algorithm_pam=sha512
 # remediation = none
 
-cat << EOF > /usr/share/pam-configs/unix
+config_file=/usr/share/pam-configs/tmpunix
+cat << EOF > "$config_file"
 Name: Unix authentication
 Default: yes
 Priority: 256
@@ -29,3 +30,4 @@ Password-Initial:
         [success=end default=ignore]    pam_unix.so obscure # sha512
 EOF
 DEBIAN_FRONTEND=noninteractive pam-auth-update
+rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/commented_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/commented_value.fail.sh
@@ -3,5 +3,29 @@
 # variables = var_password_hashing_algorithm_pam=sha512
 # remediation = none
 
-sed -i --follow-symlinks '/^\s*password.*pam_unix\.so/ s/sha512//g' /etc/pam.d/common-password
-sed -i --follow-symlinks '/^\s*password.*pam_unix\.so/ s/$/ # sha512/' /etc/pam.d/common-password
+cat << EOF > /usr/share/pam-configs/unix
+Name: Unix authentication
+Default: yes
+Priority: 256
+Auth-Type: Primary
+Auth:
+        [success=end default=ignore]    pam_unix.so try_first_pass
+Auth-Initial:
+        [success=end default=ignore]    pam_unix.so
+Account-Type: Primary
+Account:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Account-Initial:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Session-Type: Additional
+Session:
+        required        pam_unix.so
+Session-Initial:
+        required        pam_unix.so
+Password-Type: Primary
+Password:
+        [success=end default=ignore]    pam_unix.so obscure use_authtok try_first_pass # sha512
+Password-Initial:
+        [success=end default=ignore]    pam_unix.so obscure # sha512
+EOF
+DEBIAN_FRONTEND=noninteractive pam-auth-update

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/correct.pass.sh
@@ -3,11 +3,32 @@
 # variables = var_password_hashing_algorithm_pam=sha512
 
 {{% if 'ubuntu' in product %}}
-pam_file="/etc/pam.d/common-password"
-
-if ! grep -q "^\s*password.*pam_unix\.so.*sha512" "$pam_file"; then
-	sed -i --follow-symlinks '/^\s*password.*pam_unix\.so/ s/$/ sha512/' "$pam_file"
-fi
+cat << EOF > /usr/share/pam-configs/unix
+Name: Unix authentication
+Default: yes
+Priority: 256
+Auth-Type: Primary
+Auth:
+        [success=end default=ignore]    pam_unix.so try_first_pass
+Auth-Initial:
+        [success=end default=ignore]    pam_unix.so
+Account-Type: Primary
+Account:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Account-Initial:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Session-Type: Additional
+Session:
+        required        pam_unix.so
+Session-Initial:
+        required        pam_unix.so
+Password-Type: Primary
+Password:
+        [success=end default=ignore]    pam_unix.so obscure use_authtok try_first_pass sha512
+Password-Initial:
+        [success=end default=ignore]    pam_unix.so obscure sha512
+EOF
+DEBIAN_FRONTEND=noninteractive pam-auth-update
 {{% else %}}
 pam_file="/etc/pam.d/system-auth"
 

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/correct.pass.sh
@@ -3,7 +3,8 @@
 # variables = var_password_hashing_algorithm_pam=sha512
 
 {{% if 'ubuntu' in product %}}
-cat << EOF > /usr/share/pam-configs/unix
+config_file=/usr/share/pam-configs/tmpunix
+cat << EOF > "$config_file"
 Name: Unix authentication
 Default: yes
 Priority: 256
@@ -29,6 +30,7 @@ Password-Initial:
         [success=end default=ignore]    pam_unix.so obscure sha512
 EOF
 DEBIAN_FRONTEND=noninteractive pam-auth-update
+rm "$config_file"
 {{% else %}}
 pam_file="/etc/pam.d/system-auth"
 

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/missing.fail.sh
@@ -3,7 +3,32 @@
 # variables = var_password_hashing_algorithm_pam=sha512
 
 {{% if 'ubuntu' in product %}}
-sed -i --follow-symlinks '/^\s*password.*pam_unix\.so/ s/sha512//g' "/etc/pam.d/common-password"
+cat << EOF > /usr/share/pam-configs/unix
+Name: Unix authentication
+Default: yes
+Priority: 256
+Auth-Type: Primary
+Auth:
+        [success=end default=ignore]    pam_unix.so try_first_pass
+Auth-Initial:
+        [success=end default=ignore]    pam_unix.so
+Account-Type: Primary
+Account:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Account-Initial:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Session-Type: Additional
+Session:
+        required        pam_unix.so
+Session-Initial:
+        required        pam_unix.so
+Password-Type: Primary
+Password:
+        [success=end default=ignore]    pam_unix.so obscure use_authtok try_first_pass
+Password-Initial:
+        [success=end default=ignore]    pam_unix.so obscure
+EOF
+DEBIAN_FRONTEND=noninteractive pam-auth-update
 {{% else %}}
 sed -i --follow-symlinks '/^password.*sufficient.*pam_unix\.so/ s/sha512//g' "/etc/pam.d/system-auth"
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/missing.fail.sh
@@ -3,7 +3,8 @@
 # variables = var_password_hashing_algorithm_pam=sha512
 
 {{% if 'ubuntu' in product %}}
-cat << EOF > /usr/share/pam-configs/unix
+config_file=/usr/share/pam-configs/tmpunix
+cat << EOF > "$config_file"
 Name: Unix authentication
 Default: yes
 Priority: 256
@@ -29,6 +30,7 @@ Password-Initial:
         [success=end default=ignore]    pam_unix.so obscure
 EOF
 DEBIAN_FRONTEND=noninteractive pam-auth-update
+rm "$config_file"
 {{% else %}}
 sed -i --follow-symlinks '/^password.*sufficient.*pam_unix\.so/ s/sha512//g' "/etc/pam.d/system-auth"
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/wrong_value_concat.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/wrong_value_concat.fail.sh
@@ -2,7 +2,8 @@
 # platform = multi_platform_ubuntu
 # variables = var_password_hashing_algorithm_pam=sha512
 
-cat << EOF > /usr/share/pam-configs/unix
+config_file=/usr/share/pam-configs/tmpunix
+cat << EOF > "$config_file"
 Name: Unix authentication
 Default: yes
 Priority: 256
@@ -28,3 +29,4 @@ Password-Initial:
         [success=end default=ignore]    pam_unix.so obscure sha5122
 EOF
 DEBIAN_FRONTEND=noninteractive pam-auth-update
+rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/wrong_value_concat.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/wrong_value_concat.fail.sh
@@ -2,5 +2,29 @@
 # platform = multi_platform_ubuntu
 # variables = var_password_hashing_algorithm_pam=sha512
 
-sed -i --follow-symlinks '/^\s*password.*pam_unix\.so/ s/sha512//g' /etc/pam.d/common-password
-sed -i --follow-symlinks '/^\s*password.*pam_unix\.so/ s/$/ sha5122/' /etc/pam.d/common-password
+cat << EOF > /usr/share/pam-configs/unix
+Name: Unix authentication
+Default: yes
+Priority: 256
+Auth-Type: Primary
+Auth:
+        [success=end default=ignore]    pam_unix.so try_first_pass
+Auth-Initial:
+        [success=end default=ignore]    pam_unix.so
+Account-Type: Primary
+Account:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Account-Initial:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Session-Type: Additional
+Session:
+        required        pam_unix.so
+Session-Initial:
+        required        pam_unix.so
+Password-Type: Primary
+Password:
+        [success=end default=ignore]    pam_unix.so obscure use_authtok try_first_pass sha5122
+Password-Initial:
+        [success=end default=ignore]    pam_unix.so obscure sha5122
+EOF
+DEBIAN_FRONTEND=noninteractive pam-auth-update

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/bash/shared.sh
@@ -12,7 +12,19 @@ for FILE in ${NULLOK_FILES}; do
 done
 {{% elif 'ubuntu' in product %}}
 {{{ bash_pam_unix_enable() }}}
-sed --follow-symlinks -i 's/\<nullok\>//g' /usr/share/pam-configs/cac_unix
+config_file="/usr/share/pam-configs/unix"
+sed -i -E '/^Password:/,/^[^[:space:]]/ {
+    /pam_unix\.so/ {
+        s/\s*nullok//g
+    }
+}' "$config_file"
+
+sed -i -E '/^Password-Initial:/,/^[^[:space:]]/ {
+    /pam_unix\.so/ {
+        s/\s*nullok//g
+    }
+}' "$config_file"
+
 DEBIAN_FRONTEND=noninteractive pam-auth-update
 {{% else %}}
 if [ -f /usr/bin/authselect ]; then

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/bash/shared.sh
@@ -11,8 +11,9 @@ for FILE in ${NULLOK_FILES}; do
    sed --follow-symlinks -i 's/\<nullok\>//g' ${FILE}
 done
 {{% elif 'ubuntu' in product %}}
-FILE="/etc/pam.d/common-password"
-sed -i 's/\(.*pam_unix\.so.*\)\s\<nullok\>\(.*\)/\1\2/g' ${FILE}
+{{{ bash_pam_unix_enable() }}}
+sed --follow-symlinks -i 's/\<nullok\>//g' /usr/share/pam-configs/cac_unix
+DEBIAN_FRONTEND=noninteractive pam-auth-update
 {{% else %}}
 if [ -f /usr/bin/authselect ]; then
     {{{ bash_enable_authselect_feature('without-nullok') }}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/bash/shared.sh
@@ -12,7 +12,7 @@ for FILE in ${NULLOK_FILES}; do
 done
 {{% elif 'ubuntu' in product %}}
 {{{ bash_pam_unix_enable() }}}
-config_file="/usr/share/pam-configs/unix"
+config_file="/usr/share/pam-configs/cac_unix"
 sed -i -E '/^Password:/,/^[^[:space:]]/ {
     /pam_unix\.so/ {
         s/\s*nullok//g

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -908,28 +908,22 @@ DEBIAN_FRONTEND=noninteractive pam-auth-update
 {{%- macro bash_pam_unix_enable() -%}}
 conf_name=cac_unix
 conf_path="/usr/share/pam-configs/"
-remediate=false
 
 if [ ! -f "$conf_path"/"$conf_name" ]; then
     if [ -f "$conf_path"/unix ]; then
-        if grep -q `md5sum "$conf_path"/unix | cut -d ' ' -f 1` /var/lib/dpkg/info/libpam-runtime.md5sums;then
+        if grep -q $(md5sum "$conf_path"/unix | cut -d ' ' -f 1) /var/lib/dpkg/info/libpam-runtime.md5sums;then
             cp "$conf_path/unix" "$conf_path/"$conf_name""
-            remediate=true
+            sed '/Default: yes/a Priority: 257\
+Conflicts: unix' "$conf_path"/"$conf_name"
+            DEBIAN_FRONTEND=noninteractive pam-auth-update
         else
-            echo "Not remediating - checksum of $conf_path/unix does not match the original." >&2
+            echo "Not applicable - checksum of $conf_path/unix does not match the original." >&2
         fi
     else
-        echo "Not remediating - $conf_path/unix does not exist" >&2
+        echo "Not applicable - $conf_path/unix does not exist" >&2
     fi
-else
-    remediate=true
 fi
 
-if [ $remediate = "true" ]; then
-    sed '/Default: yes/a Priority: 257\
-Conflicts: unix' "$conf_path"/"$conf_name"
-    DEBIAN_FRONTEND=noninteractive pam-auth-update
-fi
 {{%- endmacro -%}}
 
 

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -902,6 +902,45 @@ DEBIAN_FRONTEND=noninteractive pam-auth-update
 
 
 {{#
+    Enable pam_unix.so PAM module by using pam-auth-update.
+    This option is only recommended when pam-auth-update tool is available for the system.
+#}}
+{{%- macro bash_pam_unix_enable() -%}}
+conf_name=cac_unix
+if [ ! -f /usr/share/pam-configs/"$conf_name" ]; then
+    cat << EOF > /usr/share/pam-configs/"$conf_name"
+Name: Unix authentication
+Default: yes
+Priority: 257
+Conflicts: unix
+Auth-Type: Primary
+Auth:
+        [success=end default=ignore]    pam_unix.so try_first_pass
+Auth-Initial:
+        [success=end default=ignore]    pam_unix.so
+Account-Type: Primary
+Account:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Account-Initial:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Session-Type: Additional
+Session:
+        required        pam_unix.so
+Session-Initial:
+        required        pam_unix.so
+Password-Type: Primary
+Password:
+        [success=end default=ignore]    pam_unix.so obscure use_authtok try_first_pass yescrypt
+Password-Initial:
+        [success=end default=ignore]    pam_unix.so obscure yescrypt
+EOF
+fi
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update
+{{%- endmacro -%}}
+
+
+{{#
     Validate an authselect custom profile integrity and ensures the correct file path is defined
     in the "PAM_FILE_PATH" variable. The macros which change PAM files are the same regardless of
     using authselect or not. The only change is the file path. However, this file path can change

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -907,13 +907,13 @@ DEBIAN_FRONTEND=noninteractive pam-auth-update
 #}}
 {{%- macro bash_pam_unix_enable() -%}}
 conf_name=cac_unix
-conf_path="/usr/share/pam-configs/"
+conf_path="/usr/share/pam-configs"
 
 if [ ! -f "$conf_path"/"$conf_name" ]; then
     if [ -f "$conf_path"/unix ]; then
         if grep -q "$(md5sum "$conf_path"/unix | cut -d ' ' -f 1)" /var/lib/dpkg/info/libpam-runtime.md5sums;then
             cp "$conf_path"/unix "$conf_path"/"$conf_name"
-            sed '/Default: yes/a Priority: 257\
+            sed -i '/Default: yes/a Priority: 257\
 Conflicts: unix' "$conf_path"/"$conf_name"
             DEBIAN_FRONTEND=noninteractive pam-auth-update
         else

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -912,7 +912,7 @@ conf_path="/usr/share/pam-configs/"
 if [ ! -f "$conf_path"/"$conf_name" ]; then
     if [ -f "$conf_path"/unix ]; then
         if grep -q "$(md5sum "$conf_path"/unix | cut -d ' ' -f 1)" /var/lib/dpkg/info/libpam-runtime.md5sums;then
-            cp "$conf_path/unix" "$conf_path/"$conf_name""
+            cp "$conf_path"/unix "$conf_path"/"$conf_name"
             sed '/Default: yes/a Priority: 257\
 Conflicts: unix' "$conf_path"/"$conf_name"
             DEBIAN_FRONTEND=noninteractive pam-auth-update

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -907,36 +907,29 @@ DEBIAN_FRONTEND=noninteractive pam-auth-update
 #}}
 {{%- macro bash_pam_unix_enable() -%}}
 conf_name=cac_unix
-if [ ! -f /usr/share/pam-configs/"$conf_name" ]; then
-    cat << EOF > /usr/share/pam-configs/"$conf_name"
-Name: Unix authentication
-Default: yes
-Priority: 257
-Conflicts: unix
-Auth-Type: Primary
-Auth:
-	[success=end default=ignore]	pam_unix.so nullok try_first_pass
-Auth-Initial:
-	[success=end default=ignore]	pam_unix.so nullok
-Account-Type: Primary
-Account:
-	[success=end new_authtok_reqd=done default=ignore]	pam_unix.so
-Account-Initial:
-	[success=end new_authtok_reqd=done default=ignore]	pam_unix.so
-Session-Type: Additional
-Session:
-	required	pam_unix.so
-Session-Initial:
-	required	pam_unix.so
-Password-Type: Primary
-Password:
-	[success=end default=ignore]	pam_unix.so obscure use_authtok try_first_pass yescrypt
-Password-Initial:
-	[success=end default=ignore]	pam_unix.so obscure yescrypt
-EOF
+conf_path="/usr/share/pam-configs/"
+remediate=false
+
+if [ ! -f "$conf_path"/"$conf_name" ]; then
+    if [ -f "$conf_path"/unix ]; then
+        if grep -q `md5sum "$conf_path"/unix | cut -d ' ' -f 1` /var/lib/dpkg/info/libpam-runtime.md5sums;then
+            cp "$conf_path/unix" "$conf_path/"$conf_name""
+            remediate=true
+        else
+            echo "Not remediating - checksum of $conf_path/unix does not match the original." >&2
+        fi
+    else
+        echo "Not remediating - $conf_path/unix does not exist" >&2
+    fi
+else
+    remediate=true
 fi
 
-DEBIAN_FRONTEND=noninteractive pam-auth-update
+if [ $remediate = "true" ]; then
+    sed '/Default: yes/a Priority: 257\
+Conflicts: unix' "$conf_path"/"$conf_name"
+    DEBIAN_FRONTEND=noninteractive pam-auth-update
+fi
 {{%- endmacro -%}}
 
 

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -911,7 +911,7 @@ conf_path="/usr/share/pam-configs/"
 
 if [ ! -f "$conf_path"/"$conf_name" ]; then
     if [ -f "$conf_path"/unix ]; then
-        if grep -q $(md5sum "$conf_path"/unix | cut -d ' ' -f 1) /var/lib/dpkg/info/libpam-runtime.md5sums;then
+        if grep -q "$(md5sum "$conf_path"/unix | cut -d ' ' -f 1)" /var/lib/dpkg/info/libpam-runtime.md5sums;then
             cp "$conf_path/unix" "$conf_path/"$conf_name""
             sed '/Default: yes/a Priority: 257\
 Conflicts: unix' "$conf_path"/"$conf_name"

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -915,24 +915,24 @@ Priority: 257
 Conflicts: unix
 Auth-Type: Primary
 Auth:
-        [success=end default=ignore]    pam_unix.so try_first_pass
+	[success=end default=ignore]	pam_unix.so nullok try_first_pass
 Auth-Initial:
-        [success=end default=ignore]    pam_unix.so
+	[success=end default=ignore]	pam_unix.so nullok
 Account-Type: Primary
 Account:
-        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+	[success=end new_authtok_reqd=done default=ignore]	pam_unix.so
 Account-Initial:
-        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+	[success=end new_authtok_reqd=done default=ignore]	pam_unix.so
 Session-Type: Additional
 Session:
-        required        pam_unix.so
+	required	pam_unix.so
 Session-Initial:
-        required        pam_unix.so
+	required	pam_unix.so
 Password-Type: Primary
 Password:
-        [success=end default=ignore]    pam_unix.so obscure use_authtok try_first_pass yescrypt
+	[success=end default=ignore]	pam_unix.so obscure use_authtok try_first_pass yescrypt
 Password-Initial:
-        [success=end default=ignore]    pam_unix.so obscure yescrypt
+	[success=end default=ignore]	pam_unix.so obscure yescrypt
 EOF
 fi
 


### PR DESCRIPTION
#### Description:

- Create bash_pam_unix_enable macro
- Use pam-auth-update to remediate the accounts_password_pam_unix_remember and set_password_hashing_algorithm_systemauth
- In oval, change from any character (.) to non-comment character ([^#]) and add word boundary to pam_unix_algorithms

#### Rationale:

- Use pam-auth-update to dynamically remediate and test pam stack
- The original oval will fail if there is a algo name sha5122, so we need word boundary to constrain the pam_unix_algorithms pattern