### PR TITLE
Ubuntu 24.04: Implement rule 5.3.3.2.2 Ensure minimum password length is configured

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -1927,8 +1927,10 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    rules:
+      - var_password_pam_minlen=14
+      - accounts_password_pam_minlen
+    status: automated
 
   - id: 5.3.3.2.3
     title: Ensure password complexity is configured (Manual)


### PR DESCRIPTION
#### Description:

- Implement rule 5.3.3.2.2 Ensure minimum password length is configured

#### Rationale:

- Satisfies Ubuntu 24.04 CIS control 5.3.3.2.2