### PR TITLE
Implement new rule firewall_single_service_active

### DIFF
--- a/components/nftables.yml
+++ b/components/nftables.yml
@@ -17,3 +17,4 @@ rules:
 - set_nftables_loopback_traffic
 - set_nftables_new_connections
 - set_nftables_table
+- firewall_single_service_active

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -1280,8 +1280,12 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    rules:
+      - firewall_single_service_active
+    status: automated
+    notes: |
+      Remediation is not automated.
+
 
   - id: 4.2.1
     title: Ensure ufw is installed (Automated)

--- a/linux_os/guide/system/network/firewall_single_service_active/oval/shared.xml
+++ b/linux_os/guide/system/network/firewall_single_service_active/oval/shared.xml
@@ -1,0 +1,53 @@
+<def-group>
+  <!-- Check that exactly one firewall service is active -->
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    <metadata>
+      <title>Ensure Only One Firewall Service is Active</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Only one firewall service (ufw, iptables, or nftables) should be active.</description>
+    </metadata>
+    <criteria>
+        <criterion comment="exactly one firewall service is active" 
+            test_ref="test_{{{ rule_id }}}_single_active_firewall"/>
+    </criteria>
+  </definition>
+
+  <!-- Objects and states to identify active firewall services -->
+  <linux:systemdunitproperty_object id="obj_{{{ rule_id }}}_firewall_services" version="1"
+      comment="All active firewall services">
+    <linux:unit operation="pattern match">^(ufw|iptables|nftables).service$</linux:unit>
+    <linux:property>ActiveState</linux:property>
+    <filter action="include">ste_{{{ rule_id }}}_firewall_services</filter>
+  </linux:systemdunitproperty_object>
+
+  <linux:systemdunitproperty_state id="ste_{{{ rule_id }}}_firewall_services" version="1">
+    <linux:value>active</linux:value>
+  </linux:systemdunitproperty_state>
+
+  <!-- Count active firewall services -->
+  <local_variable id="var_{{{ rule_id }}}_firewall_active_count" datatype="int" version="1"
+                 comment="Number of currently active firewall services">
+   <count>
+     <regex_capture pattern="^active$">
+       <object_component item_field="value" object_ref="obj_{{{ rule_id }}}_firewall_services"/>
+     </regex_capture>
+   </count>
+  </local_variable>
+
+  <!-- Test that count equals one -->
+  <ind:variable_test id="test_{{{ rule_id }}}_single_active_firewall" version="1" check="all" 
+                     comment="Verify exactly one firewall service is active">
+    <ind:object object_ref="obj_{{{ rule_id }}}_count"/>
+    <ind:state state_ref="ste_{{{ rule_id }}}_count"/>
+  </ind:variable_test>
+
+  <ind:variable_object id="obj_{{{ rule_id }}}_count" version="1">
+    <ind:var_ref>var_{{{ rule_id }}}_firewall_active_count</ind:var_ref>
+  </ind:variable_object>
+
+  <ind:variable_state id="ste_{{{ rule_id }}}_count" version="1">
+    <ind:value operation="equals" datatype="int">1</ind:value>
+  </ind:variable_state>
+</def-group>

--- a/linux_os/guide/system/network/firewall_single_service_active/rule.yml
+++ b/linux_os/guide/system/network/firewall_single_service_active/rule.yml
@@ -1,0 +1,33 @@
+documentation_complete: true
+
+
+title: 'Ensure Only One Firewall Service is Active'
+
+description: |-
+    The system must have exactly one active firewall service running to avoid conflicts
+    and ensure consistent packet filtering. Only one of the following services should
+    be enabled and active at any time:
+    <ul>
+        <li>ufw - Uncomplicated Firewall (Ubuntu/Debian default)</li>
+        <li>iptables - Classic Linux firewall</li>
+        <li>nftables - Next Generation Firewall replacement for iptables</li>
+    </ul>
+    Having zero active firewalls leaves the system vulnerable, while having multiple
+    active firewalls can lead to rule conflicts and security gaps.
+
+rationale: |-
+    Running multiple firewall services simultaneously can lead to conflicts in rule
+    processing, unpredictable behavior, and potential security gaps. A single
+    firewall service ensures consistent and predictable packet filtering.
+    
+    Having no active firewall service leaves the system exposed to network-based
+    attacks and unauthorized access.
+
+severity: medium
+
+platform: machine
+
+warnings:
+    - general: |-
+        This rule does not come with a remediation. There are specific rules
+        for enabling each firewall which should be enabled instead.

--- a/linux_os/guide/system/network/firewall_single_service_active/tests/multiple.fail.sh
+++ b/linux_os/guide/system/network/firewall_single_service_active/tests/multiple.fail.sh
@@ -1,0 +1,10 @@
+#!?bin/bash
+#
+# remediation = none
+
+apt install -y iptables nftables ufw
+systemctl stop iptables
+systemctl stop nftables
+systemctl stop ufw
+systemctl start nftables
+systemctl start ufw

--- a/linux_os/guide/system/network/firewall_single_service_active/tests/none.fail.sh
+++ b/linux_os/guide/system/network/firewall_single_service_active/tests/none.fail.sh
@@ -1,0 +1,8 @@
+#!?bin/bash
+#
+# remediation = none
+
+apt install -y iptables nftables ufw
+systemctl stop iptables
+systemctl stop nftables
+systemctl stop ufw

--- a/linux_os/guide/system/network/firewall_single_service_active/tests/single.pass.sh
+++ b/linux_os/guide/system/network/firewall_single_service_active/tests/single.pass.sh
@@ -1,0 +1,9 @@
+#!?bin/bash
+#
+# remediation = none
+
+apt install -y iptables nftables ufw
+systemctl stop iptables
+systemctl stop nftables
+systemctl stop ufw
+systemctl start ufw


### PR DESCRIPTION
#### Description:

- Implemented new rule for checking that only one firewall service is active. No remediation is provided since that is handled by other rules (service_ufw_enabled, ...)
- Added rule to Ubuntu 24.04 CIS controls

#### Rationale:

- Satisfies Ubuntu 24.04 CIS control 4.1.1