### PR TITLE
OPENSCAP-4118 - Add script to build tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ option(SSG_JINJA2_CACHE_ENABLED "If enabled, the jinja2 templating files will be
 option(SSG_SCE_ENABLED "If enabled, additional SCE audit content will be enabled alongside OVAL-based auditing." FALSE)
 option(SSG_SRG_XLSX_EXPORT "If enabled, an XLSX of SRG Export will be ceated." FALSE)
 option(SSG_SEPARATE_SCAP_FILES_ENABLED "If enabled, separate SCAP files (OVAL, XCCDF, CPE dict, ...) will be installed alongside the source data-streams" TRUE)
+option(SSG_BUILT_TESTS_ENABLED "If enabled, Automatus tests will be built" FALSE)
 # Validation Options
 option(SSG_BATS_TESTS_ENABLED "If enabled, bats will be used to run unit-tests of bash remediations." TRUE)
 option(SSG_LINKCHECKER_VALIDATION_ENABLED "If enabled, linkchecker will be used to validate URLs in all the HTML guides and tables." TRUE)
@@ -290,8 +291,9 @@ else()
     message(STATUS "jinja2 cache: disabled")
 endif()
 message(STATUS "Separate SCAP files: ${SSG_SEPARATE_SCAP_FILES_ENABLED}")
-message(STATUS "STIG Delta Taloring files: ${SSG_BUILD_DISA_DELTA_FILES}")
+message(STATUS "STIG Delta Tailoring files: ${SSG_BUILD_DISA_DELTA_FILES}")
 message(STATUS "Thin data streams: ${SSG_THIN_DS}")
+message(STATUS "Pre-build Automatus tests: ${SSG_BUILT_TESTS_ENABLED}")
 
 message(STATUS " ")
 message(STATUS "Validation options:")

--- a/build-scripts/build_tests.py
+++ b/build-scripts/build_tests.py
@@ -1,0 +1,78 @@
+#!/usr/bin/python3
+
+import argparse
+import pathlib
+
+import ssg.environment
+import ssg.jinja
+import ssg.utils
+import ssg.yaml
+import ssg.templates
+import tests.ssg_test_suite.common
+import tests.ssg_test_suite.rule
+
+SSG_ROOT = str(pathlib.Path(__file__).resolve().parent.parent.absolute())
+
+def _create_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Converts builds content tests to be rendered"
+    )
+    parser.add_argument(
+        "--build-config-yaml", required=True,
+        help="YAML file with information about the build configuration. "
+             "e.g.: ~/scap-security-guide/build/build_config.yml"
+    )
+    parser.add_argument(
+        "--product-yaml", required=True,
+        help="YAML file with information about the product we are building. "
+             "e.g.: ~/scap-security-guide/rhel10/product.yml"
+    )
+    parser.add_argument(
+        "--output", required=True,
+        help="Output path"
+             "e.g.:  ~/scap-security-guide/build/rhel10/tests"
+    )
+    parser.add_argument(
+        "--resolved-rules-dir", required=True,
+        help="Directory with <rule-id>.yml resolved rule YAMLs"
+             "e.g.: ~/scap-security-guide/build/rhel10/rules"
+    )
+    parser.add_argument("--root", default=SSG_ROOT,
+                        help=f"Path to the project. Defaults to {SSG_ROOT}")
+    return parser
+
+
+def main() -> int:
+    args = _create_arg_parser().parse_args()
+    env_yaml = ssg.environment.open_environment(
+        args.build_config_yaml, args.product_yaml)
+
+    product = ssg.utils.required_key(env_yaml, "product")
+    benchmark_cpes =  { env_yaml["cpes"][0][product]["name"], }
+    resolved_rules_dir = pathlib.Path(args.resolved_rules_dir)
+
+    for rule_file in resolved_rules_dir.iterdir():  # type: pathlib.Path
+        rendered_rule_obj = ssg.yaml.open_raw(str(rule_file))
+        rule_path = pathlib.Path(rendered_rule_obj["definition_location"])
+        rule_root = rule_path.parent
+        rule_id = rule_root.name
+        tests_root = rule_root / "tests"
+        output_path = pathlib.Path(args.output) / rule_id
+        if tests_root.exists():
+            for test in tests_root.iterdir(): # type: pathlib.Path
+                if not test.name.endswith(".sh"):
+                    continue
+                output_path.mkdir(parents=True, exist_ok=True)
+                file_contents = open(str(test.absolute())).read()
+                s = tests.ssg_test_suite.rule.Scenario(test.name, file_contents)
+                if s.matches_platform(benchmark_cpes):
+                    content = ssg.jinja.process_file_with_macros(str(test.absolute()), env_yaml)
+                    with open(output_path / test.name, 'w') as file:
+                        file.write(content)
+
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/build-scripts/build_tests.py
+++ b/build-scripts/build_tests.py
@@ -114,10 +114,12 @@ def _process_local_tests(benchmark_cpes, env_yaml, rule_output_path, rule_tests_
                 file.write(content)
                 file.write('\n')
 
+
 def _write_path(file_contents, output_path):
     with open(output_path, 'w') as file:
         file.write(file_contents)
         file.write('\n')
+
 
 def _process_rules(benchmark_cpes: Set[str], env_yaml: Dict, output_path: pathlib.Path,
                    rules: Iterable[pathlib.Path], templates_root: pathlib.Path,

--- a/build-scripts/build_tests.py
+++ b/build-scripts/build_tests.py
@@ -114,9 +114,9 @@ def _process_local_tests(product: str, env_yaml: dict, rule_output_path: pathlib
                          rule_tests_root: pathlib.Path) -> None:
     logger = logging.getLogger()
     for test in rule_tests_root.iterdir():  # type: pathlib.Path
-        if not test.name.endswith(".sh"):
-            logger.debug("Skipping file %s in rule %s is it doesn't end with .sh.",
-                         test.name, rule_output_path.name)
+        if test.is_dir():
+            logger.warning("Skipping directory %s in rule %s", test.name,
+                         rule_output_path.name)
             continue
         if not _is_test_file(test.name):
             file_contents = ssg.jinja.process_file_with_macros(str(test.absolute()),

--- a/build-scripts/build_tests.py
+++ b/build-scripts/build_tests.py
@@ -191,9 +191,10 @@ def main() -> int:
 
     output_path.mkdir(parents=True, exist_ok=True)
     _copy_and_process_shared(env_yaml, output_path, root_path)
-    product = ssg.utils.required_key(env_yaml, "product")
-    # TODO: Can this be done better?
-    benchmark_cpes = {env_yaml["cpes"][0][product]["name"], }
+    benchmark_cpes = set()
+    for cpe in env_yaml["cpes"]:
+        for cpe_id, data in cpe.items():
+            benchmark_cpes.add(data["name"])
 
     templates_root = root_path / "shared" / "templates"
     rules = resolved_rules_dir.iterdir()

--- a/build-scripts/build_tests.py
+++ b/build-scripts/build_tests.py
@@ -166,8 +166,8 @@ def _process_rules(benchmark_cpes: Set[str], env_yaml: Dict, output_path: pathli
                 scenario = tests.ssg_test_suite.rule.Scenario(test.name, file_contents)
                 if scenario.matches_platform(benchmark_cpes):
                     rule_output_path.mkdir(parents=True, exist_ok=True)
-                    output_path = rule_output_path / test.name
-                    _write_path(file_contents, output_path)
+                    test_output_path = rule_output_path / test.name
+                    _write_path(file_contents, test_output_path)
                     logger.debug('Wrote scenario %s for rule %s', test.name, rule_id)
                 else:
                     logger.debug('Skipping scenario %s for rule %s has it not applicable',

--- a/build-scripts/build_tests.py
+++ b/build-scripts/build_tests.py
@@ -177,6 +177,7 @@ def _get_benchmark_cpes(env_yaml):
             benchmark_cpes.add(data["name"])
     return benchmark_cpes
 
+
 def _get_rules_in_profile(built_profiles_root):
     rules_in_profile = list()
     for profile_file in built_profiles_root.iterdir():  # type: pathlib.Path
@@ -187,6 +188,7 @@ def _get_rules_in_profile(built_profiles_root):
             if '=' not in selection:
                 rules_in_profile.append(selection)
     return rules_in_profile
+
 
 def main() -> int:
     args = _create_arg_parser().parse_args()

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -676,7 +676,7 @@ macro(ssg_build_tests PRODUCT)
         OUTPUT "${CMAKE_BINARY_DIR}/${PRODUCT}/tests/.tests_done"
         COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/build-scripts/build_tests.py"  --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --resolved-rules-dir "${CMAKE_CURRENT_BINARY_DIR}/rules" --output  "${CMAKE_CURRENT_BINARY_DIR}/tests" --product-yaml "${CMAKE_SOURCE_DIR}/products/${PRODUCT}/product.yml"
         # Actually we mean that it depends on resolved rules - see also ssg_build_templated_content
-        DEPENDS ${PRODUCT}-compile-all "${CMAKE_CURRENT_BINARY_DIR}/ssg_build_compile_all-${PRODUCT}"
+        DEPENDS ${PRODUCT}-content
         COMMENT "[${PRODUCT}-tests] generating tests"
     )
 

--- a/docs/manual/developer/02_building_complianceascode.md
+++ b/docs/manual/developer/02_building_complianceascode.md
@@ -522,6 +522,7 @@ bash/rhel9-script-hipaa.sh
 ```
 
 ### Automatus Tests
+
 You can build the Automatus tests so they can be run directly.
 To enable build with `-DSSG_BUILT_TESTS_ENABLED:BOOL=ON`
 The tests will be `$PRODUCT/tests/` with directory for each rule.

--- a/docs/manual/developer/02_building_complianceascode.md
+++ b/docs/manual/developer/02_building_complianceascode.md
@@ -521,6 +521,11 @@ bash/rhel9-script-hipaa.sh
 ...
 ```
 
+### Automatus Tests
+You can build the Automatus tests so they can be run directly.
+To enable build with `-DSSG_BUILT_TESTS_ENABLED:BOOL=ON`
+The tests will be `$PRODUCT/tests/` with directory for each rule.
+
 ## Testing
 
 To ensure validity of built artifacts prior to installation, we recommend

--- a/tests/automatus.py
+++ b/tests/automatus.py
@@ -16,7 +16,7 @@ from glob import glob
 ssg_dir = os.path.join(os.path.dirname(__file__), "..")
 sys.path.append(ssg_dir)
 
-from ssg_test_suite.log import LogHelper
+from tests.ssg_test_suite.log import LogHelper
 import ssg_test_suite.oscap
 import ssg_test_suite.test_env
 import ssg_test_suite.profile
@@ -74,6 +74,7 @@ def parse_args():
             help="DEPRECATED: Use --remove-platforms instead; "
             "Find all CPEs that are present in local OpenSCAP's CPE dictionary "
             "that match the provided regex, "
+
             "and add them as platforms to all data stream benchmarks. "
             "If the regex doesn't match anything, it will be treated "
             "as a literal CPE, and added as a platform. "

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -21,7 +21,6 @@ from ssg.jinja import process_file_with_macros
 from ssg.products import product_yaml_path, load_product_yaml
 from ssg.rules import get_rule_dir_yaml
 from ssg.utils import mkdir_p
-from ssg_test_suite.log import LogHelper
 
 import ssg.templates
 

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -21,7 +21,7 @@ from ssg.jinja import process_file_with_macros
 from ssg.products import product_yaml_path, load_product_yaml
 from ssg.rules import get_rule_dir_yaml
 from ssg.utils import mkdir_p
-from ssg_test_suite.log import LogHelper
+from tests.ssg_test_suite.log import LogHelper
 
 import ssg.templates
 
@@ -386,6 +386,7 @@ def send_scripts(test_env, test_content_by_rule_id):
     archive_file_basename = os.path.basename(archive_file)
     remote_archive_file = os.path.join(remote_dir, archive_file_basename)
     logging.debug("Uploading scripts.")
+    logging.debug(f"LogHelper.LOG_DIR {LogHelper.LOG_DIR}")
     log_file_name = os.path.join(LogHelper.LOG_DIR, "env-preparation.log")
 
     with open(log_file_name, 'a') as log_file:

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -21,6 +21,7 @@ from ssg.jinja import process_file_with_macros
 from ssg.products import product_yaml_path, load_product_yaml
 from ssg.rules import get_rule_dir_yaml
 from ssg.utils import mkdir_p
+from ssg_test_suite.log import LogHelper
 
 import ssg.templates
 

--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -8,15 +8,16 @@ import logging
 import os.path
 import re
 import socket
+import subprocess
 import sys
 import time
 import xml.etree.ElementTree
 
 from ssg.constants import OSCAP_PROFILE_ALL_ID
 
-from tests.ssg_test_suite.log import LogHelper
-from tests.ssg_test_suite import test_env
-from tests.ssg_test_suite import common
+from ssg_test_suite.log import LogHelper
+from ssg_test_suite import test_env
+from ssg_test_suite import common
 
 from ssg.shims import input_func
 

--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -15,9 +15,9 @@ import xml.etree.ElementTree
 
 from ssg.constants import OSCAP_PROFILE_ALL_ID
 
-from ssg_test_suite.log import LogHelper
-from ssg_test_suite import test_env
-from ssg_test_suite import common
+from tests.ssg_test_suite.log import LogHelper
+from tests.ssg_test_suite import test_env
+from tests.ssg_test_suite import common
 
 from ssg.shims import input_func
 

--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -8,16 +8,15 @@ import logging
 import os.path
 import re
 import socket
-import subprocess
 import sys
 import time
 import xml.etree.ElementTree
 
 from ssg.constants import OSCAP_PROFILE_ALL_ID
 
-from ssg_test_suite.log import LogHelper
-from ssg_test_suite import test_env
-from ssg_test_suite import common
+from tests.ssg_test_suite.log import LogHelper
+from tests.ssg_test_suite import test_env
+from tests.ssg_test_suite import common
 
 from ssg.shims import input_func
 

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -17,11 +17,11 @@ from ssg.constants import OSCAP_PROFILE, OSCAP_PROFILE_ALL_ID, OSCAP_RULE
 from ssg.jinja import process_file_with_macros
 from ssg.rules import is_rule_dir
 
-from ssg_test_suite import oscap
-from ssg_test_suite import xml_operations
-from ssg_test_suite import test_env
-from ssg_test_suite import common
-from ssg_test_suite.log import LogHelper
+from tests.ssg_test_suite import oscap
+from tests.ssg_test_suite import xml_operations
+from tests.ssg_test_suite import test_env
+from tests.ssg_test_suite import common
+from tests.ssg_test_suite.log import LogHelper
 
 
 Rule = collections.namedtuple(

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -17,11 +17,11 @@ from ssg.constants import OSCAP_PROFILE, OSCAP_PROFILE_ALL_ID, OSCAP_RULE
 from ssg.jinja import process_file_with_macros
 from ssg.rules import is_rule_dir
 
-from tests.ssg_test_suite import oscap
-from tests.ssg_test_suite import xml_operations
-from tests.ssg_test_suite import test_env
-from tests.ssg_test_suite import common
-from tests.ssg_test_suite.log import LogHelper
+from ssg_test_suite import oscap
+from ssg_test_suite import xml_operations
+from ssg_test_suite import test_env
+from ssg_test_suite import common
+from ssg_test_suite.log import LogHelper
 
 
 Rule = collections.namedtuple(

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -9,8 +9,9 @@ import subprocess
 import sys
 import time
 
-from tests.ssg_test_suite import common
-from tests.ssg_test_suite.log import LogHelper
+import ssg_test_suite
+from ssg_test_suite import common
+from ssg_test_suite.log import LogHelper
 
 
 class SavedState(object):

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -9,9 +9,8 @@ import subprocess
 import sys
 import time
 
-import ssg_test_suite
-from ssg_test_suite import common
-from ssg_test_suite.log import LogHelper
+from tests.ssg_test_suite import common
+from tests.ssg_test_suite.log import LogHelper
 
 
 class SavedState(object):

--- a/tests/unit/ssg_test_suite/test_rule.py
+++ b/tests/unit/ssg_test_suite/test_rule.py
@@ -1,7 +1,5 @@
 import os
-import pytest
 
-from ssg_test_suite import rule
 from tests.ssg_test_suite.rule import Scenario
 from ssg.constants import OSCAP_PROFILE_ALL_ID
 


### PR DESCRIPTION
#### Description:

This is a very rough draft a script that renders the Automatus tests for a given product. The script will be clean up once the general form is agreed upon. 

#### Rationale:

Make running the Automatus tests possible with out Automatus script.

#### Review Hints:
1. `export ADDITIONAL_CMAKE_OPTION="-DSSG_BUILT_TESTS_ENABLED:BOOL=ON"`
1. ` ./build_product  rhel10`
