### PR TITLE
Add missing rule to Ubuntu 24.04 CIS control 2.4.1.8

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -1009,6 +1009,7 @@ controls:
       - l1_server
       - l1_workstation
     rules:
+      - file_cron_allow_exists
       - file_groupowner_crontab
       - file_owner_crontab
       - file_permissions_crontab


### PR DESCRIPTION
#### Description:

- Add missing rule `file_cron_allow_exists` to Ubuntu 24.04 CIS control 2.4.1.8