### PR TITLE
Add kernel-uek for OL in system_with_kernel CPE

### DIFF
--- a/shared/applicability/oval/system_with_kernel.xml
+++ b/shared/applicability/oval/system_with_kernel.xml
@@ -1,8 +1,11 @@
 <def-group>
   <definition class="inventory" id="system_with_kernel" version="1">
     {{{ oval_metadata("The kernel is installed", affected_platforms=["multi_platform_all"]) }}}
-    <criteria operator="AND">
+    <criteria operator="OR">
       <criterion comment="kernel is installed" test_ref="inventory_test_kernel_installed" />
+      {{% if "ol" in families %}}
+      <criterion comment="kernel-uek is installed" test_ref="inventory_test_kernel_uek_installed" />
+      {{% endif %}}
     </criteria>
   </definition>
 {{% if 'debian' in product or 'ubuntu' in product %}}
@@ -11,5 +14,8 @@
 {{{ oval_test_package_installed(package="kernel-default", test_id="inventory_test_kernel_installed") }}}
 {{% else %}}
 {{{ oval_test_package_installed(package="kernel", test_id="inventory_test_kernel_installed") }}}
+{{% endif %}}
+{{% if "ol" in families %}}
+{{{ oval_test_package_installed(package="kernel-uek", test_id="inventory_test_kernel_uek_installed") }}}
 {{% endif %}}
 </def-group>

--- a/shared/applicability/system_with_kernel.yml
+++ b/shared/applicability/system_with_kernel.yml
@@ -18,6 +18,8 @@ check_id: system_with_kernel
 {{% if pkg_system == "rpm" %}}
 {{% if "sle" in product or "slmicro" in product %}}
 bash_conditional: "rpm --quiet -q kernel-default"
+{{% elif "ol" in families %}}
+bash_conditional: "rpm --quiet -q kernel || rpm --quiet -q kernel-uek"
 {{% else %}}
 bash_conditional: "rpm --quiet -q kernel"
 {{% endif %}}
@@ -32,6 +34,8 @@ bash_conditional: "dpkg-query --show --showformat='${db:Status-Status}\n' 'kerne
 ansible_conditional: '"linux-base" in ansible_facts.packages'
 {{% elif "sle" in product or "slmicro" in product %}}
 ansible_conditional: '"kernel-default" in ansible_facts.packages'
+{{% elif "ol" in families %}}
+ansible_conditional: '("kernel" in ansible_facts.packages or "kernel-uek" in ansible_facts.packages)'
 {{% else %}}
 ansible_conditional: '"kernel" in ansible_facts.packages'
 {{% endif %}}


### PR DESCRIPTION
#### Description:

- Fix `system_with_kernel` CPE to consider `kernel-uek` for OL

#### Rationale:

- OL system can have `kernel-uek` or `kernel` packages as their kernel
