### PR TITLE
Remove service_chronyd_or_ntpd_enabled from RHEL 10

### DIFF
--- a/products/rhel10/profiles/ism_o.profile
+++ b/products/rhel10/profiles/ism_o.profile
@@ -46,3 +46,4 @@ selections:
     - '!enable_dracut_fips_module'
     # This rule is not applicable for RHEL 10
     - '!force_opensc_card_drivers'
+    - '!service_chronyd_or_ntpd_enabled'

--- a/products/rhel10/profiles/ism_o_secret.profile
+++ b/products/rhel10/profiles/ism_o_secret.profile
@@ -48,3 +48,4 @@ selections:
     - '!enable_dracut_fips_module'
     # This rule is not applicable for RHEL 10
     - '!force_opensc_card_drivers'
+    - '!service_chronyd_or_ntpd_enabled'

--- a/products/rhel10/profiles/ism_o_top_secret.profile
+++ b/products/rhel10/profiles/ism_o_top_secret.profile
@@ -46,3 +46,4 @@ selections:
     - '!enable_dracut_fips_module'
     # This rule is not applicable for RHEL 10
     - '!force_opensc_card_drivers'
+    - '!service_chronyd_or_ntpd_enabled'


### PR DESCRIPTION
#### Description:

Remove service_chronyd_or_ntpd_enabled from RHEL 10.

#### Rationale:

This is better covered by service_chronyd_enabled in RHEL 10.
