### PR TITLE
Add rules to ubuntu2404 CIS control 5.1.18

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -1705,11 +1705,10 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    related_rules:
+    rules:
       - var_sshd_set_maxstartups=10:30:60
       - sshd_set_maxstartups
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/5.2.19.
+    status: automated
 
   - id: 5.1.19
     title: Ensure sshd PermitEmptyPasswords is disabled (Automated)

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/tests/lenient_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/tests/lenient_value.fail.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-# variables = var_sshd_set_maxstartups=10:30:60
-
-if grep -q "^MaxStartups" /etc/ssh/sshd_config; then
-	sed -i "s/^MaxStartups.*/MaxStartups 10:30:60/" /etc/ssh/sshd_config
-else
-	echo "MaxStartups 20:40:60" >> /etc/ssh/sshd_config
-fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/tests/lenient_value_full.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/tests/lenient_value_full.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# variables = var_sshd_set_maxstartups=10:30:60
+
+if grep -q "^MaxStartups" /etc/ssh/sshd_config; then
+	sed -i "s/^MaxStartups.*/MaxStartups 10:30:59/" /etc/ssh/sshd_config
+else
+	echo "MaxStartups 10:30:59" >> /etc/ssh/sshd_config
+fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/tests/lenient_value_rate.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/tests/lenient_value_rate.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# variables = var_sshd_set_maxstartups=10:30:60
+
+if grep -q "^MaxStartups" /etc/ssh/sshd_config; then
+	sed -i "s/^MaxStartups.*/MaxStartups 10:29:60/" /etc/ssh/sshd_config
+else
+	echo "MaxStartups 10:29:60" >> /etc/ssh/sshd_config
+fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/tests/lenient_value_start.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/tests/lenient_value_start.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# variables = var_sshd_set_maxstartups=10:30:60
+
+if grep -q "^MaxStartups" /etc/ssh/sshd_config; then
+	sed -i "s/^MaxStartups.*/MaxStartups 11:30:60/" /etc/ssh/sshd_config
+else
+	echo "MaxStartups 11:30:60" >> /etc/ssh/sshd_config
+fi


### PR DESCRIPTION
#### Description:

- Add rules to Ubuntu 24.04 CIS control 5.1.18 (Ensure sshd MaxStartups is configured)
- Extend tests for rule `sshd_set_maxstartups` to test the logic that is unique to the rule