### PR TITLE
Move to `enable_fips_mode` from `grub2_enable_fips_mode` in RHEL 10

### DIFF
--- a/controls/ism_o.yml
+++ b/controls/ism_o.yml
@@ -435,7 +435,7 @@ use of device access control software or by disabling external communication int
             - enable_dracut_fips_module
             - system_booted_in_fips_mode
             - var_system_crypto_policy=fips
-            - grub2_enable_fips_mode
+            - enable_fips_mode
         status: automated
 
     -   id: '1449'

--- a/controls/srg_gpos/SRG-OS-000396-GPOS-00176.yml
+++ b/controls/srg_gpos/SRG-OS-000396-GPOS-00176.yml
@@ -10,5 +10,5 @@ controls:
             - package_crypto-policies_installed
             - system_booted_in_fips_mode
             - sysctl_crypto_fips_enabled
-            - grub2_enable_fips_mode
+            - enable_fips_mode
         status: automated

--- a/controls/srg_gpos/SRG-OS-000478-GPOS-00223.yml
+++ b/controls/srg_gpos/SRG-OS-000478-GPOS-00223.yml
@@ -11,5 +11,5 @@ controls:
             - system_booted_in_fips_mode
             - aide_use_fips_hashes
             - configure_kerberos_crypto_policy
-            - grub2_enable_fips_mode
+            - enable_fips_mode
         status: automated


### PR DESCRIPTION


#### Description:

The grub2_enable_fips_mode rule is very complex and many of packages needed for it don't seem to exist in RHEL 10.

#### Rationale:

Fixes #12879 
