### PR TITLE
add negative check to exclude openshift from bootc check

### DIFF
--- a/shared/applicability/bootc.yml
+++ b/shared/applicability/bootc.yml
@@ -15,5 +15,5 @@ title: Bootable containers
 # containers don't contain kernel.
 #
 check_id: bootc
-bash_conditional: "{ rpm --quiet -q kernel ;} && { rpm --quiet -q rpm-ostree ;} && { rpm --quiet -q bootc ;}"
-ansible_conditional: '"kernel" in ansible_facts.packages and "rpm-ostree" in ansible_facts.packages and "bootc" in ansible_facts.packages'
+bash_conditional: "{ rpm --quiet -q kernel ;} && { rpm --quiet -q rpm-ostree ;} && { rpm --quiet -q bootc ;} && { ! rpm --quiet -q openshift-kubelet ;}"
+ansible_conditional: '"kernel" in ansible_facts.packages and "rpm-ostree" in ansible_facts.packages and "bootc" in ansible_facts.packages and not "openshift-kubelet" in ansible_facts.packages'

--- a/shared/applicability/oval/bootc.xml
+++ b/shared/applicability/oval/bootc.xml
@@ -5,9 +5,11 @@
       <criterion comment="kernel is installed" test_ref="bootc_platform_test_kernel_installed" />
       <criterion comment="rpm-ostree is installed" test_ref="bootc_platform_test_rpm_ostree_installed" />
       <criterion comment="bootc is installed" test_ref="bootc_platform_test_bootc_installed" />
+      <criterion comment="openshift-kubelet is not installed" test_ref="bootc_platform_test_openshift_kubelet_removed" />
     </criteria>
   </definition>
 {{{ oval_test_package_installed(package="kernel", test_id="bootc_platform_test_kernel_installed") }}}
 {{{ oval_test_package_installed(package="rpm-ostree", test_id="bootc_platform_test_rpm_ostree_installed") }}}
 {{{ oval_test_package_installed(package="bootc", test_id="bootc_platform_test_bootc_installed") }}}
+{{{ oval_test_package_removed(package="openshift-kubelet", test_id="bootc_platform_test_openshift_kubelet_removed") }}}
 </def-group>

--- a/shared/checks/oval/bootc.xml
+++ b/shared/checks/oval/bootc.xml
@@ -5,9 +5,11 @@
       <criterion comment="kernel is installed" test_ref="bootc_platform_test_kernel_installed" />
       <criterion comment="rpm-ostree is installed" test_ref="bootc_platform_test_rpm_ostree_installed" />
       <criterion comment="bootc is installed" test_ref="bootc_platform_test_bootc_installed" />
+      <criterion comment="openshift-kubelet is not installed" test_ref="bootc_platform_test_openshift_kubelet_removed" />
     </criteria>
   </definition>
 {{{ oval_test_package_installed(package="kernel", test_id="bootc_platform_test_kernel_installed") }}}
 {{{ oval_test_package_installed(package="rpm-ostree", test_id="bootc_platform_test_rpm_ostree_installed") }}}
 {{{ oval_test_package_installed(package="bootc", test_id="bootc_platform_test_bootc_installed") }}}
+{{{ oval_test_package_removed(package="openshift-kubelet", test_id="bootc_platform_test_openshift_kubelet_removed") }}}
 </def-group>


### PR DESCRIPTION
#### Description:

This PR adds a conditional to the bootc check, which checks for absence of openshift-kubelet

#### Rationale:

- the bootc check should check if it runs on a bootc platform
- a rule which was running on openshift before `partition_for_var_log_audit` in the stig-v2r1 profile, did not run anymore
- no rule in the `disk_partitioning` was able to be run due to the platform conditional for the group not allowing `bootc`

#### Review Hints:

- I only tested this on an OCP 4.17.6 Cluster
- I chose the "openshift-kubelet" package at it stays within the logic of checking for packages and also should be present on all openshift systems, but not on non openshift systems.