### PR TITLE
Ubuntu 24.04 5.3.3.4.4 Ensure pam_unix includes use_authtok

### DIFF
--- a/components/pam.yml
+++ b/components/pam.yml
@@ -66,6 +66,7 @@ rules:
 - accounts_password_pam_ucredit
 - accounts_password_pam_unix_enabled
 - accounts_password_pam_unix_no_remember
+- accounts_password_pam_unix_authtok
 - accounts_password_pam_unix_remember
 - accounts_password_pam_unix_rounds_password_auth
 - accounts_password_pam_unix_rounds_system_auth

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2059,8 +2059,9 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    rules:
+      - accounts_password_pam_unix_authtok
+    status: automated
 
   - id: 5.4.1.1
     title: Ensure password expiration is configured (Automated)

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/bash/shared.sh
@@ -1,0 +1,14 @@
+# platform = multi_platform_ubuntu
+
+config_file="/usr/share/pam-configs/cac_unix"
+{{{ bash_pam_unix_enable() }}}
+sed -i -E '/^Password:/,/^[^[:space:]]/ {
+    /pam_unix\.so/ {
+        /use_authtok/! s/$/ use_authtok/g
+    }
+}'  "$config_file"
+
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update
+
+

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/bash/shared.sh
@@ -9,6 +9,6 @@ sed -i -E '/^Password:/,/^[^[:space:]]/ {
 }'  "$config_file"
 
 
-DEBIAN_FRONTEND=noninteractive pam-auth-update
+DEBIAN_FRONTEND=noninteractive pam-auth-update --remove unix --enable cac_unix
 
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/oval/shared.xml
@@ -10,14 +10,33 @@
   </definition>
 
   <ind:textfilecontent54_test id="test_password_pam_unix_use_authtok" version="1"
-    check="all" check_existence="at_least_one_exists"
+    check="all" check_existence="any_exist"
     comment="use_authtok is configured in pam unix in common_password file">
     <ind:object object_ref="obj_test_use_authtok" />
+    <ind:state state_ref="ste_test_use_authtok" />
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="obj_test_use_authtok" version="1">
-    <ind:filepath>{{{ accounts_password_pam_unix_file }}}</ind:filepath>
-    <ind:pattern operation="pattern match">^[ \t]*password[ \t]+([^\n\r]+)[\n\r]+[ \t]*password[ \t]+([^#\n\r]+)[ \t]+pam_unix\.so[ \t]+([^#\n\r]+[ \t]+)?use_authtok.*$</ind:pattern>
-    <ind:instance datatype="int" operation="equals">1</ind:instance>
+    <set>
+      <object_reference>obj_test_use_authtok_password_lines_except_first</object_reference>
+      <filter action="include">ste_test_use_authtok_pam_unix_lines</filter>
+    </set>
   </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="ste_test_use_authtok" version="1">
+      <ind:subexpression operation="pattern match">^[^#\n\r]+[ \t]+pam_unix\.so[ \t]+[^#\n\r]+use_authtok.*$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <!-- Get all password lines except the first line. This is to avoid matching a pam_unix
+  line on the top of the stack, which does not need use_authtok to pass -->
+  <ind:textfilecontent54_object id="obj_test_use_authtok_password_lines_except_first" version="1">
+    <ind:filepath>{{{ accounts_password_pam_unix_file }}}</ind:filepath>
+    <ind:pattern operation="pattern match">^[ \t]*password[ \t]+(.+)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">2</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="ste_test_use_authtok_pam_unix_lines" version="1">
+      <ind:subexpression operation="pattern match">^[^#\n\r]+[ \t]+pam_unix\.so.*$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/oval/shared.xml
@@ -10,7 +10,7 @@
   </definition>
 
   <ind:textfilecontent54_test id="test_password_pam_unix_use_authtok" version="1"
-    check="all" check_existence="only_one_exists"
+    check="all" check_existence="at_least_one_exists"
     comment="use_authtok is configured in pam unix in common_password file">
     <ind:object object_ref="obj_test_use_authtok" />
   </ind:textfilecontent54_test>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/oval/shared.xml
@@ -17,7 +17,7 @@
 
   <ind:textfilecontent54_object id="obj_test_use_authtok" version="1">
     <ind:filepath>{{{ accounts_password_pam_unix_file }}}</ind:filepath>
-    <ind:pattern operation="pattern match">^[ \t]*password[ \t]+([^#\n\r]+)[ \t]+pam_unix\.so[ \t]+([^#\n\r]+[ \t]+)?use_authtok.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[ \t]*password[ \t]+([^\n\r]+)[\n\r]+[ \t]*password[ \t]+([^#\n\r]+)[ \t]+pam_unix\.so[ \t]+([^#\n\r]+[ \t]+)?use_authtok.*$</ind:pattern>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/oval/shared.xml
@@ -1,0 +1,23 @@
+{{%- set accounts_password_pam_unix_file = '/etc/pam.d/common-password' -%}}
+
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("Configure the system to include use_authtok in pam common_password configuration file") }}}
+    <criteria>
+      <criterion test_ref="test_password_pam_unix_use_authtok"
+        comment="use_authtok is configured in pam unix in common_password file"/>
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test id="test_password_pam_unix_use_authtok" version="1"
+    check="all" check_existence="only_one_exists"
+    comment="use_authtok is configured in pam unix in common_password file">
+    <ind:object object_ref="obj_test_use_authtok" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_test_use_authtok" version="1">
+    <ind:filepath>{{{ accounts_password_pam_unix_file }}}</ind:filepath>
+    <ind:pattern operation="pattern match">^[ \t]*password[ \t]+([^#\n\r]+)[ \t]+pam_unix\.so[ \t]+([^#\n\r]+[ \t]+)?use_authtok.*$</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/rule.yml
@@ -1,0 +1,32 @@
+documentation_complete: true
+
+
+title: 'Require use_authtok for pam_unix.so'
+
+{{% set configFile = "/etc/pam.d/common-password" %}}
+
+description: |-
+    When password changing enforce the module to set the new password to the one
+    provided by a previously stacked password module
+
+rationale: |-
+    Require use_authtok in pam_unix.so configuration
+
+severity: medium
+
+ocil_clause: 'Usage of use_authtok for pam_unix.so is required'
+
+ocil: |-
+    To verify the password reuse setting is compliant, run the following command:
+    <pre>$ grep use_authtok {{{ configFile }}}</pre>
+    The output should show use_authtok on the line.
+
+fixtext: |-
+    To configure the <tt>use_authtok</tt> option for the <tt>pam_unix</tt> 
+    PAM modules, in the file <tt>{{{ configFile }}}</tt>, append <tt>use_authtok</tt>
+    to the line which refers to the <tt>pam_unix.so</tt>, as
+    shown below:
+
+    <pre>password [success=1 default=ignore] pam_unix.so <i>...existing_options...</i> use_authtok</pre>
+
+platform: package[pam]

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/tests/ubuntu_common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/tests/ubuntu_common.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+# remove all pam-auth-update configs which update the
+# primary password block and create a config with well defined
+# high priority to ensure correct stacking of our module
+grep -il "Password-Type: Primary" /usr/share/pam-configs/* | grep -v "/unix$" | xargs rm -f
+
+cat << EOF > /usr/share/pam-configs/cac_test_echo
+Name: Echo
+Default: yes
+Priority: 10000
+Password-Type: Primary
+Password:
+        password optional pam_echo.so
+Password-Initial:
+        password optional pam_echo.so
+EOF

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/tests/ubuntu_conflicting_values.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/tests/ubuntu_conflicting_values.fail.sh
@@ -30,6 +30,7 @@ Session-Initial:
 Password-Type: Primary
 Password:
         [success=end default=ignore]    pam_unix.so obscure use_authtok try_first_pass yescrypt 
+        [success=end default=ignore]    pam_unix.so obscure try_first_pass yescrypt 
 Password-Initial:
         [success=end default=ignore]    pam_unix.so obscure yescrypt 
 EOF

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/tests/ubuntu_conflicting_values2.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/tests/ubuntu_conflicting_values2.fail.sh
@@ -29,6 +29,7 @@ Session-Initial:
         required        pam_unix.so
 Password-Type: Primary
 Password:
+        [success=end default=ignore]    pam_unix.so obscure try_first_pass yescrypt 
         [success=end default=ignore]    pam_unix.so obscure use_authtok try_first_pass yescrypt 
 Password-Initial:
         [success=end default=ignore]    pam_unix.so obscure yescrypt 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/tests/ubuntu_correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/tests/ubuntu_correct_value.pass.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+config_file=/usr/share/pam-configs/tmpunix
+
+cat << EOF > "$config_file"
+Name: Unix authentication
+Default: yes
+Priority: 0
+Auth-Type: Primary
+Auth:
+        [success=end default=ignore]    pam_unix.so try_first_pass
+Auth-Initial:
+        [success=end default=ignore]    pam_unix.so
+Account-Type: Primary
+Account:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Account-Initial:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Session-Type: Additional
+Session:
+        required        pam_unix.so
+Session-Initial:
+        required        pam_unix.so
+Password-Type: Primary
+Password:
+        [success=end default=ignore]    pam_unix.so obscure use_authtok try_first_pass yescrypt 
+Password-Initial:
+        [success=end default=ignore]    pam_unix.so obscure yescrypt 
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update
+rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/tests/ubuntu_missing_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/tests/ubuntu_missing_value.fail.sh
@@ -1,12 +1,17 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 
+source ubuntu_common.sh
+
 config_file=/usr/share/pam-configs/tmpunix
 
+# lower priority to ensure the config is below the cac_test_echo
+# on the stack, thus using the "Password:" configuration
 cat << EOF > "$config_file"
 Name: Unix authentication
 Default: yes
 Priority: 1024
+Conflicts: unix
 Auth-Type: Primary
 Auth:
         [success=end default=ignore]    pam_unix.so try_first_pass
@@ -29,5 +34,5 @@ Password-Initial:
         [success=end default=ignore]    pam_unix.so obscure yescrypt 
 EOF
 
-DEBIAN_FRONTEND=noninteractive pam-auth-update --remove unix --enable tmpunix
+DEBIAN_FRONTEND=noninteractive pam-auth-update
 rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/tests/ubuntu_missing_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/tests/ubuntu_missing_value.fail.sh
@@ -24,7 +24,7 @@ Session-Initial:
         required        pam_unix.so
 Password-Type: Primary
 Password:
-        [success=end default=ignore]    pam_unix.so obscure use_authtok try_first_pass yescrypt 
+        [success=end default=ignore]    pam_unix.so obscure try_first_pass yescrypt 
 Password-Initial:
         [success=end default=ignore]    pam_unix.so obscure yescrypt 
 EOF

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/tests/ubuntu_missing_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/tests/ubuntu_missing_value.fail.sh
@@ -1,5 +1,33 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 
-config_file=/etc/pam.d/common-password
-sed -i --follow-symlinks "s/use_authtok//g" $config_file
+config_file=/usr/share/pam-configs/tmpunix
+
+cat << EOF > "$config_file"
+Name: Unix authentication
+Default: yes
+Priority: 1024
+Auth-Type: Primary
+Auth:
+        [success=end default=ignore]    pam_unix.so try_first_pass
+Auth-Initial:
+        [success=end default=ignore]    pam_unix.so
+Account-Type: Primary
+Account:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Account-Initial:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Session-Type: Additional
+Session:
+        required        pam_unix.so
+Session-Initial:
+        required        pam_unix.so
+Password-Type: Primary
+Password:
+        [success=end default=ignore]    pam_unix.so obscure use_authtok try_first_pass yescrypt 
+Password-Initial:
+        [success=end default=ignore]    pam_unix.so obscure yescrypt 
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update --remove unix --enable tmpunix --force
+rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/tests/ubuntu_missing_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/tests/ubuntu_missing_value.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+config_file=/etc/pam.d/common-password
+sed -i --follow-symlinks "s/use_authtok//g" $config_file

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/tests/ubuntu_missing_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/tests/ubuntu_missing_value.fail.sh
@@ -29,5 +29,5 @@ Password-Initial:
         [success=end default=ignore]    pam_unix.so obscure yescrypt 
 EOF
 
-DEBIAN_FRONTEND=noninteractive pam-auth-update --remove unix --enable tmpunix --force
+DEBIAN_FRONTEND=noninteractive pam-auth-update --remove unix --enable tmpunix
 rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/tests/ubuntu_missing_value_initial.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/tests/ubuntu_missing_value_initial.pass.sh
@@ -5,12 +5,12 @@ source ubuntu_common.sh
 
 config_file=/usr/share/pam-configs/tmpunix
 
-# lower priority to ensure the config is below the cac_test_echo
-# on the stack, thus using the "Password:" configuration
+# higher priority to ensure the config is above the cac_test_echo
+# on the stack, thus using the "Password-Initial:" configuration
 cat << EOF > "$config_file"
 Name: Unix authentication
 Default: yes
-Priority: 1024
+Priority: 1000000
 Conflicts: unix
 Auth-Type: Primary
 Auth:
@@ -29,7 +29,7 @@ Session-Initial:
         required        pam_unix.so
 Password-Type: Primary
 Password:
-        [success=end default=ignore]    pam_unix.so obscure use_authtok try_first_pass yescrypt 
+        [success=end default=ignore]    pam_unix.so obscure try_first_pass yescrypt 
 Password-Initial:
         [success=end default=ignore]    pam_unix.so obscure yescrypt 
 EOF

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -913,8 +913,8 @@ if [ ! -f "$conf_path"/"$conf_name" ]; then
     if [ -f "$conf_path"/unix ]; then
         if grep -q "$(md5sum "$conf_path"/unix | cut -d ' ' -f 1)" /var/lib/dpkg/info/libpam-runtime.md5sums;then
             cp "$conf_path"/unix "$conf_path"/"$conf_name"
-            sed -i '/Default: yes/a Priority: 257\
-Conflicts: unix' "$conf_path"/"$conf_name"
+            sed -i 's/Priority: [0-9]\+/Priority: 257\
+Conflicts: unix/' "$conf_path"/"$conf_name"
             DEBIAN_FRONTEND=noninteractive pam-auth-update
         else
             echo "Not applicable - checksum of $conf_path/unix does not match the original." >&2


### PR DESCRIPTION
#### Description:

- Ubuntu 24.04 5.3.3.4.4 Ensure pam_unix includes use_authtok
- Also fixes the bash_pam_unix_enable macro so that is doesn't have duplicate Priority lines. 

#### Rationale:

- Implement Ubuntu 24.04 5.3.3.4.4 Ensure pam_unix includes use_authtok
