### PR TITLE
Ubuntu 24.04 2.1.1 Ensure autofs services are not in use

### DIFF
--- a/components/autofs.yml
+++ b/components/autofs.yml
@@ -3,3 +3,4 @@ packages:
 - autofs
 rules:
 - service_autofs_disabled
+- package_autofs_removed

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -662,11 +662,11 @@ controls:
     levels:
       - l1_server
       - l2_workstation
-    related_rules:
+    rules:
       - service_autofs_disabled
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/1.1.9.
-
+      - package_autofs_removed
+    status: automated
+    
   - id: 2.1.2
     title: Ensure avahi daemon services are not in use (Automated)
     levels:

--- a/linux_os/guide/system/permissions/mounting/package_autofs_removed/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/package_autofs_removed/rule.yml
@@ -1,0 +1,22 @@
+documentation_complete: true
+
+title: 'Remove autofs Package'
+
+description: |-
+   autofs allows automatic mounting of devices, typically including CD/DVDs and USB
+   drives.
+    {{{ describe_package_remove(package="autofs") }}}
+
+rationale: |-
+    With automounting enabled anyone with physical access could attach a USB drive or
+    disc and have its contents available in the filesystem even if they lacked permissions to
+    mount it themselves.
+
+severity: low
+
+ocil: '{{{ describe_package_remove(package="autofs") }}}'
+
+template:
+    name: package_removed
+    vars:
+        pkgname: autofs


### PR DESCRIPTION
#### Description:

- Ubuntu 24.04 2.1.1 Ensure autofs services are not in use

#### Rationale:

- Implement Ubuntu 24.04 2.1.1 Ensure autofs services are not in use
