### PR TITLE
RHEL8: add back removed rules to keep datastream consistent

### DIFF
--- a/products/rhel8/profiles/default.profile
+++ b/products/rhel8/profiles/default.profile
@@ -716,3 +716,5 @@ selections:
     - configure_bashrc_tmux
     - configure_tmux_lock_keybinding
     - package_mcafeetp_installed
+    - harden_sshd_ciphers_openssh_conf_crypto_policy
+    - harden_sshd_macs_openssh_conf_crypto_policy


### PR DESCRIPTION
#### Description:

- add rules back to the datastream; they were removed in #12949 

#### Rationale:

- ensure that a rule once added to a datastream stays there for the given product


#### Review Hints:

- compare datastream before the above mentioned PR and now.