### PR TITLE
[Ubuntu2404] Fix rule 5.3.3.4.1

### DIFF
--- a/components/pam.yml
+++ b/components/pam.yml
@@ -187,6 +187,7 @@ rules:
 - no_duplicate_uids
 - no_empty_passwords
 - no_empty_passwords_etc_shadow
+- no_empty_passwords_unix
 - no_forward_files
 - no_invalid_shell_accounts_unlocked
 - no_legacy_plus_entries_etc_group

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2044,7 +2044,7 @@ controls:
       - l1_server
       - l1_workstation
     rules:
-      - no_empty_passwords
+      - no_empty_passwords_unix
     status: automated
 
   - id: 5.3.3.4.2

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_unix/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_unix/bash/shared.sh
@@ -1,0 +1,11 @@
+# platform = multi_platform_ubuntu
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = medium
+
+{{{ bash_pam_unix_enable() }}}
+config_file="/usr/share/pam-configs/cac_unix"
+sed -i '/pam_unix\.so/s/nullok//g' "$config_file"
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_unix/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_unix/oval/shared.xml
@@ -1,0 +1,19 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("The file /etc/pam.d/common-* should not contain the nullok option") }}}
+    <criteria>
+      <criterion comment="make sure the nullok option is not used in /etc/pam.d/common-*"
+                 test_ref="test_{{{ rule_id }}}" />
+    </criteria>
+  </definition>
+  <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
+                              id="test_{{{ rule_id }}}"
+                              comment="make sure nullok is not used in /etc/pam.d/common-*">
+    <ind:object object_ref="object_{{{ rule_id }}}" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_{{{ rule_id }}}" version="1">
+    <ind:filepath operation="pattern match">^/etc/pam.d/common-(password|auth|account|session|session-noninteractive)$</ind:filepath>
+    <ind:pattern operation="pattern match">^[^#]*\bnullok\b.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_unix/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_unix/rule.yml
@@ -1,0 +1,20 @@
+documentation_complete: true
+
+title: 'Prevent Login to Accounts With Empty Password'
+
+description: |-
+    If an account is configured for password authentication
+    but does not have an assigned password, it may be possible to log
+    into the account without authentication. Remove any instances of the
+    <tt>nullok</tt> in
+    <tt>/etc/pam.d/common-{password,auth,account,session,session-noninteractive}</tt>
+    to prevent logins with empty passwords.
+
+rationale: |-
+    If an account has an empty password, anyone could log in and
+    run commands with the privileges of that account. Accounts with
+    empty passwords should never be used in operational environments.
+
+severity: high
+
+platform: system_with_kernel and package[pam]

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_unix/tests/no_nullok.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_unix/tests/no_nullok.pass.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = pam
+
+config_file=/usr/share/pam-configs/tmp_unix
+
+cat << EOF > "$config_file"
+Name: Unix authentication
+Conflicts: unix
+Default: yes
+Priority: 256
+Auth-Type: Primary
+Auth:
+	[success=end default=ignore]	pam_unix.so try_first_pass
+Auth-Initial:
+	[success=end default=ignore]	pam_unix.so
+Account-Type: Primary
+Account:
+	[success=end new_authtok_reqd=done default=ignore]	pam_unix.so
+Account-Initial:
+	[success=end new_authtok_reqd=done default=ignore]	pam_unix.so
+Session-Type: Additional
+Session:
+	required	pam_unix.so
+Session-Initial:
+	required	pam_unix.so
+Password-Type: Primary
+Password:
+	[success=end default=ignore]	pam_unix.so obscure use_authtok try_first_pass yescrypt
+Password-Initial:
+	[success=end default=ignore]	pam_unix.so obscure yescrypt
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update --enable tmp_unix
+
+rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_unix/tests/nullok_commented.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_unix/tests/nullok_commented.pass.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = pam
+
+config_file=/usr/share/pam-configs/tmp_unix
+
+cat << EOF > "$config_file"
+Name: Unix authentication
+Conflicts: unix
+Default: yes
+Priority: 256
+Auth-Type: Primary
+Auth:
+	[success=end default=ignore]	pam_unix.so try_first_pass # nullok
+Auth-Initial:
+	[success=end default=ignore]	pam_unix.so # nullok
+Account-Type: Primary
+Account:
+	[success=end new_authtok_reqd=done default=ignore]	pam_unix.so
+Account-Initial:
+	[success=end new_authtok_reqd=done default=ignore]	pam_unix.so
+Session-Type: Additional
+Session:
+	required	pam_unix.so
+Session-Initial:
+	required	pam_unix.so
+Password-Type: Primary
+Password:
+	[success=end default=ignore]	pam_unix.so obscure use_authtok try_first_pass yescrypt # nullok
+Password-Initial:
+	[success=end default=ignore]	pam_unix.so obscure yescrypt # nullok
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update --enable tmp_unix
+
+rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_unix/tests/nullok_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_unix/tests/nullok_present.fail.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = pam
+
+config_file=/usr/share/pam-configs/tmp_unix
+
+cat << EOF > "$config_file"
+Name: Unix authentication
+Conflicts: unix
+Default: yes
+Priority: 256
+Auth-Type: Primary
+Auth:
+	[success=end default=ignore]	pam_unix.so nullok try_first_pass
+Auth-Initial:
+	[success=end default=ignore]	pam_unix.so nullok
+Account-Type: Primary
+Account:
+	[success=end new_authtok_reqd=done default=ignore]	pam_unix.so
+Account-Initial:
+	[success=end new_authtok_reqd=done default=ignore]	pam_unix.so
+Session-Type: Additional
+Session:
+	required	pam_unix.so
+Session-Initial:
+	required	pam_unix.so
+Password-Type: Primary
+Password:
+	[success=end default=ignore]	pam_unix.so obscure use_authtok try_first_pass yescrypt nullok
+Password-Initial:
+	[success=end default=ignore]	pam_unix.so obscure yescrypt nullok
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update --enable tmp_unix
+
+rm "$config_file"
+


### PR DESCRIPTION
#### Description:

- [oval] Check all nullok parameters in common-*
- [remediation/test] Remove all nullok parameters of pam_unix.so

Rationale:
- Benchmark requires not only common-password to be checked but /etc/pam.d/common-password,auth,account,session,session-noninteractive}
