### PR TITLE
Ubuntu 24.04: Implement 5.3.2.4 Ensure pam_pwhistory module is enabled

### DIFF
--- a/components/pam.yml
+++ b/components/pam.yml
@@ -54,6 +54,7 @@ rules:
 - accounts_password_pam_minclass
 - accounts_password_pam_minlen
 - accounts_password_pam_ocredit
+- accounts_password_pam_pwhistory_enabled
 - accounts_password_pam_pwhistory_remember
 - accounts_password_pam_pwhistory_remember_password_auth
 - accounts_password_pam_pwhistory_remember_system_auth

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -1875,8 +1875,9 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    rules:
+      - accounts_password_pam_pwhistory_enabled
+    status: automated
 
   - id: 5.3.3.1.1
     title: Ensure password failed attempts lockout is configured (Automated)

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enabled/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enabled/bash/shared.sh
@@ -1,22 +1,3 @@
 # platform = multi_platform_ubuntu
 
-conf_name=cac_pwhistory
-conf_path="/usr/share/pam-configs"
-
-if [ ! -f "$conf_path"/"$conf_name" ]; then
-    if [ -f "$conf_path"/pwhistory ]; then
-        cp "$conf_path"/pwhistory "$conf_path"/"$conf_name"
-        sed -i '/Default: yes/a Priority: 1025\
-Conflicts: pwhistory' "$conf_path"/"$conf_name"
-    else
-        cat << EOF > "$conf_path"/"$conf_name"
-Name: pwhistory password history checking
-Default: yes
-Priority: 1024
-Password-Type: Primary
-Password: requisite pam_pwhistory.so remember=24 enforce_for_root try_first_pass use_authtok
-EOF
-    fi
-fi
-
-DEBIAN_FRONTEND=noninteractive pam-auth-update
+{{{ bash_pam_pwhistory_enable() }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enabled/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enabled/bash/shared.sh
@@ -1,0 +1,22 @@
+# platform = multi_platform_ubuntu
+
+conf_name=cac_pwhistory
+conf_path="/usr/share/pam-configs"
+
+if [ ! -f "$conf_path"/"$conf_name" ]; then
+    if [ -f "$conf_path"/pwhistory ]; then
+        cp "$conf_path"/pwhistory "$conf_path"/"$conf_name"
+        sed -i '/Default: yes/a Priority: 1025\
+Conflicts: pwhistory' "$conf_path"/"$conf_name"
+    else
+        cat << EOF > "$conf_path"/"$conf_name"
+Name: pwhistory password history checking
+Default: yes
+Priority: 1024
+Password-Type: Primary
+Password: requisite pam_pwhistory.so remember=24 enforce_for_root try_first_pass use_authtok
+EOF
+    fi
+fi
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enabled/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enabled/bash/shared.sh
@@ -1,3 +1,3 @@
 # platform = multi_platform_ubuntu
 
-{{{ bash_pam_pwhistory_enable() }}}
+{{{ bash_pam_pwhistory_enable('cac_pwhistory','requisite') }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enabled/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enabled/oval/shared.xml
@@ -1,0 +1,27 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="2">
+    {{{ oval_metadata("The passwords to remember should be set correctly.") }}}
+    <criteria operator="AND" comment="Check if pam_pwhistory.so is properly enabled">
+      <!--
+        pam_pwhistory.so parameters can be defined directly in pam files or, in newer versions,
+        in /etc/security/pwhistory.conf. The last is the recommended option when available. Also,
+        is the option used by auselect tool. However, regardless the approach, a minimal
+        declaration is common in pam files. -->
+      <criterion test_ref="test_accounts_password_pam_pwhistory_remember_common_password"
+        comment="pam_pwhistory.so is properly defined in password section of common-password"/>
+    </criteria>
+  </definition>
+
+  <!-- is pam_pwhistory.so enabled? -->
+  <ind:textfilecontent54_test id="test_accounts_password_pam_pwhistory_remember_common_password" check="all"
+    check_existence="at_least_one_exists" version="1" comment="Check pam_pwhistory.so presence in /etc/pam.d/common-password">
+    <ind:object object_ref="object_accounts_password_pam_pwhistory_remember_common_password"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_accounts_password_pam_pwhistory_remember_common_password"
+    version="1">
+    <ind:filepath>/etc/pam.d/common-password</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*password[\s]+((?:\[success=\d+\s+default=ignore\])|(?:requisite)|(?:required))[\s]+pam_pwhistory\.so[\s]+.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enabled/rule.yml
@@ -1,7 +1,7 @@
 documentation_complete: true
 
 
-title: 'Ensure pam_pwhistory module is enabled'
+title: 'Verify pam_pwhistory module is activated'
 
 description: |-
     The <tt>pam_pwhistory.so</tt> module is part of the Pluggable Authentication Modules (PAM) 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enabled/rule.yml
@@ -1,0 +1,20 @@
+documentation_complete: true
+
+
+title: 'Ensure pam_pwhistory module is enabled'
+
+description: |-
+    The <tt>pam_pwhistory.so</tt> module is part of the Pluggable Authentication Modules (PAM) 
+    framework designed to increase password security. It works by storing a history of previously 
+    used passwords for each user, ensuring users cannot alternate between the same passwords too frequently.
+    <br /><br />
+    This module is incompatible with Kerberos. Furthermore, its usage with <tt>NIS</tt> or <tt>LDAP</tt> is 
+    generally impractical, as other machines can not access local password histories.
+
+rationale: |-
+    Enforcing strong passwords increases the difficulty and resources required 
+    for password compromise.
+
+severity: medium
+
+platform: package[pam]

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enabled/tests/commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enabled/tests/commented.fail.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+config_file=/usr/share/pam-configs/tmp_pwhistory
+cat << EOF > "$config_file"
+Name: pwhistory password history checking
+Default: yes
+Priority: 1024
+Password-Type: Primary
+Password: requisite # pam_pwhistory.so remember=24 enforce_for_root try_first_pass use_authtok
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update
+
+rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enabled/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enabled/tests/correct.pass.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+config_file=/usr/share/pam-configs/tmp_pwhistory
+cat << EOF > "$config_file"
+Name: pwhistory password history checking
+Default: yes
+Priority: 1024
+Password-Type: Primary
+Password: requisite pam_pwhistory.so remember=24 enforce_for_root try_first_pass use_authtok
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update
+
+rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enabled/tests/missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enabled/tests/missing.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+rm /usr/share/pam-configs/*pwhistory
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -983,7 +983,7 @@ if [ -f /usr/bin/authselect ]; then
     fi
 else
 {{% if 'ubuntu' in product %}}
-conf_name=cac_pwhistory
+conf_name={{{ pam_file }}}
 conf_path="/usr/share/pam-configs"
 
 if [ ! -f "$conf_path"/"$conf_name" ]; then
@@ -992,7 +992,7 @@ Name: pwhistory password history checking
 Default: yes
 Priority: 1024
 Password-Type: Primary
-Password: requisite pam_pwhistory.so remember=24 enforce_for_root try_first_pass use_authtok
+Password: {{{ control }}} pam_pwhistory.so remember=24 enforce_for_root try_first_pass use_authtok
 EOF
 fi
 

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -982,7 +982,24 @@ if [ -f /usr/bin/authselect ]; then
         {{{ bash_ensure_pam_module_line("$PAM_FILE_PATH", 'password', control, 'pam_pwhistory.so', after_match) | indent(8) }}}
     fi
 else
+{{% if 'ubuntu' in product %}}
+conf_name=cac_pwhistory
+conf_path="/usr/share/pam-configs"
+
+if [ ! -f "$conf_path"/"$conf_name" ]; then
+    cat << EOF > "$conf_path"/"$conf_name"
+Name: pwhistory password history checking
+Default: yes
+Priority: 1024
+Password-Type: Primary
+Password: requisite pam_pwhistory.so remember=24 enforce_for_root try_first_pass use_authtok
+EOF
+fi
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update
+{{% else %}}
     {{{ bash_ensure_pam_module_line(pam_file, 'password', control, 'pam_pwhistory.so', after_match) | indent(4) }}}
+{{% endif %}}
 fi
 {{%- endmacro -%}}
 


### PR DESCRIPTION
#### Description:

- Implement 5.3.2.4 Ensure pam_pwhistory module is enabled
- Rule checks that pam_pwhistory.so is enabled in /etc/pam.d/common-password
- Implement bash_pam_pwhistory_enable macro

#### Rationale:

- Satisfies Ubuntu 24.04 CIS control 5.3.2.4