### PR TITLE
Push arm64 k8scontent images on merge

### DIFF
--- a/.github/workflows/k8s-content.yaml
+++ b/.github/workflows/k8s-content.yaml
@@ -20,4 +20,4 @@ jobs:
       dockerfile_path: ./Dockerfiles/ocp4_content
       licenses: BSD
       vendor: ComplianceAsCode authors
-      platforms: 'linux/amd64,linux/ppc64le,linux/s390x'
+      platforms: 'linux/amd64,linux/ppc64le,linux/s390x,linux/arm64'


### PR DESCRIPTION
A previous PR added support for building k8s content for arm64:

  https://github.com/ComplianceAsCode/content/pull/12964

But e2e testing on arm64 clusters is still failing because the operator
can't pull an arm64 image from the testing registry:

```
  Warning: Pull failed, retrying in 5s ... error: build error: failed to
  pull image: After retrying 2 times, Pull image still failed due to
  error: choosing an image from manifest list
  docker://ghcr.io/complianceascode/k8scontent:latest: no image found in
  image index for architecture arm64, variant "v8", OS linux
```

As seen in the following PR: https://github.com/openshift/release/pull/61066

This commit updates the container push job to also push the arm64 image
to the k8scontent registry.
