### PR TITLE
Ubuntu 24.04 CIS section 6.1.2.1.3 Ensure systemd-journal-upload is enabled and active

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2260,7 +2260,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
+    status: automated
     rules:
       - service_systemd-journal-upload_enabled
 

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2261,7 +2261,8 @@ controls:
       - l1_server
       - l1_workstation
     status: planned
-    notes: TODO. Rule does not seem to be implemented. Analogous to ubuntu2204/4.2.1.1.3.
+    rules:
+      - service_systemd-journal-upload_enabled
 
   - id: 6.1.2.1.4
     title: Ensure systemd-journal-remote service is not in use (Automated)

--- a/tests/data/product_stability/ubuntu2404.yml
+++ b/tests/data/product_stability/ubuntu2404.yml
@@ -60,7 +60,6 @@ platform_package_overrides:
   shadow: login
   sssd: sssd-common
   sssd-ldap: null
-  systemd-journal-upload: systemd-journal-remote
   uefi: null
   zipl: s390utils-base
 product: ubuntu2404

--- a/tests/data/product_stability/ubuntu2404.yml
+++ b/tests/data/product_stability/ubuntu2404.yml
@@ -60,6 +60,7 @@ platform_package_overrides:
   shadow: login
   sssd: sssd-common
   sssd-ldap: null
+  systemd-journal-upload: systemd-journal-remote
   uefi: null
   zipl: s390utils-base
 product: ubuntu2404


### PR DESCRIPTION
#### Description:

Ubuntu 24.04 CIS section 6.1.2.1.3 Ensure systemd-journal-upload is enabled and active

#### Rationale:

- Implement Ensure systemd-journal-upload is enabled and active for Ubuntu 24.04

