### PR TITLE
Add xccdf status to profiles

### DIFF
--- a/docs/manual/developer/03_creating_content.md
+++ b/docs/manual/developer/03_creating_content.md
@@ -609,6 +609,9 @@ requirements or how it is applied.
 -   `reference`: URL pointing to page or organization that publishes the
     policy.
 
+-   `status`: The maturity and consensus level of the profile.
+    Accepted values are: `draft`, `interim`, `accepted` and `deprecated`.
+
 -   `version`: Version of the policy implemented by the profile.
 
 -   `SMEs`: List of people experienced with the profile, or how they are

--- a/products/ocp4/profiles/cis-1-4.profile
+++ b/products/ocp4/profiles/cis-1-4.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'CIS Red Hat OpenShift Container Platform 4 Benchmark'
 
 platform: ocp4
-
+status: deprecated
 metadata:
     SMEs:
         - JAORMX

--- a/products/ocp4/profiles/cis-node-1-4.profile
+++ b/products/ocp4/profiles/cis-node-1-4.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'CIS Red Hat OpenShift Container Platform 4 Benchmark'
 
 platform: ocp4-node
-
+status: deprecated
 metadata:
     SMEs:
         - JAORMX

--- a/ssg/entities/profile_base.py
+++ b/ssg/entities/profile_base.py
@@ -38,6 +38,7 @@ class Profile(XCCDFEntity, SelectionHandler):
         description=lambda: "",
         extends=lambda: "",
         hidden=lambda: "",
+        status=lambda: "",
         metadata=lambda: None,
         reference=lambda: None,
         selections=lambda: list(),
@@ -79,6 +80,12 @@ class Profile(XCCDFEntity, SelectionHandler):
                         .format(platform=platform))
                     raise CPEDoesNotExist(msg)
 
+        allowed_profile_statuses = ["draft", "interim", "accepted", "deprecated"]
+        if input_contents["status"] and input_contents["status"] not in allowed_profile_statuses:
+            msg = ("Profile status must be one of the following values: "
+                   f"{allowed_profile_statuses}"
+                   )
+            raise ValueError(msg)
         return input_contents
 
     @property
@@ -118,6 +125,8 @@ class Profile(XCCDFEntity, SelectionHandler):
 
         element = ET.Element('{%s}Profile' % XCCDF12_NS)
         element.set("id", OSCAP_PROFILE + self.id_)
+        if self.status:
+            add_sub_element(element, "status", XCCDF12_NS, str(self.status))
         if self._should_have_version():
             add_sub_element(element, "version", XCCDF12_NS, str(self.metadata["version"]))
         if self.extends:

--- a/tests/unit/ssg-module/data/ospp.xml
+++ b/tests/unit/ssg-module/data/ospp.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <ns0:Profile xmlns:ns0="http://checklists.nist.gov/xccdf/1.2" id="xccdf_org.ssgproject.content_profile_ospp">
+  <ns0:status>accepted</ns0:status>
   <ns0:version>4.2.1</ns0:version>
   <ns0:title override="true">Protection Profile for General Purpose Operating Systems</ns0:title>
   <ns0:description override="true">This profile is part of Red Hat Enterprise Linux 9 Common Criteria Guidance

--- a/tests/unit/ssg-module/data/ospp_invalid_status.profile
+++ b/tests/unit/ssg-module/data/ospp_invalid_status.profile
@@ -12,7 +12,7 @@ description: 'This profile is part of Red Hat Enterprise Linux 9 Common Criteria
 
     configuration, based on Configuration Annex to the OSPP.'
 extends: null
-status: accepted
+status: complete
 metadata:
     version: 4.2.1
     SMEs:

--- a/tests/unit/ssg-module/test_build_yaml.py
+++ b/tests/unit/ssg-module/test_build_yaml.py
@@ -574,3 +574,8 @@ def profile_with_version(profile_ospp):
 def test_profile_with_version(profile_with_version):
     profile_el = profile_with_version.to_xml_element()
     assert profile_el.find("{%s}version" % XCCDF12_NS).text == "3.2.1"
+
+def test_profile_ospp_with_invalid_status():
+    value_file = os.path.join(DATADIR, "ospp_invalid_status.profile")
+    with pytest.raises(Exception):
+        profile = ssg.build_yaml.Profile.from_yaml(value_file)


### PR DESCRIPTION
#### Description:

- Add optional `xccdf:status: element to `xccdf:Profile`.
- Deprecate OCP4 CIS v1.4.0 profiles

#### Rationale:
  - This will allow us to track the status and maturity of the profile.
  - Newer versions of CIS profiles (v1.7.0) are being implemented.

#### Review Hints:

- Check for XCCDF validity
- Check that OCP4 CIS 1.4.0 profiles are deprecated.