### PR TITLE
Implement rules for /etc/security/opasswd permissions 

### DIFF
--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -34,6 +34,8 @@ rules:
 - file_groupowner_etc_group
 - file_groupowner_etc_gshadow
 - file_groupowner_etc_passwd
+- file_groupowner_etc_security_opasswd
+- file_groupowner_etc_security_opasswd_old
 - file_groupowner_etc_shadow
 - file_groupowner_etc_shells
 - file_groupowner_systemmap
@@ -50,6 +52,8 @@ rules:
 - file_owner_etc_group
 - file_owner_etc_gshadow
 - file_owner_etc_passwd
+- file_owner_etc_security_opasswd
+- file_owner_etc_security_opasswd_old
 - file_owner_etc_shells
 - file_owner_etc_shadow
 - file_owner_systemmap
@@ -72,6 +76,8 @@ rules:
 - file_permissions_etc_group
 - file_permissions_etc_gshadow
 - file_permissions_etc_passwd
+- file_permissions_etc_security_opasswd
+- file_permissions_etc_security_opasswd_old
 - file_permissions_etc_shadow
 - file_permissions_etc_shells
 - file_permissions_library_dirs
@@ -151,3 +157,4 @@ templates:
 - mount_option
 - mount_option_remote_filesystems
 - mount_option_removable_partitions
+

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2939,8 +2939,14 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    rules:
+      - file_owner_etc_security_opasswd
+      - file_groupowner_etc_security_opasswd
+      - file_permissions_etc_security_opasswd
+      - file_owner_etc_security_opasswd_old
+      - file_groupowner_etc_security_opasswd_old
+      - file_permissions_etc_security_opasswd_old
+    status: automated
 
   - id: 7.1.11
     title: Ensure world writable files and directories are secured (Automated)

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_security_opasswd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_security_opasswd/rule.yml
@@ -1,0 +1,27 @@
+documentation_complete: true
+
+title: 'Verify Group Who Owns /etc/security/opasswd File'
+
+description: '{{{ describe_file_group_owner(file="/etc/security/opasswd", group=root) }}}'
+
+rationale: |-
+    The <tt>/etc/security/opasswd</tt> file stores old passwords to prevent
+    password reuse. Protection of this file is critical for system security.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/security/opasswd", group=root) }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/security/opasswd", group=root) }}}
+
+fixtext: '{{{ fixtext_file_group_owner(file="/etc/security/opasswd", group=root) }}}'
+
+srg_requirement: '{{{ srg_requirement_file_group_owner(file="/etc/security/opasswd", group=root) }}}'
+
+template:
+    name: file_groupowner
+    vars:
+        filepath: /etc/security/opasswd
+        gid_or_name: '0'
+        missing_file_pass: true

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_security_opasswd_old/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_security_opasswd_old/rule.yml
@@ -1,0 +1,27 @@
+documentation_complete: true
+
+title: 'Verify Group Who Owns /etc/security/opasswd.old File'
+
+description: '{{{ describe_file_group_owner(file="/etc/security/opasswd.old", group=root) }}}'
+
+rationale: |-
+    The <tt>/etc/security/opasswd.old</tt> file stores backups of old passwords to prevent
+    password reuse. Protection of this file is critical for system security.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/security/opasswd.old", group=root) }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/security/opasswd.old", group=root) }}}
+
+fixtext: '{{{ fixtext_file_group_owner(file="/etc/security/opasswd.old", group=root) }}}'
+
+srg_requirement: '{{{ srg_requirement_file_group_owner(file="/etc/security/opasswd.old", group=root) }}}'
+
+template:
+    name: file_groupowner
+    vars:
+        filepath: /etc/security/opasswd.old
+        gid_or_name: '0'
+        missing_file_pass: true

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_security_opasswd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_security_opasswd/rule.yml
@@ -1,0 +1,27 @@
+documentation_complete: true
+
+title: 'Verify User Who Owns /etc/security/opasswd File'
+
+description: '{{{ describe_file_owner(file="/etc/security/opasswd", owner="root") }}}'
+
+rationale: |-
+    The <tt>/etc/security/opasswd</tt> file stores old passwords to prevent
+    password reuse. Protection of this file is critical for system security.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/security/opasswd", owner="root") }}}'
+
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/security/opasswd", owner="root") }}}
+
+fixtext: '{{{ fixtext_file_owner(file="/etc/security/opasswd", owner="root") }}}'
+
+srg_requirement: '{{{ srg_requirement_file_owner(file="/etc/security/opasswd", owner="root") }}}'
+
+template:
+    name: file_owner
+    vars:
+        filepath: /etc/security/opasswd
+        fileuid: '0'
+        missing_file_pass: true

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_security_opasswd_old/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_security_opasswd_old/rule.yml
@@ -1,0 +1,27 @@
+documentation_complete: true
+
+title: 'Verify User Who Owns /etc/security/opasswd.old File'
+
+description: '{{{ describe_file_owner(file="/etc/security/opasswd.old", owner="root") }}}'
+
+rationale: |-
+    The <tt>/etc/security/opasswd.old</tt> file stores backups of old passwords to prevent
+    password reuse. Protection of this file is critical for system security.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/security/opasswd.old", owner="root") }}}'
+
+ocil: |-
+    {{{ ocil_file_owner(file="/etc/security/opasswd.old", owner="root") }}}
+
+fixtext: '{{{ fixtext_file_owner(file="/etc/security/opasswd.old", owner="root") }}}'
+
+srg_requirement: '{{{ srg_requirement_file_owner(file="/etc/security/opasswd.old", owner="root") }}}'
+
+template:
+    name: file_owner
+    vars:
+        filepath: /etc/security/opasswd.old
+        fileuid: '0'
+        missing_file_pass: true

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_security_opasswd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_security_opasswd/rule.yml
@@ -1,0 +1,26 @@
+documentation_complete: true
+
+title: 'Verify Permissions on /etc/security/opasswd File'
+
+description:  |-
+    {{{ describe_file_permissions(file="/etc/security/opasswd", perms="0600") }}}
+
+rationale: |-
+    The <tt>/etc/security/opasswd</tt> file stores old passwords to prevent
+    password reuse. Protection of this file is critical for system security.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/security/opasswd", perms="0600") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/security/opasswd", perms="0600") }}}
+
+fixtext: '{{{ fixtext_file_permissions(file="/etc/security/opasswd", mode="0600") }}}'
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /etc/security/opasswd
+        filemode: '0600'
+        missing_file_pass: true

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_security_opasswd_old/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_security_opasswd_old/rule.yml
@@ -1,0 +1,26 @@
+documentation_complete: true
+
+title: 'Verify Permissions on /etc/security/opasswd.old File'
+
+description:  |-
+    {{{ describe_file_permissions(file="/etc/security/opasswd.old", perms="0600") }}}
+
+rationale: |-
+    The <tt>/etc/security/opasswd.old</tt> file stores backups of old passwords to prevent
+    password reuse. Protection of this file is critical for system security.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/security/opasswd.old", perms="0600") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/etc/security/opasswd.old", perms="0600") }}}
+
+fixtext: '{{{ fixtext_file_permissions(file="/etc/security/opasswd.old", mode="0600") }}}'
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /etc/security/opasswd.old
+        filemode: '0600'
+        missing_file_pass: true


### PR DESCRIPTION
#### Description:

- Satisfies Ubuntu 24.04 CIS v1 recommendation 7.1.10 (Ensure permissions on /etc/security/opasswd are configured)
- New rules:
  - file_groupowner_etc_security_opasswd
  - file_owner_etc_security_opasswd
  - file_permissions_etc_security_opasswd
  - file_groupowner_etc_security_opasswd_old
  - file_owner_etc_security_opasswd_old
  - file_permissions_etc_security_opasswd_old

#### Rationale:
- The Ubuntu 24.04 CIS v1 recommendation 7.1.10 requires ownership and permissions to be set on both opasswd and opasswd.old. The existing rule `file_etc_security_opasswd` satisfies half of the requirement, but, since the implementation is not consistent with other similar rules (not using template or tests), both requirements were implemented as new rules instead of extending the existing rule.
