### PR TITLE
Fix broken links in CO rules

### DIFF
--- a/applications/openshift/risk-assessment/scansetting_has_autoapplyremediations/rule.yml
+++ b/applications/openshift/risk-assessment/scansetting_has_autoapplyremediations/rule.yml
@@ -3,7 +3,7 @@ documentation_complete: true
 title: Enable AutoApplyRemediation for at least One ScanSetting
 
 description: |-
-  {{{ weblink(link="https://docs.openshift.com/container-platform/latest/security/compliance_operator/compliance-operator-understanding.html#compliance-operator-understanding",
+  {{{ weblink(link="https://docs.openshift.com/container-platform/latest/security/compliance_operator/co-overview.html",
               text="The Compliance Operator") }}}
   scans the hosts and the platform (OCP)
   configurations for software flaws and improper configurations according

--- a/applications/openshift/risk-assessment/scansettingbinding_exists/rule.yml
+++ b/applications/openshift/risk-assessment/scansettingbinding_exists/rule.yml
@@ -2,7 +2,7 @@
 title: Ensure that Compliance Operator is scanning the cluster
 
 description: |-
-  {{{ weblink(link="https://docs.openshift.com/container-platform/latest/security/compliance_operator/compliance-operator-understanding.html#compliance-operator-understanding",
+  {{{ weblink(link="https://docs.openshift.com/container-platform/latest/security/compliance_operator/co-overview.html",
               text="The Compliance Operator") }}}
   scans the hosts and the platform (OCP)
   configurations for software flaws and improper configurations according

--- a/applications/openshift/risk-assessment/scansettings_have_schedule/rule.yml
+++ b/applications/openshift/risk-assessment/scansettings_have_schedule/rule.yml
@@ -2,7 +2,7 @@
 title: Ensure that Compliance Operator scans are running periodically
 
 description: |-
-  {{{ weblink(link="https://docs.openshift.com/container-platform/latest/security/compliance_operator/compliance-operator-understanding.html#compliance-operator-understanding",
+  {{{ weblink(link="https://docs.openshift.com/container-platform/latest/security/compliance_operator/co-overview.html",
               text="The Compliance Operator") }}}
   scans the hosts and the platform (OCP)
   configurations for software flaws and improper configurations according


### PR DESCRIPTION

#### Description:

- This commit updates the documentation reference in the bundle so it points to the right document, and doesn't return a 404.

#### Rationale:

- The old link pointed to a section of the compliance operator documentation before it was overhauled and reorganized.
- Follow up from https://github.com/ComplianceAsCode/compliance-operator/pull/646