### PR TITLE
Ubuntu 24.04 5.1.9 Ensure sshd GSSAPIAuthentication is disabled

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -1625,9 +1625,10 @@ controls:
     levels:
       - l1_workstation
       - l2_server
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
-
+    rules:
+      - sshd_disable_gssapi_auth
+    status: automated
+    
   - id: 5.1.10
     title: Ensure sshd HostbasedAuthentication is disabled (Automated)
     levels:


### PR DESCRIPTION
#### Description:

- Ubuntu 24.04 5.1.9 Ensure sshd GSSAPIAuthentication is disabled

#### Rationale:

- Implement Ubuntu 24.04 5.1.9 Ensure sshd GSSAPIAuthentication is disabled


