### PR TITLE
Make it flexible to load macros in SSG 

### DIFF
--- a/ssg/jinja.py
+++ b/ssg/jinja.py
@@ -32,11 +32,6 @@ from .utils import (required_key,
                     sha256
                     )
 
-if sys.version_info >= (3, 9):
-    dict_type = dict    # Python 3.9+ supports built-in generics
-else:
-    from typing import Dict as dict_type    # Fallback for older versions
-
 
 class MacroError(RuntimeError):
     pass
@@ -214,7 +209,7 @@ def add_python_functions(substitutions_dict):
     substitutions_dict['expand_yaml_path'] = expand_yaml_path
 
 
-def _load_macros_from_directory(macros_directory: str, substitutions_dict: dict) -> None:
+def _load_macros_from_directory(macros_directory, substitutions_dict):
     """
     Helper function to load and update macros from the specified directory.
 
@@ -236,7 +231,7 @@ def _load_macros_from_directory(macros_directory: str, substitutions_dict: dict)
         raise RuntimeError(msg)
 
 
-def _load_macros(macros_directory: str, substitutions_dict=None) -> dict_type:
+def _load_macros(macros_directory, substitutions_dict=None):
     """
     Load macros from a specified directory and add them to a substitutions dictionary.
 
@@ -268,7 +263,7 @@ def _load_macros(macros_directory: str, substitutions_dict=None) -> dict_type:
     return substitutions_dict
 
 
-def load_macros(substitutions_dict=None) -> dict_type:
+def load_macros(substitutions_dict=None):
     """
     Augments the provided substitutions_dict with project Jinja macros found in the in
     JINJA_MACROS_DIRECTORY from constants.py.
@@ -283,7 +278,7 @@ def load_macros(substitutions_dict=None) -> dict_type:
     return _load_macros(JINJA_MACROS_DIRECTORY, substitutions_dict)
 
 
-def load_macros_from_content_dir(content_dir: str, substitutions_dict=None) -> dict_type:
+def load_macros_from_content_dir(content_dir, substitutions_dict=None):
     """
     Augments the provided substitutions_dict with project Jinja macros found in a specified
     content directory.

--- a/ssg/jinja.py
+++ b/ssg/jinja.py
@@ -231,7 +231,6 @@ def _load_macros_from_directory(macros_directory: str, substitutions_dict: dict)
                 macros_file = os.path.join(macros_directory, filename)
                 update_substitutions_dict(macros_file, substitutions_dict)
     except Exception as exc:
-        print(macros_directory)
         msg = ("Error extracting macro definitions from '{1}': {0}"
                .format(str(exc), filename))
         raise RuntimeError(msg)

--- a/ssg/jinja.py
+++ b/ssg/jinja.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import os.path
+import sys
 import jinja2
 
 try:
@@ -30,6 +31,11 @@ from .utils import (required_key,
                     escape_yaml_key,
                     sha256
                     )
+
+if sys.version_info >= (3, 9):
+    dict_type = dict    # Python 3.9+ supports built-in generics
+else:
+    from typing import Dict as dict_type    # Fallback for older versions
 
 
 class MacroError(RuntimeError):
@@ -208,13 +214,65 @@ def add_python_functions(substitutions_dict):
     substitutions_dict['expand_yaml_path'] = expand_yaml_path
 
 
-def load_macros(substitutions_dict=None):
+def _load_macros_from_directory(macros_directory: str, substitutions_dict: dict) -> None:
     """
-    Augments the provided substitutions_dict with project Jinja macros found in the /shared/ directory.
+    Helper function to load and update macros from the specified directory.
 
-    This function loads Jinja macro files from a predefined directory, processes them, and updates
-    the substitutions_dict with the macro definitions. If no substitutions_dict is provided, a new
-    dictionary is created.
+    Args:
+        macros_directory (str): The path to the directory containing macro files.
+        substitutions_dict (dict): A dictionary to be augmented with Jinja macros.
+
+    Raises:
+        RuntimeError: If there is an error while reading or processing the macro files.
+    """
+    try:
+        for filename in sorted(os.listdir(macros_directory)):
+            if filename.endswith(".jinja"):
+                macros_file = os.path.join(macros_directory, filename)
+                update_substitutions_dict(macros_file, substitutions_dict)
+    except Exception as exc:
+        print(macros_directory)
+        msg = ("Error extracting macro definitions from '{1}': {0}"
+               .format(str(exc), filename))
+        raise RuntimeError(msg)
+
+
+def _load_macros(macros_directory: str, substitutions_dict=None) -> dict_type:
+    """
+    Load macros from a specified directory and add them to a substitutions dictionary.
+
+    This function checks if the given macros directory exists, adds Python functions to the
+    substitutions dictionary, and then loads macros from the directory into the dictionary.
+
+    Args:
+        macros_directory (str): The path to the directory containing macro files.
+        substitutions_dict (dict, optional): A dictionary to store the loaded macros.
+                                             If None, a new dictionary is created.
+
+    Returns:
+        dict: The updated substitutions dictionary containing the loaded macros.
+
+    Raises:
+        RuntimeError: If the specified macros directory does not exist.
+    """
+    if substitutions_dict is None:
+        substitutions_dict = dict()
+
+    add_python_functions(substitutions_dict)
+
+    if not os.path.isdir(macros_directory):
+        msg = (f"The directory '{macros_directory}' does not exist.")
+        raise RuntimeError(msg)
+
+    _load_macros_from_directory(macros_directory, substitutions_dict)
+
+    return substitutions_dict
+
+
+def load_macros(substitutions_dict=None) -> dict_type:
+    """
+    Augments the provided substitutions_dict with project Jinja macros found in the in
+    JINJA_MACROS_DIRECTORY from constants.py.
 
     Args:
         substitutions_dict (dict, optional): A dictionary to be augmented with Jinja macros.
@@ -222,25 +280,25 @@ def load_macros(substitutions_dict=None):
 
     Returns:
         dict: The updated substitutions_dict containing the Jinja macros.
-
-    Raises:
-        RuntimeError: If there is an error while reading or processing the macro files.
     """
-    if substitutions_dict is None:
-        substitutions_dict = dict()
+    return _load_macros(JINJA_MACROS_DIRECTORY, substitutions_dict)
 
-    add_python_functions(substitutions_dict)
-    try:
-        for filename in sorted(os.listdir(JINJA_MACROS_DIRECTORY)):
-            if filename.endswith(".jinja"):
-                macros_file = os.path.join(JINJA_MACROS_DIRECTORY, filename)
-                update_substitutions_dict(macros_file, substitutions_dict)
-    except Exception as exc:
-        msg = ("Error extracting macro definitions from '{1}': {0}"
-               .format(str(exc), filename))
-        raise RuntimeError(msg)
 
-    return substitutions_dict
+def load_macros_from_content_dir(content_dir: str, substitutions_dict=None) -> dict_type:
+    """
+    Augments the provided substitutions_dict with project Jinja macros found in a specified
+    content directory.
+
+    Args:
+        content_dir (str): The base directory containing the 'shared/macros' subdirectory.
+        substitutions_dict (dict, optional): A dictionary to be augmented with Jinja macros.
+                                             Defaults to None.
+
+    Returns:
+        dict: The updated substitutions_dict containing the Jinja macros.
+    """
+    jinja_macros_directory = os.path.join(content_dir, 'shared', 'macros')
+    return _load_macros(jinja_macros_directory, substitutions_dict)
 
 
 def process_file_with_macros(filepath, substitutions_dict):

--- a/ssg/variables.py
+++ b/ssg/variables.py
@@ -8,7 +8,7 @@ import sys
 from collections import defaultdict
 from .constants import BENCHMARKS
 from .profiles import get_profiles_from_products
-from .yaml import open_and_macro_expand
+from .yaml import open_and_macro_expand_from_dir
 
 
 if sys.version_info >= (3, 9):
@@ -82,7 +82,7 @@ def _get_variables_content(content_dir: str) -> dict_type:
 
     for var_file in get_variable_files(content_dir):
         try:
-            yaml_content = open_and_macro_expand(var_file)
+            yaml_content = open_and_macro_expand_from_dir(var_file, content_dir)
         except Exception as e:
             print(f"Error processing file {var_file}: {e}")
             continue

--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -12,7 +12,11 @@ import yaml
 
 from collections import OrderedDict
 
-from .jinja import load_macros, process_file
+from .jinja import (
+    load_macros,
+    load_macros_from_content_dir,
+    process_file,
+)
 
 try:
     from yaml import CSafeLoader as yaml_SafeLoader
@@ -214,6 +218,27 @@ def open_and_macro_expand(yaml_file, substitutions_dict=None):
         dict: The expanded content of the YAML file with macros substituted.
     """
     substitutions_dict = load_macros(substitutions_dict)
+    return open_and_expand(yaml_file, substitutions_dict)
+
+
+def open_and_macro_expand_from_dir(yaml_file, content_dir, substitutions_dict=None):
+    """
+    Opens a YAML file and expands macros from a specified directory. It is similar to
+    open_and_macro_expand but loads macro definitions from a specified directory instead of the
+    default directory defined in constants. This is useful in cases where the SSG library is
+    consumed by an external project.
+
+    Args:
+        yaml_file (str): The path to the YAML file to be opened and expanded.
+        content_dir (str): The content dir directory to be used for expansion.
+        substitutions_dict (dict, optional): A dictionary of substitutions to be used for macro
+                                             expansion. If None, a new dictionary will be created
+                                             from the content_dir.
+
+    Returns:
+        dict: The expanded content of the YAML file.
+    """
+    substitutions_dict = load_macros_from_content_dir(content_dir, substitutions_dict)
     return open_and_expand(yaml_file, substitutions_dict)
 
 

--- a/tests/unit/ssg-module/test_variables.py
+++ b/tests/unit/ssg-module/test_variables.py
@@ -1,5 +1,4 @@
 import os
-import pytest
 
 from ssg.constants import BENCHMARKS
 from ssg.variables import (
@@ -22,6 +21,10 @@ def setup_test_files(base_dir, benchmark_dirs, create_txt_file=False):
         benchmark_dirs (list[str]): List of benchmark folder paths to create.
         create_txt_file (bool): Whether to create an additional .txt file in each benchmark.
     """
+    # Ensures the shared/macros directory exists even if in this case the testing example does
+    # not use Jinja2 macros.
+    os.makedirs(base_dir / "shared" / "macros", exist_ok=True)
+
     for benchmark_dir in benchmark_dirs:
         path = base_dir / benchmark_dir
         os.makedirs(path, exist_ok=True)
@@ -118,6 +121,7 @@ def test_get_variables_from_profiles():
 
     result = get_variables_from_profiles(profiles)
     assert result == expected_result
+
 
 def test_get_variable_property(tmp_path):
     content_dir = tmp_path / "content"

--- a/tests/unit/ssg-module/test_yaml.py
+++ b/tests/unit/ssg-module/test_yaml.py
@@ -1,3 +1,5 @@
+import os
+
 import ssg.yaml
 
 
@@ -46,3 +48,21 @@ def test_list_or_string_update():
         ["something", "entirely"],
         ["entirely", "else"],
     ) == ["something", "entirely", "entirely", "else"]
+
+
+def test_open_and_macro_expand_from_dir(tmpdir):
+    # Setup: Create directory structure
+    content_dir = tmpdir / "content_dir"
+    macros_dir = content_dir / "shared" / "macros"
+    os.makedirs(macros_dir, exist_ok=True)
+
+    # Create YAML file with macro
+    yaml_file = content_dir / "test.yaml"
+    yaml_file.write("macro: {{{ test_macro() }}}")
+
+    # Create macro file with macro definition
+    macro_file = macros_dir / "test_macro.jinja"
+    macro_file.write("{{% macro test_macro() %}}test{{% endmacro %}}")
+
+    result = ssg.yaml.open_and_macro_expand_from_dir(str(yaml_file), str(content_dir))
+    assert result['macro'] == 'test'


### PR DESCRIPTION
#### Description:

The CaC/content project uses Jinja2 macros during building time in order to make the content more flexible or easier to be managed in a context with several products. Macros are used in multiple files and should be properly processed in order to return the expected data.

Until recently the SSG library was not expected to be used externally and therefore the path to load macros was hard-coded. This PR brings more flexibility to process yaml files with macros by allowing the macros to be load also from an informed directory.

#### Rationale:

Allow Jinja2 macros to be consumed when SSG library is called outside the project.

#### Review Hints:

Here is an example to simulate the [issue](https://github.com/ComplianceAsCode/content/pull/12797#discussion_r1912643640) in a virtual environment:
```
mkdir ~/tmp
cd ~/tmp
virtualenv ssg_tests
cd ssg_tests
source source bin/activate
pip install git+https://github.com/ComplianceAsCode/content.git
```
Now you can use the example script from https://github.com/ComplianceAsCode/content/pull/12797 and you will notice many exceptions similar to what was reported in https://github.com/ComplianceAsCode/content/pull/12797#discussion_r1912643640.

Once the issue is reproduced, you can try again with the fixes:
```
pip uninstall ssg
pip install git+https://github.com/marcusburghardt/content.git@ssg_external_macros
```

No issues are expected now.

Unit tests can be trying with:
```
python -m pytest tests/unit/ssg-module/test_jinja.py
python -m pytest tests/unit/ssg-module/test_variables.py
python -m pytest tests/unit/ssg-module/test_yaml.py
```