### PR TITLE
Add AlmaLinux 9 to CI

### DIFF
--- a/.github/workflows/gate_fedora.yml
+++ b/.github/workflows/gate_fedora.yml
@@ -28,6 +28,7 @@ jobs:
                         al2023 \
                         alinux2 \
                         alinux3 \
+                        almalinux9 \
                         anolis23 \
                         anolis8 \
                         chromium \


### PR DESCRIPTION
#### Description:

Add AlmaLinux 9 to CI

#### Rationale:
Make sure PRs don't break Alma Linux 9.
