### PR TITLE
Improve OVAL and tests for accounts_password_pam_unix_authtok

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/oval/shared.xml
@@ -1,41 +1,55 @@
-{{%- set accounts_password_pam_unix_file = '/etc/pam.d/common-password' -%}}
+{{%- set accounts_password_pam_file = '/etc/pam.d/common-password' -%}}
 
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("Configure the system to include use_authtok in pam common_password configuration file") }}}
-    <criteria>
-      <criterion test_ref="test_password_pam_unix_use_authtok"
-        comment="use_authtok is configured in pam unix in common_password file"/>
+    <criteria operator="AND">
+        <criterion test_ref="test_{{{ rule_id }}}_pam_unix_exists"
+        comment="at least one pam_unix line exists in common_password file"/>
+        <criterion test_ref="test_{{{ rule_id }}}_prm_exists_not_initial"
+        comment="use_authtok is configured in pam unix in common_password, ignoring first line on stack"/>
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test id="test_password_pam_unix_use_authtok" version="1"
-    check="all" check_existence="any_exist"
-    comment="use_authtok is configured in pam unix in common_password file">
-    <ind:object object_ref="obj_test_use_authtok" />
-    <ind:state state_ref="ste_test_use_authtok" />
+  <ind:textfilecontent54_test id="test_{{{ rule_id }}}_pam_unix_exists" version="1"
+    check="all" check_existence="at_least_one_exists"
+    comment="At least one pam_unix line exists">
+    <ind:object object_ref="obj_{{{ rule_id }}}_pam_unix_exists" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="obj_test_use_authtok" version="1">
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}_pam_unix_exists" version="1">
+    <ind:filepath>{{{ accounts_password_pam_file }}}</ind:filepath>
+    <ind:pattern operation="pattern match">^[ \t]*password[ \t]+[^#\n\r]+[ \t]+pam_unix\.so.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="test_{{{ rule_id }}}_prm_exists_not_initial" version="1"
+    check="all" check_existence="any_exist"
+    comment="use_authtok is configured in pam unix in common_password file, ignoring first line on stack">
+  <ind:object object_ref="obj_{{{ rule_id }}}_pam_unix_lines_not_initial" />
+  <ind:state state_ref="ste_{{{ rule_id }}}_prm_exists" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}_pam_unix_lines_not_initial" version="1">
     <set>
-      <object_reference>obj_test_use_authtok_password_lines_except_first</object_reference>
-      <filter action="include">ste_test_use_authtok_pam_unix_lines</filter>
+      <object_reference>obj_{{{ rule_id }}}_password_lines_not_initial</object_reference>
+      <filter action="include">ste_{{{ rule_id }}}_pam_unix_lines</filter>
     </set>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_state id="ste_test_use_authtok" version="1">
+  <ind:textfilecontent54_state id="ste_{{{ rule_id }}}_prm_exists" version="1">
       <ind:subexpression operation="pattern match">^[^#\n\r]+[ \t]+pam_unix\.so[ \t]+[^#\n\r]+use_authtok.*$</ind:subexpression>
   </ind:textfilecontent54_state>
 
   <!-- Get all password lines except the first line. This is to avoid matching a pam_unix
   line on the top of the stack, which does not need use_authtok to pass -->
-  <ind:textfilecontent54_object id="obj_test_use_authtok_password_lines_except_first" version="1">
-    <ind:filepath>{{{ accounts_password_pam_unix_file }}}</ind:filepath>
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}_password_lines_not_initial" version="1">
+    <ind:filepath>{{{ accounts_password_pam_file }}}</ind:filepath>
     <ind:pattern operation="pattern match">^[ \t]*password[ \t]+(.+)$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">2</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_state id="ste_test_use_authtok_pam_unix_lines" version="1">
+  <ind:textfilecontent54_state id="ste_{{{ rule_id }}}_pam_unix_lines" version="1">
       <ind:subexpression operation="pattern match">^[^#\n\r]+[ \t]+pam_unix\.so.*$</ind:subexpression>
   </ind:textfilecontent54_state>
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/tests/ubuntu_commented_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/tests/ubuntu_commented_value.fail.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+source ubuntu_common.sh
+
+config_file=/usr/share/pam-configs/tmpunix
+
+# lower priority to ensure the config is below the cac_test_echo
+# on the stack, thus using the "Password:" configuration
+cat << EOF > "$config_file"
+Name: Unix authentication
+Default: yes
+Priority: 1024
+Conflicts: unix
+Auth-Type: Primary
+Auth:
+        [success=end default=ignore]    pam_unix.so try_first_pass
+Auth-Initial:
+        [success=end default=ignore]    pam_unix.so
+Account-Type: Primary
+Account:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Account-Initial:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Session-Type: Additional
+Session:
+        required        pam_unix.so
+Session-Initial:
+        required        pam_unix.so
+Password-Type: Primary
+Password:
+        [success=end default=ignore]    pam_unix.so obscure try_first_pass yescrypt # use_authtok
+Password-Initial:
+        [success=end default=ignore]    pam_unix.so obscure yescrypt
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update
+rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/tests/ubuntu_missing_pam_unix.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_authtok/tests/ubuntu_missing_pam_unix.fail.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+source ubuntu_common.sh
+
+config_file=/usr/share/pam-configs/tmpunix
+
+# lower priority to ensure the config is below the cac_test_echo
+# on the stack, thus using the "Password:" configuration
+cat << EOF > "$config_file"
+Name: Unix authentication
+Default: yes
+Priority: 1024
+Conflicts: unix
+Auth-Type: Primary
+Auth:
+        [success=end default=ignore]    pam_unix.so try_first_pass
+Auth-Initial:
+        [success=end default=ignore]    pam_unix.so
+Account-Type: Primary
+Account:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Account-Initial:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Session-Type: Additional
+Session:
+        required        pam_unix.so
+Session-Initial:
+        required        pam_unix.so
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update
+rm "$config_file"


### PR DESCRIPTION
#### Description:

- Added a condition that at least one pam_unix must exist in PAM password file
- Cleaned up the IDs and comments in OVAL
- Added test scenarios for missing pam_unix line and for commented parameter use_authtok