### PR TITLE
Fix typo in gpgkey

### DIFF
--- a/products/rhel10/product.yml
+++ b/products/rhel10/product.yml
@@ -28,7 +28,7 @@ dconf_gdm_dir: "distro.d"
 faillock_path: "/var/log/faillock"
 
 # The fingerprints below are retrieved from https://access.redhat.com/security/team/key
-pkg_release: "4ae0493c"
+pkg_release: "4ae0493b"
 pkg_version: "fd431d51"
 aux_pkg_release: "6229229e"
 aux_pkg_version: "5a6340b3"


### PR DESCRIPTION
The PR #12767 fixed the swap of pkg_relase and pkg_version, but unfortunately, it hasn't fixed the typo in the pkg_release, so we will fix it now.
