### PR TITLE
Use nss-altfiles in file_groupowner_etc_chrony_keys

### DIFF
--- a/linux_os/guide/services/ntp/file_groupowner_etc_chrony_keys/oval/shared.xml
+++ b/linux_os/guide/services/ntp/file_groupowner_etc_chrony_keys/oval/shared.xml
@@ -1,0 +1,72 @@
+<def-group>
+
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("All files should be owned by a group") }}}
+    <criteria operator="OR">
+      <criteria operator="AND">
+        <criterion test_ref="test_file_groupowner_etc_chrony_keys_nsswitch_uses_altfiles" negate="true"
+          comment="The /etc/nsswitch.conf does not use nss-altfiles"/>
+        <criterion test_ref="test_file_groupowner_etc_chrony_keys"
+          comment="Check all local files and make sure they are owned by a group"/>
+      </criteria>
+      <criteria operator="AND">
+        <criterion test_ref="test_file_groupowner_etc_chrony_keys_nsswitch_uses_altfiles"
+          comment="The /etc/nsswitch.conf uses nss-altfiles"/>
+        <criterion test_ref="test_file_groupowner_etc_chrony_keys_with_usrlib"
+          comment="Check all local files and make sure they are owned by a group"/>
+      </criteria>
+    </criteria>
+  </definition>
+
+{{{ oval_test_nsswitch_uses_altfiles() }}}
+
+  <unix:file_test id="test_file_groupowner_etc_chrony_keys" version="1" check="all" comment="Testing group ownership of /etc/chrony.keys" check_existence="none_exist" state_operator="AND">
+    <unix:object object_ref="object_file_groupowner_etc_chrony_keys" />
+  </unix:file_test>
+  <unix:file_object id="object_file_groupowner_etc_chrony_keys" version="1" comment="/etc/chrony.keys">
+    <unix:filepath>/etc/chrony.keys</unix:filepath>
+    <filter action="exclude">state_file_groupowner_etc_chrony_keys_uid_chrony</filter>
+    <filter action="exclude">state_file_groupowner_etc_chrony_keys_gid_chrony</filter>
+  </unix:file_object>
+  <ind:textfilecontent54_object id="object_file_groupowner_etc_chrony_keys_etc_group" version="1" comment="gid of the dedicated chrony group">
+    <ind:filepath>/etc/group</ind:filepath>
+    <ind:pattern operation="pattern match">^chrony:\w+:(\w+):.*</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <unix:file_state id="state_file_groupowner_etc_chrony_keys_gid_chrony" version="1" operator="AND">
+    <unix:group_id datatype="int" var_ref="var_dedicated_groupowner_etc_chrony_keys_uid_chrony" />
+  </unix:file_state>
+  <unix:file_state id="state_file_groupowner_etc_chrony_keys_uid_chrony" version="1" operator="AND">
+    <unix:type operation="equals">symbolic link</unix:type>
+  </unix:file_state>
+  <local_variable id="var_dedicated_groupowner_etc_chrony_keys_uid_chrony" version="1" datatype="int" comment="gid of the dedicated chrony group">
+    <object_component item_field="subexpression" object_ref="object_file_groupowner_etc_chrony_keys_etc_group" />
+  </local_variable>
+
+  <unix:file_test id="test_file_groupowner_etc_chrony_keys_with_usrlib" version="1" check="all" comment="Testing group ownership of /etc/chrony.keys" check_existence="none_exist" state_operator="AND">
+    <unix:object object_ref="object_file_groupowner_etc_chrony_keys_with_usrlib" />
+  </unix:file_test>
+  <unix:file_object id="object_file_groupowner_etc_chrony_keys_with_usrlib" version="1" comment="/etc/chrony.keys">
+    <unix:filepath>/etc/chrony.keys</unix:filepath>
+    <filter action="exclude">state_file_groupowner_etc_chrony_keys_uid_chrony</filter>
+    <filter action="exclude">state_file_groupowner_etc_chrony_keys_gid_chrony_with_usrlib</filter>
+  </unix:file_object>
+  <ind:textfilecontent54_object id="object_file_groupowner_etc_chrony_keys_etc_group_with_usrlib" version="1" comment="gid of the dedicated chrony group">
+    <set>
+      <object_reference>object_file_groupowner_etc_chrony_keys_etc_group</object_reference>
+      <object_reference>object_file_groupowner_etc_chrony_keys_usr_lib_group</object_reference>
+    </set>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_object id="object_file_groupowner_etc_chrony_keys_usr_lib_group" version="1">
+    <ind:filepath>/usr/lib/group</ind:filepath>
+    <ind:pattern operation="pattern match">^chrony:\w+:(\w+):.*</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <unix:file_state id="state_file_groupowner_etc_chrony_keys_gid_chrony_with_usrlib" version="1" operator="AND">
+    <unix:group_id datatype="int" var_ref="var_dedicated_groupowner_etc_chrony_keys_uid_chrony_with_usrlib" />
+  </unix:file_state>
+  <local_variable id="var_dedicated_groupowner_etc_chrony_keys_uid_chrony_with_usrlib" version="1" datatype="int" comment="gid of the dedicated chrony group">
+    <object_component item_field="subexpression" object_ref="object_file_groupowner_etc_chrony_keys_etc_group_with_usrlib" />
+  </local_variable>
+
+</def-group>

--- a/linux_os/guide/services/ntp/file_groupowner_etc_chrony_keys/oval/shared.xml
+++ b/linux_os/guide/services/ntp/file_groupowner_etc_chrony_keys/oval/shared.xml
@@ -1,19 +1,19 @@
 <def-group>
 
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
-    {{{ oval_metadata("All files should be owned by a group") }}}
+    {{{ oval_metadata("/etc/chrony.keys should be owned by chrony group") }}}
     <criteria operator="OR">
       <criteria operator="AND">
         <criterion test_ref="test_file_groupowner_etc_chrony_keys_nsswitch_uses_altfiles" negate="true"
           comment="The /etc/nsswitch.conf does not use nss-altfiles"/>
         <criterion test_ref="test_file_groupowner_etc_chrony_keys"
-          comment="Check all local files and make sure they are owned by a group"/>
+          comment="Check group ownership of /etc/chrony.keys"/>
       </criteria>
       <criteria operator="AND">
         <criterion test_ref="test_file_groupowner_etc_chrony_keys_nsswitch_uses_altfiles"
           comment="The /etc/nsswitch.conf uses nss-altfiles"/>
         <criterion test_ref="test_file_groupowner_etc_chrony_keys_with_usrlib"
-          comment="Check all local files and make sure they are owned by a group"/>
+          comment="Check group ownership of /etc/chrony.keys"/>
       </criteria>
     </criteria>
   </definition>

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/oval/shared.xml
@@ -92,22 +92,7 @@
     <filter action="exclude">state_file_permissions_ungroupowned_sysroot</filter>
   </unix:file_object>
 
-  <ind:textfilecontent54_test id="test_file_permissions_ungroupowned_nsswitch_uses_altfiles" version="1"
-    check="all" check_existence="at_least_one_exists"
-    comment="Test if /etc/nssswitch.conf contains 'altfiles' in 'group' key">
-    <ind:object object_ref="object_file_permissions_ungroupowned_nsswitch_uses_altfiles"/>
-    <ind:state state_ref="state_file_permissions_ungroupowned_nsswitch_uses_altfiles"/>
-  </ind:textfilecontent54_test>
-
-  <ind:textfilecontent54_object id="object_file_permissions_ungroupowned_nsswitch_uses_altfiles" version="1">
-    <ind:filepath>/etc/nsswitch.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*group:\s+(.*)$</ind:pattern>
-    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-
-  <ind:textfilecontent54_state id="state_file_permissions_ungroupowned_nsswitch_uses_altfiles" version="1">
-    <ind:subexpression operation="pattern match">altfiles</ind:subexpression>
-  </ind:textfilecontent54_state>
+{{{ oval_test_nsswitch_uses_altfiles() }}}
 
   <unix:file_test id="test_file_permissions_ungroupowned" version="1"
     check="all" check_existence="none_exist"

--- a/shared/macros/10-oval.jinja
+++ b/shared/macros/10-oval.jinja
@@ -1702,3 +1702,25 @@ Generates an OVAL check that checks a particular field in the "/etc/shadow" file
   {{%- endif %}}
 {{%- endif %}}
 {{%- endmacro -%}}
+
+{{#
+Generate OVAL test that tests if the system is configured to use nss-altfiles
+by checking if '/etc/nssswitch.conf' contains 'altfiles' in 'group' key.
+The macros generates the OVAL test including the dependent OVAL object and OVAL state.
+#}}
+{{%- macro oval_test_nsswitch_uses_altfiles() -%}}
+<ind:textfilecontent54_test id="test_{{{ rule_id }}}_nsswitch_uses_altfiles" version="1"
+  check="all" check_existence="at_least_one_exists"
+  comment="Test if /etc/nssswitch.conf contains 'altfiles' in 'group' key">
+  <ind:object object_ref="object_{{{ rule_id }}}_nsswitch_uses_altfiles"/>
+  <ind:state state_ref="state_{{{ rule_id }}}_nsswitch_uses_altfiles"/>
+</ind:textfilecontent54_test>
+<ind:textfilecontent54_object id="object_{{{ rule_id }}}_nsswitch_uses_altfiles" version="1">
+  <ind:filepath>/etc/nsswitch.conf</ind:filepath>
+  <ind:pattern operation="pattern match">^\s*group:\s+(.*)$</ind:pattern>
+  <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+</ind:textfilecontent54_object>
+<ind:textfilecontent54_state id="state_{{{ rule_id }}}_nsswitch_uses_altfiles" version="1">
+  <ind:subexpression operation="pattern match">altfiles</ind:subexpression>
+</ind:textfilecontent54_state>
+{{%- endmacro -%}}


### PR DESCRIPTION
The bootable containers and Image Mode Operating systems use `/usr/lib/group` provided by the `nss-altfiles` RPM package as an alternative place to define user groups in the system.

The rule `file_groupowner_etc_chrony_keys` didn't read the `/usr/lib/group`. As a result the rule failed in the after-deployment scan with the ANSSI BP28 High profile.  This commit extends the check to read `/usr/lib/group`, which makes the rule pass in Image Mode.

This change has been inspired by the code in rule
`file_permissions_ungroupowned` which already has been modified for Image Mode. The code that is same in OVALs in both rules has been extracted to a Jinja 2 macro to prevent code duplication and enable further reuse in future.
