### PR TITLE
Fix RHEL 10 ISM profile fails in Image Mode

### DIFF
--- a/controls/ism_o.yml
+++ b/controls/ism_o.yml
@@ -127,6 +127,7 @@ controls:
             - audit_rules_privileged_commands
             - audit_rules_session_events
             - audit_rules_unsuccessful_file_modification
+            - package_audit_installed
             - sshd_print_last_log
             - sebool_auditadm_exec_content
         status: automated
@@ -145,6 +146,7 @@ controls:
             - audit_rules_privileged_commands
             - audit_rules_session_events
             - audit_rules_unsuccessful_file_modification
+            - package_audit_installed
             - sshd_print_last_log
             - sebool_auditadm_exec_content
         status: automated


### PR DESCRIPTION
The rules `audit_access_failed` and `audit_access_success` fail in the scan of a RHEL 10 Image Mode system hardened with ISM profiles. The reason is that the profiles don't install the `audit` RPM package required by these rules to work and at the same time the `audit` RPM package isn't part of the rhel10-bootc base image. This is similar to this PR but it fixed only RHEL 9: https://github.com/ComplianceAsCode/content/pull/12670
