### PR TITLE
CMP-3121: Build ocp4 content for arm64

### DIFF
--- a/.github/workflows/k8s-content-pr.yaml
+++ b/.github/workflows/k8s-content-pr.yaml
@@ -91,7 +91,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
-          platforms: 'linux/amd64,linux/ppc64le,linux/s390x'
+          platforms: 'linux/amd64,linux/ppc64le,linux/s390x,linux/arm64'
       - name: Get container info
         id: container_info
         run: |

--- a/Dockerfiles/ocp4_content
+++ b/Dockerfiles/ocp4_content
@@ -7,7 +7,7 @@ RUN microdnf -y install cmake make git /usr/bin/python3 python3-pyyaml python3-j
 COPY . .
 
 # Enable only certain profiles on ppc64le and s390x
-RUN if [ "$(uname -m)" == "x86_64" ]; then \
+RUN if [ "$(uname -m)" == "x86_64" ] || [ "$(uname -m)" == "arm64" ]; then \
     echo "Building OpenShift and RHCOS content for x86_64"; \
     else echo "Building OpenShift content for $(uname -m)" && \
         # Disable all profiles first
@@ -44,7 +44,7 @@ RUN if [ "$(uname -m)" == "x86_64" ]; then \
 # Build the OpenShift, EKS, and RHCOS content for x86 architectures. Only build
 # OpenShift content for ppc64le and s390x architectures since we're not
 # including any RHCOS profiles on those architectures right now anyway.
-RUN if [ "$(uname -m)" = "x86_64" ]; then \
+RUN if [ "$(uname -m)" = "x86_64" ] || [ "$(uname -m)" == "arm64" ]; then \
         ./build_product ocp4 rhcos4 eks --datastream-only; \
         elif [ "$(uname -m)" = "ppc64le" ]; then \
         ./build_product ocp4 rhcos4 --datastream-only; \


### PR DESCRIPTION
This makes it so the container image we use for testing is build for
arm64 architecture in addition to Power/Z/AMD64.

This will get used in CI testing the Compliance Operatoron ARM:

  https://github.com/openshift/release/pull/61066
