### PR TITLE
Ubuntu 24.04 1.1.1.6 Ensure overlayfs kernel module is not available

### DIFF
--- a/components/kernel.yml
+++ b/components/kernel.yml
@@ -110,6 +110,7 @@ rules:
 - kernel_module_iwlwifi_disabled
 - kernel_module_jffs2_disabled
 - kernel_module_mac80211_disabled
+- kernel_module_overlayfs_disabled
 - kernel_module_rds_disabled
 - kernel_module_sctp_disabled
 - kernel_module_squashfs_disabled

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -62,8 +62,9 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    rules:
+      - kernel_module_overlayfs_disabled
+    status: automated
 
   - id: 1.1.1.7
     title: Ensure squashfs kernel module is not available (Automated)

--- a/linux_os/guide/system/permissions/mounting/kernel_module_overlayfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_overlayfs_disabled/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+title: 'Ensure overlayfs kernel module is not available'
+
+description: |-
+    {{{ describe_module_disable(module="overlayfs") }}}
+    overlayfs is a Linux filesystem that layers multiple filesystems to create a single
+    unified view which allows a user to "merge" several mount points into a unified
+    filesystem.
+
+rationale: |-
+    The overlayfs has known CVE's. Disabling the overlayfs reduces the local attack 
+    surface by removing support for unnecessary filesystem types and mitigates potential
+    risks associated with unauthorized execution of setuid files, enhancing the overall
+    system security.
+
+severity: low
+
+platform: system_with_kernel
+
+template:
+    name: kernel_module_disabled
+    vars:
+        kernmodule: overlayfs


### PR DESCRIPTION
#### Description:

- Ensure overlayfs kernel module is not available

#### Rationale:

- Implement Ensure overlayfs kernel module is not available
