### PR TITLE
[Ubuntu2404] Fix remediation of rule accounts_user_dot_group_ownership

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/ansible/shared.yml
@@ -7,4 +7,6 @@
 - name: Ensure interactive local users are the group-owners of their respective initialization files
   ansible.builtin.command:
     cmd: |
-      awk -F':' '{ if ($4 >= {{{ gid_min }}} && $4 != {{{ nobody_gid }}}) system("find "$6" -maxdepth 1 -name \.[^.]?* -exec chgrp -f "$4" {} \;") }' /etc/passwd
+      while IFS=: read -r gid home; do
+          find "$home" -maxdepth 1 -name "\.[^.]*" -exec chgrp -f $gid {} \;
+      done < <(awk -F: '{if ($4 >= {{{ gid_min }}} && $4 != {{{ nobody_gid }}}) print $4":"$6}' /etc/passwd)

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/ansible/shared.yml
@@ -7,4 +7,4 @@
 - name: Ensure interactive local users are the group-owners of their respective initialization files
   ansible.builtin.command:
     cmd: |
-      awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) system("chgrp -f " $4" "$6"/.[^\.]?*") }' /etc/passwd
+      awk -F':' '{ if ($4 >= {{{ gid_min }}} && $4 != {{{ nobody_gid }}}) system("find "$6" -maxdepth 1 -name \.[^.]?* -exec chgrp -f "$4" {} \;") }' /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/ansible/shared.yml
@@ -5,8 +5,6 @@
 # disruption = low
 
 - name: Ensure interactive local users are the group-owners of their respective initialization files
-  ansible.builtin.command:
+  ansible.builtin.shell:
     cmd: |
-      while IFS=: read -r gid home; do
-          find "$home" -maxdepth 1 -name "\.[^.]*" -exec chgrp -f $gid {} \;
-      done < <(awk -F: '{if ($4 >= {{{ gid_min }}} && $4 != {{{ nobody_gid }}}) print $4":"$6}' /etc/passwd)
+      awk -F: '{if ($4 >= {{{ gid_min }}} && $4 != {{{ nobody_gid }}}) print $4":"$6}' /etc/passwd | while IFS=: read -r gid home; do find "$home" -maxdepth 1 -name "\.[^.]*" -exec chgrp -f $gid "{}" \;; done

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/bash/shared.sh
@@ -4,4 +4,4 @@
 # complexity = low
 # disruption = low
 
-awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) system("find "$6" -maxdepth 1 -name \.[^.]?* -exec chgrp -f "$4" {} \;") }' /etc/passwd
+awk -F':' '{ if ($4 >= {{{ gid_min }}} && $4 != {{{ nobody_gid }}}) system("find "$6" -maxdepth 1 -name \.[^.]?* -exec chgrp -f "$4" {} \;") }' /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/bash/shared.sh
@@ -4,4 +4,6 @@
 # complexity = low
 # disruption = low
 
-awk -F':' '{ if ($4 >= {{{ gid_min }}} && $4 != {{{ nobody_gid }}}) system("find "$6" -maxdepth 1 -name \.[^.]?* -exec chgrp -f "$4" {} \;") }' /etc/passwd
+while IFS=: read -r gid home; do
+    find "$home" -maxdepth 1 -name "\.[^.]*" -exec chgrp -f $gid {} \;
+done < <(awk -F: '{if ($4 >= {{{ gid_min }}} && $4 != {{{ nobody_gid }}}) print $4":"$6}' /etc/passwd)

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/bash/shared.sh
@@ -4,4 +4,4 @@
 # complexity = low
 # disruption = low
 
-awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) system("chgrp -f " $4" "$6"/.[^\.]?*") }' /etc/passwd
+awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) system("find "$6" -maxdepth 1 -name \.[^.]?* -exec chgrp -f "$4" {} \;") }' /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/bash/shared.sh
@@ -4,6 +4,4 @@
 # complexity = low
 # disruption = low
 
-while IFS=: read -r gid home; do
-    find "$home" -maxdepth 1 -name "\.[^.]*" -exec chgrp -f $gid {} \;
-done < <(awk -F: '{if ($4 >= {{{ gid_min }}} && $4 != {{{ nobody_gid }}}) print $4":"$6}' /etc/passwd)
+awk -F: '{if ($4 >= {{{ gid_min }}} && $4 != {{{ nobody_gid }}}) print $4":"$6}' /etc/passwd | while IFS=: read -r gid home; do find "$home" -maxdepth 1 -name "\.[^.]*" -exec chgrp -f $gid "{}" \;; done


### PR DESCRIPTION
#### Description:

- Use find instead globbing inside awk
- Change occurrence of uid into gid

#### Rationale:

- Same as #13026 