### PR TITLE
Ubuntu 24.04: Implement 2.1.21 Ensure mail transfer agent is configured for local-only mode

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -865,11 +865,11 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    related_rules:
+    rules:
       - has_nonlocal_mta
+      - var_postfix_inet_interfaces=loopback-only
       - postfix_network_listening_disabled
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/2.2.15.
+    status: automated
 
   - id: 2.1.22
     title: Ensure only approved services are listening on a network interface (Manual)

--- a/linux_os/guide/services/mail/has_nonlocal_mta/oval/shared.xml
+++ b/linux_os/guide/services/mail/has_nonlocal_mta/oval/shared.xml
@@ -1,9 +1,13 @@
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("Verify MTA is not listening on any non-loopback address") }}}
-    <criteria>
-      <criterion test_ref="tst_nothing_listening_external_mta_port"
-            comment="mta is not listening on any non-loopbackaddress" />
+    <criteria operator="AND">
+      <criterion test_ref="tst_nothing_listening_external_mta_port_25"
+            comment="mta is not listening on any non-loopbackaddress for port 25" />
+{{% if 'ubuntu' in product %}}
+      <criterion test_ref="tst_nothing_listening_external_mta_port_465_587"
+                comment="mta is not listening on any non-loopback address for ports 465 and 587" />
+{{% endif %}}
     </criteria>
   </definition>
   <linux:inetlisteningservers_object id="obj_listening_port_25" version="1">
@@ -20,8 +24,33 @@
     <linux:local_address operation="equals">::1</linux:local_address>
   </linux:inetlisteningservers_state>
   <linux:inetlisteningservers_test check="all" check_existence="none_exist"
-      id="tst_nothing_listening_external_mta_port" version="1"
+      id="tst_nothing_listening_external_mta_port_25" version="1"
       comment="mta is not listening on any non-loopback address">
     <linux:object object_ref="obj_listening_port_25" />
   </linux:inetlisteningservers_test>
+{{% if 'ubuntu' in product %}}
+  <linux:inetlisteningservers_object id="obj_listening_ports_465_587" version="1">
+    <linux:protocol>tcp</linux:protocol>
+    <linux:local_address operation="not equal">127.0.0.1</linux:local_address>
+    <linux:local_port datatype="int">465</linux:local_port>
+    <linux:local_port datatype="int">587</linux:local_port>
+    <filter action="exclude">ste_not_ports_465</filter>
+    <filter action="exclude">ste_not_ports_587</filter>
+    <filter action="exclude">ste_not_on_localhost</filter>
+  </linux:inetlisteningservers_object>
+
+  <linux:inetlisteningservers_state id="ste_not_ports_465" version="1">
+    <linux:local_port datatype="int" operation="not equal">465</linux:local_port>
+  </linux:inetlisteningservers_state>
+
+  <linux:inetlisteningservers_state id="ste_not_ports_587" version="1">
+    <linux:local_port datatype="int" operation="not equal">587</linux:local_port>
+  </linux:inetlisteningservers_state>
+
+  <linux:inetlisteningservers_test check="all" check_existence="none_exist"
+      id="tst_nothing_listening_external_mta_port_465_587" version="1"
+      comment="mta is not listening on any non-loopback address">
+    <linux:object object_ref="obj_listening_ports_465_587" />
+  </linux:inetlisteningservers_test>
+{{% endif %}}
 </def-group>

--- a/linux_os/guide/services/mail/has_nonlocal_mta/oval/shared.xml
+++ b/linux_os/guide/services/mail/has_nonlocal_mta/oval/shared.xml
@@ -1,56 +1,49 @@
+{{% macro generate_criteria_listening_port(port) %}}
+<criterion test_ref="tst_nothing_listening_external_mta_port_{{{ port }}}"
+            comment="mta is not listening on any non-loopbackaddress for port {{{ port }}}" />
+{{% endmacro %}}
+
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("Verify MTA is not listening on any non-loopback address") }}}
     <criteria operator="AND">
-      <criterion test_ref="tst_nothing_listening_external_mta_port_25"
-            comment="mta is not listening on any non-loopbackaddress for port 25" />
+      {{{ generate_criteria_listening_port("25")}}}
 {{% if 'ubuntu' in product %}}
-      <criterion test_ref="tst_nothing_listening_external_mta_port_465_587"
-                comment="mta is not listening on any non-loopback address for ports 465 and 587" />
+      {{{ generate_criteria_listening_port("465")}}}
+      {{{ generate_criteria_listening_port("587")}}}
 {{% endif %}}
     </criteria>
   </definition>
-  <linux:inetlisteningservers_object id="obj_listening_port_25" version="1">
-    <linux:protocol>tcp</linux:protocol>
-    <linux:local_address operation="not equal">127.0.0.1</linux:local_address>
-    <linux:local_port datatype="int">25</linux:local_port>
-    <filter action="exclude">ste_not_port_25</filter>
-    <filter action="exclude">ste_not_on_localhost</filter>
-  </linux:inetlisteningservers_object>
-  <linux:inetlisteningservers_state id="ste_not_port_25" version="1">
-    <linux:local_port datatype="int" operation="not equal">25</linux:local_port>
-  </linux:inetlisteningservers_state>
+
   <linux:inetlisteningservers_state id="ste_not_on_localhost" version="1">
     <linux:local_address operation="equals">::1</linux:local_address>
   </linux:inetlisteningservers_state>
-  <linux:inetlisteningservers_test check="all" check_existence="none_exist"
-      id="tst_nothing_listening_external_mta_port_25" version="1"
-      comment="mta is not listening on any non-loopback address">
-    <linux:object object_ref="obj_listening_port_25" />
-  </linux:inetlisteningservers_test>
-{{% if 'ubuntu' in product %}}
-  <linux:inetlisteningservers_object id="obj_listening_ports_465_587" version="1">
+
+  {{% macro generate_test_listening_port(port) %}}
+
+  <linux:inetlisteningservers_object id="obj_listening_port_{{{ port }}}" version="1">
     <linux:protocol>tcp</linux:protocol>
     <linux:local_address operation="not equal">127.0.0.1</linux:local_address>
-    <linux:local_port datatype="int">465</linux:local_port>
-    <linux:local_port datatype="int">587</linux:local_port>
-    <filter action="exclude">ste_not_ports_465</filter>
-    <filter action="exclude">ste_not_ports_587</filter>
+    <linux:local_port datatype="int">{{{ port }}}</linux:local_port>
+    <filter action="exclude">ste_not_port_{{{ port }}}</filter>
     <filter action="exclude">ste_not_on_localhost</filter>
   </linux:inetlisteningservers_object>
 
-  <linux:inetlisteningservers_state id="ste_not_ports_465" version="1">
-    <linux:local_port datatype="int" operation="not equal">465</linux:local_port>
-  </linux:inetlisteningservers_state>
-
-  <linux:inetlisteningservers_state id="ste_not_ports_587" version="1">
-    <linux:local_port datatype="int" operation="not equal">587</linux:local_port>
+  <linux:inetlisteningservers_state id="ste_not_port_{{{ port }}}" version="1">
+    <linux:local_port datatype="int" operation="not equal">{{{ port }}}</linux:local_port>
   </linux:inetlisteningservers_state>
 
   <linux:inetlisteningservers_test check="all" check_existence="none_exist"
-      id="tst_nothing_listening_external_mta_port_465_587" version="1"
-      comment="mta is not listening on any non-loopback address">
-    <linux:object object_ref="obj_listening_ports_465_587" />
+      id="tst_nothing_listening_external_mta_port_{{{ port }}}" version="1"
+      comment="mta is not listening on any non-loopback address {{{ port }}}">
+    <linux:object object_ref="obj_listening_port_{{{ port }}}" />
   </linux:inetlisteningservers_test>
-{{% endif %}}
+
+  {{% endmacro %}}
+
+  {{{ generate_test_listening_port("25") }}}
+  {{% if 'ubuntu' in product %}}
+  {{{ generate_test_listening_port("465")}}}
+  {{{ generate_test_listening_port("587")}}}
+  {{% endif %}}
 </def-group>

--- a/linux_os/guide/services/mail/has_nonlocal_mta/tests/correct.pass.sh
+++ b/linux_os/guide/services/mail/has_nonlocal_mta/tests/correct.pass.sh
@@ -2,4 +2,4 @@
 # packages = postfix
 
 echo "inet_interfaces = localhost" > /etc/postfix/main.cf
-systemctl restart postfix
+postfix reload || postfix start

--- a/linux_os/guide/services/mail/has_nonlocal_mta/tests/wrong.fail.sh
+++ b/linux_os/guide/services/mail/has_nonlocal_mta/tests/wrong.fail.sh
@@ -3,4 +3,4 @@
 # remediation = none
 
 echo "inet_interfaces = all" > /etc/postfix/main.cf
-systemctl restart postfix
+postfix reload || postfix start


### PR DESCRIPTION
#### Description:

- Implement 2.1.21 Ensure mail transfer agent is configured for local-only mode
- Add oval check logic for port 465 and 587

#### Rationale:

- Satisfies Ubuntu 24.04 CIS control 2.1.21