### PR TITLE
Fixing rule checks for CMP-3034

### DIFF
--- a/applications/openshift/confinement/security_profiles_operator_exists/rule.yml
+++ b/applications/openshift/confinement/security_profiles_operator_exists/rule.yml
@@ -20,20 +20,20 @@ ocil_clause: 'the security profiles operator is not installed'
 
 ocil: |-
   To check if the Security Profiles Operator is installed, run the following command:
-  <pre>oc get sub -nopenshift-security-profiles security-profiles-operator-sub -ojsonpath='{.status.installedCSV}'</pre>
+  <pre>oc get sub -nopenshift-security-profiles security-profiles-operator -ojsonpath='{.status.installedCSV}'</pre>
   the output should return the version of the CSV that represents the installed operator.
 
 severity: medium
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/apis/operators.coreos.com/v1alpha1/namespaces/openshift-security-profiles/subscriptions/security-profiles-operator-sub") | indent(4) }}}
+    {{{ openshift_cluster_setting("/apis/operators.coreos.com/v1alpha1/namespaces/openshift-security-profiles/subscriptions/security-profiles-operator") | indent(4) }}}
 
 template:
     name: yamlfile_value
     vars:
       ocp_data: 'true'
-      filepath: /apis/operators.coreos.com/v1alpha1/namespaces/openshift-security-profiles/subscriptions/security-profiles-operator-sub
+      filepath: /apis/operators.coreos.com/v1alpha1/namespaces/openshift-security-profiles/subscriptions/security-profiles-operator
       yamlpath: .status.installedCSV
       values:
       - value: security-profiles-operator\.v.*

--- a/applications/openshift/confinement/security_profiles_operator_exists/tests/ocp4/e2e-remediation.sh
+++ b/applications/openshift/confinement/security_profiles_operator_exists/tests/ocp4/e2e-remediation.sh
@@ -16,6 +16,6 @@ oc wait -n openshift-security-profiles --for=condition=Available  --timeout=300s
     deployment/security-profiles-operator
 
 echo "waiting the subscription to have .status.installedCSV"
-while [ -z "$(oc get subscription security-profiles-operator-sub -nopenshift-security-profiles -o jsonpath='{.status.installedCSV}')" ]; do
+while [ -z "$(oc get subscription security-profiles-operator -nopenshift-security-profiles -o jsonpath='{.status.installedCSV}')" ]; do
     sleep 3
 done


### PR DESCRIPTION
#### Description:

The PCI-DSS compliance rule `ocp4-security-profiles-operator-exists` is not able to check existence of subscription object due to an extra suffix `-sub` in the command `oc get subscription security-profiles-operator-sub -nopenshift-security-profiles -o jsonpath='{.status.installedCSV}'`, as well inside filepath: `/apis/operators.coreos.com/v1alpha1/namespaces/openshift-security-profiles-sub/subscriptions/`

#### Rationale:
Fixes [CMP-3034](https://issues.redhat.com/browse/CMP-3034)

#### Review Hints:
1. Install compliance-operator v1.6.0
2. Run `ocp4-pci-dss-4-0/ocp4-pci-dss` profile scan
3. Check the CCR for failed rule `ocp4-security-profiles-operator-exists`
4. Install the security-profile-operator to remediate this rule.
5.  re-run the compliance scan
6.  The CCR would still show FAIL status for rule `ocp4-security-profiles-operator-exists`