### PR TITLE
Change platform in Mail Server Software group

### DIFF
--- a/linux_os/guide/services/mail/group.yml
+++ b/linux_os/guide/services/mail/group.yml
@@ -24,4 +24,4 @@ description: |-
     SELinux as its modular design has resulted in separate processes performing specific actions.
     More information is available on its website, {{{ weblink(link="http://www.postfix.org") }}}.
 
-platform: machine
+platform: system_with_kernel


### PR DESCRIPTION
Rules from the Mail Server Software group should also be applicable in bootable containers build environment.