### PR TITLE
CMP-2859: Resolve failing Image-stream-sets-schedule

### DIFF
--- a/applications/openshift/registry/imagestream_sets_schedule/rule.yml
+++ b/applications/openshift/registry/imagestream_sets_schedule/rule.yml
@@ -32,17 +32,17 @@ references:
     srg: SRG-APP-000456-CTR-001125
 
 {{% set api_path = '/apis/image.openshift.io/v1/imagestreams' %}}
-{{% set jqfilter = '[[.items[] | select( .metadata.ownerReferences? // [] | all(.kind != "ClusterVersion")) | select(.metadata.labels[]? | select("samples.operator.openshift.io/managed: true") | not) | select(.spec.tags[]?.from.kind != "ImageStreamTag" and (.importPolicy.scheduled != null or .importPolicy.scheduled != false))] | any]' %}}
+{{% set jqfilter = '[[.items[] | ( .spec.tags[]?.from.kind != "ImageStreamTag" and ([.spec.tags[]? | (.importPolicy.scheduled == null or .importPolicy.scheduled == false)] | any) ) and ((.metadata.labels == null) or (.metadata.labels."samples.operator.openshift.io/managed" == null) or (.metadata.labels."samples.operator.openshift.io/managed" != "true")) and ((.metadata.ownerReferences == null) or (.metadata.ownerReferences | length == 0) or (.metadata.ownerReferences?[].kind == null) or (isempty(.metadata.ownerReferences?[] | select(.kind == "ClusterVersion"))))] | any]' %}}
 
 ocil_clause: 'imagestream is not configured to perform periodical updates'
 
 ocil: |-
   To list all the imagestreams and identify which imagestream tags are
   configured to periodically check for updates (<pre>imagePolicy = { scheduled: true }</pre>), run the following command:
-  <pre>oc get imagestream -A -ojson | jq -r '.items[] | select( .metadata.ownerReferences? // [] | all(.kind == "ClusterVersion")) | select(.metadata.labels[]? | select( "samples.operator.openshift.io/managed: true")) | select( .spec.tags[]?.from.kind != "ImageStreamTag" and .importPolicy.scheduled == true).metadata.name' | sort | uniq</pre>
+  <pre>oc get imagestream -A -ojson | jq -r '.items[] | select(( (.spec.tags[]?.from.kind != "ImageStreamTag") and ([.spec.tags[]? | (.importPolicy.scheduled == null or .importPolicy.scheduled == false)] | any) and ((.metadata.labels == null) or (.metadata.labels["samples.operator.openshift.io/managed"] == null) or (.metadata.labels["samples.operator.openshift.io/managed"] != "true")) and ((.metadata.ownerReferences == null) or (.metadata.ownerReferences | length == 0) or (.metadata.ownerReferences[]?.kind == null) or (isempty(.metadata.ownerReferences[]? | select(.kind == "ClusterVersion")))) )|not) | "\(.metadata.namespace),\(.metadata.name)"' | sort | uniq</pre>
   Alternatively, to view a list of ImageStreams that do not schedule updates,
   run:
-  <pre>oc get imagestream -A -ojson | jq -r '.items[] | select( .metadata.ownerReferences? // [] | all(.kind != "ClusterVersion")) | select(.metadata.labels[]? | select( "samples.operator.openshift.io/managed: true") | not) | select( .spec.tags[]?.from.kind != "ImageStreamTag" and (.importPolicy.scheduled == null or .importPolicy.scheduled == false)) | "\(.metadata.namespace),\(.metadata.name)"' | sort | uniq</pre>
+  <pre>oc get imagestream -A -ojson | jq -r '.items[] | select(( (.spec.tags[]?.from.kind != "ImageStreamTag") and ([.spec.tags[]? | (.importPolicy.scheduled == null or .importPolicy.scheduled == false)] | any) and ((.metadata.labels == null) or (.metadata.labels["samples.operator.openshift.io/managed"] == null) or (.metadata.labels["samples.operator.openshift.io/managed"] != "true")) and ((.metadata.ownerReferences == null) or (.metadata.ownerReferences | length == 0) or (.metadata.ownerReferences[]?.kind == null) or (isempty(.metadata.ownerReferences[]? | select(.kind == "ClusterVersion")))) )) | "\(.metadata.namespace),\(.metadata.name)"' | sort | uniq</pre>
 
 warnings:
 - general: |-
@@ -55,7 +55,7 @@ template:
     filepath: |-
       {{{ openshift_filtered_path(api_path, jqfilter) }}}
     yamlpath: "[:]"
-    check_existence: "only_one_exists"
+    check_existence: "at_least_one_exists"
     values:
       - value: "false"
         operation: "equals"

--- a/applications/openshift/registry/imagestream_sets_schedule/rule.yml
+++ b/applications/openshift/registry/imagestream_sets_schedule/rule.yml
@@ -32,7 +32,7 @@ references:
     srg: SRG-APP-000456-CTR-001125
 
 {{% set api_path = '/apis/image.openshift.io/v1/imagestreams' %}}
-{{% set jqfilter = '[.items[] | select( .metadata.ownerReferences? // [] | all(.kind != "ClusterVersion")) | select(.metadata.labels[]? | select("samples.operator.openshift.io/managed: true") | not) | select(.spec.tags[]?.from.kind != "ImageStreamTag" and (.importPolicy.scheduled != null or .importPolicy.scheduled != false))] | any' %}}
+{{% set jqfilter = '[[.items[] | select( .metadata.ownerReferences? // [] | all(.kind != "ClusterVersion")) | select(.metadata.labels[]? | select("samples.operator.openshift.io/managed: true") | not) | select(.spec.tags[]?.from.kind != "ImageStreamTag" and (.importPolicy.scheduled != null or .importPolicy.scheduled != false))] | any]' %}}
 
 ocil_clause: 'imagestream is not configured to perform periodical updates'
 
@@ -57,5 +57,5 @@ template:
     yamlpath: "[:]"
     check_existence: "only_one_exists"
     values:
-      - value: "true"
+      - value: "false"
         operation: "equals"

--- a/applications/openshift/registry/imagestream_sets_schedule/rule.yml
+++ b/applications/openshift/registry/imagestream_sets_schedule/rule.yml
@@ -32,17 +32,17 @@ references:
     srg: SRG-APP-000456-CTR-001125
 
 {{% set api_path = '/apis/image.openshift.io/v1/imagestreams' %}}
-{{% set jqfilter = '[.items[] | .spec.tags[]? | select(.from.kind != "ImageStreamTag") | (.importPolicy.scheduled != null and .importPolicy.scheduled != false)] | all' %}}
+{{% set jqfilter = '[.items[] | select( .metadata.ownerReferences? // [] | all(.kind != "ClusterVersion")) | select(.metadata.labels[]? | select("samples.operator.openshift.io/managed: true") | not) | select(.spec.tags[]?.from.kind != "ImageStreamTag" and (.importPolicy.scheduled != null or .importPolicy.scheduled != false))] | any' %}}
 
 ocil_clause: 'imagestream is not configured to perform periodical updates'
 
 ocil: |-
   To list all the imagestreams and identify which imagestream tags are
   configured to periodically check for updates (<pre>imagePolicy = { scheduled: true }</pre>), run the following command:
-  <pre>oc get imagestreams -A -ojson | jq '.items[] | select(.spec.tags[]?.importPolicy.scheduled == true) | .metadata.name' | sort | uniq</pre>
+  <pre>oc get imagestream -A -ojson | jq -r '.items[] | select( .metadata.ownerReferences? // [] | all(.kind == "ClusterVersion")) | select(.metadata.labels[]? | select( "samples.operator.openshift.io/managed: true")) | select( .spec.tags[]?.from.kind != "ImageStreamTag" and .importPolicy.scheduled == true).metadata.name' | sort | uniq</pre>
   Alternatively, to view a list of ImageStreams that do not schedule updates,
   run:
-  <pre>oc get imagestreams -A -ojson | jq -r '.items[] | select(.spec.tags[]? | select(.from.kind != "ImageStreamTag" and (.importPolicy.scheduled == null or .importPolicy.scheduled == false))) | "\(.metadata.namespace),\(.metadata.name)"' | sort | uniq</pre>
+  <pre>oc get imagestream -A -ojson | jq -r '.items[] | select( .metadata.ownerReferences? // [] | all(.kind != "ClusterVersion")) | select(.metadata.labels[]? | select( "samples.operator.openshift.io/managed: true") | not) | select( .spec.tags[]?.from.kind != "ImageStreamTag" and (.importPolicy.scheduled == null or .importPolicy.scheduled == false)) | "\(.metadata.namespace),\(.metadata.name)"' | sort | uniq</pre>
 
 warnings:
 - general: |-

--- a/applications/openshift/registry/imagestream_sets_schedule/tests/ocp4/e2e.yml
+++ b/applications/openshift/registry/imagestream_sets_schedule/tests/ocp4/e2e.yml
@@ -1,3 +1,3 @@
 ---
-default_result: FAIL
+default_result: PASS
 

--- a/tests/assertions/ocp4/ocp4-stig-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.12.yml
@@ -228,8 +228,8 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-stig-imagestream-sets-schedule:
-    default_result: FAIL
-    result_after_remediation: FAIL
+    default_result: PASS
+    result_after_remediation: PASS
   e2e-stig-ingress-controller-tls-security-profile:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-stig-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.13.yml
@@ -227,8 +227,8 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-stig-imagestream-sets-schedule:
-    default_result: FAIL
-    result_after_remediation: FAIL
+    default_result: PASS
+    result_after_remediation: PASS
   e2e-stig-ingress-controller-tls-security-profile:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-stig-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.14.yml
@@ -227,8 +227,8 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-stig-imagestream-sets-schedule:
-    default_result: FAIL
-    result_after_remediation: FAIL
+    default_result: PASS
+    result_after_remediation: PASS
   e2e-stig-ingress-controller-tls-security-profile:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-stig-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.15.yml
@@ -227,8 +227,8 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-stig-imagestream-sets-schedule:
-    default_result: FAIL
-    result_after_remediation: FAIL
+    default_result: PASS
+    result_after_remediation: PASS
   e2e-stig-ingress-controller-tls-security-profile:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-stig-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.16.yml
@@ -227,8 +227,8 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-stig-imagestream-sets-schedule:
-    default_result: FAIL
-    result_after_remediation: FAIL
+    default_result: PASS
+    result_after_remediation: PASS
   e2e-stig-ingress-controller-tls-security-profile:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-stig-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.17.yml
@@ -228,8 +228,8 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-stig-imagestream-sets-schedule:
-    default_result: FAIL
-    result_after_remediation: FAIL
+    default_result: PASS
+    result_after_remediation: PASS
   e2e-stig-ingress-controller-tls-security-profile:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-stig-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.18.yml
@@ -228,8 +228,8 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-stig-imagestream-sets-schedule:
-    default_result: FAIL
-    result_after_remediation: FAIL
+    default_result: PASS
+    result_after_remediation: PASS
   e2e-stig-ingress-controller-tls-security-profile:
     default_result: PASS
     result_after_remediation: PASS


### PR DESCRIPTION
#### Description:

- Resolve failing Image-stream-sets-schedule. Changes to samples operator which were not accounted for, and ClusterVersion managed imagestreams should be excluded. 

#### Rationale:

- fixes failing rule

- Fixes #CMP-2859

#### Review Hints:

- Part of DISA-STIG profile for OCP 