### PR TITLE
Workaround package_nfs-utils_removed issue on bootable containers

### DIFF
--- a/linux_os/guide/services/nfs_and_rpc/package_nfs-utils_removed/bash/rhel10.sh
+++ b/linux_os/guide/services/nfs_and_rpc/package_nfs-utils_removed/bash/rhel10.sh
@@ -1,0 +1,14 @@
+# platform = Red Hat Enterprise Linux 10
+# reboot = false
+# strategy = disable
+# complexity = low
+# disruption = low
+
+# This RHEL 10 special remediation is a workaround for
+# https://issues.redhat.com/browse/RHEL-74244
+# and once the issue is resolved we will remove it.
+if {{{ bash_bootc_build() }}}; then
+    mkdir -p /var/lib/rpm-state
+fi
+
+dnf -y remove nfs-utils

--- a/linux_os/guide/services/nfs_and_rpc/package_nfs-utils_removed/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/package_nfs-utils_removed/rule.yml
@@ -40,3 +40,5 @@ template:
     name: package_removed
     vars:
         pkgname: nfs-utils
+    backends:
+        bootc: "off"

--- a/linux_os/guide/system/software/system-tools/package_gssproxy_removed/bash/rhel10.sh
+++ b/linux_os/guide/system/software/system-tools/package_gssproxy_removed/bash/rhel10.sh
@@ -1,0 +1,14 @@
+# platform = Red Hat Enterprise Linux 10
+# reboot = false
+# strategy = disable
+# complexity = low
+# disruption = low
+
+# This RHEL 10 special remediation is a workaround for
+# https://issues.redhat.com/browse/RHEL-74244
+# and once the issue is resolved we will remove it.
+if {{{ bash_bootc_build() }}}; then
+    mkdir -p /var/lib/rpm-state
+fi
+
+dnf -y remove gssproxy

--- a/linux_os/guide/system/software/system-tools/package_gssproxy_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_gssproxy_removed/rule.yml
@@ -42,3 +42,4 @@ template:
         pkgname: gssproxy
     backends:
         anaconda: "off"
+        bootc: "off"


### PR DESCRIPTION
The rule is affected by https://issues.redhat.com/browse/RHEL-74244 which causes that RHEL 10 bootable container hardened with STIG profile fails to build. Therefore, until this issue is resolved, we will have a special RHEL 10 only remediation which workarounds the problem on bootable containers.