### PR TITLE
Select enable_dracut_fips_module in RHEL 9 ISM_O profile

### DIFF
--- a/products/rhel9/profiles/ism_o.profile
+++ b/products/rhel9/profiles/ism_o.profile
@@ -127,6 +127,7 @@ selections:
   ## 0479 / 0480 / 0481 / 0489 / 0497 / 0994 / 0998 / 1001 /  1139 / 
   ## 1372 / 1373 / 1374 / 1375
   - enable_fips_mode
+  - enable_dracut_fips_module
   - var_system_crypto_policy=fips
   - configure_crypto_policy
 


### PR DESCRIPTION
As RHEL 9 ISM_O profile enables FIPS mode (selects rules `enable_fips_mode` and `configure_crypto_policy` with `var_system_crypto_policy=fips`) it also needs to select the rule `enable_dracut_fips_module`.

This issue was not discovered before because on normal systems the `fips-mode-setup` (called in `enable_fips_mode` rule remediation) ensures the installation of the FIPS dracut module. But in RHEL Image Mode the `fips-mode-setup` is not used and so the FIPS dracut module needs to be enabled by remediation of the `enable_dracut_fips_module` rule.