### PR TITLE
Add file_permissions_etc_audit_rulesd to RHEL 9 default profile

### DIFF
--- a/products/rhel9/profiles/default.profile
+++ b/products/rhel9/profiles/default.profile
@@ -571,3 +571,4 @@ selections:
     - set_password_hashing_min_rounds_logindefs
     - sshd_use_priv_separation
     - tftpd_uses_secure_mode
+    - file_permissions_etc_audit_rulesd


### PR DESCRIPTION
https://github.com/ComplianceAsCode/content/pull/12922 removed the rule from STIG and as it was not in any other profile it disappeared from the RHEL 9 data stream.