### PR TITLE
Fix audit_rules_privileged_commands_unix2_chkpwd

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix2_chkpwd/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix2_chkpwd/rule.yml
@@ -1,5 +1,7 @@
+{{%- set unix2_chkpwd_binary="/usr/sbin/unix2_chkpwd" %}}
 {{%- if product in ["sle15"] %}}
   {{%- set perm_x="-F perm=x " %}}
+  {{%- set unix2_chkpwd_binary="/sbin/unix2_chkpwd" %}}
 {{%- endif %}}
 
 documentation_complete: true
@@ -13,11 +15,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/sbin/unix2_chkpwd {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    <pre>-a always,exit -F path={{{ unix2_chkpwd_binary }}} {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/sbin/unix2_chkpwd {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    <pre>-a always,exit -F path={{{ unix2_chkpwd_binary }}} {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
@@ -62,4 +64,5 @@ ocil: |-
 template:
     name: audit_rules_privileged_commands
     vars:
-        path: /sbin/unix2_chkpwd
+        path: "/usr/sbin/unix2_chkpwd"
+        path@sle15: "/sbin/unix2_chkpwd"

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix2_chkpwd/tests/only_chkpwd_rule.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix2_chkpwd/tests/only_chkpwd_rule.fail.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
 # packages = audit
 
-echo "-a always,exit -F path=/sbin/unix2_chkpwd -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules
+{{%- if product in ["sle15"] %}}
+    {{%- set unix2_chkpwd_wrong_binary="/usr/sbin/unix2_chkpwd" %}}
+{{%- else %}}
+    {{%- set unix2_chkpwd_wrong_binary="/sbin/unix2_chkpwd" %}}
+{{%- endif %}}
+echo "-a always,exit -F path={{{ unix2_chkpwd_wrong_binary }}} -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix2_chkpwd/tests/only_chkpwd_rule.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix2_chkpwd/tests/only_chkpwd_rule.fail.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # packages = audit
 
+# in SLE the default place to check for the unix2_chkpwd binary as defined in STIG is /sbin/
+# whereas in other products they check in /usr/sbin. They are technically the same, but the OVAL
+# check will look for specific directories according to the product. Here for the sake of the
+# test scenario setup we invert the binaries so the OVAL fails the check on purpose.
 {{%- if product in ["sle15"] %}}
     {{%- set unix2_chkpwd_wrong_binary="/usr/sbin/unix2_chkpwd" %}}
 {{%- else %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/rule.yml
@@ -1,4 +1,7 @@
-{{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}  {{%- set perm_x="-F perm=x " %}}
+{{%- set unix_chkpwd_binary="/usr/sbin/unix_chkpwd" %}}
+{{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}  
+    {{%- set perm_x="-F perm=x " %}}
+    {{%- set unix_chkpwd_binary="/sbin/unix_chkpwd" %}}
 {{%- endif %}}
 
 documentation_complete: true
@@ -12,11 +15,11 @@ description: |-
     configured to use the <tt>augenrules</tt> program to read audit rules during
     daemon startup (the default), add a line of the following form to a file with
     suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/unix_chkpwd {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    <pre>-a always,exit -F path={{{ unix_chkpwd_binary }}} {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the following
     form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/unix_chkpwd {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    <pre>-a always,exit -F path={{{ unix_chkpwd_binary }}} {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/tests/only_chkpwd_rule.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/tests/only_chkpwd_rule.fail.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 # packages = audit
-
-echo "-a always,exit -F path=/sbin/unix_chkpwd -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules
+{{%- if 'sl' in product %}}
+    {{%- set unix_chkpwd_wrong_binary="/usr/sbin/unix_chkpwd" %}}
+{{%- else %}}
+    {{%- set unix_chkpwd_wrong_binary="/sbin/unix_chkpwd" %}}
+{{%- endif %}}
+echo "-a always,exit -F path={{{ unix_chkpwd_wrong_binary }}} -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules


### PR DESCRIPTION
#### Description:

- Fix audit_rules_privileged_commands_unix2_chkpwd

#### Rationale:


- Fixes #12880

#### Review Hints:

- tests/automatus.py rule --libvirt qemu:///system rhel10 --debug --datastream build/ssg-rhel10-ds.xml --remediate-using bash --scenarios only_chkpwd_rule.fail audit_rules_privileged_commands_unix2_chkpwd


I'm opening as draft as it should fix the issue but I didn't have time to verify it. I should get back to this next week, in the meantime feel free to reuse the idea and close this one in case you fix it in another PR.

