### PR TITLE
Add a script to ensure coredump configuration file exists

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_backtraces/tests/common.sh
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_backtraces/tests/common.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+COREDUMP_PATH=/etc/systemd/coredump.conf
+
+if [ ! -f $COREDUMP_PATH ]; then
+    echo "[Coredump]" >> $COREDUMP_PATH
+fi

--- a/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_backtraces/tests/coredumps_processsizemax_0.pass.sh
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_backtraces/tests/coredumps_processsizemax_0.pass.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+source common.sh
+
 echo ProcessSizeMax=0 >> /etc/systemd/coredump.conf

--- a/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_backtraces/tests/coredumps_processsizemax_default.fail.sh
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_backtraces/tests/coredumps_processsizemax_default.fail.sh
@@ -1,1 +1,3 @@
 #!/bin/bash
+
+source common.sh

--- a/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_backtraces/tests/coredumps_processsizemax_nonzero.fail.sh
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_backtraces/tests/coredumps_processsizemax_nonzero.fail.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+source common.sh
+
 echo ProcessSizeMax=2G >> /etc/systemd/coredump.conf


### PR DESCRIPTION
#### Description:

- Add a script to ensure coredump configuration file exists
- In RHEL10, the /etc/systemd/coredump.conf file does not exist by default and it needs to be created properly with the [Coredump] section in order for the test scenarios to work as expected.