### PR TITLE
[Ubuntu2404] Template sysctl improvement 

### DIFF
--- a/shared/templates/sysctl/ansible.template
+++ b/shared/templates/sysctl/ansible.template
@@ -34,6 +34,14 @@
     replace: '#{{{ SYSCTLVAR }}}'
   loop: "{{ find_sysctl_d.files }}"
 
+{{% if product in [ "ubuntu2004", "ubuntu2204", "ubuntu2404"] %}}
+- name: Comment out any occurrences of {{{ SYSCTLVAR }}} from /etc/ufw/sysctl.conf
+  replace:
+    path: "/etc/ufw/sysctl.conf"
+    regexp: '(^[\s]*{{{ SYSCTLVAR }}}.*$)'
+    replace: '# \1'
+{{% endif %}}
+
 {{% if sysctl_remediate_drop_in_file == "true" %}}
 - name: Comment out any occurrences of {{{ SYSCTLVAR }}} from /etc/sysctl.conf
   replace:

--- a/shared/templates/sysctl/bash.template
+++ b/shared/templates/sysctl/bash.template
@@ -7,7 +7,9 @@
 # Comment out any occurrences of {{{ SYSCTLVAR }}} from /etc/sysctl.d/*.conf files
 {{% if product in [ "sle12", "sle15", "slmicro5"] %}}
 for f in /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf; do
-{{% elif product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel8", "rhel9", "rhel10", "ubuntu2004", "ubuntu2204", "ubuntu2404"] %}}
+{{% elif product in [ "ubuntu2004", "ubuntu2204", "ubuntu2404"] %}}
+for f in /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /etc/ufw/sysctl.conf; do
+{{% elif product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel8", "rhel9", "rhel10"] %}}
 for f in /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf; do
 {{% else %}}
 for f in /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf; do

--- a/shared/templates/sysctl/oval.template
+++ b/shared/templates/sysctl/oval.template
@@ -205,7 +205,7 @@
     </set>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_object id="object_static_sysctl_{{{ rule_id }}}" version="1">
-{{% if product in [ "ubuntu2004", "ubuntu2204", "ubuntu2404" ] %}}
+{{% if "ubuntu" in product %}}
     <ind:filepath operation="pattern match">/etc(/ufw){0,1}/sysctl.conf$</ind:filepath>
 {{% else %}}
     <ind:filepath>/etc/sysctl.conf</ind:filepath>

--- a/shared/templates/sysctl/oval.template
+++ b/shared/templates/sysctl/oval.template
@@ -205,7 +205,11 @@
     </set>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_object id="object_static_sysctl_{{{ rule_id }}}" version="1">
+{{% if product in [ "ubuntu2004", "ubuntu2204", "ubuntu2404" ] %}}
+    <ind:filepath operation="pattern match">/etc(/ufw){0,1}/sysctl.conf$</ind:filepath>
+{{% else %}}
     <ind:filepath>/etc/sysctl.conf</ind:filepath>
+{{% endif %}}
     {{{ sysctl_match() }}}
   </ind:textfilecontent54_object>
 

--- a/shared/templates/sysctl/sce-bash.template
+++ b/shared/templates/sysctl/sce-bash.template
@@ -11,6 +11,9 @@ FILES_NOT_MANAGED_BY_PACKAGES=("/etc/sysctl.conf" "/etc/sysctl.d/*.conf" "/usr/l
 FILES_NOT_MANAGED_BY_PACKAGES=("/etc/sysctl.conf" "/etc/sysctl.d/*.conf" "/lib/sysctl.d/*.conf" "/usr/local/lib/sysctl.d/*.conf" "/run/sysctl.d/*.conf")
 {{% endif %}}
 FILES_MANAGED_BY_PACKAGES=("/usr/lib/sysctl.d/*.conf")
+{{% if product in [ "ubuntu2004", "ubuntu2204", "ubuntu2404"] %}}
+FILES_NOT_MANAGED_BY_PACKAGES+=("/etc/ufw/sysctl.conf")
+{{% endif %}}
 
 function pass_if_set_correctly()
 {

--- a/shared/templates/sysctl/tests/comment.fail.sh
+++ b/shared/templates/sysctl/tests/comment.fail.sh
@@ -4,7 +4,11 @@
 {{% endif %}}
 
 # Clean sysctl config directories
+{{% if "ubuntu" in product %}}
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/* /etc/ufw/sysctl.conf
+{{% else %}}
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+{{% endif %}}
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "# {{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf

--- a/shared/templates/sysctl/tests/correct_etc_ufw_correct_rt.pass.sh
+++ b/shared/templates/sysctl/tests/correct_etc_ufw_correct_rt.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_ubuntu
 {{% if SYSCTLVAL == "" %}}
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}
@@ -12,7 +13,6 @@ rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 
-echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.d/first.conf
-echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_WRONG_VALUE }}}" >> /etc/sysctl.d/second.conf
+echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/ufw/sysctl.conf
 
 sysctl -w {{{ SYSCTLVAR }}}="{{{ SYSCTL_CORRECT_VALUE }}}"

--- a/shared/templates/sysctl/tests/correct_etc_ufw_wrong_rt.fail.sh
+++ b/shared/templates/sysctl/tests/correct_etc_ufw_wrong_rt.fail.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+# platform = multi_platform_ubuntu
 {{% if SYSCTLVAL == "" %}}
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}
@@ -12,7 +12,6 @@ rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 
-echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.d/first.conf
-echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_WRONG_VALUE }}}" >> /etc/sysctl.d/second.conf
+echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/ufw/sysctl.conf
 
-sysctl -w {{{ SYSCTLVAR }}}="{{{ SYSCTL_CORRECT_VALUE }}}"
+sysctl -w {{{ SYSCTLVAR }}}="{{{ SYSCTL_WRONG_VALUE }}}"

--- a/shared/templates/sysctl/tests/correct_value.pass.sh
+++ b/shared/templates/sysctl/tests/correct_value.pass.sh
@@ -4,7 +4,11 @@
 {{% endif %}}
 
 # Clean sysctl config directories
+{{% if "ubuntu" in product %}}
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/* /etc/ufw/sysctl.conf
+{{% else %}}
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+{{% endif %}}
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf

--- a/shared/templates/sysctl/tests/correct_value_usr_lib.pass.sh
+++ b/shared/templates/sysctl/tests/correct_value_usr_lib.pass.sh
@@ -4,7 +4,11 @@
 {{% endif %}}
 
 # Clean sysctl config directories
-rm -rf /usr/lib/sysctl.d/* /usr/local/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+{{% if "ubuntu" in product %}}
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/* /etc/ufw/sysctl.conf
+{{% else %}}
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+{{% endif %}}
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 mkdir -p /usr/lib/sysctl.d

--- a/shared/templates/sysctl/tests/correct_value_usr_local_lib.pass.sh
+++ b/shared/templates/sysctl/tests/correct_value_usr_local_lib.pass.sh
@@ -4,8 +4,13 @@
 {{% endif %}}
 
 # Clean sysctl config directories
-{{% if product not in ["sle12", "sle15", "slmicro5"] %}}
+{{% if "ubuntu" in product %}}
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/* /etc/ufw/sysctl.conf
+{{% elif product not in ["sle12", "sle15", "slmicro5"] %}}
 rm -rf /usr/lib/sysctl.d/* /usr/local/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+{{% else %}}
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+{{% endif %}}
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 mkdir -p /usr/local/lib/sysctl.d

--- a/shared/templates/sysctl/tests/line_not_there.fail.sh
+++ b/shared/templates/sysctl/tests/line_not_there.fail.sh
@@ -4,7 +4,11 @@
 {{% endif %}}
 
 # Clean sysctl config directories
+{{% if "ubuntu" in product %}}
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/* /etc/ufw/sysctl.conf
+{{% else %}}
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+{{% endif %}}
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 

--- a/shared/templates/sysctl/tests/one_sysctl_conf_one_sysctl_d.pass.sh
+++ b/shared/templates/sysctl/tests/one_sysctl_conf_one_sysctl_d.pass.sh
@@ -4,7 +4,11 @@
 {{% endif %}}
 
 # Clean sysctl config directories
+{{% if "ubuntu" in product %}}
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/* /etc/ufw/sysctl.conf
+{{% else %}}
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+{{% endif %}}
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf

--- a/shared/templates/sysctl/tests/one_sysctl_conf_one_sysctl_d_conflicting.fail.sh
+++ b/shared/templates/sysctl/tests/one_sysctl_conf_one_sysctl_d_conflicting.fail.sh
@@ -4,7 +4,11 @@
 {{% endif %}}
 
 # Clean sysctl config directories
+{{% if "ubuntu" in product %}}
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/* /etc/ufw/sysctl.conf
+{{% else %}}
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+{{% endif %}}
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf

--- a/shared/templates/sysctl/tests/symlink_conflicting.fail.sh
+++ b/shared/templates/sysctl/tests/symlink_conflicting.fail.sh
@@ -4,7 +4,11 @@
 {{% endif %}}
 
 # Clean sysctl config directories
+{{% if "ubuntu" in product %}}
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/* /etc/ufw/sysctl.conf
+{{% else %}}
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+{{% endif %}}
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf

--- a/shared/templates/sysctl/tests/symlink_different_option.pass.sh
+++ b/shared/templates/sysctl/tests/symlink_different_option.pass.sh
@@ -4,7 +4,11 @@
 {{% endif %}}
 
 # Clean sysctl config directories
+{{% if "ubuntu" in product %}}
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/* /etc/ufw/sysctl.conf
+{{% else %}}
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+{{% endif %}}
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf

--- a/shared/templates/sysctl/tests/symlink_repeated_sysctl_conf.pass.sh
+++ b/shared/templates/sysctl/tests/symlink_repeated_sysctl_conf.pass.sh
@@ -4,7 +4,11 @@
 {{% endif %}}
 
 # Clean sysctl config directories
+{{% if "ubuntu" in product %}}
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/* /etc/ufw/sysctl.conf
+{{% else %}}
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+{{% endif %}}
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf

--- a/shared/templates/sysctl/tests/symlink_root_duplicate.pass.sh
+++ b/shared/templates/sysctl/tests/symlink_root_duplicate.pass.sh
@@ -4,7 +4,11 @@
 {{% endif %}}
 
 # Clean sysctl config directories
+{{% if "ubuntu" in product %}}
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/* /etc/ufw/sysctl.conf
+{{% else %}}
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+{{% endif %}}
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf

--- a/shared/templates/sysctl/tests/symlink_root_duplicate_conflicting.fail.sh
+++ b/shared/templates/sysctl/tests/symlink_root_duplicate_conflicting.fail.sh
@@ -4,7 +4,7 @@
 {{% endif %}}
 
 # Clean sysctl config directories
-rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/* /etc/ufw/sysctl.conf
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf

--- a/shared/templates/sysctl/tests/symlink_root_incompliant.fail.sh
+++ b/shared/templates/sysctl/tests/symlink_root_incompliant.fail.sh
@@ -4,7 +4,11 @@
 {{% endif %}}
 
 # Clean sysctl config directories
+{{% if "ubuntu" in product %}}
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/* /etc/ufw/sysctl.conf
+{{% else %}}
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+{{% endif %}}
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf

--- a/shared/templates/sysctl/tests/symlink_same_option.pass.sh
+++ b/shared/templates/sysctl/tests/symlink_same_option.pass.sh
@@ -4,7 +4,11 @@
 {{% endif %}}
 
 # Clean sysctl config directories
+{{% if "ubuntu" in product %}}
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/* /etc/ufw/sysctl.conf
+{{% else %}}
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+{{% endif %}}
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf

--- a/shared/templates/sysctl/tests/symlinks_to_same_file.pass.sh
+++ b/shared/templates/sysctl/tests/symlinks_to_same_file.pass.sh
@@ -4,7 +4,11 @@
 {{% endif %}}
 
 # Clean sysctl config directories
+{{% if "ubuntu" in product %}}
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/* /etc/ufw/sysctl.conf
+{{% else %}}
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+{{% endif %}}
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf

--- a/shared/templates/sysctl/tests/two_sysctls_on_d.pass.sh
+++ b/shared/templates/sysctl/tests/two_sysctls_on_d.pass.sh
@@ -4,7 +4,11 @@
 {{% endif %}}
 
 # Clean sysctl config directories
+{{% if "ubuntu" in product %}}
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/* /etc/ufw/sysctl.conf
+{{% else %}}
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+{{% endif %}}
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 

--- a/shared/templates/sysctl/tests/two_sysctls_on_same_file.pass.sh
+++ b/shared/templates/sysctl/tests/two_sysctls_on_same_file.pass.sh
@@ -4,7 +4,11 @@
 {{% endif %}}
 
 # Clean sysctl config directories
+{{% if "ubuntu" in product %}}
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/* /etc/ufw/sysctl.conf
+{{% else %}}
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+{{% endif %}}
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 

--- a/shared/templates/sysctl/tests/two_sysctls_on_same_file_name.pass.sh
+++ b/shared/templates/sysctl/tests/two_sysctls_on_same_file_name.pass.sh
@@ -4,7 +4,11 @@
 {{% endif %}}
 
 # Clean sysctl config directories
+{{% if "ubuntu" in product %}}
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/* /etc/ufw/sysctl.conf
+{{% else %}}
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+{{% endif %}}
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 

--- a/shared/templates/sysctl/tests/two_sysctls_on_same_file_name_conflicting.fail.sh
+++ b/shared/templates/sysctl/tests/two_sysctls_on_same_file_name_conflicting.fail.sh
@@ -4,7 +4,11 @@
 {{% endif %}}
 
 # Clean sysctl config directories
+{{% if "ubuntu" in product %}}
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/* /etc/ufw/sysctl.conf
+{{% else %}}
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+{{% endif %}}
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 

--- a/shared/templates/sysctl/tests/wrong_etc_ufw_correct_rt.fail.sh
+++ b/shared/templates/sysctl/tests/wrong_etc_ufw_correct_rt.fail.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+# platform = multi_platform_ubuntu
 {{% if SYSCTLVAL == "" %}}
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}
@@ -12,7 +12,6 @@ rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 
-echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.d/first.conf
-echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_WRONG_VALUE }}}" >> /etc/sysctl.d/second.conf
+echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_WRONG_VALUE }}}" >> /etc/ufw/sysctl.conf
 
 sysctl -w {{{ SYSCTLVAR }}}="{{{ SYSCTL_CORRECT_VALUE }}}"

--- a/shared/templates/sysctl/tests/wrong_runtime.fail.sh
+++ b/shared/templates/sysctl/tests/wrong_runtime.fail.sh
@@ -4,7 +4,11 @@
 {{% endif %}}
 
 # Clean sysctl config directories
+{{% if "ubuntu" in product %}}
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/* /etc/ufw/sysctl.conf
+{{% else %}}
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+{{% endif %}}
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf

--- a/shared/templates/sysctl/tests/wrong_usr_lib_correct_etc.pass.sh
+++ b/shared/templates/sysctl/tests/wrong_usr_lib_correct_etc.pass.sh
@@ -4,7 +4,11 @@
 {{% endif %}}
 
 # Clean sysctl config directories
+{{% if "ubuntu" in product %}}
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/* /etc/ufw/sysctl.conf
+{{% else %}}
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+{{% endif %}}
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 

--- a/shared/templates/sysctl/tests/wrong_usr_lib_wrong_etc.fail.sh
+++ b/shared/templates/sysctl/tests/wrong_usr_lib_wrong_etc.fail.sh
@@ -3,7 +3,11 @@
 {{% endif %}}
 
 # Clean sysctl config directories
+{{% if "ubuntu" in product %}}
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/* /etc/ufw/sysctl.conf
+{{% else %}}
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+{{% endif %}}
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 

--- a/shared/templates/sysctl/tests/wrong_value.fail.sh
+++ b/shared/templates/sysctl/tests/wrong_value.fail.sh
@@ -4,7 +4,11 @@
 {{% endif %}}
 
 # Clean sysctl config directories
+{{% if "ubuntu" in product %}}
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/* /etc/ufw/sysctl.conf
+{{% else %}}
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+{{% endif %}}
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_WRONG_VALUE }}}" >> /etc/sysctl.conf

--- a/shared/templates/sysctl/tests/wrong_value_d_directory.fail.sh
+++ b/shared/templates/sysctl/tests/wrong_value_d_directory.fail.sh
@@ -4,7 +4,11 @@
 {{% endif %}}
 
 # Clean sysctl config directories
+{{% if "ubuntu" in product %}}
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/* /etc/ufw/sysctl.conf
+{{% else %}}
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+{{% endif %}}
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_WRONG_VALUE }}}" >> /etc/sysctl.d/98-sysctl.conf

--- a/shared/templates/sysctl/tests/wrong_value_usr_local_lib.fail.sh
+++ b/shared/templates/sysctl/tests/wrong_value_usr_local_lib.fail.sh
@@ -5,7 +5,11 @@
 
 # Clean sysctl config directories
 {{% if product not in ["sle12", "sle15", "slmicro5"] %}}
+{{% if "ubuntu" in product %}}
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/* /etc/ufw/sysctl.conf
+{{% else %}}
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+{{% endif %}}
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 mkdir -p /usr/local/lib/sysctl.d


### PR DESCRIPTION
#### Description:

- Check & remediate /etc/ufw/sysctl.conf in template sysctl

#### Rationale:

- Fix the Ubuntu2404 cis rule 3.3.9 Ensure suspicious packets are logged
- The configuration file /etc/ufw/sysctl.conf will override the overlapped and active kernel parameter. We need to check this file and comment out any occurrence of sysctlvar
- The existing {oval,bash,sce-bash} use the sysctlvar as part of their regex. The sysctlvar is organised using "." which can also represent  the kernel format in /etcufw/sysctl.conf e.g. net.ipv4.conf.default.log_martians can capture literal string "net.ipv4.conf.default.log_martians" and also "net/ipv4/conf/default/log_martians" in /etc/ufw/sysctl.conf