### PR TITLE
Remove RHEL-08-020220 and RHEL-08-020221 from the RHEL 8 STIG

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/rule.yml
@@ -54,7 +54,6 @@ references:
     nist@sle15: IA-5(1)(e),IA-5(1).1(v)
     pcidss: Req-8.2.5
     srg: SRG-OS-000077-GPOS-00045
-    stigid@rhel8: RHEL-08-020220
 
 ocil_clause: |-
     the pam_pwhistory.so module is not used, the "remember" module option is not set in

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/rule.yml
@@ -54,7 +54,6 @@ references:
     nist@sle15: IA-5(1)(e),IA-5(1).1(v)
     pcidss: Req-8.2.5
     srg: SRG-OS-000077-GPOS-00045
-    stigid@rhel8: RHEL-08-020221
 
 ocil_clause: |-
     the pam_pwhistory.so module is not used, the "remember" module option is not set in

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -613,12 +613,6 @@ selections:
     # RHEL-08-020210
     - accounts_password_set_max_life_existing
 
-    # RHEL-08-020220
-    - accounts_password_pam_pwhistory_remember_system_auth
-
-    # RHEL-08-020221
-    - accounts_password_pam_pwhistory_remember_password_auth
-
     # RHEL-08-020230
     - accounts_password_pam_minlen
 

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -53,8 +53,6 @@ selections:
 - accounts_password_pam_minclass
 - accounts_password_pam_minlen
 - accounts_password_pam_ocredit
-- accounts_password_pam_pwhistory_remember_password_auth
-- accounts_password_pam_pwhistory_remember_system_auth
 - accounts_password_pam_pwquality_password_auth
 - accounts_password_pam_pwquality_system_auth
 - accounts_password_pam_retry

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -64,8 +64,6 @@ selections:
 - accounts_password_pam_minclass
 - accounts_password_pam_minlen
 - accounts_password_pam_ocredit
-- accounts_password_pam_pwhistory_remember_password_auth
-- accounts_password_pam_pwhistory_remember_system_auth
 - accounts_password_pam_pwquality_password_auth
 - accounts_password_pam_pwquality_system_auth
 - accounts_password_pam_retry


### PR DESCRIPTION
#### Description:
Remove RHEL-08-020220 and RHEL-08-020221 from the RHEL 8 STIG

#### Rationale:

No longer in the STIG

Partially addressees #12801 