### PR TITLE
Define var_user_initialization_files_regex on Ubuntu 24.04

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -3105,6 +3105,8 @@ controls:
       - no_netrc_files
       - accounts_user_dot_user_ownership
       - accounts_user_dot_group_ownership
+      - var_user_initialization_files_regex=all_dotfiles
       - file_permission_user_init_files
       - file_permission_user_bash_history
     status: automated
+


### PR DESCRIPTION
#### Description:

- Set var_user_initialization_files_regex on Ubuntu 24.04 to `all_dotfiles`
