### PR TITLE
Enable correct OVAL criteria for RHEL9/RHEL10 in file_ownership_var_log_audit_stig

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/oval/shared.xml
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/oval/shared.xml
@@ -6,7 +6,7 @@
         <extend_definition comment="log_file not set in auditd.conf" definition_ref="auditd_conf_log_file_not_set" negate="true" />
         <criterion comment="audit log files are root owned" test_ref="test_user_ownership_audit_log_files" />
       </criteria>
-      {{% if product in ["ol8", "rhel8"] %}}
+      {{% if "ol" in families or "rhel" in product %}}
       <criteria operator="AND" comment="log_file not set">
         <extend_definition comment="log_file not set in auditd.conf"
           definition_ref="auditd_conf_log_file_not_set"/>
@@ -28,7 +28,7 @@
     <filter action="include">state_owner_not_root_var_log_audit</filter>
   </unix:file_object>
   
-  {{% if product in ["ol8", "rhel8"] %}}
+  {{% if "ol" in families or "rhel" in product %}}
   <unix:file_test check="all" check_existence="none_exist"
       comment="var/log/audit/audit.log file uid root"
       id="test_user_ownership_audit_default_log_files" version="1">

--- a/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/tests/correct_value_default_file.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/tests/correct_value_default_file.pass.sh
@@ -1,6 +1,8 @@
 # platform = multi_platform_ol,multi_platform_rhel
 #!/bin/bash
 
+# packages = audit
+
 sed -i "/^\s*log_file.*/d" /etc/audit/auditd.conf
 useradd testuser_123
 touch "/var/log/audit/audit2.log"

--- a/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/tests/wrong_value_default_file.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/tests/wrong_value_default_file.fail.sh
@@ -1,6 +1,8 @@
 # platform = multi_platform_ol,multi_platform_rhel
 #!/bin/bash
 
+# packages = audit
+
 sed -i "/^\s*log_file.*/d" /etc/audit/auditd.conf
 useradd testuser_123
 touch "/var/log/audit/audit2.log"


### PR DESCRIPTION
#### Description:
- Enable correct OVAL criteria for RHEL9/RHEL10 in file_ownership_var_log_audit_stig
- The check was only being applied to RHEL8 which was originally designed for. The jinja macro was modified to include all versions of RHEL and OL. This should resolve the problems with the test scenarios.
