### PR TITLE
Add -Initial line without use_authtok for pwhistory configuration

### DIFF
--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1019,6 +1019,7 @@ Default: yes
 Priority: 1024
 Password-Type: Primary
 Password: {{{ control }}} pam_pwhistory.so remember=24 enforce_for_root try_first_pass use_authtok
+Password-Initial: {{{ control }}} pam_pwhistory.so remember=24 enforce_for_root try_first_pass
 EOF
 fi
 


### PR DESCRIPTION
#### Description:

- Add -Initial line without use_authtok for pwhistory configuration

#### Rationale:

- https://github.com/ComplianceAsCode/content/pull/12760#discussion_r1913007172