### PR TITLE
Implement rule accounts_umask_root 

### DIFF
--- a/components/bash.yml
+++ b/components/bash.yml
@@ -3,3 +3,4 @@ packages:
 - bash
 rules:
 - accounts_umask_etc_bashrc
+- accounts_umask_root

--- a/components/pam.yml
+++ b/components/pam.yml
@@ -92,6 +92,7 @@ rules:
 - accounts_umask_etc_login_defs
 - accounts_umask_etc_profile
 - accounts_umask_interactive_users
+- accounts_umask_root
 - accounts_user_dot_group_ownership
 - accounts_user_dot_no_world_writable_programs
 - accounts_user_dot_user_ownership

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2163,8 +2163,9 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    rules:
+      - accounts_umask_root
+    status: automated
 
   - id: 5.4.2.7
     title: Ensure system accounts do not have a valid login shell (Automated)

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/bash/shared.sh
@@ -1,0 +1,3 @@
+# platform = multi_platform_all
+
+sed -i -E -e "s/^([^#]*\bumask)[[:space:]]+[[:digit:]]+/\1 0027/g" /root/.bashrc /root/.profile

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/oval/shared.xml
@@ -1,0 +1,21 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("The umask for root user of the bash shell") }}}
+    <criteria operator="AND">
+      <criterion test_ref="tst_{{{ rule_id }}}" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}"
+      comment="Umask value from /root/.bashrc and /root/.profile" version="1">
+  <ind:filepath operation="pattern match">^(/root/.bashrc|/root/.profile)$</ind:filepath>
+    <ind:pattern operation="pattern match">^[^#]*\bumask\s+[0-7]?[0-7]([0-1][0-7]|[0-7][0-6])\s*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="tst_{{{ rule_id }}}" check="all" check_existence="none_exist"
+      comment="Test that no umask with lenient permissions exists" version="1">
+      <ind:object object_ref="obj_{{{ rule_id }}}"/>
+  </ind:textfilecontent54_test>
+
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/rule.yml
@@ -1,0 +1,18 @@
+documentation_complete: true
+
+title: 'Ensure the Root Bash Umask is Set Correctly'
+
+description: |-
+    To ensure the root user's umask of the Bash shell is set properly,
+    add or correct the <tt>umask</tt> setting in <tt>/root/.bashrc</tt>
+    or <tt>/root/.bashrc</tt> to read as follows:
+    <pre>umask 0027</pre>
+
+rationale: |-
+    The umask value influences the permissions assigned to files when they are created.
+    A misconfigured umask value could result in files with excessive permissions that can be read or
+    written to by unauthorized users.
+
+severity: medium
+
+platform: package[bash]

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/commented.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/commented.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sed '/umask/d' -i /root/.bashrc /root/.profile
+echo "# umask 0022" >> /root/.bashrc
+

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/correct_bashrc.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/correct_bashrc.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sed '/umask/d' -i /root/.bashrc /root/.profile
+echo "umask 0027" >> /root/.bashrc

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/correct_profile.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/correct_profile.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sed '/umask/d' -i /root/.bashrc /root/.profile
+echo "umask 0027" >> /root/.profile

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/lenient.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/lenient.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sed '/umask/d' -i /root/.bashrc /root/.profile
+echo "umask 0022" >> /root/.profile

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/lenient2.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/lenient2.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sed '/umask/d' -i /root/.bashrc /root/.profile
+echo "umask 0017" >> /root/.profile

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/lenient_bashrc_correct_profile.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/lenient_bashrc_correct_profile.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sed '/umask/d' -i /root/.bashrc /root/.profile
+echo "umask 0000" >> /root/.bashrc
+echo "umask 0027" >> /root/.profile

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/lenient_threedigit.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/lenient_threedigit.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sed '/umask/d' -i /root/.bashrc /root/.profile
+echo "umask 022" >> /root/.profile

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/missing.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/missing.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sed '/umask/d' -i /root/.bashrc /root/.profile
+

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/strict.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/strict.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sed '/umask/d' -i /root/.bashrc /root/.profile
+echo "umask 0777" >> /root/.profile


### PR DESCRIPTION
#### Description:

- Implement rule `accounts_umask_root`
- Rule checks that umask in /root/.bashrc and /root/.profile is 0027 or stricter, or undefined

#### Rationale:

- Satisfies Ubuntu 24.04 CIS control 5.4.2.6
