### PR TITLE
Improve regex in sudo_defaults_option oval

### DIFF
--- a/linux_os/guide/system/software/sudo/sudo_add_use_pty/tests/use_pty_disabled.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_add_use_pty/tests/use_pty_disabled.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = multi_platform_all
+# packages = sudo
+
+sed '/Defaults.*use_pty/ s/.*/#&/g' -i /etc/sudoers /etc/sudoers.d/*
+echo "Defaults !use_pty" >> /etc/sudoers.d/enable_use_pty

--- a/shared/templates/sudo_defaults_option/oval.template
+++ b/shared/templates/sudo_defaults_option/oval.template
@@ -13,7 +13,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_{{{ OPTION }}}_sudoers" version="1">
     <ind:filepath operation="pattern match">^/etc/sudoers(|\.d/.*)$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*Defaults[\s]*\b{{{ OPTION_REGEX }}}.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*Defaults[\s]*[^!]\b{{{ OPTION_REGEX }}}.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal" >1</ind:instance>
   </ind:textfilecontent54_object>
 


### PR DESCRIPTION
#### Description:

- Improve regex in `sudo_defaults_option` template oval

#### Rationale:

- The oval now fails if the sudo defaults option is preceeded by a '!' character (negated option).
