### PR TITLE
Add kickstart remediation to service_kdump_disabled

### DIFF
--- a/linux_os/guide/services/base/service_kdump_disabled/kickstart/shared.cfg
+++ b/linux_os/guide/services/base/service_kdump_disabled/kickstart/shared.cfg
@@ -1,0 +1,3 @@
+# platform = Red Hat Enterprise Linux 10
+kdump disable
+service disable kdump


### PR DESCRIPTION
This change will cause that the kickstart file generated by OpenSCAP will contain `%addon com_redhat_kdump --disable` section.

This PR partially addresses #12832 but it doesn't fix it completely.

Adding the section  `%addon com_redhat_kdump --disable` to kickstart causes that `kdump` doesn't work in the installed system. Adding the section is equivalent to clicking on "Disable kdump" in the GUI installation. Both makes the kdump.service fail to start. 

However, disabling kdump this way will not make our rule service_kdump_disabled pass. This rule will still fail because it requires the kdump.service to be masked. 

The   `%addon com_redhat_kdump --disable` doesn't mask the kdump.service. And unfortunately, the `service --disable` command in kickstart also doesn't mask the kdump.service.

In other words, we have hit one of the current issues of the Liteweight Anaconda hardening feature, that it doesn't mask the services. This has already been reported in https://github.com/ComplianceAsCode/content/issues/12282 (second part of the description section).
