### PR TITLE
Implement audit rules for nsswitch.conf, pam.conf and pam.d

### DIFF
--- a/components/audit.yml
+++ b/components/audit.yml
@@ -260,6 +260,7 @@ rules:
 - audit_rules_usergroup_modification_opasswd
 - audit_rules_usergroup_modification_passwd
 - audit_rules_usergroup_modification_shadow
+- audit_rules_usergroup_modification_nsswitch_conf
 - audit_rules_var_log_journal
 - audit_sudo_log_events
 - auditd_audispd_configure_remote_server

--- a/components/audit.yml
+++ b/components/audit.yml
@@ -262,6 +262,7 @@ rules:
 - audit_rules_usergroup_modification_shadow
 - audit_rules_usergroup_modification_nsswitch_conf
 - audit_rules_usergroup_modification_pam_conf
+- audit_rules_usergroup_modification_pamd
 - audit_rules_var_log_journal
 - audit_sudo_log_events
 - auditd_audispd_configure_remote_server

--- a/components/audit.yml
+++ b/components/audit.yml
@@ -261,6 +261,7 @@ rules:
 - audit_rules_usergroup_modification_passwd
 - audit_rules_usergroup_modification_shadow
 - audit_rules_usergroup_modification_nsswitch_conf
+- audit_rules_usergroup_modification_pam_conf
 - audit_rules_var_log_journal
 - audit_sudo_log_events
 - auditd_audispd_configure_remote_server

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2577,14 +2577,16 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    related_rules:
+    rules:
       - audit_rules_usergroup_modification_group
       - audit_rules_usergroup_modification_gshadow
       - audit_rules_usergroup_modification_opasswd
       - audit_rules_usergroup_modification_passwd
       - audit_rules_usergroup_modification_shadow
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/4.1.3.8.
+      - audit_rules_usergroup_modification_nsswitch_conf
+      - audit_rules_usergroup_modification_pam_conf
+      - audit_rules_usergroup_modification_pamd
+    status: automated
 
   - id: 6.2.3.9
     title: Ensure discretionary access control permission modification events are collected (Automated)

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_usergroup_modification_nsswitch_conf/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_usergroup_modification_nsswitch_conf/rule.yml
@@ -1,0 +1,33 @@
+documentation_complete: true
+
+title: 'Record Events that Modify User/Group Information - /etc/nsswitch.conf'
+
+description: |-
+    If the <tt>auditd</tt> daemon is configured to use the
+    <tt>augenrules</tt> program to read audit rules during daemon startup (the
+    default), add the following lines to a file with suffix <tt>.rules</tt> in the
+    directory <tt>/etc/audit/rules.d</tt>, in order to capture events that modify
+    account changes:
+    <br /><br />
+    <pre>-w /etc/nsswitch.conf -p wa -k audit_rules_usergroup_modification</pre>
+    <br /><br />
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add the following lines to
+    <tt>/etc/audit/audit.rules</tt> file, in order to capture events that modify
+    account changes:
+    <br /><br />
+    <pre>-w /etc/nsswitch.conf -p wa -k audit_rules_usergroup_modification</pre>
+
+rationale: |-
+    The nsswitch file defines how the system uses various databases and name
+    resolution mechanisms. Any unexpected changes to nsswitch configuration
+    should be investigated.
+
+severity: medium
+
+fixtext: '{{{ fixtext_audit_file_watch_rule("/etc/nsswitch.conf", "identity", "/etc/audit/rules.d/audit.rules") }}}'
+
+template:
+    name: audit_rules_usergroup_modification
+    vars:
+        path: /etc/nsswitch.conf

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_usergroup_modification_pam_conf/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_usergroup_modification_pam_conf/rule.yml
@@ -1,0 +1,33 @@
+documentation_complete: true
+
+title: 'Record Events that Modify User/Group Information - /etc/pam.conf'
+
+description: |-
+    If the <tt>auditd</tt> daemon is configured to use the
+    <tt>augenrules</tt> program to read audit rules during daemon startup (the
+    default), add the following lines to a file with suffix <tt>.rules</tt> in the
+    directory <tt>/etc/audit/rules.d</tt>, in order to capture events that modify
+    account changes:
+    <br /><br />
+    <pre>-w /etc/pam.conf -p wa -k audit_rules_usergroup_modification</pre>
+    <br /><br />
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add the following lines to
+    <tt>/etc/audit/audit.rules</tt> file, in order to capture events that modify
+    account changes:
+    <br /><br />
+    <pre>-w /etc/pam.conf -p wa -k audit_rules_usergroup_modification</pre>
+
+rationale: |-
+    The PAM configuration file defines the authentication mechanism
+    used by PAM-aware applications. Any unexpected changes to PAM configuration
+    should be investigated.
+
+severity: medium
+
+fixtext: '{{{ fixtext_audit_file_watch_rule("/etc/pam.conf", "identity", "/etc/audit/rules.d/audit.rules") }}}'
+
+template:
+    name: audit_rules_usergroup_modification
+    vars:
+        path: /etc/pam.conf

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_usergroup_modification_pamd/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_usergroup_modification_pamd/rule.yml
@@ -1,0 +1,33 @@
+documentation_complete: true
+
+title: 'Record Events that Modify User/Group Information - /etc/pam.d/'
+
+description: |-
+    If the <tt>auditd</tt> daemon is configured to use the
+    <tt>augenrules</tt> program to read audit rules during daemon startup (the
+    default), add the following lines to a file with suffix <tt>.rules</tt> in the
+    directory <tt>/etc/audit/rules.d</tt>, in order to capture events that modify
+    account changes:
+    <br /><br />
+    <pre>-w /etc/pam.d/ -p wa -k audit_rules_usergroup_modification</pre>
+    <br /><br />
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add the following lines to
+    <tt>/etc/audit/audit.rules</tt> file, in order to capture events that modify
+    account changes:
+    <br /><br />
+    <pre>-w /etc/pam.d/ -p wa -k audit_rules_usergroup_modification</pre>
+
+rationale: |-
+    The PAM configuration files in /etc/pam.d define the authentication mechanism
+    used by PAM-aware applications. Any unexpected changes to PAM configuration
+    should be investigated.
+
+severity: medium
+
+fixtext: '{{{ fixtext_audit_file_watch_rule("/etc/pam.d/", "identity", "/etc/audit/rules.d/audit.rules") }}}'
+
+template:
+    name: audit_rules_usergroup_modification
+    vars:
+        path: /etc/pam.d/


### PR DESCRIPTION
#### Description:

- Implement rule `audit_rules_usergroup_modification_nsswitch_conf`  (adds audit check for /etc/nsswitch.conf)
- Implement rule `audit_rules_usergroup_modification_pam_conf`  (adds audit check for /etc/pam.conf)
- Implement rule `audit_rules_usergroup_modification_pamd`  (adds audit check for /etc/pam.d/)
- Add rules to ubuntu2404 CIS control 6.2.3.8

#### Rationale:

- Rules partially satisfy Ubuntu 24.04 CIS v1 control 6.2.3.8
