### PR TITLE
Fix audit access rules in ISM_O

### DIFF
--- a/products/rhel9/profiles/e8.profile
+++ b/products/rhel9/profiles/e8.profile
@@ -95,6 +95,7 @@ selections:
   ### Audit
   - package_rsyslog_installed
   - service_rsyslog_enabled
+  - package_audit_installed
   - service_auditd_enabled
   - var_auditd_flush=incremental_async
   - auditd_data_retention_flush


### PR DESCRIPTION
The rules `audit_access_failed` and `audit_access_success` fail after building and booting a CentOS Stream 9 hardened container image with the `ism_o` profile. The reason is that the remediation fails to create the files required by these rules because the package `audit` that provides the directory `/etc/audit/rules.d` where these files should be created isn't installed by default. The solution is to install the `audit` package as a part of the profile remediation.

