### PR TITLE
Remove old rules from RHEL 10 profiles

### DIFF
--- a/controls/cis_rhel10.yml
+++ b/controls/cis_rhel10.yml
@@ -3120,6 +3120,5 @@ controls:
       - var_user_initialization_files_regex=all_dotfiles
       - no_forward_files
       - no_netrc_files
-      - no_rsh_trust_files
     related_rules:
       - accounts_users_netrc_file_permissions

--- a/controls/hipaa.yml
+++ b/controls/hipaa.yml
@@ -344,7 +344,6 @@ controls:
             - package_ypbind_removed
             - package_ypserv_removed
             - service_ypbind_disabled
-            - no_rsh_trust_files
             - package_rsh-server_removed
             - package_rsh_removed
             - service_rexec_disabled
@@ -613,7 +612,6 @@ controls:
             - package_ypbind_removed
             - package_ypserv_removed
             - service_ypbind_disabled
-            - no_rsh_trust_files
             - package_rsh-server_removed
             - package_rsh_removed
             - service_rexec_disabled
@@ -681,7 +679,6 @@ controls:
             - package_ypbind_removed
             - package_ypserv_removed
             - service_ypbind_disabled
-            - no_rsh_trust_files
             - package_rsh-server_removed
             - package_rsh_removed
             - service_rexec_disabled
@@ -878,7 +875,6 @@ controls:
             - package_ypbind_removed
             - package_ypserv_removed
             - service_ypbind_disabled
-            - no_rsh_trust_files
             - package_rsh-server_removed
             - package_rsh_removed
             - service_rexec_disabled
@@ -1646,7 +1642,6 @@ controls:
             - package_ypbind_removed
             - package_ypserv_removed
             - service_ypbind_disabled
-            - no_rsh_trust_files
             - package_rsh-server_removed
             - package_rsh_removed
             - service_rexec_disabled
@@ -1719,7 +1714,6 @@ controls:
             - package_ypbind_removed
             - package_ypserv_removed
             - service_ypbind_disabled
-            - no_rsh_trust_files
             - package_rsh-server_removed
             - package_rsh_removed
             - service_rexec_disabled

--- a/products/rhel10/profiles/anssi_bp28_enhanced.profile
+++ b/products/rhel10/profiles/anssi_bp28_enhanced.profile
@@ -75,3 +75,5 @@ selections:
     - '!sssd_enable_pam_services'
     - '!sssd_ldap_configure_tls_reqcert'
     - '!sssd_ldap_start_tls'
+    # These rules are no longer relevant
+    - '!prefer_64bit_os'

--- a/products/rhel10/profiles/anssi_bp28_high.profile
+++ b/products/rhel10/profiles/anssi_bp28_high.profile
@@ -79,3 +79,5 @@ selections:
     - '!sssd_enable_pam_services'
     - '!sssd_ldap_configure_tls_reqcert'
     - '!sssd_ldap_start_tls'
+    # These rules are no longer relevant
+    - '!prefer_64bit_os'


### PR DESCRIPTION
#### Description:

Remove the following rules from RHEL 10
* `no_rsh_trust_files`
* `prefer_64bit_os`

#### Rationale:

Prep for RHEL 10.

#### Review Hints:

Use `grep` on built profiles or data stream to ensure the rules are gone.