### PR TITLE
Adjust to regex for building scap delta tailoring files

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -777,7 +777,7 @@ macro(ssg_build_product PRODUCT)
     ssg_render_policies_for_product(${PRODUCT})
     add_dependencies(render-policies ${PRODUCT}-render-policies)
 
-    if(SSG_BUILD_DISA_DELTA_FILES AND "${PRODUCT}" MATCHES "rhel(7|8)|ol8")
+    if(SSG_BUILD_DISA_DELTA_FILES AND "${PRODUCT}" MATCHES "rhel(8|9)|ol8")
         ssg_build_disa_delta(${PRODUCT} "stig")
         add_dependencies(${PRODUCT} generate-ssg-delta-${PRODUCT}-stig)
     endif()


### PR DESCRIPTION


#### Description:
Adjust to regex for building scap delta tailoring files to build on RHEL 9 and remove RHEL 7 reference.

#### Rationale:

RHEL 9 has a STIG now and RHEL 7 is gone.


#### Review Hints
Build with

```
$ export ADDITIONAL_CMAKE_OPTIONS="-DSSG_BUILD_DISA_DELTA_FILES=ON"
$ ./build_product rhel8 rhel9
```

Review the files in `build/rhel8/tailoring/rhel8_stig_delta_tailoring.xml` and `build/rhel9/tailoring/rhel9_stig_delta_tailoring.xml`.

