### PR TITLE
Add missing rule to Ubuntu 24.04 CIS control 6.2.4.5

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2794,6 +2794,7 @@ controls:
       - l2_workstation
     rules:
       - file_permissions_etc_audit_auditd
+      - file_permissions_etc_audit_rules
       - file_permissions_etc_audit_rulesd
     status: automated
 


### PR DESCRIPTION
#### Description:

- Add missing rule to Ubuntu 24.04 CIS control 6.2.4.5