### PR TITLE
Add new rule logging_services_active

### DIFF
--- a/components/rsyslog.yml
+++ b/components/rsyslog.yml
@@ -14,6 +14,7 @@ rules:
 - journald_compress
 - journald_forward_to_syslog
 - journald_storage
+- logging_services_active
 - logwatch_configured_hostlimit
 - logwatch_configured_splithosts
 - package_logrotate_installed

--- a/components/systemd.yml
+++ b/components/systemd.yml
@@ -25,6 +25,7 @@ rules:
 - journald_forward_to_syslog
 - journald_disable_forward_to_syslog
 - journald_storage
+- logging_services_active
 - package_systemd-journal-remote_installed
 - package_timesyncd_installed
 - package_timesyncd_removed

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2272,8 +2272,16 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    rules:
+      - logging_services_active
+    status: automated
+    notes: |
+      The title of this rule is misleading. The actual audit checks that at least
+      one of "rsyslogd" and "systemd-journald" is active.
+      See https://workbench.cisecurity.org/benchmarks/18959/tickets/23601
+
+      Remediation is not automated as the choice of correct logging service
+      is dependent on site policy.
 
   - id: 6.1.2.1.1
     title: Ensure systemd-journal-remote is installed (Automated)

--- a/linux_os/guide/system/logging/logging_services_active/oval/shared.xml
+++ b/linux_os/guide/system/logging/logging_services_active/oval/shared.xml
@@ -1,0 +1,47 @@
+<def-group>
+  <!-- Check that one logging service is active -->
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("Ensure one logging service is in use") }}}
+    <criteria>
+        <criterion comment="one logging service is active"
+            test_ref="test_{{{ rule_id }}}_single_active_logging_service"/>
+    </criteria>
+  </definition>
+
+  <!-- Objects and states to identify active logging_service services -->
+  <linux:systemdunitproperty_object id="obj_{{{ rule_id }}}_logging_services" version="1"
+      comment="All active logging_service services">
+    <linux:unit operation="pattern match">^(rsyslog|systemd-journald).service$</linux:unit>
+    <linux:property>ActiveState</linux:property>
+    <filter action="include">ste_{{{ rule_id }}}_logging_services</filter>
+  </linux:systemdunitproperty_object>
+
+  <linux:systemdunitproperty_state id="ste_{{{ rule_id }}}_logging_services" version="1">
+    <linux:value>active</linux:value>
+  </linux:systemdunitproperty_state>
+
+  <!-- Count active logging_service services -->
+  <local_variable id="var_{{{ rule_id }}}_logging_service_active_count" datatype="int" version="1"
+                 comment="Number of currently active logging_service services">
+   <count>
+     <regex_capture pattern="^active$">
+       <object_component item_field="value" object_ref="obj_{{{ rule_id }}}_logging_services"/>
+     </regex_capture>
+   </count>
+  </local_variable>
+
+  <!-- Test that count is at least one -->
+  <ind:variable_test id="test_{{{ rule_id }}}_single_active_logging_service" version="1" check="all"
+                     comment="Verify one logging_service service is active">
+    <ind:object object_ref="obj_{{{ rule_id }}}_count"/>
+    <ind:state state_ref="ste_{{{ rule_id }}}_count"/>
+  </ind:variable_test>
+
+  <ind:variable_object id="obj_{{{ rule_id }}}_count" version="1">
+    <ind:var_ref>var_{{{ rule_id }}}_logging_service_active_count</ind:var_ref>
+  </ind:variable_object>
+
+  <ind:variable_state id="ste_{{{ rule_id }}}_count" version="1">
+    <ind:value operation="greater than or equal" datatype="int">1</ind:value>
+  </ind:variable_state>
+</def-group>

--- a/linux_os/guide/system/logging/logging_services_active/rule.yml
+++ b/linux_os/guide/system/logging/logging_services_active/rule.yml
@@ -1,0 +1,23 @@
+documentation_complete: true
+
+title: 'Ensure One Logging Service Is In Use'
+
+description: |-
+    Ensure that a logging system is active and in use.
+    <pre>
+    systemctl is-active rsyslog systemd-journald
+    </pre>
+    The command should return at least one <tt>active</tt>.
+
+rationale: |-
+    The system should have one active logging service to avoid conflicts
+    and ensure consistency.
+
+severity: medium
+
+platform: machine
+
+warnings:
+    - general: |-
+        This rule does not come with a remediation. There are specific rules
+        for enabling each logging service which should be enabled instead.

--- a/linux_os/guide/system/logging/logging_services_active/tests/journald.pass.sh
+++ b/linux_os/guide/system/logging/logging_services_active/tests/journald.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# packages = rsyslog
+# remediation = none
+
+systemctl stop syslog*
+systemctl stop rsyslog*
+systemctl start systemd-journald

--- a/linux_os/guide/system/logging/logging_services_active/tests/multiple.pass.sh
+++ b/linux_os/guide/system/logging/logging_services_active/tests/multiple.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# packages = rsyslog
+# remediation = none
+
+systemctl start rsyslog
+systemctl start systemd-journald

--- a/linux_os/guide/system/logging/logging_services_active/tests/none.fail.sh
+++ b/linux_os/guide/system/logging/logging_services_active/tests/none.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# packages = rsyslog
+# remediation = none
+
+systemctl stop systemd-journald*
+systemctl stop syslog*
+systemctl stop rsyslog*

--- a/linux_os/guide/system/network/firewall_single_service_active/oval/shared.xml
+++ b/linux_os/guide/system/network/firewall_single_service_active/oval/shared.xml
@@ -1,13 +1,7 @@
 <def-group>
   <!-- Check that exactly one firewall service is active -->
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
-    <metadata>
-      <title>Ensure Only One Firewall Service is Active</title>
-      <affected family="unix">
-        <platform>multi_platform_all</platform>
-      </affected>
-      <description>Only one firewall service (ufw, iptables, or nftables) should be active.</description>
-    </metadata>
+    {{{ oval_metadata("Ensure Only One Firewall Service is Active") }}}
     <criteria>
         <criterion comment="exactly one firewall service is active" 
             test_ref="test_{{{ rule_id }}}_single_active_firewall"/>

--- a/linux_os/guide/system/network/firewall_single_service_active/tests/multiple.fail.sh
+++ b/linux_os/guide/system/network/firewall_single_service_active/tests/multiple.fail.sh
@@ -1,4 +1,4 @@
-#!?bin/bash
+#!/bin/bash
 #
 # remediation = none
 

--- a/linux_os/guide/system/network/firewall_single_service_active/tests/none.fail.sh
+++ b/linux_os/guide/system/network/firewall_single_service_active/tests/none.fail.sh
@@ -1,4 +1,4 @@
-#!?bin/bash
+#!/bin/bash
 #
 # remediation = none
 

--- a/linux_os/guide/system/network/firewall_single_service_active/tests/single.pass.sh
+++ b/linux_os/guide/system/network/firewall_single_service_active/tests/single.pass.sh
@@ -1,4 +1,4 @@
-#!?bin/bash
+#!/bin/bash
 #
 # remediation = none
 


### PR DESCRIPTION
#### Description:

- Checks that one of rsyslog/systemd-journald is active.
- Add rule to Ubuntu 24.04 CIS controls
- Fix metadata in rule `firewall_single_service_active`
 
#### Rationale:

- Satisfies Ubuntu 24.04 CIS control 6.1.1.4
