### PR TITLE
Fix grep commands

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/bash/shared.sh
@@ -11,7 +11,7 @@ test -f ${CONF_FILE} || touch ${CONF_FILE}
 # Ensure CRYPTO_POLICY is not commented out
 sed -i 's/#CRYPTO_POLICY=/CRYPTO_POLICY=/' ${CONF_FILE}
 
-if ! grep -q "$correct_value" "$CONF_FILE"; then
+if ! grep -q "\\$correct_value" "$CONF_FILE"; then
     # We need to get the existing value, using PCRE to maintain same regex
     existing_value=$(grep -Po '(-oCiphers=\S+)' ${CONF_FILE})
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/bash/shared.sh
@@ -11,7 +11,7 @@ test -f ${CONF_FILE} || touch ${CONF_FILE}
 # Ensure CRYPTO_POLICY is not commented out
 sed -i 's/#CRYPTO_POLICY=/CRYPTO_POLICY=/' ${CONF_FILE}
 
-if ! grep -q "$correct_value" "$CONF_FILE"; then
+if ! grep -q "\\$correct_value" "$CONF_FILE"; then
     # We need to get the existing value, using PCRE to maintain same regex
     existing_value=$(grep -Po '(-oMACs=\S+)' ${CONF_FILE})
 


### PR DESCRIPTION
Addressing:

harden_sshd_ciphers_opensshserver_conf_crypto_policy:

```
grep: iphers=aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes128-ctr: invalid context length argument
```

harden_sshd_macs_opensshserver_conf_crypto_policy:

```
grep: invalid option -- 'M'
Usage: grep [OPTION]... PATTERN [FILE]...
Try 'grep --help' for more information.
```

Related to: https://github.com/ComplianceAsCode/content/issues/12942
