### PR TITLE
RHEL 9 STIG: make sysctl_user_max_user_namespaces not scored and informational

### DIFF
--- a/products/rhel9/profiles/stig.profile
+++ b/products/rhel9/profiles/stig.profile
@@ -28,3 +28,6 @@ selections:
   - stig_rhel9:all
   # Following rules once had a prodtype incompatible with the rhel9 product
   - '!audit_rules_immutable_login_uids'
+# the following rule causes problems with irqbalance which is present in default RHEL 9 installation, therefore it is not enforced
+  - sysctl_user_max_user_namespaces.role=unscored
+  - sysctl_user_max_user_namespaces.severity=info

--- a/products/rhel9/profiles/stig_gui.profile
+++ b/products/rhel9/profiles/stig_gui.profile
@@ -43,9 +43,5 @@ selections:
     # RHEL-09-215025
     - '!package_nfs-utils_removed'
 
-    # RHEL-09-213105
-    # Limiting user namespaces cause issues with user apps, such as Firefox and Cheese
-    # https://issues.redhat.com/browse/RHEL-10416
-    - '!sysctl_user_max_user_namespaces'
     # locking of idle sessions is handled by screensaver when GUI is present, the following rule is therefore redundant
     - '!logind_session_timeout'

--- a/tests/data/profile_stability/rhel9/stig.profile
+++ b/tests/data/profile_stability/rhel9/stig.profile
@@ -506,6 +506,8 @@ selections:
 - sysctl_net_ipv6_conf_default_accept_redirects
 - sysctl_net_ipv6_conf_default_accept_source_route
 - sysctl_user_max_user_namespaces
+- sysctl_user_max_user_namespaces.role=unscored
+- sysctl_user_max_user_namespaces.severity=info
 - usbguard_generate_policy
 - use_pam_wheel_for_su
 - wireless_disable_interfaces

--- a/tests/data/profile_stability/rhel9/stig_gui.profile
+++ b/tests/data/profile_stability/rhel9/stig_gui.profile
@@ -515,6 +515,9 @@ selections:
 - sysctl_net_ipv6_conf_default_accept_ra
 - sysctl_net_ipv6_conf_default_accept_redirects
 - sysctl_net_ipv6_conf_default_accept_source_route
+- sysctl_user_max_user_namespaces
+- sysctl_user_max_user_namespaces.role=unscored
+- sysctl_user_max_user_namespaces.severity=info
 - usbguard_generate_policy
 - use_pam_wheel_for_su
 - wireless_disable_interfaces


### PR DESCRIPTION
#### Description:

- make the rule not scored and informational in both rhel9 stig and stig_gui profiles
- update profile stability files

#### Rationale:

- This is the related stig: https://stigaview.com/products/rhel9/v2r2/RHEL-09-213105/

I think is is a ballanced approach. DISA allows exceptions to the rule, if operationally required and documented. At the same time, users can make the rule scored and enforced with proper tailoring.

#### Review Hints:

- perform a scan with both stig and stig_gui profile on rhel9 and check results
- the rule should be marked as informational and remediation should not be applied