### PR TITLE
OPENSCAP-5220 Change macro bash_bootc_build

### DIFF
--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -2669,7 +2669,7 @@ This macro defines a conditional expression that is evaluated as true
 if the remediation is performed during a build of a bootable container image.
 #}}
 {{%- macro bash_bootc_build() -%}}
-[[ "$OSCAP_BOOTC_BUILD" == "YES" ]]
+rpm --quiet -q kernel rpm-ostree bootc && ! rpm --quiet -q openshift-kubelet && { [ -f "/run/.containerenv" ] || [ -f "/.containerenv" ]; }
 {{%- endmacro -%}}
 
 {{#
@@ -2677,7 +2677,7 @@ This macro defines a conditional expression that is evaluated as true
 if the remediation is not performed during a build of a bootable container image.
 #}}
 {{%- macro bash_not_bootc_build() -%}}
-[[ "$OSCAP_BOOTC_BUILD" != "YES" ]]
+! ( {{{ bash_bootc_build() }}} )
 {{%- endmacro -%}}
 
 

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -2669,7 +2669,7 @@ This macro defines a conditional expression that is evaluated as true
 if the remediation is performed during a build of a bootable container image.
 #}}
 {{%- macro bash_bootc_build() -%}}
-rpm --quiet -q kernel rpm-ostree bootc && ! rpm --quiet -q openshift-kubelet && { [ -f "/run/.containerenv" ] || [ -f "/.containerenv" ]; }
+{ rpm --quiet -q kernel rpm-ostree bootc && ! rpm --quiet -q openshift-kubelet && { [ -f "/run/.containerenv" ] || [ -f "/.containerenv" ]; }; }
 {{%- endmacro -%}}
 
 {{#
@@ -2677,7 +2677,7 @@ This macro defines a conditional expression that is evaluated as true
 if the remediation is not performed during a build of a bootable container image.
 #}}
 {{%- macro bash_not_bootc_build() -%}}
-! ( {{{ bash_bootc_build() }}} )
+! {{{ bash_bootc_build() }}}
 {{%- endmacro -%}}
 
 


### PR DESCRIPTION
Currently, Bash remediations for bootable containers hardening depend on OpenSCAP passing the OSCAP_BOOTC_BUILD environment variable. We will change this approach. Instead, the Bash remediation code will detect the environment. It won't depend on the OSCAP_BOOTC_BUILD environment variable. Specifically, Jinja macros bash_bootc_build() and bash_not_bootc_build() will be reworked to contain a detection condition. We already do it similar way in IB, where the environment variable container sets them to bwrap-osbuild.

