### PR TITLE
add rule fapolicy_default_deny to rhel9 stig

### DIFF
--- a/controls/stig_rhel9.yml
+++ b/controls/stig_rhel9.yml
@@ -2714,6 +2714,14 @@ controls:
             - service_fapolicyd_enabled
         status: automated
 
+    -   id: RHEL-09-433016
+        levels:
+            - medium
+        title: The RHEL 9 fapolicy module must be configured to employ a deny-all, permit-by-exception policy to allow the execution of authorized software programs.
+        rules:
+            - fapolicy_default_deny
+        status: automated
+
     -   id: RHEL-09-611010
         levels:
             - medium

--- a/tests/data/profile_stability/rhel9/stig.profile
+++ b/tests/data/profile_stability/rhel9/stig.profile
@@ -226,6 +226,7 @@ selections:
 - ensure_gpgcheck_local_packages
 - ensure_gpgcheck_never_disabled
 - ensure_redhat_gpgkey_installed
+- fapolicy_default_deny
 - file_audit_tools_group_ownership
 - file_audit_tools_ownership
 - file_audit_tools_permissions

--- a/tests/data/profile_stability/rhel9/stig_gui.profile
+++ b/tests/data/profile_stability/rhel9/stig_gui.profile
@@ -238,6 +238,7 @@ selections:
 - ensure_gpgcheck_local_packages
 - ensure_gpgcheck_never_disabled
 - ensure_redhat_gpgkey_installed
+- fapolicy_default_deny
 - file_audit_tools_group_ownership
 - file_audit_tools_ownership
 - file_audit_tools_permissions


### PR DESCRIPTION
#### Description:

- add rule fapolicy_default_deny to rhel9 stig

#### Rationale:

- Rule is now part of the RHEL9 STIG