### PR TITLE
disable_ctrlaltdel_burstaction: make sure config file exists

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/tests/correct_value.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+touch /etc/systemd/system.conf
 
 if grep -q "^CtrlAltDelBurstAction=" /etc/systemd/system.conf; then
 	sed -i "s/^CtrlAltDelBurstAction.*/CtrlAltDelBurstAction=none/" /etc/systemd/system.conf

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/tests/line_not_there.fail.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 
+# make sure the file exist
+touch /etc/systemd/system.conf
+
 
 sed -i "/^CtrlAltDelBurstAction.*/d" /etc/systemd/system.conf

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/tests/wrong_value.fail.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# make sure the file exist
+touch /etc/systemd/system.conf
 
 if grep -q "^CtrlAltDelBurstAction=" /etc/systemd/system.conf; then
 	sed -i "s/^CtrlAltDelBurstAction.*/CtrlAltDelBurstAction=poweroff-immediate/" /etc/systemd/system.conf


### PR DESCRIPTION


#### Description:
- disable_ctrlaltdel_burstaction: make sure config file exists
- Starting from RHEL10, the file does not exist by default, it is expected that the file is created by copying /usr/lib/systemd/system.conf or creating a new one into /etc/systemd/ or /etc/systemd/system.conf.d/ for drop-in files.

Just touching the file should be enough for the test scenarios to work properly. The remediation should still be okay as they will create the file if is not there and it doesn't need to be a ini file with the [Manager] key since it loads the /usr/lib/systemd/system.conf file first and then loads the rest of the files giving priority to drop-in files, in other words they are loaded last so any configuration there should be the last to be loaded which should be the one taking place.
