### PR TITLE
RHEL8 STIG: update SSH algorithms

### DIFF
--- a/linux_os/guide/services/ssh/sshd_approved_ciphers.var
+++ b/linux_os/guide/services/ssh/sshd_approved_ciphers.var
@@ -12,7 +12,7 @@ interactive: false
 
 options:
     stig: aes256-ctr,aes192-ctr,aes128-ctr
-    stig_extended: aes256-ctr,aes192-ctr,aes128-ctr,aes256-gcm@openssh.com,aes128-gcm@openssh.com
+    stig_extended: aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes128-ctr
     stig_rhel9: aes256-gcm@openssh.com,aes256-ctr,aes128-gcm@openssh.com,aes128-ctr
     default: aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc,rijndael-cbc@lysator.liu.se
     cis_rhel8: -3des-cbc,aes128-cbc,aes192-cbc,aes256-cbc,rijndael-cbc@lysator.liu.se

--- a/linux_os/guide/services/ssh/sshd_approved_macs.var
+++ b/linux_os/guide/services/ssh/sshd_approved_macs.var
@@ -12,7 +12,7 @@ interactive: false
 
 options:
     stig: hmac-sha2-512,hmac-sha2-256
-    stig_extended: hmac-sha2-512,hmac-sha2-256,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com
+    stig_extended: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
     default: hmac-sha2-512,hmac-sha2-256,hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com
     cis_sle12: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
     cis_sle15: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -203,11 +203,9 @@ selections:
     - configure_ssh_crypto_policy
 
     # RHEL-08-010290
-    - harden_sshd_macs_openssh_conf_crypto_policy
     - harden_sshd_macs_opensshserver_conf_crypto_policy
 
     # RHEL-08-010291
-    - harden_sshd_ciphers_openssh_conf_crypto_policy
     - harden_sshd_ciphers_opensshserver_conf_crypto_policy
 
     # RHEL-08-010292

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -250,9 +250,7 @@ selections:
 - grub2_uefi_admin_username
 - grub2_uefi_password
 - grub2_vsyscall_argument
-- harden_sshd_ciphers_openssh_conf_crypto_policy
 - harden_sshd_ciphers_opensshserver_conf_crypto_policy
-- harden_sshd_macs_openssh_conf_crypto_policy
 - harden_sshd_macs_opensshserver_conf_crypto_policy
 - install_smartcard_packages
 - installed_OS_is_vendor_supported

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -261,9 +261,7 @@ selections:
 - grub2_uefi_admin_username
 - grub2_uefi_password
 - grub2_vsyscall_argument
-- harden_sshd_ciphers_openssh_conf_crypto_policy
 - harden_sshd_ciphers_opensshserver_conf_crypto_policy
-- harden_sshd_macs_openssh_conf_crypto_policy
 - harden_sshd_macs_opensshserver_conf_crypto_policy
 - install_smartcard_packages
 - installed_OS_is_vendor_supported


### PR DESCRIPTION
#### Description:

- update XCCDF variable according to latest STIG
- remove no longer used rules, reacting to changes in the latest STIG checks

#### Rationale:

- alignment with the latest RHEL 8 STIG
