### PR TITLE
[Ubuntu2404] Fix tests of rule has_nonlocal_mta

### DIFF
--- a/linux_os/guide/services/mail/has_nonlocal_mta/tests/correct.pass.sh
+++ b/linux_os/guide/services/mail/has_nonlocal_mta/tests/correct.pass.sh
@@ -2,4 +2,4 @@
 # packages = postfix
 
 echo "inet_interfaces = localhost" > /etc/postfix/main.cf
-postfix reload || postfix start
+postfix stop || postfix start

--- a/linux_os/guide/services/mail/has_nonlocal_mta/tests/wrong.fail.sh
+++ b/linux_os/guide/services/mail/has_nonlocal_mta/tests/wrong.fail.sh
@@ -3,4 +3,4 @@
 # remediation = none
 
 echo "inet_interfaces = all" > /etc/postfix/main.cf
-postfix reload || postfix start
+postfix stop || postfix start


### PR DESCRIPTION
#### Description:

- Restart postfix instead of reload

#### Rationale:

- postfix reload won't help the configuration take effect, unless using systemctl restart postfix or postfix itself to restart. 