### PR TITLE
Bump OpenSCAP Version for Windows Tests

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -180,8 +180,8 @@ jobs:
     name: Build on Windows
     runs-on: windows-latest
     env:
-      OPENSCAP_VERSION: "1.4.1"
-      OPENSCAP_ROOT_DIR: "C:\\Program Files\\OpenSCAP 1.4.1"
+      OPENSCAP_VERSION: "1.4.2"
+      OPENSCAP_ROOT_DIR: "C:\\Program Files\\OpenSCAP 1.4.2"
     steps:
         - name: Install Deps
           run: choco install xsltproc


### PR DESCRIPTION
#### Description:

`1.4.1` -> `1.4.2` since we using latest master for the build.

#### Rationale:
Make CI green

#### Review Hints:
Make sure the Windows gating tests pass.
