### PR TITLE
Adjust `set_password_hashing_algorithm_*` for RHEL 10

### DIFF
--- a/controls/ism_o.yml
+++ b/controls/ism_o.yml
@@ -31,7 +31,7 @@ controls:
             - set_password_hashing_algorithm_passwordauth
             - set_password_hashing_algorithm_systemauth
             - sshd_disable_gssapi_auth
-            - var_password_hashing_algorithm_pam=sha512
+            - var_password_hashing_algorithm_pam=yescrypt
         status: automated
 
     -   id: '0421'

--- a/controls/srg_gpos/SRG-OS-000730-GPOS-00190.yml
+++ b/controls/srg_gpos/SRG-OS-000730-GPOS-00190.yml
@@ -10,7 +10,6 @@ controls:
             - var_password_pam_maxclassrepeat=3
             - var_password_pam_dictcheck=1
             - accounts_password_pam_dictcheck
-            - var_password_hashing_algorithm_pam=sha512
-            - var_password_pam_unix_rounds=5000
+            - var_password_pam_unix_rounds=5
             - var_password_pam_remember=5
             - var_password_pam_remember_control_flag=requisite_or_required

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/rule.yml
@@ -63,7 +63,7 @@ ocil: |-
 
 platform: package[pam]
 
-{{% if product in ['ol9', 'rhel9'] %}}
+{{% if product in ['ol9', 'rhel9', 'rhel10'] %}}
 srg_requirement: 'The {{{ full_name }}} pam_unix.so module must be configured in the password-auth file to use a FIPS 140-3 approved cryptographic hashing algorithm for system authentication.'
 
 fixtext: |-

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/authselect_correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/authselect_correct_value.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel,multi_platform_fedora
 # variables = var_password_hashing_algorithm_pam=sha512
 
 authselect create-profile hardening -b sssd

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/authselect_incorrect_option.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/authselect_incorrect_option.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel,multi_platform_fedora
 # variables = var_password_hashing_algorithm_pam=sha512
 
 authselect create-profile hardening -b sssd

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/authselect_missing_option.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/authselect_missing_option.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel,multi_platform_fedora
 # variables = var_password_hashing_algorithm_pam=sha512
 
 authselect create-profile hardening -b sssd

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/authselect_modified_pam.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/authselect_modified_pam.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel,multi_platform_fedora
 # variables = var_password_hashing_algorithm_pam=sha512
 # remediation = none
 

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/authselect_multiple_options.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/authselect_multiple_options.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel,multi_platform_fedora
 # variables = var_password_hashing_algorithm_pam=sha512
 
 authselect create-profile hardening -b sssd

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/authselect_wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/authselect_wrong_control.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel,multi_platform_fedora
 # variables = var_password_hashing_algorithm_pam=sha512
 
 authselect create-profile hardening -b sssd

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/bash/shared.sh
@@ -4,13 +4,13 @@
 
 {{% if 'sle' in product or 'slmicro' in product -%}}
 PAM_FILE_PATH="/etc/pam.d/common-password"
-CONTROL="required"
+{{% set control = "required" %}}
 {{%- elif 'ubuntu' in product -%}}
 {{{ bash_pam_unix_enable() }}}
 PAM_FILE_PATH=/usr/share/pam-configs/cac_unix
 {{%- else -%}}
 PAM_FILE_PATH="/etc/pam.d/system-auth"
-CONTROL="sufficient"
+{{% set control = "sufficient" %}}
 {{%- endif %}}
 
 {{% if 'ubuntu' in product -%}}
@@ -31,7 +31,7 @@ if ! grep -qzP "Password-Initial:\s*\n\s+.*\s+pam_unix.so\s+.*\b$var_password_ha
 fi
 
 {{%- else -%}}
-{{{ bash_ensure_pam_module_configuration("$PAM_FILE_PATH", 'password', "$CONTROL", 'pam_unix.so', "$var_password_hashing_algorithm_pam", '', '') }}}
+{{{ bash_ensure_pam_module_configuration("$PAM_FILE_PATH", 'password', control, 'pam_unix.so', "$var_password_hashing_algorithm_pam", '', '') }}}
 {{%- endif %}}
 
 # Ensure only the correct hashing algorithm option is used.

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/rule.yml
@@ -90,7 +90,7 @@ ocil: |-
 platform: package[pam]
 
 fixtext: |-
-    {{% if product in ['ol9', 'rhel9', 'ubuntu2204', 'ubuntu2404'] -%}}
+    {{% if product in ['ol9', 'rhel9', 'rhel10', 'ubuntu2204', 'ubuntu2404'] -%}}
     Configure {{{ full_name }}} to use a FIPS 140-3 approved cryptographic hashing algorithm for system authentication.
     {{% else %}}
     Configure {{{ full_name }}} to use a FIPS 140-2 approved cryptographic hashing algorithm for system authentication.
@@ -106,7 +106,7 @@ fixtext: |-
     password sufficient pam_unix.so {{{ xccdf_value("var_password_hashing_algorithm_pam") }}}
     {{%- endif %}}
 
-{{% if product in ['ol9', 'rhel9'] -%}}
+{{% if product in ['ol9', 'rhel9', 'rhel10'] -%}}
 srg_requirement: 'The {{{ full_name }}} pam_unix.so module must be configured in the system-auth file to use a FIPS 140-3 approved cryptographic hashing algorithm for system authentication.'
 {{%- endif %}}
 

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/authselect_correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/authselect_correct_value.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel,multi_platform_fedora
 # variables = var_password_hashing_algorithm_pam=sha512
 
 authselect create-profile hardening -b sssd

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/authselect_incorrect_option.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/authselect_incorrect_option.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel,multi_platform_fedora
 # variables = var_password_hashing_algorithm_pam=sha512
 
 authselect create-profile hardening -b sssd

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/authselect_missing_option.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/authselect_missing_option.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel,multi_platform_fedora
 # variables = var_password_hashing_algorithm_pam=sha512
 
 authselect create-profile hardening -b sssd

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/authselect_modified_pam.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/authselect_modified_pam.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel,multi_platform_fedora
 # variables = var_password_hashing_algorithm_pam=sha512
 # remediation = none
 

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/authselect_multiple_options.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/authselect_multiple_options.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel,multi_platform_fedora
 # variables = var_password_hashing_algorithm_pam=sha512
 
 authselect create-profile hardening -b sssd

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/authselect_wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/authselect_wrong_control.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel,multi_platform_fedora
 # variables = var_password_hashing_algorithm_pam=sha512
 
 authselect create-profile hardening -b sssd


### PR DESCRIPTION
#### Description:

* Add RHEL 10 to tests for `set_password_hashing_algorithm_systemauth` and `set_password_hashing_algorithm_passwordauth`
* Adjust RHEL 10 profiles to use `yescrypt`
* Adjust text in `set_password_hashing_algorithm_systemauth` and `set_password_hashing_algorithm_passwordauth` for RHEL 10
* Fix 

#### Rationale:

Fixes #12769

#### Review Hints:

1. `./build_product rhel10`
2. `cd tests`
3. `./automatus.py rule --datastream ../build/ssg-rhel10-ds.xml --libvirt qemu:///system automatus_rhel10 set_password_hashing_algorithm_passwordauth,set_password_hashing_algorithm_systemauth`