### PR TITLE
restore petalinux detection

### DIFF
--- a/shared/checks/oval/installed_OS_is_petalinux.xml
+++ b/shared/checks/oval/installed_OS_is_petalinux.xml
@@ -26,7 +26,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_petalinux" version="1" comment="Check Petalinux">
     <ind:filepath>/etc/os-release</ind:filepath>
-    <ind:pattern operation="pattern match">^ID=&quot;petalinux&quot;$</ind:pattern>
+    <ind:pattern operation="pattern match">^ID=petalinux$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 


### PR DESCRIPTION
#### Description:

- Fix petalinux OS check

#### Rationale:

- required for OS scan applicability

- Fixes broken regex

#### Review Hints:

- Sadly I have no idea where the cruft crept in; previously my patch was fine.
