### PR TITLE
Rule: mount_option_boot_efi_nosuid, remove "uefi" platform

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/rule.yml
@@ -28,8 +28,6 @@ references:
     stigid@ol8: OL08-00-010572
     stigid@rhel8: RHEL-08-010572
 
-platform: uefi
-
 template:
     name: mount_option
     vars:


### PR DESCRIPTION
#### Description:

- We should not care if the system is UEFI or non-UEFI at the moment of check/remediation and fix the options if the entry is configured.

#### Rationale:

- The rule does not care about `/sys/firmware/efi`, so we should not use existence of this directory as a guardian.
- Moreover following the logic of `mount_option` template the rule will check and remediate options only if mount point is active/present in `/etc/fstab`. That's enough to not interfere with non-UEFI systems.

- Fixes #12510.

#### Review Hints:

- See logs of the system state inside `osbuild` env. in the linked issue.