### PR TITLE
Fix permissions on ocp test workflow

### DIFF
--- a/.github/workflows/ocp-test-profiles.yaml
+++ b/.github/workflows/ocp-test-profiles.yaml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: fedora:latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Install Deps
         run: dnf install -y cmake make openscap-utils python3-pyyaml python3-jinja2 git python3-deepdiff python3-requests jq python3-pip nodejs


### PR DESCRIPTION
#### Description:

- Fixes  [Trigger OCP Tests When Relevant](https://github.com/ComplianceAsCode/content/actions/workflows/ocp-test-profiles.yaml)
  See this log: https://github.com/ComplianceAsCode/content/actions/runs/12231657817/job/34115147556

#### Rationale:

- We want to trigger OCP tests automatically