### PR TITLE
Add new rule no_nologin_in_shells

### DIFF
--- a/components/pam.yml
+++ b/components/pam.yml
@@ -185,6 +185,7 @@ rules:
 - no_legacy_plus_entries_etc_passwd
 - no_legacy_plus_entries_etc_shadow
 - no_netrc_files
+- no_nologin_in_shells
 - no_password_auth_for_systemaccounts
 - no_root_webbrowsing
 - no_shelllogin_for_systemaccounts

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2210,8 +2210,9 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    rules:
+      - no_nologin_in_shells
+    status: automated
 
   - id: 5.4.3.2
     title: Ensure default user shell timeout is configured (Automated)

--- a/linux_os/guide/system/accounts/accounts-restrictions/no_nologin_in_shells/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/no_nologin_in_shells/bash/shared.sh
@@ -1,0 +1,10 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+
+if grep -q -E "^[^#]*/nologin\b.*$" /etc/shells; then
+  sed -i --follow-symlinks 's/^[^#]*\/nologin\b.*$/#&/g' /etc/shells
+fi
+

--- a/linux_os/guide/system/accounts/accounts-restrictions/no_nologin_in_shells/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/no_nologin_in_shells/oval/shared.xml
@@ -1,0 +1,28 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    <metadata>
+      <title>Ensure nologin Shell is Not Listed in /etc/shells</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>The nologin shell should not be listed in /etc/shells.</description>
+    </metadata>
+    <criteria>
+      <criterion comment="nologin not in /etc/shells" test_ref="test_{{{ rule_id }}}" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="none_exist"
+    comment="Check for nologin in /etc/shells"
+    id="test_{{{ rule_id }}}" version="1">
+    <ind:object object_ref="obj_{{{ rule_id }}}"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}" version="1">
+    <ind:filepath>/etc/shells</ind:filepath>
+    <ind:pattern operation="pattern match">^[^#]*/nologin\b.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>
+
+

--- a/linux_os/guide/system/accounts/accounts-restrictions/no_nologin_in_shells/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/no_nologin_in_shells/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+title: 'Ensure nologin Shell is Not Listed in /etc/shells'
+
+description: |-
+    The <tt>/sbin/nologin</tt> shell is used to restrict accounts from having login access
+    and should not be listed as a valid login shell in <tt>/etc/shells</tt>.
+    To verify that nologin is not listed in /etc/shells, run:
+    <pre>$ grep nologin /etc/shells</pre>
+    The command should return no output.
+
+rationale: |-
+    The <tt>/etc/shells</tt> is consulted by various programs to evaluate
+    whether the user is somehow restricted. For example, the chsh utility will
+    consult the file to determine if the user is allowed to change their shell. 
+
+severity: medium
+
+ocil_clause: 'nologin is listed in /etc/shells'
+
+ocil: |-
+    To verify that nologin is not listed in /etc/shells, run:
+    <pre>$ grep nologin /etc/shells</pre>
+    The command should return no output.

--- a/linux_os/guide/system/accounts/accounts-restrictions/no_nologin_in_shells/tests/commented.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/no_nologin_in_shells/tests/commented.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+sed -i --follow-symlinks '/nologin/d' /etc/shells
+echo "#/sbin/nologin" >> /etc/shells
+
+ 

--- a/linux_os/guide/system/accounts/accounts-restrictions/no_nologin_in_shells/tests/exists.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/no_nologin_in_shells/tests/exists.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+sed -i --follow-symlinks '/nologin/d' /etc/shells
+echo "/sbin/nologin" >> /etc/shells
+
+ 

--- a/linux_os/guide/system/accounts/accounts-restrictions/no_nologin_in_shells/tests/missing.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/no_nologin_in_shells/tests/missing.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sed -i --follow-symlinks '/nologin/d' /etc/shells
+
+ 

--- a/linux_os/guide/system/accounts/accounts-restrictions/no_nologin_in_shells/tests/multiple.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/no_nologin_in_shells/tests/multiple.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+sed -i --follow-symlinks '/nologin/d' /etc/shells
+echo "/sbin/nologin" >> /etc/shells
+echo "/usr/sbin/nologin" >> /etc/shells
+
+ 

--- a/linux_os/guide/system/accounts/accounts-restrictions/no_nologin_in_shells/tests/similar.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/no_nologin_in_shells/tests/similar.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+sed -i --follow-symlinks '/nologin/d' /etc/shells
+echo "/sbin/nologinormaybe" >> /etc/shells
+
+ 


### PR DESCRIPTION
#### Description:

- Implement new rule `no_nologin_in_shell` which checks that nologin shell is not listed in /etc/shells.
- Add rule to Ubuntu 24.04 CIS control file

#### Rationale:

- Satisfies Ubuntu 24.04 CIS control 5.4.3.1
