### PR TITLE
Ubuntu 24.04: Implement rule 5.3.3.4.3 Ensure pam_unix includes a strong password hashing algorithm

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2048,11 +2048,10 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    related_rules:
-      - var_password_hashing_algorithm=yescrypt
-      - set_password_hashing_algorithm_logindefs
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/5.4.4.
+    rules:
+      - var_password_hashing_algorithm_pam=yescrypt
+      - set_password_hashing_algorithm_systemauth
+    status: automated
 
   - id: 5.3.3.4.4
     title: Ensure pam_unix includes use_authtok (Automated)


### PR DESCRIPTION
#### Description:

- Implement rule 5.3.3.4.3 Ensure pam_unix includes a strong password hashing algorithm

#### Rationale:

- Satisfies Ubuntu 24.04 CIS control 5.3.3.4.3