### PR TITLE
[Ubuntu2404] Only enforce valid profile to avoid apparmor issue

### DIFF
--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/bash/shared.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/bash/shared.sh
@@ -5,7 +5,12 @@
 
 # Ensure all AppArmor Profiles are enforcing
 apparmor_parser -q -r /etc/apparmor.d/
+{{% if 'ubuntu' in product %}}
+# Current version of apparmor-utils has issue https://gitlab.com/apparmor/apparmor/-/issues/411 and we're waiting for https://gitlab.com/apparmor/apparmor/-/merge_requests/1218 to be landed on noble
+find /etc/apparmor.d -maxdepth 1 ! -type d -exec aa-enforce "{}" \;
+{{% else %}}
 aa-enforce /etc/apparmor.d/*
+{{% endif %}}
 
 {{% if 'ubuntu' in product %}}
 UNCONFINED=$(aa-status | grep "processes are unconfined" | awk '{print $1;}')

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/correct_apparmor_profiles_enforced.pass.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/correct_apparmor_profiles_enforced.pass.sh
@@ -4,7 +4,11 @@
 #Replace apparmor definitions
 apparmor_parser -q -r /etc/apparmor.d/
 #Set all profiles in enforce mode
+{{% if 'ubuntu' in product %}}
+find /etc/apparmor.d -maxdepth 1 ! -type d -exec aa-enforce "{}" \;
+{{% else %}}
 aa-enforce /etc/apparmor.d/*
+{{% endif %}}
 
 # rsyslogd apparmor profile is disabled in focal and jammy.
 # Reloading the profile results in an unconfined process

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/incorrect_apparmor_profiles_enforced.fail.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/tests/incorrect_apparmor_profiles_enforced.fail.sh
@@ -4,8 +4,11 @@
 #Replace apparmor definitions and force profiles into compliant mode
 apparmor_parser -q -r  /etc/apparmor.d/ 
 #Set all profiles in complain mode
+{{% if 'ubuntu' in product %}}
+find /etc/apparmor.d -maxdepth 1 ! -type d -exec aa-complain "{}" \;
+{{% else %}}
 aa-complain /etc/apparmor.d/*
-
+{{% endif %}}
 # rsyslogd apparmor profile is disabled in focal and jammy.
 # Reloading the profile results in an unconfined process
 # which fails the SCE, so we need to restart the process manually.


### PR DESCRIPTION
#### Description:

- Only enforce valid profile file instead of recursive enforce

#### Rationale:

- Current version of noble apparmor-utils has [issue](https://gitlab.com/apparmor/apparmor/-/issues/387), although it's been [fixed](https://gitlab.com/apparmor/apparmor/-/merge_requests/1218), this patch hasn't landed in noble yet. We need to find all the profiles then we can enforce to mitigate this issue
