### PR TITLE
require_singleuser_auth: rewrite rule to use systemd override mechanism

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/ansible/shared.yml
@@ -5,7 +5,7 @@
 # disruption = low
 
 {{% if 'rhel' not in product and product != 'fedora' %}}
-- name: Require single user mode password
+- name: "{{{ rule_title }}} - Require single user mode password"
   lineinfile:
       create: yes
       dest: /usr/lib/systemd/system/rescue.service
@@ -16,10 +16,32 @@
       line: 'ExecStart=-/bin/sh -c "/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"'
       {{%- endif %}}
 {{% else %}}
+- name: "{{{ rule_title }}} - find files which already override Execstart of rescue.service"
+  ansible.builtin.find:
+    paths: "/etc/systemd/system/rescue.service.d"
+    patterns: "*.conf"
+    contains: '^\s*ExecStart=.*$'
+  register: rescue_service_overrides_found
+
+- name: "{{{ rule_title }}} - set files containing ExecStart overrides as target"
+  ansible.builtin.set_fact:
+    rescue_service_remediation_target_file: "{{ rescue_service_overrides_found.files | map(attribute='path') | list }}"
+  when: rescue_service_overrides_found.matched is defined and rescue_service_overrides_found.matched > 0
+
+- name: "{{{ rule_title }}} - set default target for rescue.service override"
+  ansible.builtin.set_fact:
+    rescue_service_remediation_target_file:
+      - "/etc/systemd/system/rescue.service.d/10-oscap.conf"
+  when: rescue_service_overrides_found.matched is defined and rescue_service_overrides_found.matched == 0
+
 - name: "{{{ rule_title }}} - Require emergency user mode password"
   community.general.ini_file:
-    path: "/etc/systemd/system/rescue.service.d/10-oscap.conf"
+    path: "{{ item }}"
     section: "Service"
     option: "ExecStart"
-    value: "-/usr/lib/systemd/systemd-sulogin-shell rescue"
+    values:
+      - ""
+      - "-/usr/lib/systemd/systemd-sulogin-shell rescue"
+  loop: "{{ rescue_service_remediation_target_file }}"
+
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/bash/shared.sh
@@ -1,9 +1,9 @@
 # platform = multi_platform_all
 
 {{% if product in ["fedora", "sle12", "sle15", "slmicro5"] or 'ol' in families or 'rhel' in product -%}}
-{{% set sulogin="-/usr/lib/systemd/systemd-sulogin-shell rescue" %}}
+{{% set sulogin="\\nExecStart=-/usr/lib/systemd/systemd-sulogin-shell rescue" %}}
 {{%- else -%}}
 {{% set sulogin='-/bin/sh -c "/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"'  %}}
 {{%- endif %}}
 
-{{{ bash_ensure_ini_config("/etc/systemd/system/rescue.service.d/10-oscap.conf", "Service", "ExecStart", sulogin) }}}
+{{{ bash_ensure_ini_config("/etc/systemd/system/rescue.service.d/10-oscap.conf /etc/systemd/system/rescue.service.d/*.conf", "Service", "ExecStart", sulogin) }}}

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
@@ -3,8 +3,16 @@
     {{{ oval_metadata("The requirement for a password to boot into single-user mode
       should be configured correctly.") }}}
     <criteria operator="AND">
-      <criterion comment="Conditions are satisfied"
-      test_ref="test_require_rescue_service" />
+      <criteria operator="OR">
+        <criteria operator="AND">
+          <criterion comment="authentication for single user mode is configured in the file provided by distro"
+          test_ref="test_require_rescue_service_distro" />
+          <criterion comment="Execstart directive of rescue.service is not overridden"
+          test_ref="test_rescue_service_not_overridden" />
+        </criteria>
+        <criterion comment="authentication for single user mode is configured in the override file"
+        test_ref="test_require_rescue_service_override" />
+      </criteria>
       {{%- if 'ol' not in families  and 'rhel' not in product and "fedora" != product-%}}
       <criterion test_ref="test_require_rescue_service_runlevel1" />
       <criterion test_ref="test_no_custom_runlevel1_target" negate="true"/>
@@ -12,6 +20,7 @@
       {{%- endif -%}}
     </criteria>
   </definition>
+
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
     comment="Tests that
     {{% if product in ["fedora", "rhcos4", "sle12", "sle15", "slmicro5"] or 'ol' in families or 'rhel' in product -%}}
@@ -21,25 +30,58 @@
     {{%- endif %}}
     was not removed from the default systemd rescue.service to ensure that a
   password must be entered to access single user mode"
-  id="test_require_rescue_service" version="1">
-    <ind:object object_ref="obj_require_rescue_service" />
+  id="test_require_rescue_service_distro" version="1">
+    <ind:object object_ref="obj_require_rescue_service_distro" />
+    <ind:state state_ref="state_require_rescue_service" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="obj_require_rescue_service" version="1">
-    {{%- if 'rhel' in product or product == 'fedora' -%}}
-    <ind:path>/etc/systemd/system/rescue.service.d</ind:path>
-    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
-    {{%- else -%}}
+
+
+  <ind:textfilecontent54_object id="obj_require_rescue_service_distro" version="1">
     <ind:filepath>/usr/lib/systemd/system/rescue.service</ind:filepath>
-    {{%- endif -%}}
-    {{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "slmicro5"] or 'ol' in families or 'rhel' in product -%}}
-    <ind:pattern operation="pattern match">^ExecStart\s?=\s?\-.*/usr/lib/systemd/systemd-sulogin-shell[ ]+rescue</ind:pattern>
-    {{%- else -%}}
-    <ind:pattern operation="pattern match">^ExecStart\s?=\s?\-/bin/sh[\s]+-c[\s]+\"(/usr)?/sbin/sulogin;[\s]+/usr/bin/systemctl[\s]+--fail[\s]+--no-block[\s]+default\"</ind:pattern>
-    {{%- endif -%}}
+
+    <ind:pattern operation="pattern match">^ExecStart\s?=\s?\-?(.*)$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  {{%- if 'ol' not in families and 'rhel' not in product -%}}
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+    comment="Tests that
+    {{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "slmicro5"] or 'ol' in families or 'rhel' in product -%}}
+    /usr/lib/systemd/systemd-sulogin-shell
+    {{%- else -%}}
+    /sbin/sulogin
+    {{%- endif %}}
+    is defined in /etc/systemd/system/rescue.service.d/*.conf"
+  id="test_require_rescue_service_override" version="1">
+    <ind:object object_ref="obj_require_rescue_service_override" />
+    <ind:state state_ref="state_require_rescue_service" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_require_rescue_service_override" version="1">
+    <ind:behaviors singleline="true" multiline="false" />
+    <ind:path>/etc/systemd/system/rescue.service.d</ind:path>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^.*ExecStart\s?=\s+.*ExecStart\s?=\s?\-?(.*)$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  
+
+  <ind:textfilecontent54_state id="state_require_rescue_service" version="1">
+    {{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "slmicro5"] or 'ol' in families or 'rhel' in product -%}}
+    <ind:subexpression datatype="string" operation="pattern match">.*/usr/lib/systemd/systemd-sulogin-shell[ ]+rescue</ind:subexpression>
+    {{%- else -%}}
+    <ind:subexpression datatype="string" operation="pattern match">/bin/sh[\s]+-c[\s]+\"(/usr)?/sbin/sulogin;[\s]+/usr/bin/systemctl[\s]+--fail[\s]+--no-block[\s]+default\"</ind:subexpression>
+    {{%- endif -%}}
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_test check="all" check_existence="none_exist"
+    comment="Check that there is no override file for rescue.service with Execstart - directive"
+    id="test_rescue_service_not_overridden" version="1">
+    <ind:object object_ref="obj_require_rescue_service_override"/>
+  </ind:textfilecontent54_test>
+
+
+  {{%- if product not in ["ol8"] and 'rhel' not in product -%}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
     comment="Tests that the systemd rescue.service is in the runlevel1.target"
     id="test_require_rescue_service_runlevel1" version="1">

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/tests/correct_dropin.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/tests/correct_dropin.pass.sh
@@ -4,5 +4,6 @@ rm -rf /etc/systemd/system/rescue.service.d
 mkdir -p /etc/systemd/system/rescue.service.d
 cat << EOF > /etc/systemd/system/rescue.service.d/10-automatus.conf
 [Service]
+ExecStart=
 ExecStart=-/usr/lib/systemd/systemd-sulogin-shell rescue
 EOF

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/tests/correct_value.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Oracle Linux 8,Oracle Linux 9
+# platform = multi_platform_fedora,multi_platform_rhel,multi_platform_ol
 
 service_file="/usr/lib/systemd/system/rescue.service"
 sulogin="/usr/lib/systemd/systemd-sulogin-shell"

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/tests/wrong_dropin.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/tests/wrong_dropin.fail.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 # platform = multi_platform_fedora,multi_platform_rhel
+
 rm -rf /etc/systemd/system/rescue.service.d
 mkdir -p /etc/systemd/system/rescue.service.d
 cat << EOF > /etc/systemd/system/rescue.service.d/10-automatus.conf
 [Service]
+ExecStart=
 ExecStart=/bin/bash
 EOF
+

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -2236,18 +2236,18 @@ for f in $(echo -n "{{{ files }}}"); do
     # find key in section and change value
     if grep -qzosP "[[:space:]]*\[{{{ section }}}\]([^\n\[]*\n+)+?[[:space:]]*{{{ key }}}" "$f"; then
 {{% if no_quotes %}}
-            sed -i "s/{{{ key }}}[^(\n)]*/{{{ key }}}={{{ value }}}/" "$f"
+            sed -i "s/{{{ key }}}[^(\n)]*/{{{ key }}}={{{ value | replace("/", "\/") }}}/" "$f"
 {{% else %}}
-            sed -i 's/{{{ key }}}[^(\n)]*/{{{ key }}}="{{{ value }}}"/' "$f"
+            sed -i 's/{{{ key }}}[^(\n)]*/{{{ key }}}="{{{ value | replace("/", "\/") }}}"/' "$f"
 {{% endif %}}
             found=true
 
     # find section and add key = value to it
     elif grep -qs "[[:space:]]*\[{{{ section }}}\]" "$f"; then
 {{% if no_quotes %}}
-            sed -i "/[[:space:]]*\[{{{ section }}}\]/a {{{ key }}}={{{ value }}}" "$f"
+            sed -i "/[[:space:]]*\[{{{ section }}}\]/a {{{ key }}}={{{ value | replace("/", "\/") }}}" "$f"
 {{% else %}}
-            sed -i '/[[:space:]]*\[{{{ section }}}\]/a {{{ key }}}="{{{ value }}}"' "$f"
+            sed -i '/[[:space:]]*\[{{{ section }}}\]/a {{{ key }}}="{{{ value | replace ("/", "\/") }}}"' "$f"
 {{% endif %}}
             found=true
     fi


### PR DESCRIPTION
#### Description:

- rewrite OVAL, Bash, Ansible
- add test scenario

#### Rationale:

- the rule had several problems which made it fail often. Remediation was not consistent with the check at all, at least for Bash.
- Currently, the rule checks for the parameter in /usr/lib/systemd/systemúrescue.service and also for possible overrides in /etc/systemd/system/rescue.service.d/*.conf. Please see OVAL criteria for more details.
- Remediations both create files only in /etc/systemd/system/rescue.service.d.


#### Review Hints:

- Running Automatus scenarios should be enough.