### PR TITLE
[Ubuntu2404] Fix tests of no_shelllogin_for_systemaccounts

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/first_sys_uid_max.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/first_sys_uid_max.pass.sh
@@ -12,3 +12,13 @@ sed -Ei '
 }
 /^'"$key"'/d;
 ' /etc/login.defs
+
+key=SYS_UID_MIN
+
+# Add key as 1st line, drop others
+sed -Ei '
+1{i\
+'"$key"' 201
+}
+/^'"$key"'/d;
+' /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/first_sys_uid_min.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/first_sys_uid_min.pass.sh
@@ -3,6 +3,16 @@
 useradd --system --shell /sbin/nologin -u 999 sysuser
 useradd -u {{{ uid_min }}} testuser
 
+key=SYS_UID_MAX
+
+# Add key as 1st line, drop others
+sed -Ei '
+1{i\
+'"$key"' 999
+}
+/^'"$key"'/d;
+' /etc/login.defs
+
 key=SYS_UID_MIN
 
 # Add key as 1st line, drop others

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/last_sys_uid_max.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/last_sys_uid_max.pass.sh
@@ -3,6 +3,10 @@
 useradd --system --shell /sbin/nologin -u 999 sysuser
 useradd -u {{{ uid_min }}} testuser
 
+key=SYS_UID_MIN
+
+printf "%s 201\n" "$key" >> /etc/login.defs
+
 key=SYS_UID_MAX
 
 # Add bogus key as 2nd last and valid last line w/o nl

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/last_sys_uid_min.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/last_sys_uid_min.pass.sh
@@ -3,6 +3,10 @@
 useradd --system --shell /sbin/nologin -u 999 sysuser
 useradd -u {{{ uid_min }}} testuser
 
+key=SYS_UID_MAX
+
+printf "%s 999\n" "$key" >> /etc/login.defs
+
 key=SYS_UID_MIN
 
 # Add bogus key as 2nd last and valid last line w/o nl


### PR DESCRIPTION
#### Description:

- Define the missing SYS_UID_ value in tests of no_shelllogin_for_systemaccounts

#### Rationale:

- The check test_shell_defined_reserved_uid_range and test_shell_defined_dynalloc_uid_range in oval need both min and max to define the range otherwise the oval will produce result of error in the only one of SYS_UID_(MIN|MAX) defined case.