### PR TITLE
Ubuntu 24.04 3.1.3 Ensure bluetooth services are not in use

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -1121,7 +1121,7 @@ controls:
       - l1_server
       - l2_workstation
     rules:
-      - sshd_disable_forwarding
+      - service_bluetooth_disabled
     status: automated
 
   - id: 3.2.1


### PR DESCRIPTION
#### Description:

- Ubuntu 24.04 3.1.3 Ensure bluetooth services are not in use

#### Rationale:

- Implement Ubuntu 24.04 3.1.3 Ensure bluetooth services are not in use

