### PR TITLE
Ubuntu 24.04: Implement 5.3.2.3 Ensure pam_pwquality module is enabled

### DIFF
--- a/components/pam.yml
+++ b/components/pam.yml
@@ -59,6 +59,7 @@ rules:
 - accounts_password_pam_pwhistory_remember_system_auth
 - accounts_password_pam_pwquality_password_auth
 - accounts_password_pam_pwquality_system_auth
+- accounts_password_pam_pwquality_enabled
 - accounts_password_pam_retry
 - accounts_password_pam_ucredit
 - accounts_password_pam_unix_remember

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -1866,8 +1866,9 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    rules: 
+      - accounts_password_pam_pwquality_enabled
+    status: automated
 
   - id: 5.3.2.4
     title: Ensure pam_pwhistory module is enabled (Automated)

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_enabled/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_enabled/bash/shared.sh
@@ -1,0 +1,3 @@
+# platform = multi_platform_ubuntu
+
+{{{ bash_pam_pwquality_enable() }}}

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_enabled/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_enabled/oval/shared.xml
@@ -1,0 +1,37 @@
+{{% if 'ubuntu' in product or 'debian' in product %}}
+{{% set configuration_files = ["common-password"] %}}
+{{% endif %}}
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="2">
+    {{{ oval_metadata("Check pam_pwquality module is enabled") }}}
+    <criteria operator="AND" comment="Check for pam_pwquality module in PAM files">
+      {{% for file in configuration_files %}}
+      <criterion comment="pam_pwquality has correctly set in {{{ file }}}"
+      test_ref="test_password_pam_pwquality_enabled_{{{ file | escape_id }}}" />
+      {{% endfor %}}
+    </criteria>
+  </definition>
+
+  {{% macro test_pwquality_enabled(path, test_ref) %}}
+  <ind:textfilecontent54_test check="all" id="test_{{{ test_ref }}}" version="1"
+  check_existence="at_least_one_exists"
+  comment="Check for pam_pwquality.so module in PAM file of {{{ path }}}">
+    <ind:object object_ref="obj_{{{ test_ref }}}" />
+  </ind:textfilecontent54_test>
+  {{% endmacro %}}
+
+  {{% macro object_pwquality_enabled(path, test_ref) %}}
+  <ind:textfilecontent54_object id="obj_{{{ test_ref }}}" version="1">
+    <ind:filepath>{{{ path }}}</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*password\s+(?:(?:required)|(?:requisite))\s+pam_pwquality\.so.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  {{% endmacro %}}
+
+  {{% for file in configuration_files %}}
+  {{{ test_pwquality_enabled( path="/etc/pam.d/" ~ file ,
+                             test_ref="password_pam_pwquality_enabled_" ~ (file | escape_id)) }}}
+  {{{ object_pwquality_enabled( path="/etc/pam.d/" ~ file ,
+                               test_ref="password_pam_pwquality_enabled_" ~ (file | escape_id)) }}}
+  {{% endfor %}}
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_enabled/oval/ubuntu.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_enabled/oval/ubuntu.xml
@@ -1,4 +1,4 @@
-{{% if 'ubuntu' in product or 'debian' in product %}}
+{{% if 'ubuntu' in product %}}
 {{% set configuration_files = ["common-password"] %}}
 {{% endif %}}
 <def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_enabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_enabled/rule.yml
@@ -1,0 +1,21 @@
+documentation_complete: true
+
+
+title: 'Verify pam_pwquality module is activated'
+
+description: |-
+    The <tt>pam_pwquality.so</tt> module ensures password quality by evaluating user-created passwords 
+    against a system dictionary and a set of rules designed to detect weak choices. Originally derived 
+    from the pam_cracklib module, this module is backward-compatible with options of pam_cracklib.
+    <br /><br />
+    The module's process includes prompting the user for a password, checking its strength, and if it 
+    meets the criteria requesting the password again for confirmation. If both entries match, the 
+    password is passed to subsequent modules to be set as the new authentication token.
+
+rationale: |-
+    Strong passwords significantly increase the time and effort required for unauthorized access, 
+    increasing overall system security.
+
+severity: medium
+
+platform: package[pam]

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_enabled/tests/commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_enabled/tests/commented.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+sed -i 's/\(^.*pam_pwquality\.so.*\)/# \1/' /etc/pam.d/common-password

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_enabled/tests/common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_enabled/tests/common.sh
@@ -1,0 +1,27 @@
+{{% if 'ubuntu' in product %}}
+configuration_files=("common-password")
+{{% elif product in ['ol8', 'ol9', 'rhel8', 'rhel9'] %}}
+configuration_files=("password-auth" "system-auth")
+{{% else %}}
+configuration_files=("system-auth")
+{{% endif %}}
+
+
+{{% if product in ['ol8', 'ol9', 'rhel8', 'rhel9'] %}}
+authselect create-profile testingProfile --base-on sssd
+
+for file in ${configuration_files[@]}; do
+	sed -i --follow-symlinks "/pam_pwquality\.so/d" \
+		"/etc/authselect/custom/testingProfile/$file"
+done
+authselect select --force custom/testingProfile
+{{% elif 'ubuntu' in product %}}
+rm -f /usr/share/pam-configs/pwquality
+DEBIAN_FRONTEND=noninteractive pam-auth-update
+{{% else %}}
+for file in ${configuration_files[@]}; do
+	sed -i --follow-symlinks "/pam_pwquality\.so/d" "/etc/pam.d/$file"
+done
+{{% endif%}}
+
+truncate -s 0 /etc/security/pwquality.conf

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_enabled/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_enabled/tests/correct.pass.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+cat << EOF > /usr/share/pam-configs/pwquality
+Name: Pwquality password strength checking
+Default: yes
+Priority: 1024
+Conflicts: cracklib
+Password-Type: Primary
+Password:
+    requisite                   pam_pwquality.so
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_enabled/tests/missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_enabled/tests/missing.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+source common.sh


### PR DESCRIPTION
#### Description:

- Implement 5.3.2.3 Ensure pam_pwquality module is enabled
- Rule checks that pam_pwquality.so is enabled in /etc/pam.d/common-password

#### Rationale:

- Satisfies Ubuntu 24.04 CIS control 5.3.2.3