### PR TITLE
Fix ensure_redhat_gpgkey_installed on RHEL 10

### DIFF
--- a/products/rhel10/product.yml
+++ b/products/rhel10/product.yml
@@ -28,10 +28,10 @@ dconf_gdm_dir: "distro.d"
 faillock_path: "/var/log/faillock"
 
 # The fingerprints below are retrieved from https://access.redhat.com/security/team/key
-pkg_release: "fd431d51"
-pkg_version: "4ae0493c"
-aux_pkg_release: "5a6340b3"
-aux_pkg_version: "6229229e"
+pkg_release: "4ae0493c"
+pkg_version: "fd431d51"
+aux_pkg_release: "6229229e"
+aux_pkg_version: "5a6340b3"
 
 release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
 auxiliary_key_fingerprint: "7E4624258C406535D56D6F135054E4A45A6340B3"


### PR DESCRIPTION
We have discovered during productization that the rule ensure_redhat_gpgkey_installed fails on RHEL 10.
It seems to have an easy fix so we aren't opening a ticket but we are fixing it directly.
The release and version values in product.yml were swapped.

```
[root@XXX ~]# rpm -q redhat-release
redhat-release-10.0-24.el10.x86_64
[root@XXX ~]# rpm -q --queryformat 'release=%{RELEASE} version=%{VERSION}\n' gpg-pubkey
release=4ae0493b version=fd431d51
release=6229229e version=5a6340b3
```

