### PR TITLE
Fix RHEL 10 DISA and SRG References 

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pkexec/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pkexec/rule.yml
@@ -38,7 +38,8 @@ identifiers:
     cce@rhel10: CCE-89134-1
 
 references:
-    srg: SRG-APP-000029-CTR-000085
+    disa: CCI-000130
+    srg: SRG-APP-000029-CTR-000085,SRG-OS-000037-GPOS-00015
 
 {{{ ocil_fix_srg_privileged_command("pkexec") }}}
 

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_permissions_cron_allow/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_permissions_cron_allow/rule.yml
@@ -35,6 +35,7 @@ references:
     cis@sle15: 5.1.8
     cis@ubuntu2004: 5.1.8
     cis@ubuntu2204: 5.1.8
+    disa: CCI-000366
     srg: SRG-OS-000480-GPOS-00227
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/cron.allow", perms=target_perms) }}}'

--- a/linux_os/guide/services/ntp/chrony_set_nts/rule.yml
+++ b/linux_os/guide/services/ntp/chrony_set_nts/rule.yml
@@ -17,6 +17,11 @@ rationale: |-
 identifiers:
     cce@rhel10: CCE-86471-0
 
+references:
+    disa: CCI-000366
+    srg: SRG-OS-000480-GPOS-00227
+
+
 severity: medium
 
 platforms:

--- a/linux_os/guide/services/obsolete/tftp/package_tftp_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/tftp/package_tftp_removed/rule.yml
@@ -23,6 +23,11 @@ identifiers:
     cce@sle12: CCE-91465-5
     cce@sle15: CCE-91158-6
 
+references:
+    disa: CCI-000197
+    srg: SRG-OS-000074-GPOS-00042
+
+
 ocil: '{{{ describe_package_remove(package="tftp") }}}'
 
 template:

--- a/linux_os/guide/services/obsolete/tftp/tftp_uses_secure_mode_systemd/rule.yml
+++ b/linux_os/guide/services/obsolete/tftp/tftp_uses_secure_mode_systemd/rule.yml
@@ -39,6 +39,9 @@ warnings:
         An OVAL check is not currently available since <tt>ExecStart</tt> cannot be checked with OVAL since it is not exposed via dbus.
         Currently, a remedation is not available for this rule.
 
-
 identifiers:
     cce@rhel10: CCE-86495-9
+
+references:
+    disa: CCI-000197
+    srg: SRG-OS-000074-GPOS-00042

--- a/linux_os/guide/system/software/gnome/package_gdm_removed/rule.yml
+++ b/linux_os/guide/system/software/gnome/package_gdm_removed/rule.yml
@@ -37,6 +37,7 @@ references:
     cis@sle15: '1.10'
     cis@ubuntu2004: '1.10'
     cis@ubuntu2204: 1.8.1
+    disa: CCI-000366
     nist: CM-7(a),CM-7(b),CM-6(a)
     srg: SRG-OS-000480-GPOS-00227
 


### PR DESCRIPTION
#### Description:

Add CCI and disa references to files that are missing them.

#### Rationale:

Keep content up-to-date.