### PR TITLE
Add applicability checks to rsyslog and journal rules on Ubuntu 2404

### DIFF
--- a/linux_os/guide/system/logging/journald/journald_compress/rule.yml
+++ b/linux_os/guide/system/logging/journald/journald_compress/rule.yml
@@ -1,6 +1,5 @@
 documentation_complete: true
 
-
 title: Ensure journald is configured to compress large log files
 
 description: |-
@@ -64,3 +63,7 @@ template:
         value: yes
         no_quotes: 'true'
 {{% endif -%}}
+
+{{% if product in ['ubuntu2404'] %}}
+platform: service_disabled[rsyslog]
+{{% endif %}}

--- a/linux_os/guide/system/logging/journald/journald_disable_forward_to_syslog/rule.yml
+++ b/linux_os/guide/system/logging/journald/journald_disable_forward_to_syslog/rule.yml
@@ -9,7 +9,11 @@ rationale:
     If journald is the method for capturing logs, all logs of the system should be
     handled by journald and not forwarded to other logging mechanisms.
 
+{{% if product in ['ubuntu2404'] %}}
+platform: package[systemd] and service_disabled[rsyslog]
+{{% else %}}
 platform: package[systemd]
+{{% endif %}}
 
 severity: medium
 

--- a/linux_os/guide/system/logging/journald/journald_forward_to_syslog/rule.yml
+++ b/linux_os/guide/system/logging/journald/journald_forward_to_syslog/rule.yml
@@ -63,3 +63,7 @@ template:
         value: yes
         no_quotes: 'true'
 {{% endif -%}}
+
+{{% if product in ['ubuntu2404'] %}}
+platform: not service_disabled[rsyslog]
+{{% endif %}}

--- a/linux_os/guide/system/logging/journald/journald_storage/rule.yml
+++ b/linux_os/guide/system/logging/journald/journald_storage/rule.yml
@@ -63,3 +63,7 @@ template:
         value: persistent
         no_quotes: 'true'
 {{% endif -%}}
+
+{{% if product in ['ubuntu2404'] %}}
+platform: service_disabled[rsyslog]
+{{% endif %}}

--- a/linux_os/guide/system/logging/journald/package_systemd-journal-remote_installed/rule.yml
+++ b/linux_os/guide/system/logging/journald/package_systemd-journal-remote_installed/rule.yml
@@ -34,5 +34,9 @@ template:
     vars:
         pkgname: systemd-journal-remote
 
+{{% if product in ['ubuntu2404'] %}}
+platform: service_disabled[rsyslog]
+{{% endif %}}
+
 fixtext: |-
     {{{ describe_package_install(package="systemd-journal-remote") }}}

--- a/linux_os/guide/system/logging/journald/service_systemd-journal-upload_enabled/rule.yml
+++ b/linux_os/guide/system/logging/journald/service_systemd-journal-upload_enabled/rule.yml
@@ -29,7 +29,7 @@ fixtext: |-
 
 srg_requirement: '{{{ srg_requirement_service_enabled("systemd-journal-upload") }}}'
 
-platform: machine
+platform: machine and package[systemd-journal-remote]
 
 template:
     name: service_enabled

--- a/linux_os/guide/system/logging/journald/systemd_journal_upload_server_tls/rule.yml
+++ b/linux_os/guide/system/logging/journald/systemd_journal_upload_server_tls/rule.yml
@@ -34,3 +34,7 @@ fixtext: |-
     Configure systemd-journal-upload ServerKeyFile to {{{ xccdf_value("var_journal_upload_server_key_file") }}}
     Configure systemd-journal-upload ServerCertificateFile to {{{ xccdf_value("var_journal_upload_server_certificate_file") }}}
     Configure systemd-journal-upload TrustedCertificateFile to {{{ xccdf_value("var_journal_upload_server_trusted_certificate_file") }}}
+
+{{% if product in ['ubuntu2404'] %}}
+platform: service_disabled[rsyslog]
+{{% endif %}}

--- a/linux_os/guide/system/logging/journald/systemd_journal_upload_url/rule.yml
+++ b/linux_os/guide/system/logging/journald/systemd_journal_upload_url/rule.yml
@@ -29,3 +29,7 @@ ocil: |-
 
 fixtext: |-
    Configure systemd-journal-upload URL to {{{ xccdf_value("var_journal_upload_url") }}}
+
+{{% if product in ['ubuntu2404'] %}}
+platform: service_disabled[rsyslog]
+{{% endif %}}

--- a/linux_os/guide/system/logging/rsyslog_accepting_remote_messages/rsyslog_nolisten/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_accepting_remote_messages/rsyslog_nolisten/rule.yml
@@ -82,3 +82,7 @@ ocil: |-
 fixtext: |-
     The {{{ full_name }}} must be configured so that the rsyslog daemon does not accept log
     messages from other servers unless the server is being used for log aggregation.
+
+{{% if product in ['ubuntu2404'] %}}
+platform: not service_disabled[rsyslog]
+{{% endif %}}

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/rule.yml
@@ -38,3 +38,7 @@ fixtext: |-
     $FileCreateMode 0640
     Restart the service:
     # systemctl restart rsyslog
+
+{{% if product in ['ubuntu2404'] %}}
+platform: not service_disabled[rsyslog]
+{{% endif %}}

--- a/linux_os/guide/system/logging/service_rsyslog_enabled/rule.yml
+++ b/linux_os/guide/system/logging/service_rsyslog_enabled/rule.yml
@@ -52,3 +52,7 @@ template:
     name: service_enabled
     vars:
         servicename: rsyslog
+
+{{% if product in ['ubuntu2404'] %}}
+platform: package[rsyslog]
+{{% endif %}}

--- a/shared/applicability/package.yml
+++ b/shared/applicability/package.yml
@@ -118,6 +118,8 @@ args:
     pkgname: sudo
   systemd:
     pkgname: systemd
+  systemd-journal-remote:
+    pkgname: systemd-journal-remote
   systemd-timesyncd:
     pkgname: systemd-timesyncd
   telnet-server:

--- a/shared/applicability/service_disabled.yml
+++ b/shared/applicability/service_disabled.yml
@@ -16,3 +16,6 @@ args:
   ufw:
       servicename: ufw
       packagename: ufw
+  rsyslog:
+      servicename: rsyslog
+      packagename: rsyslog

--- a/shared/applicability/system_with_kernel.yml
+++ b/shared/applicability/system_with_kernel.yml
@@ -25,9 +25,9 @@ bash_conditional: "rpm --quiet -q kernel"
 {{% endif %}}
 {{% else %}}
 {{% if "debian" in product or "ubuntu" in product %}}
-bash_conditional: "dpkg-query --show --showformat='${db:Status-Status}\n' 'linux-base' 2>/dev/null | grep -q ^installed"
+bash_conditional: "dpkg-query --show --showformat='${db:Status-Status}' 'linux-base' 2>/dev/null | grep -q '^installed$'"
 {{% else %}}
-bash_conditional: "dpkg-query --show --showformat='${db:Status-Status}\n' 'kernel' 2>/dev/null | grep -q ^installed"
+bash_conditional: "dpkg-query --show --showformat='${db:Status-Status}' 'kernel' 2>/dev/null | grep -q '^installed$'"
 {{% endif %}}
 {{% endif %}}
 {{% if "debian" in product or "ubuntu" in product %}}

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1456,7 +1456,7 @@ done
 #}}
 {{%- macro bash_package_installed(pkgname) -%}}
 {{%- if pkg_manager == "apt_get" -%}}
-dpkg-query --show --showformat='${db:Status-Status}\n' "{{{ pkgname }}}" 2>/dev/null | grep -q ^installed
+dpkg-query --show --showformat='${db:Status-Status}' "{{{ pkgname }}}" 2>/dev/null | grep -q '^installed$'
 {{%- else -%}}
 rpm --quiet -q "{{{ pkgname }}}"
 {{%- endif -%}}
@@ -2147,9 +2147,9 @@ This macro creates a Bash conditional which uses dpkg to check if a package pass
 #}}
 {{%- macro bash_pkg_conditional_dpkg(package, op=None, ver=None) -%}}
 {{%- if ver -%}}
-dpkg-query --show --showformat='${db:Status-Status}\n' '{{{ package }}}' 2>/dev/null | grep -q '^installed' && {{{ bash_compare_version_dpkg(package, op, ver) }}}
+dpkg-query --show --showformat='${db:Status-Status}' '{{{ package }}}' 2>/dev/null | grep -q '^installed$' && {{{ bash_compare_version_dpkg(package, op, ver) }}}
 {{%- else -%}}
-dpkg-query --show --showformat='${db:Status-Status}\n' '{{{ package }}}' 2>/dev/null | grep -q '^installed'
+dpkg-query --show --showformat='${db:Status-Status}' '{{{ package }}}' 2>/dev/null | grep -q '^installed$'
 {{%- endif -%}}
 {{%- endmacro -%}}
 

--- a/shared/templates/platform_service_disabled/bash.template
+++ b/shared/templates/platform_service_disabled/bash.template
@@ -1,0 +1,1 @@
+! (systemctl is-active {{{ SERVICENAME }}} &>/dev/null)

--- a/shared/templates/platform_service_disabled/template.yml
+++ b/shared/templates/platform_service_disabled/template.yml
@@ -1,2 +1,3 @@
 supported_languages:
+  - bash
   - cpe-oval

--- a/shared/templates/service_disabled_guard_var/oval.template
+++ b/shared/templates/service_disabled_guard_var/oval.template
@@ -11,7 +11,7 @@
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
     {{{ oval_metadata("The " + SERVICENAME + " service should be disabled.", affected_platforms=["multi_platform_all"]) }}}
     <criteria operator="OR" comment="package {{{ PACKAGENAME }}} removed or service {{{ SERVICENAME }}} is not configured to start">
-      <criteria comment="{{{ PKGNAME }}} and service {{{ SERVICENAME }}} are needed" operator="AND">
+      <criteria comment="{{{ PACKAGENAME }}} and service {{{ SERVICENAME }}} are needed" operator="AND">
         <criterion comment="variable {{{ VARIABLE }}} is set to {{{ VALUE }}}"
         test_ref="{{{ variable_value_test_id }}}"/>
       </criteria>


### PR DESCRIPTION
#### Description:

Ubuntu 24.04 CIS v1.0.0 introduces the concept of “chosen method for client side logging”, where the applicability of specific rules depends on whether the user has chosen rsyslog or journald as their primary logging system.

Rule 6.1.1.4 attempts to determine the chosen system by checking if rsyslog service is active. If active, rsyslog is considered as the chosen logging system and rules in section 6.1.2 are ignored. Otherwise, systemd-journald is the chosen logging system and rules in 6.1.3 are ignored.

This PR introduces applicability checks to emulate this.

Applicable only when rsyslog is active:
- rsyslog_nolisten
- rsyslog_filecreatemode
- journald_forward_to_syslog

Applicable only when rsyslog is not active:
- journald_storage
- journald_compress
- package_systemd-journal-remote_installed
- systemd_journal_upload_server_tls
- systemd_journal_upload_url
- journald_disable_forward_to_syslog

Applicable only when systemd-journal-remote package is installed:
- service_systemd-journal-upload_enabled

Applicable only when rsyslog package is installed:
- service_rsyslog_enabled
