### PR TITLE
Ubuntu 24.04 1.1.1.5 Ensure jffs2 kernel module is not available

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -54,8 +54,9 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    rules:
+      - kernel_module_jffs2_disabled
+    status: automated
 
   - id: 1.1.1.6
     title: Ensure overlayfs kernel module is not available (Automated)


### PR DESCRIPTION
#### Description:

- Ensure jffs2 kernel module is not available

#### Rationale:

- Implement Ensure jffs2 kernel module is not available
