### PR TITLE
Add new variable to set_password_hashing_min_rounds_logindefs rule

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/bash/shared.sh
@@ -2,8 +2,22 @@
 
 {{{ bash_instantiate_variables("var_password_hashing_min_rounds_login_defs") }}}
 
-{{{ set_config_file(path="/etc/login.defs",
-                    parameter="SHA_CRYPT_MIN_ROUNDS",
+config_file="/etc/login.defs"
+current_min_rounds=$(grep -Po '^\s*SHA_CRYPT_MIN_ROUNDS\s+\K\d+' "$config_file")
+current_max_rounds=$(grep -Po '^\s*SHA_CRYPT_MAX_ROUNDS\s+\K\d+' "$config_file")
+
+if [[ -z "$current_min_rounds" || "$current_min_rounds" -le "$var_password_hashing_min_rounds_login_defs" ]]; then
+    {{{ set_config_file(path="/etc/login.defs",
+                parameter="SHA_CRYPT_MIN_ROUNDS",
+                value="$var_password_hashing_min_rounds_login_defs",
+                separator=" ",
+                separator_regex="\s*") | indent(4) }}}
+fi
+
+if [[ -n "$current_max_rounds" && "$current_max_rounds" -le "$var_password_hashing_min_rounds_login_defs" ]]; then
+    {{{ set_config_file(path="/etc/login.defs",
+                    parameter="SHA_CRYPT_MAX_ROUNDS",
                     value="$var_password_hashing_min_rounds_login_defs",
                     separator=" ",
-                    separator_regex="\s*") }}}
+                    separator_regex="\s*") | indent(4) }}}
+fi

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -127,6 +127,7 @@ selections:
 
     # OL08-00-010130
     - set_password_hashing_min_rounds_logindefs
+    - var_password_hashing_min_rounds_login_defs=100000
 
     # OL08-00-010140
     - grub2_uefi_password


### PR DESCRIPTION
#### Description:

- Add new variable to `set_password_hashing_min_rounds_logindefs` and update remediations, oval file, rule and policy files.
- Add two new test to check the new possible values of the variable
- Update oval file, ansible and bash remediation to support values large than the default
- Add the correct value to ol8 stig

#### Rationale:

Add variable to manage different values of `SHA_CRYPT_MIN_ROUNDS` and `SHA_CRYPT_MAX_ROUNDS` in `/etc/login.defs
`