### PR TITLE
Fix path to timesyncd.conf for sle15

### DIFF
--- a/linux_os/guide/services/ntp/service_timesyncd_root_distance_configured/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/service_timesyncd_root_distance_configured/ansible/shared.yml
@@ -6,7 +6,11 @@
 
 - name: {{{ rule_title }}} - Add missing / update wrong records for root distance
   ansible.builtin.lineinfile:
+{{% if "sle15" in product %}}
+    path: /usr/lib/systemd/timesyncd.conf.d/oscap-remedy.conf
+{{% else %}}
     path: /etc/systemd/timesyncd.d/oscap-remedy.conf
+{{% endif %}}
     regexp: '^\s*RootDistanceMax\s*='
     state: present
     line: 'RootDistanceMax=1'

--- a/linux_os/guide/services/ntp/service_timesyncd_root_distance_configured/bash/shared.sh
+++ b/linux_os/guide/services/ntp/service_timesyncd_root_distance_configured/bash/shared.sh
@@ -4,8 +4,13 @@
 # complexity = low
 # disruption = low
 
+{{% if "sle15" in product %}}
+config_file="/usr/lib/systemd/timesyncd.conf.d/oscap-remedy.conf"
+IFS=" " mapfile -t current_cfg_arr < <(ls -1 /usr/lib/systemd/timesyncd.conf.d/* 2>/dev/null)
+{{% else %}}
 config_file="/etc/systemd/timesyncd.d/oscap-remedy.conf"
 IFS=" " mapfile -t current_cfg_arr < <(ls -1 /etc/systemd/timesyncd.d/* 2>/dev/null)
+{{% endif %}}
 current_cfg_arr+=( "/etc/systemd/timesyncd.conf" )
 # Comment existing NTP RootDistanceMax settings
 if [ ${#current_cfg_arr[@]} -ne 0 ]; then

--- a/linux_os/guide/services/ntp/service_timesyncd_root_distance_configured/oval/shared.xml
+++ b/linux_os/guide/services/ntp/service_timesyncd_root_distance_configured/oval/shared.xml
@@ -9,7 +9,11 @@
 
   <ind:textfilecontent54_object comment="Ensure NTP server distance is set"
     id="{{{ rule_id }}}_object_systemd_timesyncd_dropin_distance_configuration" version="1">
+    {{% if "sle15" in product %}}
+    <ind:path>/usr/lib/systemd/timesyncd.conf.d/</ind:path>
+    {{% else %}}
     <ind:path>/etc/systemd/timesyncd.d</ind:path>
+    {{% endif %}}
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
     <ind:pattern operation="pattern match">^\s*RootDistanceMax=\d+</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>


### PR DESCRIPTION
#### Description:

- SUSE's SLE15 system  configuration for timesyncd is in /usr/lib instead of /etc

#### Rationale:

- add sle15 specific paths to use in oval/bash and ansible code

