### PR TITLE
Add new profile for CIS OpenShift 1.7.0

### DIFF
--- a/products/ocp4/profiles/cis-1-7.profile
+++ b/products/ocp4/profiles/cis-1-7.profile
@@ -2,14 +2,14 @@ documentation_complete: true
 
 title: 'CIS Red Hat OpenShift Container Platform 4 Benchmark'
 
-platform: ocp4-node
+platform: ocp4
 
 metadata:
     SMEs:
         - rhmdnd
         - Vincent056
         - yuumasato
-    version: 1.5.0
+    version: 1.7.0
 
 description: |-
     This profile defines a baseline that aligns to the Center for Internet Security®
@@ -18,9 +18,18 @@ description: |-
     This profile includes Center for Internet Security®
     Red Hat OpenShift Container Platform 4 CIS Benchmarks™ content.
 
-    Note that this part of the profile is meant to run on the Operating System that
+    Note that this part of the profile is meant to run on the Platform that
     Red Hat OpenShift Container Platform 4 runs on top of.
 
     This profile is applicable to OpenShift versions 4.12 and greater.
 
-extends: cis-node-1-7
+filter_rules: '"ocp4-node" not in platforms and "ocp4-master-node" not in platforms and "ocp4-node-on-sdn" not in platforms and "ocp4-node-on-ovn" not in platforms'
+
+selections:
+    - cis_ocp_1_4_0:all
+    ### Variables
+    - var_openshift_audit_profile=WriteRequestBodies
+    ### Helper Rules
+    ### This is a helper rule to fetch the required api resource for detecting OCP version
+    - version_detect_in_ocp
+    - version_detect_in_hypershift

--- a/products/ocp4/profiles/cis-node-1-7.profile
+++ b/products/ocp4/profiles/cis-node-1-7.profile
@@ -9,7 +9,7 @@ metadata:
         - rhmdnd
         - Vincent056
         - yuumasato
-    version: 1.5.0
+    version: 1.7.0
 
 description: |-
     This profile defines a baseline that aligns to the Center for Internet Security®
@@ -23,4 +23,7 @@ description: |-
 
     This profile is applicable to OpenShift versions 4.12 and greater.
 
-extends: cis-node-1-7
+filter_rules: '"ocp4-node" in platforms or "ocp4-master-node" in platforms or "ocp4-node-on-sdn" in platforms or "ocp4-node-on-ovn" in platforms'
+
+selections:
+    - cis_ocp_1_4_0:all

--- a/products/ocp4/profiles/cis.profile
+++ b/products/ocp4/profiles/cis.profile
@@ -6,17 +6,14 @@ platform: ocp4
 
 metadata:
     SMEs:
-        - JAORMX
-        - mrogers950
-        - jhrozek
         - rhmdnd
         - Vincent056
         - yuumasato
-    version: 1.5.0
+    version: 1.7.0
 
 description: |-
     This profile defines a baseline that aligns to the Center for Internet Security®
-    Red Hat OpenShift Container Platform 4 Benchmark™, V1.5.
+    Red Hat OpenShift Container Platform 4 Benchmark™, V1.7.
 
     This profile includes Center for Internet Security®
     Red Hat OpenShift Container Platform 4 CIS Benchmarks™ content.
@@ -26,4 +23,4 @@ description: |-
 
     This profile is applicable to OpenShift versions 4.12 and greater.
 
-extends: cis-1-5
+extends: cis-1-7


### PR DESCRIPTION

#### Description:

- Add new Profile for  CIS OpenShift 4 version 1.7.0.
- There are no technical differences between version 1.5.0 and 1.6.0, and no technical differences between 1.6.0 and 1.7.0.

#### Rationale:

- CIS OpenShfit 4 version 1.7.0 was released in Dec 23rd 2024.
- https://issues.redhat.com/browse/CMP-3084
