### PR TITLE
Fix RHEL 8 CIS reference on Ensure noexec option set on /var/tmp

### DIFF
--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -265,7 +265,7 @@ controls:
     rules:
       - mount_option_var_tmp_nosuid
 
-  - id: 1.1.3.5.4
+  - id: 1.1.2.5.4
     title: Ensure noexec option set on /var/tmp partition (Automated)
     levels:
       - l1_server


### PR DESCRIPTION
#### Description:

1.1.3.5.4 doesn't exist, should be 1.1.2.5.4.

#### Rationale:

Fixes #12829