### PR TITLE
Remove stray end if

### DIFF
--- a/shared/templates/sysctl/tests/correct_value_usr_local_lib.pass.sh
+++ b/shared/templates/sysctl/tests/correct_value_usr_local_lib.pass.sh
@@ -18,4 +18,3 @@ echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /usr/local/lib/sysctl
 
 # set correct runtime value to check if the filesystem configuration is evaluated properly
 sysctl -w {{{ SYSCTLVAR }}}="{{{ SYSCTL_CORRECT_VALUE }}}"
-{{% endif %}}


### PR DESCRIPTION
This problem appeared in daily productization on 2025-02-12.

Addressing:
jinja2.exceptions.TemplateSyntaxError: Encountered unknown tag 'endif'.


#### Review Hints:
python3 tests/automatus.py rule --libvirt qemu:///system ssgts_rhel9 sysctl_fs_protected_symlinks
