### PR TITLE
[Stabilization]: Rule: sshd_include_crypto_policy, platform: not osbuild

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_include_crypto_policy/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_include_crypto_policy/rule.yml
@@ -35,3 +35,5 @@ fixtext: |-
     Configure the RHEL 9 SSH daemon to use systemwide crypto policies.
     Reinstall OpenSSH server package contents with the following command:
     <pre>sudo dnf -y remove openssh-server && sudo dnf -y install openssh-server</pre>
+
+platform: not osbuild


### PR DESCRIPTION
#### Description:

- We temporary(?) ignore the rule in Image Builder until we would be able to sort out the problems with `sshd` configuration without reinstalling the package (which is not possible in osbuild environment).

#### Rationale:

- Image Builder remediation stage can't reinstall packages.

- Fixes #12968.

#### Review Hints:

- I'll probably be passing anyways.