### PR TITLE
Fix the bash conditional for checking system architecture

### DIFF
--- a/shared/applicability/aarch64_arch.yml
+++ b/shared/applicability/aarch64_arch.yml
@@ -1,5 +1,5 @@
 name: cpe:/a:aarch64_arch
 title: System architecture is AARCH64
 check_id: proc_sys_kernel_osrelease_arch_aarch64
-bash_conditional: 'grep -q aarch64 /proc/sys/kernel/{osrelease,arch}'
+bash_conditional: {{{ bash_arch_conditional("aarch64") }}}
 ansible_conditional: 'ansible_architecture == "aarch64"'

--- a/shared/applicability/not_aarch64_arch.yml
+++ b/shared/applicability/not_aarch64_arch.yml
@@ -1,5 +1,5 @@
 name: cpe:/a:not_aarch64_arch
 title: System architecture is not AARCH64
 check_id: proc_sys_kernel_osrelease_arch_not_aarch64
-bash_conditional: ! {{{ bash_arch_conditional("aarch64") }}}
+bash_conditional: '! {{{ bash_arch_conditional("aarch64") }}}'
 ansible_conditional: 'ansible_architecture != "aarch64"'

--- a/shared/applicability/not_aarch64_arch.yml
+++ b/shared/applicability/not_aarch64_arch.yml
@@ -1,5 +1,5 @@
 name: cpe:/a:not_aarch64_arch
 title: System architecture is not AARCH64
 check_id: proc_sys_kernel_osrelease_arch_not_aarch64
-bash_conditional: '! grep -q aarch64 /proc/sys/kernel/{osrelease,arch}'
+bash_conditional: ! {{{ bash_arch_conditional("aarch64") }}}
 ansible_conditional: 'ansible_architecture != "aarch64"'

--- a/shared/applicability/not_s390x_arch.yml
+++ b/shared/applicability/not_s390x_arch.yml
@@ -1,5 +1,5 @@
 name: cpe:/a:not_s390x_arch
 title: System architecture is not S390X
 check_id: proc_sys_kernel_osrelease_arch_not_s390x
-bash_conditional: ! {{{ bash_arch_conditional("s390x") }}}
+bash_conditional: '! {{{ bash_arch_conditional("s390x") }}}'
 ansible_conditional: 'ansible_architecture != "s390x"'

--- a/shared/applicability/not_s390x_arch.yml
+++ b/shared/applicability/not_s390x_arch.yml
@@ -1,5 +1,5 @@
 name: cpe:/a:not_s390x_arch
 title: System architecture is not S390X
 check_id: proc_sys_kernel_osrelease_arch_not_s390x
-bash_conditional: '! grep -q s390x /proc/sys/kernel/{osrelease,arch}'
+bash_conditional: ! {{{ bash_arch_conditional("s390x") }}}
 ansible_conditional: 'ansible_architecture != "s390x"'

--- a/shared/applicability/ppc64le_arch.yml
+++ b/shared/applicability/ppc64le_arch.yml
@@ -1,5 +1,5 @@
 name: "cpe:/a:ppc64le_arch"
 title: "System architecture is ppc64le"
 check_id: proc_sys_kernel_osrelease_arch_ppc64le
-bash_conditional: 'grep -q ppc64le /proc/sys/kernel/{osrelease,arch}'
+bash_conditional: {{{ bash_arch_conditional("ppc64le") }}}
 ansible_conditional: 'ansible_architecture == "ppc64le"'

--- a/shared/applicability/s390x_arch.yml
+++ b/shared/applicability/s390x_arch.yml
@@ -1,5 +1,5 @@
 name: cpe:/a:s390x_arch
 title: System architecture is S390X
 check_id: proc_sys_kernel_osrelease_arch_s390x
-bash_conditional: 'grep -q s390x /proc/sys/kernel/{osrelease,arch}'
+bash_conditional: {{{ bash_arch_conditional("s390x") }}}
 ansible_conditional: 'ansible_architecture == "s390x"'

--- a/shared/applicability/x86_64_arch.yml
+++ b/shared/applicability/x86_64_arch.yml
@@ -1,5 +1,5 @@
 name: cpe:/a:x86_64_arch
 title: System architecture is x86_64
 check_id: proc_sys_kernel_osrelease_arch_x86_64
-bash_conditional: 'grep -q x86_64 /proc/sys/kernel/{osrelease,arch}'
+bash_conditional: {{{ bash_arch_conditional("x86_64") }}}
 ansible_conditional: 'ansible_architecture == "x86_64"'

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -2668,3 +2668,14 @@ if the remediation is not performed during a build of a bootable container image
 {{%- macro bash_not_bootc_build() -%}}
 [[ "$OSCAP_BOOTC_BUILD" != "YES" ]]
 {{%- endmacro -%}}
+
+
+{{#
+This macro creates a Bash conditional which checks the system architecture in /proc/sys/kernel/{osrelease,arch}
+
+  :param arch: system architecture (x86_64, aarch64, s90x, ppc64le, ...)
+  :type arch: str
+#}}
+{{%- macro bash_arch_conditional(arch) -%}}
+( grep -sqE "^.*\.{{{ arch }}}$" /proc/sys/kernel/osrelease || grep -sqE "^{{{ arch }}}$" /proc/sys/kernel/arch; )
+{{%- endmacro -%}}

--- a/shared/macros/10-oval.jinja
+++ b/shared/macros/10-oval.jinja
@@ -1729,6 +1729,7 @@ The macros generates the OVAL test including the dependent OVAL object and OVAL 
   Macro for checking the system architecture in /proc/sys/kernel/{osrelease,arch}
 
   :param arch: system architecture (x86_64, aarch64, s90x, ppc64le, ...)
+  :type arch: str
 #}}
 {{%- macro oval_check_proc_sys_kernel_osrelease_arch(arch) -%}}
 <def-group>


### PR DESCRIPTION
#### Description:

- Fix the bash conditional for checking system architecture introduced in #12793 

#### Rationale:

The previous conditional exited with RC=2 when either of the files were missing ('arch' is reported to be missing on older kernels). This resulted in:
- false positive when the check was negated
- error messages on stderr
