### PR TITLE
Fix sssd service enabled test scenarios

### DIFF
--- a/linux_os/guide/services/sssd/service_sssd_enabled/rule.yml
+++ b/linux_os/guide/services/sssd/service_sssd_enabled/rule.yml
@@ -42,6 +42,6 @@ warnings:
     - general:
         The service requires a valid sssd configuration. If the configuration is
         not present, the service will fail to start and consequently this rule
-        will will be reported as failing. The configuration shipped in your
+        will be reported as failing. The configuration shipped in your
         distribution package might not be sufficient. Manual modification of
         configuration files might be required.

--- a/linux_os/guide/services/sssd/service_sssd_enabled/tests/common.sh
+++ b/linux_os/guide/services/sssd/service_sssd_enabled/tests/common.sh
@@ -7,15 +7,30 @@ services = nss, pam
 domains = example.com
 
 [domain/example.com]
+{{%- if ('rhel' in product or 'ol' in families) and product not in ['ol8', 'ol9', 'rhel8', 'rhel9']%}}
+id_provider = proxy
+proxy_lib_name = files
+local_auth_policy = only
+{{%- else %}}
 id_provider = files
 access_provider = simple
 simple_allow_users = user1, user2
+{{%- endif %}}
 
 [nss]
 filter_groups = root
 filter_users = root
 
 [pam]
+{{%- if ('rhel' in product or 'ol' in families) and product not in ['ol8', 'ol9', 'rhel8', 'rhel9']%}}
+pam_cert_auth = True
+{{%- endif %}}
 EOF
+	{{%- if ('rhel' in product or 'ol' in families) and product not in ['ol8', 'ol9', 'rhel8', 'rhel9']%}}
+	dnf install sssd-proxy -y
+	authselect select sssd with-smartcard
+	chmod 0640 /etc/sssd/sssd.conf
+	{{%- else %}}
 	chmod 0600 /etc/sssd/sssd.conf
+	{{%- endif %}}
 fi


### PR DESCRIPTION
#### Description:

-   The 'files' directive is now deprecated and there the 'proxy' directive
    that can be used as a replacement. Preserve the old test scenario so it should still work on older RHEL
    versions for example. RHEL9 should work with the new style but kept the
    same for integrity.
