### PR TITLE
Workaround failing pip install pcre2

### DIFF
--- a/.github/workflows/gate_fedora.yml
+++ b/.github/workflows/gate_fedora.yml
@@ -21,7 +21,7 @@ jobs:
             -   name: Checkout
                 uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
             -   name: Install deps python
-                run: pip install pcre2 -r requirements.txt -r test-requirements.txt
+                run: pip install pcre2==0.4.0 -r requirements.txt -r test-requirements.txt
             -   name: Build
                 run: |-
                     ./build_product -j2 \

--- a/.github/workflows/gate_thin_ds.yml
+++ b/.github/workflows/gate_thin_ds.yml
@@ -22,7 +22,7 @@ jobs:
                 uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
             -   name: Install deps python
                 # pytest-xdist is used for parallel execution of thin ds test
-                run: pip install pcre2 pytest-xdist -r requirements.txt -r test-requirements.txt
+                run: pip install pcre2==0.4.0 pytest-xdist -r requirements.txt -r test-requirements.txt
             -   name: Build
                 run: ./build_product rhel9 --thin
             -   name: Test


### PR DESCRIPTION
The command `pip install pcre2` fails which causes that CI jobs on Fedora latest can't run.
We have reported it in https://github.com/grtetrault/pcre2.py/issues/12 We will workaround it by pin to previous version.


