### PR TITLE
Add python3-apt to ubuntu2404 dockerfile

### DIFF
--- a/Dockerfiles/test_suite-ubuntu2404
+++ b/Dockerfiles/test_suite-ubuntu2404
@@ -4,6 +4,7 @@ FROM ubuntu:24.04
 ENV AUTH_KEYS=/root/.ssh/authorized_keys
 
 ARG CLIENT_PUBLIC_KEY
+ARG ADDITIONAL_PACKAGES
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install Python so Ansible remediations can work
@@ -11,7 +12,9 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN true \
         && apt update \
         && apt install -y openscap-utils openscap-scanner \
-        && apt install -y openssh-server
+                          openssh-server python3 python3-apt \
+                          $ADDITIONAL_PACKAGES \
+        && true
 
 RUN true \
         && ssh-keygen -A \


### PR DESCRIPTION
#### Description:

- Add python3-apt to ubuntu2404 dockerfile to enable ansible remediations in tests

#### Rationale:

- ansible remediations were failing in Ubuntu 24.04 automatus tests with error: 
> Could not detect a supported package manager from the following list: ['portage', 'pacman', 'rpm', 'apk', 'pkg', 'apt', 'pkg_info', 'dnf', 'dnf5', 'yum', 'zypper', 'pkg5', 'pkgng', 'openbsd_pkg'], or the required Python library is not installed.
