### PR TITLE
Remove xwindows_remove_packages from RHEL 10

### DIFF
--- a/controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml
+++ b/controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml
@@ -240,7 +240,6 @@ controls:
             - display_login_attempts
             - installed_OS_is_vendor_supported
             - selinux_all_devicefiles_labeled
-            - xwindows_remove_packages
             - chrony_set_nts
             - tftp_uses_secure_mode_systemd
         status: automated


### PR DESCRIPTION


#### Description:

Remove rule `xwindows_remove_packages` from RHEL 10.

#### Rationale:
Getting ready for RHEL 10.