### PR TITLE
Ubuntu 24.04 5.3.2.1 Ensure pam_unix module is enabled

### DIFF
--- a/components/pam.yml
+++ b/components/pam.yml
@@ -61,6 +61,7 @@ rules:
 - accounts_password_pam_pwquality_system_auth
 - accounts_password_pam_retry
 - accounts_password_pam_ucredit
+- accounts_password_pam_unix_enabled
 - accounts_password_pam_unix_remember
 - accounts_password_pam_unix_rounds_password_auth
 - accounts_password_pam_unix_rounds_system_auth

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -1850,8 +1850,9 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    rules:
+      - accounts_password_pam_unix_enabled
+    status: automated
 
   - id: 5.3.2.2
     title: Ensure pam_faillock module is enabled (Automated)

--- a/linux_os/guide/system/accounts/accounts-pam/accounts_password_pam_unix_enabled/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/accounts_password_pam_unix_enabled/bash/shared.sh
@@ -1,0 +1,3 @@
+# platform = multi_platform_ubuntu
+
+{{{ bash_pam_unix_enable() }}}

--- a/linux_os/guide/system/accounts/accounts-pam/accounts_password_pam_unix_enabled/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/accounts_password_pam_unix_enabled/oval/shared.xml
@@ -1,0 +1,36 @@
+{{% set file_stem = ["auth","account","password","session"] %}}
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+  {{{ oval_metadata("Ensure pam_unix.so is properly configured in PAM configuration files") }}}
+    <criteria operator="AND" comment="Check if pam_unix.so is properly defined in all PAM files">      
+      {{% for stem in file_stem %}}
+      <criterion test_ref="test_pam_unix_common_{{{ stem }}}"
+          comment="pam_unix has correctly set in common-{{{ stem }}}"/>
+      {{% endfor %}}
+    </criteria>
+  </definition>
+
+  <!-- Check occurrences of pam_unix.so in common-{auth,account,password} file -->
+  {{% macro test_pam_unix(stem) %}}
+  <ind:textfilecontent54_test check="all" id="test_pam_unix_common_{{{ stem }}}" version="1"
+        check_existence="only_one_exists"
+        comment="No more than one pam_unix.so is expected in {{{ stem }}} section of /etc/pam.d/common-{{{ stem }}}">
+    <ind:object object_ref="obj_pam_unix_common_{{{ stem }}}" />
+  </ind:textfilecontent54_test>
+  {{% endmacro %}}
+
+  {{% macro object_pam_unix(stem) %}}
+  <ind:textfilecontent54_object id="obj_pam_unix_common_{{{ stem }}}" version="1"
+        comment="Get the occurrences of pam_unix.so in {{{ stem }}} section of /etc/pam.d/common-{{{ stem }}}">
+    <ind:filepath>/etc/pam.d/common-{{{ stem }}}</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*{{{stem}}}[\s]+(required|\[(?=.*?\bsuccess=\d+\b)?(?=.*?\bnew_authtok_reqd=ok\b)?(?=.*?\bdefault=ignore\b)?.*\])[\s]+pam_unix\.so.*$</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+  {{% endmacro %}}
+
+  {{% for file in file_stem %}}
+  {{{ test_pam_unix(stem=file) }}}
+  {{{ object_pam_unix(stem=file) }}}
+  {{% endfor %}}
+
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/accounts_password_pam_unix_enabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/accounts_password_pam_unix_enabled/rule.yml
@@ -1,0 +1,26 @@
+documentation_complete: true
+
+
+title: Ensure pam_unix module is enabled
+
+description: |-
+    pam_unix is the standard Unix authentication module. It uses standard calls from the
+    system's libraries to retrieve and set account information as well as authentication.
+    Usually this is obtained from the /etc/passwd and if shadow is enabled, the
+    /etc/shadow file as well.
+    The account component performs the task of establishing the status of the user's
+    account and password based on the following shadow elements: expire,
+    last_change, max_change, min_change, warn_change. In the case of the latter, it may
+    offer advice to the user on changing their password or, through the
+    PAM_AUTHTOKEN_REQD return, delay giving service to the user until they have
+    established a new password. The entries listed above are documented in the shadow(5)
+    manual page. Should the user's record not contain one or more of these entries, the
+    corresponding shadow check is not performed.
+    The authentication component performs the task of checking the users credentials
+    (password). The default action of this module is to not permit the user access to a
+    service if their official password is blank.
+
+rationale: |-
+    The system should only provide access after performing authentication of a user.
+
+severity: medium

--- a/linux_os/guide/system/accounts/accounts-pam/accounts_password_pam_unix_enabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/accounts_password_pam_unix_enabled/rule.yml
@@ -24,3 +24,5 @@ rationale: |-
     The system should only provide access after performing authentication of a user.
 
 severity: medium
+
+platform: package[pam]

--- a/linux_os/guide/system/accounts/accounts-pam/accounts_password_pam_unix_enabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/accounts_password_pam_unix_enabled/rule.yml
@@ -1,7 +1,7 @@
 documentation_complete: true
 
 
-title: Ensure pam_unix module is enabled
+title: Verify pam_unix module is activated
 
 description: |-
     <tt>pam_unix</tt> is the standard Unix authentication module. It uses standard calls from the

--- a/linux_os/guide/system/accounts/accounts-pam/accounts_password_pam_unix_enabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/accounts_password_pam_unix_enabled/rule.yml
@@ -4,18 +4,20 @@ documentation_complete: true
 title: Ensure pam_unix module is enabled
 
 description: |-
-    pam_unix is the standard Unix authentication module. It uses standard calls from the
+    <tt>pam_unix</tt> is the standard Unix authentication module. It uses standard calls from the
     system's libraries to retrieve and set account information as well as authentication.
-    Usually this is obtained from the /etc/passwd and if shadow is enabled, the
-    /etc/shadow file as well.
+    Usually this is obtained from the <tt>/etc/passwd</tt> and if shadow is enabled, the
+    <tt>/etc/shadow</tt> file as well.
+    <br /><br />
     The account component performs the task of establishing the status of the user's
-    account and password based on the following shadow elements: expire,
-    last_change, max_change, min_change, warn_change. In the case of the latter, it may
+    account and password based on the following shadow elements: <tt>expire,
+    last_change, max_change, min_change, warn_change</tt>. In the case of the latter, it may
     offer advice to the user on changing their password or, through the
-    PAM_AUTHTOKEN_REQD return, delay giving service to the user until they have
+    <tt>PAM_AUTHTOKEN_REQD</tt> return, delay giving service to the user until they have
     established a new password. The entries listed above are documented in the shadow(5)
     manual page. Should the user's record not contain one or more of these entries, the
     corresponding shadow check is not performed.
+    <br /><br />
     The authentication component performs the task of checking the users credentials
     (password). The default action of this module is to not permit the user access to a
     service if their official password is blank.


### PR DESCRIPTION
#### Description:

- Ubuntu 24.04 5.3.2.1 Ensure pam_unix module is enabled

#### Rationale:

- Implement Ubuntu 24.04 5.3.2.1 Ensure pam_unix module is enabled
