### PR TITLE
Adapt audit_rules_suid_privilege_function for Ubuntu 24.04 CIS

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/ansible/shared.yml
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = low
 
-{{% if product != "ol8" %}}
+{{% if product not in ["ol8", "ubuntu2404"] %}}
 {{% set egid_arg = " -F egid=0" %}}
 {{% set euid_arg = " -F euid=0" %}}
 {{% endif %}}
@@ -13,7 +13,7 @@
 {{% set rx_b32 = "-F[\s]+arch=b32[\s]+" %}}
 {{% set rx_b64 = "-F[\s]+arch=b64[\s]+" %}}
 
-{{% if product == "ol8" %}}
+{{% if product in ["ol8", "ubuntu2404"] %}}
 {{% set rx_uid = "-S[\s]+execve[\s]+-C[\s]+uid!=euid[\s]+" %}}
 {{% set rx_gid = "-S[\s]+execve[\s]+-C[\s]+gid!=egid[\s]+" %}}
 {{% else %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/bash/shared.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/bash/shared.sh
@@ -7,7 +7,7 @@
 for ARCH in "${RULE_ARCHS[@]}"
 do
 	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
-	{{% if product == "ol8" %}}
+    {{% if product in ["ol8", "ubuntu2404"] %}}
 	OTHER_FILTERS="-C uid!=euid"
 	{{% else %}}
 	OTHER_FILTERS="-C uid!=euid -F euid=0"
@@ -24,7 +24,7 @@ done
 for ARCH in "${RULE_ARCHS[@]}"
 do
 	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
-	{{% if product == "ol8" %}}
+    {{% if product in ["ol8", "ubuntu2404"] %}}
 	OTHER_FILTERS="-C gid!=egid"
 	{{% else %}}
 	OTHER_FILTERS="-C gid!=egid -F egid=0"

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/oval/shared.xml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/oval/shared.xml
@@ -1,7 +1,7 @@
 {{% set rx_beg = "^[\s]*-a[\s]+always,exit[\s]+" %}}
 {{% set rx_b32 = "-F[\s]+arch=b32[\s]+" %}}
 {{% set rx_b64 = "-F[\s]+arch=b64[\s]+" %}}
-{{% if product == "ol8" %}}
+{{% if product in ["ol8", "ubuntu2404"] %}}
 {{% set rx_uid = "-S[\s]+execve[\s]+-C[\s]+uid!=euid[\s]+" %}}
 {{% set rx_gid = "-S[\s]+execve[\s]+-C[\s]+gid!=egid[\s]+" %}}
 {{% else %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/rule.yml
@@ -1,6 +1,5 @@
 documentation_complete: true
 
-
 title: 'Record Events When Privileged Executables Are Run'
 
 description: |-
@@ -14,7 +13,7 @@ description: |-
 
     <pre>$ sudo grep -r execve /etc/audit/rules.d</pre>
 
-    {{% if product == "ol8" %}}
+    {{% if product in ["ol8", "ubuntu2404"] %}}
     <pre>-a always,exit -F arch=b32 -S execve -C uid!=euid -k setuid</pre>
     <pre>-a always,exit -F arch=b64 -S execve -C uid!=euid -k setuid</pre>
     <pre>-a always,exit -F arch=b32 -S execve -C gid!=egid -k setgid</pre>
@@ -78,7 +77,7 @@ ocil: |-
 
     The output should be the following:
 
-    {{% if product == "ol8" %}}
+    {{% if product in ["ol8", "ubuntu2404"] %}}
     <pre>-a always,exit -F arch=b32 -S execve -C uid!=euid -k setuid</pre>
     <pre>-a always,exit -F arch=b64 -S execve -C uid!=euid -k setuid</pre>
     <pre>-a always,exit -F arch=b32 -S execve -C gid!=egid -k setgid</pre>
@@ -95,7 +94,7 @@ fixtext: |-
 
     Add or update the following rules to "/etc/audit/rules.d/audit.rules":
 
-    {{% if product == "ol8" %}}
+    {{% if product in ["ol8", "ubuntu2404"] %}}
     <pre>-a always,exit -F arch=b32 -S execve -C uid!=euid -k setuid</pre>
     <pre>-a always,exit -F arch=b64 -S execve -C uid!=euid -k setuid</pre>
     <pre>-a always,exit -F arch=b32 -S execve -C gid!=egid -k setgid</pre>

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/correct_value.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/correct_value.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = audit
 
-{{% if product == "ol8" %}}
+{{% if product in ["ol8", "ubuntu2404"] %}}
 OTHER_FILTERS_EUID=" -C uid!=euid"
 OTHER_FILTERS_EGID=" -C gid!=egid"
 {{% else %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/miss_arch.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/miss_arch.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = audit
 
-{{% if product == "ol8" %}}
+{{% if product in ["ol8", "ubuntu2404"] %}}
 OTHER_FILTERS_EUID=" -C uid!=euid"
 OTHER_FILTERS_EGID=" -C gid!=egid"
 {{% else %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/miss_c.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/miss_c.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = audit
 
-{{% if product != "ol8" %}}
+{{% if product not in ["ol8", "ubuntu2404"] %}}
 OTHER_FILTERS_EUID=" -F euid=0"
 OTHER_FILTERS_EGID=" -F egid=0"
 {{% endif %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/other_key.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/other_key.pass.sh
@@ -3,7 +3,7 @@
 
 # This tests situation where key value is not std. And also situation where there is extra spaces in rules.
 
-{{% if product == "ol8" %}}
+{{% if product in ["ol8", "ubuntu2404"] %}}
 OTHER_FILTERS_EUID=" -C     uid!=euid"
 OTHER_FILTERS_EGID=" -C     gid!=egid"
 {{% else %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/use_f_key.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/use_f_key.pass.sh
@@ -2,7 +2,7 @@
 # packages = audit
 
 
-{{% if product == "ol8" %}}
+{{% if product in ["ol8", "ubuntu2404"] %}}
 OTHER_FILTERS_EUID=" -C uid!=euid"
 OTHER_FILTERS_EGID=" -C gid!=egid"
 {{% else %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_a.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_a.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = audit
 
-{{% if product == "ol8" %}}
+{{% if product in ["ol8", "ubuntu2404"] %}}
 OTHER_FILTERS_EUID=" -C uid!=euid"
 OTHER_FILTERS_EGID=" -C gid!=egid"
 {{% else %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_c_egid.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_c_egid.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = audit
 
-{{% if product == "ol8" %}}
+{{% if product in ["ol8", "ubuntu2404"] %}}
 OTHER_FILTERS_EUID=" -C uid!=egid"
 OTHER_FILTERS_EGID=" -C gid!=egid"
 {{% else %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_c_euid.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_c_euid.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = audit
 
-{{% if product == "ol8" %}}
+{{% if product in ["ol8", "ubuntu2404"] %}}
 OTHER_FILTERS_EUID=" -C uid!=euid"
 OTHER_FILTERS_EGID=" -C gid!=euid"
 {{% else %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_f_egid.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_f_egid.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
-{{% if product == "ol8" %}}
+{{% if product in ["ol8", "ubuntu2404"] %}}
 # platform = Not Applicable
 {{% endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_f_euid.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_f_euid.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
-{{% if product == "ol8" %}}
+{{% if product in ["ol8", "ubuntu2404"] %}}
 # platform = Not Applicable
 {{% endif %}}
 


### PR DESCRIPTION
#### Description:
- Omit checking for '-F euid=0' in rule audit_rules_suid_privilege_function on Ubuntu 24.04

#### Rationale:
- Satisfies Ubuntu 24.04 CIS control 6.2.3.2 which recommends that all actions as another user are logged and not only when euid=0

#### Tests:
Ubuntu 24.04 in KVM:

WARNING - Script wrong_f_egid.fail.sh is not applicable on given platform
WARNING - Script wrong_f_euid.fail.sh is not applicable on given platform
INFO - xccdf_org.ssgproject.content_rule_audit_rules_suid_privilege_function
INFO - Script wrong_c_euid.fail.sh using profile (all) OK
INFO - Script wrong_c_egid.fail.sh using profile (all) OK
INFO - Script other_key.pass.sh using profile (all) OK
INFO - Script correct_value.pass.sh using profile (all) OK
INFO - Script wrong_a.fail.sh using profile (all) OK
INFO - Script use_f_key.pass.sh using profile (all) OK
INFO - Script no_rules.fail.sh using profile (all) OK
INFO - Script miss_arch.fail.sh using profile (all) OK
INFO - Script miss_c.fail.sh using profile (all) OK