### PR TITLE
Update `logind_session_timeout/not_configured.fail` to handle if the systemd config is not there

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/logind_session_timeout/tests/not_configured.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/logind_session_timeout/tests/not_configured.fail.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 # variables = var_logind_session_timeout = 5_minutes
 
+mkdir -p /etc/systemd
+touch /etc/systemd/logind.conf
+
 sed -i '/^.*StopIdleSessionSec.*$/d' /etc/systemd/logind.conf


### PR DESCRIPTION


#### Description:

Update `logind_session_timeout/not_configured.fail ` to handle if the systemd config is not there.

#### Rationale:

Fixes #12876