### PR TITLE
Ubuntu 24.04: Implement rule 5.4.2.2 Ensure root is the only GID 0 account

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2136,8 +2136,10 @@ controls:
       - l1_workstation
     related_rules:
       - accounts_root_gid_zero
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/5.5.3.
+    status: automated
+    notes: |
+      The remediation is not automated as the removal or modification
+      of group IDs from a system is too disruptive.
 
   - id: 5.4.2.3
     title: Ensure group root is the only GID 0 group (Automated)

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2134,7 +2134,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    related_rules:
+    rules:
       - accounts_root_gid_zero
     status: automated
     notes: |

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_root_gid_zero/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_root_gid_zero/oval/shared.xml
@@ -1,8 +1,11 @@
 <def-group>
   <definition class="compliance" id="{{{rule_id}}}" version="1">
     {{{ oval_metadata("The root account should have primary group of 0") }}}
-    <criteria>
+    <criteria operator="AND">
       <criterion comment="tests that the root account's gid is equal to 0" test_ref="test_{{{rule_id}}}" />
+      {{% if 'ubuntu' in product %}}
+      <criterion comment="no other users have primary group ID 0" test_ref="test_{{{rule_id}}}_no_other_gid_0" />
+      {{% endif %}}
     </criteria>
   </definition>
 
@@ -23,19 +26,14 @@
 
   {{% if 'ubuntu' in product %}}
   <!-- Test for other users with GID 0 (excluding sync, shutdown, halt, operator) -->
-  <ind:textfilecontent54_test id="test_{{{rule_id}}}_no_other_gid_0" check="all" comment="test that there are no other accounts with GID 0 except root" version="1">
+  <ind:textfilecontent54_test id="test_{{{rule_id}}}_no_other_gid_0" check="all" check_existence="none_exist" comment="test that there are no other accounts with GID 0 except root" version="1">
     <ind:object object_ref="object_{{{rule_id}}}_no_other_gid_0" />
-    <ind:state state_ref="state_{{{rule_id}}}_no_other_gid_0" />
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_{{{rule_id}}}_no_other_gid_0" version="1">
     <ind:filepath>/etc/passwd</ind:filepath>
-    <ind:pattern operation="pattern match">^(?!\b(root|sync|shutdown|halt|operator)\b).+:.+:\d+:(\d+).+</ind:pattern>
+    <ind:pattern operation="pattern match">^(?!\b(root|sync|shutdown|halt|operator)\b).+:.+:\d+:0:.+$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-
-  <ind:textfilecontent54_state id="state_{{{rule_id}}}_no_other_gid_0" version="1" comment="no other users have GID 0">
-    <ind:subexpression operation="not equal" datatype="int">0</ind:subexpression>
-  </ind:textfilecontent54_state>
   {{% endif %}}
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_root_gid_zero/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_root_gid_zero/oval/shared.xml
@@ -6,7 +6,7 @@
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test id="test_{{{rule_id}}}" check="all" comment="test that there are no accounts with UID 0 except root in the /etc/passwd file" version="1">
+  <ind:textfilecontent54_test id="test_{{{rule_id}}}" check="all" comment="test that the root user has GID 0 in the /etc/passwd file" version="1">
     <ind:object object_ref="object_{{{rule_id}}}" />
     <ind:state state_ref="state_{{{rule_id}}}" />
   </ind:textfilecontent54_test>
@@ -20,4 +20,22 @@
   <ind:textfilecontent54_state id="state_{{{rule_id}}}" version="1" comment="root account's gid is equal to 0">
     <ind:subexpression operation="equals" datatype="int">0</ind:subexpression>
   </ind:textfilecontent54_state>
+
+  {{% if 'ubuntu' in product %}}
+  <!-- Test for other users with GID 0 (excluding sync, shutdown, halt, operator) -->
+  <ind:textfilecontent54_test id="test_{{{rule_id}}}_no_other_gid_0" check="all" comment="test that there are no other accounts with GID 0 except root" version="1">
+    <ind:object object_ref="object_{{{rule_id}}}_no_other_gid_0" />
+    <ind:state state_ref="state_{{{rule_id}}}_no_other_gid_0" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_{{{rule_id}}}_no_other_gid_0" version="1">
+    <ind:filepath>/etc/passwd</ind:filepath>
+    <ind:pattern operation="pattern match">^(?!\b(root|sync|shutdown|halt|operator)\b).+:.+:\d+:(\d+).+</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_{{{rule_id}}}_no_other_gid_0" version="1" comment="no other users have GID 0">
+    <ind:subexpression operation="not equal" datatype="int">0</ind:subexpression>
+  </ind:textfilecontent54_state>
+  {{% endif %}}
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_root_gid_zero/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_root_gid_zero/tests/correct_value.pass.sh
@@ -1,2 +1,9 @@
 #!/bin/bash
 # remediation = none
+
+{{% if 'ubuntu' in product %}}
+users_to_remove=$(awk -F: '$4 == 0 && $1 !~ /^(root|sync|shutdown|halt|operator)$/ {print $1}' /etc/passwd)
+for user in $users_to_remove; do
+    sudo userdel -rf "$user"
+done
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_root_gid_zero/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_root_gid_zero/tests/correct_value.pass.sh
@@ -2,8 +2,5 @@
 # remediation = none
 
 {{% if 'ubuntu' in product %}}
-users_to_remove=$(awk -F: '$4 == 0 && $1 !~ /^(root|sync|shutdown|halt|operator)$/ {print $1}' /etc/passwd)
-for user in $users_to_remove; do
-    sudo userdel -rf "$user"
-done
+awk -F: '$4 == 0 && $1 !~ /^(root|sync|shutdown|halt|operator)$/ {print $1}' /etc/passwd | xargs --no-run-if-empty -I '{}' userdel -f '{}'
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_root_gid_zero/tests/other_user_uid_0.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_root_gid_zero/tests/other_user_uid_0.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Remediation doesn't fix the rule, only locks passwords
+# of non-root accounts with uid 0.
+# remediation = none
+
+useradd --gid 0 root2


### PR DESCRIPTION
#### Description:

- Add rule 5.4.2.2 Ensure root is the only GID 0 account into ubuntu24 cis control
- Add oval check for no other user has primary group 0
- Improve accounts_root_gid_zero test
- Fix small typo in comment of accounts_root_gid_zero oval

#### Rationale:

- Satisfies Ubuntu 24.04 CIS control 5.3.3.4.1