### PR TITLE
Ubuntu 24.04 5.1.12 Ensure sshd KexAlgorithms is configured

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -1652,11 +1652,10 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    related_rules:
+    rules:
       - sshd_strong_kex=cis_ubuntu2404
       - sshd_use_strong_kex
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/5.2.15.
+    status: automated
 
   - id: 5.1.13
     title: Ensure sshd LoginGraceTime is configured (Automated)

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/good_kex_sle.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/good_kex_sle.pass.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_sle,multi_platform_ubuntu
 
 sed -i 's/^\s*KexAlgorithms\s.*//i' /etc/ssh/sshd_config
 echo "KexAlgorithms diffie-hellman-group14-sha256" >> /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/sshd_strong_kex.var
+++ b/linux_os/guide/services/ssh/sshd_strong_kex.var
@@ -19,4 +19,5 @@ options:
     cis_sle15: curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
     cis_ubuntu2004: curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256
     cis_ubuntu2204: curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256
+    cis_ubuntu2404: sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256
     std_openeuler: curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256


### PR DESCRIPTION
#### Description:

- Ubuntu 24.04 5.1.12 Ensure sshd KexAlgorithms is configured

#### Rationale:

- Implement Ubuntu 24.04 5.1.12 Ensure sshd KexAlgorithms is configured

