### PR TITLE
Ubuntu 24.04: Implement 5.3.3.2.7 Ensure password quality checking is enforced

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -1985,8 +1985,10 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    rules:
+      - var_password_pam_enforcing=1
+      - accounts_password_pam_enforcing
+    status: automated
 
   - id: 5.3.3.2.8
     title: Ensure password quality is enforced for the root user (Automated)

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_enforcing/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_enforcing/rule.yml
@@ -42,6 +42,13 @@ ocil: |-
 
 platform: package[pam]
 
+{{% if product == "ubuntu2404" %}}
+template:
+    name: accounts_password
+    vars:
+        variable: enforcing
+        operation: equals
+{{% else %}}
 template:
     name: "lineinfile"
     vars:
@@ -49,3 +56,5 @@ template:
         path: "/etc/security/pwquality.conf"
     oval_extend_definitions:
         - accounts_password_pam_pwquality
+{{% endif %}}
+

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_enforcing/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_enforcing/tests/correct.pass.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
+{{% if product == "ubuntu2404" %}}
+{{{ bash_pam_pwquality_enable() }}}
+{{% endif %}}
+
 echo 'enforcing = 1' > /etc/security/pwquality.conf

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/var_password_pam_enforcing.var
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/var_password_pam_enforcing.var
@@ -1,0 +1,17 @@
+documentation_complete: true
+
+title: enforcing
+
+description: |-
+    Disallow a password that does not meet the criteria
+
+type: number
+
+operator: equals
+
+interactive: false
+
+options:
+    1: 1
+    default: 1
+


### PR DESCRIPTION
#### Description:

- Implement 5.3.3.2.7 Ensure password quality checking is enforced
- Add var_password_pam_enforcing variable

#### Rationale:

- Satisfies Ubuntu 24.04 CIS control 5.3.3.2.6
- To avoid breaking compatibility, only use accounts_passwords template when it's Ubuntu 24.04. Not decided yet about whether phase out the use of lineinfile usage in this rule.