### PR TITLE
Fix ocp4_content to use aarch64 instead of arm64

### DIFF
--- a/Dockerfiles/ocp4_content
+++ b/Dockerfiles/ocp4_content
@@ -7,7 +7,7 @@ RUN microdnf -y install cmake make git /usr/bin/python3 python3-pyyaml python3-j
 COPY . .
 
 # Enable only certain profiles on ppc64le and s390x
-RUN if [ "$(uname -m)" == "x86_64" ] || [ "$(uname -m)" == "arm64" ]; then \
+RUN if [ "$(uname -m)" == "x86_64" ] || [ "$(uname -m)" == "aarch64" ]; then \
     echo "Building OpenShift and RHCOS content for x86_64"; \
     else echo "Building OpenShift content for $(uname -m)" && \
         # Disable all profiles first
@@ -44,7 +44,7 @@ RUN if [ "$(uname -m)" == "x86_64" ] || [ "$(uname -m)" == "arm64" ]; then \
 # Build the OpenShift, EKS, and RHCOS content for x86 architectures. Only build
 # OpenShift content for ppc64le and s390x architectures since we're not
 # including any RHCOS profiles on those architectures right now anyway.
-RUN if [ "$(uname -m)" = "x86_64" ] || [ "$(uname -m)" == "arm64" ]; then \
+RUN if [ "$(uname -m)" = "x86_64" ] || [ "$(uname -m)" == "aarch64" ]; then \
         ./build_product ocp4 rhcos4 eks --datastream-only; \
         elif [ "$(uname -m)" = "ppc64le" ]; then \
         ./build_product ocp4 rhcos4 --datastream-only; \


### PR DESCRIPTION
The ocp4_content Dockerfile determines the system architecture using
`uname -m`. For the ARM64 case, we should be comparing that to `aarch64`
not `arm64`. This commit updates the Dockerfile accordingly.

Without this, the Compliance Operator fails to parse the content from
the content container image because the resulting datastream isn't
copied into the /content/ directory.
