### PR TITLE
Ubuntu 24.04: Implement rule 5.3.3.3.3 Ensure pam_pwhistory includes use_authtok

### DIFF
--- a/components/pam.yml
+++ b/components/pam.yml
@@ -59,6 +59,7 @@ rules:
 - accounts_password_pam_pwhistory_remember
 - accounts_password_pam_pwhistory_remember_password_auth
 - accounts_password_pam_pwhistory_remember_system_auth
+- accounts_password_pam_pwhistory_use_authtok
 - accounts_password_pam_pwquality_password_auth
 - accounts_password_pam_pwquality_system_auth
 - accounts_password_pam_pwquality_enabled

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2027,8 +2027,9 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    rules:
+      - accounts_password_pam_pwhistory_use_authtok
+    status: automated
 
   - id: 5.3.3.4.1
     title: Ensure pam_unix does not include nullok (Automated)

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_use_authtok/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_use_authtok/bash/ubuntu.sh
@@ -1,0 +1,13 @@
+# platform = multi_platform_ubuntu
+
+{{{ bash_pam_pwhistory_enable('cac_pwhistory','requisite') }}}
+conf_file=/usr/share/pam-configs/cac_pwhistory
+if ! grep -qE 'pam_pwhistory\.so\s+[^#]*\buse_authtok\b' "$conf_file"; then
+	sed -i -E '/^Password:/,/^[^[:space:]]/ {
+    /pam_pwhistory\.so/ {
+        s/$/ use_authtok/g
+    }
+    }' "$conf_file"
+fi
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update --enable cac_pwhistory

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_use_authtok/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_use_authtok/oval/shared.xml
@@ -1,0 +1,75 @@
+{{% if "sle12" in product or "debian" in product or "ubuntu" in product %}}
+{{%- set accounts_password_pam_file = '/etc/pam.d/common-password' -%}}
+{{% else %}}
+{{%- set accounts_password_pam_file = '/etc/pam.d/system-auth' -%}}
+{{% endif %}}
+
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("Configure the system to include use_authtok for pam_pwhistory common_password configuration file") }}}
+    <criteria operator="AND" comment="Check if pam_pwhistory.so is properly configured">
+      <criterion test_ref="{{{ rule_id }}}_test_pwhistory_exists"
+        comment="At least one pwhistory line exists"/>
+      <criterion test_ref="{{{ rule_id }}}_test_password_pam_pwhistory_use_authtok"
+        comment="use_authtok is configured in pam pwhistory in common_password file"/>
+      <criterion test_ref="{{{ rule_id }}}_test_password_pam_pwhistory_without_use_authtok"
+        comment="use_authtok is configured not in pam pwhistory in common_password file"/>
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test id="{{{ rule_id }}}_test_pwhistory_exists" version="1"
+    check="all" check_existence="at_least_one_exists"
+    comment="At least one pwhistory line exists">
+    <ind:object object_ref="{{{ rule_id }}}_obj_pwhistory_exists" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="{{{ rule_id }}}_obj_pwhistory_exists" version="1">
+    <ind:filepath>{{{ accounts_password_pam_file }}}</ind:filepath>
+    <ind:pattern operation="pattern match">^[^#\n\r]*password[ \t]+.*pam_pwhistory\.so.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="{{{ rule_id }}}_test_password_pam_pwhistory_use_authtok" version="1"
+    check="all" check_existence="any_exist" state_operator="AND"
+    comment="use_authtok is configured in pam pwhistory in common_password file">
+    <ind:object object_ref="{{{ rule_id }}}_obj_use_authtok" />
+    <ind:state state_ref="{{{ rule_id }}}_ste_use_authtok" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="{{{ rule_id }}}_obj_use_authtok" version="1">
+    <set>
+      <object_reference>{{{ rule_id }}}_obj_use_authtok_password_lines_except_first</object_reference>
+      <filter action="include">{{{ rule_id }}}_ste_use_authtok_pam_pwhistory_lines</filter>
+    </set>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="{{{ rule_id }}}_ste_use_authtok" version="1">
+      <ind:subexpression operation="pattern match">^[^#\n\r]*pam_pwhistory\.so[ \t]+[^#\n\r]*use_authtok.*$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <!-- Get all password lines except the first line. This is to avoid matching a pam_pwhistory
+  line on the top of the stack, which does not need use_authtok to pass -->
+  <ind:textfilecontent54_object id="{{{ rule_id }}}_obj_use_authtok_password_lines_except_first" version="1">
+    <ind:filepath>{{{ accounts_password_pam_file }}}</ind:filepath>
+    <ind:pattern operation="pattern match">^[ \t]*password[ \t]+(.+)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">2</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="{{{ rule_id }}}_ste_use_authtok_pam_pwhistory_lines" version="1">
+      <ind:subexpression operation="pattern match">^[^#\n\r]*pam_pwhistory\.so.*$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <!-- Test to check if use_authtok is not configured in the first password line containing pam_pwhistory.so -->
+  <ind:textfilecontent54_test id="{{{ rule_id }}}_test_password_pam_pwhistory_without_use_authtok" version="1"
+    check="all" check_existence="all_exist"
+    comment="use_authtok is configured not in pam pwhistory on top of stack in common_password file">
+    <ind:object object_ref="{{{ rule_id }}}_obj_without_use_authtok" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="{{{ rule_id }}}_obj_without_use_authtok" version="1">
+    <ind:filepath>{{{ accounts_password_pam_file }}}</ind:filepath>
+    <ind:pattern operation="pattern match">^[ \t]*password[ \t]+[^#\n\r]*pam_pwhistory\.so.*$</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_use_authtok/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_use_authtok/oval/shared.xml
@@ -12,8 +12,6 @@
         comment="At least one pwhistory line exists"/>
       <criterion test_ref="{{{ rule_id }}}_test_password_pam_pwhistory_use_authtok"
         comment="use_authtok is configured in pam pwhistory in common_password file"/>
-      <criterion test_ref="{{{ rule_id }}}_test_password_pam_pwhistory_without_use_authtok"
-        comment="use_authtok is configured not in pam pwhistory in common_password file"/>
     </criteria>
   </definition>
 
@@ -58,18 +56,5 @@
   <ind:textfilecontent54_state id="{{{ rule_id }}}_ste_use_authtok_pam_pwhistory_lines" version="1">
       <ind:subexpression operation="pattern match">^[^#\n\r]*pam_pwhistory\.so.*$</ind:subexpression>
   </ind:textfilecontent54_state>
-
-  <!-- Test to check if use_authtok is not configured in the first password line containing pam_pwhistory.so -->
-  <ind:textfilecontent54_test id="{{{ rule_id }}}_test_password_pam_pwhistory_without_use_authtok" version="1"
-    check="all" check_existence="all_exist"
-    comment="use_authtok is configured not in pam pwhistory on top of stack in common_password file">
-    <ind:object object_ref="{{{ rule_id }}}_obj_without_use_authtok" />
-  </ind:textfilecontent54_test>
-
-  <ind:textfilecontent54_object id="{{{ rule_id }}}_obj_without_use_authtok" version="1">
-    <ind:filepath>{{{ accounts_password_pam_file }}}</ind:filepath>
-    <ind:pattern operation="pattern match">^[ \t]*password[ \t]+[^#\n\r]*pam_pwhistory\.so.*$</ind:pattern>
-    <ind:instance datatype="int" operation="equals">1</ind:instance>
-  </ind:textfilecontent54_object>
 
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_use_authtok/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_use_authtok/rule.yml
@@ -1,0 +1,18 @@
+documentation_complete: true
+
+
+title: 'Enforce Password History with use_authtok'
+
+description: |-
+    The <tt>use_authtok</tt> option ensures the pam_pwhistory module uses the new
+    password provided by a previously stacked PAM module during password
+    changes, rather than prompting the user again.
+
+rationale: |-
+    The <tt>use_authtok</tt> option allows multiple PAM modules to validate the new
+    password before it is accepted, ensuring it meets all security requirements
+    without requiring the user to re-enter it multiple times.
+
+severity: medium
+
+platform: package[pam]

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_use_authtok/tests/ubuntu_argument_missing_first_line.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_use_authtok/tests/ubuntu_argument_missing_first_line.pass.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = pam
+
+config_file=/usr/share/pam-configs/tmp_pwhistory
+
+cat << EOF > "$config_file"
+Name: pwhistory password history checking
+Default: yes
+Priority: 1024
+Password-Type: Primary
+Password: requisite pam_pwhistory.so remember=24 enforce_for_root try_first_pass
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update --enable tmp_pwhistory
+rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_use_authtok/tests/ubuntu_argument_missing_second_line.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_use_authtok/tests/ubuntu_argument_missing_second_line.fail.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = pam
+
+config_file=/usr/share/pam-configs/tmp_pwhistory
+
+cat << EOF > "$config_file"
+Name: pwhistory password history checking
+Default: yes
+Priority: 1024
+Password-Type: Primary
+Password: 
+    requisite pam_pwhistory.so remember=24 enforce_for_root try_first_pass # use_authtok
+    [success=end default=ignore] pam_unix.so obscure use_authtok try_first_pass yescrypt
+    requisite pam_pwhistory.so remember=24 enforce_for_root try_first_pass
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update --enable tmp_pwhistory
+rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_use_authtok/tests/ubuntu_commented_argument.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_use_authtok/tests/ubuntu_commented_argument.fail.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = pam
+
+config_file=/usr/share/pam-configs/tmp_pwhistory
+
+cat << EOF > "$config_file"
+Name: pwhistory password history checking
+Default: yes
+Priority: 1024
+Password-Type: Primary
+Password: 
+    requisite pam_pwhistory.so remember=24 enforce_for_root try_first_pass # use_authtok
+    [success=end default=ignore] pam_unix.so obscure use_authtok try_first_pass yescrypt
+    requisite pam_pwhistory.so remember=24 enforce_for_root try_first_pass # use_authtok
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update --enable tmp_pwhistory
+rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_use_authtok/tests/ubuntu_commented_argument_first_line.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_use_authtok/tests/ubuntu_commented_argument_first_line.pass.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = pam
+
+config_file=/usr/share/pam-configs/tmp_pwhistory
+
+cat << EOF > "$config_file"
+Name: pwhistory password history checking
+Default: yes
+Priority: 1024
+Password-Type: Primary
+Password: 
+    requisite pam_pwhistory.so remember=24 enforce_for_root try_first_pass # use_authtok
+    [success=end default=ignore] pam_unix.so obscure use_authtok try_first_pass yescrypt
+    requisite pam_pwhistory.so remember=24 enforce_for_root try_first_pass use_authtok
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update --enable tmp_pwhistory
+rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_use_authtok/tests/ubuntu_correct_first_line.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_use_authtok/tests/ubuntu_correct_first_line.pass.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = pam
+
+config_file=/usr/share/pam-configs/tmp_pwhistory
+
+cat << EOF > "$config_file"
+Name: pwhistory password history checking
+Default: yes
+Priority: 1024
+Password-Type: Primary
+Password-Initial: requisite pam_pwhistory.so remember=24 enforce_for_root try_first_pass
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update --enable tmp_pwhistory
+rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_use_authtok/tests/ubuntu_null.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_use_authtok/tests/ubuntu_null.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = pam
+
+if [[ -f /usr/share/pam-configs/pwhistory ]]; then
+    pam-auth-update --disable pwhistory
+fi


### PR DESCRIPTION
#### Description:

- Implement rule 5.3.3.3.3 Ensure pam_pwhistory includes use_authtok
- Exclude line break match

#### Rationale:

- Satisfies Ubuntu 24.04 CIS control 5.3.3.3.3
- If not exclude line break, the regex `pam_pwhistory\.so\s+[^#\n\r]*\buse_authtok\b.*$` will match content like
```
password	requisite pam_pwhistory.so remember=24 enforce_for_root try_first_pass
password	[success=1 default=ignore]	pam_unix.so obscure use_authtok try_first_pass yescrypt
```