### PR TITLE
Ubuntu 24.04: Implement rule 5.4.2.8 Ensure accounts without a valid login shell are locked

### DIFF
--- a/components/pam.yml
+++ b/components/pam.yml
@@ -185,6 +185,7 @@ rules:
 - no_empty_passwords
 - no_empty_passwords_etc_shadow
 - no_forward_files
+- no_invalid_shell_accounts_unlocked
 - no_legacy_plus_entries_etc_group
 - no_legacy_plus_entries_etc_passwd
 - no_legacy_plus_entries_etc_shadow

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2208,8 +2208,11 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
-    notes: TODO. Rule does not seem to be implemented, nor does it map to any rules in ubuntu2204 profile.
+    rules:
+      - no_invalid_shell_accounts_unlocked
+    status: automated
+    notes: |
+      Remediation is not automated.
 
   - id: 5.4.3.1
     title: Ensure nologin is not listed in /etc/shells (Automated)

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_invalid_shell_accounts_unlocked/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_invalid_shell_accounts_unlocked/oval/shared.xml
@@ -1,0 +1,80 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("Ensure Accounts Without Valid Login Shell Are Locked") }}}
+    <criteria>
+      <criterion comment="Check that the accounts do not have valid shells" test_ref="test_{{{ rule_id }}}_no_invalid_shell_accounts" negate="true" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test id="test_{{{ rule_id }}}_no_invalid_shell_accounts" check="all" check_existence="at_least_one_exists"
+    version="1" comment="Verify there is no account with invalid shell which is not locked exists">
+    <ind:object object_ref="obj_{{{ rule_id }}}_shells" />
+    <ind:state state_ref="state_{{{ rule_id }}}_valid_shells" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_state id="state_{{{ rule_id }}}_valid_shells" version="1">
+    <ind:subexpression datatype="string" operation="not equal" var_check="all" var_ref="var_{{{ rule_id }}}_valid_shells" ></ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <local_variable id="var_{{{ rule_id }}}_valid_shells" datatype="string" version="1" comment="Local variable which includes all valid shells">
+      <object_component item_field="text" object_ref="obj_{{{ rule_id }}}_valid_shells" />
+  </local_variable>
+
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}_valid_shells" version="1">
+      <ind:filepath>/etc/shells</ind:filepath>
+      <ind:pattern operation="pattern match">^\/[^\n\r]*$</ind:pattern>
+      <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+      <filter action="exclude">filter_{{{ rule_id }}}_not_valid_shell</filter>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="filter_{{{ rule_id }}}_not_valid_shell" version="1"
+  comment="The nologin shell can be safely ignored" >
+    <ind:pattern operation="pattern match">^.*\bnologin\b.*$</ind:pattern>
+  </ind:textfilecontent54_state>
+
+  <!-- OVAL object to collect shell of local interactive users -->
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}_shells" version="1">
+    <ind:filepath>/etc/passwd</ind:filepath>
+    <!--  Shell from /etc/passwd (7th column) captured as subexpression of this object -->
+    <ind:pattern operation="pattern match" var_ref="variable_{{{ rule_id }}}_regex" var_check="at least one"/>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <local_variable id="variable_{{{ rule_id }}}_regex" datatype="string" version="1" comment="shell rows retrieved from /etc/passwd">
+    <concat>
+      <literal_component>^(?:</literal_component>
+      <object_component item_field="subexpression" object_ref="obj_{{{ rule_id }}}_local_interactive_users" />
+      <literal_component>):(?:[^:]*:){5}([^:]+)$</literal_component>
+    </concat>
+  </local_variable>
+
+  <!-- OVAL object to collect user names of local interactive users -->
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}_local_interactive_users" version="1">
+    <ind:filepath>/etc/passwd</ind:filepath>
+    <ind:pattern operation="pattern match">^([^:]*):[^:]*:\d+:(?:[^:]*:){3}(?!(\/usr)?(\/sbin\/nologin|\/bin\/false))[^:]*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    <filter action="exclude">state_{{{ rule_id }}}_users_ignored</filter>
+    <filter action="exclude">state_{{{ rule_id }}}_locked_accounts</filter>
+  </ind:textfilecontent54_object>
+
+  {{%- set ignored_users_list="(nobody|nfsnobody|root)" %}}
+  <ind:textfilecontent54_state id="state_{{{ rule_id }}}_users_ignored" version="1">
+    <ind:subexpression operation="pattern match">^{{{ ignored_users_list }}}$</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_state id="state_{{{ rule_id }}}_locked_accounts" version="1">
+    <ind:subexpression datatype="string" operation="equals" var_check="at least one" var_ref="var_{{{ rule_id }}}_locked_accounts" ></ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <local_variable id="var_{{{ rule_id }}}_locked_accounts" datatype="string" version="1" comment="Account name of locked acounts">
+      <object_component item_field="subexpression" object_ref="obj_{{{ rule_id }}}_locked_accounts" />
+  </local_variable>
+
+  <!-- The indicator characters for locked accounts are referenced from man 5 crypt -->
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}_locked_accounts" version="1">
+      <ind:filepath>/etc/shadow</ind:filepath>
+      <ind:pattern operation="pattern match">^([^:]*):(?:[ \t\n\r\:\;\*\!\\]*):(?:[^:]*:){6}$</ind:pattern>
+      <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_invalid_shell_accounts_unlocked/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_invalid_shell_accounts_unlocked/rule.yml
@@ -1,0 +1,20 @@
+documentation_complete: true
+
+title: 'Verify Non-Interactive Accounts Are Locked'
+
+description: |-
+    Accounts meant for non-interactive purposes should be locked to prevent
+    unauthorized access. Accounts with non-standard shells (those not defined in
+    <tt>/etc/shells</tt>) should be locked using <tt>usermod -L</tt>.
+
+rationale: |-
+    Locking non-interactive accounts improves security by preventing potential
+    misuse. While many systems configure these accounts with invalid strings,
+    setting the shell field to <tt>nologin</tt> is also suggested
+
+severity: medium
+
+warnings:
+    - general: |-
+        Automatic remediation of this control is not recommended. Locking system accounts
+        could be highly disruptive.

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_invalid_shell_accounts_unlocked/tests/asterisks.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_invalid_shell_accounts_unlocked/tests/asterisks.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# remediation = none
+
+sed -i 's/^\([^:]*\):x:/\1:\*:/' /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_invalid_shell_accounts_unlocked/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_invalid_shell_accounts_unlocked/tests/correct.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# remediation = none
+
+echo "testuser:*:1001:1001::/home/testuser:/bin/bash" > /etc/passwd
+echo "testuser:!:20111:0:99999:7:::" > /etc/shadow
+echo "/bin/bash" >> /etc/shells

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_invalid_shell_accounts_unlocked/tests/invalid_shell.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_invalid_shell_accounts_unlocked/tests/invalid_shell.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# remediation = none
+
+echo "testuser:x:8000:8000:testuser:/home/testuser:/bin/dash" > /etc/passwd
+echo "/bin/bash" > /etc/shells


### PR DESCRIPTION
#### Description:

- Implement rule 5.4.2.8 Ensure accounts without a valid login shell are locked

#### Rationale:

-  Satisfies Ubuntu 24.04 CIS control 5.4.2.8