### PR TITLE
Add custom test scenario dconf_gnome_lock_screen_on_smartcard_removal

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_lock_screen_on_smartcard_removal/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_lock_screen_on_smartcard_removal/tests/wrong_value.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# packages = dconf,gdm
+
+. $SHARED/dconf_test_functions.sh
+
+clean_dconf_settings
+# this test is required because the removal-action parameter requires single quoted value which the templated test does not include
+add_dconf_setting "org/gnome/settings-daemon/peripherals/smartcard" "removal-action" "'none'" "local.d" "00-security-settings"
+add_dconf_lock "org/gnome/settings-daemon/peripherals/smartcard" "removal-action" "local.d" "00-security-settings-lock"
+
+dconf update


### PR DESCRIPTION
#### Description:

- Add custom test scenario dconf_gnome_lock_screen_on_smartcard_removal.
- This is required because the removal-action parameter requires single quoted value which the templated test does not include.
