### PR TITLE
Refactor ubuntu oval for audit_rules_networkconfig_modification 

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2526,10 +2526,9 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    related_rules:
+    rules:
       - audit_rules_networkconfig_modification
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/4.1.3.5.
+    status: automated
 
   - id: 6.2.3.6
     title: Ensure use of privileged commands are collected (Automated)

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/ansible/shared.yml
@@ -69,6 +69,8 @@
 {{{ ansible_audit_auditctl_add_watch_rule(path='/etc/networks', permissions='wa', key='audit_rules_networkconfig_modification') }}}
 {{{ ansible_audit_augenrules_add_watch_rule(path='/etc/network/', permissions='wa', key='audit_rules_networkconfig_modification') }}}
 {{{ ansible_audit_auditctl_add_watch_rule(path='/etc/network/', permissions='wa', key='audit_rules_networkconfig_modification') }}}
+{{{ ansible_audit_augenrules_add_watch_rule(path='/etc/netplan/', permissions='wa', key='audit_rules_networkconfig_modification') }}}
+{{{ ansible_audit_auditctl_add_watch_rule(path='/etc/netplan/', permissions='wa', key='audit_rules_networkconfig_modification') }}}
 {{% else -%}}
 {{{ ansible_audit_augenrules_add_watch_rule(path='/etc/sysconfig/network', permissions='wa', key='audit_rules_networkconfig_modification') }}}
 {{{ ansible_audit_auditctl_add_watch_rule(path='/etc/sysconfig/network', permissions='wa', key='audit_rules_networkconfig_modification') }}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/bash/shared.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/bash/shared.sh
@@ -31,6 +31,8 @@ done
 {{{ bash_fix_audit_watch_rule("augenrules", "/etc/networks", "wa", "audit_rules_networkconfig_modification") }}}
 {{{ bash_fix_audit_watch_rule("auditctl", "/etc/network/", "wa", "audit_rules_networkconfig_modification") }}}
 {{{ bash_fix_audit_watch_rule("augenrules", "/etc/network/", "wa", "audit_rules_networkconfig_modification") }}}
+{{{ bash_fix_audit_watch_rule("auditctl", "/etc/netplan/", "wa", "audit_rules_networkconfig_modification") }}}
+{{{ bash_fix_audit_watch_rule("augenrules", "/etc/netplan/", "wa", "audit_rules_networkconfig_modification") }}}
 {{% else -%}}
 {{{ bash_fix_audit_watch_rule("auditctl", "/etc/sysconfig/network", "wa", "audit_rules_networkconfig_modification") }}}
 {{{ bash_fix_audit_watch_rule("augenrules", "/etc/sysconfig/network", "wa", "audit_rules_networkconfig_modification") }}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/oval/ubuntu.xml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/oval/ubuntu.xml
@@ -1,3 +1,9 @@
+{{% if product in ['ubuntu2404'] %}}
+{{% set paths = ('/etc/issue', '/etc/issue.net', '/etc/hosts', '/etc/networks', '/etc/network/', '/etc/netplan/') %}}
+{{% else %}}
+{{% set paths = ('/etc/issue', '/etc/issue.net', '/etc/hosts', '/etc/networks', '/etc/network/') %}}
+{{% endif %}}
+
 <def-group>
   <definition class="compliance" id="audit_rules_networkconfig_modification" version="1">
     {{{ oval_metadata("The network environment should not be modified by anything other than
@@ -8,11 +14,9 @@
       <!-- Test the augenrules case -->
       <criteria operator="AND">
         <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
-        <criterion comment="audit /etc/issue augenrules" test_ref="test_arnm_etc_issue_augenrules" />
-        <criterion comment="audit /etc/issue.net augenrules" test_ref="test_arnm_etc_issue_net_augenrules" />
-        <criterion comment="audit /etc/hosts augenrules" test_ref="test_arnm_etc_hosts_augenrules" />
-        <criterion comment="audit /etc/networks augenrules" test_ref="test_arnm_etc_networks_augenrules" />
-        <criterion comment="audit /etc/network/ augenrules" test_ref="test_arnm_etc_networkdir_augenrules" />
+        {{% for path in paths %}}
+        <criterion comment="audit {{{ path }}} augenrules" test_ref="test_{{{ rule_id }}}_{{{ path | escape_id }}}_augenrules" />
+        {{% endfor %}}
         <extend_definition comment="audit augenrules sethostname" definition_ref="audit_rules_networkconfig_modification_hostname" />
         <extend_definition comment="audit augenrules setdomainname" definition_ref="audit_rules_networkconfig_modification_domainname" />
       </criteria>
@@ -20,11 +24,9 @@
       <!-- Test the auditctl case -->
       <criteria operator="AND">
         <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
-        <criterion comment="audit /etc/issue auditctl" test_ref="test_arnm_etc_issue_auditctl" />
-        <criterion comment="audit /etc/issue.net auditctl" test_ref="test_arnm_etc_issue_net_auditctl" />
-        <criterion comment="audit /etc/hosts auditctl" test_ref="test_arnm_etc_hosts_auditctl" />
-        <criterion comment="audit /etc/networks auditctl" test_ref="test_arnm_etc_networks_auditctl" />
-        <criterion comment="audit /etc/network/ auditctl" test_ref="test_arnm_etc_networkdir_auditctl" />
+        {{% for path in paths %}}
+        <criterion comment="audit {{{ path }}} auditctl" test_ref="test_{{{ rule_id }}}_{{{ path | escape_id }}}_auditctl" />
+        {{% endfor %}}
         <extend_definition comment="audit augenrules sethostname" definition_ref="audit_rules_networkconfig_modification_hostname" />
         <extend_definition comment="audit augenrules setdomainname" definition_ref="audit_rules_networkconfig_modification_domainname" />
       </criteria>
@@ -32,94 +34,24 @@
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" comment="audit /etc/issue augenrules" id="test_arnm_etc_issue_augenrules" version="1">
-    <ind:object object_ref="object_arnm_etc_issue_augenrules" />
+  {{% for path in paths %}}
+  <ind:textfilecontent54_test check="all" comment="audit {{{ path }}} augenrules" id="test_{{{ rule_id }}}_{{{ path | escape_id }}}_augenrules" version="1">
+      <ind:object object_ref="obj_{{{ rule_id }}}_{{{ path | escape_id }}}_augenrules" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_arnm_etc_issue_augenrules" version="1">
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}_{{{ path | escape_id }}}_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w[\s]+/etc/issue[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\-w[\s]+{{{ path | escape_regex }}}[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" comment="audit /etc/issue.net augenrules" id="test_arnm_etc_issue_net_augenrules" version="1">
-    <ind:object object_ref="object_arnm_etc_issue_net_augenrules" />
+  <ind:textfilecontent54_test check="all" comment="audit {{{ path }}} auditctl" id="test_{{{ rule_id }}}_{{{ path | escape_id }}}_auditctl" version="1">
+    <ind:object object_ref="obj_{{{ rule_id }}}_{{{ path | escape_id }}}_auditctl" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_arnm_etc_issue_net_augenrules" version="1">
-    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w[\s]+/etc/issue\.net[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-
-  <ind:textfilecontent54_test check="all" comment="audit /etc/hosts augenrules" id="test_arnm_etc_hosts_augenrules" version="1">
-    <ind:object object_ref="object_arnm_etc_hosts_augenrules" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_arnm_etc_hosts_augenrules" version="1">
-    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w[\s]+/etc/hosts[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-
-  <ind:textfilecontent54_test check="all" comment="audit /etc/networks augenrules" id="test_arnm_etc_networks_augenrules" version="1">
-    <ind:object object_ref="object_arnm_etc_networks_augenrules" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_arnm_etc_networks_augenrules" version="1">
-    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w[\s]+/etc/networks[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-
-  <ind:textfilecontent54_test check="all" comment="audit /etc/network/ augenrules" id="test_arnm_etc_networkdir_augenrules" version="1">
-    <ind:object object_ref="object_arnm_etc_networkdir_augenrules" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_arnm_etc_networkdir_augenrules" version="1">
-    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w[\s]+/etc/network/[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-
-  <ind:textfilecontent54_test check="all" comment="audit /etc/issue auditctl" id="test_arnm_etc_issue_auditctl" version="1">
-    <ind:object object_ref="object_arnm_etc_issue_auditctl" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_arnm_etc_issue_auditctl" version="1">
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}_{{{ path | escape_id }}}_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w[\s]+/etc/issue[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\-w[\s]+{{{ path | escape_regex }}}[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-
-  <ind:textfilecontent54_test check="all" comment="audit /etc/issue.net auditctl" id="test_arnm_etc_issue_net_auditctl" version="1">
-    <ind:object object_ref="object_arnm_etc_issue_net_auditctl" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_arnm_etc_issue_net_auditctl" version="1">
-    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w[\s]+/etc/issue\.net[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-
-  <ind:textfilecontent54_test check="all" comment="audit /etc/hosts auditctl" id="test_arnm_etc_hosts_auditctl" version="1">
-    <ind:object object_ref="object_arnm_etc_hosts_auditctl" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_arnm_etc_hosts_auditctl" version="1">
-    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w[\s]+/etc/hosts[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-
-  <ind:textfilecontent54_test check="all" comment="audit /etc/networks auditctl" id="test_arnm_etc_networks_auditctl" version="1">
-    <ind:object object_ref="object_arnm_etc_networks_auditctl" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_arnm_etc_networks_auditctl" version="1">
-    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w[\s]+/etc/networks[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-
-  <ind:textfilecontent54_test check="all" comment="audit /etc/network/ auditctl" id="test_arnm_etc_networkdir_auditctl" version="1">
-    <ind:object object_ref="object_arnm_etc_networkdir_auditctl" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_arnm_etc_networkdir_auditctl" version="1">
-    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w[\s]+/etc/network/[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
+  {{% endfor %}}
 
 </def-group>

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/rule.yml
@@ -12,6 +12,9 @@ description: |-
     -w /etc/issue -p wa -k audit_rules_networkconfig_modification
     -w /etc/issue.net -p wa -k audit_rules_networkconfig_modification
     -w /etc/hosts -p wa -k audit_rules_networkconfig_modification
+    {{% if product in ['ubuntu2404'] %}}
+    -w /etc/netplan/ -p wa -k audit_rules_networkconfig_modification
+    {{% endif %}}
     {{% if 'ubuntu' in product -%}}
     -w /etc/networks -p wa -k audit_rules_networkconfig_modification
     -w /etc/network/ -p wa -k audit_rules_networkconfig_modification</pre>
@@ -72,7 +75,9 @@ ocil_clause: 'the system is not configured to audit changes of the network confi
 ocil: |-
     To determine if the system is configured to audit changes to its network configuration,
     run the following command:
-    {{% if 'ubuntu' in product -%}}
+    {{% if product in ['ubuntu2404'] -%}}
+    <pre>auditctl -l | grep -E '(/etc/issue|/etc/issue.net|/etc/hosts|/etc/networks|/etc/network/|/etc/netplan/)'</pre>
+    {{% elif 'ubuntu' in product -%}}
     <pre>auditctl -l | grep -E '(/etc/issue|/etc/issue.net|/etc/hosts|/etc/networks|/etc/network/)'</pre>
     {{% else -%}}
     <pre>auditctl -l | grep -E '(/etc/issue|/etc/issue.net|/etc/hosts|/etc/sysconfig/network)'</pre>

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/auditctl_correct_rules.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/auditctl_correct_rules.pass.sh
@@ -20,3 +20,6 @@ echo "-w /etc/network/ -p wa -k audit_rules_networkconfig_modification" >> /etc/
 {{% else -%}}
 echo "-w /etc/sysconfig/network -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/audit.rules
 {{% endif %}}
+{{% if product in ['ubuntu2404'] %}}
+echo "-w /etc/netplan/ -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/audit.rules
+{{% endif %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/auditctl_correct_rules_watch_rules_without_key.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/auditctl_correct_rules_watch_rules_without_key.pass.sh
@@ -20,3 +20,6 @@ echo "-w /etc/network/ -p wa" >> /etc/audit/audit.rules
 {{% else -%}}
 echo "-w /etc/sysconfig/network -p wa" >> /etc/audit/audit.rules
 {{% endif %}}
+{{% if product in ['ubuntu2404'] %}}
+echo "-w /etc/netplan/ -p wa" >> /etc/audit/audit.rules
+{{% endif %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/augen_correct_rules.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/augen_correct_rules.pass.sh
@@ -13,3 +13,6 @@ echo "-w /etc/network/ -p wa -k audit_rules_networkconfig_modification" >> /etc/
 {{% else -%}}
 echo "-w /etc/sysconfig/network -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/rules.d/networkconfig.rules
 {{% endif %}}
+{{% if product in ['ubuntu2404'] %}}
+echo "-w /etc/netplan/ -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/rules.d/networkconfig.rules
+{{% endif %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/augen_correct_rules_watch_rules_without_key.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/augen_correct_rules_watch_rules_without_key.pass.sh
@@ -12,3 +12,6 @@ echo "-w /etc/network/ -p wa" >> /etc/audit/rules.d/networkconfig.rules
 {{% else -%}}
 echo "-w /etc/sysconfig/network -p wa" >> /etc/audit/rules.d/networkconfig.rules
 {{% endif %}}
+{{% if product in ['ubuntu2404'] %}}
+echo "-w /etc/netplan/ -p wa" >> /etc/audit/rules.d/networkconfig.rules
+{{% endif %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/partial_rules.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/partial_rules.fail.sh
@@ -13,3 +13,6 @@ echo "-w /etc/network/ -p wa -k audit_rules_networkconfig_modification" >> /etc/
 {{% else -%}}
 echo "-w /etc/sysconfig/network -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/audit.rules
 {{% endif %}}
+{{% if product in ['ubuntu2404'] %}}
+echo "-w /etc/netplan/ -p wa -k audit_rules_networkconfig_modification" >> /etc/audit/audit.rules
+{{% endif %}}


### PR DESCRIPTION
#### Description:

- Refactor ubuntu oval for `audit_rules_networkconfig_modification`
- Add rules to Ubuntu 24.04 CIS v1 control 6.2.3.5

#### Rationale:

- use loops to avoid duplicated code
- add '/etc/netplan/' check for Ubuntu 24.04 CIS