### PR TITLE
Ubuntu 24.04: Implement rule 5.3.3.3.2 Ensure password history is enforced for the root user

### DIFF
--- a/components/pam.yml
+++ b/components/pam.yml
@@ -56,6 +56,7 @@ rules:
 - accounts_password_pam_minlen
 - accounts_password_pam_ocredit
 - accounts_password_pam_pwhistory_enabled
+- accounts_password_pam_pwhistory_enforce_root
 - accounts_password_pam_pwhistory_remember
 - accounts_password_pam_pwhistory_remember_password_auth
 - accounts_password_pam_pwhistory_remember_system_auth

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2019,8 +2019,9 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    rules:
+      - accounts_password_pam_pwhistory_enforce_root
+    status: automated
 
   - id: 5.3.3.3.3
     title: Ensure pam_pwhistory includes use_authtok (Automated)

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enforce_root/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enforce_root/bash/ubuntu.sh
@@ -1,0 +1,13 @@
+# platform = multi_platform_ubuntu
+
+{{{ bash_pam_pwhistory_enable('cac_pwhistory','requisite') }}}
+conf_file=/usr/share/pam-configs/cac_pwhistory
+if ! grep -qE 'pam_pwhistory\.so\s+[^#\n]*\benforce_for_root\b' "$conf_file"; then
+	sed -i -E '/^Password:/,/^[^[:space:]]/ {
+    /pam_pwhistory\.so/ {
+        s/$/ enforce_for_root/g
+    }
+    }' "$conf_file"
+fi
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update --enable cac_pwhistory

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enforce_root/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enforce_root/bash/ubuntu.sh
@@ -8,6 +8,12 @@ if ! grep -qE 'pam_pwhistory\.so\s+[^#\n]*\benforce_for_root\b' "$conf_file"; th
         s/$/ enforce_for_root/g
     }
     }' "$conf_file"
+
+    sed -i -E '/^Password-Initial:/,/^[^[:space:]]/ {
+    /pam_pwhistory\.so/ {
+        s/$/ enforce_for_root/g
+    }
+    }' "$conf_file"
 fi
 
 DEBIAN_FRONTEND=noninteractive pam-auth-update --enable cac_pwhistory

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enforce_root/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enforce_root/oval/shared.xml
@@ -1,0 +1,52 @@
+{{% if "sle12" in product or "debian" in product or "ubuntu" in product %}}
+{{%- set accounts_password_pam_file = '/etc/pam.d/common-password' -%}}
+{{% else %}}
+{{%- set accounts_password_pam_file = '/etc/pam.d/system-auth' -%}}
+{{% endif %}}
+
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="2">
+    {{{ oval_metadata("Enforce password history for root of pam_pwhistory.") }}}
+      <criteria operator="AND" comment="Check if pam_pwhistory.so is properly configured">
+        <criterion test_ref="test_accounts_password_pam_pwhistory_enabled"
+                   comment="pam_pwhistory.so is properly defined in password section of PAM file"/>
+        <criterion test_ref="test_accounts_password_pam_pwhistory_enforce_for_root_parameter"
+                 comment="enforce_for_root parameter of pam_pwhistory.so is properly configured"/>
+      </criteria>
+  </definition>
+
+  <!-- is pam_pwhistory.so enabled? -->
+  <ind:textfilecontent54_test id="test_accounts_password_pam_pwhistory_enabled"
+                              check="all" version="1" comment="Check pam_pwhistory.so presence in PAM file">
+    <ind:object object_ref="object_accounts_password_pam_pwhistory_enabled"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_accounts_password_pam_pwhistory_enabled"
+                                version="1">
+    <ind:filepath>{{{ accounts_password_pam_file }}}</ind:filepath>
+    <ind:pattern var_ref="var_accounts_password_pam_pwhistory_module_regex"
+                 var_check="at least one" operation="pattern match"/>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- variables used to check the module implementation -->
+  <local_variable id="var_accounts_password_pam_pwhistory_module_regex"
+		  datatype="string" version="1"
+		  comment="The regex is to confirm the pam_pwhistory.so module is enabled">
+    <literal_component>^[ \t]*password[ \t]+(?:(?:sufficient)|(?:required)|(?:requisite)|(?:\[.*\]))[ \t]+pam_pwhistory\.so.*$</literal_component>
+  </local_variable>
+
+  <!-- Check the pam_pwhistory.so enforce_for_root parameter -->
+  <ind:textfilecontent54_test id="test_accounts_password_pam_pwhistory_enforce_for_root_parameter" version="1"
+                              check="all" check_existence="all_exist"
+                              comment="Test if enforce_for_root attribute of pam_pwhistory.so is set correctly in {{{ accounts_password_pam_file }}}">
+    <ind:object object_ref="object_accounts_password_pam_pwhistory_enforce_for_root_parameter" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_accounts_password_pam_pwhistory_enforce_for_root_parameter" version="1">
+    <ind:filepath>{{{ accounts_password_pam_file }}}</ind:filepath>
+    <ind:pattern operation="pattern match">^[ \t]*password[ \t]+(?:(?:sufficient)|(?:required)|(?:requisite)|(?:\[.*\]))[ \t]+pam_pwhistory\.so[ \t]+[^#\n\r]*\benforce_for_root\b.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enforce_root/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enforce_root/rule.yml
@@ -1,0 +1,18 @@
+documentation_complete: true
+
+
+title: 'Limit Password Reuse'
+
+description: |-
+    Do not allow root to reuse recent passwords. This can be
+    accomplished by using the <tt>enforce_for_root</tt> option for the
+    <tt>pam_pwhistory</tt> PAM modules.
+    <br /><br />
+    In the file <tt>/etc/pam.d/common-password</tt>, make sure the parameters
+    <tt>enforce_for_root</tt> is present.
+
+rationale: 'Preventing re-use of previous passwords helps ensure that a compromised password is not re-used by a user.'
+
+severity: medium
+
+platform: package[pam]

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enforce_root/tests/ubuntu_argument_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enforce_root/tests/ubuntu_argument_missing.fail.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = pam
+
+config_file=/usr/share/pam-configs/tmp_pwhistory
+
+cat << EOF > "$config_file"
+Name: pwhistory password history checking
+Default: yes
+Priority: 1024
+Password-Type: Primary
+Password: requisite pam_pwhistory.so try_first_pass use_authtok
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update --enable tmp_pwhistory
+rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enforce_root/tests/ubuntu_commented_argument.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enforce_root/tests/ubuntu_commented_argument.fail.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = pam
+
+config_file=/usr/share/pam-configs/tmp_pwhistory
+
+cat << EOF > "$config_file"
+Name: pwhistory password history checking
+Default: yes
+Priority: 1024
+Password-Type: Primary
+Password: requisite pam_pwhistory.so remember=6 try_first_pass use_authtok # enforce_for_root
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update --enable tmp_pwhistory
+rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enforce_root/tests/ubuntu_correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enforce_root/tests/ubuntu_correct_value.pass.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = pam
+
+config_file=/usr/share/pam-configs/tmp_pwhistory
+
+cat << EOF > "$config_file"
+Name: pwhistory password history checking
+Default: yes
+Priority: 1024
+Password-Type: Primary
+Password: requisite pam_pwhistory.so remember=24 enforce_for_root try_first_pass use_authtok
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update --enable tmp_pwhistory
+rm "$config_file"


### PR DESCRIPTION
#### Description:

- Implement rule 5.3.3.3.2 Ensure password history is enforced for the root user

#### Rationale:

- Satisfies Ubuntu 24.04 CIS control 5.3.3.3.2