### PR TITLE
 Disable bootc applicability checks on Ubuntu

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/rule.yml
@@ -50,7 +50,11 @@ fixtext: '{{{ fixtext_file_group_owner(grub2_boot_path ~ "/grub.cfg", "root") }}
 
 srg_requirement: '{{{ srg_requirement_file_group_owner(grub2_boot_path ~ "/grub.cfg", "root") }}}'
 
+{{% if 'ubuntu' in product %}}
+platform: not container
+{{% else %}}
 platform: not bootc
+{{% endif %}}
 
 template:
     name: file_groupowner

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/rule.yml
@@ -46,7 +46,11 @@ ocil_clause: '{{{ ocil_clause_file_owner(file=grub2_boot_path ~ "/grub.cfg", own
 ocil: |-
     {{{ ocil_file_owner(file=grub2_boot_path ~ "/grub.cfg", owner="root") }}}
 
+{{% if 'ubuntu' in product %}}
+platform: not container
+{{% else %}}
 platform: not bootc
+{{% endif %}}
 
 template:
     name: file_owner

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_grub2_cfg/rule.yml
@@ -46,7 +46,11 @@ ocil: |-
     If properly configured, the output should indicate the following
     permissions: <tt>-rw-------</tt>
 
+{{% if 'ubuntu' in product %}}
+platform: not container
+{{% else %}}
 platform: not bootc
+{{% endif %}}
 
 template:
     name: file_permissions

--- a/linux_os/guide/system/permissions/partitions/group.yml
+++ b/linux_os/guide/system/permissions/partitions/group.yml
@@ -8,4 +8,8 @@ description: |-
     are set in the <tt>/etc/fstab</tt> configuration file, and can be
     used to make certain types of malicious behavior more difficult.
 
+{{% if 'ubuntu' in product %}}
+platform: not container
+{{% else %}}
 platform: not container and not bootc
+{{% endif %}}

--- a/linux_os/guide/system/software/disk_partitioning/group.yml
+++ b/linux_os/guide/system/software/disk_partitioning/group.yml
@@ -26,4 +26,8 @@ description: |-
     modify it to create separate logical volumes for the directories
     listed above. The Logical Volume Manager (LVM) makes this possible.
 
+{{% if 'ubuntu' in product %}}
+platform: not container
+{{% else %}}
 platform: not container and not bootc
+{{% endif %}}


### PR DESCRIPTION
#### Description:

- Disable bootc applicability checks on Ubuntu

#### Rationale:

- The bootc applicability checks break several rules on Ubuntu since they are rpm based and since bootc is not available on Ubuntu at the moment.