### PR TITLE
Update enable_fips_mode for bootable containers

### DIFF
--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/bash/shared.sh
@@ -1,9 +1,16 @@
 # platform = multi_platform_all
 {{{ bash_instantiate_variables("var_system_crypto_policy") }}}
 
-fips-mode-setup --enable
+if {{{ bash_bootc_build() }}}; then
+	crypto_policies_no_reload="--no-reload"
+	cat > /usr/lib/bootc/kargs.d/01-fips.toml << EOF
+kargs = ["fips=1"]
+EOF
+else
+	fips-mode-setup --enable
+fi
 
-stderr_of_call=$(update-crypto-policies --set ${var_system_crypto_policy} 2>&1 > /dev/null)
+stderr_of_call=$(update-crypto-policies $crypto_policies_no_reload --set ${var_system_crypto_policy} 2>&1 > /dev/null)
 rc=$?
 
 if test "$rc" = 127; then

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/oval/shared.xml
@@ -1,44 +1,93 @@
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("Check if FIPS mode is enabled on the system") }}}
-    <criteria operator="AND">
-        <criterion test_ref="test_proc_sys_crypto_fips_enabled"
-            comment="check contents of /proc/sys/crypto/fips_enabled"/>
-      <extend_definition definition_ref="sysctl_crypto_fips_enabled"
-        comment="check option crypto.fips_enabled = 1 in sysctl"/>
-      {{%- if product not in ["rhel10"] -%}}
-      <extend_definition definition_ref="enable_dracut_fips_module"
-        comment="dracut FIPS module is enabled"/>
-      {{%- endif -%}}
-      <extend_definition definition_ref="configure_crypto_policy"
-        comment="system cryptography policy is configured"/>
-      <criterion test_ref="test_system_crypto_policy_value"
-        comment="check if var_system_crypto_policy variable selection is set to FIPS"/>
-      {{% if "ol" in product or "rhel" in product %}}
-      <criteria operator="OR">
-        <criteria operator="AND">
-          <extend_definition definition_ref="system_info_architecture_s390_64"
-            comment="generic test for s390x architecture"/>
-          <criterion test_ref="test_fips_1_argument_in_boot_loader_entries_conf"
-            comment="check if kernel option fips=1 is present in /boot/loader/entries/.*.conf"/>
-        </criteria>
-        <criteria operator="AND">
-          <criteria negate="true">
-            <extend_definition definition_ref="system_info_architecture_s390_64"
-              comment="generic test for non-s390x architecture"/>
-          </criteria>
-          {{% if product in ["ol8", "rhel8"] %}}
-          <criterion test_ref="test_grubenv_fips_mode"
-            comment="check if the kernel boot parameter is configured for FIPS mode"/>
-          {{% else %}}
-          <criterion test_ref="test_fips_1_argument_in_boot_loader_entries_conf"
-            comment="check if kernel option fips=1 is present in /boot/loader/entries/.*.conf"/>
-          {{% endif %}}
-        </criteria>
+
+    {{% if bootable_containers_supported == "true" %}}
+    <criteria operator="OR">
+      <criteria operator="AND">
+        <extend_definition definition_ref="bootc" comment="The system is RHEL Image Mode"/>
+        <extend_definition definition_ref="installed_env_is_a_container" comment="The system is container"/>
+        {{%- if product not in ["rhel10"] -%}}
+        <extend_definition definition_ref="enable_dracut_fips_module"
+          comment="dracut FIPS module is enabled"/>
+        {{%- endif -%}}
+        <extend_definition definition_ref="configure_crypto_policy"
+          comment="system cryptography policy is configured"/>
+        <criterion test_ref="test_system_crypto_policy_value"
+          comment="check if var_system_crypto_policy variable selection is set to FIPS"/>
+        <criterion test_ref="test_fips_1_argument_in_usr_lib_bootc_kargs_d"
+          comment="check if fips=1 present in the /usr/lib/bootc/kargs.d/*.toml"/>
       </criteria>
-      {{% endif %}}
+    {{% endif %}}
+
+      <criteria operator="AND">
+        {{% if bootable_containers_supported == "true" %}}
+        <criteria operator="OR">
+          <extend_definition definition_ref="bootc" negate="true" comment="The system is RHEL Image Mode"/>
+          <criteria operator="AND">
+            <extend_definition definition_ref="bootc" comment="The system is RHEL Image Mode"/>
+            <extend_definition definition_ref="installed_env_is_a_container" negate="true" comment="The system is container"/>
+          </criteria>
+        </criteria>
+        {{% endif %}}
+        <criterion test_ref="test_proc_sys_crypto_fips_enabled"
+          comment="check contents of /proc/sys/crypto/fips_enabled"/>
+        <extend_definition definition_ref="sysctl_crypto_fips_enabled"
+          comment="check option crypto.fips_enabled = 1 in sysctl"/>
+        {{%- if product not in ["rhel10"] -%}}
+        <extend_definition definition_ref="enable_dracut_fips_module"
+          comment="dracut FIPS module is enabled"/>
+        {{%- endif -%}}
+        <extend_definition definition_ref="configure_crypto_policy"
+          comment="system cryptography policy is configured"/>
+        <criterion test_ref="test_system_crypto_policy_value"
+          comment="check if var_system_crypto_policy variable selection is set to FIPS"/>
+        {{% if "ol" in product or "rhel" in product %}}
+        <criteria operator="OR">
+          <criteria operator="AND">
+            <extend_definition definition_ref="system_info_architecture_s390_64"
+              comment="generic test for s390x architecture"/>
+            <criterion test_ref="test_fips_1_argument_in_boot_loader_entries_conf"
+              comment="check if kernel option fips=1 is present in /boot/loader/entries/.*.conf"/>
+          </criteria>
+          <criteria operator="AND">
+            <criteria negate="true">
+              <extend_definition definition_ref="system_info_architecture_s390_64"
+                comment="generic test for non-s390x architecture"/>
+            </criteria>
+            {{% if product in ["ol8", "rhel8"] %}}
+            <criterion test_ref="test_grubenv_fips_mode"
+              comment="check if the kernel boot parameter is configured for FIPS mode"/>
+            {{% else %}}
+            <criterion test_ref="test_fips_1_argument_in_boot_loader_entries_conf"
+              comment="check if kernel option fips=1 is present in /boot/loader/entries/.*.conf"/>
+            {{% endif %}}
+          </criteria>
+        </criteria>
+        {{% endif %}}
+      </criteria>
+    {{% if bootable_containers_supported == "true" %}}
     </criteria>
+    {{% endif %}}
   </definition>
+
+  <ind:textfilecontent54_test id="test_fips_1_argument_in_usr_lib_bootc_kargs_d" version="1"
+    check="at least one" check_existence="at_least_one_exists"
+    comment="check if fips=1 present in the /usr/lib/bootc/kargs.d/*.toml">
+    <ind:object object_ref="object_fips_1_argument_in_usr_lib_bootc_kargs_d" />
+    <ind:state state_ref="state_fips_1_argument_in_usr_lib_bootc_kargs_d" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_fips_1_argument_in_usr_lib_bootc_kargs_d" version="1">
+    <ind:path>/usr/lib/bootc/kargs.d/</ind:path>
+    <ind:filename operation="pattern match">^.*\.toml$</ind:filename>
+    <ind:pattern operation="pattern match">^kargs[\s]*=[\s]*\[([^\]]+)\]$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_fips_1_argument_in_usr_lib_bootc_kargs_d" version="1">
+    <ind:subexpression operation="pattern match">^.*"[\s]*fips[\s]*=[\s]*1[\s]*".*$</ind:subexpression>
+  </ind:textfilecontent54_state>
 
   <ind:textfilecontent54_test id="test_fips_1_argument_in_boot_loader_entries_conf" version="1"
     check="all" check_existence="all_exist"

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/rule.yml
@@ -1,6 +1,5 @@
 documentation_complete: true
 
-
 title: Enable FIPS Mode
 
 description: |-
@@ -16,6 +15,13 @@ description: |-
     <li>Setting the system crypto policy in <tt>/etc/crypto-policies/config</tt> to <tt>{{{ xccdf_value("var_system_crypto_policy") }}}</tt></li>
     <li>Loading the Dracut <tt>fips</tt> module</li>
     </ul>
+
+    <br />
+    To enable FIPS mode at bootable container build time configure <tt>fips=1</tt> kernel argument
+    in <tt>/usr/lib/bootc/kargs.d/01-fips.toml</tt>:
+    <pre>kargs = ["fips=1"]</pre>
+    Then set the cryptographic policy to <tt>{{{ xccdf_value("var_system_crypto_policy") }}}</tt>:
+    <pre>update-crypto-policies --no-reload --set {{{ xccdf_value("var_system_crypto_policy") }}}</pre>
 {{% else %}}
     OpenShift has an installation-time flag that can enable FIPS mode
     for the cluster. The flag <pre>fips: true</pre> must be enabled
@@ -77,5 +83,10 @@ fixtext: |-
     $ sudo update-crypto-policies --set {{{ xccdf_value("var_system_crypto_policy") }}}
 
     The system needs to be rebooted for these changes to take effect.
+
+    To enable FIPS mode at bootable container build time, add the following commands in Containerfile:
+
+    RUN echo 'kargs = ["fips=1"]' > /usr/lib/bootc/kargs.d/01-fips.toml
+    RUN update-crypto-policies --no-reload --set {{{ xccdf_value("var_system_crypto_policy") }}}
 
 srg_requirement: '{{{ full_name }}} must implement NIST FIPS-validated cryptography for the following: to provision digital signatures, to generate cryptographic hashes, and to protect data requiring data-at-rest protections in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, and standards.'

--- a/shared/checks/oval/installed_env_is_a_container.xml
+++ b/shared/checks/oval/installed_env_is_a_container.xml
@@ -1,0 +1,32 @@
+<def-group>
+  <definition class="inventory" id="installed_env_is_a_container" version="2">
+    <metadata>
+      <title>Check if the scan target is a container</title>
+       <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Check for presence of files characterizing container filesystems.</description>
+      <reference ref_id="cpe:/a:container" source="CPE" />
+    </metadata>
+    <criteria operator="OR">
+      <criterion comment="Check if /.dockerenv exists" test_ref="test_installed_env_is_a_docker_container" />
+      <criterion comment="Check if /run/.containerenv exists" test_ref="test_installed_env_is_a_podman_container" />
+    </criteria>
+  </definition>
+
+  <unix:file_test check="all" check_existence="all_exist" comment="Check if /.dockerenv exists" id="test_installed_env_is_a_docker_container" version="1">
+    <unix:object object_ref="object_installed_env_is_a_docker_container" />
+  </unix:file_test>
+
+  <unix:file_object comment="Check file /.dockerenv" id="object_installed_env_is_a_docker_container" version="1">
+    <unix:filepath datatype="string">/.dockerenv</unix:filepath>
+  </unix:file_object>
+
+  <unix:file_test check="all" check_existence="all_exist" comment="Check if /run/.containerenv exists" id="test_installed_env_is_a_podman_container" version="1">
+    <unix:object object_ref="object_installed_env_is_a_podman_container" />
+  </unix:file_test>
+
+  <unix:file_object comment="Check file /run/.containerenv" id="object_installed_env_is_a_podman_container" version="1">
+     <unix:filepath datatype="string">/run/.containerenv</unix:filepath>
+  </unix:file_object>
+</def-group>


### PR DESCRIPTION
This commit extends rule `enable_fips_mode` for bootable containers.

To enable FIPS mode at bootable container build time we need to configure `fips=1` kernel argument through a configuration file in `/usr/lib/bootc/kargs.d/` directory and set the cryptographic policy to `FIPS`.

The OVAL check of the rule has also been updated to distinguish between bootable container build environment and other environments.

For more details see:
https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10-beta/html/using_image_mode_for_rhel_to_build_deploy_and_manage_operating_systems/enabling-the-fips-mode-while-building-a-bootc-image#enabling-the-fips-mode-while-building-a-bootc-image