### PR TITLE
Change shellcheck tests

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -202,11 +202,26 @@ macro(ssg_collect_remediations PRODUCT LANGUAGES)
         DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/collect-remediations-${PRODUCT}"
     )
     if(SSG_SHELLCHECK_BASH_FIXES_VALIDATION_ENABLED AND SHELLCHECK_EXECUTABLE)
+        # Get the shellcheck version
+        execute_process(
+            COMMAND ${SHELLCHECK_EXECUTABLE} --version
+            OUTPUT_VARIABLE SHELLCHECK_VERSION_OUTPUT
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+
+        # Extract the version number from the output
+        string(REGEX MATCH "version: [0-9]+\\.[0-9]+\\.[0-9]+" SHELLCHECK_VERSION_LINE "${SHELLCHECK_VERSION_OUTPUT}")
+        string(REGEX REPLACE "version: " "" SHELLCHECK_VERSION "${SHELLCHECK_VERSION_LINE}")
+
+        if(SHELLCHECK_VERSION VERSION_GREATER_EQUAL "0.10.0")
+            set(SHELLCHECK_EXTENDED_ANALYSIS_OPTION "--extended-analysis=false")
+        else()
+            set(SHELLCHECK_EXTENDED_ANALYSIS_OPTION "")
+        endif()
         add_test(
             NAME "${PRODUCT}-bash-shellcheck"
-            COMMAND "${CMAKE_SOURCE_DIR}/utils/shellcheck_wrapper.sh" "${SHELLCHECK_EXECUTABLE}" "${CMAKE_BINARY_DIR}/${PRODUCT}/fixes/bash" -s bash -S warning
+            COMMAND "${CMAKE_SOURCE_DIR}/utils/shellcheck_wrapper.sh" "${SHELLCHECK_EXECUTABLE}" "${CMAKE_BINARY_DIR}/${PRODUCT}/fixes/bash" -s bash -S warning "${SHELLCHECK_EXTENDED_ANALYSIS_OPTION}"
         )
-        set_tests_properties("${PRODUCT}-bash-shellcheck" PROPERTIES LABELS quick)
     endif()
 endmacro()
 

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -214,14 +214,17 @@ macro(ssg_collect_remediations PRODUCT LANGUAGES)
         string(REGEX REPLACE "version: " "" SHELLCHECK_VERSION "${SHELLCHECK_VERSION_LINE}")
 
         if(SHELLCHECK_VERSION VERSION_GREATER_EQUAL "0.10.0")
-            set(SHELLCHECK_EXTENDED_ANALYSIS_OPTION "--extended-analysis=false")
+            add_test(
+                NAME "${PRODUCT}-bash-shellcheck"
+                COMMAND "${CMAKE_SOURCE_DIR}/utils/shellcheck_wrapper.sh" "${SHELLCHECK_EXECUTABLE}" "${CMAKE_BINARY_DIR}/${PRODUCT}/fixes/bash" -s bash -S warning "--extended-analysis=false"
+            )
         else()
-            set(SHELLCHECK_EXTENDED_ANALYSIS_OPTION "")
+            add_test(
+                NAME "${PRODUCT}-bash-shellcheck"
+                COMMAND "${CMAKE_SOURCE_DIR}/utils/shellcheck_wrapper.sh" "${SHELLCHECK_EXECUTABLE}" "${CMAKE_BINARY_DIR}/${PRODUCT}/fixes/bash" -s bash -S warning
+            )
         endif()
-        add_test(
-            NAME "${PRODUCT}-bash-shellcheck"
-            COMMAND "${CMAKE_SOURCE_DIR}/utils/shellcheck_wrapper.sh" "${SHELLCHECK_EXECUTABLE}" "${CMAKE_BINARY_DIR}/${PRODUCT}/fixes/bash" -s bash -S warning "${SHELLCHECK_EXTENDED_ANALYSIS_OPTION}"
-        )
+
     endif()
 endmacro()
 


### PR DESCRIPTION
The shellcheck tests take a lot of time, each of them up to 20 seconds. This commit does the following changes:
1. Disable the data flow analysis. The data flow analysis can find more issues but is slow.
2. Don't mark the test as quick.

