### PR TITLE
Fix file_permissions_etc_audit_rulesd in Image Mode

### DIFF
--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1858,7 +1858,7 @@ if [ "$skip" -ne 0 ]; then
         auid_string=$([[ {{{ auid_filters }}} ]] && echo " {{{ auid_filters }}}") || /bin/true
         full_rule="{{{ action_arch_filters }}}${syscall_string}${other_string}${auid_string} -F key={{{ key }}}" || /bin/true
         echo "$full_rule" >> "$default_file"
-        chmod o-rwx ${default_file}
+        chmod 0600 ${default_file}
     else
         # Check if the syscalls are declared as a comma separated list or
         # as multiple -S parameters


### PR DESCRIPTION
The rule file_permissions_etc_audit_rulesd fails in a scan executed after VM deployment of a CentOS Stream 9 bootable container image hardened with the STIG profile. The rule requires that all files in the `/etc/audit/rules.d/*.rules` directory need to have mode 0600.  However, the scan report shows 2 files with mode 0640. This rule passed during the build of the bootable container image. Therefore, the offending files were created after the rule is evaluated.  These files are created by a remediation of a different rule
`audit_rules_kernel_module_loading_delete`.  We can fix the problem by setting the expected mode at the time of creating these files.  The file mode set by `bash_fix_audit_syscall_rule` was inconsistent: on line 1768 we set it to 0600, but in this case we just removed permissions of the others. With this fix the file mode value in the macro will be consistently set to 0600.

