### PR TITLE
Fix rule ip6tables_rules_for_open_ports and add to ubuntu2404 controls

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -1527,10 +1527,11 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    related_rules:
+    rules:
       - ip6tables_rules_for_open_ports
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/3.5.3.3.4.
+    status: automated
+    notes: |
+      Remediation is not automated to avoid lockout.
 
   - id: 5.1.1
     title: Ensure permissions on /etc/ssh/sshd_config are configured (Automated)

--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/ip6tables_rules_for_open_ports/sce/shared.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/ip6tables_rules_for_open_ports/sce/shared.sh
@@ -3,14 +3,14 @@
 # check-import = stdout
 
 result=$XCCDF_RESULT_PASS
-iptables_status="$(ip6tables -L INPUT -v -n)"
 
-while read -r lpn;
+iptables_status="$(ip6tables -S INPUT -v)"
+while read -r proto port;
 do
-        if ! grep -Pq "dpt:$lpn" <<< "$iptables_status"; then
-                result=$XCCDF_RESULT_FAIL
-                break
-        fi
-    done < <(ss -6tulnH | awk '($5!~/::1/) {n=split($5, a, ":"); print a[n]}' | sort -u)
+    if ! grep -Piq " \-p $proto .* \-\-dport(s)? [0-9,]*\b$port\b" <<< "$iptables_status"; then
+        result=$XCCDF_RESULT_FAIL
+        break
+    fi
+done < <(ss -6tulnH | awk '($5!~/::1/) {n=split($5, a, ":"); print $1, a[n]}' | sort -u)
 
-exit "$result"
+exit $result

--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/ip6tables_rules_for_open_ports/tests/correct.pass.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/ip6tables_rules_for_open_ports/tests/correct.pass.sh
@@ -1,0 +1,13 @@
+# platform = multi_platform_ubuntu
+# packages = iptables,iptables-persistent
+
+apt purge -y ufw nftables avahi-daemon
+
+# listen on port 5000 and set rules for a few ports including the open ports 22 and 5000
+nohup nc -6ul 5000 &>/dev/null &
+ip6tables -A INPUT -p tcp --dport 22 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
+ip6tables -A INPUT -p tcp --dport 222 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
+ip6tables -A INPUT -p udp --dport 5000 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
+ip6tables -A INPUT -p udp --dport 15000 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
+ip6tables -A INPUT -p udp --dport 50000 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
+

--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/ip6tables_rules_for_open_ports/tests/correct_multiport.pass.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/ip6tables_rules_for_open_ports/tests/correct_multiport.pass.sh
@@ -1,0 +1,9 @@
+# platform = multi_platform_ubuntu
+# packages = iptables,iptables-persistent
+
+apt purge -y ufw nftables avahi-daemon
+
+# listen on port 5000 and set rules for a few ports including the open ports 22 and 5000
+nohup nc -6l 5000 &>/dev/null &
+ip6tables -A INPUT -p tcp --match multiport --dport 22,222,5000,15000,50000 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
+

--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/ip6tables_rules_for_open_ports/tests/missing.fail.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/ip6tables_rules_for_open_ports/tests/missing.fail.sh
@@ -1,0 +1,13 @@
+# platform = multi_platform_ubuntu
+# packages = iptables,iptables-persistent
+
+apt purge -y ufw nftables avahi-daemon
+
+# listen on port 5000 and set rules for a few ports, not including the open ports 22 and 5000
+nohup nc -6ul 5000 &>/dev/null &
+#ip6tables -A INPUT -p tcp --dport 22 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
+ip6tables -A INPUT -p tcp --dport 222 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
+#ip6tables -A INPUT -p udp --dport 5000 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
+ip6tables -A INPUT -p udp --dport 15000 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
+ip6tables -A INPUT -p udp --dport 50000 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
+

--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/ip6tables_rules_for_open_ports/tests/missing_multiport.fail.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/ip6tables_rules_for_open_ports/tests/missing_multiport.fail.sh
@@ -1,0 +1,9 @@
+# platform = multi_platform_ubuntu
+# packages = iptables,iptables-persistent
+
+apt purge -y ufw nftables avahi-daemon
+
+# listen on port 5000 and set rules for a few ports, not including the open ports 22 and 5000
+nohup nc -6l 5000 &>/dev/null &
+ip6tables -A INPUT -p tcp --match multiport --dport 222,15000,50000 -m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT
+


### PR DESCRIPTION
#### Description:

- Fixed sce for rule `ip6tables_rules_for_open_ports` to also consider the protocol of the open port (tcp/udp) and match on rules which use `--multiport`.
- Added tests for rule
- Added rule to Ubuntu 24.04 CIS control 4.4.3.4 (Ensure ip6tables firewall rules exist for all open ports)

#### Rationale:

- The sce incorrectly passed when an ip6tables rule was defined for the open port but with the wrong protocol.
- The sce was also improved to match ip6tables rules where ports are defined with --multiport.

#### Notes:
- Automatus tests pass locally in KVM, but fail in podman. Same reason as in https://github.com/ComplianceAsCode/content/pull/12659 .