### PR TITLE
Ubuntu 24.04: Implement rule 5.4.2.5 Ensure root path integrity

### DIFF
--- a/components/pam.yml
+++ b/components/pam.yml
@@ -203,6 +203,7 @@ rules:
 - require_emergency_target_auth
 - require_singleuser_auth
 - restrict_serial_port_logins
+- root_path_all_dirs
 - root_path_default
 - root_path_no_dot
 - sebool_httpd_can_check_spam

--- a/components/pam.yml
+++ b/components/pam.yml
@@ -177,6 +177,7 @@ rules:
 - install_smartcard_packages
 - logind_session_timeout
 - no_direct_root_logins
+- no_dirs_unowned_by_root
 - no_duplicate_uids
 - no_empty_passwords
 - no_empty_passwords_etc_shadow

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2173,11 +2173,12 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    related_rules:
+    rules:
       - accounts_root_path_dirs_no_write
+      - root_path_all_dirs
       - root_path_no_dot
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/6.2.9.
+      - no_dirs_unowned_by_root
+    status: automated
 
   - id: 5.4.2.6
     title: Ensure root user umask is configured (Automated)

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/no_dirs_unowned_by_root/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/no_dirs_unowned_by_root/oval/shared.xml
@@ -1,0 +1,47 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="2">
+    {{{ oval_metadata("Check each directory in root's path and make sure it is owned by root") }}}
+    <criteria comment="Check that each directory in root's path is owned by root">
+      <criterion comment="Check for directories not owned by root in root's path"
+      test_ref="test_accounts_root_path_dirs_owned_by_root" />
+    </criteria>
+  </definition>
+
+  <ind:environmentvariable58_object id="object_accounts_root_path_dirs_owned_by_root_pathenv" version="1">
+    <ind:pid xsi:nil="true" datatype="int" />
+    <ind:name>PATH</ind:name>
+  </ind:environmentvariable58_object>
+
+  <local_variable comment="Split the PATH on the : delimiter" datatype="string"
+  id="var_accounts_root_path_dirs_owned_by_root" version="1">
+    <split delimiter=":">
+      <object_component item_field="value"
+      object_ref="object_accounts_root_path_dirs_owned_by_root_pathenv" />
+    </split>
+  </local_variable>
+
+  <unix:file_test check="all" check_existence="none_exist"
+  comment="Check if there aren't directories in root's path not owned by root"
+  id="test_accounts_root_path_dirs_owned_by_root" version="1">
+    <unix:object object_ref="object_accounts_root_path_dirs_not_owned_by_root" />
+  </unix:file_test>
+
+  <unix:file_object comment="root's path directories not owned by root"
+  id="object_accounts_root_path_dirs_not_owned_by_root" version="1">
+    <unix:path var_ref="var_accounts_root_path_dirs_owned_by_root" var_check="at least one" />
+    <unix:filename xsi:nil="true" />
+    <filter action="include">state_accounts_root_path_dirs_not_owned_by_root</filter>
+    <filter action="exclude">state_accounts_root_path_dirs_symlink</filter>
+  </unix:file_object>
+
+  <unix:file_state comment="directory not owned by root"
+  id="state_accounts_root_path_dirs_not_owned_by_root" version="1">
+    <unix:user_id datatype="int" operation="not equal">0</unix:user_id>
+  </unix:file_state>
+
+  <unix:file_state comment="symbolic link"
+  id="state_accounts_root_path_dirs_symlink" version="1">
+    <unix:type operation="equals">symbolic link</unix:type>
+  </unix:file_state>
+
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/no_dirs_unowned_by_root/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/no_dirs_unowned_by_root/rule.yml
@@ -1,0 +1,15 @@
+documentation_complete: true
+
+title: 'Ensure that All Root''s Path Directories Are Owned by Root'
+
+description: |-
+    For each element in root's path, run:
+    <pre># ls -ld <i>DIR</i></pre>
+    and ensure that the directory is owned by the root user.
+
+rationale: |-
+    Directories in root's path that are not owned by root could allow
+    unprivileged users to manipulate the execution environment of root,
+    potentially leading to privilege escalation or execution of malicious code.
+
+severity: medium

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/no_dirs_unowned_by_root/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/no_dirs_unowned_by_root/tests/correct.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+( IFS=:
+  for p in $PATH; do
+    if [ -d "$p" ]; then
+      chown root "$p"
+    fi
+  done
+)

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/no_dirs_unowned_by_root/tests/wrong.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/no_dirs_unowned_by_root/tests/wrong.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+( IFS=:
+  for p in $PATH; do
+    if [ -d "$p" ]; then
+      chown nobody "$p"
+    fi
+  done
+)

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_all_dirs/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_all_dirs/oval/shared.xml
@@ -1,0 +1,41 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="2">
+    {{{ oval_metadata("Check each directory in root's path and ensure it is a directory") }}}
+    <criteria comment="Check that each entry in root's path is a directory">
+      <criterion comment="Check for directory type in root's path"
+      test_ref="test_accounts_root_path_dirs_are_directories" />
+    </criteria>
+  </definition>
+
+  <ind:environmentvariable58_object id="object_accounts_root_path_all_dirs" version="1">
+    <ind:pid xsi:nil="true" datatype="int" />
+    <ind:name>PATH</ind:name>
+  </ind:environmentvariable58_object>
+
+  <local_variable comment="Split the PATH on the : delimiter" datatype="string"
+  id="var_accounts_root_path_all_dirs" version="1">
+    <split delimiter=":">
+      <object_component item_field="value"
+      object_ref="object_accounts_root_path_all_dirs" />
+    </split>
+  </local_variable>
+
+  <unix:file_test check="all" check_existence="none_exist"
+  comment="Check if all entries in root's path are directories"
+  id="test_accounts_root_path_dirs_are_directories" version="1">
+    <unix:object object_ref="object_accounts_root_path_not_dirs" />
+  </unix:file_test>
+
+  <unix:file_object comment="root's path directories"
+  id="object_accounts_root_path_not_dirs" version="1">
+    <!-- path does not work on directories and will return only the regular files -->
+    <unix:filepath var_ref="var_accounts_root_path_all_dirs" var_check="at least one" />
+    <filter action="exclude">state_accounts_root_path_dirs_symlink</filter>
+  </unix:file_object>
+
+  <unix:file_state comment="symbolic link"
+  id="state_accounts_root_path_dirs_symlink" version="1">
+    <unix:type operation="equals">symbolic link</unix:type>
+  </unix:file_state>
+
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_all_dirs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_all_dirs/rule.yml
@@ -1,0 +1,15 @@
+documentation_complete: true
+
+title: 'Ensure that All Entries in The Path of Root Are Directories'
+
+description: |-
+    For each element in root's path, run:
+    <pre># ls -ld <i>DIR</i></pre>
+    and ensure that the entry is a directory.
+
+rationale: |-
+    Locations in root's path that are not directories could cause unexpected behavior,
+    such as executing scrips from unintended locations. Ensuring that all locations in
+    root's path are directories helps maintain a secure environment for root.
+
+severity: medium

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_all_dirs/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_all_dirs/tests/correct.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# remediation = none
+
+( IFS=:
+  for p in $PATH; do
+    if [ ! -d "$p" ]; then
+      rm -f "$p"
+      mkdir -p "$p"
+    fi
+  done
+)

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_all_dirs/tests/wrong.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_all_dirs/tests/wrong.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# remediation = none
+
+echo 'PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"' > /etc/environment
+rm -rf /snap
+mkdir /snap
+touch /snap/bin


### PR DESCRIPTION
#### Description:

- Implement rule no_dirs_unowned_by_root
- Implement rule root_path_all_dirs
- Add them to cis Ubuntu2404 5.4.2.5

#### Rationale:

- Satisfies Ubuntu 24.04 CIS control 5.4.2.5

