### PR TITLE
Fix tests for root_path_no_dot on Ubuntu

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/tests/absolute_path.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/tests/absolute_path.fail.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 # remediation = none
 
+{{% if 'ubuntu' in product %}}
+echo 'export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:./:/root/bin"' >> /etc/environment
+{{% else %}}
 echo 'export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:./:/root/bin"' >> /etc/bashrc
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/tests/colon_on_path.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/tests/colon_on_path.fail.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 # remediation = none
 
+{{% if 'ubuntu' in product %}}
+echo 'export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:"' >> /etc/environment
+{{% else %}}
 echo 'export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:"' >> /etc/bashrc
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/tests/doublecolon_on_path.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/tests/doublecolon_on_path.fail.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 # remediation = none
 
+{{% if 'ubuntu' in product %}}
+echo 'export PATH="/usr/local/sbin::/usr/local/bin:/usr/sbin:/usr/bin:/root/bin"' >> /etc/environment
+{{% else %}}
 echo 'export PATH="/usr/local/sbin::/usr/local/bin:/usr/sbin:/usr/bin:/root/bin"' >> /etc/bashrc
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/tests/doubleperiod_on_path.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/tests/doubleperiod_on_path.fail.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 # remediation = none
 
+{{% if 'ubuntu' in product %}}
+echo 'export PATH="/usr/local/sbin:..:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin"' >> /etc/environment
+{{% else %}}
 echo 'export PATH="/usr/local/sbin:..:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin"' >> /etc/bashrc
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/tests/no_risky_path.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/tests/no_risky_path.pass.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 #
 
+{{% if 'ubuntu' in product %}}
+echo 'export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin"' >> /etc/environment
+{{% else %}}
 echo 'export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin"' >> /etc/bashrc
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/tests/period_on_path.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/tests/period_on_path.fail.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 # remediation = none
 
+{{% if 'ubuntu' in product %}}
+echo 'export PATH=".:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin"' >> /etc/environment
+{{% else %}}
 echo 'export PATH=".:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin"' >> /etc/bashrc
+{{% endif %}}


### PR DESCRIPTION
#### Description:

- Fix tests for root_path_no_dot on Ubuntu

#### Rationale:

- `/etc/bashrc` isn't used on Ubuntu
