### PR TITLE
Make `coredump_disable_storage/coredumps_storage_none.pass` work on RHEL 10

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_storage/tests/coredumps_storage_none.pass.sh
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_storage/tests/coredumps_storage_none.pass.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
+mkdir -p /etc/systemd/
 
+if ! grep -q "[Coredump]" /etc/systemd/coredump.conf; then
+    echo "[Coredump]" >> /etc/systemd/coredump.conf
+fi
 echo Storage=none >> /etc/systemd/coredump.conf


### PR DESCRIPTION

#### Description:

Make `coredump_disable_storage/coredumps_storage_none.pass` work on RHEL 10

#### Rationale:

Fixes #12878 