### PR TITLE
Remove RHEL-09-672035 and RHEL-09-672040 from RHEL 9 STIG

### DIFF
--- a/controls/stig_rhel9.yml
+++ b/controls/stig_rhel9.yml
@@ -4124,22 +4124,6 @@ controls:
             - configure_crypto_policy
         status: automated
 
-    -   id: RHEL-09-672035
-        levels:
-            - medium
-        title: RHEL 9 must implement DOD-approved encryption in the OpenSSL package.
-        rules:
-            - configure_openssl_crypto_policy
-        status: automated
-
-    -   id: RHEL-09-672040
-        levels:
-            - medium
-        title: RHEL 9 must implement DOD-approved TLS encryption in the OpenSSL package.
-        rules:
-            - configure_openssl_tls_crypto_policy
-        status: automated
-
     -   id: RHEL-09-672050
         levels:
             - medium

--- a/tests/data/profile_stability/rhel9/stig.profile
+++ b/tests/data/profile_stability/rhel9/stig.profile
@@ -184,8 +184,6 @@ selections:
 - configure_kerberos_crypto_policy
 - configure_libreswan_crypto_policy
 - configure_opensc_card_drivers
-- configure_openssl_crypto_policy
-- configure_openssl_tls_crypto_policy
 - configure_ssh_crypto_policy
 - configure_usbguard_auditbackend
 - configured_firewalld_default_deny

--- a/tests/data/profile_stability/rhel9/stig_gui.profile
+++ b/tests/data/profile_stability/rhel9/stig_gui.profile
@@ -196,8 +196,6 @@ selections:
 - configure_kerberos_crypto_policy
 - configure_libreswan_crypto_policy
 - configure_opensc_card_drivers
-- configure_openssl_crypto_policy
-- configure_openssl_tls_crypto_policy
 - configure_ssh_crypto_policy
 - configure_usbguard_auditbackend
 - configured_firewalld_default_deny


### PR DESCRIPTION

#### Description:

Remove RHEL-09-672035 and RHEL-09-672040 from RHEL 9 STIG
#### Rationale:

They are no longer in the STIG.
