### PR TITLE
Fix rule package_iptables-persistent_installed on Ubuntu 2404

### DIFF
--- a/linux_os/guide/system/network/network-iptables/package_iptables-persistent_installed/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/package_iptables-persistent_installed/rule.yml
@@ -22,10 +22,19 @@ ocil_clause: 'the package is not installed'
 
 ocil: '{{{ ocil_package(package="iptables-persistent") }}}'
 
+{{%- if product in [ "ubuntu2404" ] %}}
+template:
+    name: package_installed_guard_var
+    vars:
+        pkgname: iptables-persistent
+        variable: var_network_filtering_service
+        value: iptables
+{{%- else %}}
 template:
     name: package_installed
     vars:
         pkgname: iptables-persistent
+{{%- endif %}}
 
 fixtext: |-
     {{{ describe_package_install(package="iptables-persistent") }}}


### PR DESCRIPTION
#### Description:

- Modify the rule to use the template `package_installed_guard_var`

#### Rationale:

- To disable installing iptables-persistent unless `var_network_filtering_service=iptables`
