### PR TITLE
Switch to _guard_var templates for timesync rules on Ubuntu 24.04

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -940,8 +940,18 @@ controls:
       - l1_server
       - l1_workstation
     rules:
+      - var_timesync_service=systemd-timesyncd
+      - package_chrony_installed
+      - service_chronyd_enabled
+      - service_chronyd_disabled
+      - package_timesyncd_installed
+      - service_timesyncd_enabled
+      - service_timesyncd_disabled
       - ntp_single_service_active
     status: automated
+    notes: |
+      To select which timesync daemon to install and configure, use the
+      profile variable var_timesync_service.
 
   - id: 2.3.2.1
     title: Ensure systemd-timesyncd configured with authorized timeserver (Automated)
@@ -958,10 +968,11 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    rules:
-      - service_chronyd_disabled
+    related_rules:
       - service_timesyncd_enabled
+      - service_timesyncd_disabled
     status: automated
+    notes: Implemented in 2.3.1.1
 
   - id: 2.3.3.1
     title: Ensure chrony is configured with authorized timeserver (Automated)
@@ -977,7 +988,6 @@ controls:
       Rule does not check or remediate config files included via
       confdir and sourcedir directives.
 
-
   - id: 2.3.3.2
     title: Ensure chrony is running as user _chrony (Automated)
     levels:
@@ -992,10 +1002,11 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    rules:
-      - "!service_chronyd_enabled"
-      - "!service_timesyncd_disabled"
+    related_rules:
+      - service_chronyd_enabled
+      - service_chronyd_disabled
     status: automated
+    notes: Implemented in 2.3.1.1
 
   - id: 2.4.1.1
     title: Ensure cron daemon is enabled and active (Automated)

--- a/linux_os/guide/services/ntp/package_chrony_installed/rule.yml
+++ b/linux_os/guide/services/ntp/package_chrony_installed/rule.yml
@@ -15,7 +15,6 @@ rationale: |-
 
 severity: medium
 
-
 identifiers:
     cce@rhel8: CCE-82874-9
     cce@rhel9: CCE-84215-3
@@ -46,7 +45,16 @@ fixtext: '{{{ describe_package_install(package="chrony") }}}'
 
 srg_requirement: '{{{ srg_requirement_package_installed("chrony") }}}'
 
+{{%- if product in [ "ubuntu2404" ] %}}
+template:
+    name: package_installed_guard_var
+    vars:
+        pkgname: chrony
+        variable: var_timesync_service
+        value: chronyd
+{{%- else %}}
 template:
     name: package_installed
     vars:
         pkgname: chrony
+{{%- endif %}}

--- a/linux_os/guide/services/ntp/package_timesyncd_installed/rule.yml
+++ b/linux_os/guide/services/ntp/package_timesyncd_installed/rule.yml
@@ -22,7 +22,16 @@ references:
     nist-csf: PR.PT-1
     pcidss: Req-10.4
 
+{{%- if product in [ "ubuntu2404" ] %}}
+template:
+    name: package_installed_guard_var
+    vars:
+        pkgname: systemd-timesyncd
+        variable: var_timesync_service
+        value: systemd-timesyncd
+{{%- else %}}
 template:
     name: package_installed
     vars:
         pkgname: systemd-timesyncd
+{{%- endif %}}

--- a/linux_os/guide/services/ntp/package_timesyncd_removed/rule.yml
+++ b/linux_os/guide/services/ntp/package_timesyncd_removed/rule.yml
@@ -18,7 +18,16 @@ references:
     disa: CCI-000366
     stigid@ubuntu2204: UBTU-22-215020
 
+{{%- if product in [ "ubuntu2404" ] %}}
+template:
+    name: package_removed_guard_var
+    vars:
+        pkgname: systemd-timesyncd
+        variable: var_timesync_service
+        value: systemd-timesyncd
+{{%- else %}}
 template:
     name: package_removed
     vars:
         pkgname: systemd-timesyncd
+{{%- endif %}}

--- a/linux_os/guide/services/ntp/service_chronyd_disabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_chronyd_disabled/rule.yml
@@ -13,6 +13,15 @@ severity: medium
 
 platform: package[chrony]
 
+{{%- if product in [ "ubuntu2404" ] %}}
+template:
+    name: service_disabled_guard_var
+    vars:
+        packagename: chrony
+        servicename: chrony
+        variable: var_timesync_service
+        value: chronyd
+{{%- else %}}
 template:
     name: service_disabled
     vars:
@@ -21,3 +30,4 @@ template:
         servicename@ubuntu2004: chrony
         servicename@ubuntu2204: chrony
         servicename@debian12: chrony
+{{%- endif %}}

--- a/linux_os/guide/services/ntp/service_chronyd_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_chronyd_enabled/rule.yml
@@ -41,6 +41,15 @@ fixtext: '{{{ fixtext_service_enabled(service="chronyd") }}}'
 
 srg_requirement: '{{{ srg_requirement_service_enabled(service="chronyd") }}}'
 
+{{%- if product in [ "ubuntu2404" ] %}}
+template:
+    name: service_enabled_guard_var
+    vars:
+        packagename: chrony
+        servicename: chrony
+        variable: var_timesync_service
+        value: chronyd
+{{%- else %}}
 template:
     name: service_enabled
     vars:
@@ -49,3 +58,4 @@ template:
         servicename@ubuntu2004: chrony
         servicename@ubuntu2204: chrony
         servicename@debian12: chrony
+{{%- endif %}}

--- a/linux_os/guide/services/ntp/service_timesyncd_disabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_timesyncd_disabled/rule.yml
@@ -1,6 +1,5 @@
 documentation_complete: true
 
-
 title: 'Disable systemd_timesyncd Service'
 
 description: |-
@@ -18,8 +17,18 @@ severity: medium
 
 platform: package[systemd-timesyncd]
 
+{{%- if product in [ "ubuntu2404" ] %}}
+template:
+    name: service_disabled_guard_var
+    vars:
+        packagename: systemd-timesyncd
+        servicename: systemd-timesyncd
+        variable: var_timesync_service
+        value: systemd-timesyncd
+{{%- else %}}
 template:
     name: service_disabled
     vars:
         servicename: systemd-timesyncd
         packagename: systemd-timesyncd
+{{%- endif %}}

--- a/linux_os/guide/services/ntp/service_timesyncd_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_timesyncd_enabled/rule.yml
@@ -43,8 +43,18 @@ references:
 ocil: |-
     {{{ ocil_service_enabled(service="systemd_timesyncd") }}}
 
+{{%- if product in [ "ubuntu2404" ] %}}
+template:
+    name: service_enabled_guard_var
+    vars:
+        packagename: systemd-timesyncd
+        servicename: systemd-timesyncd
+        variable: var_timesync_service
+        value: systemd-timesyncd
+{{%- else %}}
 template:
     name: service_enabled
     vars:
         servicename: systemd-timesyncd
         packagename: systemd
+{{%- endif %}}

--- a/linux_os/guide/services/ntp/var_timesync_service.var
+++ b/linux_os/guide/services/ntp/var_timesync_service.var
@@ -1,0 +1,17 @@
+documentation_complete: true
+
+title: 'Time synchronization service'
+
+description: |-
+   Time synchronization service: systemd-timesyncd or chronyd
+
+type: string
+
+operator: equals
+
+interactive: true
+
+options:
+    systemd-timesyncd: systemd-timesyncd
+    chronyd: chronyd
+    default: systemd-timesyncd


### PR DESCRIPTION
#### Description:

- Modify timesync package/service install/enable rules to use _guard_var templates on Ubuntu 24.04
- Introduce variable `var_timesync_service`
- Adapt Ubuntu 24.04 CIS controls

#### Rationale:

- _guard_var templates allow the user to select the desired timesync service via an XCCDF variable instead of having to enable/disable the actual rules (analogous to #12902)
