### PR TITLE
Fix bash_instantiate_variables jinja macro

### DIFF
--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -10,7 +10,10 @@ Then, assume that variables of that names are defined and contain the correct va
 #}}
 {{%- macro bash_instantiate_variables() -%}}
 {{%- for name in varargs -%}}
-{{{ name }}}='(bash-populate {{{ name }}})'
+{{{ name }}}=$(cat << EOF
+(bash-populate {{{ name }}})
+EOF
+)
 {{% endfor -%}}
 {{%- endmacro -%}}
 


### PR DESCRIPTION
#### Description:

When the variable contains single quotes, the remediation script being generated broke, as shown in the example below:
~~~
<xccdf:set-value idref="xccdf_org.ssgproject.content_value_login_banner_text">Hey' man!</xccdf:set-value>
~~~
Remediation script excerpt:
~~~
login_banner_text='Hey'[\s\n]+man!'
~~~
Result:
~~~
line 3: unexpected EOF while looking for matching `''
~~~
---

The fix consists in using "cat << EOF" to let bash source the value correctly.

New remediation script excerpt:
~~~
login_banner_text=$(cat << EOF
Hey'[\s\n]+man!
EOF
)
~~~

#### Rationale:

Banners may have single quotes inside, typically for French language (`C'est-y[\s\n]+pas[\s\n]+beau[\s\n]+!`).

#### Review Hints:

Generate a tailoring file with a banner containing single quotes (rule `xccdf_org.ssgproject.content_value_login_banner_text`)

This is a follow up of [PR 7784](https://github.com/ComplianceAsCode/content/pull/7784).