### PR TITLE
[Ubuntu2404] Fix tests of rule grub2_password

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/tests/invalid_username.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/tests/invalid_username.fail.sh
@@ -4,6 +4,8 @@
 
 . $SHARED/grub2.sh
 
+set_grub_uefi_root
+
 make_grub_password
 
 set_superusers "use r"

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/tests/missing.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/tests/missing.fail.sh
@@ -4,5 +4,7 @@
 
 . $SHARED/grub2.sh
 
+set_grub_uefi_root
+
 touch "$GRUB_CFG_ROOT/grub.cfg"
 rm -f "$GRUB_CFG_ROOT/user.cfg"

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/tests/password-set.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/tests/password-set.pass.sh
@@ -2,4 +2,6 @@
 
 . $SHARED/grub2.sh
 
+set_grub_uefi_root
+
 make_grub_password

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/tests/unquoted_username.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/tests/unquoted_username.pass.sh
@@ -2,6 +2,8 @@
 
 . $SHARED/grub2.sh
 
+set_grub_uefi_root
+
 make_grub_password
 
 set_superusers_unquoted "koksic"

--- a/tests/shared/grub2.sh
+++ b/tests/shared/grub2.sh
@@ -11,6 +11,8 @@ function set_grub_uefi_root {
 		fi
 	elif grep NAME /etc/os-release | grep -iq "Oracle"; then
 		GRUB_CFG_ROOT=/boot/efi/EFI/redhat
+	elif grep NAME /etc/os-release | grep -iq "Ubuntu"; then
+		GRUB_CFG_ROOT=/boot/grub
 	fi
 }
 


### PR DESCRIPTION
#### Description:

- Call set_grub_uefi_root to override the grub path in tests

#### Rationale:

- The grub2_boot_path defined by Ubuntu is /boot/grub, we need to override the default one in tests
- Backport from #13007 