### PR TITLE
Remove Python 2 support from the build system

### DIFF
--- a/docs/manual/developer/04_style_guide.md
+++ b/docs/manual/developer/04_style_guide.md
@@ -176,6 +176,7 @@ and keep these guidelines in mind when writing new code.
 * Methods should be defined before they are called
 * Shall use the `.py` for the file extension
 * Shall use 4-space indentation
+* Shall support Python 3.6 and later
 * New methods and scripts should have type hints
 
 ### YAML

--- a/docs/manual/developer/04_style_guide.md
+++ b/docs/manual/developer/04_style_guide.md
@@ -174,11 +174,9 @@ and keep these guidelines in mind when writing new code.
     * We use [Code Climate](https://codeclimate.com/quality) to help automate the checking for PEP 8 issues.
     * We do make one change from PEP 8; our maximum line length is 99 characters
 * Methods should be defined before they are called
-* The files in the build system shall be Python 2.7 and Python 3 compatible
-* Utilities may only support Python 3
 * Shall use the `.py` for the file extension
 * Shall use 4-space indentation
-* New Python 3 methods and scripts should have type hints
+* New methods and scripts should have type hints
 
 ### YAML
 


### PR DESCRIPTION

#### Description:

Well, the project technically still does support Python 2, but we will not be making an effort to keep this up. Update the docs to reflect this.
 
#### Rationale:

See https://github.com/ComplianceAsCode/content/discussions/12046

