### PR TITLE
Fix CIS reference URI for AlmaLinux 9

### DIFF
--- a/products/almalinux9/product.yml
+++ b/products/almalinux9/product.yml
@@ -27,4 +27,4 @@ release_key_fingerprint: "BF18AC2876178908D6E71267D36CB86CB86B3716"
 oval_feed_url: "https://security.almalinux.org/oval/org.almalinux.alsa-9.xml.bz2"
 
 reference_uris:
-  cis: 'https://workbench.cisecurity.org/files/5425/download/7650'
+  cis: 'https://www.cisecurity.org/benchmark/almalinuxos_linux/'


### PR DESCRIPTION
#### Description:

This change fixes the CIS reference URI for AlmaLinux 9. This allows the generated XML SCAP file to contain proper references to control IDs.

Fixes #12849.