### PR TITLE
Add rule for ubuntu2404 CIS control 4.4.3.2

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -1510,10 +1510,9 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    related_rules:
+    rules:
       - set_ipv6_loopback_traffic
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/3.5.3.3.2.
+    status: automated
 
   - id: 4.4.3.3
     title: Ensure ip6tables outbound and established connections are configured (Manual)

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_ipv6_loopback_traffic/sce/ubuntu.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_ipv6_loopback_traffic/sce/ubuntu.sh
@@ -7,15 +7,21 @@ if [ ! -e /proc/sys/net/ipv6/conf/all/disable_ipv6 ] || [ "$(cat /proc/sys/net/i
     exit "$XCCDF_RESULT_PASS"
 fi
 
-regex="\s+[0-9]+\s+[0-9]+\s+ACCEPT\s+all\s+lo\s+\*\s+::\/0\s+::\/0[[:space:]]+[0-9]+\s+[0-9]+\s+DROP\s+all\s+\*\s+\*\s+::1\s+::\/0"
+{{% if product in ['ubuntu2404'] %}}
+regex_input="\s+[0-9]+\s+[0-9]+\s+ACCEPT\s+[0-9]+\s+--\s+lo\s+\*\s+::\/0\s+::\/0[[:space:]]+[0-9]+\s+[0-9]+\s+DROP\s+[0-9]+\s+--\s+\*\s+\*\s+::1\s+::\/0"
+regex_output="\s[0-9]+\s+[0-9]+\s+ACCEPT\s+[0-9]+\s+--\s+\*\s+lo\s+::\/0\s+::\/0"
+{{% else %}}
+regex_input="\s+[0-9]+\s+[0-9]+\s+ACCEPT\s+all\s+lo\s+\*\s+::\/0\s+::\/0[[:space:]]+[0-9]+\s+[0-9]+\s+DROP\s+all\s+\*\s+\*\s+::1\s+::\/0"
+regex_output="\s[0-9]+\s+[0-9]+\s+ACCEPT\s+all\s+\*\s+lo\s+::\/0\s+::\/0"
+{{% endif %}}
 
 # Check chain INPUT for loopback related rules
-if ! ip6tables -L INPUT -v -n -x | grep -Ezq "$regex" ; then
+if ! ip6tables -L INPUT -v -n -x | grep -Ezq "$regex_input" ; then
     exit "$XCCDF_RESULT_FAIL"
 fi
 
  # Check chain OUTPUT for loopback related rules
-if ! ip6tables -L OUTPUT -v -n -x | grep -Eq "\s[0-9]+\s+[0-9]+\s+ACCEPT\s+all\s+\*\s+lo\s+::\/0\s+::\/0" ; then
+if ! ip6tables -L OUTPUT -v -n -x | grep -Eq "$regex_output"; then
     exit "$XCCDF_RESULT_FAIL"
 fi
 

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_ipv6_loopback_traffic/tests/correct.pass.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_ipv6_loopback_traffic/tests/correct.pass.sh
@@ -1,0 +1,8 @@
+# platform = multi_platform_ubuntu
+# packages = iptables,iptables-persistent
+
+apt purge -y nftables ufw
+
+ip6tables -A INPUT -i lo -j ACCEPT
+ip6tables -A OUTPUT -o lo -j ACCEPT
+ip6tables -A INPUT -s ::1 -j DROP

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_ipv6_loopback_traffic/tests/ipv6_disabled.pass.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_ipv6_loopback_traffic/tests/ipv6_disabled.pass.sh
@@ -1,0 +1,7 @@
+# platform = multi_platform_ubuntu
+# packages = iptables,iptables-persistent
+
+apt purge -y nftables ufw
+
+ip6tables -F
+sysctl net.ipv6.conf.all.disable_ipv6=1

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_ipv6_loopback_traffic/tests/wrong.fail.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_ipv6_loopback_traffic/tests/wrong.fail.sh
@@ -1,0 +1,7 @@
+# platform = multi_platform_ubuntu
+# remediation = none
+# packages = iptables,iptables-persistent
+
+apt purge -y nftables ufw
+
+ip6tables -F


### PR DESCRIPTION
#### Description:

- Add rule `set_ipv6_loopback_traffic` to ubuntu2404 CIS profile
- Add tests to `set_ipv6_loopback_traffic`
- Fix broken regex for Ubuntu 24.04

#### Notes

- Automatus tests pass locally in KVM, but fail in podman. Same reason as in https://github.com/ComplianceAsCode/content/pull/12659 .
```