### PR TITLE
Fix CentOS Stream 10 applicability check

### DIFF
--- a/shared/checks/oval/installed_OS_is_centos10.xml
+++ b/shared/checks/oval/installed_OS_is_centos10.xml
@@ -38,7 +38,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_version_centos10" version="1" comment="Check os-release VERSION_ID">
     <ind:filepath>/etc/os-release</ind:filepath>
-    <ind:pattern operation="pattern match">^VERSION_ID=&quot;(\d)&quot;$</ind:pattern>
+    <ind:pattern operation="pattern match">^VERSION_ID=&quot;(\d+)&quot;$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_state id="state_version_centos10" version="1">


### PR DESCRIPTION
The VERSION_ID on CS10 is "10", so we need to match multiple digits in our regular expression.

