### PR TITLE
Authselect profile minimal is now called local in RHEL10

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/common.sh
@@ -1,6 +1,11 @@
 pam_files=("password-auth" "system-auth")
 
+{{%- if ('rhel' in product or 'ol' in families) and product not in ['ol8', 'ol9', 'rhel8', 'rhel9']%}}
+# rhel>=10 default profile is now called local
+authselect create-profile testingProfile --base-on local
+{{%- else %}}
 authselect create-profile testingProfile --base-on minimal
+{{%- endif %}}
 
 CUSTOM_PROFILE_DIR="/etc/authselect/custom/testingProfile"
 

--- a/linux_os/guide/system/accounts/enable_authselect/tests/not_remediable.fail.sh
+++ b/linux_os/guide/system/accounts/enable_authselect/tests/not_remediable.fail.sh
@@ -1,7 +1,7 @@
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
+# platform = multi_platform_fedora,Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 # packages = authselect,pam
 # remediation = none
 
-authselect select --force minimal
+authselect select minimal --force
 rm -f /etc/pam.d/system-auth
 dnf reinstall -y pam

--- a/linux_os/guide/system/accounts/enable_authselect/tests/profile.pass.sh
+++ b/linux_os/guide/system/accounts/enable_authselect/tests/profile.pass.sh
@@ -1,4 +1,9 @@
 # platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # packages = authselect,pam
 
+{{%- if ('rhel' in product or 'ol' in families) and product not in ['ol8', 'ol9', 'rhel8', 'rhel9']%}}
+# rhel>=10 default profile is now called local
+authselect select local --force
+{{%- else %}}
 authselect select minimal --force
+{{%- endif %}}

--- a/linux_os/guide/system/accounts/enable_authselect/tests/remediable.fail.sh
+++ b/linux_os/guide/system/accounts/enable_authselect/tests/remediable.fail.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
+# platform = multi_platform_fedora,Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 # packages = authselect,pam
 
 rm -f /etc/pam.d/{fingerprint-auth,password-auth,postlogin,smartcard-auth,system-auth}

--- a/linux_os/guide/system/accounts/var_authselect_profile.var
+++ b/linux_os/guide/system/accounts/var_authselect_profile.var
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: Authselect  profile
+title: Authselect profile
 
 description: |-
     Specify the authselect profile to select
@@ -12,6 +12,12 @@ operator: equals
 interactive: false
 
 options:
+{{%- if ('rhel' in product or 'ol' in families) and product not in ['ol8', 'ol9', 'rhel8', 'rhel9']%}}
+    default: local
+    minimal: local
+    local: local
+{{%- else %}}
     default: minimal
     minimal: minimal
+{{%- endif %}}
     sssd: sssd


### PR DESCRIPTION

#### Description:
- Authselect profile minimal is now called local in RHEL10.
- Adjust variables and test scenarios to take this into account. Setting minimal variable to local should make the conversion transparent for users that have selected this in their profiles. RHEL10 profile will select minimal as well and it will translate correctly into local profile which should be the same as minimal. Minimal profile is not even available as deprecated in RHEL10.