### PR TITLE
Fix Automatus tests

### DIFF
--- a/shared/templates/rsyslog_logfiles_attributes_modify/tests/legacy_correct_attr_include.pass.sh
+++ b/shared/templates/rsyslog_logfiles_attributes_modify/tests/legacy_correct_attr_include.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle,mutli_platform_almalinux
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle,multi_platform_almalinux
 
 # Declare variables used for the tests and define the create_rsyslog_test_logs function
 source $SHARED/rsyslog_log_utils.sh


### PR DESCRIPTION
Addressing:

```
jcerny@fedora:~/work/git/scap-security-guide (master)$ python3 tests/automatus.py rule --libvirt qemu:///system ssgts_rhel9 rsyslog_files_permissions
Setting console output to log level INFO
INFO - The base image option has not been specified, choosing libvirt-based test environment.
INFO - Logging into /home/jcerny/work/git/scap-security-guide/logs/rule-custom-2025-02-05-1658/test_suite.log
ERROR - Unknown product name: mutli_platform_almalinux is not from Alibaba Cloud Linux 2, Alibaba Cloud Linux 3, AlmaLinux OS 9, Anolis OS 8, Anolis OS 23, Amazon Linux 2023, Chromium, Debian 11, Debian 12, Example, Amazon Elastic Kubernetes Service, Fedora, Firefox, Apple macOS 10.15, Kylin Server 10, Red Hat OpenShift Container Platform 4, Red Hat Enterprise Linux CoreOS 4, Oracle Linux 7, Oracle Linux 8, Oracle Linux 9, Oracle Linux 10, openEuler 2203, openSUSE, Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9, Red Hat Enterprise Linux 10, Red Hat Virtualization 4, SUSE Linux Enterprise 12, SUSE Linux Enterprise 15, SUSE Linux Enterprise Micro 5, Ubuntu 16.04, Ubuntu 18.04, Ubuntu 20.04, Ubuntu 22.04, Ubuntu 24.04, OpenEmbedded, Not Applicable
WARNING - Nothing has been tested!
Traceback (most recent call last):
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/common.py", line 210, in _get_platform_cpes
    product = FULL_NAME_TO_PRODUCT_MAPPING[platform]
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
KeyError: 'mutli_platform_almalinux'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/jcerny/work/git/scap-security-guide/tests/automatus.py", line 517, in <module>
    main()
    ~~~~^^
  File "/home/jcerny/work/git/scap-security-guide/tests/automatus.py", line 513, in main
    options.func(options)
    ~~~~~~~~~~~~^^^^^^^^^
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/rule.py", line 715, in perform_rule_check
    checker.test_target()
    ~~~~~~~~~~~~~~~~~~~^^
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/oscap.py", line 683, in test_target
    self._test_target()
    ~~~~~~~~~~~~~~~~~^^
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/rule.py", line 462, in _test_target
    test_content_by_rule_id = self._get_test_content_by_rule_id(
        rules_to_test)
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/rule.py", line 444, in _get_test_content_by_rule_id
    rule_test_content = self._get_rule_test_content(rule)
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/rule.py", line 419, in _get_rule_test_content
    if scenario.matches_regex_and_check_and_platform(
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
            self.scenarios_regex, checks, self.benchmark_cpes):
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/rule.py", line 690, in matches_regex_and_check_and_platform
    and self.matches_platform(benchmark_cpes))
        ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/rule.py", line 665, in matches_platform
    if common.matches_platform(
       ~~~~~~~~~~~~~~~~~~~~~~~^
            self.script_params["platform"], benchmark_cpes):
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/common.py", line 230, in matches_platform
    scenario_cpes |= _get_platform_cpes(p)
                     ~~~~~~~~~~~~~~~~~~^^^
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/common.py", line 215, in _get_platform_cpes
    raise ValueError
ValueError
```

