### PR TITLE
Create a minimalist reproduction of content directory for unit tests

### DIFF
--- a/tests/unit/ssg-module/data/content_dir/controls/abcd-levels.yml
+++ b/tests/unit/ssg-module/data/content_dir/controls/abcd-levels.yml
@@ -1,0 +1,68 @@
+policy: ABCD Benchmark for securing Linux systems with levels
+title: ABCD Benchmark for securing Linux systems with levels
+id: abcd-levels
+version: 1.2.3
+source: https://www.abcd.com/linux.pdf
+levels:
+  - id: low
+  - id: medium
+    inherits_from:
+    - low
+  - id: high
+    inherits_from:
+    - medium
+
+controls:
+  - id: S1
+    title: User session timeout
+
+  - id: S2
+    levels:
+    - low
+    rules:
+      - var_password_pam_minlen=1
+
+  - id: S3
+    levels:
+    - medium
+
+  - id: S4
+    title: Configure authentication
+    controls:
+      - id: S4.a
+        title: Disable administrator accounts
+        levels:
+        - low
+
+      - id: S4.b
+        title: Enforce password quality standards
+        levels:
+        - high
+        rules:
+          - var_password_pam_minlen=2
+
+  # S5, S6 and S7 are used to test if level inheritance is working corectly
+  # when multiple levels select the same rule
+  - id: S5
+    title: Default Crypto Policy
+    levels:
+    - low
+    rules:
+      - configure_crypto_policy
+      - var_system_crypto_policy=default_policy
+
+  - id: S6
+    title: FIPS Crypto Policy
+    levels:
+    - medium
+    rules:
+      - configure_crypto_policy
+      - var_system_crypto_policy=fips
+
+  - id: S7
+    title: Future Crypto Policy
+    levels:
+    - high
+    rules:
+      - configure_crypto_policy
+      - var_system_crypto_policy=future

--- a/tests/unit/ssg-module/data/content_dir/controls/abcd-levels.yml
+++ b/tests/unit/ssg-module/data/content_dir/controls/abcd-levels.yml
@@ -1,3 +1,4 @@
+---
 policy: ABCD Benchmark for securing Linux systems with levels
 title: ABCD Benchmark for securing Linux systems with levels
 id: abcd-levels
@@ -7,10 +8,10 @@ levels:
   - id: low
   - id: medium
     inherits_from:
-    - low
+      - low
   - id: high
     inherits_from:
-    - medium
+      - medium
 
 controls:
   - id: S1
@@ -18,13 +19,13 @@ controls:
 
   - id: S2
     levels:
-    - low
+      - low
     rules:
       - var_password_pam_minlen=1
 
   - id: S3
     levels:
-    - medium
+      - medium
 
   - id: S4
     title: Configure authentication
@@ -32,21 +33,21 @@ controls:
       - id: S4.a
         title: Disable administrator accounts
         levels:
-        - low
+          - low
 
       - id: S4.b
         title: Enforce password quality standards
         levels:
-        - high
+          - high
         rules:
           - var_password_pam_minlen=2
 
-  # S5, S6 and S7 are used to test if level inheritance is working corectly
+  # S5, S6 and S7 are used to test if level inheritance is working correctly
   # when multiple levels select the same rule
   - id: S5
     title: Default Crypto Policy
     levels:
-    - low
+      - low
     rules:
       - configure_crypto_policy
       - var_system_crypto_policy=default_policy
@@ -54,7 +55,7 @@ controls:
   - id: S6
     title: FIPS Crypto Policy
     levels:
-    - medium
+      - medium
     rules:
       - configure_crypto_policy
       - var_system_crypto_policy=fips
@@ -62,7 +63,7 @@ controls:
   - id: S7
     title: Future Crypto Policy
     levels:
-    - high
+      - high
     rules:
       - configure_crypto_policy
       - var_system_crypto_policy=future

--- a/tests/unit/ssg-module/data/content_dir/linux_os/guide/benchmark.yml
+++ b/tests/unit/ssg-module/data/content_dir/linux_os/guide/benchmark.yml
@@ -1,0 +1,51 @@
+---
+documentation_complete: true
+
+title: Guide to the Secure Configuration of {{{ full_name }}}
+
+status: draft
+
+description: |
+    This guide presents a catalog of security-relevant
+    configuration settings for {{{ full_name }}}. It is a rendering of
+    content structured in the eXtensible Configuration Checklist Description Format (XCCDF)
+    in order to support security automation.  The SCAP content is
+    is available in the <tt>scap-security-guide</tt> package which is developed at
+    {{{ weblink(link="https://www.open-scap.org/security-policies/scap-security-guide") }}}.
+    <br/><br/>
+    Providing system administrators with such guidance informs them how to securely
+    configure systems under their control in a variety of network roles. Policy
+    makers and baseline creators can use this catalog of settings, with its
+    associated references to higher-level security control catalogs, in order to
+    assist them in security baseline creation. This guide is a <em>catalog, not a
+    checklist</em>, and satisfaction of every item is not likely to be possible or
+    sensible in many operational scenarios. However, the XCCDF format enables
+    granular selection and adjustment of settings, and their association with OVAL
+    and OCIL content provides an automated checking capability. Transformations of
+    this document, and its associated automated checking content, are capable of
+    providing baselines that meet a diverse set of policy objectives. Some example
+    XCCDF <em>Profiles</em>, which are selections of items that form checklists and
+    can be used as baselines, are available with this guide. They can be
+    processed, in an automated fashion, with tools that support the Security
+    Content Automation Protocol (SCAP). The DISA STIG, which provides required
+    settings for US Department of Defense systems, is one example of a baseline
+    created from this guidance.
+
+notice:
+    id: terms_of_use
+    description: |
+        Do not attempt to implement any of the settings in
+        this guide without first testing them in a non-operational environment. The
+        creators of this guidance assume no responsibility whatsoever for its use by
+        other parties, and makes no guarantees, expressed or implied, about its
+        quality, reliability, or any other characteristic.
+
+front-matter: |
+    The SCAP Security Guide Project<br/>
+    {{{ weblink(link="https://www.open-scap.org/security-policies/scap-security-guide") }}}
+
+rear-matter: |
+    Red Hat and Red Hat Enterprise Linux are either registered
+    trademarks or trademarks of Red Hat, Inc. in the United States and other
+    countries. All other names are registered trademarks or trademarks of their
+    respective companies.

--- a/tests/unit/ssg-module/data/content_dir/linux_os/guide/benchmark.yml
+++ b/tests/unit/ssg-module/data/content_dir/linux_os/guide/benchmark.yml
@@ -6,46 +6,24 @@ title: Guide to the Secure Configuration of {{{ full_name }}}
 status: draft
 
 description: |
-    This guide presents a catalog of security-relevant
-    configuration settings for {{{ full_name }}}. It is a rendering of
-    content structured in the eXtensible Configuration Checklist Description Format (XCCDF)
-    in order to support security automation.  The SCAP content is
-    is available in the <tt>scap-security-guide</tt> package which is developed at
-    {{{ weblink(link="https://www.open-scap.org/security-policies/scap-security-guide") }}}.
-    <br/><br/>
-    Providing system administrators with such guidance informs them how to securely
-    configure systems under their control in a variety of network roles. Policy
-    makers and baseline creators can use this catalog of settings, with its
-    associated references to higher-level security control catalogs, in order to
-    assist them in security baseline creation. This guide is a <em>catalog, not a
-    checklist</em>, and satisfaction of every item is not likely to be possible or
-    sensible in many operational scenarios. However, the XCCDF format enables
-    granular selection and adjustment of settings, and their association with OVAL
-    and OCIL content provides an automated checking capability. Transformations of
-    this document, and its associated automated checking content, are capable of
-    providing baselines that meet a diverse set of policy objectives. Some example
-    XCCDF <em>Profiles</em>, which are selections of items that form checklists and
-    can be used as baselines, are available with this guide. They can be
-    processed, in an automated fashion, with tools that support the Security
-    Content Automation Protocol (SCAP). The DISA STIG, which provides required
-    settings for US Department of Defense systems, is one example of a baseline
-    created from this guidance.
+    This guide presents a catalog of security-relevant configuration settings for {{{ full_name }}}.
+    It is a rendering of content structured in the eXtensible Configuration Checklist Description Format (XCCDF)
+    in order to support security automation.  The SCAP content is available in the <tt>scap-security-guide</tt>
+    package which is developed at {{{ weblink(link="https://www.open-scap.org/security-policies/scap-security-guide") }}}.
 
 notice:
     id: terms_of_use
     description: |
-        Do not attempt to implement any of the settings in
-        this guide without first testing them in a non-operational environment. The
-        creators of this guidance assume no responsibility whatsoever for its use by
-        other parties, and makes no guarantees, expressed or implied, about its
-        quality, reliability, or any other characteristic.
+        Do not attempt to implement any of the settings in this guide without first testing them
+        in a non-operational environment. The creators of this guidance assume no responsibility
+        whatsoever for its use by other parties, and makes no guarantees, expressed or implied,
+        about its quality, reliability, or any other characteristic.
 
 front-matter: |
     The SCAP Security Guide Project<br/>
     {{{ weblink(link="https://www.open-scap.org/security-policies/scap-security-guide") }}}
 
 rear-matter: |
-    Red Hat and Red Hat Enterprise Linux are either registered
-    trademarks or trademarks of Red Hat, Inc. in the United States and other
-    countries. All other names are registered trademarks or trademarks of their
-    respective companies.
+    Red Hat and Red Hat Enterprise Linux are either registered trademarks or trademarks of
+    Red Hat, Inc. in the United States and other countries. All other names are registered
+    trademarks or trademarks of their respective companies.

--- a/tests/unit/ssg-module/data/content_dir/linux_os/guide/test/configure_crypto_policy/rule.yml
+++ b/tests/unit/ssg-module/data/content_dir/linux_os/guide/test/configure_crypto_policy/rule.yml
@@ -1,0 +1,117 @@
+documentation_complete: true
+
+
+title: 'Configure System Cryptography Policy'
+
+description: |-
+    To configure the system cryptography policy to use ciphers only from the <tt>{{{ xccdf_value("var_system_crypto_policy") }}}</tt>
+    {{% if product != "rhcos4" -%}}
+    policy, run the following command:
+    <pre>$ sudo update-crypto-policies --set {{{ xccdf_value("var_system_crypto_policy") }}}</pre>
+    {{% else -%}}
+    policy, create a <tt>MachineConfig</tt> as follows:
+    <pre>
+    ---
+    apiVersion: machineconfiguration.openshift.io/v1
+    kind: MachineConfig
+    metadata:
+      labels:
+        machineconfiguration.openshift.io/role: master
+      name: 50-master-configure-crypto-policy
+    spec:
+      config:
+        ignition:
+          version: 3.1.0
+        systemd:
+          units:
+            - name: configure-crypto-policy.service
+              enabled: true
+              contents: |
+                [Unit]
+                Before=kubelet.service
+                [Service]
+                Type=oneshot
+                ExecStart=update-crypto-policies --set {{{ xccdf_value("var_system_crypto_policy") }}}
+                RemainAfterExit=yes
+                [Install]
+                WantedBy=multi-user.target
+    </pre>
+    <p>
+    This will configure the crypto policy appropriately in all the
+    nodes labeled with the "master" role.
+    </p>
+    {{{ machineconfig_description_footer() | indent(4) }}}
+    {{% endif -%}}
+    The rule checks if settings for selected crypto policy are configured as expected. Configuration files in the <tt>/etc/crypto-policies/back-ends</tt> are either symlinks to correct files provided by Crypto-policies package or they are regular files in case crypto policy customizations are applied.
+    Crypto policies may be customized by crypto policy modules, in which case it is delimited from the base policy using a colon.
+
+rationale: |-
+    Centralized cryptographic policies simplify applying secure ciphers across an operating system and
+    the applications that run on that operating system. Use of weak or untested encryption algorithms
+    undermines the purposes of utilizing encryption to protect data.
+
+severity: high
+
+identifiers:
+    cce@rhcos4: CCE-82541-4
+    cce@rhel8: CCE-80935-0
+    cce@rhel9: CCE-83450-7
+    cce@rhel10: CCE-89085-5
+    cce@sle15: CCE-85776-3
+
+references:
+    disa: CCI-000068,CCI-003123,CCI-002450,CCI-000877,CCI-002418,CCI-001453,CCI-002890
+    hipaa: 164.308(a)(4)(i),164.308(b)(1),164.308(b)(3),164.312(e)(1),164.312(e)(2)(ii)
+    ism: "1446"
+    nerc-cip: CIP-003-8 R4.2,CIP-007-3 R5.1,CIP-007-3 R7.1
+    nist: AC-17(a),AC-17(2),CM-6(a),MA-4(6),SC-13,SC-12(2),SC-12(3)
+    ospp: FCS_COP.1(1),FCS_COP.1(2),FCS_COP.1(3),FCS_COP.1(4),FCS_CKM.1,FCS_CKM.2,FCS_TLSC_EXT.1
+    srg: SRG-OS-000396-GPOS-00176,SRG-OS-000393-GPOS-00173,SRG-OS-000394-GPOS-00174
+    stigid@ol8: OL08-00-010020
+    stigid@rhel8: RHEL-08-010020
+
+ocil_clause: 'cryptographic policy is not configured or is configured incorrectly'
+
+ocil: |-
+    To verify that cryptography policy has been configured correctly, run the
+    following command:
+    <pre>$ update-crypto-policies --show</pre>
+    The output should return <pre>{{{ xccdf_value("var_system_crypto_policy") }}}</pre>.
+    Run the command to check if the policy is correctly applied:
+    <pre>$ update-crypto-policies --is-applied</pre>
+    The output should be <pre>The configured policy is applied</pre>.
+    Moreover, check if settings for selected crypto policy are as expected.
+    List all libraries for which it holds that their crypto policies do not have symbolic link in <pre>/etc/crypto-policies/back-ends</pre>.
+    <pre>$ ls -l /etc/crypto-policies/back-ends/ | grep '^[^l]' | tail -n +2 | awk -F' ' '{print $NF}' | awk -F'.' '{print $1}' | sort</pre>
+    Subsequently, check if matching libraries have drop in files in the <pre>/etc/crypto-policies/local.d</pre> directory.
+    <pre>$ ls /etc/crypto-policies/local.d/ | awk -F'-' '{print $1}' | uniq | sort</pre>
+    Outputs of two previous commands should match.
+
+warnings:
+    - general: |-
+        The system needs to be rebooted for these changes to take effect.
+    - regulatory: |-
+        System Crypto Modules must be provided by a vendor that undergoes
+        FIPS-140 certifications.
+        FIPS-140 is applicable to all Federal agencies that use
+        cryptographic-based security systems to protect sensitive information
+        in computer and telecommunication systems (including voice systems) as
+        defined in Section 5131 of the Information Technology Management Reform
+        Act of 1996, Public Law 104-106. This standard shall be used in
+        designing and implementing cryptographic modules that Federal
+        departments and agencies operate or are operated for them under
+        contract. See <b>{{{ weblink(link="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.140-2.pdf") }}}</b>
+        To meet this, the system has to have cryptographic software provided by
+        a vendor that has undergone this certification. This means providing
+        documentation, test results, design information, and independent third
+        party review by an accredited lab. While open source software is
+        capable of meeting this, it does not meet FIPS-140 unless the vendor
+        submits to this process.
+
+fixtext: |-
+    Configure {{{ full_name }}} to use system cryptography policy.
+    Run the following command:
+
+    $ sudo update-crypto-policies --set {{{ xccdf_value("var_system_crypto_policy") }}}
+
+srg_requirement: '{{{ full_name }}} must use {{{ xccdf_value("var_system_crypto_policy") }}} for the system cryptography policy.'

--- a/tests/unit/ssg-module/data/content_dir/linux_os/guide/test/configure_crypto_policy/rule.yml
+++ b/tests/unit/ssg-module/data/content_dir/linux_os/guide/test/configure_crypto_policy/rule.yml
@@ -1,54 +1,16 @@
 documentation_complete: true
 
 
-title: 'Configure System Cryptography Policy'
+title: 'Test Configure System Cryptography Policy'
 
 description: |-
+    This is a modified copy from original rule.yml. For testing purposes only.
     To configure the system cryptography policy to use ciphers only from the <tt>{{{ xccdf_value("var_system_crypto_policy") }}}</tt>
-    {{% if product != "rhcos4" -%}}
-    policy, run the following command:
-    <pre>$ sudo update-crypto-policies --set {{{ xccdf_value("var_system_crypto_policy") }}}</pre>
-    {{% else -%}}
-    policy, create a <tt>MachineConfig</tt> as follows:
-    <pre>
-    ---
-    apiVersion: machineconfiguration.openshift.io/v1
-    kind: MachineConfig
-    metadata:
-      labels:
-        machineconfiguration.openshift.io/role: master
-      name: 50-master-configure-crypto-policy
-    spec:
-      config:
-        ignition:
-          version: 3.1.0
-        systemd:
-          units:
-            - name: configure-crypto-policy.service
-              enabled: true
-              contents: |
-                [Unit]
-                Before=kubelet.service
-                [Service]
-                Type=oneshot
-                ExecStart=update-crypto-policies --set {{{ xccdf_value("var_system_crypto_policy") }}}
-                RemainAfterExit=yes
-                [Install]
-                WantedBy=multi-user.target
-    </pre>
-    <p>
-    This will configure the crypto policy appropriately in all the
-    nodes labeled with the "master" role.
-    </p>
-    {{{ machineconfig_description_footer() | indent(4) }}}
-    {{% endif -%}}
-    The rule checks if settings for selected crypto policy are configured as expected. Configuration files in the <tt>/etc/crypto-policies/back-ends</tt> are either symlinks to correct files provided by Crypto-policies package or they are regular files in case crypto policy customizations are applied.
-    Crypto policies may be customized by crypto policy modules, in which case it is delimited from the base policy using a colon.
 
 rationale: |-
-    Centralized cryptographic policies simplify applying secure ciphers across an operating system and
-    the applications that run on that operating system. Use of weak or untested encryption algorithms
-    undermines the purposes of utilizing encryption to protect data.
+    Centralized cryptographic policies simplify applying secure ciphers across an operating
+    system and the applications that run on that operating system. Use of weak or untested
+    encryption algorithms undermines the purposes of utilizing encryption to protect data.
 
 severity: high
 
@@ -62,8 +24,6 @@ identifiers:
 references:
     disa: CCI-000068,CCI-003123,CCI-002450,CCI-000877,CCI-002418,CCI-001453,CCI-002890
     hipaa: 164.308(a)(4)(i),164.308(b)(1),164.308(b)(3),164.312(e)(1),164.312(e)(2)(ii)
-    ism: "1446"
-    nerc-cip: CIP-003-8 R4.2,CIP-007-3 R5.1,CIP-007-3 R7.1
     nist: AC-17(a),AC-17(2),CM-6(a),MA-4(6),SC-13,SC-12(2),SC-12(3)
     ospp: FCS_COP.1(1),FCS_COP.1(2),FCS_COP.1(3),FCS_COP.1(4),FCS_CKM.1,FCS_CKM.2,FCS_TLSC_EXT.1
     srg: SRG-OS-000396-GPOS-00176,SRG-OS-000393-GPOS-00173,SRG-OS-000394-GPOS-00174
@@ -73,40 +33,13 @@ references:
 ocil_clause: 'cryptographic policy is not configured or is configured incorrectly'
 
 ocil: |-
-    To verify that cryptography policy has been configured correctly, run the
-    following command:
+    To verify that cryptography policy has been configured correctly, run the following command:
     <pre>$ update-crypto-policies --show</pre>
     The output should return <pre>{{{ xccdf_value("var_system_crypto_policy") }}}</pre>.
-    Run the command to check if the policy is correctly applied:
-    <pre>$ update-crypto-policies --is-applied</pre>
-    The output should be <pre>The configured policy is applied</pre>.
-    Moreover, check if settings for selected crypto policy are as expected.
-    List all libraries for which it holds that their crypto policies do not have symbolic link in <pre>/etc/crypto-policies/back-ends</pre>.
-    <pre>$ ls -l /etc/crypto-policies/back-ends/ | grep '^[^l]' | tail -n +2 | awk -F' ' '{print $NF}' | awk -F'.' '{print $1}' | sort</pre>
-    Subsequently, check if matching libraries have drop in files in the <pre>/etc/crypto-policies/local.d</pre> directory.
-    <pre>$ ls /etc/crypto-policies/local.d/ | awk -F'-' '{print $1}' | uniq | sort</pre>
-    Outputs of two previous commands should match.
 
 warnings:
     - general: |-
         The system needs to be rebooted for these changes to take effect.
-    - regulatory: |-
-        System Crypto Modules must be provided by a vendor that undergoes
-        FIPS-140 certifications.
-        FIPS-140 is applicable to all Federal agencies that use
-        cryptographic-based security systems to protect sensitive information
-        in computer and telecommunication systems (including voice systems) as
-        defined in Section 5131 of the Information Technology Management Reform
-        Act of 1996, Public Law 104-106. This standard shall be used in
-        designing and implementing cryptographic modules that Federal
-        departments and agencies operate or are operated for them under
-        contract. See <b>{{{ weblink(link="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.140-2.pdf") }}}</b>
-        To meet this, the system has to have cryptographic software provided by
-        a vendor that has undergone this certification. This means providing
-        documentation, test results, design information, and independent third
-        party review by an accredited lab. While open source software is
-        capable of meeting this, it does not meet FIPS-140 unless the vendor
-        submits to this process.
 
 fixtext: |-
     Configure {{{ full_name }}} to use system cryptography policy.

--- a/tests/unit/ssg-module/data/content_dir/linux_os/guide/test/configure_crypto_policy/rule.yml
+++ b/tests/unit/ssg-module/data/content_dir/linux_os/guide/test/configure_crypto_policy/rule.yml
@@ -1,6 +1,5 @@
 documentation_complete: true
 
-
 title: 'Test Configure System Cryptography Policy'
 
 description: |-
@@ -15,11 +14,8 @@ rationale: |-
 severity: high
 
 identifiers:
-    cce@rhcos4: CCE-82541-4
-    cce@rhel8: CCE-80935-0
-    cce@rhel9: CCE-83450-7
-    cce@rhel10: CCE-89085-5
-    cce@sle15: CCE-85776-3
+    cce@rhel8: CCE-12345-0
+    cce@rhel9: CCE-12345-1
 
 references:
     disa: CCI-000068,CCI-003123,CCI-002450,CCI-000877,CCI-002418,CCI-001453,CCI-002890

--- a/tests/unit/ssg-module/data/content_dir/linux_os/guide/test/file_groupownership_sshd_private_key/rule.yml
+++ b/tests/unit/ssg-module/data/content_dir/linux_os/guide/test/file_groupownership_sshd_private_key/rule.yml
@@ -1,0 +1,38 @@
+documentation_complete: true
+
+title: 'Verify Group Ownership on SSH Server Private *_key Key Files'
+
+{{% set dedicated_ssh_groupname = groups.get("dedicated_ssh_keyowner", {}).get("name") %}}
+
+description: |-
+    SSH server private keys, files that match the <code>/etc/ssh/*_key</code> glob, must be
+    group-owned by <code>{{{ dedicated_ssh_groupname if dedicated_ssh_groupname else 'root' }}}</code> group.
+
+rationale: |-
+    If an unauthorized user obtains the private SSH host key file, the host could be impersonated.
+
+severity: medium
+
+identifiers:
+    cce@rhel8: CCE-86126-0
+    cce@rhel9: CCE-86127-8
+    cce@rhel10: CCE-90288-2
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/ssh/*_key", group="root") }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/etc/ssh/*_key", group="root") }}}
+
+template:
+    name: file_groupowner
+    vars:
+        filepath:
+            - /etc/ssh/
+        file_regex:
+            - ^.*_key$
+        gid_or_name: '{{{ dedicated_ssh_groupname if dedicated_ssh_groupname else '0' }}}'
+
+warnings:
+    - general: |-
+        Remediation is not possible at bootable container build time because SSH host
+        keys are generated post-deployment.

--- a/tests/unit/ssg-module/data/content_dir/linux_os/guide/test/file_groupownership_sshd_private_key/rule.yml
+++ b/tests/unit/ssg-module/data/content_dir/linux_os/guide/test/file_groupownership_sshd_private_key/rule.yml
@@ -14,9 +14,8 @@ rationale: |-
 severity: medium
 
 identifiers:
-    cce@rhel8: CCE-86126-0
-    cce@rhel9: CCE-86127-8
-    cce@rhel10: CCE-90288-2
+    cce@rhel8: CCE-12345-2
+    cce@rhel9: CCE-12345-3
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/ssh/*_key", group="root") }}}'
 

--- a/tests/unit/ssg-module/data/content_dir/linux_os/guide/test/file_groupownership_sshd_private_key/rule.yml
+++ b/tests/unit/ssg-module/data/content_dir/linux_os/guide/test/file_groupownership_sshd_private_key/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Verify Group Ownership on SSH Server Private *_key Key Files'
+title: 'Test Verify Group Ownership on SSH Server Private *_key Key Files'
 
 {{% set dedicated_ssh_groupname = groups.get("dedicated_ssh_keyowner", {}).get("name") %}}
 

--- a/tests/unit/ssg-module/data/content_dir/linux_os/guide/test/group.yml
+++ b/tests/unit/ssg-module/data/content_dir/linux_os/guide/test/group.yml
@@ -1,0 +1,13 @@
+documentation_complete: true
+
+title: Services
+
+description: |-
+    The best protection against vulnerable software is running less software. This section describes how to review
+    the software which {{{ full_name }}} installs on a system and disable software which is not needed. It
+    then enumerates the software packages installed on a default {{{ full_name }}} system and provides guidance about which
+    ones can be safely disabled.
+    <br /><br />
+    {{{ full_name }}} provides a convenient minimal install option that essentially installs the bare necessities for a functional
+    system. When building {{{ full_name }}} systems, it is highly recommended to select the minimal packages and then build up
+    the system from there.

--- a/tests/unit/ssg-module/data/content_dir/linux_os/guide/test/group.yml
+++ b/tests/unit/ssg-module/data/content_dir/linux_os/guide/test/group.yml
@@ -3,11 +3,7 @@ documentation_complete: true
 title: Services
 
 description: |-
-    The best protection against vulnerable software is running less software. This section describes how to review
-    the software which {{{ full_name }}} installs on a system and disable software which is not needed. It
-    then enumerates the software packages installed on a default {{{ full_name }}} system and provides guidance about which
-    ones can be safely disabled.
-    <br /><br />
-    {{{ full_name }}} provides a convenient minimal install option that essentially installs the bare necessities for a functional
-    system. When building {{{ full_name }}} systems, it is highly recommended to select the minimal packages and then build up
-    the system from there.
+    The best protection against vulnerable software is running less software. This section
+    describes how to review the software which {{{ full_name }}} installs on a system and disable
+    software which is not needed. It then enumerates the software packages installed on a default
+    {{{ full_name }}} system and provides guidance about which ones can be safely disabled.

--- a/tests/unit/ssg-module/data/content_dir/linux_os/guide/test/sshd_set_keepalive/rule.yml
+++ b/tests/unit/ssg-module/data/content_dir/linux_os/guide/test/sshd_set_keepalive/rule.yml
@@ -1,0 +1,83 @@
+documentation_complete: true
+
+title: 'Set SSH Client Alive Count Max'
+
+description: |-
+    The SSH server sends at most <tt>ClientAliveCountMax</tt> messages
+    during a SSH session and waits for a response from the SSH client.
+    The option <tt>ClientAliveInterval</tt> configures timeout after
+    each <tt>ClientAliveCountMax</tt> message. If the SSH server does not
+    receive a response from the client, then the connection is considered unresponsive
+    and terminated.
+    For SSH earlier than v8.2, a <tt>ClientAliveCountMax</tt> value of <tt>0</tt>
+    causes a timeout precisely when the <tt>ClientAliveInterval</tt> is set.
+    Starting with v8.2, a value of <tt>0</tt> disables the timeout functionality
+    completely. If the option is set to a number greater than <tt>0</tt>, then
+    the session will be disconnected after
+    <tt>ClientAliveInterval * ClientAliveCountMax</tt> seconds without receiving
+    a keep alive message.
+
+rationale: |-
+    This ensures a user login will be terminated as soon as the <tt>ClientAliveInterval</tt>
+    is reached.
+
+severity: medium
+
+identifiers:
+    cce@rhcos4: CCE-82464-9
+    cce@rhel8: CCE-80907-9
+    cce@rhel9: CCE-90805-3
+    cce@rhel10: CCE-86794-5
+    cce@sle12: CCE-83034-9
+    cce@sle15: CCE-91228-7
+    cce@slmicro5: CCE-93694-8
+
+references:
+    cis-csc: 1,12,13,14,15,16,18,3,5,7,8
+    cis@sle12: 5.2.16
+    cis@sle15: 5.2.16
+    cis@slmicro5: 5.2.16
+    cis@ubuntu2004: 5.2.15
+    cis@ubuntu2204: 5.2.22
+    cjis: 5.5.6
+    cobit5: APO13.01,BAI03.01,BAI03.02,BAI03.03,DSS01.03,DSS03.05,DSS05.04,DSS05.05,DSS05.07,DSS05.10,DSS06.03,DSS06.10
+    cui: 3.1.11
+    disa: CCI-001133,CCI-002361
+    hipaa: 164.308(a)(4)(i),164.308(b)(1),164.308(b)(3),164.310(b),164.312(e)(1),164.312(e)(2)(ii)
+    isa-62443-2009: 4.3.3.2.2,4.3.3.5.1,4.3.3.5.2,4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9,4.3.3.7.2,4.3.3.7.3,4.3.3.7.4,4.3.4.3.3
+    isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.2,SR 1.3,SR 1.4,SR 1.5,SR 1.7,SR 1.8,SR 1.9,SR 2.1,SR 6.2'
+    iso27001-2013: A.12.4.1,A.12.4.3,A.14.1.1,A.14.2.1,A.14.2.5,A.18.1.4,A.6.1.2,A.6.1.5,A.7.1.1,A.9.1.2,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.1,A.9.4.2,A.9.4.3,A.9.4.4,A.9.4.5
+    nerc-cip: CIP-004-6 R2.2.3,CIP-007-3 R5.1,CIP-007-3 R5.2,CIP-007-3 R5.3.1,CIP-007-3 R5.3.2,CIP-007-3 R5.3.3
+    nist: AC-2(5),AC-12,AC-17(a),SC-10,CM-6(a)
+    nist-csf: DE.CM-1,DE.CM-3,PR.AC-1,PR.AC-4,PR.AC-6,PR.AC-7,PR.IP-2
+    pcidss: Req-8.1.8
+    srg: SRG-OS-000163-GPOS-00072,SRG-OS-000279-GPOS-00109
+    stigid@ol8: OL08-00-010200
+    stigid@rhel8: RHEL-08-010200
+    stigid@sle12: SLES-12-030191
+    stigid@sle15: SLES-15-010320
+    stigid@ubuntu2004: UBTU-20-010036
+    stigid@ubuntu2204: UBTU-22-255030
+
+requires:
+    - sshd_set_idle_timeout
+
+ocil_clause: 'it is commented out or not configured properly'
+
+ocil: |-
+    To ensure <tt>ClientAliveInterval</tt> is set correctly, run the following command:
+    <pre>$ sudo grep ClientAliveCountMax /etc/ssh/sshd_config</pre>
+    If properly configured, the output should be:
+    <pre>ClientAliveCountMax {{{ xccdf_value("var_sshd_set_keepalive") }}}</pre>
+    For SSH earlier than v8.2, a <tt>ClientAliveCountMax</tt> value of <tt>0</tt> causes a timeout precisely when
+    the <tt>ClientAliveInterval</tt> is set.  Starting with v8.2, a value of <tt>0</tt> disables the timeout
+    functionality completely.
+    If the option is set to a number greater than <tt>0</tt>, then the session will be disconnected after
+    <tt>ClientAliveInterval * ClientAliveCountMax</tt> seconds without receiving a keep alive message.
+
+template:
+    name: sshd_lineinfile
+    vars:
+        parameter: ClientAliveCountMax
+        xccdf_variable: var_sshd_set_keepalive
+        datatype: int

--- a/tests/unit/ssg-module/data/content_dir/linux_os/guide/test/sshd_set_keepalive/rule.yml
+++ b/tests/unit/ssg-module/data/content_dir/linux_os/guide/test/sshd_set_keepalive/rule.yml
@@ -14,12 +14,8 @@ rationale: |-
 severity: medium
 
 identifiers:
-    cce@rhcos4: CCE-82464-9
-    cce@rhel8: CCE-80907-9
-    cce@rhel9: CCE-90805-3
-    cce@rhel10: CCE-86794-5
-    cce@sle12: CCE-83034-9
-    cce@sle15: CCE-91228-7
+    cce@rhel8: CCE-12345-4
+    cce@rhel9: CCE-12345-5
 
 references:
     cis-csc: 1,12,13,14,15,16,18,3,5,7,8

--- a/tests/unit/ssg-module/data/content_dir/linux_os/guide/test/sshd_set_keepalive/rule.yml
+++ b/tests/unit/ssg-module/data/content_dir/linux_os/guide/test/sshd_set_keepalive/rule.yml
@@ -1,21 +1,11 @@
 documentation_complete: true
 
-title: 'Set SSH Client Alive Count Max'
+title: 'Test Set SSH Client Alive Count Max'
 
 description: |-
-    The SSH server sends at most <tt>ClientAliveCountMax</tt> messages
-    during a SSH session and waits for a response from the SSH client.
-    The option <tt>ClientAliveInterval</tt> configures timeout after
-    each <tt>ClientAliveCountMax</tt> message. If the SSH server does not
-    receive a response from the client, then the connection is considered unresponsive
-    and terminated.
-    For SSH earlier than v8.2, a <tt>ClientAliveCountMax</tt> value of <tt>0</tt>
-    causes a timeout precisely when the <tt>ClientAliveInterval</tt> is set.
-    Starting with v8.2, a value of <tt>0</tt> disables the timeout functionality
-    completely. If the option is set to a number greater than <tt>0</tt>, then
-    the session will be disconnected after
-    <tt>ClientAliveInterval * ClientAliveCountMax</tt> seconds without receiving
-    a keep alive message.
+    The SSH server sends at most <tt>ClientAliveCountMax</tt> messages during a SSH session and
+    waits for a response from the SSH client. The option <tt>ClientAliveInterval</tt> configures
+    timeout after each <tt>ClientAliveCountMax</tt> message.
 
 rationale: |-
     This ensures a user login will be terminated as soon as the <tt>ClientAliveInterval</tt>
@@ -30,33 +20,19 @@ identifiers:
     cce@rhel10: CCE-86794-5
     cce@sle12: CCE-83034-9
     cce@sle15: CCE-91228-7
-    cce@slmicro5: CCE-93694-8
 
 references:
     cis-csc: 1,12,13,14,15,16,18,3,5,7,8
-    cis@sle12: 5.2.16
     cis@sle15: 5.2.16
-    cis@slmicro5: 5.2.16
-    cis@ubuntu2004: 5.2.15
     cis@ubuntu2204: 5.2.22
-    cjis: 5.5.6
-    cobit5: APO13.01,BAI03.01,BAI03.02,BAI03.03,DSS01.03,DSS03.05,DSS05.04,DSS05.05,DSS05.07,DSS05.10,DSS06.03,DSS06.10
-    cui: 3.1.11
     disa: CCI-001133,CCI-002361
     hipaa: 164.308(a)(4)(i),164.308(b)(1),164.308(b)(3),164.310(b),164.312(e)(1),164.312(e)(2)(ii)
-    isa-62443-2009: 4.3.3.2.2,4.3.3.5.1,4.3.3.5.2,4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9,4.3.3.7.2,4.3.3.7.3,4.3.3.7.4,4.3.4.3.3
-    isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.2,SR 1.3,SR 1.4,SR 1.5,SR 1.7,SR 1.8,SR 1.9,SR 2.1,SR 6.2'
-    iso27001-2013: A.12.4.1,A.12.4.3,A.14.1.1,A.14.2.1,A.14.2.5,A.18.1.4,A.6.1.2,A.6.1.5,A.7.1.1,A.9.1.2,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.1,A.9.4.2,A.9.4.3,A.9.4.4,A.9.4.5
-    nerc-cip: CIP-004-6 R2.2.3,CIP-007-3 R5.1,CIP-007-3 R5.2,CIP-007-3 R5.3.1,CIP-007-3 R5.3.2,CIP-007-3 R5.3.3
     nist: AC-2(5),AC-12,AC-17(a),SC-10,CM-6(a)
-    nist-csf: DE.CM-1,DE.CM-3,PR.AC-1,PR.AC-4,PR.AC-6,PR.AC-7,PR.IP-2
     pcidss: Req-8.1.8
     srg: SRG-OS-000163-GPOS-00072,SRG-OS-000279-GPOS-00109
     stigid@ol8: OL08-00-010200
     stigid@rhel8: RHEL-08-010200
-    stigid@sle12: SLES-12-030191
     stigid@sle15: SLES-15-010320
-    stigid@ubuntu2004: UBTU-20-010036
     stigid@ubuntu2204: UBTU-22-255030
 
 requires:
@@ -67,13 +43,6 @@ ocil_clause: 'it is commented out or not configured properly'
 ocil: |-
     To ensure <tt>ClientAliveInterval</tt> is set correctly, run the following command:
     <pre>$ sudo grep ClientAliveCountMax /etc/ssh/sshd_config</pre>
-    If properly configured, the output should be:
-    <pre>ClientAliveCountMax {{{ xccdf_value("var_sshd_set_keepalive") }}}</pre>
-    For SSH earlier than v8.2, a <tt>ClientAliveCountMax</tt> value of <tt>0</tt> causes a timeout precisely when
-    the <tt>ClientAliveInterval</tt> is set.  Starting with v8.2, a value of <tt>0</tt> disables the timeout
-    functionality completely.
-    If the option is set to a number greater than <tt>0</tt>, then the session will be disconnected after
-    <tt>ClientAliveInterval * ClientAliveCountMax</tt> seconds without receiving a keep alive message.
 
 template:
     name: sshd_lineinfile

--- a/tests/unit/ssg-module/data/content_dir/linux_os/guide/test/var_password_pam_minlen.var
+++ b/tests/unit/ssg-module/data/content_dir/linux_os/guide/test/var_password_pam_minlen.var
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+title: minlen
+
+description: 'Minimum number of characters in password'
+
+type: number
+
+operator: equals
+
+interactive: false
+
+options:
+    10: 10
+    12: 12
+    14: 14
+    15: 15
+    17: 17
+    18: 18
+    20: 20
+    6: 6
+    7: 7
+    8: 8
+    default: 15

--- a/tests/unit/ssg-module/data/content_dir/linux_os/guide/test/var_sshd_set_keepalive.var
+++ b/tests/unit/ssg-module/data/content_dir/linux_os/guide/test/var_sshd_set_keepalive.var
@@ -1,0 +1,19 @@
+documentation_complete: true
+
+title: 'SSH Max Keep Alive Count'
+
+description: 'Specify the maximum number of idle message counts before session is terminated.'
+
+type: number
+
+operator: equals
+
+interactive: false
+
+options:
+    10: 10
+    3: 3
+    5: 5
+    0: 0
+    1: 1
+    default: 0

--- a/tests/unit/ssg-module/data/content_dir/linux_os/guide/test/var_system_crypto_policy.var
+++ b/tests/unit/ssg-module/data/content_dir/linux_os/guide/test/var_system_crypto_policy.var
@@ -1,0 +1,22 @@
+documentation_complete: true
+
+title: 'The system-provided crypto policies'
+
+description: |-
+    Specify the crypto policy for the system.
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: DEFAULT
+    default_policy: DEFAULT
+    default_nosha1: "DEFAULT:NO-SHA1"
+    fips: FIPS
+    fips_ospp: "FIPS:OSPP"
+    legacy: LEGACY
+    future: FUTURE
+    next: NEXT

--- a/tests/unit/ssg-module/data/content_dir/products/rhel8/product.yml
+++ b/tests/unit/ssg-module/data/content_dir/products/rhel8/product.yml
@@ -1,0 +1,109 @@
+product: rhel8
+full_name: Red Hat Enterprise Linux 8
+type: platform
+
+families:
+  - rhel
+  - rhel-like
+
+major_version_ordinal: 8
+
+benchmark_id: RHEL-8
+benchmark_root: "../../linux_os/guide"
+components_root: "../../components"
+
+profiles_root: "./profiles"
+
+pkg_manager: "yum"
+
+init_system: "systemd"
+
+# The fingerprints below are retrieved from https://access.redhat.com/security/team/key
+pkg_release: "4ae0493b"
+pkg_version: "fd431d51"
+aux_pkg_release: "5b32db75"
+aux_pkg_version: "d4082792"
+
+release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
+auxiliary_key_fingerprint: "6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792"
+
+groups:
+  dedicated_ssh_keyowner:
+    name: ssh_keys
+
+faillock_path: "/var/log/faillock"
+
+cpes_root: "../../shared/applicability"
+cpes:
+  - rhel8:
+      name: "cpe:/o:redhat:enterprise_linux:8"
+      title: "Red Hat Enterprise Linux 8"
+      check_id: installed_OS_is_rhel8
+
+  - rhel8.0:
+      name: "cpe:/o:redhat:enterprise_linux:8.0"
+      title: "Red Hat Enterprise Linux 8.0"
+      check_id: installed_OS_is_rhel8_0
+
+  - rhel8.1:
+      name: "cpe:/o:redhat:enterprise_linux:8.1"
+      title: "Red Hat Enterprise Linux 8.1"
+      check_id: installed_OS_is_rhel8_1
+
+  - rhel8.2:
+      name: "cpe:/o:redhat:enterprise_linux:8.2"
+      title: "Red Hat Enterprise Linux 8.2"
+      check_id: installed_OS_is_rhel8_2
+
+  - rhel8.3:
+      name: "cpe:/o:redhat:enterprise_linux:8.3"
+      title: "Red Hat Enterprise Linux 8.3"
+      check_id: installed_OS_is_rhel8_3
+
+  - rhel8.4:
+      name: "cpe:/o:redhat:enterprise_linux:8.4"
+      title: "Red Hat Enterprise Linux 8.4"
+      check_id: installed_OS_is_rhel8_4
+
+  - rhel8.5:
+      name: "cpe:/o:redhat:enterprise_linux:8.5"
+      title: "Red Hat Enterprise Linux 8.5"
+      check_id: installed_OS_is_rhel8_5
+
+  - rhel8.6:
+      name: "cpe:/o:redhat:enterprise_linux:8.6"
+      title: "Red Hat Enterprise Linux 8.6"
+      check_id: installed_OS_is_rhel8_6
+
+  - rhel8.7:
+      name: "cpe:/o:redhat:enterprise_linux:8.7"
+      title: "Red Hat Enterprise Linux 8.7"
+      check_id: installed_OS_is_rhel8_7
+
+  - rhel8.8:
+      name: "cpe:/o:redhat:enterprise_linux:8.8"
+      title: "Red Hat Enterprise Linux 8.8"
+      check_id: installed_OS_is_rhel8_8
+
+  - rhel8.9:
+      name: "cpe:/o:redhat:enterprise_linux:8.9"
+      title: "Red Hat Enterprise Linux 8.9"
+      check_id: installed_OS_is_rhel8_9
+
+  - rhel8.10:
+      name: "cpe:/o:redhat:enterprise_linux:8.10"
+      title: "Red Hat Enterprise Linux 8.10"
+      check_id: installed_OS_is_rhel8_10
+
+# Mapping of CPE platform to package
+platform_package_overrides:
+  login_defs: "shadow-utils"
+
+centos_pkg_release: "5ccc5b19"
+centos_pkg_version: "8483c65d"
+centos_major_version: "8"
+
+reference_uris:
+  cis: 'https://www.cisecurity.org/benchmark/red_hat_linux/'
+
+journald_conf_dir_path: /etc/systemd/journald.conf.d

--- a/tests/unit/ssg-module/data/content_dir/products/rhel8/profiles/example.profile
+++ b/tests/unit/ssg-module/data/content_dir/products/rhel8/profiles/example.profile
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'Sample Security Profile for Linux-like OSes'
+
+description: |-
+    This profile is an sample for use in documentation and example conten.
+    The selected rules are standard and should pass quickly on most systems.
+
+selections:
+    - abcd-levels:all:medium
+    - file_groupownership_sshd_private_key
+    - sshd_set_keepalive
+    - var_sshd_set_keepalive=1
+

--- a/tests/unit/ssg-module/data/content_dir/products/rhel8/profiles/example.profile
+++ b/tests/unit/ssg-module/data/content_dir/products/rhel8/profiles/example.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'Sample Security Profile for Linux-like OSes'
 
 description: |-
-    This profile is an sample for use in documentation and example conten.
+    This profile is an sample for use in documentation and example content.
     The selected rules are standard and should pass quickly on most systems.
 
 selections:
@@ -11,4 +11,3 @@ selections:
     - file_groupownership_sshd_private_key
     - sshd_set_keepalive
     - var_sshd_set_keepalive=1
-

--- a/tests/unit/ssg-module/test_profiles.py
+++ b/tests/unit/ssg-module/test_profiles.py
@@ -11,17 +11,7 @@ from ssg.profiles import (
 )
 
 
-# The get_profiles_from_products function interacts with many objects and other functions that
-# would be complex to mock. So it will be tested with a real content directory. To make it
-# predictable, all existing products will be collected and the first rhel product will be used
-# for testing. The decision to use a rhel product is that I am more used to them and I know their
-# profiles also use control files.
-content_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
-
-def get_first_rhel_product_from_products_dir():
-    products = get_all(content_dir)
-    rhel_products = [product for product in products.linux if "rhel" in product]
-    return rhel_products[0]
+content_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "data/content_dir"))
 
 
 def count_profiles_in_products_dir(product):
@@ -31,7 +21,7 @@ def count_profiles_in_products_dir(product):
 
 
 def test_get_profiles_from_products():
-    products = [get_first_rhel_product_from_products_dir()]
+    products = ["rhel8"]
     profiles = get_profiles_from_products(content_dir, products, sorted=True)
 
     assert len(profiles) == count_profiles_in_products_dir(products[0])

--- a/tests/unit/ssg-module/test_profiles.py
+++ b/tests/unit/ssg-module/test_profiles.py
@@ -1,10 +1,6 @@
 import os
-import pytest
 
-from ssg.products import (
-    get_all,
-    get_profile_files_from_root,
-)
+from ssg.products import get_profile_files_from_root
 from ssg.profiles import (
     get_profiles_from_products,
     _load_product_yaml,


### PR DESCRIPTION
#### Description:

With the introduction of https://github.com/ComplianceAsCode/content/pull/12797, during the development of unit tests it was not simple to mock all necessary information in runtime. The existing directory structure in `ssg-module/data` was not sufficient as well and I would like to avoid duplicating much data so it was temporarily used real content for unit tests, which is not ideal.

In a discussion with @vojtapolasek , he proposed a minimalist reproduction of content directory including the necessary files for unit tests and this PR is just some minor improvements and cleanup on top of it.

More context in https://github.com/ComplianceAsCode/content/pull/12797#issuecomment-2582183616

#### Rationale:

- Create a minimalist example of content directory that can be scaled on-demand.
- Fix the temporary approach to use real content in unit tests.

#### Review Hints:

```
python -m pytest tests/unit/ssg-module/test_profiles.py
```