### PR TITLE
Ubuntu 24.04 1.1.1.4 Ensure hfsplus kernel module is not available

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -46,8 +46,9 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    rules:
+      - kernel_module_hfsplus_disabled
+    status: automated
 
   - id: 1.1.1.5
     title: Ensure jffs2 kernel module is not available (Automated)


### PR DESCRIPTION
#### Description:

- Ensure hfsplus kernel module is not available

#### Rationale:

- Implement Ensure hfsplus kernel module is not available
