### PR TITLE
Ubuntu 24.04: Implement rule 5.3.3.4.2 Ensure pam_unix does not include remember

### DIFF
--- a/components/pam.yml
+++ b/components/pam.yml
@@ -65,6 +65,7 @@ rules:
 - accounts_password_pam_retry
 - accounts_password_pam_ucredit
 - accounts_password_pam_unix_enabled
+- accounts_password_pam_unix_no_remember
 - accounts_password_pam_unix_remember
 - accounts_password_pam_unix_rounds_password_auth
 - accounts_password_pam_unix_rounds_system_auth

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2036,8 +2036,9 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    rules:
+      - accounts_password_pam_unix_no_remember
+    status: automated
 
   - id: 5.3.3.4.3
     title: Ensure pam_unix includes a strong password hashing algorithm (Automated)

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/bash/shared.sh
@@ -1,0 +1,27 @@
+# platform = multi_platform_ubuntu
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = medium
+
+{{{ bash_pam_unix_enable() }}}
+config_file="/usr/share/pam-configs/cac_unix"
+sed -i -E '/^Password:/,/^[^[:space:]]/ {
+    /pam_unix\.so/ {
+        s/\s*\bremember=\d+\b//g
+    }
+}' "$config_file"
+
+sed -i -E '/^Password-Initial:/,/^[^[:space:]]/ {
+    /pam_unix\.so/ {
+        s/\s*\bremember=\d+\b//g
+    }
+}' "$config_file"
+
+{{{ bash_remove_pam_module_option('/etc/pam.d/common-auth', 'auth', '', 'pam_unix.so', 'remember') }}}
+{{{ bash_remove_pam_module_option('/etc/pam.d/common-account', 'account', '', 'pam_unix.so', 'remember') }}}
+{{{ bash_remove_pam_module_option('/etc/pam.d/common-password', 'password', '', 'pam_unix.so', 'remember') }}}
+{{{ bash_remove_pam_module_option('/etc/pam.d/common-session', 'session', '', 'pam_unix.so', 'remember') }}}
+{{{ bash_remove_pam_module_option('/etc/pam.d/common-session-noninteractive', 'session', '', 'pam_unix.so', 'remember') }}}
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/bash/shared.sh
@@ -6,22 +6,10 @@
 
 {{{ bash_pam_unix_enable() }}}
 config_file="/usr/share/pam-configs/cac_unix"
-sed -i -E '/^Password:/,/^[^[:space:]]/ {
+sed -i -E '/^Password(-Initial)?:/,/^[^[:space:]]/ {
     /pam_unix\.so/ {
         s/\s*\bremember=\d+\b//g
     }
 }' "$config_file"
-
-sed -i -E '/^Password-Initial:/,/^[^[:space:]]/ {
-    /pam_unix\.so/ {
-        s/\s*\bremember=\d+\b//g
-    }
-}' "$config_file"
-
-{{{ bash_remove_pam_module_option('/etc/pam.d/common-auth', 'auth', '', 'pam_unix.so', 'remember') }}}
-{{{ bash_remove_pam_module_option('/etc/pam.d/common-account', 'account', '', 'pam_unix.so', 'remember') }}}
-{{{ bash_remove_pam_module_option('/etc/pam.d/common-password', 'password', '', 'pam_unix.so', 'remember') }}}
-{{{ bash_remove_pam_module_option('/etc/pam.d/common-session', 'session', '', 'pam_unix.so', 'remember') }}}
-{{{ bash_remove_pam_module_option('/etc/pam.d/common-session-noninteractive', 'session', '', 'pam_unix.so', 'remember') }}}
 
 DEBIAN_FRONTEND=noninteractive pam-auth-update

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/oval/shared.xml
@@ -13,7 +13,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_pam_unix_no_remember" version="1">
     <ind:filepath operation="pattern match">^/etc/pam.d/common-(password|auth|account|session|session-noninteractive)$</ind:filepath>
-    <ind:pattern operation="pattern match">^[^#]*\bremember=\d+\b.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*password\s+(?:(?:sufficient)|(?:required)|(?:\[.*\]))\s+pam_unix\.so.*\bremember=\d+\b.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/oval/shared.xml
@@ -13,7 +13,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_pam_unix_no_remember" version="1">
     <ind:filepath operation="pattern match">^/etc/pam.d/common-(password|auth|account|session|session-noninteractive)$</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*password\s+(?:(?:sufficient)|(?:required)|(?:\[.*\]))\s+pam_unix\.so.*\bremember=\d+\b.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*password\s+(?:(?:sufficient)|(?:required)|(?:\[.*\]))\s+pam_unix\.so[^#]+\bremember=\d+\b.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/oval/shared.xml
@@ -1,0 +1,19 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("The pam_unix module should not include remember option") }}}
+    <criteria>
+      <criterion comment="make sure the remember option is not used in pam_unix.so module"
+                 test_ref="test_pam_unix_no_remember" />
+    </criteria>
+  </definition>
+  <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
+                              id="test_pam_unix_no_remember"
+                              comment="make sure remember is not used in /etc/pam.d/common-auth">
+    <ind:object object_ref="object_pam_unix_no_remember" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_pam_unix_no_remember" version="1">
+    <ind:filepath operation="pattern match">^/etc/pam.d/common-(password|auth|account|session|session-noninteractive)$</ind:filepath>
+    <ind:pattern operation="pattern match">^[^#]*\bremember=\d+\b.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/rule.yml
@@ -1,0 +1,21 @@
+documentation_complete: true
+
+title: 'Avoid using remember in pam_unix module'
+
+description: |-
+    The <tt>remember</tt> option stores the last n passwords for each user in <tt>/etc/security/opasswd</tt>,
+    enforcing password history and preventing users from reusing the same passwords. However, this feature
+    relies on the MD5 password hash algorithm, which is less secure. Instead, the <tt>pam_pwhistory</tt>
+    module should be used. This module also stores the last n passwords in <tt>/etc/security/opasswd</tt>
+    and it uses the password hash algorithm configured in the pam_unix module, such as yescrypt or SHA512,
+    offering enhanced security.
+
+rationale: |-
+    Removing the <tt>remember</tt> argument ensures the use of a stronger password hashing algorithm.
+    A more robust hash algorithm increases the difficulty for attackers to crack stored
+    passwords in <tt>/etc/security/opasswd</tt>, thereby improving system security and
+    protecting user credentials. 
+
+severity: medium
+
+platform: package[pam]

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/tests/no_remember.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/tests/no_remember.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+sed -i --follow-symlinks '/\bremember=\d+\b/d' /etc/pam.d/common-*

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/tests/no_remember.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/tests/no_remember.pass.sh
@@ -1,4 +1,33 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 
-sed -i --follow-symlinks '/\bremember=\d+\b/d' /etc/pam.d/common-*
+config_file=/usr/share/pam-configs/tmpunix
+
+cat << EOF > "$config_file"
+Name: Unix authentication
+Default: yes
+Priority: 256
+Auth-Type: Primary
+Auth:
+        [success=end default=ignore]    pam_unix.so try_first_pass
+Auth-Initial:
+        [success=end default=ignore]    pam_unix.so
+Account-Type: Primary
+Account:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Account-Initial:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Session-Type: Additional
+Session:
+        required        pam_unix.so
+Session-Initial:
+        required        pam_unix.so
+Password-Type: Primary
+Password:
+        [success=end default=ignore]    pam_unix.so obscure use_authtok try_first_pass yescrypt
+Password-Initial:
+        [success=end default=ignore]    pam_unix.so obscure yescrypt
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update
+rm $config_file

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/tests/no_remember.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/tests/no_remember.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
+# packages = pam
 
 config_file=/usr/share/pam-configs/tmpunix
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/tests/remember_commented.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/tests/remember_commented.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+for pam_file in /etc/pam.d/common-*; do
+    sed -i --follow-symlinks '/\bremember=\d+\b/d' $pam_file
+    echo "# auth  sufficient  pam_unix.so try_first_pass bremember=1" >> $pam_file
+done

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/tests/remember_commented.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/tests/remember_commented.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
+# packages = pam
 
 config_file=/usr/share/pam-configs/tmpunix
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/tests/remember_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/tests/remember_present.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+for FILE in "/etc/pam.d/common-*"; do
+    if ! grep -q "^[^#].*pam_unix\.so.*\bremember=\d+\b" ${FILE}; then
+        sed -i 's/\(^[^#].*pam_unix\.so\)/\1 remember=1/g' ${FILE}
+    fi
+done
+

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/tests/remember_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/tests/remember_present.fail.sh
@@ -1,9 +1,34 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 
-for FILE in "/etc/pam.d/common-*"; do
-    if ! grep -q "^[^#].*pam_unix\.so.*\bremember=\d+\b" ${FILE}; then
-        sed -i 's/\(^[^#].*pam_unix\.so\)/\1 remember=1/g' ${FILE}
-    fi
-done
+config_file=/usr/share/pam-configs/tmpunix
 
+cat << EOF > "$config_file"
+Name: Unix authentication
+Default: yes
+Priority: 256
+Auth-Type: Primary
+Auth:
+        [success=end default=ignore]    pam_unix.so try_first_pass
+Auth-Initial:
+        [success=end default=ignore]    pam_unix.so
+Account-Type: Primary
+Account:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Account-Initial:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Session-Type: Additional
+Session:
+        required        pam_unix.so
+Session-Initial:
+        required        pam_unix.so
+Password-Type: Primary
+Password:
+        [success=end default=ignore]    pam_unix.so obscure use_authtok try_first_pass yescrypt remember=5
+Password-Initial:
+        [success=end default=ignore]    pam_unix.so obscure yescrypt remember=5
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update
+
+rm $config_file

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/tests/remember_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/tests/remember_present.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
+# packages = pam
 
 config_file=/usr/share/pam-configs/tmpunix
 


### PR DESCRIPTION
#### Description:

- Implement rule 5.3.3.4.2 Ensure pam_unix does not include remember

#### Rationale:

- Satisfies Ubuntu 24.04 CIS control 5.3.3.4.2