### PR TITLE
Switch to _guard_var templates for firewall rules on Ubuntu 24.04

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -1284,8 +1284,8 @@ controls:
       - var_network_filtering_service=nftables
     status: automated
     notes: |
-      Remediation is not automated.
-
+      Remediation is not automated. To select which firewall to
+      install and configure, use the profile variable var_network_filtering_service.
 
   - id: 4.2.1
     title: Ensure ufw is installed (Automated)
@@ -1464,7 +1464,6 @@ controls:
       - l1_server
       - l1_workstation
     rules:
-      - package_nftables_removed
       - service_nftables_disabled
     status: automated
 

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -1281,6 +1281,7 @@ controls:
       - l1_workstation
     rules:
       - firewall_single_service_active
+      - var_network_filtering_service=nftables
     status: automated
     notes: |
       Remediation is not automated.

--- a/linux_os/guide/system/network/network-iptables/package_iptables_installed/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/package_iptables_installed/rule.yml
@@ -36,7 +36,7 @@ ocil_clause: 'the package is not installed'
 
 ocil: '{{{ ocil_package(package="iptables") }}}'
 
-{{%- if product in [ "sle12", "sle15" ] %}}
+{{%- if product in [ "sle12", "sle15", "ubuntu2404" ] %}}
 template:
     name: package_installed_guard_var
     vars:

--- a/linux_os/guide/system/network/network-iptables/package_iptables_installed/tests/rhel8.fail.sh
+++ b/linux_os/guide/system/network/network-iptables/package_iptables_installed/tests/rhel8.fail.sh
@@ -1,3 +1,4 @@
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 #!/bin/bash
 
 mkdir -p "/etc"

--- a/linux_os/guide/system/network/network-iptables/package_iptables_installed/tests/rhel9.2.notapplicable.sh
+++ b/linux_os/guide/system/network/network-iptables/package_iptables_installed/tests/rhel9.2.notapplicable.sh
@@ -1,3 +1,4 @@
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 #!/bin/bash
 
 mkdir -p "/etc"

--- a/linux_os/guide/system/network/network-iptables/package_iptables_installed/tests/rhel9.notapplicable.sh
+++ b/linux_os/guide/system/network/network-iptables/package_iptables_installed/tests/rhel9.notapplicable.sh
@@ -1,3 +1,4 @@
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 #!/bin/bash
 
 mkdir -p "/etc"

--- a/linux_os/guide/system/network/network-nftables/package_nftables_installed/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/package_nftables_installed/rule.yml
@@ -1,6 +1,5 @@
 documentation_complete: true
 
-
 title: 'Install nftables Package'
 
 description: |-
@@ -36,10 +35,19 @@ ocil: '{{{ ocil_package(package="nftables") }}}'
 
 platform: system_with_kernel and service_disabled[iptables] and service_disabled[ufw]
 
+{{%- if product in [ "ubuntu2404" ] %}}
+template:
+    name: package_installed_guard_var
+    vars:
+        pkgname: nftables
+        variable: var_network_filtering_service
+        value: nftables
+{{%- else %}}
 template:
     name: package_installed
     vars:
         pkgname: nftables
+{{%- endif %}}
 
 fixtext: |-
     {{{ describe_package_install(package="nftables") }}}

--- a/linux_os/guide/system/network/network-nftables/service_nftables_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/service_nftables_disabled/rule.yml
@@ -1,6 +1,5 @@
 documentation_complete: true
 
-
 title: 'Verify nftables Service is Disabled'
 
 description: |-
@@ -38,7 +37,7 @@ fixtext: '{{{ fixtext_service_disabled("nftables") }}}'
 
 platform: system_with_kernel and package[nftables] and package[firewalld]
 
-{{%- if product in [ "sle12", "sle15" ] %}}
+{{%- if product in [ "sle12", "sle15", "ubuntu2404" ] %}}
 template:
     name: service_disabled_guard_var
     vars:

--- a/linux_os/guide/system/network/network-nftables/service_nftables_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/service_nftables_enabled/rule.yml
@@ -1,6 +1,5 @@
 documentation_complete: true
 
-
 title: 'Verify nftables Service is Enabled'
 
 description: |-
@@ -34,11 +33,9 @@ ocil: |-
 fixtext: |-
     {{{ fixtext_service_enabled("nftables") }}}
 
-
 platform: system_with_kernel and package[nftables] and service_disabled[firewalld]
 
-
-{{%- if product in [ "sle12", "sle15" ] %}}
+{{%- if product in [ "sle12", "sle15", "ubuntu2404" ] %}}
 template:
     name: service_enabled_guard_var
     vars:

--- a/linux_os/guide/system/network/network-ufw/package_ufw_installed/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/package_ufw_installed/rule.yml
@@ -1,6 +1,5 @@
 documentation_complete: true
 
-
 title: 'Install ufw Package'
 
 description: |-
@@ -25,7 +24,17 @@ ocil_clause: 'the package is not installed'
 
 ocil: '{{{ ocil_package(package="ufw") }}}'
 
+{{%- if product in [ "ubuntu2404" ] %}}
+template:
+    name: package_installed_guard_var
+    vars:
+        pkgname: ufw
+        variable: var_network_filtering_service
+        value: ufw
+        operation: pattern match
+{{%- else %}}
 template:
     name: package_installed
     vars:
         pkgname: ufw
+{{%- endif %}}

--- a/linux_os/guide/system/network/network-ufw/package_ufw_removed/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/package_ufw_removed/rule.yml
@@ -1,6 +1,5 @@
 documentation_complete: true
 
-
 title: 'Remove ufw Package'
 
 description: |-
@@ -20,10 +19,21 @@ ocil_clause: 'the package is installed'
 
 ocil: '{{{ ocil_package(package="ufw") }}}'
 
+platform: system_with_kernel
+
+{{%- if product in [ "ubuntu2404" ] %}}
+template:
+    name: package_removed_guard_var
+    vars:
+        pkgname: ufw
+        variable: var_network_filtering_service
+        value: ufw
+{{%- else %}}
 template:
     name: package_removed
     vars:
         pkgname: ufw
+{{%- endif %}}
 
 fixtext: |-
     {{{ describe_package_remove(package="ufw") }}}

--- a/linux_os/guide/system/network/network-ufw/service_ufw_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/service_ufw_enabled/rule.yml
@@ -23,9 +23,19 @@ ocil_clause: 'the service is not enabled'
 ocil: |-
     {{{ ocil_service_enabled(service="ufw") }}}
 
+platform: system_with_kernel and package[ufw]
+
+{{%- if product in [ "ubuntu2404" ] %}}
+template:
+    name: service_enabled_guard_var
+    vars:
+        packagename: ufw
+        servicename: ufw
+        variable: var_network_filtering_service
+        value: ufw
+{{%- else %}}
 template:
     name: service_enabled
     vars:
         servicename: ufw
-
-platform: system_with_kernel and package[ufw]
+{{%- endif %}}

--- a/linux_os/guide/system/network/var_network_filtering_service.var
+++ b/linux_os/guide/system/network/var_network_filtering_service.var
@@ -11,9 +11,17 @@ operator: equals
 
 interactive: true
 
+{{% if 'ubuntu' in product %}}
+options:
+    iptables: iptables
+    nftables: nftables
+    ufw: ufw
+    default: nftables
+{{% else %}}
 options:
     iptables: iptables
     nftables: nftables
     firewalld: firewalld
     ufw: ufw
     default: firewalld
+{{% endif %}}

--- a/shared/templates/package_installed_guard_var/ansible.template
+++ b/shared/templates/package_installed_guard_var/ansible.template
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # strategy = enable
 # complexity = low

--- a/shared/templates/package_installed_guard_var/bash.template
+++ b/shared/templates/package_installed_guard_var/bash.template
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # strategy = enable
 # complexity = low

--- a/shared/templates/package_installed_guard_var/oval.template
+++ b/shared/templates/package_installed_guard_var/oval.template
@@ -7,7 +7,7 @@
   {{% endif %}}
   <definition class="compliance" id="{{{ _RULE_ID }}}"
   version="1">
-    {{{ oval_metadata("The " + pkg_system|upper + " package " + PKGNAME + " should be installed.", affected_platforms=["multi_platform_sle"]) }}}
+    {{{ oval_metadata("The " + pkg_system|upper + " package " + PKGNAME + " should be installed.", affected_platforms=["multi_platform_all"]) }}}
     <criteria operator="OR" comment="package {{{ PKGNAME }}} is installed or not needed">
       <criteria comment="{{{ PKGNAME }}} is not needed" operator="AND">
         <criterion comment="variable {{{ VARIABLE }}} is set to {{{ VALUE }}}"

--- a/shared/templates/package_installed_guard_var/tests/package-installed-removed.fail.sh
+++ b/shared/templates/package_installed_guard_var/tests/package-installed-removed.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# variables = {{{ VARIABLE }}}={{{ VALUE }}}
+
+{{{ bash_package_install(PKGNAME) }}}
+{{{ bash_package_remove(PKGNAME) }}}

--- a/shared/templates/package_installed_guard_var/tests/package-installed.pass.sh
+++ b/shared/templates/package_installed_guard_var/tests/package-installed.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# variables = {{{ VARIABLE }}}={{{ VALUE }}}
+
+{{{ bash_package_install(PKGNAME) }}}

--- a/shared/templates/package_installed_guard_var/tests/package-removed-wrong-var.pass.sh
+++ b/shared/templates/package_installed_guard_var/tests/package-removed-wrong-var.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# variables = {{{ VARIABLE }}}=wrongvalue
+
+{{{ bash_package_remove(PKGNAME) }}}

--- a/shared/templates/package_installed_guard_var/tests/package-removed.fail.sh
+++ b/shared/templates/package_installed_guard_var/tests/package-removed.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# variables = {{{ VARIABLE }}}={{{ VALUE }}}
+
+{{{ bash_package_remove(PKGNAME) }}}

--- a/shared/templates/package_removed_guard_var/ansible.template
+++ b/shared/templates/package_removed_guard_var/ansible.template
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # strategy = disable
 # complexity = low

--- a/shared/templates/package_removed_guard_var/bash.template
+++ b/shared/templates/package_removed_guard_var/bash.template
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # strategy = disable
 # complexity = low

--- a/shared/templates/package_removed_guard_var/oval.template
+++ b/shared/templates/package_removed_guard_var/oval.template
@@ -7,7 +7,7 @@
   {{% endif %}}
   <definition class="compliance" id="{{{ _RULE_ID }}}"
   version="1">
-    {{{ oval_metadata("The " + pkg_system|upper + " package " + PKGNAME + " should be removed.", affected_platforms=["multi_platform_sle"]) }}}
+    {{{ oval_metadata("The " + pkg_system|upper + " package " + PKGNAME + " should be removed.", affected_platforms=["multi_platform_all"]) }}}
     <criteria operator="OR" comment="package {{{ PKGNAME }}} is removed or not needed">
       <criteria comment="{{{ PKGNAME }}} is needed" operator="AND">
         <criterion comment="variable {{{ VARIABLE }}} is set to {{{ VALUE }}}"

--- a/shared/templates/package_removed_guard_var/tests/package-installed-correct-var.pass.sh
+++ b/shared/templates/package_removed_guard_var/tests/package-installed-correct-var.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# variables = {{{ VARIABLE }}}={{{ VALUE }}}
+
+{{{ bash_package_install(PKGNAME) }}}

--- a/shared/templates/package_removed_guard_var/tests/package-installed-removed.pass.sh
+++ b/shared/templates/package_removed_guard_var/tests/package-installed-removed.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# variables = {{{ VARIABLE }}}=wrongvalue
+
+{{{ bash_package_install(PKGNAME) }}}
+{{{ bash_package_remove(PKGNAME) }}}

--- a/shared/templates/package_removed_guard_var/tests/package-installed.fail.sh
+++ b/shared/templates/package_removed_guard_var/tests/package-installed.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# variables = {{{ VARIABLE }}}=wrongvalue
+
+{{{ bash_package_install(PKGNAME) }}}

--- a/shared/templates/package_removed_guard_var/tests/package-removed.pass.sh
+++ b/shared/templates/package_removed_guard_var/tests/package-removed.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# variables = {{{ VARIABLE }}}=wrongvalue
+
+{{{ bash_package_remove(PKGNAME) }}}

--- a/shared/templates/service_disabled_guard_var/oval.template
+++ b/shared/templates/service_disabled_guard_var/oval.template
@@ -9,7 +9,7 @@
 {{% endif %}}
 
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
-    {{{ oval_metadata("The " + SERVICENAME + " service should be disabled.", affected_platforms=["multi_platform_sle"]) }}}
+    {{{ oval_metadata("The " + SERVICENAME + " service should be disabled.", affected_platforms=["multi_platform_all"]) }}}
     <criteria operator="OR" comment="package {{{ PACKAGENAME }}} removed or service {{{ SERVICENAME }}} is not configured to start">
       <criteria comment="{{{ PKGNAME }}} and service {{{ SERVICENAME }}} are needed" operator="AND">
         <criterion comment="variable {{{ VARIABLE }}} is set to {{{ VALUE }}}"

--- a/shared/templates/service_disabled_guard_var/tests/service_disabled.pass.sh
+++ b/shared/templates/service_disabled_guard_var/tests/service_disabled.pass.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# packages = {{{ PACKAGENAME }}}
+# variables = {{{ VARIABLE }}}=wrongvalue
+
+SYSTEMCTL_EXEC='/usr/bin/systemctl'
+# Some services use <name>@.service style that is not meant to be activated at all,
+# and only used via socket activation.
+if "$SYSTEMCTL_EXEC" -q list-unit-files '{{{ DAEMONNAME }}}.service'; then
+    "$SYSTEMCTL_EXEC" stop '{{{ DAEMONNAME }}}.service'
+    "$SYSTEMCTL_EXEC" disable '{{{ DAEMONNAME }}}.service'
+    "$SYSTEMCTL_EXEC" mask '{{{ DAEMONNAME }}}.service'
+fi
+# Disable socket activation if we have a unit file for it
+if "$SYSTEMCTL_EXEC" -q list-unit-files '{{{ DAEMONNAME }}}.socket'; then
+    "$SYSTEMCTL_EXEC" stop '{{{ DAEMONNAME }}}.socket'
+    "$SYSTEMCTL_EXEC" mask '{{{ DAEMONNAME }}}.socket'
+fi
+# The service may not be running because it has been started and failed,
+# so let's reset the state so OVAL checks pass.
+# Service should be 'inactive', not 'failed' after reboot though.
+"$SYSTEMCTL_EXEC" reset-failed '{{{ DAEMONNAME }}}.service' || true

--- a/shared/templates/service_disabled_guard_var/tests/service_enabled-var_is_value.pass.sh
+++ b/shared/templates/service_disabled_guard_var/tests/service_enabled-var_is_value.pass.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# packages = {{{ PACKAGENAME }}}
+# variables = {{{ VARIABLE }}}={{{ VALUE }}}
+
+SYSTEMCTL_EXEC='/usr/bin/systemctl'
+# Some services use <name>@.service style that is not meant to be activated at all,
+# and only used via socket activation.
+if "$SYSTEMCTL_EXEC" -q list-unit-files '{{{ DAEMONNAME }}}.service'; then
+    "$SYSTEMCTL_EXEC" unmask '{{{ DAEMONNAME }}}.service'
+    "$SYSTEMCTL_EXEC" start '{{{ DAEMONNAME }}}.service'
+    "$SYSTEMCTL_EXEC" enable '{{{ DAEMONNAME }}}.service'
+fi
+# Enable socket activation if we have a unit file for it
+if "$SYSTEMCTL_EXEC" -q list-unit-files '{{{ DAEMONNAME }}}.socket'; then
+    "$SYSTEMCTL_EXEC" unmask '{{{ DAEMONNAME }}}.socket'
+    "$SYSTEMCTL_EXEC" start '{{{ DAEMONNAME }}}.socket'
+fi
+
+# The service may not be running because it has been started and failed,
+# so let's reset the state so OVAL checks pass.
+# Service should be 'inactive', not 'failed' after reboot though.
+"$SYSTEMCTL_EXEC" reset-failed '{{{ DAEMONNAME }}}.service' || true

--- a/shared/templates/service_disabled_guard_var/tests/service_enabled-var_not_value.fail.sh
+++ b/shared/templates/service_disabled_guard_var/tests/service_enabled-var_not_value.fail.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# packages = {{{ PACKAGENAME }}}
+# variables = {{{ VARIABLE }}}=wrongvalue
+
+SYSTEMCTL_EXEC='/usr/bin/systemctl'
+# Some services use <name>@.service style that is not meant to be activated at all,
+# and only used via socket activation.
+if "$SYSTEMCTL_EXEC" -q list-unit-files '{{{ DAEMONNAME }}}.service'; then
+    "$SYSTEMCTL_EXEC" unmask '{{{ DAEMONNAME }}}.service'
+    "$SYSTEMCTL_EXEC" start '{{{ DAEMONNAME }}}.service'
+    "$SYSTEMCTL_EXEC" enable '{{{ DAEMONNAME }}}.service'
+fi
+# Enable socket activation if we have a unit file for it
+if "$SYSTEMCTL_EXEC" -q list-unit-files '{{{ DAEMONNAME }}}.socket'; then
+    "$SYSTEMCTL_EXEC" unmask '{{{ DAEMONNAME }}}.socket'
+    "$SYSTEMCTL_EXEC" start '{{{ DAEMONNAME }}}.socket'
+fi
+
+# The service may not be running because it has been started and failed,
+# so let's reset the state so OVAL checks pass.
+# Service should be 'inactive', not 'failed' after reboot though.
+"$SYSTEMCTL_EXEC" reset-failed '{{{ DAEMONNAME }}}.service' || true

--- a/shared/templates/service_enabled_guard_var/ansible.template
+++ b/shared/templates/service_enabled_guard_var/ansible.template
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # strategy = enable
 # complexity = low

--- a/shared/templates/service_enabled_guard_var/bash.template
+++ b/shared/templates/service_enabled_guard_var/bash.template
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # strategy = enable
 # complexity = low

--- a/shared/templates/service_enabled_guard_var/tests/service_disabled-var_not_value.pass.sh
+++ b/shared/templates/service_enabled_guard_var/tests/service_disabled-var_not_value.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+{{% if SERVICENAME == "sshd" %}}
+# platform = Not Applicable
+{{% endif %}}
+# packages = {{{ PACKAGENAME }}}
+# variables = {{{ VARIABLE }}}=wrongvalue
+
+SYSTEMCTL_EXEC='/usr/bin/systemctl'
+"$SYSTEMCTL_EXEC" unmask '{{{ DAEMONNAME }}}.service'
+"$SYSTEMCTL_EXEC" start '{{{ DAEMONNAME }}}.service'
+"$SYSTEMCTL_EXEC" enable '{{{ DAEMONNAME }}}.service'

--- a/shared/templates/service_enabled_guard_var/tests/service_disabled.fail.sh
+++ b/shared/templates/service_enabled_guard_var/tests/service_disabled.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+{{% if SERVICENAME in ["ssh", "sshd"] %}}
+# platform = Not Applicable
+{{% endif %}}
+# packages = {{{ PACKAGENAME }}}
+# variables = {{{ VARIABLE }}}={{{ VALUE }}}
+
+SYSTEMCTL_EXEC='/usr/bin/systemctl'
+"$SYSTEMCTL_EXEC" stop '{{{ DAEMONNAME }}}.service'
+"$SYSTEMCTL_EXEC" disable '{{{ DAEMONNAME }}}.service'

--- a/shared/templates/service_enabled_guard_var/tests/service_enabled.pass.sh
+++ b/shared/templates/service_enabled_guard_var/tests/service_enabled.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+{{% if SERVICENAME == "sshd" %}}
+# platform = Not Applicable
+{{% endif %}}
+# packages = {{{ PACKAGENAME }}}
+# variables = {{{ VARIABLE }}}={{{ VALUE }}}
+
+SYSTEMCTL_EXEC='/usr/bin/systemctl'
+"$SYSTEMCTL_EXEC" unmask '{{{ DAEMONNAME }}}.service'
+"$SYSTEMCTL_EXEC" start '{{{ DAEMONNAME }}}.service'
+"$SYSTEMCTL_EXEC" enable '{{{ DAEMONNAME }}}.service'


### PR DESCRIPTION
#### Description:

- Modify firewall package/service install/enable rules to use _guard_var templates on Ubuntu 24.04
- Add tests to _guard_var templates
- Remove package_nftables_removed from Ubuntu 24.04 controls

#### Rationale:

- _guard_var templates allow the user to select the desired firewall via an XCCDF variable instead of having to enable/disable the actual rules (see #11818)
- Removing nftables removes ubuntu-standard package which is not recommended. It's enough to disable and mask the service.
