### PR TITLE
Umask interactive users limit depth

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/oval/shared.xml
@@ -19,6 +19,7 @@
   <!-- #### creation of object #### -->
   <ind:textfilecontent54_object id="object_accounts_umask_interactive_users"
                                 comment="Umask value from initialization files" version="1">
+    <ind:behaviors max_depth="0" recurse_direction="down" />
     <ind:path var_ref="var_accounts_umask_interactive_users_dirs" var_check="at least one"/>
     <ind:filename operation="pattern match">^\..*</ind:filename>
     <ind:pattern operation="pattern match">^[\s]*umask\s*</ind:pattern>

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/policy/stig/shared.yml
@@ -13,10 +13,10 @@ checktext: |-
 
     Note: The example is for a system that is configured to create users home directories in the "/home" directory.
 
-    $ sudo grep -ir umask /home
+    $ sudo find /home -maxdepth 2 -type f -name ".[^.]*" -exec grep -iH -d skip --exclude=.bash_history umask {} \;
 
-    /home/smithj/.bash_history:grep -i umask /etc/bashrc /etc/csh.cshrc /etc/profile
-    /home/smithj/.bash_history:grep -i umask /etc/login.defs
+    /home/wadea/.bash_history:grep -i umask /etc/bashrc /etc/csh.cshrc /etc/profile
+    /home/wadea/.bash_history:grep -i umask /etc/login.defs
 
     If any local interactive user initialization files are found to have a umask statement that sets a value less restrictive than "077", this is a finding.
 

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/rule.yml
@@ -40,10 +40,10 @@ ocil: |-
 
     Note: The example is for a system that is configured to create users home directories in the "/home" directory.
 
-    # grep -ri umask /home/
+    $ sudo find /home -maxdepth 2 -type f -name ".[^.]*" -exec grep -iH -d skip --exclude=.bash_history umask {} \;
 
-    /home/smithj/.bash_history:grep -i umask /etc/bashrc /etc/csh.cshrc /etc/profile
-    /home/smithj/.bash_history:grep -i umask /etc/login.defs
+    /home/wadea/.bash_history:grep -i umask /etc/bashrc /etc/csh.cshrc /etc/profile
+    /home/wadea/.bash_history:grep -i umask /etc/login.defs
 
 fixtext: |-
     Remove the umask statement from all local interactive user's initialization files.

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/tests/deeper_than_two_levels_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/tests/deeper_than_two_levels_ignored.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m $USER
+mkdir -p /home/"${USER}"/folder
+echo "umask 022" > /home/"${USER}"/folder/.bashrc


### PR DESCRIPTION
#### Description:

- Umask interactive users limit depth

#### Rationale:

- Update with regards to new RHEL9 STIG