### PR TITLE
fix reg error in 10-bash.jinjia

### DIFF
--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1937,7 +1937,7 @@ Part of the grub2_bootloader_argument template.
 {{%- macro update_etc_default_grub_manually_absent(arg_name) -%}}
 # Correct the form of default kernel command line in GRUB
 if grep -q '^GRUB_CMDLINE_LINUX=.*{{{ arg_name }}}=.*"'  '/etc/default/grub' ; then
-       sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\){{{ arg_name }}}=?[^[:space:]]*\(.*"\)/\1 \2/' '/etc/default/grub'
+       sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\){{{ arg_name }}}=\?[^[:space:]]*\(.*"\)/\1 \2/' '/etc/default/grub'
 fi
 {{%- endmacro %}}
 


### PR DESCRIPTION
sed -i use Basic Regular Expression(BRE), so it needs to use Escape character when using character like ')', '?', '+' and so on. I see it may be forgot here. There is another question here. After modifying /etc/default/grub, grub2-mkconfig is not used to make it effective, so the modification is meaningless. Should I directly modify /etc/grub2.cfg (x86) or /etc/grub2-efi/cfg?