### PR TITLE
Adjust `kernel_module_disabled/missing_blacklist.fail.sh`

### DIFF
--- a/shared/templates/kernel_module_disabled/tests/missing_blacklist.fail.sh
+++ b/shared/templates/kernel_module_disabled/tests/missing_blacklist.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_rhel,multi_platform_ol,multi_platform_ubuntu
 
-echo > /etc/modprobe.d/{{{ KERNMODULE }}}.conf
+sed -i /{{{ KERNMODULE }}}/d /etc/modprobe.d/*.conf
 echo "install {{{ KERNMODULE }}} /bin/true" > /etc/modprobe.d/{{{ KERNMODULE }}}.conf


### PR DESCRIPTION

#### Description:

The might some default config that disables a kernel module. To ensure we're testing this correctly remove the "blacklist" line from all `.conf` files under `/etc/modprobe.d/*.conf`.


#### Rationale:

Fixes #12877 

#### Review Hints:

Run the Automatus tests for `kernel_module_sctp_disabled` (the one failing in the linked issue) and then some other module like `kernel_module_can_disabled`.