### PR TITLE
Update rule enable_fips_mode for RHEL 10

### DIFF
--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/ansible/shared.yml
@@ -5,6 +5,7 @@
 # disruption = medium
 {{{ ansible_instantiate_variables("var_system_crypto_policy") }}}
 
+{{% if product != "rhel10" %}}
 - name: "{{{ rule_title }}} - Check to See the Current Status of FIPS Mode"
   ansible.builtin.command: /usr/bin/fips-mode-setup --check
   register: is_fips_enabled
@@ -15,6 +16,7 @@
   ansible.builtin.command: /usr/bin/fips-mode-setup --enable
   when:
     - is_fips_enabled.stdout.find('FIPS mode is enabled.') == -1
+{{% endif %}}
 
 - name: "{{{ rule_title }}} - Configure Crypto Policy"
   ansible.builtin.lineinfile:

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/bash/shared.sh
@@ -6,8 +6,10 @@ if {{{ bash_bootc_build() }}}; then
 	cat > /usr/lib/bootc/kargs.d/01-fips.toml << EOF
 kargs = ["fips=1"]
 EOF
+{{% if product != "rhel10" %}}
 else
 	fips-mode-setup --enable
+{{% endif %}}
 fi
 
 stderr_of_call=$(update-crypto-policies $crypto_policies_no_reload --set ${var_system_crypto_policy} 2>&1 > /dev/null)

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/rule.yml
@@ -3,7 +3,22 @@ documentation_complete: true
 title: Enable FIPS Mode
 
 description: |-
-{{% if product != "rhcos4" %}}
+{{% if product == "rhcos4" %}}
+    OpenShift has an installation-time flag that can enable FIPS mode
+    for the cluster. The flag <pre>fips: true</pre> must be enabled
+    at install time in the <pre>install-config.yaml</pre> file. If
+    this rule fails on an installed cluster, then this is a permanent
+    finding and cannot be fixed.
+{{% elif product == "rhel10" %}}
+    Add the <tt>fips=1</tt> option to the kernel command line during the system installation.
+    During the software selection stage, do not install any third-party software.
+    After the installation, the system starts in FIPS mode automatically.
+    <br />
+    After the system starts, check that FIPS mode is enabled:
+    <pre>cat /proc/sys/crypto/fips_enabled
+    1</pre>
+    <br />
+{{% else %}}
     To enable FIPS mode, run the following command:
     <pre>fips-mode-setup --enable</pre>
     <br />
@@ -15,19 +30,15 @@ description: |-
     <li>Setting the system crypto policy in <tt>/etc/crypto-policies/config</tt> to <tt>{{{ xccdf_value("var_system_crypto_policy") }}}</tt></li>
     <li>Loading the Dracut <tt>fips</tt> module</li>
     </ul>
+{{% endif %}}
 
-    <br />
+{{% if bootable_containers_supported == "true" %}}
+    <br /><br />
     To enable FIPS mode at bootable container build time configure <tt>fips=1</tt> kernel argument
     in <tt>/usr/lib/bootc/kargs.d/01-fips.toml</tt>:
     <pre>kargs = ["fips=1"]</pre>
     Then set the cryptographic policy to <tt>{{{ xccdf_value("var_system_crypto_policy") }}}</tt>:
     <pre>update-crypto-policies --no-reload --set {{{ xccdf_value("var_system_crypto_policy") }}}</pre>
-{{% else %}}
-    OpenShift has an installation-time flag that can enable FIPS mode
-    for the cluster. The flag <pre>fips: true</pre> must be enabled
-    at install time in the <pre>install-config.yaml</pre> file. If
-    this rule fails on an installed cluster, then this is a permanent
-    finding and cannot be fixed.
 {{% endif %}}
 
 rationale: |-
@@ -58,17 +69,28 @@ ocil_clause: 'FIPS mode is not enabled'
 
 ocil: |-
     To verify that FIPS mode is enabled properly, run the following command:
+{{% if product == "rhel10" %}}
+    <pre>cat /proc/sys/crypto/fips_enabled</pre>
+    The output should contain the following:
+    <pre>1</pre>
+{{% else %}}
     <pre>fips-mode-setup --check</pre>
     The output should contain the following:
     <pre>FIPS mode is enabled.</pre>
+{{% endif %}}
     To verify that the cryptographic policy has been configured correctly, run the
     following command:
     <pre>$ update-crypto-policies --show</pre>
     The output should return <pre>{{{ xccdf_value("var_system_crypto_policy") }}}</pre>.
 
 warnings:
+{{% if product == "rhel10" %}}
+    - general: |-
+        Only enabling FIPS mode during the RHEL installation ensures that the system generates all keys with FIPS-approved algorithms and continuous monitoring tests in place.
+{{% else %}}
     - general: |-
         The system needs to be rebooted for these changes to take effect.
+{{% endif %}}
     - regulatory: |-
         This rule DOES NOT CHECK if the components of the operating system are FIPS certified.
         You can find the list of FIPS certified modules at {{{ weblink(link="https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search") }}}.
@@ -76,17 +98,21 @@ warnings:
 
 fixtext: |-
     Configure {{{ full_name }}} to run in FIPS mode.
-
+{{% if product == "rhel10" %}}
+    Add the fips=1 option to the kernel command line during the system installation.
+{{% else %}}
     Run the following commands:
 
     $ sudo fips-mode-setup --enable
     $ sudo update-crypto-policies --set {{{ xccdf_value("var_system_crypto_policy") }}}
 
     The system needs to be rebooted for these changes to take effect.
-
+{{% endif %}}
+{{% if bootable_containers_supported == "true" %}}
     To enable FIPS mode at bootable container build time, add the following commands in Containerfile:
 
     RUN echo 'kargs = ["fips=1"]' > /usr/lib/bootc/kargs.d/01-fips.toml
     RUN update-crypto-policies --no-reload --set {{{ xccdf_value("var_system_crypto_policy") }}}
+{{% endif %}}
 
 srg_requirement: '{{{ full_name }}} must implement NIST FIPS-validated cryptography for the following: to provision digital signatures, to generate cryptographic hashes, and to protect data requiring data-at-rest protections in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, and standards.'


### PR DESCRIPTION
To enable FIPS mode in RHEL 10 you need to enable FIPS mode during system installation. The `fips-mode-setup` tool doesn't exist in RHEL 10.
We will remove all occurences of `fips-mode-setup`. We will update the prose accordingly.

See:

- https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10-beta/html/security_hardening/switching-rhel-to-fips-mode#installing-the-system-with-fips-mode-enabled
- https://issues.redhat.com/browse/RHEL-65652



#### Review Hints:

Originally, I proposed this verification approach:

```
./autocontest.sh test -t '/hardening/kickstart/stig' -h HOSTNAME
```

But, the problem is that the test will fail because the produced virtual machine isn't in FIPS mode. I tried to add a kickstart remediation with `bootloader fips=1`. However, this doesn't work either, the produced VM won't boot. The reason is that the `fips=1` argument can't be in the kickstart but needs to be an argument of `virt-install`.