### PR TITLE
Process files in tests/shared by Jinja

### DIFF
--- a/shared/checks/oval/audit_rules_augenrules.xml
+++ b/shared/checks/oval/audit_rules_augenrules.xml
@@ -20,7 +20,7 @@
   <ind:textfilecontent54_object id="object_audit_rules_augenrules" version="1">
   {{% if product in ['rhel10', 'ol10']  %}}
     <ind:filepath>/usr/lib/systemd/system/audit-rules.service</ind:filepath>
-    <ind:pattern operation="pattern match">^ExecStart=\/sbin\/augenrules.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^ExecStart=(\/usr|)?\/sbin\/augenrules.*$</ind:pattern>
   {{% else %}}
     <ind:filepath>/usr/lib/systemd/system/auditd.service</ind:filepath>
     <ind:pattern operation="pattern match">^(ExecStartPost=\-\/sbin\/augenrules.*$|Requires=augenrules.service)</ind:pattern>

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -324,8 +324,13 @@ def write_rule_test_content_to_dir(rule_dir, test_content):
         scenario_file_path = os.path.join(rule_dir, scenario.script)
         with open(scenario_file_path, "w") as f:
             f.write(scenario.contents)
-    for file_name, file_content in test_content.other_content.items():
-        file_path = os.path.join(rule_dir, file_name)
+    for rel_file_path, file_content in test_content.other_content.items():
+        if os.path.dirname(rel_file_path) != "":
+            # file_path contains a directory, make sure it exists
+            subdir = os.path.join(rule_dir, os.path.dirname(rel_file_path))
+            if not os.path.exists(subdir):
+                os.mkdir(subdir)
+        file_path = os.path.join(rule_dir, rel_file_path)
         with open(file_path, "w") as f:
             f.write(file_content)
 

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -19,7 +19,7 @@ from ssg.constants import FULL_NAME_TO_PRODUCT_MAPPING
 from ssg.constants import OSCAP_RULE
 from ssg.jinja import process_file_with_macros
 from ssg.products import product_yaml_path, load_product_yaml
-from ssg.rules import get_rule_dir_yaml, is_rule_dir
+from ssg.rules import get_rule_dir_yaml
 from ssg.utils import mkdir_p
 from ssg_test_suite.log import LogHelper
 

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -354,7 +354,6 @@ def create_tarball(test_content_by_rule_id):
         with tempfile.NamedTemporaryFile(
                 "wb", suffix=".tar.gz", delete=False) as fp:
             with tarfile.TarFile.open(fileobj=fp, mode="w") as tarball:
-                tarball.add(_SHARED_DIR, arcname="shared", filter=_make_file_root_owned)
                 for rule_id in os.listdir(tmpdir):
                     # When a top-level directory exists under the temporary
                     # templated tests directory, we've already validated that

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -333,6 +333,9 @@ def write_rule_test_content_to_dir(rule_dir, test_content):
         file_path = os.path.join(rule_dir, rel_file_path)
         with open(file_path, "w") as f:
             f.write(file_content)
+            # Ensure newline at the end of the file because
+            # process_file_with_macros strips it off
+            f.write("\n")
 
 
 def create_tarball(test_content_by_rule_id):

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -15,6 +15,8 @@ import subprocess
 import tempfile
 
 from ssg.constants import OSCAP_PROFILE, OSCAP_PROFILE_ALL_ID, OSCAP_RULE
+from ssg.jinja import process_file_with_macros
+
 from ssg_test_suite import oscap
 from ssg_test_suite import xml_operations
 from ssg_test_suite import test_env
@@ -422,6 +424,21 @@ class RuleChecker(oscap.Checker):
                 other_content[file_name] = file_content
         return RuleTestContent(scenarios, other_content)
 
+    def _get_shared_test_content(self):
+        product_yaml = common.get_product_context(self.test_env.product)
+        other_content = dict()
+        for dirpath, _, filenames in os.walk(common._SHARED_DIR):
+            for file_name in filenames:
+                file_path = os.path.join(dirpath, file_name)
+                rel_path = os.path.relpath(file_path, common._SHARED_DIR)
+                try:
+                    file_content = process_file_with_macros(file_path, product_yaml)
+                except Exception as e:
+                    logging.error("Error processing file {0}: {1}".format(file_path, str(e)))
+                    continue
+                other_content[rel_path] = file_content
+        return RuleTestContent([], other_content)
+
     def _get_test_content_by_rule_id(self, rules_to_test):
         test_content_by_rule_id = dict()
         for rule in rules_to_test:
@@ -429,6 +446,7 @@ class RuleChecker(oscap.Checker):
             test_content_by_rule_id[rule.id] = rule_test_content
         sliced_test_content_by_rule_id = self._slice_sbr(
             test_content_by_rule_id, self.slice_current, self.slice_total)
+        sliced_test_content_by_rule_id["shared"] = self._get_shared_test_content()
         return sliced_test_content_by_rule_id
 
     def _test_target(self):

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -11,11 +11,11 @@ import os
 import os.path
 import re
 import shutil
-import subprocess
 import tempfile
 
 from ssg.constants import OSCAP_PROFILE, OSCAP_PROFILE_ALL_ID, OSCAP_RULE
 from ssg.jinja import process_file_with_macros
+from ssg.rules import is_rule_dir
 
 from ssg_test_suite import oscap
 from ssg_test_suite import xml_operations
@@ -23,7 +23,6 @@ from ssg_test_suite import test_env
 from ssg_test_suite import common
 from ssg_test_suite.log import LogHelper
 
-import ssg.templates
 
 Rule = collections.namedtuple(
     "Rule",
@@ -304,7 +303,7 @@ class RuleChecker(oscap.Checker):
 
         for dirpath, dirnames, filenames in common.walk_through_benchmark_dirs(
                 product):
-            if not common.is_rule_dir(dirpath):
+            if not is_rule_dir(dirpath):
                 continue
             short_rule_id = os.path.basename(dirpath)
             full_rule_id = OSCAP_RULE + short_rule_id


### PR DESCRIPTION
#### Description:

Resolve Jinja expressions in files in the `tests/shared` directory when running Automatus tests. The files will be processed with Jinja before they will be packed to a tarball and sent to the testing back end.

For more details, please read commit messages of every commit.

#### Rationale:

This change will fix some failing test scenarios in rules starting with `audit_rules_unsuccessful_file_modification`, specifically:

- audit_rules_unsuccessful_file_modification_open_o_creat/o_creat_rules.pass
- audit_rules_unsuccessful_file_modification_open_o_trunc_write/o_trunc_rules.pass
- audit_rules_unsuccessful_file_modification_open_rule_order/ordered_by_arch.pass
- audit_rules_unsuccessful_file_modification_open_rule_order/ordered_by_filter.pass
- audit_rules_unsuccessful_file_modification_openat_o_creat/o_creat_last.pass
- audit_rules_unsuccessful_file_modification_openat_o_creat/o_creat_rules.pass

These scenarios were erroring because they use files from `tests/shared`, these files contain Jinja expressions but the expansion of the Jinja expressions wasn't performed by `automatus`. A specific example is that the `{{{ uid_min }}}` expression wasn't expanded in `tests/shared/audit_open_o_creat.rules` and `tests/shared/audit_open_o_creat.rules`.

#### Review Hints:

```
python3 tests/automatus.py rule --libvirt qemu:///system ssgts_rhel10 audit_rules_unsuccessful_file_modification_open_o_creat audit_rules_unsuccessful_file_modification_open_o_trunc_write audit_rules_unsuccessful_file_modification_open_rule_order audit_rules_unsuccessful_file_modification_openat_o_creat 
```