### PR TITLE
Fix TypeError in processing profile selections

### DIFF
--- a/ssg/variables.py
+++ b/ssg/variables.py
@@ -258,7 +258,7 @@ def _process_selections(profile_yaml: dict, profile_variables: dict, policies: d
     Returns:
         dict: The updated profile variables dictionary.
     """
-    selections = profile_yaml.get("selections")
+    selections = profile_yaml.get("selections", [])
     for selected in selections:
         if "=" in selected and "!" not in selected:
             variable_name, variable_value = selected.split('=', 1)


### PR DESCRIPTION
#### Description:

Fix the TypeError: 'NoneType' object is not iterable when processing profile selections


#### Review Hints:

Some profiles has no 'selections' but just a 'extends'. e.g., ocp4/profiles/pci-dss-node.profile

