### PR TITLE
Add rules to several ubuntu2404 CIS controls

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2351,8 +2351,11 @@ controls:
       - l1_workstation
     related_rules:
       - rsyslog_remote_loghost
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/4.2.2.6.
+    status: manual
+    notes: |
+      Existing rule (rsyslog_remote_loghost) is not used because rsyslog configuration
+      is site-specific and can be too complex to reliably audit and remediate.
+      See also https://github.com/ComplianceAsCode/content/issues/11812
 
   - id: 6.1.3.7
     title: Ensure rsyslog is not configured to receive logs from a remote client (Automated)
@@ -2448,15 +2451,12 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    related_rules:
-      - var_auditd_disk_error_action=halt
-      - var_auditd_disk_full_action=halt
+    rules:
+      - var_auditd_disk_error_action=cis_ubuntu2404
+      - var_auditd_disk_full_action=cis_ubuntu2404
       - auditd_data_disk_error_action
       - auditd_data_disk_full_action
-    status: planned
-    notes: |
-      TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/4.1.2.3.
-      The variables should allow multiple options.
+    status: automated
 
   - id: 6.2.2.4
     title: Ensure system warns when audit logs are low on space (Automated)
@@ -2497,24 +2497,21 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    related_rules:
+    rules:
       - audit_sudo_log_events
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/4.1.3.3.
+    status: automated
 
   - id: 6.2.3.4
     title: Ensure events that modify date and time information are collected (Automated)
     levels:
       - l2_server
       - l2_workstation
-    related_rules:
+    rules:
       - audit_rules_time_adjtimex
       - audit_rules_time_clock_settime
       - audit_rules_time_settimeofday
-      - audit_rules_time_stime
       - audit_rules_time_watch_localtime
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/4.1.3.4.
+    status: automated
 
   - id: 6.2.3.5
     title: Ensure events that modify the system's network environment are collected (Automated)
@@ -2931,8 +2928,11 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    rules:
+      - file_owner_etc_shells
+      - file_groupowner_etc_shells
+      - file_permissions_etc_shells
+    status: automated
 
   - id: 7.1.10
     title: Ensure permissions on /etc/security/opasswd are configured (Automated)

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/rule.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/rule.yml
@@ -9,8 +9,13 @@ description: |-
     substituting <i>ACTION</i> appropriately:
     <pre>disk_error_action = <i>ACTION</i></pre>
     Set this value to <tt>single</tt> to cause the system to switch to single-user
-    mode for corrective action. Acceptable values also include <tt>syslog</tt>,
-    <tt>exec</tt>, <tt>single</tt>, and <tt>halt</tt>. For certain systems, the need for availability
+    mode for corrective action. Acceptable values also include
+    {{% if product in ['ubuntu2404'] %}}
+    <tt>syslog</tt>, <tt>single</tt> and <tt>halt</tt>
+    {{% else %}}
+    <tt>syslog</tt>, <tt>exec</tt>, <tt>single</tt>, and <tt>halt</tt>
+    {{% endif %}}
+    For certain systems, the need for availability
     outweighs the need to log all actions, and a different setting should be
     determined. Details regarding all possible values for <i>ACTION</i> are described in the
     <tt>auditd.conf</tt> man page.
@@ -56,7 +61,11 @@ ocil: |-
 fixtext: |-
     Configure {{{ full_name }}} to shut down by default upon audit failure (unless availability is an overriding concern).
 
+    {{% if product in ['ubuntu2404'] %}}
+    Add or update the following line ("disk_error_action" can be set to "SYSLOG", "SINGLE", or "HALT" depending on configuration) in "/etc/audit/auditd.conf" file:
+    {{% else %}}
     Add or update the following line ("disk_error_action" can be set to "SYSLOG" or "SINGLE" depending on configuration) in "/etc/audit/auditd.conf" file:
+    {{% endif %}}
 
     disk_error_action = {{{ xccdf_value("var_auditd_disk_error_action") }}}
 

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/rule.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/rule.yml
@@ -9,11 +9,15 @@ description: |-
     substituting <i>ACTION</i> appropriately:
     <pre>disk_full_action = <i>ACTION</i></pre>
     Set this value to <tt>single</tt> to cause the system to switch to single-user
-    mode for corrective action. Acceptable values also include <tt>syslog</tt>,
-    {{% if product not in ["sle12", "sle15"] %}}
-    <tt>exec</tt>,
+    mode for corrective action. Acceptable values also include
+    {{% if product in ['ubuntu2404'] %}}
+    <tt>single</tt> and <tt>halt</tt>
+    {{% elif product in ["sle12", "sle15"] %}}
+    <tt>syslog</tt>, <tt>single</tt>, and <tt>halt</tt>
+    {{% else %}}
+    <tt>syslog</tt>, <tt>exec</tt>, <tt>single</tt>, and <tt>halt</tt>
     {{% endif %}}
-    <tt>single</tt>, and <tt>halt</tt>. For certain systems, the need for availability
+    For certain systems, the need for availability
     outweighs the need to log all actions, and a different setting should be
     determined. Details regarding all possible values for <i>ACTION</i> are described in the
     <tt>auditd.conf</tt> man page.
@@ -67,7 +71,11 @@ ocil: |-
 fixtext: |-
     Configure {{{ full_name }}} to shut down by default upon audit failure (unless availability is an overriding concern).
 
+    {{% if product in ['ubuntu2404'] %}}
+    Add or update the following line ("disk_full_action" can be set to "HALT" or "SINGLE" depending on configuration) in "/etc/audit/auditd.conf" file:
+    {{% else %}}
     Add or update the following line ("disk_full_action" can be set to "SYSLOG" or "SINGLE" depending on configuration) in "/etc/audit/auditd.conf" file:
+    {{% endif %}}
 
     disk_full_action = {{{ xccdf_value("var_auditd_disk_full_action") }}}
 

--- a/linux_os/guide/auditing/configure_auditd_data_retention/var_auditd_disk_error_action.var
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/var_auditd_disk_error_action.var
@@ -23,3 +23,4 @@ options:
     rhel8: syslog|single|halt
     cis_rhel8: syslog|single|halt
     cis_rhel9: syslog|single|halt
+    cis_ubuntu2404: syslog|single|halt

--- a/linux_os/guide/auditing/configure_auditd_data_retention/var_auditd_disk_full_action.var
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/var_auditd_disk_full_action.var
@@ -24,3 +24,4 @@ options:
     rhel8: syslog|single|halt
     cis_rhel8: syslog|single|halt
     cis_rhel9: halt|single
+    cis_ubuntu2404: halt|single


### PR DESCRIPTION
#### Description:

Add rules to several ubuntu2404 CIS controls

- 6.1.3.6 Ensure rsyslog is configured to send logs to a remote log host
- 6.2.2.3 Ensure system is disabled when audit logs are full
- 6.2.3.3 Ensure events that modify the sudo log file are collected
- 6.2.3.4 Ensure events that modify date and time information are collected
- 7.1.9 Ensure permissions on /etc/shells are configured