### PR TITLE
Update tests for file_groupownership_sshd_private_key

### DIFF
--- a/linux_os/guide/services/ssh/file_groupownership_sshd_private_key/tests/correct_groupowner.pass.sh
+++ b/linux_os/guide/services/ssh/file_groupownership_sshd_private_key/tests/correct_groupowner.pass.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 # platform = multi_platform_ol,multi_platform_rhel
+{{% set dedicated_ssh_groupname = groups.get("dedicated_ssh_keyowner", {}).get("name", "root") %}}
 
-if ! grep -q ssh_keys /etc/group; then
-    groupadd ssh_keys
+if ! grep -q "{{{ dedicated_ssh_groupname }}}" /etc/group; then
+    groupadd "{{{ dedicated_ssh_groupname }}}"
 fi
 
 FAKE_KEY=$(mktemp -p /etc/ssh/ XXXX_key)
-chgrp ssh_keys "$FAKE_KEY"
+chgrp  "{{{ dedicated_ssh_groupname }}}" "$FAKE_KEY"

--- a/linux_os/guide/services/ssh/file_groupownership_sshd_private_key/tests/multiple_keys.fail.sh
+++ b/linux_os/guide/services/ssh/file_groupownership_sshd_private_key/tests/multiple_keys.fail.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 # platform = multi_platform_ol,multi_platform_rhel
+{{% set dedicated_ssh_groupname = groups.get("dedicated_ssh_keyowner", {}).get("name", "root") %}}
 
 test_group="cac_testgroup"
 groupadd $test_group
 
 FAKE_KEY=$(mktemp -p /etc/ssh/ XXXX_key)
-chgrp ssh_keys "$FAKE_KEY"
+chgrp {{{ dedicated_ssh_groupname }}} "$FAKE_KEY"
 
 FAKE_KEY2=$(mktemp -p /etc/ssh/ XXXX_key)
 chgrp $test_group "$FAKE_KEY2"


### PR DESCRIPTION
#### Description:

Make the tests in `file_groupownership_sshd_private_key` select the correct group for owning ssh keys based on the OS.

#### Rationale:
Fixes #12893 
