### PR TITLE
Disable oscal ctest on Ubuntu 24.04 gate workflow

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -137,7 +137,7 @@ jobs:
         run: |-
           ./build_product ubuntu2404
       - name: Test
-        run: ctest -j2 --output-on-failure -E unique-stigids
+        run: ctest -j2 --output-on-failure -E "unique-stigids|python-unit-utils/oscal"
         working-directory: ./build
 
   validate-fedora-rawhide:


### PR DESCRIPTION
#### Description:

- Disable oscal ctest on Ubuntu 24.04 gate workflow

#### Rationale:

- Oscal is not a critical requirement for Ubuntu at the moment, thus we silence the errors until issue#12795 is resolved