### PR TITLE
Ubuntu 24.04 2.2.6 Ensure ftp client is not installed

### DIFF
--- a/components/ftp.yml
+++ b/components/ftp.yml
@@ -1,5 +1,7 @@
 name: ftp
 packages:
 - ftp
+- tnftp
 rules:
 - package_ftp_removed
+- package_tnftp_removed

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -927,8 +927,10 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    rules:
+      - package_ftp_removed
+      - package_tnftp_removed
+    status: automated
 
   - id: 2.3.1.1
     title: Ensure a single time synchronization daemon is in use (Automated)

--- a/linux_os/guide/services/ftp/package_tnftp_removed/rule.yml
+++ b/linux_os/guide/services/ftp/package_tnftp_removed/rule.yml
@@ -1,0 +1,25 @@
+documentation_complete: true
+
+
+
+title: 'Remove tnftp Package'
+
+description: |-
+    tnftp an enhanced FTP client, is the user interface to the Internet standard File
+    Transfer Protocol. The program allows a user to transfer files to and from a remote
+    network site.
+    {{{ describe_package_remove(package="ftp") }}}
+
+rationale: |-
+    Unless there is a need to run the system using Internet standard File Transfer Protocol
+    (for example, to allow anonymous downloads), it is recommended that the package be
+    removed to reduce the potential attack surface.
+
+severity: low
+
+ocil: '{{{ describe_package_remove(package="tnftp") }}}'
+
+template:
+    name: package_removed
+    vars:
+        pkgname: tnftp


### PR DESCRIPTION
#### Description:

- Ubuntu 24.04 2.2.6 Ensure ftp client is not installed

#### Rationale:

- Implement Ubuntu 24.04 2.2.6 Ensure ftp client is not installed
