### PR TITLE
OCPBUGS-52287: Add PAM rules to default RHCOS profiles

### DIFF
--- a/products/rhcos4/profiles/default.profile
+++ b/products/rhcos4/profiles/default.profile
@@ -281,3 +281,5 @@ selections:
     - enable_dracut_fips_module
     - audit_delete_success
     - mount_option_var_log_nodev
+    - use_pam_wheel_group_for_su
+    - ensure_pam_wheel_group_empty


### PR DESCRIPTION
These rules are used in CIS linux benchmarks, and make sense to apply to
OpenShift environments. Since there isn't a CIS benchmark for RHCOS,
we'll just have to add them to the default profile so they're available
for users to enable with a TailoredProfile.
