### PR TITLE
Ubuntu 24.04: Implement rule 5.3.3.1.2 Ensure password unlock time is configured

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -1901,7 +1901,7 @@ controls:
       - l1_workstation
     status: automated
     rules:
-      - var_accounts_passwords_pam_faillock_unlock_time=600
+      - var_accounts_passwords_pam_faillock_unlock_time=900
       - accounts_passwords_pam_faillock_unlock_time
 
   - id: 5.3.3.1.3

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -1899,8 +1899,10 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    status: automated
+    rules:
+      - var_accounts_passwords_pam_faillock_unlock_time=600
+      - accounts_passwords_pam_faillock_unlock_time
 
   - id: 5.3.3.1.3
     title: Ensure password failed attempts lockout includes root account (Automated)


### PR DESCRIPTION
#### Description:

- Implement rule 5.3.3.1.2 Ensure password unlock time is configured

#### Rationale:

- Satisfies Ubuntu 24.04 CIS control 5.3.3.1.2