### PR TITLE
Mark /boot rules as not applicable in bootable containers

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/rule.yml
@@ -50,6 +50,7 @@ fixtext: '{{{ fixtext_file_group_owner(grub2_boot_path ~ "/grub.cfg", "root") }}
 
 srg_requirement: '{{{ srg_requirement_file_group_owner(grub2_boot_path ~ "/grub.cfg", "root") }}}'
 
+platform: not bootc
 
 template:
     name: file_groupowner

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_user_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_user_cfg/rule.yml
@@ -44,6 +44,7 @@ fixtext: '{{{ fixtext_file_group_owner(grub2_boot_path ~ "/user.cfg", "root") }}
 
 srg_requirement: '{{{ srg_requirement_file_group_owner(grub2_boot_path ~ "/user.cfg", "root") }}}'
 
+platform: not bootc
 
 template:
     name: file_groupowner

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/rule.yml
@@ -46,6 +46,7 @@ ocil_clause: '{{{ ocil_clause_file_owner(file=grub2_boot_path ~ "/grub.cfg", own
 ocil: |-
     {{{ ocil_file_owner(file=grub2_boot_path ~ "/grub.cfg", owner="root") }}}
 
+platform: not bootc
 
 template:
     name: file_owner

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_user_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_user_cfg/rule.yml
@@ -39,6 +39,7 @@ ocil_clause: '{{{ ocil_clause_file_owner(file=grub2_boot_path ~ "/user.cfg", own
 ocil: |-
     {{{ ocil_file_owner(file=grub2_boot_path ~ "/user.cfg", owner="root") }}}
 
+platform: not bootc
 
 template:
     name: file_owner

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_grub2_cfg/rule.yml
@@ -46,6 +46,7 @@ ocil: |-
     If properly configured, the output should indicate the following
     permissions: <tt>-rw-------</tt>
 
+platform: not bootc
 
 template:
     name: file_permissions

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_user_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_user_cfg/rule.yml
@@ -35,6 +35,7 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file=grub2_boot_path ~ "/user.cfg
 ocil: |-
     {{{ ocil_file_permissions(file=grub2_boot_path ~ "/user.cfg", perms="-rw-------") }}}
 
+platform: not bootc
 
 template:
     name: file_permissions


### PR DESCRIPTION
We will mark rules that checks files in the `/boot/grub2/` directory as not applicable in the bootable containers. The reason is that these files don't exist during the container image build. They are generated from configuration during deployment of the image by the bootc toolset.

