### PR TITLE
Add new rules to replace audit_rules_mac_modification on Ubuntu

### DIFF
--- a/components/audit.yml
+++ b/components/audit.yml
@@ -124,6 +124,8 @@ rules:
 - audit_rules_login_events_lastlog
 - audit_rules_login_events_tallylog
 - audit_rules_mac_modification
+- audit_rules_mac_modification_etc_apparmor
+- audit_rules_mac_modification_etc_apparmor_d
 - audit_rules_mac_modification_usr_share
 - audit_rules_media_export
 - audit_rules_networkconfig_modification

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2682,7 +2682,8 @@ controls:
       - l2_server
       - l2_workstation
     rules:
-      - audit_rules_mac_modification
+      - audit_rules_mac_modification_etc_apparmor
+      - audit_rules_mac_modification_etc_apparmor_d
     status: automated
 
   - id: 6.2.3.15

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification_etc_apparmor/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification_etc_apparmor/rule.yml
@@ -1,0 +1,36 @@
+documentation_complete: true
+
+title: 'Record Events that Modify the System''s Mandatory Access Controls (/etc/apparmor)'
+
+description: |-
+    If the <tt>auditd</tt> daemon is configured to use the
+    <tt>augenrules</tt> program to read audit rules during daemon startup (the
+    default), add the following line to a file with suffix <tt>.rules</tt> in the
+    directory <tt>/etc/audit/rules.d</tt>:
+    <pre>-w /etc/apparmor/ -p wa -k MAC-policy</pre>
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add the following line to
+    <tt>/etc/audit/audit.rules</tt> file:
+    <pre>-w /etc/apparmor/ -p wa -k MAC-policy</pre>
+
+rationale: |-
+    The system's mandatory access policy (Apparmor) should not be
+    arbitrarily changed by anything other than administrator action. All changes to
+    MAC policy should be audited.
+
+severity: medium
+
+ocil_clause: 'the system is not configured to audit attempts to change files within the /etc/apparmor directory'
+
+ocil: |-
+    To determine if the system is configured to audit changes to its Apparmor
+    configuration files, run the following command:
+    <pre>$ sudo auditctl -l | grep "dir=/etc/apparmor"</pre>
+    If the system is configured to watch for changes to its Apparmor
+    configuration, a line should be returned (including
+    <tt>perm=wa</tt> indicating permissions that are watched).
+
+template:
+    name: audit_rules_watch
+    vars:
+        path: /etc/apparmor

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification_etc_apparmor_d/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_mac_modification_etc_apparmor_d/rule.yml
@@ -1,0 +1,36 @@
+documentation_complete: true
+
+title: 'Record Events that Modify the System''s Mandatory Access Controls (/etc/apparmor.d)'
+
+description: |-
+    If the <tt>auditd</tt> daemon is configured to use the
+    <tt>augenrules</tt> program to read audit rules during daemon startup (the
+    default), add the following line to a file with suffix <tt>.rules</tt> in the
+    directory <tt>/etc/audit/rules.d</tt>:
+    <pre>-w /etc/apparmor.d/ -p wa -k MAC-policy</pre>
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add the following line to
+    <tt>/etc/audit/audit.rules</tt> file:
+    <pre>-w /etc/apparmor.d/ -p wa -k MAC-policy</pre>
+
+rationale: |-
+    The system's mandatory access policy (Apparmor) should not be
+    arbitrarily changed by anything other than administrator action. All changes to
+    MAC policy should be audited.
+
+severity: medium
+
+ocil_clause: 'the system is not configured to audit attempts to change files within the /etc/apparmor.d directory'
+
+ocil: |-
+    To determine if the system is configured to audit changes to its Apparmor
+    configuration files, run the following command:
+    <pre>$ sudo auditctl -l | grep "dir=/etc/apparmor.d"</pre>
+    If the system is configured to watch for changes to its Apparmor
+    configuration, a line should be returned (including
+    <tt>perm=wa</tt> indicating permissions that are watched).
+
+template:
+    name: audit_rules_watch
+    vars:
+        path: /etc/apparmor.d


### PR DESCRIPTION
#### Description:

- create new rules `audit_rules_mac_modification_etc_apparmor` and `audit_rules_mac_modification_etc_apparmor_d`
- add rules to ubuntu 24.04 profile instead of `audit_rules_mac_modification`

#### Rationale:

- See discussion in #12790 and analogous rhel implementation in #12826