### PR TITLE
Change authselect base profile for custom profiles

### DIFF
--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1699,7 +1699,15 @@ Part of the grub2_bootloader_argument_absent template.
     cmd: authselect create-profile hardening -b {{ authselect_current_profile }}
   when:
     - result_authselect_check_cmd is success
-    - authselect_current_profile is not match("custom/")
+    - authselect_current_profile is not match("^(custom/|local)")
+    - not result_authselect_custom_profile_present.stat.exists
+
+- name: '{{{ rule_title }}} - Create an authselect custom profile based on sssd profile'
+  ansible.builtin.command:
+    cmd: authselect create-profile hardening -b sssd
+  when:
+    - result_authselect_check_cmd is success
+    - authselect_current_profile is match("local")
     - not result_authselect_custom_profile_present.stat.exists
 
 {{{ ansible_apply_authselect_changes('before-hardening-custom-profile') }}}

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -2421,6 +2421,11 @@ CURRENT_PROFILE=$(authselect current -r | awk '{ print $1 }')
 # If not already in use, a custom profile is created preserving the enabled features.
 if [[ ! $CURRENT_PROFILE == custom/* ]]; then
     ENABLED_FEATURES=$(authselect current | tail -n+3 | awk '{ print $2 }')
+    # The "local" profile does not contain essential security features required by multiple Benchmarks.
+    # If currently used, it is replaced by "sssd", which is the best option in this case.
+    if [[ $CURRENT_PROFILE == local ]]; then
+        CURRENT_PROFILE="sssd"
+    fi
     authselect create-profile hardening -b $CURRENT_PROFILE
     CURRENT_PROFILE="custom/hardening"
     {{{ bash_apply_authselect_changes('before-hardening-custom-profile') | indent(4) }}}


### PR DESCRIPTION
#### Description:

In more recent versions of `authselect` the `local` profile was introduced to replace the minimal profile and it is the default `authselect` profile for some products.
However the `local` profile does not include all features required by Benchmarks.
This PR ensures the `sssd` profile is used as reference to create custom profiles only in cases `local` profile is currently selected.

#### Rationale:

- Fixes #12907

#### Review Hints:

Automatus can be used to tests the `sssd_enable_smartcards` rule in a RHEL 10 before and after this PR.