### PR TITLE
Ubuntu 24.04 1.1.1.3 Ensure hfs kernel module is not available

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -38,8 +38,9 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    rules:
+      - kernel_module_hfs_disabled
+    status: automated
 
   - id: 1.1.1.4
     title: Ensure hfsplus kernel module is not available (Automated)


### PR DESCRIPTION
#### Description:

- Ensure hfs kernel module is not available

#### Rationale:

- Implement Ensure hfs kernel module is not available


