### PR TITLE
Ubuntu 24.04: Implement rule 5.3.3.3.1 Ensure password history remember is configured

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2008,11 +2008,10 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    related_rules:
-      - var_password_pam_remember=5
-      - accounts_password_pam_unix_remember
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/5.4.3.
+    rules:
+      - var_password_pam_remember=24
+      - accounts_password_pam_pwhistory_remember
+    status: automated
 
   - id: 5.3.3.3.2
     title: Ensure password history is enforced for the root user (Automated)

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/bash/ubuntu.sh
@@ -1,0 +1,21 @@
+# platform = multi_platform_ubuntu
+
+{{{ bash_pam_pwhistory_enable('cac_pwhistory','requisite') }}}
+
+{{{ bash_instantiate_variables("var_password_pam_remember") }}}
+
+sed -i -E '/^Password:/,/^[^[:space:]]/ {
+    /pam_pwhistory\.so/ {
+        s/\s*remember=[^[:space:]]*//g
+        s/$/ remember='"$var_password_pam_remember"'/g
+    }
+}' /usr/share/pam-configs/cac_pwhistory
+
+sed -i -E '/^Password-Initial:/,/^[^[:space:]]/ {
+    /pam_pwhistory\.so/ {
+        s/\s*remember=[^[:space:]]*//g
+        s/$/ remember='"$var_password_pam_remember"'/g
+    }
+}' /usr/share/pam-configs/cac_pwhistory
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update --enable cac_pwhistory

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/oval/shared.xml
@@ -1,0 +1,58 @@
+{{% if "sle12" in product or "debian" in product or "ubuntu" in product %}}
+{{%- set accounts_password_pam_file = '/etc/pam.d/common-password' -%}}
+{{% endif %}}
+
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="2">
+    {{{ oval_metadata("The passwords to remember of pam_pwhistory should be set correctly.") }}}
+      <criteria operator="AND" comment="Check if pam_pwhistory.so is properly configured">
+        <criterion test_ref="test_accounts_password_pam_pwhistory_enabled"
+                   comment="pam_pwhistory.so is properly defined in password section of PAM file"/>
+        <criterion test_ref="test_accounts_password_pam_pwhistory_remember_parameter"
+                 comment="Remember parameter of pam_pwhistory.so is properly configured"/>
+      </criteria>
+  </definition>
+
+  <external_variable comment="number of passwords that should be remembered" datatype="int" id="var_password_pam_remember" version="1" />
+
+  <!-- is pam_pwhistory.so enabled? -->
+  <ind:textfilecontent54_test id="test_accounts_password_pam_pwhistory_enabled"
+                              check="all" version="1" comment="Check pam_pwhistory.so presence in PAM file">
+    <ind:object object_ref="object_accounts_password_pam_pwhistory_enabled"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_accounts_password_pam_pwhistory_enabled"
+                                version="1">
+    <ind:filepath>{{{ accounts_password_pam_file }}}</ind:filepath>
+    <ind:pattern var_ref="var_accounts_password_pam_pwhistory_module_regex"
+                 var_check="at least one" operation="pattern match"/>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- variables used to check the module implementation -->
+  <local_variable id="var_accounts_password_pam_pwhistory_module_regex"
+		  datatype="string" version="1"
+		  comment="The regex is to confirm the pam_pwhistory.so module is enabled">
+    <literal_component>^[ \t]*password[ \t]+(?:(?:sufficient)|(?:required)|(?:requisite)|(?:\[.*\]))[ \t]+pam_pwhistory\.so.*$</literal_component>
+  </local_variable>
+
+  <ind:textfilecontent54_state id="state_accounts_password_pam_pwhistory_remember" version="1">
+    <ind:subexpression datatype="int" operation="greater than or equal"
+                       var_ref="var_password_pam_remember"/>
+  </ind:textfilecontent54_state>
+
+  <!-- Check the pam_pwhistory.so remember parameter -->
+  <ind:textfilecontent54_test id="test_accounts_password_pam_pwhistory_remember_parameter" version="1"
+                              check="all" check_existence="all_exist"
+                              comment="Test if remember attribute of pam_pwhistory.so is set correctly in {{{ accounts_password_pam_file }}}">
+    <ind:object object_ref="object_accounts_password_pam_pwhistory_remember_parameter" />
+    <ind:state state_ref="state_accounts_password_pam_pwhistory_remember" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_accounts_password_pam_pwhistory_remember_parameter" version="1">
+    <ind:filepath>{{{ accounts_password_pam_file }}}</ind:filepath>
+    <ind:pattern operation="pattern match">^[ \t]*password[ \t]+(?:(?:sufficient)|(?:required)|(?:requisite)|(?:\[.*\]))[ \t]+pam_pwhistory\.so[ \t]+[^#\n\r]*\bremember=([0-9]*)\b.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/rule.yml
@@ -49,6 +49,7 @@ ocil: |-
 
 platform: package[pam]
 
+{{% if 'ubuntu' not in product or product == 'ubuntu2004' %}}
 template:
     name: pam_options
     vars:
@@ -61,3 +62,4 @@ template:
           operation: greater than or equal
         - argument: use_authtok
           new_argument: use_authtok
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/tests/ubuntu_argument_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/tests/ubuntu_argument_missing.fail.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = pam
+# variables = var_password_pam_remember=5
+
+config_file=/usr/share/pam-configs/tmp_pwhistory
+
+cat << EOF > "$config_file"
+Name: pwhistory password history checking
+Default: yes
+Priority: 1024
+Password-Type: Primary
+Password: requisite pam_pwhistory.so enforce_for_root try_first_pass use_authtok
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update --enable tmp_pwhistory
+rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/tests/ubuntu_correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/tests/ubuntu_correct_value.pass.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = pam
+# variables = var_password_pam_remember=5
+
+config_file=/usr/share/pam-configs/tmp_pwhistory
+
+cat << EOF > "$config_file"
+Name: pwhistory password history checking
+Default: yes
+Priority: 1024
+Password-Type: Primary
+Password: requisite pam_pwhistory.so remember=5 enforce_for_root try_first_pass use_authtok
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update --enable tmp_pwhistory
+rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/tests/ubuntu_wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/tests/ubuntu_wrong_value.fail.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = pam
+# variables = var_password_pam_remember=5
+
+config_file=/usr/share/pam-configs/tmp_pwhistory
+
+cat << EOF > "$config_file"
+Name: pwhistory password history checking
+Default: yes
+Priority: 1024
+Password-Type: Primary
+Password: requisite pam_pwhistory.so remember=4 enforce_for_root try_first_pass use_authtok
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update --enable tmp_pwhistory
+rm "$config_file"


### PR DESCRIPTION
#### Description:

- Implement rule 5.3.3.3.1 Ensure password history remember is configured

#### Rationale:

- Rewrite the remediation and tests of accounts_password_pam_pwhistory_rmember to use pam-auth-update
- Satisfies Ubuntu 24.04 CIS control 5.3.3.3.1