### PR TITLE
Fix oval and remediations for journald-upload rules

### DIFF
--- a/linux_os/guide/system/logging/journald/systemd_journal_upload_server_tls/bash/shared.sh
+++ b/linux_os/guide/system/logging/journald/systemd_journal_upload_server_tls/bash/shared.sh
@@ -1,23 +1,10 @@
-# platform = multi_platform_slmicro,multi_platform_ubuntu
-
-{{% if 'ubuntu' in product %}}
-var_journal_upload_conf_file=/etc/systemd/journal-upload.conf.d/60-journald_upload.conf
-mkdir -p /etc/systemd/journal-upload.conf.d
-touch /etc/systemd/journal-upload.conf.d/60-journald_upload.conf
-
-{{{ bash_comment_config_line("/etc/systemd/journal-upload.conf(\.d/[^/]+\.conf)", '^ServerKeyFile') }}}
-{{{ bash_comment_config_line("/etc/systemd/journal-upload.conf(\.d/[^/]+\.conf)", '^ServerCertificateFile') }}}
-{{{ bash_comment_config_line("/etc/systemd/journal-upload.conf(\.d/[^/]+\.conf)", '^TrustedCertificateFile') }}}
-{{% else %}}
-var_journal_upload_conf_file=/etc/systemd/journal-upload.conf
-{{% endif %}}
+# platform = multi_platform_slmicro
 
 {{{ bash_instantiate_variables("var_journal_upload_server_key_file") }}}
-{{{ bash_replace_or_append('$var_journal_upload_conf_file', '^ServerKeyFile', "$var_journal_upload_server_key_file", '%s=%s') }}}
+{{{ bash_replace_or_append('/etc/systemd/journal-upload.conf', '^ServerKeyFile', "$var_journal_upload_server_key_file", '%s=%s') }}}
 
 {{{ bash_instantiate_variables("var_journal_upload_server_certificate_file") }}}
-{{{ bash_replace_or_append('$var_journal_upload_conf_file', '^ServerCertificateFile', "$var_journal_upload_server_certificate_file", '%s=%s') }}}
+{{{ bash_replace_or_append('/etc/systemd/journal-upload.conf', '^ServerCertificateFile', "$var_journal_upload_server_certificate_file", '%s=%s') }}}
 
 {{{ bash_instantiate_variables("var_journal_upload_server_trusted_certificate_file") }}}
-{{{ bash_replace_or_append('$var_journal_upload_conf_file', '^TrustedCertificateFile', "$var_journal_upload_server_trusted_certificate_file", '%s=%s') }}}
-
+{{{ bash_replace_or_append('/etc/systemd/journal-upload.conf', '^TrustedCertificateFile', "$var_journal_upload_server_trusted_certificate_file", '%s=%s') }}}

--- a/linux_os/guide/system/logging/journald/systemd_journal_upload_server_tls/bash/ubuntu.sh
+++ b/linux_os/guide/system/logging/journald/systemd_journal_upload_server_tls/bash/ubuntu.sh
@@ -1,0 +1,22 @@
+# platform = multi_platform_ubuntu
+
+dropin_conf=/etc/systemd/journal-upload.conf.d/60-journald_upload.conf
+mkdir -p /etc/systemd/journal-upload.conf.d
+touch "${dropin_conf}"
+
+for conf in /etc/systemd/journal-upload.conf /etc/systemd/journal-upload.conf.d/*; do
+    [[ -e "${conf}" ]] || continue
+    sed -i --follow-symlinks \
+        -e 's/^ServerKeyFile\>/#&/g' \
+        -e 's/^ServerCertificateFile\>/#&/g' \
+        -e 's/^TrustedCertificateFile\>/#&/g' "${conf}"
+done
+
+{{{ bash_instantiate_variables("var_journal_upload_server_key_file") }}}
+{{{ bash_instantiate_variables("var_journal_upload_server_certificate_file") }}}
+{{{ bash_instantiate_variables("var_journal_upload_server_trusted_certificate_file") }}}
+
+{{{ bash_ensure_ini_config("${dropin_conf}", 'Upload', 'ServerKeyFile', "$var_journal_upload_server_key_file") }}}
+{{{ bash_ensure_ini_config("${dropin_conf}", 'Upload', 'ServerCertificateFile', "$var_journal_upload_server_certificate_file") }}}
+{{{ bash_ensure_ini_config("${dropin_conf}", 'Upload', 'TrustedCertificateFile', "$var_journal_upload_server_trusted_certificate_file") }}}
+

--- a/linux_os/guide/system/logging/journald/systemd_journal_upload_server_tls/oval/shared.xml
+++ b/linux_os/guide/system/logging/journald/systemd_journal_upload_server_tls/oval/shared.xml
@@ -21,7 +21,7 @@
 
   <ind:textfilecontent54_object id="object_systemd_journal_upload_server_key_file" version="2">
     <ind:filepath operation="pattern match">^/etc/systemd/journal-upload.conf(\.d/[^/]+\.conf)?$</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*ServerKeyFile\s*=\s*(.*)\s*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\[Upload\](?:[^\n]*\n+)+?^\h*ServerKeyFile\h*=\h*(.*)\h*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -40,7 +40,7 @@
 
   <ind:textfilecontent54_object id="object_systemd_journal_upload_server_certificate_file" version="2">
     <ind:filepath operation="pattern match">^/etc/systemd/journal-upload.conf(\.d/[^/]+\.conf)?$</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*ServerCertificateFile\s*=\s*(.*)\s*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\[Upload\](?:[^\n]*\n+)+?^\h*ServerCertificateFile\h*=\h*(.*)\h*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -59,7 +59,7 @@
 
   <ind:textfilecontent54_object id="object_systemd_journal_upload_server_trusted_certificate_file" version="2">
     <ind:filepath operation="pattern match">^/etc/systemd/journal-upload.conf(\.d/[^/]+\.conf)?$</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*TrustedCertificateFile\s*=\s*(.*)\s*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\[Upload\](?:[^\n]*\n+)+?^\h*TrustedCertificateFile\h*=\h*(.*)\h*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/logging/journald/systemd_journal_upload_url/bash/shared.sh
+++ b/linux_os/guide/system/logging/journald/systemd_journal_upload_url/bash/shared.sh
@@ -1,15 +1,4 @@
-# platform = multi_platform_slmicro,multi_platform_ubuntu
-
-{{% if 'ubuntu' in product %}}
-var_journal_upload_conf_file=/etc/systemd/journal-upload.conf.d/60-journald_upload.conf
-mkdir -p /etc/systemd/journal-upload.conf.d
-touch /etc/systemd/journal-upload.conf.d/60-journald_upload.conf
-
-{{{ bash_comment_config_line("/etc/systemd/journal-upload.conf(\.d/[^/]+\.conf)", '^URL') }}}
-{{% else %}}
-var_journal_upload_conf_file=/etc/systemd/journal-upload.conf
-{{% endif %}}
+# platform = multi_platform_slmicro
 
 {{{ bash_instantiate_variables("var_journal_upload_url") }}}
-{{{ bash_replace_or_append('$var_journal_upload_conf_file', '^URL', "$var_journal_upload_url", '%s=%s') }}}
-
+{{{ bash_replace_or_append('/etc/systemd/journal-upload.conf', '^URL', "$var_journal_upload_url", '%s=%s') }}}

--- a/linux_os/guide/system/logging/journald/systemd_journal_upload_url/bash/ubuntu.sh
+++ b/linux_os/guide/system/logging/journald/systemd_journal_upload_url/bash/ubuntu.sh
@@ -1,0 +1,14 @@
+# platform = multi_platform_ubuntu
+
+dropin_conf=/etc/systemd/journal-upload.conf.d/60-journald_upload.conf
+mkdir -p /etc/systemd/journal-upload.conf.d
+touch "${dropin_conf}"
+
+for conf in /etc/systemd/journal-upload.conf /etc/systemd/journal-upload.conf.d/*; do
+    [[ -e "${conf}" ]] || continue
+    sed -i --follow-symlinks 's/^URL\>/#&/g' "${conf}"
+done
+
+{{{ bash_instantiate_variables("var_journal_upload_url") }}}
+
+{{{ bash_ensure_ini_config("${dropin_conf}", 'Upload', 'URL', "$var_journal_upload_url") }}}

--- a/linux_os/guide/system/logging/journald/systemd_journal_upload_url/oval/shared.xml
+++ b/linux_os/guide/system/logging/journald/systemd_journal_upload_url/oval/shared.xml
@@ -14,7 +14,7 @@
 
   <ind:textfilecontent54_object id="object_test_systemd_journal_upload_url" version="2">
     <ind:filepath operation="pattern match">^/etc/systemd/journal-upload.conf(\.d/[^/]+\.conf)?$</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*URL\s*=\s*(.*)\s*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\[Upload\](?:[^\n]*\n+)+?^\h*URL\h*=\h*(.*)\h*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -23,5 +23,4 @@
   </ind:textfilecontent54_state>
 
   <external_variable comment="systemd-journal-upload URL" datatype="string" id="var_journal_upload_url" version="1" />
-
 </def-group>


### PR DESCRIPTION
#### Description:

- fix missing section in config file by switching to macro bash_ensure_ini_config
- fix commenting by replacing broken macro with sed (macro searches for keywords ending in space and fails when keyword ends with '=')
- improve OVAL to check for correct section
