### PR TITLE
Fix to prevent oscap crashing on ubuntu

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/rule.yml
@@ -62,8 +62,10 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} must display the Standard Mandatory DoD Notice and Consent Banner before granting local or remote access to the system via a ssh logon.'
 
+{{% if 'ubuntu' not in product %}}
 conflicts:
     - sshd_enable_warning_banner_net
+{{% endif %}}
 
 template:
     name: sshd_lineinfile

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner_net/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner_net/rule.yml
@@ -46,8 +46,10 @@ references:
 
 {{{ complete_ocil_entry_sshd_option(default="no", option="Banner", value="/etc/issue.net") }}}
 
+{{% if 'ubuntu' not in product %}}
 conflicts:
     - sshd_enable_warning_banner
+{{% endif %}}
 
 template:
     name: sshd_lineinfile


### PR DESCRIPTION
#### Description:

- The recently added conflicts tags to sshd_enable_warning_banner_* rules cause openscap to crash on Ubuntu
- This change disables the conflicts tags on Ubuntu products until a proper fix is implemented

#### Rationale:

- Temporarily fixes #12718