### PR TITLE
Ubuntu 24.04 1.1.1.2 Ensure freevxfs kernel module is not available

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -30,9 +30,10 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
-
+    rules:
+      - kernel_module_freevxfs_disabled
+    status: automated
+    
   - id: 1.1.1.3
     title: Ensure hfs kernel module is not available (Automated)
     levels:


### PR DESCRIPTION
#### Description:

- Ensure freevxfs kernel module is not available

#### Rationale:

- Implement Ensure freevxfs kernel module is not available

