### PR TITLE
Enable bash remediation template for slmicro platforms

### DIFF
--- a/shared/templates/service_disabled/bash.template
+++ b/shared/templates/service_disabled/bash.template
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle,multi_platform_slmicro,multi_platform_ubuntu
 # reboot = false
 # strategy = disable
 # complexity = low


### PR DESCRIPTION
#### Description:

- Bash remediation template for service disabled is needed and supported also for SLE Micro platforms

#### Rationale:

- Enable the multi_platform_slmicro in service_disabled  bash template
