### PR TITLE
Fix auditd rule to watch apparmor instead of selinux on Ubuntu

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification/bash/shared.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicro,multi_platform_ubuntu
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicro
 
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 {{{ bash_fix_audit_watch_rule("auditctl", "/etc/selinux/", "wa", "MAC-policy") }}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification/bash/ubuntu.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification/bash/ubuntu.sh
@@ -1,0 +1,7 @@
+# platform = multi_platform_ubuntu
+
+# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
+{{{ bash_fix_audit_watch_rule("auditctl", "/etc/apparmor/", "wa", "MAC-policy") }}}
+{{{ bash_fix_audit_watch_rule("augenrules", "/etc/apparmor/", "wa", "MAC-policy") }}}
+{{{ bash_fix_audit_watch_rule("auditctl", "/etc/apparmor.d/", "wa", "MAC-policy") }}}
+{{{ bash_fix_audit_watch_rule("augenrules", "/etc/apparmor.d/", "wa", "MAC-policy") }}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification/oval/ubuntu.xml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification/oval/ubuntu.xml
@@ -1,0 +1,62 @@
+<def-group>
+  <definition class="compliance" id="audit_rules_mac_modification" version="1">
+    {{{ oval_metadata("Audit rules that detect changes to the system's mandatory access controls (Apparmor) are enabled.") }}}
+
+    <criteria operator="OR">
+
+      <!-- Test the augenrules case -->
+      <criteria operator="AND">
+        <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
+        <criterion comment="audit apparmor changes augenrules" test_ref="test_armm_apparmor_watch_augenrules" />
+        <criterion comment="audit apparmor.d changes augenrules" test_ref="test_armm_apparmord_watch_augenrules" />
+      </criteria>
+
+      <!-- Test the auditctl case -->
+      <criteria operator="AND">
+        <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
+        <criterion comment="audit apparmor changes auditctl" test_ref="test_armm_apparmor_watch_auditctl" />
+        <criterion comment="audit apparmor.d changes auditctl" test_ref="test_armm_apparmord_watch_auditctl" />
+      </criteria>
+
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" comment="audit apparmor changes augenrules" id="test_armm_apparmor_watch_augenrules" version="1">
+    <ind:object object_ref="object_armm_apparmor_watch_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_armm_apparmor_watch_augenrules" version="1">
+    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w[\s]+/etc/apparmor/[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit apparmor changes auditctl" id="test_armm_apparmor_watch_auditctl" version="1">
+    <ind:object object_ref="object_armm_apparmor_watch_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_armm_apparmor_watch_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w[\s]+/etc/apparmor/[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit apparmor.d changes augenrules" id="test_armm_apparmord_watch_augenrules" version="1">
+    <ind:object object_ref="object_armm_apparmord_watch_augenrules" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_armm_apparmord_watch_augenrules" version="1">
+    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w[\s]+/etc/apparmor\.d/[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" comment="audit apparmor.d changes auditctl" id="test_armm_apparmord_watch_auditctl" version="1">
+    <ind:object object_ref="object_armm_apparmord_watch_auditctl" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_armm_apparmord_watch_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^\-w[\s]+/etc/apparmor\.d/[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification/rule.yml
@@ -7,14 +7,24 @@ description: |-
     <tt>augenrules</tt> program to read audit rules during daemon startup (the
     default), add the following line to a file with suffix <tt>.rules</tt> in the
     directory <tt>/etc/audit/rules.d</tt>:
+    {{% if 'ubuntu' in product %}}
+    <pre>-w /etc/apparmor/ -p wa -k MAC-policy</pre>
+    <pre>-w /etc/apparmor.d/ -p wa -k MAC-policy</pre>
+    {{% else %}}
     <pre>-w /etc/selinux/ -p wa -k MAC-policy</pre>
+    {{% endif %}}
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
+    {{% if 'ubuntu' in product %}}
+    <pre>-w /etc/apparmor/ -p wa -k MAC-policy</pre>
+    <pre>-w /etc/apparmor.d/ -p wa -k MAC-policy</pre>
+    {{% else %}}
     <pre>-w /etc/selinux/ -p wa -k MAC-policy</pre>
+    {{% endif %}}
 
 rationale: |-
-    The system's mandatory access policy (SELinux) should not be
+    The system's mandatory access policy (SELinux or Apparmor) should not be
     arbitrarily changed by anything other than administrator action. All changes to
     MAC policy should be audited.
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification/tests/auditctl_correct.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification/tests/auditctl_correct.pass.sh
@@ -4,4 +4,9 @@
 # use auditctl
 {{{ setup_auditctl_environment() }}}
 
+{{% if 'ubuntu' in product %}}
+echo "-w /etc/apparmor/ -p wa -k MAC-policy" > /etc/audit/audit.rules
+echo "-w /etc/apparmor.d/ -p wa -k MAC-policy" >> /etc/audit/audit.rules
+{{% else %}}
 echo "-w /etc/selinux/ -p wa -k MAC-policy" > /etc/audit/audit.rules
+{{% endif %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification/tests/auditctl_correct_without_key.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification/tests/auditctl_correct_without_key.pass.sh
@@ -4,4 +4,9 @@
 # use auditctl
 {{{ setup_auditctl_environment() }}}
 
+{{% if 'ubuntu' in product %}}
+echo "-w /etc/apparmor/ -p wa" > /etc/audit/audit.rules
+echo "-w /etc/apparmor.d/ -p wa" >> /etc/audit/audit.rules
+{{% else %}}
 echo "-w /etc/selinux/ -p wa" > /etc/audit/audit.rules
+{{% endif %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification/tests/augen_correct.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification/tests/augen_correct.pass.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
 # packages = audit
 
+{{% if 'ubuntu' in product %}}
+echo "-w /etc/apparmor/ -p wa -k MAC-policy" > /etc/audit/rules.d/MAC-policy.rules
+echo "-w /etc/apparmor.d/ -p wa -k MAC-policy" >> /etc/audit/rules.d/MAC-policy.rules
+{{% else %}}
 echo "-w /etc/selinux/ -p wa -k MAC-policy" > /etc/audit/rules.d/MAC-policy.rules
+{{% endif %}}
+

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification/tests/augen_correct_without_key.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification/tests/augen_correct_without_key.pass.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
 # packages = audit
 
+{{% if 'ubuntu' in product %}}
+echo "-w /etc/apparmor/ -p wa" > /etc/audit/rules.d/MAC-policy.rules
+echo "-w /etc/apparmor.d/ -p wa" >> /etc/audit/rules.d/MAC-policy.rules
+{{% else %}}
 echo "-w /etc/selinux/ -p wa" > /etc/audit/rules.d/MAC-policy.rules
+{{% endif %}}


### PR DESCRIPTION
#### Description:

- Fix auditd rule `audit_rules_mac_modifications` to watch apparmor dirs `/etc/apparmor` and `/etc/apparmor.d` instead of `/etc/selinux` on Ubuntu