### PR TITLE
Update file_permissions_unauthorized_world_writable

### DIFF
--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/bash/shared.sh
@@ -5,12 +5,16 @@
 # disruption = low
 
 FILTER_NODEV=$(awk '/nodev/ { print $2 }' /proc/filesystems | paste -sd,)
-PARTITIONS=$(findmnt -n -l -k -it $FILTER_NODEV | awk '{ print $1 }')
+
+# Do not consider /sysroot partition because it contains only the physical
+# read-only root on bootable containers.
+PARTITIONS=$(findmnt -n -l -k -it $FILTER_NODEV | awk '{ print $1 }' | grep -v "/sysroot")
+
 for PARTITION in $PARTITIONS; do
   find "${PARTITION}" -xdev -type f -perm -002 -exec chmod o-w {} \; 2>/dev/null
 done
 
-# Ensure /tmp is also fixed whem tmpfs is used.
+# Ensure /tmp is also fixed when tmpfs is used.
 if grep "^tmpfs /tmp" /proc/mounts; then
   find /tmp -xdev -type f -perm -002 -exec chmod o-w {} \; 2>/dev/null
 fi

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/oval/shared.xml
@@ -17,6 +17,11 @@
       operation="pattern match">^/selinux/(?:(?:member)|(?:user)|(?:relabel)|(?:create)|(?:access)|(?:context))$</unix:filepath>
   </unix:file_state>
 
+  <unix:file_state id="state_file_permissions_unauthorized_world_write_sysroot" version="1"
+    comment="Used to filter out all files in the /sysroot directory">
+    <unix:filepath operation="pattern match">^/sysroot/.*$</unix:filepath>
+  </unix:file_state>
+
   {{%- set var_local_mount_points = "var_" ~ rule_id ~ "_local_mountpoints" -%}}
   {{{ create_local_mount_points_list(var_local_mount_points) }}}
 
@@ -35,6 +40,7 @@
     <unix:filename operation="pattern match">^.*$</unix:filename>
     <filter action="include">state_file_permissions_unauthorized_world_write</filter>
     <filter action="exclude">state_file_permissions_unauthorized_world_write_special_selinux_files</filter>
+    <filter action="exclude">state_file_permissions_unauthorized_world_write_sysroot</filter>
   </unix:file_object>
 
   <unix:file_test id="test_file_permissions_unauthorized_world_write" version="1"


### PR DESCRIPTION
Update file_permissions_unauthorized_world_writable for bootable containers. Filter out the `/sysroot` directory from results because it contains only the physical read-only root and not the real file system, see https://containers.github.io/bootc/filesystem-sysroot.html#sysroot-mount.