### PR TITLE
Fix variable name in Ubuntu 22.04 CIS profiles

### DIFF
--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -872,7 +872,7 @@ selections:
     - accounts_passwords_pam_faillock_unlock_time
 
     ### 5.4.3 Ensure password reuse is limited (Automated)
-    - var_password_pam_remember=5
+    - var_password_pam_unix_remember=5
     - accounts_password_pam_unix_remember
 
     ### 5.4.4 Ensure password hashing algorithm is up to date with the latest standards (Automated)


### PR DESCRIPTION

#### Description:

- Fix variable name in Ubuntu 22.04 CIS profiles

#### Rationale:

- Fixes https://bugs.launchpad.net/usg/+bug/2097448
