### PR TITLE
Ubuntu 24.04: Implement rule 5.3.3.2.4 Ensure password same consecutive characters is configured

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -1880,10 +1880,8 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    rules:
-      - var_password_pam_maxrepeat=3
-      - accounts_password_pam_maxrepeat
-    status: automated
+    status: planned
+    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
 
   - id: 5.3.3.1.1
     title: Ensure password failed attempts lockout is configured (Automated)
@@ -1961,8 +1959,10 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    rules:
+      - var_password_pam_maxrepeat=3
+      - accounts_password_pam_maxrepeat
+    status: automated
 
   - id: 5.3.3.2.5
     title: Ensure password maximum sequential characters is configured (Automated)

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -1880,8 +1880,10 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    rules:
+      - var_password_pam_maxrepeat=3
+      - accounts_password_pam_maxrepeat
+    status: automated
 
   - id: 5.3.3.1.1
     title: Ensure password failed attempts lockout is configured (Automated)

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxrepeat/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxrepeat/rule.yml
@@ -58,6 +58,9 @@ template:
     vars:
         variable: maxrepeat
         operation: less than or equal
+{{%- if product == "ubuntu2404" %}}
+        zero_comparison_operation: greater than
+{{%- endif %}}
 
 fixtext: |-
     Configure {{{ full_name }}} to require the change of the number of repeating consecutive characters when passwords are changed by setting the "maxrepeat" option.


### PR DESCRIPTION
#### Description:

- Implement rule 5.3.3.2.4 Ensure password same consecutive characters is configured

#### Rationale:

- Satisfies Ubuntu 24.04 CIS control 5.3.3.2.4