### PR TITLE
Remove RHEL 8 STIG reference from `file_permission_user_init_files`

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/file_permission_user_init_files/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_permission_user_init_files/rule.yml
@@ -28,7 +28,6 @@ references:
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-020710
     stigid@ol8: OL08-00-010770
-    stigid@rhel8: RHEL-08-010770
     stigid@sle12: SLES-12-010760
     stigid@sle15: SLES-15-040110
 


### PR DESCRIPTION
#### Description:

Remove RHEL 8 STIG reference from `file_permission_user_init_files`

#### Rationale:

Keeping the references up-to-date.
