### PR TITLE
Add AlmaLinux 9 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,7 @@ option(SSG_PRODUCT_UBUNTU2404 "If enabled, the Ubuntu 24.04 SCAP content will be
 option(SSG_PRODUCT_AL2023 "If enabled, the AL2023 SCAP content will be built" ${SSG_PRODUCT_DEFAULT})
 # Products derivatives
 option(SSG_CENTOS_DERIVATIVES_ENABLED "If enabled, CentOS derivative content will be built from the RHEL content" TRUE)
+option(SSG_ALMALINUX_DERIVATIVES_ENABLED "If enabled, AlmaLinux derivative content will be built from the RHEL content" TRUE)
 
 if("$ENV{PYTHONPATH}" STREQUAL "")
     set(ENV{PYTHONPATH} "${PROJECT_SOURCE_DIR}")

--- a/build-scripts/enable_derivatives.py
+++ b/build-scripts/enable_derivatives.py
@@ -25,8 +25,10 @@ XCCDF12_NS = ssg.constants.XCCDF12_NS
 oval_ns = ssg.constants.oval_namespace
 
 CENTOS_NOTICE_ELEMENT = ssg.xml.ElementTree.fromstring(ssg.constants.CENTOS_NOTICE)
+ALMALINUX_NOTICE_ELEMENT = ssg.xml.ElementTree.fromstring(ssg.constants.ALMALINUX_NOTICE)
 
 CENTOS_WARNING = 'centos_warning'
+ALMALINUX_WARNING = 'almalinux_warning'
 
 
 def parse_args():
@@ -34,6 +36,8 @@ def parse_args():
     parser = OptionParser(usage=usage)
     parser.add_option("--enable-centos", dest="centos", default=False,
                       action="store_true", help="Enable CentOS")
+    parser.add_option("--enable-almalinux", dest="almalinux", default=False,
+                      action="store_true", help="Enable AlmaLinux")
     parser.add_option("-i", "--input", dest="input_content", default=False,
                       action="store",
                       help="INPUT can be XCCDF or Source data stream")
@@ -73,6 +77,12 @@ def main():
         warning = CENTOS_WARNING
         derivative = "CentOS"
 
+    if options.almalinux:
+        mapping = ssg.constants.RHEL_ALMALINUX_CPE_MAPPING
+        notice = ALMALINUX_NOTICE_ELEMENT
+        warning = ALMALINUX_WARNING
+        derivative = "AlmaLinux"
+
     tree = ssg.xml.open_xml(options.input_content)
     root = tree.getroot()
 
@@ -89,9 +99,10 @@ def main():
         raise RuntimeError("No Benchmark found!")
 
     for namespace, benchmark in benchmarks:
-        if args[1] not in ("cs9", "cs10") and not args[1].startswith("centos"):
+        if args[1] not in ("cs9", "cs10", "almalinux9") and not args[1].startswith("centos"):
             # In all CentOS and CentOS Streams, profiles are kept because they are systems
             # intended to test content that will get into RHEL
+            # In AlmaLinux, profiles are kept because this is a clone of RHEL.
             ssg.build_derivatives.profile_handling(benchmark, namespace)
         if not ssg.build_derivatives.add_cpes(benchmark, namespace, mapping):
             import pprint

--- a/build_product
+++ b/build_product
@@ -335,6 +335,9 @@ set_no_derivatives_options() {
 	if grep -q 'rhel' <<< "${_arg_product[*]}"; then
 		CMAKE_OPTIONS+=("-DSSG_CENTOS_DERIVATIVES_ENABLED:BOOL=OFF")
 	fi
+	if grep -q 'rhel' <<< "${_arg_product[*]}"; then
+		CMAKE_OPTIONS+=("-DSSG_ALMALINUX_DERIVATIVES_ENABLED:BOOL=OFF")
+	fi
 }
 
 set_sce_options() {

--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/oval/shared.xml
@@ -22,6 +22,13 @@
         test_ref="test_redhat_package_gpgkey-{{{ centos_pkg_version }}}-{{{ centos_pkg_release }}}_installed" />
       </criteria>
       {{%- endif %}}
+      {{%- if almalinux_major_version %}}
+      <criteria comment="AlmaLinux Vendor Keys" operator="AND">
+        <extend_definition comment="AlmaLinux{{{ almalinux_major_version }}} installed" definition_ref="installed_OS_is_almalinux{{{ almalinux_major_version }}}" />
+        <criterion comment="package gpg-pubkey-{{{ almalinux_pkg_version }}}-{{{ almalinux_pkg_release }}} is installed"
+        test_ref="test_redhat_package_gpgkey-{{{ almalinux_pkg_version }}}-{{{ almalinux_pkg_release }}}_installed" />
+      </criteria>
+      {{%- endif %}}
     </criteria>
   </definition>
 
@@ -68,6 +75,20 @@
   <linux:rpminfo_state id="state_redhat_package_gpg-pubkey-{{{ centos_pkg_version }}}-{{{ centos_pkg_release }}}" version="1">
     <linux:release>{{{ centos_pkg_release }}}</linux:release>
     <linux:version>{{{ centos_pkg_version }}}</linux:version>
+  </linux:rpminfo_state>
+  {{%- endif %}}
+
+  {{%- if almalinux_major_version %}}
+  <linux:rpminfo_test check="only one" check_existence="at_least_one_exists"
+  id="test_redhat_package_gpgkey-{{{ almalinux_pkg_version }}}-{{{ almalinux_pkg_release }}}_installed" version="1"
+  comment="AlmaLinux{{{ almalinux_major_version }}} key package is installed">
+    <linux:object object_ref="object_redhat_package_gpg-pubkey" />
+    <linux:state state_ref="state_redhat_package_gpg-pubkey-{{{ almalinux_pkg_version }}}-{{{ almalinux_pkg_release }}}" />
+  </linux:rpminfo_test>
+
+  <linux:rpminfo_state id="state_redhat_package_gpg-pubkey-{{{ almalinux_pkg_version }}}-{{{ almalinux_pkg_release }}}" version="1">
+    <linux:release>{{{ almalinux_pkg_release }}}</linux:release>
+    <linux:version>{{{ almalinux_pkg_version }}}</linux:version>
   </linux:rpminfo_state>
   {{%- endif %}}
 

--- a/products/rhel9/CMakeLists.txt
+++ b/products/rhel9/CMakeLists.txt
@@ -24,3 +24,7 @@ ssg_build_html_stig_tables_per_profile(${PRODUCT} "stig_gui")
 if(SSG_CENTOS_DERIVATIVES_ENABLED)
     ssg_build_derivative_product(${PRODUCT} "centos" "cs9")
 endif()
+
+if(SSG_ALMALINUX_DERIVATIVES_ENABLED)
+    ssg_build_derivative_product(${PRODUCT} "almalinux" "almalinux9")
+endif()

--- a/products/rhel9/product.yml
+++ b/products/rhel9/product.yml
@@ -58,4 +58,8 @@ centos_pkg_release: "5ccc5b19"
 centos_pkg_version: "8483c65d"
 centos_major_version: "9"
 
+almalinux_pkg_release: "61e69f29"
+almalinux_pkg_version: "b86b3716"
+almalinux_major_version: "9"
+
 journald_conf_dir_path: /etc/systemd/journald.conf.d

--- a/shared/applicability/almalinux9.yml
+++ b/shared/applicability/almalinux9.yml
@@ -1,0 +1,3 @@
+name: cpe:/o:almalinux:almalinux:9
+title: AlmaLinux 9
+check_id: installed_OS_is_almalinux9

--- a/shared/checks/oval/installed_OS_is_almalinux9.xml
+++ b/shared/checks/oval/installed_OS_is_almalinux9.xml
@@ -1,0 +1,34 @@
+<def-group>
+  <definition class="inventory"
+  id="installed_OS_is_almalinux9" version="1">
+    <metadata>
+      <title>AlmaLinux 9</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <reference ref_id="cpe:/o:almalinux:almalinux:9"
+      source="CPE" />
+      <description>The operating system installed on the system is
+      AlmaLinux 9</description>
+    </metadata>
+    <criteria>
+      <extend_definition comment="Installed OS is part of the Unix family"
+      definition_ref="installed_OS_is_part_of_Unix_family" />
+      <criteria operator="OR">
+          <criterion comment="AlmaLinux 9 System is installed"
+            test_ref="test_almalinux9_system" />
+      </criteria>
+    </criteria>
+  </definition>
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="almalinux-release is version 9" id="test_almalinux9_system" version="1">
+    <linux:object object_ref="obj_almalinux9_system" />
+    <linux:state state_ref="state_almalinux9_system" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_almalinux9_system" version="1">
+    <linux:version operation="pattern match">^9.*$</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_almalinux9_system" version="1">
+    <linux:name>almalinux-release</linux:name>
+  </linux:rpminfo_object>
+</def-group>

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -320,6 +320,10 @@ RHEL_CENTOS_CPE_MAPPING = {
     "cpe:/o:redhat:enterprise_linux:10": "cpe:/o:centos:centos:10",
 }
 
+RHEL_ALMALINUX_CPE_MAPPING = {
+    "cpe:/o:redhat:enterprise_linux:9": "cpe:/o:almalinux:almalinux:9",
+}
+
 CENTOS_NOTICE = \
     "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n" \
     "<p>This benchmark is a direct port of a <i>SCAP Security Guide </i> " \
@@ -343,6 +347,41 @@ CENTOS_NOTICE = \
     "</ul>\n" \
     "\n" \
     "<p>Members of the <i>CentOS</i> community are invited to participate in " \
+    "<a href=\"http://open-scap.org\">OpenSCAP</a> and " \
+    "<a href=\"https://github.com/ComplianceAsCode/content\">" \
+    "SCAP Security Guide</a> development. Bug reports and patches " \
+    "can be sent to GitHub: " \
+    "<a href=\"https://github.com/ComplianceAsCode/content\">" \
+    "https://github.com/ComplianceAsCode/content</a>. " \
+    "The mailing list is at " \
+    "<a href=\"https://fedorahosted.org/mailman/listinfo/scap-security-guide\">" \
+    "https://fedorahosted.org/mailman/listinfo/scap-security-guide</a>" \
+    ".</p>" \
+    "</div>"
+
+ALMALINUX_NOTICE = \
+    "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n" \
+    "<p>This benchmark is a direct port of a <i>SCAP Security Guide </i> " \
+    "benchmark developed for <i>Red Hat Enterprise Linux</i>. It has been " \
+    "modified through an automated process to remove specific dependencies " \
+    "on <i>Red Hat Enterprise Linux</i> and to function with <i>AlmaLinux</i>. " \
+    "The result is a generally useful <i>SCAP Security Guide</i> benchmark " \
+    "with the following caveats:</p>\n" \
+    "<ul>\n" \
+    "<li><i>AlmaLinux</i> is not an exact copy of " \
+    "<i>Red Hat Enterprise Linux</i>. There may be configuration differences " \
+    "that produce false positives and/or false negatives. If this occurs " \
+    "please file a bug report.</li>\n" \
+    "\n" \
+    "<li><i>AlmaLinux</i> has its own build system, compiler options, patchsets, " \
+    "and is a community supported, non-commercial operating system. " \
+    "<i>AlmaLinux</i> does not inherit " \
+    "certifications or evaluations from <i>Red Hat Enterprise Linux</i>. As " \
+    "such, some configuration rules (such as those requiring " \
+    "<i>FIPS 140-2</i> encryption) will continue to fail on <i>AlmaLinux</i>.</li>\n" \
+    "</ul>\n" \
+    "\n" \
+    "<p>Members of the <i>AlmaLinux</i> community are invited to participate in " \
     "<a href=\"http://open-scap.org\">OpenSCAP</a> and " \
     "<a href=\"https://github.com/ComplianceAsCode/content\">" \
     "SCAP Security Guide</a> development. Bug reports and patches " \
@@ -483,6 +522,7 @@ DERIVATIVES_PRODUCT_MAPPING = {
     "centos8": "rhel8",
     "cs9": "rhel9",
     "cs10": "rhel10",
+    "almalinux9": "rhel9",
 }
 
 BENCHMARKS = {

--- a/tests/data/product_stability/rhel9.yml
+++ b/tests/data/product_stability/rhel9.yml
@@ -13,6 +13,9 @@ benchmark_root: ../../linux_os/guide
 centos_major_version: '9'
 centos_pkg_release: 5ccc5b19
 centos_pkg_version: 8483c65d
+almalinux_major_version: "9"
+almalinux_pkg_release: "61e69f29"
+almalinux_pkg_version: "b86b3716"
 chrony_conf_path: /etc/chrony.conf
 chrony_d_path: /etc/chrony.d/
 components_root: ../../components


### PR DESCRIPTION
#### Description:

This PR adds AlmaLinux 9 support.

The AlmaLinux 9 support has been implemented as a derivative of RHEL 9, since AlmaLinux 9 is a clone of RHEL 9 and the CIS Benchmarks are pretty much identical.

#### Rationale:

[AlmaLinux](https://almalinux.org/) is a community-supported clone of Red Hat Enterprise Linux. CIS Benchmark for AlmaLinux has been firstly published in [November 2021](https://almalinux.org/blog/official-cis-benchmark-for-almalinux-and-openscap-guide-now-published/).