### PR TITLE
RHEL 10 Kernel Config and Module Clean Up

### DIFF
--- a/components/kernel.yml
+++ b/components/kernel.yml
@@ -24,7 +24,6 @@ rules:
 - directory_owner_etc_sysctld
 - directory_permissions_etc_sysctld
 - grub2_ipv6_disable_argument
-- grub2_kernel_trust_cpu_rng
 - install_PAE_kernel_on_x86-32
 - kernel_config_acpi_custom_method
 - kernel_config_arm64_sw_ttbr0_pan

--- a/controls/cis_rhel10.yml
+++ b/controls/cis_rhel10.yml
@@ -40,56 +40,6 @@ controls:
       - var_authselect_profile=sssd
       - enable_authselect
 
-  - id: 1.1.1.1
-    title: Ensure cramfs kernel module is not available (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: Review the availability of this module when the product is out.
-    rules:
-      - kernel_module_cramfs_disabled
-
-  - id: 1.1.1.2
-    title: Ensure freevxfs kernel module is not available (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: Review the availability of this module when the product is out.
-    rules:
-      - kernel_module_freevxfs_disabled
-
-  - id: 1.1.1.3
-    title: Ensure hfs kernel module is not available (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: Review the availability of this module when the product is out.
-    rules:
-      - kernel_module_hfs_disabled
-
-  - id: 1.1.1.4
-    title: Ensure hfsplus kernel module is not available (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: Review the availability of this module when the product is out.
-    rules:
-      - kernel_module_hfsplus_disabled
-
-  - id: 1.1.1.5
-    title: Ensure jffs2 kernel module is not available (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: Review the availability of this module when the product is out.
-    rules:
-      - kernel_module_jffs2_disabled
-
   - id: 1.1.1.6
     title: Ensure squashfs kernel module is not available (Automated)
     levels:
@@ -1225,16 +1175,6 @@ controls:
     rules:
       - service_bluetooth_disabled
 
-  - id: 3.2.1
-    title: Ensure dccp kernel module is not available (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    notes: Review the availability of this module when the product is out.
-    rules:
-      - kernel_module_dccp_disabled
-
   - id: 3.2.2
     title: Ensure tipc kernel module is not available (Automated)
     levels:
@@ -1243,15 +1183,6 @@ controls:
     status: automated
     rules:
       - kernel_module_tipc_disabled
-
-  - id: 3.2.3
-    title: Ensure rds kernel module is not available (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - kernel_module_rds_disabled
 
   - id: 3.2.4
     title: Ensure sctp kernel module is not available (Automated)

--- a/products/rhel10/profiles/anssi_bp28_high.profile
+++ b/products/rhel10/profiles/anssi_bp28_high.profile
@@ -81,3 +81,11 @@ selections:
     - '!sssd_ldap_start_tls'
     # These rules are no longer relevant
     - '!prefer_64bit_os'
+    - '!kernel_config_devkmem'
+    - '!kernel_config_hardened_usercopy_fallback'
+    - '!kernel_config_page_poisoning_no_sanity'
+    - '!kernel_config_page_poisoning_zero'
+    - '!kernel_config_page_table_isolation'
+    - '!kernel_config_refcount_full'
+    - '!kernel_config_retpoline'
+    - '!kernel_config_security_writable_hooks'

--- a/products/rhel10/profiles/pci-dss.profile
+++ b/products/rhel10/profiles/pci-dss.profile
@@ -74,3 +74,4 @@ selections:
     - '!sshd_use_approved_macs'
     - '!sshd_use_approved_ciphers'
     - '!security_patches_up_to_date'
+    - '!kernel_module_dccp_disabled'


### PR DESCRIPTION
#### Description:
Remove old kernel config and module rules from RHEL 10.

#### Rationale:
Getting ready for RHEL 10.
#### Review Hints:
Ensure that list modules and config options are not in a RHEL 10 compose.