### PR TITLE
Fix grub2-tools setup & dependencies in grub2 template tests

### DIFF
--- a/Dockerfiles/test_suite-sle15
+++ b/Dockerfiles/test_suite-sle15
@@ -5,6 +5,9 @@ ENV AUTH_KEYS=/root/.ssh/authorized_keys
 ARG CLIENT_PUBLIC_KEY
 ARG ADDITIONAL_PACKAGES
 
+RUN zypper ar --no-gpgcheck http://download.opensuse.org/distribution/leap/15.5/repo/oss/ oss
+RUN zypper refresh
+
 RUN true \
         && zypper --non-interactive in openssh-clients openssh-server openscap-utils \
         python3 python3-rpm tar gawk\

--- a/shared/templates/grub2_bootloader_argument_absent/tests/superstring_arg.pass.sh
+++ b/shared/templates/grub2_bootloader_argument_absent/tests/superstring_arg.pass.sh
@@ -1,5 +1,17 @@
 # platform = multi_platform_all
+{{%- if 'sle15' in product %}}
+# packages = grub2,grubby
+mkdir -p /boot/grub2
+rm -f /boot/grub2/grub.cfg
+       {
+    echo 'menuentry "SLES Mocked" {'
+               echo 'linux   mock'
+    echo '}'
+       } > /boot/grub2/grub.cfg
+{{%- else %}}
 # packages = grub2-tools,grubby
+{{%- endif %}}
+
 
 # Ensure the kernel command line for each installed kernel in the bootloader
 grubby --update-kernel=ALL --remove-args="{{{ ARG_NAME }}}"


### PR DESCRIPTION
#### Description:

- Make adjustments for sle15 setup of automatus tests for grub2 template tests

#### Rationale:

- Set correct package dependencies and an extra setup test  step

- Fixes # Failures in grub2-related automatus tests in SLE15 like those in #12653 
