### PR TITLE
Use `dedicated_ssh_keyowner` variable in test scenarios

### DIFF
--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/altcorrect_permissions.pass.sh
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/altcorrect_permissions.pass.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 # platform = multi_platform_ol,multi_platform_rhel
 
+{{% set dedicated_ssh_groupname = groups.get("dedicated_ssh_keyowner", {"name": "root"}).get("name") %}}
+
 FAKE_KEY=$(mktemp -p /etc/ssh/ XXXX_key)
-chown root:ssh_keys "$FAKE_KEY"
+chown root:{{{ dedicated_ssh_groupname }}} "$FAKE_KEY"
+
+{{%- if dedicated_ssh_groupname == 'root' %}}
+chmod 0600 "$FAKE_KEY"
+{{%- else %}}
 chmod 0640 "$FAKE_KEY"
+{{%- endif %}}

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/altlenient_permissions.fail.sh
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/altlenient_permissions.fail.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # platform = multi_platform_ol,multi_platform_rhel
 
+{{% set dedicated_ssh_groupname = groups.get("dedicated_ssh_keyowner", {"name": "root"}).get("name") %}}
+
 FAKE_KEY=$(mktemp -p /etc/ssh/ XXXX_key)
-chown root:ssh_keys "$FAKE_KEY"
+chown root:{{{ dedicated_ssh_groupname }}} "$FAKE_KEY"
 chmod 0777 "$FAKE_KEY"

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/supercompliance.pass.sh
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/supercompliance.pass.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 # platform = multi_platform_ol,multi_platform_rhel
 
+{{% set dedicated_ssh_groupname = groups.get("dedicated_ssh_keyowner", {"name": "root"}).get("name") %}}
+
 FAKE_KEY=$(mktemp -p /etc/ssh/ XXXX_key)
-chown root:ssh_keys "$FAKE_KEY"
+chown root:{{{ dedicated_ssh_groupname }}} "$FAKE_KEY"
 chmod 0400 "$FAKE_KEY"
 
 FAKE_KEY_ROOT=$(mktemp -p /etc/ssh/ XXXX_key)


### PR DESCRIPTION

#### Description:
- Use dedicated_ssh_keyowner variable in test scenarios.
- in RHEL10 for example, the ssh key owner is now root, so it needs to pick the correct one according to the product being tested.
