### PR TITLE
Add package_ypbind_removed to e8 profile to OL8

### DIFF
--- a/products/ol8/profiles/e8.profile
+++ b/products/ol8/profiles/e8.profile
@@ -28,6 +28,7 @@ selections:
   - service_avahi-daemon_disabled
   - package_squid_removed
   - service_squid_disabled
+  - package_ypbind_removed
 
   ### Software update
   - ensure_oracle_gpgkey_installed


### PR DESCRIPTION
#### Description:

Add package_ypbind_removed to e8 profile to OL8

#### Rationale:

Enhance OL8 alignment with the e8 profile.