### PR TITLE
[Stabilization]: fix set_password_hashing_min_rounds_logindefs

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/ansible/shared.yml
@@ -22,30 +22,29 @@
 - name: "{{{ rule_title }}} - Ensure SHA_CRYPT_MIN_ROUNDS has Minimum Value of 5000"
   ansible.builtin.replace:
     path: /etc/login.defs
-    regexp: '(^\s*SHA_CRYPT_MIN_ROUNDS\s+)(?!(?:[5-9]\d{3,}|\d{5,}))\S*(\s*$)'
+    regexp: '(^\s*SHA_CRYPT_MIN_ROUNDS\s+)(?:\d+)(.*$)'
     replace: '\g<1>{{ var_password_hashing_min_rounds_login_defs }}\g<2>'
     backup: no
-  when: etc_login_defs_sha_crypt_min_rounds | length > 0 and etc_login_defs_sha_crypt_min_rounds | first | int < var_password_hashing_min_rounds_login_defs | int
+  when: etc_login_defs_sha_crypt_min_rounds is defined and etc_login_defs_sha_crypt_min_rounds | length > 0 and etc_login_defs_sha_crypt_min_rounds | first | int < var_password_hashing_min_rounds_login_defs | int
 
 - name: "{{{ rule_title }}} - Ensure SHA_CRYPT_MAX_ROUNDS has Minimum Value of 5000"
   ansible.builtin.replace:
     path: /etc/login.defs
-    regexp: '(^\s*SHA_CRYPT_MAX_ROUNDS\s+)(?!(?:[5-9]\d{3,}|\d{5,}))\S*(\s*$)'
+    regexp: '(^\s*SHA_CRYPT_MAX_ROUNDS\s+)(?:\d+)(.*$)'
     replace: '\g<1>{{ var_password_hashing_min_rounds_login_defs }}\g<2>'
     backup: no
-  when: etc_login_defs_sha_crypt_max_rounds | length > 0 and etc_login_defs_sha_crypt_max_rounds | first | int < var_password_hashing_min_rounds_login_defs | int
+  when: etc_login_defs_sha_crypt_max_rounds is defined and etc_login_defs_sha_crypt_max_rounds | length > 0 and etc_login_defs_sha_crypt_max_rounds | first | int < var_password_hashing_min_rounds_login_defs | int
 
-- name: "{{ rule_title }} - SHA_CRYPT_MIN_ROUNDS add configuration if not found"
+- name: "{{{ rule_title }}} - SHA_CRYPT_MIN_ROUNDS add configuration if not found"
   ansible.builtin.lineinfile:
     line: "SHA_CRYPT_MIN_ROUNDS {{ var_password_hashing_min_rounds_login_defs }}"
     path: /etc/login.defs
     state: present
   when: etc_login_defs_sha_crypt_min_rounds | length == 0
 
-- name: "{{ rule_title }} - SHA_CRYPT_MAX_ROUNDS add configuration if not found"
+- name: "{{{ rule_title }}} - SHA_CRYPT_MAX_ROUNDS add configuration if not found"
   ansible.builtin.lineinfile:
     line: "SHA_CRYPT_MAX_ROUNDS {{ var_password_hashing_min_rounds_login_defs }}"
     path: /etc/login.defs
     state: present
   when: etc_login_defs_sha_crypt_max_rounds | length == 0
-

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -41,7 +41,7 @@ selections:
     - var_password_pam_remember_control_flag=requisite_or_required
     - var_selinux_state=enforcing
     - var_selinux_policy_name=targeted
-    - var_password_pam_unix_rounds=5000
+    - var_password_hashing_min_rounds_login_defs=100000
     - var_password_pam_minlen=15
     - var_password_pam_ocredit=1
     - var_password_pam_dcredit=1

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -443,7 +443,7 @@ selections:
 - var_password_pam_remember_control_flag=requisite_or_required
 - var_selinux_state=enforcing
 - var_selinux_policy_name=targeted
-- var_password_pam_unix_rounds=5000
+- var_password_hashing_min_rounds_login_defs=100000
 - var_password_pam_minlen=15
 - var_password_pam_ocredit=1
 - var_password_pam_dcredit=1

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -449,7 +449,7 @@ selections:
 - var_password_pam_remember_control_flag=requisite_or_required
 - var_selinux_state=enforcing
 - var_selinux_policy_name=targeted
-- var_password_pam_unix_rounds=5000
+- var_password_hashing_min_rounds_login_defs=100000
 - var_password_pam_minlen=15
 - var_password_pam_ocredit=1
 - var_password_pam_dcredit=1


### PR DESCRIPTION
#### Description:

- use correct variable in RHEL 8 STIG profiles
- remove a variable which was not used in the profile but had a confusing name, suggesting that it is used with this rule
- fix Ansible remediation of the rule so that it is more robust

#### Rationale:

- remediation of the rule was not working properly
- thanks to the wrong variable (default value) the content was not aligned with DISA


#### Review Hints:

- remediate with Bash / Ansible and verify with the latest STIG SCAP content