### PR TITLE
Add ubuntu platform to grub2_bootloader_argument template

### DIFF
--- a/shared/templates/grub2_bootloader_argument/bash.template
+++ b/shared/templates/grub2_bootloader_argument/bash.template
@@ -1,4 +1,4 @@
-# platform = multi_platform_debian,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_rhv,multi_platform_sle,multi_platform_slmicro
+# platform = multi_platform_debian,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_rhv,multi_platform_sle,multi_platform_slmicro,multi_platform_ubuntu
 {{#
    See the OVAL template for more comments.
    Product-specific categorization should be synced across all template content types


### PR DESCRIPTION
#### Description:

- Add Ubuntu platform to grub2_bootloader_argument bash remediation

#### Rationale:

- Ubuntu was chomped from the platforms list in a previous commit

#### Tests:
Automatus tests in podman will fail because there's no grub. 
Results from local KVM on Ubuntu 24.04:
```
INFO - xccdf_org.ssgproject.content_rule_grub2_audit_argument
INFO - Script correct_value_remediated.pass.sh using profile (all) OK
INFO - Script correct_recovery_disabled.pass.sh using profile (all) OK
INFO - Script correct_value_etcdefault_dir.pass.sh using profile (all) OK
INFO - Script arg_not_in_etcdefaultgrub.fail.sh using profile (all) OK
INFO - Script correct_value_noupdate.fail.sh using profile (all) OK
INFO - Script wrong_value_etcdefault.fail.sh using profile (all) OK
INFO - Script wrong_value_etcdefaultgrub_recovery_disabled.fail.sh using profile (all) OK
INFO - Script correct_value_etcdefault_dir_noupdate.fail.sh using profile (all) OK
INFO - Script arg_not_in_etcdefaultgrub_recovery_disabled.fail.sh using profile (all) OK
INFO - Script wrong_value_etcdefault_dir.fail.sh using profile (all) OK

INFO - xccdf_org.ssgproject.content_rule_grub2_audit_backlog_limit_argument
INFO - Script correct_value_remediated.pass.sh using profile (all) OK
INFO - Script correct_value_etcdefault_dir.pass.sh using profile (all) OK
INFO - Script arg_not_in_etcdefaultgrub.fail.sh using profile (all) OK
INFO - Script arg_not_in_etcdefaultgrub_recovery_disabled.fail.sh using profile (all) OK
INFO - Script wrong_value_etcdefault_dir.fail.sh using profile (all) OK
INFO - Script correct_recovery_disabled.pass.sh using profile (all) OK
INFO - Script wrong_value_etcdefaultgrub_recovery_disabled.fail.sh using profile (all) OK
INFO - Script correct_value_noupdate.fail.sh using profile (all) OK
INFO - Script correct_value_etcdefault_dir_noupdate.fail.sh using profile (all) OK
INFO - Script wrong_value_etcdefault.fail.sh using profile (all) OK
```