### PR TITLE
Ubuntu: Make stig not applicable for Ubuntu2404

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/commented_stig.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/commented_stig.fail.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
+{{% if product == "ubuntu2404" %}}
+# platform = Not Applicable
+{{% else %}}
 # profiles = xccdf_org.ssgproject.content_profile_stig
+{{% endif %}}
+
 
 rm -f /etc/login.defs
 echo '#PASS_MAX_DAYS 60' > /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/correct_stig.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/correct_stig.pass.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
+{{% if product == "ubuntu2404" %}}
+# platform = Not Applicable
+{{% else %}}
 # profiles = xccdf_org.ssgproject.content_profile_stig
+{{% endif %}}
 
 rm -f /etc/login.defs
 echo "PASS_MAX_DAYS        60" > /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/correct_stig_double.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/correct_stig_double.pass.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
+{{% if product == "ubuntu2404" %}}
+# platform = Not Applicable
+{{% else %}}
 # profiles = xccdf_org.ssgproject.content_profile_stig
+{{% endif %}}
+
 
 rm -f /etc/login.defs
 echo "PASS_MAX_DAYS        60" > /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/incorrect_stig.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/incorrect_stig.fail.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
+{{% if product == "ubuntu2404" %}}
+# platform = Not Applicable
+{{% else %}}
 # profiles = xccdf_org.ssgproject.content_profile_stig
+{{% endif %}}
+
 
 rm -f /etc/login.defs
 echo "PASS_MAX_DAYS 120" > /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/incorrect_stig_double.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/incorrect_stig_double.fail.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
+{{% if product == "ubuntu2404" %}}
+# platform = Not Applicable
+{{% else %}}
 # profiles = xccdf_org.ssgproject.content_profile_stig
+{{% endif %}}
+
 
 rm -f /etc/login.defs
 echo "PASS_MAX_DAYS        60" > /etc/login.defs


### PR DESCRIPTION
#### Description:

- Skip stig tests for Ubuntu2404

#### Rationale:

- Currently Ubuntu2404 only has cis which make `# profiles = xccdf_org.ssgproject.content_profile_stig` has unexpected effect (choose the var value from cis)