### PR TITLE
Change authselect base profile for custom profiles and Updates for RHEL 10

### DIFF
--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/oval/shared.xml
@@ -8,6 +8,8 @@
       {{% if product in ["fedora", "ol8", "ol9"] or 'rhel' in product %}}
       <criterion comment="Check allow_missing_name in /etc/pam.d/smartcard-auth"
                  test_ref="test_sssd_enable_smartcards_allow_missing_name_smartcard_auth"/>
+      {{% endif %}}
+      {{% if product in ["ol8", "ol9", "rhel8", "rhel9"] %}}
       <criterion comment="Check try_cert_auth or require_cert_auth in /etc/pam.d/system-auth"
                  test_ref="test_sssd_enable_smartcards_cert_auth_system_auth"/>
       {{% endif %}}
@@ -38,18 +40,23 @@
     <ind:state state_ref="state_sssd_enable_smartcards_allow_missing_name" />
   </ind:textfilecontent54_test>
 
+  <ind:textfilecontent54_object id="obj_sssd_enable_smartcards_smartcard_auth_options" version="2">
+    <ind:filepath>/etc/pam.d/smartcard-auth</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*auth.*?pam_sss\.so(.*)</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_sssd_enable_smartcards_allow_missing_name" version="1">
+    <ind:subexpression operation="pattern match">^.*allow_missing_name.*$</ind:subexpression>
+  </ind:textfilecontent54_state>
+  {{% endif %}}
+  {{% if product in ["ol8", "ol9", "rhel8", "rhel9"] %}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
   comment="tests the presence of try_cert_auth or require_cert_auth in /etc/pam.d/system-auth"
   id="test_sssd_enable_smartcards_cert_auth_system_auth" version="2">
     <ind:object object_ref="obj_sssd_enable_smartcards_system_auth_options" />
     <ind:state state_ref="state_sssd_enable_smartcards_cert_auth" />
   </ind:textfilecontent54_test>
-
-  <ind:textfilecontent54_object id="obj_sssd_enable_smartcards_smartcard_auth_options" version="2">
-    <ind:filepath>/etc/pam.d/smartcard-auth</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*auth.*?pam_sss\.so(.*)</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_object id="obj_sssd_enable_smartcards_system_auth_options" version="2">
     <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
@@ -60,10 +67,6 @@
   <ind:textfilecontent54_state id="state_sssd_enable_smartcards_cert_auth" version="1">
     <ind:subexpression
     operation="pattern match">^.*(try_cert_auth|require_cert_auth).*$</ind:subexpression>
-  </ind:textfilecontent54_state>
-
-  <ind:textfilecontent54_state id="state_sssd_enable_smartcards_allow_missing_name" version="1">
-    <ind:subexpression operation="pattern match">^.*allow_missing_name.*$</ind:subexpression>
   </ind:textfilecontent54_state>
   {{% endif %}}
 

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1699,7 +1699,15 @@ Part of the grub2_bootloader_argument_absent template.
     cmd: authselect create-profile hardening -b {{ authselect_current_profile }}
   when:
     - result_authselect_check_cmd is success
-    - authselect_current_profile is not match("custom/")
+    - authselect_current_profile is not match("^(custom/|local)")
+    - not result_authselect_custom_profile_present.stat.exists
+
+- name: '{{{ rule_title }}} - Create an authselect custom profile based on sssd profile'
+  ansible.builtin.command:
+    cmd: authselect create-profile hardening -b sssd
+  when:
+    - result_authselect_check_cmd is success
+    - authselect_current_profile is match("local")
     - not result_authselect_custom_profile_present.stat.exists
 
 {{{ ansible_apply_authselect_changes('before-hardening-custom-profile') }}}

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -2426,6 +2426,11 @@ CURRENT_PROFILE=$(authselect current -r | awk '{ print $1 }')
 # If not already in use, a custom profile is created preserving the enabled features.
 if [[ ! $CURRENT_PROFILE == custom/* ]]; then
     ENABLED_FEATURES=$(authselect current | tail -n+3 | awk '{ print $2 }')
+    # The "local" profile does not contain essential security features required by multiple Benchmarks.
+    # If currently used, it is replaced by "sssd", which is the best option in this case.
+    if [[ $CURRENT_PROFILE == local ]]; then
+        CURRENT_PROFILE="sssd"
+    fi
     authselect create-profile hardening -b $CURRENT_PROFILE
     CURRENT_PROFILE="custom/hardening"
     {{{ bash_apply_authselect_changes('before-hardening-custom-profile') | indent(4) }}}


### PR DESCRIPTION
#### Description:

In more recent versions of `authselect` the `local` profile was introduced to replace the minimal profile and it is the default `authselect` profile for some products.
However the `local` profile does not include all features required by Benchmarks.
This PR ensures the `sssd` profile is used as reference to create custom profiles only in cases `local` profile is currently selected.

This PR also adjusts the logic for `sssd_enable_smartcards` so that it works on RHEL 10.
#### Rationale:

- Fixes #12907

#### Review Hints:

* Automatus can be used to tests the `sssd_enable_smartcards` rule in a RHEL 10 before and after this PR.
* Reviewing `/etc/pam.d/smartcard-auth` with the `with-smartcard` feature disabled on enabled on RHEL 10 Box with the sssd authselect profile.