### PR TITLE
Fix Lexicological ordering of immutable.rules

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_immutable/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_immutable/ansible/shared.yml
@@ -16,6 +16,7 @@
     regexp: '^\s*(?:-e)\s+.*$'
     state: absent
   loop: "{{ find_rules_d.files | map(attribute='path') | list + ['/etc/audit/audit.rules'] }}"
+  register: auditd_immutable_option
   
 - name: Add Audit -e option into /etc/audit/rules.d/90-immutable.rules
   lineinfile:

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_immutable/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_immutable/ansible/shared.yml
@@ -16,13 +16,12 @@
     regexp: '^\s*(?:-e)\s+.*$'
     state: absent
   loop: "{{ find_rules_d.files | map(attribute='path') | list + ['/etc/audit/audit.rules'] }}"
-
-- name: Add Audit -e option into /etc/audit/rules.d/90-immutable.rules and /etc/audit/audit.rules
+  
+- name: Add Audit -e option into /etc/audit/rules.d/90-immutable.rules
   lineinfile:
     path: "{{ item }}"
     create: True
     line: "-e 2"
     mode: g-rwx,o-rwx
   loop:
-    - "/etc/audit/audit.rules"
     - "/etc/audit/rules.d/90-immutable.rules"

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_immutable/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_immutable/ansible/shared.yml
@@ -16,7 +16,7 @@
     regexp: '^\s*(?:-e)\s+.*$'
     state: absent
   loop: "{{ find_rules_d.files | map(attribute='path') | list + ['/etc/audit/audit.rules'] }}"
-  
+
 - name: Add Audit -e option into /etc/audit/rules.d/90-immutable.rules
   lineinfile:
     path: "{{ item }}"

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_immutable/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_immutable/ansible/shared.yml
@@ -16,7 +16,6 @@
     regexp: '^\s*(?:-e)\s+.*$'
     state: absent
   loop: "{{ find_rules_d.files | map(attribute='path') | list + ['/etc/audit/audit.rules'] }}"
-  register: auditd_immutable_option
   
 - name: Add Audit -e option into /etc/audit/rules.d/90-immutable.rules
   lineinfile:

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_immutable/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_immutable/ansible/shared.yml
@@ -17,7 +17,7 @@
     state: absent
   loop: "{{ find_rules_d.files | map(attribute='path') | list + ['/etc/audit/audit.rules'] }}"
 
-- name: Add Audit -e option into /etc/audit/rules.d/immutable.rules and /etc/audit/audit.rules
+- name: Add Audit -e option into /etc/audit/rules.d/90-immutable.rules and /etc/audit/audit.rules
   lineinfile:
     path: "{{ item }}"
     create: True
@@ -25,4 +25,4 @@
     mode: g-rwx,o-rwx
   loop:
     - "/etc/audit/audit.rules"
-    - "/etc/audit/rules.d/immutable.rules"
+    - "/etc/audit/rules.d/90-immutable.rules"

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_immutable/bash/shared.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_immutable/bash/shared.sh
@@ -14,7 +14,7 @@ find /etc/audit /etc/audit/rules.d -maxdepth 1 -type f -name '*.rules' -exec sed
 # * /etc/audit/audit.rules file 		(for auditctl case)
 # * /etc/audit/rules.d/immutable.rules		(for augenrules case)
 
-for AUDIT_FILE in "/etc/audit/audit.rules" "/etc/audit/rules.d/immutable.rules"
+for AUDIT_FILE in "/etc/audit/audit.rules" "/etc/audit/rules.d/90-immutable.rules"
 do
 	echo '' >> $AUDIT_FILE
 	echo '# Set the audit.rules configuration immutable per security requirements' >> $AUDIT_FILE


### PR DESCRIPTION
#### Description:

The filename for the auditd immutable rules is 90-immutable.rules in some areas, but not in others. This fixes it.

#### Rationale:

With lexicological ordering naming the file immutable.rules will not let it load last. The DISA STIG, and common practice is to put the immutable rule at the last entry in the audit.rules file.  Also, the DISA STIG checks for the last line in the audit.rules file for this check. Instead of loading the -e option into audit.rules in a random fashion, the system should be rebooted, then it will pick up the -e from the 90-immutable.rules and put it at the end.

