### PR TITLE
Change applicability of RPM verification rules

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/group.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/group.yml
@@ -12,3 +12,5 @@ description: |-
     modification of important files. To list which files on the system differ from what is expected by the RPM database:
     <pre>$ rpm -qVa</pre>
     See the man page for <tt>rpm</tt> to see a complete explanation of each column.
+
+platform: not bootc


### PR DESCRIPTION
This commit changes applicability of rules in the `rpm_verification` group, ie. `rpm_verify_hashes`, `rpm_verify_ownership`, `rpm_verify_permissions`. These rules will not be applicable on bootable containers - both during the image build and on the running RHEL Image Mode systems. The reason is a large difference in permissions and hashes caused by `rpm-ostree`.

