### PR TITLE
Add rules and vars to ubuntu2404 CIS control 5.1.16

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -1684,11 +1684,10 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    related_rules:
+    rules:
       - sshd_max_auth_tries_value=4
       - sshd_set_max_auth_tries
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/5.2.18.
+    status: automated
 
   - id: 5.1.17
     title: Ensure sshd MaxSessions is configured (Automated)

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/tests/correct_value_equals.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/tests/correct_value_equals.pass.sh
@@ -1,0 +1,9 @@
+# platform = multi_platform_all
+# variables = sshd_max_auth_tries_value=4
+SSHD_CONFIG="/etc/ssh/sshd_config"
+
+if grep -q "^MaxAuthTries" $SSHD_CONFIG; then
+	sed -i "s/^MaxAuthTries.*/MaxAuthTries 4/" $SSHD_CONFIG
+else
+	echo "MaxAuthTries 4" >> $SSHD_CONFIG
+fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/tests/wrong_value_less_than_0.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/tests/wrong_value_less_than_0.fail.sh
@@ -1,0 +1,9 @@
+# platform = multi_platform_all
+# variables = sshd_max_auth_tries_value=4
+SSHD_CONFIG="/etc/ssh/sshd_config"
+
+if grep -q "^MaxAuthTries" $SSHD_CONFIG; then
+	sed -i "s/^MaxAuthTries.*/MaxAuthTries 0/" $SSHD_CONFIG
+else
+	echo "MaxAuthTries 0" >> $SSHD_CONFIG
+fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/tests/wrong_value_more_than.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/tests/wrong_value_more_than.fail.sh
@@ -1,0 +1,9 @@
+# platform = multi_platform_all
+# variables = sshd_max_auth_tries_value=4
+SSHD_CONFIG="/etc/ssh/sshd_config"
+
+if grep -q "^MaxAuthTries" $SSHD_CONFIG; then
+	sed -i "s/^MaxAuthTries.*/MaxAuthTries 1000/" $SSHD_CONFIG
+else
+	echo "MaxAuthTries 1000" >> $SSHD_CONFIG
+fi


### PR DESCRIPTION
#### Description:

- Add rules and vars to Ubuntu 24.04 CIS control 5.1.16 (Ensure sshd MaxAuthTries is configured)
- Extend tests for rule `sshd_set_max_auth_tries` to test the logic that is unique to the rule