### PR TITLE
[Ubuntu2404] Fix remediation of rule accounts_user_dot_user_ownership

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/ansible/shared.yml
@@ -5,8 +5,6 @@
 # disruption = low
 
 - name: Ensure interactive local users are the owners of their respective initialization files
-  ansible.builtin.command:
+  ansible.builtin.shell:
     cmd: |
-      while IFS=: read -r uid home; do
-          find "$home" -maxdepth 1 -name "\.[^.]*" -exec chown -f $uid {} \;
-      done < <(awk -F: '{if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) print $3":"$6}' /etc/passwd)
+      awk -F: '{if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) print $3":"$6}' /etc/passwd | while IFS=: read -r uid home; do find "$home" -maxdepth 1 -name "\.[^.]*" -exec chown -f $uid "{}" \;; done

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/ansible/shared.yml
@@ -7,4 +7,4 @@
 - name: Ensure interactive local users are the owners of their respective initialization files
   ansible.builtin.command:
     cmd: |
-      awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) system("chown -f " $3" "$6"/.[^\.]?*") }' /etc/passwd
+      awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) system("find "$6" -maxdepth 1 -name \.[^.]?* -exec chown -f "$3" {} \;") }' /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/ansible/shared.yml
@@ -7,4 +7,6 @@
 - name: Ensure interactive local users are the owners of their respective initialization files
   ansible.builtin.command:
     cmd: |
-      awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) system("find "$6" -maxdepth 1 -name \.[^.]?* -exec chown -f "$3" {} \;") }' /etc/passwd
+      while IFS=: read -r uid home; do
+          find "$home" -maxdepth 1 -name "\.[^.]*" -exec chown -f $uid {} \;
+      done < <(awk -F: '{if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) print $3":"$6}' /etc/passwd)

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/bash/shared.sh
@@ -4,4 +4,4 @@
 # complexity = low
 # disruption = low
 
-awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) system("chown -f " $3" "$6"/.[^\.]?*") }' /etc/passwd
+awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) system("find "$6" -maxdepth 1 -name \.[^.]?* -exec chown -f "$3" {} \;") }' /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/bash/shared.sh
@@ -4,4 +4,6 @@
 # complexity = low
 # disruption = low
 
-awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) system("find "$6" -maxdepth 1 -name \.[^.]?* -exec chown -f "$3" {} \;") }' /etc/passwd
+while IFS=: read -r uid home; do
+    find "$home" -maxdepth 1 -name "\.[^.]*" -exec chown -f "$uid" {} \;
+done < <(awk -F: '{if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) print $3":"$6}' /etc/passwd)

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/bash/shared.sh
@@ -4,6 +4,4 @@
 # complexity = low
 # disruption = low
 
-while IFS=: read -r uid home; do
-    find "$home" -maxdepth 1 -name "\.[^.]*" -exec chown -f "$uid" {} \;
-done < <(awk -F: '{if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) print $3":"$6}' /etc/passwd)
+awk -F: '{if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) print $3":"$6}' /etc/passwd | while IFS=: read -r uid home; do find "$home" -maxdepth 1 -name "\.[^.]*" -exec chown -f $uid "{}" \;; done


### PR DESCRIPTION
#### Description:

- Use find instead globbing inside awk

#### Rationale:

- According to `man chown`, -f only suppress error msg. So replace the -f with -v (verbose) to debug 
- The result of  `awk -F':' '{ if ($3 >= 1000 && $3 != 65534) system("chown -v " $3" "$6"/.[^\.]?*") }' /etc/passwd` is:

```bash
root@sec-noble-amd64:/home/am# awk -F':' '{ if ($3 >= 1000 && $3 != 65534) system("chown -v " $3" "$6"/.[^\.]?*") }' /etc/passwd
chown: cannot access '/home/am/.[^.]?*': No such file or directory
failed to change ownership of '/home/am/.[^.]?*' to 1000
```