### PR TITLE
Add ubuntu specific check and remediation for aide_periodic_checking_systemd_timer

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2829,10 +2829,9 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    related_rules:
-      - aide_periodic_cron_checking
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/1.3.2.
+    rules:
+      - aide_periodic_checking_systemd_timer
+    status: automated
 
   - id: 6.3.3
     title: Ensure cryptographic mechanisms are used to protect the integrity of audit tools (Automated)

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/ansible/ubuntu.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/ansible/ubuntu.yml
@@ -1,0 +1,20 @@
+# platform = multi_platform_ubuntu
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+
+- name: "{{{ rule_title }}} - Ensure AIDE Service is Enabled"
+  ansible.builtin.systemd:
+    name: dailyaidecheck.service
+    enabled: true
+    daemon_reload: true
+    masked: false
+
+- name: "{{{ rule_title }}} - Ensure AIDE Service Timer is Enabled"
+  ansible.builtin.systemd:
+    name: dailyaidecheck.timer
+    state: started
+    enabled: true
+    daemon_reload: true
+    masked: false

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/bash/ubuntu.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/bash/ubuntu.sh
@@ -1,0 +1,8 @@
+# platform = multi_platform_ubuntu
+#!/bin/bash
+
+{{{ bash_package_install("aide") }}}
+
+systemctl unmask dailyaidecheck.service
+systemctl unmask dailyaidecheck.timer
+systemctl --now enable dailyaidecheck.timer

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/oval/ubuntu.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/oval/ubuntu.xml
@@ -1,0 +1,56 @@
+{{% set aide_service = 'dailyaidecheck.service' %}}
+{{% set aide_timer = 'dailyaidecheck.timer' %}}
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="3">
+    {{{ oval_metadata("Make sure systemd timer is defined to run perodic AIDE check.") }}}
+    <criteria operator="AND">
+      <extend_definition comment="Aide is installed" definition_ref="package_aide_installed"/>
+      <criteria operator="AND">
+        <criterion test_ref="tst_{{{ rule_id }}}_aidecheck-service_static"
+          comment="systemd aidecheck.service static"/>
+        <criterion test_ref="tst_{{{ rule_id }}}_aidecheck-timer_enabled"
+          comment="systemd aidecheck.timer enabled"/>
+        <criterion test_ref="tst_{{{ rule_id }}}_aidecheck-timer_active"
+          comment="systemd aidecheck.timer active"/>
+      </criteria>
+    </criteria>
+  </definition>
+
+  <linux:systemdunitproperty_object id="obj_{{{ rule_id }}}_aidecheck-service_unitfilestate" version="1">
+    <linux:unit>{{{ aide_service }}}</linux:unit>
+    <linux:property>UnitFileState</linux:property>
+  </linux:systemdunitproperty_object>
+  <linux:systemdunitproperty_object id="obj_{{{ rule_id }}}_aidecheck-timer_unitfilestate" version="1">
+    <linux:unit>{{{ aide_timer }}}</linux:unit>
+    <linux:property>UnitFileState</linux:property>
+  </linux:systemdunitproperty_object>
+  <linux:systemdunitproperty_object id="obj_{{{ rule_id }}}_aidecheck-timer_activestate" version="1">
+    <linux:unit>{{{ aide_timer }}}</linux:unit>
+    <linux:property>ActiveState</linux:property>
+  </linux:systemdunitproperty_object>
+  <linux:systemdunitproperty_state id="ste_{{{ rule_id }}}_aide_is_static" version="1">
+    <linux:value>static</linux:value>
+  </linux:systemdunitproperty_state>
+  <linux:systemdunitproperty_state id="ste_{{{ rule_id }}}_aide_is_enabled" version="1">
+    <linux:value>enabled</linux:value>
+  </linux:systemdunitproperty_state>
+  <linux:systemdunitproperty_state id="ste_{{{ rule_id }}}_aide_is_active" version="1">
+    <linux:value>active</linux:value>
+  </linux:systemdunitproperty_state>
+
+  <linux:systemdunitproperty_test check="all" id="tst_{{{ rule_id }}}_aidecheck-service_static" version="1"
+    comment="systemd aidecheck.service static">
+    <linux:object object_ref="obj_{{{ rule_id }}}_aidecheck-service_unitfilestate" />
+    <linux:state state_ref="ste_{{{ rule_id }}}_aide_is_static" />
+  </linux:systemdunitproperty_test>
+  <linux:systemdunitproperty_test check="all" id="tst_{{{ rule_id }}}_aidecheck-timer_enabled" version="1"
+    comment="systemd aidecheck.timer enabled">
+    <linux:object object_ref="obj_{{{ rule_id }}}_aidecheck-timer_unitfilestate" />
+    <linux:state state_ref="ste_{{{ rule_id }}}_aide_is_enabled" />
+  </linux:systemdunitproperty_test>
+  <linux:systemdunitproperty_test check="all" id="tst_{{{ rule_id }}}_aidecheck-timer_active" version="1"
+    comment="systemd aidecheck.timer active">
+    <linux:object object_ref="obj_{{{ rule_id }}}_aidecheck-timer_activestate" />
+    <linux:state state_ref="ste_{{{ rule_id }}}_aide_is_active" />
+  </linux:systemdunitproperty_test>
+</def-group>

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/rule.yml
@@ -1,6 +1,4 @@
-
 documentation_complete: true
-
 
 title: 'Configure Systemd Timer Execution of AIDE'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/rule.yml
@@ -41,7 +41,7 @@ references:
     stigid@ol7: OL07-00-020030
     stigid@sle15: SLES-15-010570
 
-platform: package[aide]
+platform: package[aide] and package[systemd]
 
 ocil_clause: 'AIDE is not configured to scan periodically'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/tests/aide_timer_weekly.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/tests/aide_timer_weekly.pass.sh
@@ -1,3 +1,4 @@
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicro
 #!/bin/bash
 # packages = aide
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/tests/ubuntu_aide_service_masked.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/tests/ubuntu_aide_service_masked.fail.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_ubuntu
+# packages = aide
+
+systemctl mask dailyaidecheck.service
+systemctl --now enable dailyaidecheck.timer

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/tests/ubuntu_aide_timer_daily.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/tests/ubuntu_aide_timer_daily.pass.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_ubuntu
+# packages = aide
+
+systemctl enable dailyaidecheck.service
+systemctl --now enable dailyaidecheck.timer

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/tests/ubuntu_aide_timer_disabled.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_checking_systemd_timer/tests/ubuntu_aide_timer_disabled.fail.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_ubuntu
+# packages = aide
+
+systemctl enable dailyaidecheck.service
+systemctl --now disable dailyaidecheck.timer


### PR DESCRIPTION
#### Description:

- Add ubuntu specific check and remediation for aide_periodic_checking_systemd_timer
- Add rules to ubuntu2404 CIS control 6.3.2

#### Rationale:

- fixed OVAL to use correct filenames for systemd unit files
- fixed OVAL to check if dailyaidecheck.service is 'static' instead of 'enabled'
- fixed remediation to not create systemd unit files since these
  are shipped with the aide package on Ubuntu 24.04