### PR TITLE
Align file_groupownership_system_commands_dirs with Ubuntu STIGs

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicro,multi_platform_ubuntu,multi_platform_almalinux
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicro,multi_platform_almalinux
 
 for SYSCMDFILES in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin
 do

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/bash/ubuntu.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/bash/ubuntu.sh
@@ -1,0 +1,6 @@
+# platform = multi_platform_ubuntu
+
+for SYSCMDFILES in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin
+do
+   find -L $SYSCMDFILES ! -group root -type f ! -perm /2000 -exec chgrp root '{}' \;
+done

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/oval/ubuntu.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/oval/ubuntu.xml
@@ -1,0 +1,29 @@
+<def-group>
+  <definition class="compliance" id="file_groupownership_system_commands_dirs" version="1">
+    {{{ oval_metadata("
+        Checks that system commands in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin 
+        are owned by root group.
+      ") }}}
+    <criteria >
+      <criterion test_ref="test_groupownership_system_commands_dirs" />
+    </criteria>
+  </definition>
+
+  <unix:file_test  check="all" check_existence="none_exist" comment="system commands are owned by root" id="test_groupownership_system_commands_dirs" version="1">
+    <unix:object object_ref="object_groupownership_system_commands_dirs" />
+  </unix:file_test>
+
+  <unix:file_object comment="system commands files" id="object_groupownership_system_commands_dirs" version="1">
+    <!-- Check that system commands within directories /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin 
+         belong to group with gid 0 (root) -->
+    <unix:path operation="pattern match">^\/s?bin|^\/usr\/s?bin|^\/usr\/local\/s?bin</unix:path>
+    <unix:filename operation="pattern match">^.*$</unix:filename>
+   <filter action="include">state_groupowner_system_commands_dirs_not_root_not_sgid</filter>
+  </unix:file_object>
+
+  <unix:file_state id="state_groupowner_system_commands_dirs_not_root_not_sgid" version="1">
+    <unix:group_id datatype="int" operation="not equal">0</unix:group_id>
+    <unix:sgid datatype="boolean">false</unix:sgid>
+  </unix:file_state>
+
+</def-group>

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_groupownership_sgid.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_groupownership_sgid.pass.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+for SYSLIBDIRS in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin
+do
+  find -L  $SYSLIBDIRS \! -group root -type f -exec chgrp root '{}' \;
+done
+
+groupadd group_test
+
+for TESTFILE in /bin/test_me /sbin/test_me /usr/bin/test_me /usr/sbin/test_me /usr/local/bin/test_me /usr/local/sbin/test_me
+do
+   if [[ ! -f $TESTFILE ]]
+   then
+     touch $TESTFILE
+   fi
+   chgrp group_test $TESTFILE
+   chmod g+s $TESTFILE
+done

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/system_account_groupownership.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/system_account_groupownership.pass.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+{{% if 'ubuntu' in product %}}
+# platform = Not Applicable
+{{% endif %}}
 
 # gid of sshd group is 74
 test_group="sshd"


### PR DESCRIPTION
#### Description:

- Modify bash and OVAL to exclude commands that are not Set Group ID upon execution (SGID) to align with Ubuntu STIGs

#### Rationale:

- Ubuntu STIG rules UBTU-20-010458 and UBTU-22-232055 excluded SGID binaries from the check (and indirectly the remediation)