### PR TITLE
Implement rule groups_no_zero_gid_except_root 

### DIFF
--- a/components/pam.yml
+++ b/components/pam.yml
@@ -162,6 +162,7 @@ rules:
 - gid_passwd_group_same
 - group_unique_id
 - group_unique_name
+- groups_no_zero_gid_except_root
 - grub2_disable_interactive_boot
 - gui_login_dod_acknowledgement
 - install_smartcard_packages

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2136,8 +2136,12 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    rules:
+      - groups_no_zero_gid_except_root
+    status: automated
+    notes: |
+      The remediation is not automated as the removal or modification
+      of group IDs from a system is too disruptive.
 
   - id: 5.4.2.4
     title: Ensure root account access is controlled (Automated)

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/groups_no_zero_gid_except_root/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/groups_no_zero_gid_except_root/oval/shared.xml
@@ -1,0 +1,20 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("Only the root group should be assigned a GID of 0.") }}}
+    <criteria>
+      <criterion comment="no groups with GID 0 except root in the /etc/group file" test_ref="test_{{{ rule_id }}}" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="none_exist"
+      comment="no groups with GID 0 except root in the /etc/group file"
+      id="test_{{{ rule_id }}}" version="1">
+    <ind:object object_ref="obj_{{{ rule_id }}}" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}" version="1">
+    <ind:filepath>/etc/group</ind:filepath>
+    <ind:pattern operation="pattern match">^(?!root:)[^:]*:[^:]*:0</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/groups_no_zero_gid_except_root/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/groups_no_zero_gid_except_root/rule.yml
@@ -1,0 +1,31 @@
+documentation_complete: true
+
+title: 'Verify Only Group Root Has GID 0'
+
+description: |-
+    If any group other than root has a GID of 0, this misconfiguration should
+    be investigated and the groups other than root should be removed or have
+    their GID changed.
+
+rationale: |-
+    Ensuring that only the <tt>root</tt> group has a GID of 0 helps prevent
+    root group owned files from becoming accidentally accessible to
+    non-privileged users.
+
+severity: high
+
+ocil_clause: 'any groups other than "root" have a GID of "0"'
+
+ocil: |-
+    Verify that only the "root" group has a GID "0" assignment with the
+    following command:
+    <pre>$ awk -F: '$3 == 0 {print $1}' /etc/group</pre>
+    <pre>root</pre>
+
+fixtext: |-
+    Change the GID of any group on the system, other than root, that has a GID of "0".
+
+warnings:
+  - general: |-
+       This rule doesn't come with a remediation. The removal of groups from a system
+       or reassigning the GID is considered too disruptive.

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/groups_no_zero_gid_except_root/tests/only_root.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/groups_no_zero_gid_except_root/tests/only_root.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# remediation = none
+
+# Delete all groups with gid 0 except root.
+awk -F: '$3 == 0 && $1 != "root" { print $1 }' /etc/group | xargs -I '{}' groupdel -f '{}'

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/groups_no_zero_gid_except_root/tests/other_user_uid_0.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/groups_no_zero_gid_except_root/tests/other_user_uid_0.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# remediation = none
+
+groupadd --non-unique --gid 0 root2


### PR DESCRIPTION
#### Description:

- Implement rule `groups_no_zero_gid_except_root`
- Rule checks that no group except root has GID of 0

#### Rationale:
- Satisfies Ubuntu 24.04 CIS control 5.4.2.3