### PR TITLE
RHEL now checks no other users have primary group ID 0

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_root_gid_zero/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_root_gid_zero/oval/shared.xml
@@ -3,7 +3,7 @@
     {{{ oval_metadata("The root account should have primary group of 0") }}}
     <criteria operator="AND">
       <criterion comment="tests that the root account's gid is equal to 0" test_ref="test_{{{rule_id}}}" />
-      {{% if 'ubuntu' in product %}}
+      {{% if 'ubuntu' in product or 'rhel' in product %}}
       <criterion comment="no other users have primary group ID 0" test_ref="test_{{{rule_id}}}_no_other_gid_0" />
       {{% endif %}}
     </criteria>
@@ -24,7 +24,7 @@
     <ind:subexpression operation="equals" datatype="int">0</ind:subexpression>
   </ind:textfilecontent54_state>
 
-  {{% if 'ubuntu' in product %}}
+  {{% if 'ubuntu' in product or 'rhel' in product %}}
   <!-- Test for other users with GID 0 (excluding sync, shutdown, halt, operator) -->
   <ind:textfilecontent54_test id="test_{{{rule_id}}}_no_other_gid_0" check="all" check_existence="none_exist" comment="test that there are no other accounts with GID 0 except root" version="1">
     <ind:object object_ref="object_{{{rule_id}}}_no_other_gid_0" />

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_root_gid_zero/tests/other_user_uid_0.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_root_gid_zero/tests/other_user_uid_0.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+# platform = multi_platform_rhel,multi_platform_ubuntu
 # Remediation doesn't fix the rule, only locks passwords
 # of non-root accounts with uid 0.
 # remediation = none


### PR DESCRIPTION
#### Description:

RHEL now checks no other users have primary group ID 0
Also make the test only work on RHEL and Ubuntu since those are the only platforms that have the OVAL test.

#### Rationale:

Fixes #12874 