### PR TITLE
Add ubuntu platforms to auditd_data_disk_error_action remediation

### DIFF
--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/bash/shared.sh
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,multi_platform_ubuntu
 
 {{{ bash_instantiate_variables("var_auditd_disk_error_action") }}}
 


### PR DESCRIPTION
#### Description:

- Add ubuntu platforms to auditd_data_disk_error_action remediation

#### Tests:

Ubuntu 24.04.1 Desktop in KVM:
```
INFO - xccdf_org.ssgproject.content_rule_auditd_data_disk_error_action
INFO - Script wrong_value.fail.sh using profile (all) OK
INFO - Script correct_and_wrong_value_multiple_possible.fail.sh using profile (all) OK
INFO - Script correct_and_wrong_value_one_possible.fail.sh using profile (all) OK
INFO - Script correct_value_multiple_possible.pass.sh using profile (all) OK
INFO - Script no_value.fail.sh using profile (all) OK
INFO - Script correct_value_one_possible.pass.sh using profile (all) OK
```