### PR TITLE
Implement workaround for broken file-traversing rules on Ubuntu 24.04

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
@@ -1,3 +1,4 @@
+{{% if product not in ['ubuntu2404'] %}}
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("Audit rules about the information on the use of privileged commands are enabled.") }}}
@@ -310,3 +311,4 @@
     <ind:state state_ref="state_priv_cmds_from_auditctl_count_bootc" />
   </ind:variable_test>
 </def-group>
+{{% endif %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/sce/ubuntu.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/sce/ubuntu.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# platform = Ubuntu 24.04
+# check-import = stdout
+
+result=$XCCDF_RESULT_PASS
+
+# Get all rules matching regex for privileged commands
+# Check if using auditctl or augenrules
+regex='^[\s]*-a always,exit (?:-F path=([\S]+))+(?: -F perm=x)? -F auid>={{{ auid }}} -F auid!=(?:4294967295|unset|-1)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$'
+if grep -Pq '^ExecStartPost=\-\/sbin\/auditctl.*$' /usr/lib/systemd/system/auditd.service; then
+    priv_cmd_rules=$(grep -P -- "$regex" /etc/audit/audit.rules)
+else
+    priv_cmd_rules=$(grep -P -- "$regex" /etc/audit/rules.d/*.rules)
+fi
+
+# find all suid commands on device partitions
+filter_nodev=$(awk '/nodev/ { print $2 }' /proc/filesystems | paste -sd,)
+readarray -t partitions < <(findmnt -n -l -k -it "${filter_nodev}" | grep -Pv "noexec|nosuid|/proc($|/.*$)" | awk '{ print $1 }')
+for partition in "${partitions[@]}"; do
+    while IFS= read -r -d $'\0' priv_cmd; do
+        # fail if entry doesn't exist in auditd rules or has duplicates
+        nmatches=$(grep -Pc -- "-F path=${priv_cmd}\b" <<< "${priv_cmd_rules}")
+        if [[ "${nmatches}" -eq 0 ]]; then
+            echo "Entry for binary '${priv_cmd}' not found in auditd rules"
+            result=$XCCDF_RESULT_FAIL
+        elif [[ "${nmatches}" -gt 1 ]]; then
+            echo "Multiple entries for binary '${priv_cmd}' found in auditd rules"
+            result=$XCCDF_RESULT_FAIL
+        fi
+    done < <(find "${partition}" -xdev -type f -perm /6000 -print0)
+done
+
+exit $result

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_default.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_default.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # packages = audit
-# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8,multi_platform_ubuntu
 
 {{{ setup_auditctl_environment() }}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_missing_rule.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_missing_rule.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8,multi_platform_ubuntu
 
 {{{ setup_auditctl_environment() }}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_one_rule.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_one_rule.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8,multi_platform_ubuntu
 
 {{{ setup_auditctl_environment() }}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_rules_configured.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_rules_configured.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8,multi_platform_ubuntu
 
 {{{ setup_auditctl_environment() }}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_rules_without_perm_x.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_rules_without_perm_x.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8,multi_platform_ubuntu
 
 {{{ setup_auditctl_environment() }}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_default.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_default.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # packages = audit
-# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8,multi_platform_ubuntu
 
 # augenrules is default for rhel7

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_duplicated.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_duplicated.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = audit
 # remediation = none
-# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8,multi_platform_ubuntu
 
 ./generate_privileged_commands_rule.sh {{{ uid_min }}} privileged /tmp/privileged.rules
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_extra_rules_configured.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_extra_rules_configured.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8,multi_platform_ubuntu
 
 ./generate_privileged_commands_rule.sh {{{ uid_min }}} privileged /etc/audit/rules.d/privileged.rules
 echo "-a always,exit -F path=/usr/bin/notrelevant -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_missing_rule.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_missing_rule.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8,multi_platform_ubuntu
 
 ./generate_privileged_commands_rule.sh {{{ uid_min }}} privileged /etc/audit/rules.d/privileged.rules
  sed -i '/newgrp/d' /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_one_rule.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_one_rule.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # packages = audit
-# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8,multi_platform_ubuntu
 
 echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # packages = audit
-# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8,multi_platform_ubuntu
 
 ./generate_privileged_commands_rule.sh {{{ uid_min }}} privileged /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured_mixed_keys.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured_mixed_keys.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8,multi_platform_ubuntu
 
 ./generate_privileged_commands_rule.sh {{{ uid_min }}} privileged /etc/audit/rules.d/privileged.rules
 # change key of rules for binaries in /usr/sbin

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_multiple_partitions.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_multiple_partitions.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8,multi_platform_ubuntu
 
 . $SHARED/partition.sh
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_without_perm_x.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_without_perm_x.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8,multi_platform_ubuntu
 
 ./generate_privileged_commands_rule.sh {{{ uid_min }}} privileged /etc/audit/rules.d/privileged.rules
 sed -i -E 's/^(.*path=[[:graph:]]+) -F perm=x(.*$)/\1\2/' /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_mixed_keys.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_mixed_keys.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8,multi_platform_ubuntu
 
 echo "-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -k privileged" >> /etc/audit/rules.d/privileged.rules
 echo "-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_sep_files.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_sep_files.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8,multi_platform_ubuntu
 
 echo "-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/priv.rules
 echo "-a always,exit -F path=/usr/bin/notrelevant -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/priv.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rules_with_own_key.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rules_with_own_key.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # packages = audit
-# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8,multi_platform_ubuntu
 
 ./generate_privileged_commands_rule.sh {{{ uid_min }}} own_key /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/oval/shared.xml
@@ -1,3 +1,4 @@
+{{% if product not in ['ubuntu2404'] %}}
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("The world-write permission should be disabled for all files.") }}}
@@ -49,3 +50,4 @@
     <unix:object object_ref="object_file_permissions_unauthorized_world_write" />
   </unix:file_test>
 </def-group>
+{{% endif %}}

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/sce/ubuntu.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/sce/ubuntu.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# platform = Ubuntu 24.04
+# check-import = stdout
+
+filter_nodev=$(awk '/nodev/ { print $2 }' /proc/filesystems | paste -sd,)
+readarray -t partitions < <(findmnt -n -l -k -it "${filter_nodev}" | awk '{ print $1 }')
+
+# Ensure /tmp is also checked when tmpfs is used.
+if grep -Pq "^tmpfs\h+/tmp" /proc/mounts; then
+    partitions+=("/tmp")
+fi
+
+for partition in "${partitions[@]}"; do
+    files=$(find "${partition}" -xdev -type f -perm -002)
+    if [[ -n "${files}" ]]; then
+        echo -e "Found world-writable files:\n${files}"
+        exit "${XCCDF_RESULT_FAIL}"
+    fi
+done
+
+exit "${XCCDF_RESULT_PASS}"

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/tests/world_writable_tmp.fail.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/tests/world_writable_tmp.fail.sh
@@ -1,0 +1,10 @@
+# platform = multi_platform_ubuntu
+#!/bin/bash
+#
+
+find / -xdev -type f -perm -002 -exec chmod o-w {} \;
+
+mount tmpfs /tmp -t tmpfs
+
+touch /tmp/test
+chmod o+w /tmp/test

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/oval/shared.xml
@@ -1,3 +1,4 @@
+{{% if product not in ['ubuntu2404'] %}}
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="2">
     {{{ oval_metadata("All files should be owned by a group") }}}
@@ -106,3 +107,4 @@
     <unix:object object_ref="object_file_permissions_ungroupowned_with_usrlib"/>
   </unix:file_test>
 </def-group>
+{{% endif %}}

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/sce/ubuntu.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/sce/ubuntu.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# platform = Ubuntu 24.04
+# check-import = stdout
+
+filter_nodev=$(awk '/nodev/ { print $2 }' /proc/filesystems | paste -sd,)
+readarray -t partitions < <(findmnt -n -l -k -it "${filter_nodev}" | awk '{ print $1 }')
+
+# Ensure /tmp is also checked when tmpfs is used.
+if grep -Pq "^tmpfs\h+/tmp" /proc/mounts; then
+    partitions+=("/tmp")
+fi
+
+for partition in "${partitions[@]}"; do
+    files=$(find "${partition}" -xdev -type f -nogroup)
+    if [[ -n "${files}" ]]; then
+        echo -e "Found ungroupowned files:\n${files}"
+        exit "${XCCDF_RESULT_FAIL}"
+    fi
+done
+
+exit "${XCCDF_RESULT_PASS}"

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/tests/group_in_usr_lib.pass.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/tests/group_in_usr_lib.pass.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 #
+# remediation = none
+{{% if 'ubuntu' in product %}}
+# platform = Not Applicable
+{{% endif %}}
+
 UNOWNED_FILES=$(df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nogroup)
 
 IFS=$"\n"

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/tests/unowned_file_tmp.fail.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/tests/unowned_file_tmp.fail.sh
@@ -1,0 +1,9 @@
+# platform = multi_platform_ubuntu
+#!/bin/bash
+#
+# remediation = none
+
+mount tmpfs /tmp -t tmpfs
+
+touch /tmp/test
+chown 9999:9999 /tmp/test

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/tests/unowned_in_sysroot.pass.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/tests/unowned_in_sysroot.pass.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 #
 # remediation = none
+{{% if 'ubuntu' in product %}}
+# platform = Not Applicable
+{{% endif %}}
 
 UNOWNED_FILES=$(df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nogroup)
 

--- a/linux_os/guide/system/permissions/files/no_files_unowned_by_user/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/no_files_unowned_by_user/oval/shared.xml
@@ -1,3 +1,4 @@
+{{% if product not in ['ubuntu2404'] %}}
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("All files should be owned by a user") }}}
@@ -47,3 +48,4 @@
     <unix:object object_ref="object_no_files_unowned_by_user"/>
   </unix:file_test>
 </def-group>
+{{% endif %}}

--- a/linux_os/guide/system/permissions/files/no_files_unowned_by_user/sce/ubuntu.sh
+++ b/linux_os/guide/system/permissions/files/no_files_unowned_by_user/sce/ubuntu.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# platform = Ubuntu 24.04
+# check-import = stdout
+
+filter_nodev=$(awk '/nodev/ { print $2 }' /proc/filesystems | paste -sd,)
+readarray -t partitions < <(findmnt -n -l -k -it "${filter_nodev}" | awk '{ print $1 }')
+
+# Ensure /tmp is also checked when tmpfs is used.
+if grep -Pq "^tmpfs\h+/tmp" /proc/mounts; then
+    partitions+=("/tmp")
+fi
+
+for partition in "${partitions[@]}"; do
+    files=$(find "${partition}" -xdev -type f -nouser)
+    if [[ -n "${files}" ]]; then
+        echo -e "Found unowned files:\n${files}"
+        exit "${XCCDF_RESULT_FAIL}"
+    fi
+done
+
+exit "${XCCDF_RESULT_PASS}"

--- a/linux_os/guide/system/permissions/files/no_files_unowned_by_user/tests/unowned_file_tmp.fail.sh
+++ b/linux_os/guide/system/permissions/files/no_files_unowned_by_user/tests/unowned_file_tmp.fail.sh
@@ -1,0 +1,9 @@
+# platform = multi_platform_ubuntu
+#!/bin/bash
+#
+# remediation = none
+
+mount tmpfs /tmp -t tmpfs
+
+touch /tmp/test
+chown 9999:9999 /tmp/test


### PR DESCRIPTION
#### Description:

- Disable OVALs which produce false positives on Ubuntu 24.04:
  - file_permissions_unauthorized_world_writable
  - file_permissions_ungroupowned
  - no_files_unowned_by_user
  - audit_rules_privileged_commands 
- Implement SCE checks

#### Rationale:

- The partition probe has a bug on Ubuntu 24.04 (oscap 1.3.9) which results in the OVALs always returning true. See https://github.com/OpenSCAP/openscap/issues/2026 .
