### PR TITLE
Ubuntu 24.04 5.1.15 Ensure sshd MACs are configured

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -1683,11 +1683,10 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    related_rules:
+    rules:
       - sshd_strong_macs=cis_ubuntu2404
       - sshd_use_strong_macs
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/5.2.14.
+    status: automated
 
   - id: 5.1.16
     title: Ensure sshd MaxAuthTries is configured (Automated)

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/good_mac.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/good_mac.pass.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_ubuntu
 
 sed -i 's/^\s*MACs\s.*//i' /etc/ssh/sshd_config
 echo "MACs hmac-sha2-512" >> /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/no_macs.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/no_macs.fail.sh
@@ -1,3 +1,3 @@
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_ubuntu
 
 sed -i 's/^\s*MACs\s/# &/i' /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/sshd_strong_macs.var
+++ b/linux_os/guide/services/ssh/sshd_strong_macs.var
@@ -17,3 +17,4 @@ options:
     cis_sle12: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160
     cis_sle15: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
     cis_ubuntu2204: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
+    cis_ubuntu2404: umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1


### PR DESCRIPTION
#### Description:

- Ubuntu 24.04 5.1.15 Ensure sshd MACs are configured

#### Rationale:

- Implement Ubuntu 24.04 5.1.15 Ensure sshd MACs are configured