### PR TITLE
Fix processing platform key in SCE

### DIFF
--- a/tests/unit/ssg-module/test_build_sce_data/selinux_state/sce/shared.sh
+++ b/tests/unit/ssg-module/test_build_sce_data/selinux_state/sce/shared.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # check-import = stdout
+# platform = Red Hat Enterprise Linux 9
 if [[ $(getenforce) == "Enforcing" ]] ; then
     exit "$XCCDF_RESULT_PASS"
 fi


### PR DESCRIPTION
During review of PR #12959 we discovered a bug that SCE checks don't propagate to the built SCAP data stream if the `platform` key in SCE header specifies platform using a full product name. We will fix this problem by reusing the function used for processing `platform` key in remediation files. That will ensure the behavior in SCE will be the same as in remediations. The unit test data will be extended so that the test would fail if this bug isn't fixed.

