### PR TITLE
Add templated tests to `tests/validate_automatus_metadata.py`

### DIFF
--- a/tests/validate_automatus_metadata.py
+++ b/tests/validate_automatus_metadata.py
@@ -25,7 +25,9 @@ def _parse_args() -> argparse.Namespace:
 
 
 def get_files(root: str):
-    result = glob.glob("linux_os/**/tests/*.sh", recursive=True, root_dir=root)
+    result = list()
+    result.extend(glob.glob("linux_os/**/tests/*.sh", recursive=True, root_dir=root))
+    result.extend(glob.glob("shared/templates/*/tests/*.sh", recursive=True, root_dir=root))
     return result
 
 


### PR DESCRIPTION
#### Description:

Add templated tests to `tests/validate_automatus_metadata.py`

#### Rationale:

Help catch errors.

#### Review Hints:
Edit a tests such as `shared/templates/rsyslog_logfiles_attributes_modify/tests/legacy_correct_attr_include.pass.sh` to have an  invalid platform and observe the failure.