### PR TITLE
Add rules to ubuntu2404 CIS control 7.2.10

### DIFF
--- a/components/pam.yml
+++ b/components/pam.yml
@@ -150,6 +150,7 @@ rules:
 - file_owner_etc_motd
 - file_ownership_home_directories
 - file_ownership_lastlog
+- file_permission_user_bash_history
 - file_permission_user_init_files
 - file_permission_user_init_files_root
 - file_permissions_etc_issue

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -3069,12 +3069,12 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    related_rules:
+    rules:
       - no_rsh_trust_files
       - no_forward_files
       - no_netrc_files
-      - accounts_user_dot_group_ownership
-      - accounts_user_dot_no_world_writable_programs
       - accounts_user_dot_user_ownership
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/6.2.14,6.2.15,6.2.17,6.2.16.
+      - accounts_user_dot_group_ownership
+      - file_permission_user_init_files
+      - file_permission_user_bash_history
+    status: automated

--- a/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/bash/shared.sh
@@ -1,0 +1,20 @@
+# platform = multi_platform_ubuntu
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+readarray -t interactive_users < <(awk -F: '$3>={{{ uid_min }}}   {print $1}' /etc/passwd)
+readarray -t interactive_users_home < <(awk -F: '$3>={{{ uid_min }}}   {print $6}' /etc/passwd)
+readarray -t interactive_users_shell < <(awk -F: '$3>={{{ uid_min }}}   {print $7}' /etc/passwd)
+
+USERS_IGNORED_REGEX='nobody|nfsnobody'
+
+for (( i=0; i<"${#interactive_users[@]}"; i++ )); do
+    if ! grep -qP "$USERS_IGNORED_REGEX" <<< "${interactive_users[$i]}" && \
+        [ "${interactive_users_shell[$i]}" != "/sbin/nologin" ]; then
+        
+        chmod u-sx,go= "${interactive_users_home[$i]}/.bash_history"
+    fi
+done
+

--- a/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/oval/shared.xml
@@ -1,0 +1,46 @@
+<def-group>
+    <definition class="compliance" id="{{{ rule_id }}}" version="1">
+        {{{ oval_metadata("User Bash History File Has Correct Permissions") }}}
+        <criteria>
+            <criterion comment="User Bash History File Has Correct Permissions"
+                test_ref="test_{{{ rule_id }}}" />
+        </criteria>
+    </definition>
+
+    <unix:file_test id="test_{{{ rule_id }}}" check="all"
+                    check_existence="any_exist" version="1"
+          comment="User Bash History File Has Correct Permissions">
+        <unix:object object_ref="object_{{{ rule_id }}}"/>
+        <unix:state state_ref="state_{{{ rule_id }}}"/>
+    </unix:file_test>
+
+    <unix:file_object id="object_{{{ rule_id }}}" version="1">
+        <unix:path var_ref="var_{{{ rule_id }}}_home_dirs" var_check="at least one"/>
+        <unix:filename operation="equals">.bash_history</unix:filename>
+    </unix:file_object>
+
+
+    <unix:file_state id="state_{{{ rule_id }}}" operator="AND" version="1">
+        <unix:suid datatype="boolean">false</unix:suid>
+        <unix:sgid datatype="boolean">false</unix:sgid>
+        <unix:sticky datatype="boolean">false</unix:sticky>
+        <unix:uexec datatype="boolean">false</unix:uexec>
+        <unix:gread datatype="boolean">false</unix:gread>
+        <unix:gwrite datatype="boolean">false</unix:gwrite>
+        <unix:gexec datatype="boolean">false</unix:gexec>
+        <unix:oread datatype="boolean">false</unix:oread>
+        <unix:owrite datatype="boolean">false</unix:owrite>
+        <unix:oexec datatype="boolean">false</unix:oexec>
+    </unix:file_state>
+
+
+    {{%- set interactive_users_object = "object_" ~ rule_id ~ "_objects" -%}}
+    {{{ create_interactive_users_list_object(interactive_users_object) }}}
+
+    <local_variable id="var_{{{ rule_id }}}_home_dirs" datatype="string" version="1"
+                    comment="Variable including all home dirs from interactive users">
+        <object_component item_field="home_dir"
+                        object_ref="{{{ interactive_users_object }}}"/>
+    </local_variable>
+    
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/rule.yml
@@ -1,0 +1,29 @@
+documentation_complete: true
+
+title: 'Ensure User Bash History File Has Correct Permissions'
+
+description: |-
+    Set the mode of the bash history file to <tt>0600</tt> with the
+    following command:
+    <pre>$ sudo chmod 0600 /home/<i>USER</i>/.bash_history</pre>
+
+rationale: |-
+    Incorrect permissions may enable malicious users to recover
+    other users' command history.
+
+severity: medium
+
+ocil_clause: 'file is not 0600 or more permissive'
+
+ocil: |-
+    To verify that .bash_history has a mode of <tt>0600</tt> or
+    less permissive, run the following command:
+    <pre>$ sudo find /home -type f -name '\.bash_history' -perm /0177</pre>
+    There should be no output.
+
+fixtext: |-
+    Set the mode of the bash history file to "0600" with the following command:
+
+    Note: The example will be for the smithj user, who has a home directory of "/home/smithj".
+
+    $ sudo chmod 0600 /home/smithj/.bash_history

--- a/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/tests/all_permissions.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/tests/all_permissions.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source common.sh
+
+chmod 7777 /home/dummy/.bash_history

--- a/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/tests/common.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/tests/common.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+for username in $(awk -F: '($3>={{{ uid_min }}} && $3!=65534) {print $1}' /etc/passwd)
+do
+    userdel -fr $username
+done
+
+useradd -m dummy
+
+touch /home/dummy/.bash_history
+chmod 0600 /home/dummy/.bash_history
+
+touch /home/dummy/.ignored_file
+chmod 0777 /home/dummy/.ignored_file

--- a/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/tests/correct_permissions.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/tests/correct_permissions.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+source common.sh

--- a/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/tests/different_home_correct_permissions.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/tests/different_home_correct_permissions.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+source common.sh
+
+useradd -m -d /var/dummy2 dummy2
+
+touch /var/dummy2/.bash_history
+chmod 0600 /var/dummy2/.bash_history

--- a/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/tests/different_home_wrong_permissions.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/tests/different_home_wrong_permissions.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+source common.sh
+
+useradd -m -d /var/dummy2 dummy2
+
+touch /var/dummy2/.bash_history
+chmod 0750 /var/dummy2/.bash_history

--- a/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/tests/lenient_permissions.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/tests/lenient_permissions.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source common.sh
+
+chmod 0604 /home/dummy/.bash_history

--- a/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/tests/lenient_permissions2.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/tests/lenient_permissions2.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source common.sh
+
+chmod 0640 /home/dummy/.bash_history

--- a/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/tests/stricter_permissions.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/tests/stricter_permissions.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source common.sh
+
+chmod 0400 /home/dummy/.bash_history

--- a/linux_os/guide/system/accounts/accounts-session/file_permission_user_init_files/tests/different_home_correct_permissions.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_permission_user_init_files/tests/different_home_correct_permissions.pass.sh
@@ -4,7 +4,7 @@
 
 source common.sh
 
-useradd -d /var/dummy2 dummy2
+useradd -m -d /var/dummy2 dummy2
 
 touch /var/dummy2/.init
 chmod 0740 /var/dummy2/.init

--- a/linux_os/guide/system/accounts/accounts-session/file_permission_user_init_files/tests/different_home_wrong_permissions.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_permission_user_init_files/tests/different_home_wrong_permissions.fail.sh
@@ -4,7 +4,7 @@
 
 source common.sh
 
-useradd -d /var/dummy2 dummy2
+useradd -m -d /var/dummy2 dummy2
 
 touch /var/dummy2/.init
 chmod 0750 /var/dummy2/.init


### PR DESCRIPTION
#### Description:

- Implement new rule `file_permission_user_bash_history`
- Fix tests for rule `file_permission_user_init_files`

#### Rationale:

- See commit messages
