### PR TITLE
Update accounts_password_pam_retry for RHEL 10

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/ansible/shared.yml
@@ -5,7 +5,7 @@
 # disruption = medium
 {{% if 'ubuntu' in product %}}
 {{% set configuration_files = ["common-password"] %}}
-{{% elif product in ['ol8', 'ol9', 'rhel8', 'rhel9'] %}}
+{{% elif product in ['ol8', 'ol9'] or 'rhel' in product %}}
 {{% set configuration_files = ["password-auth","system-auth"] %}}
 {{% else %}}
 {{% set configuration_files = ["system-auth"] %}}

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/bash/shared.sh
@@ -1,6 +1,6 @@
 # platform = multi_platform_all
 
-{{% if product in ['ol8', 'ol9', 'rhel8', 'rhel9'] %}}
+{{% if product in ['ol8', 'ol9'] or 'rhel' in product %}}
 {{% set configuration_files = ["password-auth","system-auth"] %}}
 {{% else %}}
 {{% set configuration_files = ["system-auth"] %}}
@@ -9,7 +9,7 @@
 
 {{{ bash_instantiate_variables("var_password_pam_retry") }}}
 
-{{% if product in ['ol8', 'ol9', 'rhel8', 'rhel9'] -%}}
+{{% if product in ['ol8', 'ol9'] or 'rhel' in product -%}}
 	{{{ bash_replace_or_append('/etc/security/pwquality.conf',
 							   '^retry',
 							   '$var_password_pam_retry',

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
@@ -1,6 +1,6 @@
 {{% if 'ubuntu' in product or 'debian' in product %}}
 {{% set configuration_files = ["common-password"] %}}
-{{% elif product in ['ol8','ol9','rhel8', 'rhel9'] %}}
+{{% elif product in ['ol8','ol9'] or 'rhel' in product %}}
 {{% set configuration_files = ["password-auth","system-auth"] %}}
 {{% else %}}
 {{% set configuration_files = ["system-auth"] %}}
@@ -17,7 +17,7 @@
       </criteria>
       <criteria operator="AND" comment="Conditions for retry in pwquality.conf file are satisfied">
         {{% for file in configuration_files %}}
-        <criterion 
+        <criterion
         comment="retry value not set in PAM files"
         test_ref="test_password_pam_pwquality_retry_{{{ (file | escape_id) }}}_not_set"/>
         {{% endfor %}}

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/rule.yml
@@ -5,7 +5,7 @@ title: 'Ensure PAM Enforces Password Requirements - Authentication Retry Prompts
 
 description: |-
     To configure the number of retry prompts that are permitted per-session:
-    {{% if product in ['ol8', 'ol9', 'rhel8', 'rhel9'] %}}
+    {{% if product in ['ol8', 'ol9'] or 'rhel' in product %}}
     Edit the <tt>/etc/security/pwquality.conf</tt> to include
     {{% else %}}
     Edit the <tt>pam_pwquality.so</tt> statement in
@@ -56,7 +56,7 @@ ocil_clause: 'the value of "retry" is set to "0" or greater than "{{{ xccdf_valu
 ocil: |-
     Verify {{{ full_name }}} is configured to limit the "pwquality" retry option to {{{ xccdf_value("var_password_pam_retry") }}}.
 
-    {{% if product in ['ol8', 'ol9', 'rhel8', 'rhel9'] %}}
+    {{% if product in ['ol8', 'ol9'] or 'rhel' in product %}}
     Check for the use of the "pwquality" retry option in the pwquality.conf file with the following command:
     <pre>$ grep retry /etc/security/pwquality.conf</pre>
     {{% else %}}
@@ -75,7 +75,7 @@ platform: package[pam]
 fixtext: |-
     Configure {{{ full_name }}} to limit the "pwquality" retry option to {{{ xccdf_value("var_password_pam_retry") }}}.
 
-    {{% if product in ['ol8', 'ol9', 'rhel8', 'rhel9'] %}}
+    {{% if product in ['ol8', 'ol9'] or 'rhel' in product %}}
     Add the following line to the "/etc/security/pwquality.conf" file (or modify the line to have the required value):
 
     retry={{{ xccdf_value("var_password_pam_retry") }}}

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/common.sh
@@ -1,13 +1,13 @@
 {{% if 'ubuntu' in product %}}
 configuration_files=("common-password")
-{{% elif product in ['ol8', 'ol9', 'rhel8', 'rhel9'] %}}
+{{% elif product in ['ol8', 'ol9'] or 'rhel' in product %}}
 configuration_files=("password-auth" "system-auth")
 {{% else %}}
 configuration_files=("system-auth")
 {{% endif %}}
 
 
-{{% if product in ['ol8', 'ol9', 'rhel8', 'rhel9'] %}}
+{{% if product in ['ol8', 'ol9'] or 'rhel' in product %}}
 authselect create-profile testingProfile --base-on sssd
 
 for file in ${configuration_files[@]}; do

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_commented.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+# platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel
 # variables = var_password_pam_retry=3
 
 source common.sh

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_correct.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+# platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel
 # variables = var_password_pam_retry=3
 
 source common.sh

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_correct_with_space.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_correct_with_space.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+# platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel
 # variables = var_password_pam_retry=3
 
 source common.sh

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_overriden.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_overriden.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+# platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel
 # variables = var_password_pam_retry=3
 
 source common.sh

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_wrong.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_wrong.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+# platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel
 # variables = var_password_pam_retry=3
 
 source common.sh


### PR DESCRIPTION
#### Description:

Update `accounts_password_pam_retry` for RHEL 10.

#### Rationale:

Fixes #12768

#### Review Hints:
`./automatus.py rule --datastream ../build/ssg-rhel10-ds.xml --libvirt qemu:///system automatus_rhel10 --remediate-using ansible accounts_password_pam_retry`
