### PR TITLE
ensure_logrotate_activated: Check timers.target.wants as well

### DIFF
--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/oval/shared.xml
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/oval/shared.xml
@@ -12,7 +12,7 @@
       <criteria comment="Check if either logrotate timer or cron job is enabled" operator="OR">
         <criterion comment="Check if /etc/cron.daily/logrotate file exists (and calls logrotate)" test_ref="test_cron_daily_logrotate_existence" />
 {{% if product in ["rhcos4", "rhel9", "rhel10", "sle12", "sle15", "ol9"] %}}
-        <criterion comment="Check if logrotate timer is enabled" test_ref="test_logrotate_enabled_multi_user_target" />
+        <criterion comment="Check if logrotate timer is enabled" test_ref="test_logrotate_enabled_systemd_target" />
 {{% endif %}}
       </criteria>
     </criteria>
@@ -56,14 +56,14 @@
 
 {{% if product in ["rhcos4", "rhel9", "rhel10", "sle12", "sle15", "ol9"] %}}
   <unix:file_test check="all" check_existence="all_exist"
-   comment="look for logrotate.timer in /etc/systemd/system/multi-user.target.wants"
-   id="test_logrotate_enabled_multi_user_target" version="1">
-    <unix:object object_ref="object_logrotate_enabled_multi_user_target" />
+   comment="look for logrotate.timer in multi-user.target.wants and timers.target.wants"
+   id="test_logrotate_enabled_systemd_target" version="1">
+    <unix:object object_ref="object_logrotate_enabled_systemd_target" />
   </unix:file_test>
 
-  <unix:file_object comment="look for logrotate.timer in /etc/systemd/system/multi-user.target.wants"
-   id="object_logrotate_enabled_multi_user_target" version="1">
-    <unix:filepath>/etc/systemd/system/multi-user.target.wants/logrotate.timer</unix:filepath>
+  <unix:file_object comment="look for logrotate.timer in /etc/systemd/system/multi-user.target.wants and /etc/systemd/system/timers.target.wants"
+   id="object_logrotate_enabled_systemd_target" version="1">
+    <unix:filepath operation="pattern match">^/etc/systemd/system/(multi-user|timers)\.target\.wants/logrotate\.timer$</unix:filepath>
     <filter action="include">unit_logrotate_state_symlink</filter>
   </unix:file_object>
 


### PR DESCRIPTION
#### Description:

- Expand check to also verify `systemd timers.target.wants` directory. Some systems may not have `logrotate.timers` defined in `multi-user.target.wants`.

#### Rationale:

- RHCOS4 has `logrotate.timers` included in `timers.target.wants` by default.
- From what I could check RHEL9 defines like that too.
- Fixes our CI runs: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-ComplianceAsCode-content-master-4.17-e2e-aws-rhcos4-high-weekly/1864452299477225472
```
    helpers.go:872: Result - Name: e2e-high-master-ensure-logrotate-activated - Status: FAIL - Severity: medium
    helpers.go:879: E2E-FAILURE: The expected remediated result for the e2e-high-master-ensure-logrotate-activated rule didn't match. Expected 'PASS', Got 'FAIL' 
```
- Follow up from: https://github.com/ComplianceAsCode/content/pull/12645

#### Review Hints:

- Check that tests pass, :P

#### Additional information:
Debugging a 4.17 node:
```console
sh-5.1# cat /etc/redhat-release 
Red Hat Enterprise Linux CoreOS release 4.17
sh-5.1# 
sh-5.1# file /etc/systemd/system/timers.target.wants/logrotate.timer
/etc/systemd/system/timers.target.wants/logrotate.timer: symbolic link to /usr/lib/systemd/system/logrotate.timer
sh-5.1# 
sh-5.1# file /etc/systemd/system/multi-user.target.wants/logrotate.timer
/etc/systemd/system/multi-user.target.wants/logrotate.timer: cannot open `/etc/systemd/system/multi-user.target.wants/logrotate.timer' (No such file or directory)
```

On 1minutetip machine:
```console
[root@vm-10-0-186-171 ~]# cat /etc/redhat-release 
Red Hat Enterprise Linux release 9.6 Beta (Plow)
[root@vm-10-0-186-171 ~]# 
[root@vm-10-0-186-171 ~]# file /etc/systemd/system/timers.target.wants/logrotate.timer
/etc/systemd/system/timers.target.wants/logrotate.timer: symbolic link to /usr/lib/systemd/system/logrotate.timer
[root@vm-10-0-186-171 ~]# 
[root@vm-10-0-186-171 ~]# file /etc/systemd/system/multi-user.target.wants/logrotate.timer
/etc/systemd/system/multi-user.target.wants/logrotate.timer: cannot open `/etc/systemd/system/multi-user.target.wants/logrotate.timer' (No such file or directory)
```

- https://www.freedesktop.org/software/systemd/man/latest/bootup.html