### PR TITLE
Add new rule journald_disable_forward_to_syslog

### DIFF
--- a/components/systemd.yml
+++ b/components/systemd.yml
@@ -23,6 +23,7 @@ rules:
 - file_permissions_system_journal
 - journald_compress
 - journald_forward_to_syslog
+- journald_disable_forward_to_syslog
 - journald_storage
 - package_systemd-journal-remote_installed
 - package_timesyncd_installed

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2278,8 +2278,9 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented. Analogous to ubuntu2204/4.2.1.5.
+    rules:
+      - journald_disable_forward_to_syslog
+    status: automated
 
   - id: 6.1.2.3
     title: Ensure journald Compress is configured (Automated)

--- a/linux_os/guide/system/logging/journald/journald_disable_forward_to_syslog/rule.yml
+++ b/linux_os/guide/system/logging/journald/journald_disable_forward_to_syslog/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+title: Ensure journald ForwardToSyslog is disabled
+
+description: |-
+    Data from journald should be kept in the confines of the service and not forwarded to other services.
+
+rationale:
+    If journald is the method for capturing logs, all logs of the system should be
+    handled by journald and not forwarded to other logging mechanisms.
+
+platform: package[systemd]
+
+severity: medium
+
+{{%- if product in ["rhel8", "rhel9", "sle15"] %}}
+template:
+    name: systemd_dropin_configuration
+    vars:
+        master_cfg_file: /etc/systemd/journald.conf
+        dropin_dir: {{{ journald_conf_dir_path }}}
+        section: Journal
+        param: ForwardToSyslog
+        value: no
+        no_quotes: 'true'
+{{% else %}}
+template:
+    name: shell_lineinfile
+    vars:
+        path: /etc/systemd/journald.conf
+        parameter: ForwardToSyslog
+        value: no
+        no_quotes: 'true'
+{{% endif -%}}


### PR DESCRIPTION
#### Description:

- satisfies Ubuntu 24.04 CIS control 6.1.2.2 (Ensure journald ForwardToSyslog is disabled)
- based on journal_forward_to_syslog

#### Notes:

- rule is not applicable in podman
- all tests are passing locally in KVM 