### PR TITLE
Ubuntu 24.04 6.1.4.1 Ensure access to all logfiles has been configured

### DIFF
--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -70,6 +70,7 @@ rules:
 - file_owner_etc_shadow
 - file_owner_systemmap
 - file_owner_var_log
+- file_owner_var_log_auth
 - file_owner_var_log_messages
 - file_owner_var_log_syslog
 - file_ownership_audit_binaries

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -124,6 +124,7 @@ rules:
 - file_permissions_var_log_sssd
 - file_permissions_var_log_syslog
 - file_permissions_var_log_waagent
+- file_permissions_var_log_wbtmp
 - groupowner_local_var_log
 - mount_option_boot_efi_nosuid
 - mount_option_boot_noauto

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -112,6 +112,7 @@ rules:
 - file_permissions_unauthorized_world_writable
 - file_permissions_ungroupowned
 - file_permissions_var_log
+- file_permissions_var_log_apt
 - file_permissions_var_log_messages
 - file_permissions_var_log_syslog
 - groupowner_local_var_log

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -79,6 +79,7 @@ rules:
 - file_owner_var_log_localmessages
 - file_owner_var_log_messages
 - file_owner_var_log_secure
+- file_owner_var_log_sssd
 - file_owner_var_log_syslog
 - file_ownership_audit_binaries
 - file_ownership_binary_dirs

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -73,6 +73,7 @@ rules:
 - file_owner_var_log_auth
 - file_owner_var_log_cloud_init
 - file_owner_var_log_gdm
+- file_owner_var_log_gdm3
 - file_owner_var_log_messages
 - file_owner_var_log_syslog
 - file_ownership_audit_binaries

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -121,6 +121,7 @@ rules:
 - file_permissions_var_log_localmessages
 - file_permissions_var_log_messages
 - file_permissions_var_log_secure
+- file_permissions_var_log_sssd
 - file_permissions_var_log_syslog
 - groupowner_local_var_log
 - mount_option_boot_efi_nosuid

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -72,6 +72,7 @@ rules:
 - file_owner_var_log
 - file_owner_var_log_auth
 - file_owner_var_log_cloud_init
+- file_owner_var_log_gdm
 - file_owner_var_log_messages
 - file_owner_var_log_syslog
 - file_ownership_audit_binaries

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -74,6 +74,7 @@ rules:
 - file_owner_var_log_cloud_init
 - file_owner_var_log_gdm
 - file_owner_var_log_gdm3
+- file_owner_var_log_journal
 - file_owner_var_log_messages
 - file_owner_var_log_syslog
 - file_ownership_audit_binaries

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -81,6 +81,7 @@ rules:
 - file_owner_var_log_secure
 - file_owner_var_log_sssd
 - file_owner_var_log_syslog
+- file_owner_var_log_waagent
 - file_ownership_audit_binaries
 - file_ownership_binary_dirs
 - file_ownership_library_dirs

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -53,6 +53,7 @@ rules:
 - file_groupowner_var_log_sssd
 - file_groupowner_var_log_syslog
 - file_groupowner_var_log_waagent
+- file_groupowner_var_log_wbtmp
 - file_groupownership_audit_binaries
 - file_groupownership_system_commands_dirs
 - file_owner_backup_etc_group

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -45,6 +45,7 @@ rules:
 - file_groupowner_var_log_cloud_init
 - file_groupowner_var_log_gdm
 - file_groupowner_var_log_gdm3
+- file_groupowner_var_log_journal
 - file_groupowner_var_log_messages
 - file_groupowner_var_log_syslog
 - file_groupownership_audit_binaries

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -120,6 +120,7 @@ rules:
 - file_permissions_var_log_lastlog
 - file_permissions_var_log_localmessages
 - file_permissions_var_log_messages
+- file_permissions_var_log_secure
 - file_permissions_var_log_syslog
 - groupowner_local_var_log
 - mount_option_boot_efi_nosuid

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -42,6 +42,7 @@ rules:
 - file_groupowner_var_log
 - file_groupowner_var_log_apt
 - file_groupowner_var_log_auth
+- file_groupowner_var_log_cloud_init
 - file_groupowner_var_log_messages
 - file_groupowner_var_log_syslog
 - file_groupownership_audit_binaries

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -47,6 +47,7 @@ rules:
 - file_groupowner_var_log_gdm3
 - file_groupowner_var_log_journal
 - file_groupowner_var_log_lastlog
+- file_groupowner_var_log_localmessages
 - file_groupowner_var_log_messages
 - file_groupowner_var_log_syslog
 - file_groupownership_audit_binaries

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -113,6 +113,7 @@ rules:
 - file_permissions_ungroupowned
 - file_permissions_var_log
 - file_permissions_var_log_apt
+- file_permissions_var_log_auth
 - file_permissions_var_log_messages
 - file_permissions_var_log_syslog
 - groupowner_local_var_log

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -114,6 +114,7 @@ rules:
 - file_permissions_var_log
 - file_permissions_var_log_apt
 - file_permissions_var_log_auth
+- file_permissions_var_log_cloud-init
 - file_permissions_var_log_messages
 - file_permissions_var_log_syslog
 - groupowner_local_var_log

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -71,6 +71,7 @@ rules:
 - file_owner_systemmap
 - file_owner_var_log
 - file_owner_var_log_auth
+- file_owner_var_log_cloud_init
 - file_owner_var_log_messages
 - file_owner_var_log_syslog
 - file_ownership_audit_binaries

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -118,6 +118,7 @@ rules:
 - file_permissions_var_log_gdm
 - file_permissions_var_log_gdm3
 - file_permissions_var_log_lastlog
+- file_permissions_var_log_localmessages
 - file_permissions_var_log_messages
 - file_permissions_var_log_syslog
 - groupowner_local_var_log

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -117,6 +117,7 @@ rules:
 - file_permissions_var_log_cloud-init
 - file_permissions_var_log_gdm
 - file_permissions_var_log_gdm3
+- file_permissions_var_log_lastlog
 - file_permissions_var_log_messages
 - file_permissions_var_log_syslog
 - groupowner_local_var_log

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -49,6 +49,7 @@ rules:
 - file_groupowner_var_log_lastlog
 - file_groupowner_var_log_localmessages
 - file_groupowner_var_log_messages
+- file_groupowner_var_log_secure
 - file_groupowner_var_log_syslog
 - file_groupownership_audit_binaries
 - file_groupownership_system_commands_dirs

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -50,6 +50,7 @@ rules:
 - file_groupowner_var_log_localmessages
 - file_groupowner_var_log_messages
 - file_groupowner_var_log_secure
+- file_groupowner_var_log_sssd
 - file_groupowner_var_log_syslog
 - file_groupownership_audit_binaries
 - file_groupownership_system_commands_dirs

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -76,6 +76,7 @@ rules:
 - file_owner_var_log_gdm3
 - file_owner_var_log_journal
 - file_owner_var_log_lastlog
+- file_owner_var_log_localmessages
 - file_owner_var_log_messages
 - file_owner_var_log_syslog
 - file_ownership_audit_binaries

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -134,6 +134,7 @@ rules:
 - mount_option_var_tmp_noexec
 - mount_option_var_tmp_nosuid
 - no_files_unowned_by_user
+- owner_local_var_log
 - partition_for_boot
 - partition_for_dev_shm
 - partition_for_home

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -116,6 +116,7 @@ rules:
 - file_permissions_var_log_auth
 - file_permissions_var_log_cloud-init
 - file_permissions_var_log_gdm
+- file_permissions_var_log_gdm3
 - file_permissions_var_log_messages
 - file_permissions_var_log_syslog
 - groupowner_local_var_log

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -40,6 +40,7 @@ rules:
 - file_groupowner_etc_shells
 - file_groupowner_systemmap
 - file_groupowner_var_log
+- file_groupowner_var_log_apt
 - file_groupowner_var_log_messages
 - file_groupowner_var_log_syslog
 - file_groupownership_audit_binaries

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -78,6 +78,7 @@ rules:
 - file_owner_var_log_lastlog
 - file_owner_var_log_localmessages
 - file_owner_var_log_messages
+- file_owner_var_log_secure
 - file_owner_var_log_syslog
 - file_ownership_audit_binaries
 - file_ownership_binary_dirs

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -75,6 +75,7 @@ rules:
 - file_owner_var_log_gdm
 - file_owner_var_log_gdm3
 - file_owner_var_log_journal
+- file_owner_var_log_lastlog
 - file_owner_var_log_messages
 - file_owner_var_log_syslog
 - file_ownership_audit_binaries

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -46,6 +46,7 @@ rules:
 - file_groupowner_var_log_gdm
 - file_groupowner_var_log_gdm3
 - file_groupowner_var_log_journal
+- file_groupowner_var_log_lastlog
 - file_groupowner_var_log_messages
 - file_groupowner_var_log_syslog
 - file_groupownership_audit_binaries

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -92,6 +92,7 @@ rules:
 - file_permissions_var_log
 - file_permissions_var_log_messages
 - file_permissions_var_log_syslog
+- groupowner_local_var_log
 - mount_option_boot_efi_nosuid
 - mount_option_boot_noauto
 - mount_option_boot_nodev

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -52,6 +52,7 @@ rules:
 - file_groupowner_var_log_secure
 - file_groupowner_var_log_sssd
 - file_groupowner_var_log_syslog
+- file_groupowner_var_log_waagent
 - file_groupownership_audit_binaries
 - file_groupownership_system_commands_dirs
 - file_owner_backup_etc_group

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -43,6 +43,7 @@ rules:
 - file_groupowner_var_log_apt
 - file_groupowner_var_log_auth
 - file_groupowner_var_log_cloud_init
+- file_groupowner_var_log_gdm
 - file_groupowner_var_log_messages
 - file_groupowner_var_log_syslog
 - file_groupownership_audit_binaries

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -41,6 +41,7 @@ rules:
 - file_groupowner_systemmap
 - file_groupowner_var_log
 - file_groupowner_var_log_apt
+- file_groupowner_var_log_auth
 - file_groupowner_var_log_messages
 - file_groupowner_var_log_syslog
 - file_groupownership_audit_binaries

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -123,6 +123,7 @@ rules:
 - file_permissions_var_log_secure
 - file_permissions_var_log_sssd
 - file_permissions_var_log_syslog
+- file_permissions_var_log_waagent
 - groupowner_local_var_log
 - mount_option_boot_efi_nosuid
 - mount_option_boot_noauto

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -115,6 +115,7 @@ rules:
 - file_permissions_var_log_apt
 - file_permissions_var_log_auth
 - file_permissions_var_log_cloud-init
+- file_permissions_var_log_gdm
 - file_permissions_var_log_messages
 - file_permissions_var_log_syslog
 - groupowner_local_var_log

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -44,6 +44,7 @@ rules:
 - file_groupowner_var_log_auth
 - file_groupowner_var_log_cloud_init
 - file_groupowner_var_log_gdm
+- file_groupowner_var_log_gdm3
 - file_groupowner_var_log_messages
 - file_groupowner_var_log_syslog
 - file_groupownership_audit_binaries

--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -82,6 +82,7 @@ rules:
 - file_owner_var_log_sssd
 - file_owner_var_log_syslog
 - file_owner_var_log_waagent
+- file_owner_var_log_wbtmp
 - file_ownership_audit_binaries
 - file_ownership_binary_dirs
 - file_ownership_library_dirs

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2433,10 +2433,52 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    related_rules:
+    rules:  
+      - file_groupowner_var_log_apt
+      - file_groupowner_var_log_auth
+      - file_groupowner_var_log_cloud_init
+      - file_groupowner_var_log_gdm
+      - file_groupowner_var_log_gdm3
+      - file_groupowner_var_log_journal
+      - file_groupowner_var_log_lastlog
+      - file_groupowner_var_log_localmessages
+      - file_groupowner_var_log_messages
+      - file_groupowner_var_log_secure
+      - file_groupowner_var_log_sssd
+      - file_groupowner_var_log_syslog
+      - file_groupowner_var_log_waagent
+      - file_groupowner_var_log_wbtmp
+      - file_owner_var_log_auth
+      - file_owner_var_log_cloud_init
+      - file_owner_var_log_gdm
+      - file_owner_var_log_gdm3
+      - file_owner_var_log_journal
+      - file_owner_var_log_lastlog
+      - file_owner_var_log_localmessages
+      - file_owner_var_log_messages
+      - file_owner_var_log_secure
+      - file_owner_var_log_sssd
+      - file_owner_var_log_syslog
+      - file_owner_var_log_waagent
+      - file_owner_var_log_wbtmp
+      - file_permissions_var_log_apt
+      - file_permissions_var_log_auth
+      - file_permissions_var_log_cloud-init
+      - file_permissions_var_log_gdm
+      - file_permissions_var_log_gdm3
+      - file_permissions_var_log_lastlog
+      - file_permissions_var_log_cloud-init
+      - file_permissions_var_log_localmessages
+      - file_permissions_var_log_messages
+      - file_permissions_var_log_secure
+      - file_permissions_var_log_sssd
+      - file_permissions_var_log_syslog
+      - file_permissions_var_log_waagent
+      - file_permissions_var_log_wbtmp
+      - groupowner_local_var_log
+      - owner_local_var_log
       - permissions_local_var_log
-    status: planned
-    notes: TODO. Partial/incorrect implementation exists.See related rules. Analogous to ubuntu2204/4.2.3.
+    status: automated
 
   - id: 6.2.1.1
     title: Ensure auditd packages are installed (Automated)

--- a/linux_os/guide/system/permissions/files/groupowner_local_var_log/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/groupowner_local_var_log/bash/shared.sh
@@ -1,0 +1,13 @@
+# platform = Ubuntu 24.04
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+
+if getent group "adm" >/dev/null 2>&1; then
+    group="adm"
+else
+    group="root"
+fi
+
+find -L /var/log/ -maxdepth 1 -regextype posix-extended ! -group root ! -group adm -name '*' ! -path '/var/log/apt/*' ! -name 'auth.log' ! -path '/var/log/[bw]tmp*' ! -path '/var/log/cloud-init.log*' ! -name 'gdm' ! -name 'gdm3' ! -regex '.*\.journal[~]?' ! -regex '.*lastlog(\.[^\/]+)?$' ! -regex '.*localmessages(.*)'  ! -name 'messages' ! -regex '.*secure(.*)' ! -name 'sssd' ! -name 'syslog' ! -regex '.*waagent.log(.*)' -regex '.*' -exec chgrp $group {} \;

--- a/linux_os/guide/system/permissions/files/groupowner_local_var_log/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/groupowner_local_var_log/oval/shared.xml
@@ -1,0 +1,87 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+      {{{ oval_metadata("Group owner of /var/log/* should be root or adm.") }}}
+    <criteria comment="Check group ownership of /var/log/*">
+     <criterion test_ref="test_group_ownership_var_log" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_object id="object_adm_gid" version="1" comment="gid of the dedicated adm group">
+    <ind:filepath>/etc/group</ind:filepath>
+    <ind:pattern operation="pattern match">^adm:\w+:(\w+):.*</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <local_variable id="var_adm_gid" datatype="int" version="1"
+                  comment="Retrieve the gid of adm group">
+    <object_component item_field="subexpression" object_ref="object_adm_gid"/>
+  </local_variable>
+
+  <unix:file_test check="all" comment="/var/log/* group owner is root|adm"
+      id="test_group_ownership_var_log" state_operator="OR" version="1">
+    <unix:object object_ref="object_group_ownership_var_log" />
+    <unix:state state_ref="state_group_ownership_adm_var_log_auth_log"/>
+    <unix:state state_ref="state_group_ownership_root_var_log_auth_log"/>
+  </unix:file_test>
+  <unix:file_object comment="/var/log/*" id="object_group_ownership_var_log" version="1">
+    <unix:path>/var/log</unix:path>
+    <unix:filename operation="pattern match">.*</unix:filename>
+    <filter action="exclude">exclude_files_apt</filter>
+    <filter action="exclude">exclude_files_auth_log</filter>
+    <filter action="exclude">exclude_files_bwtmp</filter>
+    <filter action="exclude">exclude_files_cloudinit</filter>
+    <filter action="exclude">exclude_files_gdm</filter>
+    <filter action="exclude">exclude_files_journal</filter>
+    <filter action="exclude">exclude_files_lastlog</filter>
+    <filter action="exclude">exclude_files_localmessages</filter>
+    <filter action="exclude">exclude_files_messages</filter>
+    <filter action="exclude">exclude_files_secure</filter>
+    <filter action="exclude">exclude_files_sssd</filter>
+    <filter action="exclude">exclude_files_syslog</filter>
+    <filter action="exclude">exclude_files_waagent</filter>
+  </unix:file_object>
+  <unix:file_state id="state_group_ownership_adm_var_log_auth_log" version="1">
+    <unix:group_id datatype="int" operation="equals" var_ref="var_adm_gid"/>
+  </unix:file_state>
+  <unix:file_state id="state_group_ownership_root_var_log_auth_log" version="1">
+    <unix:group_id datatype="int" operation="equals">0</unix:group_id>
+  </unix:file_state>
+  <unix:file_state id="exclude_files_apt" version="1">
+    <unix:path operation="pattern match">^.*apt</unix:path>
+  </unix:file_state>
+  <unix:file_state id="exclude_files_auth_log" version="1">
+    <unix:filename>auth.log</unix:filename>
+  </unix:file_state>
+  <unix:file_state id="exclude_files_bwtmp" version="1">
+    <unix:filename operation="pattern match">^.*[bw]tmp((\.|-).*)?$</unix:filename>
+  </unix:file_state>
+  <unix:file_state id="exclude_files_cloudinit" version="1">
+    <unix:filename operation="pattern match">^.*cloud-init\.log.*</unix:filename>
+  </unix:file_state>
+  <unix:file_state id="exclude_files_gdm" version="1" operator="AND">
+    <unix:path operation="pattern match">^.*gdm|gdm3</unix:path>
+  </unix:file_state>
+  <unix:file_state id="exclude_files_journal" version="1" operator="AND">
+    <unix:filename operation="pattern match">^.*\.journal.*$</unix:filename>
+  </unix:file_state>
+  <unix:file_state id="exclude_files_lastlog" version="1">
+    <unix:filename operation="pattern match">^.*lastlog.*$</unix:filename>
+  </unix:file_state>
+  <unix:file_state id="exclude_files_localmessages" version="1">
+    <unix:filename operation="pattern match">^.*localmessages.*$</unix:filename>
+  </unix:file_state>
+  <unix:file_state id="exclude_files_messages" version="1">
+    <unix:filename>messages</unix:filename>
+  </unix:file_state>
+  <unix:file_state id="exclude_files_secure" version="1">
+    <unix:filename operation="pattern match">^.*secure.*$</unix:filename>
+  </unix:file_state>
+  <unix:file_state id="exclude_files_sssd" version="1" operator="AND">
+    <unix:path operation="pattern match">^.*(sssd|SSSD)$</unix:path>
+  </unix:file_state>
+  <unix:file_state id="exclude_files_syslog" version="1">
+    <unix:filename>syslog</unix:filename>
+  </unix:file_state>
+  <unix:file_state id="exclude_files_waagent" version="1">
+    <unix:filename operation="pattern match">^.*waagent\.log.*$</unix:filename>
+  </unix:file_state>
+</def-group>

--- a/linux_os/guide/system/permissions/files/groupowner_local_var_log/rule.yml
+++ b/linux_os/guide/system/permissions/files/groupowner_local_var_log/rule.yml
@@ -25,7 +25,7 @@ rationale: |-
 
 severity: medium
 
-ocil_clause: 'not all log files owned by root or syslog'
+ocil_clause: 'not all log files group-owned by root or adm'
 
 ocil: |-
     Verify the operating system has all system log files under the

--- a/linux_os/guide/system/permissions/files/groupowner_local_var_log/rule.yml
+++ b/linux_os/guide/system/permissions/files/groupowner_local_var_log/rule.yml
@@ -1,0 +1,33 @@
+documentation_complete: true
+
+
+title: 'Verify ownership of log files'
+
+description: |-
+    Any operating system providing too much information in error messages
+    risks compromising the data and security of the structure, and content
+    of error messages needs to be carefully considered by the organization.
+
+    Organizations carefully consider the structure/content of error messages.
+    The extent to which information systems are able to identify and handle
+    error conditions is guided by organizational policy and operational
+    requirements. Information that could be exploited by adversaries includes,
+    for example, erroneous logon attempts with passwords entered by mistake
+    as the username, mission/business information that can be derived from
+    (if not stated explicitly by) information recorded, and personal
+    information, such as account numbers, social security numbers, and credit
+    card numbers.
+
+rationale: |-
+    The {{{ full_name }}} must generate error messages that provide information
+    necessary for corrective actions without revealing information that could
+    be exploited by adversaries.
+
+severity: medium
+
+ocil_clause: 'not all log files owned by root or syslog'
+
+ocil: |-
+    Verify the operating system has all system log files under the
+    <pre>/var/log</pre> directory, that are not excluded, with a group owner set to root | adm,
+

--- a/linux_os/guide/system/permissions/files/groupowner_local_var_log/tests/excluded_files.pass.sh
+++ b/linux_os/guide/system/permissions/files/groupowner_local_var_log/tests/excluded_files.pass.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+chgrp root /var/log/*
+mkdir -p /var/log/apt
+chgrp nogroup /var/log/apt
+touch /var/log/auth.log
+chgrp nogroup /var/log/auth.log
+touch /var/log/btmp.log
+touch /var/log/btmp.log.1
+touch /var/log/btmp.log-1
+chgrp nogroup /var/log/btmp*
+touch /var/log/wtmp.log
+touch /var/log/wtmp.log.1
+touch /var/log/wtmp.log-1
+chgrp nogroup /var/log/wtmp*
+touch /var/log/cloud-init.log
+touch /var/log/cloud-init.log.1
+chgrp nogroup /var/log/cloud-init.log*
+mkdir -p /var/log/gdm
+chgrp nogroup /var/log/gdm
+mkdir -p /var/log/gdm3
+chgrp nogroup /var/log/gdm3
+touch /var/log/test.journal
+touch /var/log/test.journal~
+chgrp nogroup /var/log/*.journal*
+touch /var/log/lastlog
+touch /var/log/lastlog.1
+chgrp nogroup /var/log/lastlog*
+touch /var/log/localmessages
+touch /var/log/localmessages.1
+chgrp nogroup /var/log/localmessages*
+touch /var/log/messages
+chgrp nogroup /var/log/messages
+touch /var/log/secure
+chgrp nogroup /var/log/secure*
+mkdir -p /var/log/sssd
+chgrp nogroup /var/log/sssd
+touch /var/log/syslog
+chgrp nogroup /var/log/syslog
+touch /var/log/waagent.log
+touch /var/log/waagent.log.1
+chgrp nogroup /var/log/waagent.log*

--- a/linux_os/guide/system/permissions/files/groupowner_local_var_log/tests/owned_by_adm.pass.sh
+++ b/linux_os/guide/system/permissions/files/groupowner_local_var_log/tests/owned_by_adm.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/test.log
+chgrp adm /var/log/test.log

--- a/linux_os/guide/system/permissions/files/groupowner_local_var_log/tests/owned_by_nobody.fail.sh
+++ b/linux_os/guide/system/permissions/files/groupowner_local_var_log/tests/owned_by_nobody.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/test.log
+chgrp nogroup /var/log/test.log

--- a/linux_os/guide/system/permissions/files/groupowner_local_var_log/tests/owned_by_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/groupowner_local_var_log/tests/owned_by_root.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/test.log
+chgrp root /var/log/test.log

--- a/linux_os/guide/system/permissions/files/owner_local_var_log/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/owner_local_var_log/bash/shared.sh
@@ -1,0 +1,13 @@
+# platform = Ubuntu 24.04
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+
+if id "syslog" >/dev/null 2>&1; then
+    username="syslog"
+else
+    username="root"
+fi
+
+find -L /var/log/ -maxdepth 1 -regextype posix-extended ! -user root ! -user syslog ! -path '/var/log/apt/*' ! -name 'auth.log' ! -path '/var/log/[bw]tmp*' ! -path '/var/log/cloud-init.log*' ! -name 'gdm' ! -name 'gdm3' ! -regex '.*\.journal[~]?' ! -regex '.*lastlog(\.[^\/]+)?$' ! -regex '.*localmessages(.*)'  ! -name 'messages' ! -regex '.*secure(.*)' ! -name 'sssd' ! -name 'syslog' ! -regex '.*waagent.log(.*)' -regex '.*' -exec chown $username {} \;

--- a/linux_os/guide/system/permissions/files/owner_local_var_log/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/owner_local_var_log/oval/shared.xml
@@ -1,0 +1,84 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+      {{{ oval_metadata("Owner of /var/log/* should be root or syslog.") }}}
+    <criteria comment="Check file ownership of /var/log/*">
+     <criterion test_ref="test_file_ownership_var_log" />
+    </criteria>
+  </definition>
+
+  <unix:password_object id="object_syslog_uid" version="1">
+    <unix:username operation="pattern match">syslog</unix:username>
+  </unix:password_object>
+  <local_variable id="var_syslog_uid" comment="Retrieve the uid of syslog" datatype="int" version="1">
+    <object_component item_field="user_id" object_ref="object_syslog_uid" />
+  </local_variable>
+
+  <unix:file_test check="all" comment="/var/log/* owner is root|syslog"
+      id="test_file_ownership_var_log" state_operator="OR" version="1">
+    <unix:object object_ref="object_file_ownership_var_log" />
+    <unix:state state_ref="state_file_ownership_syslog_var_log_auth_log"/>
+    <unix:state state_ref="state_file_ownership_root_var_log_auth_log"/>
+  </unix:file_test>
+  <unix:file_object comment="/var/log/*" id="object_file_ownership_var_log" version="1">
+    <unix:path>/var/log</unix:path>
+    <unix:filename operation="pattern match">.*</unix:filename>
+    <filter action="exclude">exclude_files_apt</filter>
+    <filter action="exclude">exclude_files_auth_log</filter>
+    <filter action="exclude">exclude_files_bwtmp</filter>
+    <filter action="exclude">exclude_files_cloudinit</filter>
+    <filter action="exclude">exclude_files_gdm</filter>
+    <filter action="exclude">exclude_files_journal</filter>
+    <filter action="exclude">exclude_files_lastlog</filter>
+    <filter action="exclude">exclude_files_localmessages</filter>
+    <filter action="exclude">exclude_files_messages</filter>
+    <filter action="exclude">exclude_files_secure</filter>
+    <filter action="exclude">exclude_files_sssd</filter>
+    <filter action="exclude">exclude_files_syslog</filter>
+    <filter action="exclude">exclude_files_waagent</filter>
+  </unix:file_object>
+  <unix:file_state id="state_file_ownership_syslog_var_log_auth_log" version="1">
+    <unix:user_id datatype="int" operation="equals" var_ref="var_syslog_uid"/>
+  </unix:file_state>
+  <unix:file_state id="state_file_ownership_root_var_log_auth_log" version="1">
+    <unix:user_id datatype="int" operation="equals">0</unix:user_id>
+  </unix:file_state>
+  <unix:file_state id="exclude_files_apt" version="1">
+    <unix:path operation="pattern match">^.*apt</unix:path>
+  </unix:file_state>
+  <unix:file_state id="exclude_files_auth_log" version="1">
+    <unix:filename>auth.log</unix:filename>
+  </unix:file_state>
+  <unix:file_state id="exclude_files_bwtmp" version="1">
+    <unix:filename operation="pattern match">^.*[bw]tmp((\.|-).*)?$</unix:filename>
+  </unix:file_state>
+  <unix:file_state id="exclude_files_cloudinit" version="1">
+    <unix:filename operation="pattern match">^.*cloud-init\.log.*</unix:filename>
+  </unix:file_state>
+  <unix:file_state id="exclude_files_gdm" version="1" operator="AND">
+    <unix:path operation="pattern match">^.*gdm|gdm3</unix:path>
+  </unix:file_state>
+  <unix:file_state id="exclude_files_journal" version="1" operator="AND">
+    <unix:filename operation="pattern match">^.*\.journal.*$</unix:filename>
+  </unix:file_state>
+  <unix:file_state id="exclude_files_lastlog" version="1">
+    <unix:filename operation="pattern match">^.*lastlog.*$</unix:filename>
+  </unix:file_state>
+  <unix:file_state id="exclude_files_localmessages" version="1">
+    <unix:filename operation="pattern match">^.*localmessages.*$</unix:filename>
+  </unix:file_state>
+  <unix:file_state id="exclude_files_messages" version="1">
+    <unix:filename>messages</unix:filename>
+  </unix:file_state>
+  <unix:file_state id="exclude_files_secure" version="1">
+    <unix:filename operation="pattern match">^.*secure.*$</unix:filename>
+  </unix:file_state>
+  <unix:file_state id="exclude_files_sssd" version="1" operator="AND">
+    <unix:path operation="pattern match">^.*(sssd|SSSD)$</unix:path>
+  </unix:file_state>
+  <unix:file_state id="exclude_files_syslog" version="1">
+    <unix:filename>syslog</unix:filename>
+  </unix:file_state>
+  <unix:file_state id="exclude_files_waagent" version="1">
+    <unix:filename operation="pattern match">^.*waagent\.log.*$</unix:filename>
+  </unix:file_state>
+</def-group>

--- a/linux_os/guide/system/permissions/files/owner_local_var_log/rule.yml
+++ b/linux_os/guide/system/permissions/files/owner_local_var_log/rule.yml
@@ -1,0 +1,33 @@
+documentation_complete: true
+
+
+title: 'Verify ownership of log files'
+
+description: |-
+    Any operating system providing too much information in error messages
+    risks compromising the data and security of the structure, and content
+    of error messages needs to be carefully considered by the organization.
+
+    Organizations carefully consider the structure/content of error messages.
+    The extent to which information systems are able to identify and handle
+    error conditions is guided by organizational policy and operational
+    requirements. Information that could be exploited by adversaries includes,
+    for example, erroneous logon attempts with passwords entered by mistake
+    as the username, mission/business information that can be derived from
+    (if not stated explicitly by) information recorded, and personal
+    information, such as account numbers, social security numbers, and credit
+    card numbers.
+
+rationale: |-
+    The {{{ full_name }}} must generate error messages that provide information
+    necessary for corrective actions without revealing information that could
+    be exploited by adversaries.
+
+severity: medium
+
+ocil_clause: 'not all log files owned by root or syslog'
+
+ocil: |-
+    Verify the operating system has all system log files under the
+    <pre>/var/log</pre> directory, that are not excluded, with an owner set to root | syslog,
+

--- a/linux_os/guide/system/permissions/files/owner_local_var_log/tests/excluded_files.pass.sh
+++ b/linux_os/guide/system/permissions/files/owner_local_var_log/tests/excluded_files.pass.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+chown root /var/log/*
+mkdir -p /var/log/apt
+chown nobody /var/log/apt
+touch /var/log/auth.log
+chown nobody /var/log/auth.log
+touch /var/log/btmp.log
+touch /var/log/btmp.log.1
+touch /var/log/btmp.log-1
+chown nobody /var/log/btmp*
+touch /var/log/wtmp.log
+touch /var/log/wtmp.log.1
+touch /var/log/wtmp.log-1
+chown nobody /var/log/wtmp*
+touch /var/log/cloud-init.log
+touch /var/log/cloud-init.log.1
+chown nobody /var/log/cloud-init.log*
+mkdir -p /var/log/gdm
+chown nobody /var/log/gdm
+mkdir -p /var/log/gdm3
+chown nobody /var/log/gdm3
+touch /var/log/test.journal
+touch /var/log/test.journal~
+chown nobody /var/log/*.journal*
+touch /var/log/lastlog
+touch /var/log/lastlog.1
+chown nobody /var/log/lastlog*
+touch /var/log/localmessages
+touch /var/log/localmessages.1
+chown nobody /var/log/localmessages*
+touch /var/log/messages
+chown nobody /var/log/messages
+touch /var/log/secure
+chown nobody /var/log/secure*
+mkdir -p /var/log/sssd
+chown nobody /var/log/sssd
+touch /var/log/syslog
+chown nobody /var/log/syslog
+touch /var/log/waagent.log
+touch /var/log/waagent.log.1
+chown nobody /var/log/waagent.log*

--- a/linux_os/guide/system/permissions/files/owner_local_var_log/tests/owned_by_nobody.fail.sh
+++ b/linux_os/guide/system/permissions/files/owner_local_var_log/tests/owned_by_nobody.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/test.log
+chown nobody /var/log/test.log

--- a/linux_os/guide/system/permissions/files/owner_local_var_log/tests/owned_by_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/owner_local_var_log/tests/owned_by_root.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/test.log
+chown root /var/log/test.log

--- a/linux_os/guide/system/permissions/files/owner_local_var_log/tests/owned_by_syslog.pass.sh
+++ b/linux_os/guide/system/permissions/files/owner_local_var_log/tests/owned_by_syslog.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/test.log
+chown syslog /var/log/test.log

--- a/linux_os/guide/system/permissions/files/permissions_local_var_log/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_local_var_log/rule.yml
@@ -59,9 +59,9 @@ template:
     vars:
         excluded_files@sle15: ['*[bw]tmp', '*lastlog']
         excluded_files@slmicro5: ['*[bw]tmp', '*lastlog']
-        excluded_files@ubuntu2004: ['history.log', 'eipp.log.xz', '*[bw]tmp', '*lastlog']
-        excluded_files@ubuntu2204: ['history.log', 'eipp.log.xz', '*[bw]tmp', '*lastlog']
-        excluded_files@ubuntu2404: ['*[bw]tmp', '*lastlog', '*cloud-init', '*localmessages', '*waagent', '*sssd|*SSSD', '*gdm', '*apt/*']
+        excluded_files@ubuntu2004: ['history.log', 'eipp.log.xz', '[bw]tmp', '[bw]tmp.*', '[bw]tmp-*', 'lastlog', 'lastlog.*']
+        excluded_files@ubuntu2204: ['history.log', 'eipp.log.xz', '[bw]tmp', '[bw]tmp.*', '[bw]tmp-*', 'lastlog', 'lastlog.*']
+        excluded_files@ubuntu2404: ['[bw]tmp', '[bw]tmp.*', '[bw]tmp-*', 'lastlog', 'lastlog.*', 'cloud-init.log*', 'localmessages*', 'waagent.log*']
         file_regex: '.*'
         filemode: '0640'
         filepath: /var/log/

--- a/linux_os/guide/system/permissions/files/permissions_local_var_log/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_local_var_log/rule.yml
@@ -61,6 +61,7 @@ template:
         excluded_files@slmicro5: ['*[bw]tmp', '*lastlog']
         excluded_files@ubuntu2004: ['history.log', 'eipp.log.xz', '*[bw]tmp', '*lastlog']
         excluded_files@ubuntu2204: ['history.log', 'eipp.log.xz', '*[bw]tmp', '*lastlog']
+        excluded_files@ubuntu2404: ['*[bw]tmp', '*lastlog', '*cloud-init', '*localmessages', '*waagent', '*sssd|*SSSD', '*gdm', '*apt/*']
         file_regex: '.*'
         filemode: '0640'
         filepath: /var/log/

--- a/linux_os/guide/system/permissions/files/permissions_local_var_log/tests/excluded_files.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_local_var_log/tests/excluded_files.pass.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+find /var/log -exec chmod g-rwx,o-rwx {} \;
+
+{{% if product in ['ubuntu2004', 'ubuntu2204'] %}}
+excluded_files=('history.log' 'eipp.log.xz' 'btmp' 'btmp.1' 'btmp-1' 'wtmp' 'wtmp.1' 'wtmp-1' 'lastlog' 'lastlog.1')
+{{% elif product in ['ubuntu2404'] %}}
+excluded_files=('btmp' 'btmp.1' 'btmp-1' 'wtmp' 'wtmp.1' 'wtmp-1' 'lastlog' 'lastlog.1'\
+                'cloud-init.log' 'cloud-init.log2' 'localmessages' 'localmessages2' 'waagent.log' 'waagent.log2')
+{{% elif product in ['sle12', 'sle15'] %}}
+excluded_files=('btmp', 'wtmp', 'lastlog')
+{{% endif %}}
+
+for f in ${excluded_files[@]}
+do
+    touch /var/log/$f
+    chmod 777 /var/log/$f
+done

--- a/linux_os/guide/system/permissions/files/permissions_local_var_log/tests/excluded_files_similar.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_local_var_log/tests/excluded_files_similar.fail.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+find /var/log -exec chmod g-rwx,o-rwx {} \;
+
+{{% if product in ['ubuntu2004', 'ubuntu2204'] %}}
+excluded_files=('history.log.1' 'eipp.log.xz.1' 'btmp1' 'wtmp1' 'lastlog1')
+{{% elif product in ['ubuntu2404'] %}}
+excluded_files=('btmp1' 'wtmp1' 'lastlog1' '2cloud-init.log''2localmessages' '2waagent.log')
+{{% elif product in ['sle12', 'sle15'] %}}
+excluded_files=('btmp.1', 'wtmp.1', 'lastlog.1')
+{{% endif %}}
+
+for f in ${excluded_files[@]}
+do
+    touch /var/log/$f
+    chmod 777 /var/log/$f
+done

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_apt/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_apt/bash/shared.sh
@@ -1,0 +1,6 @@
+# platform = Ubuntu 24.04
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+find -L /var/log/ -maxdepth 1 ! -group root ! -group adm -type d -regextype posix-extended -name 'apt' -exec chgrp root {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_apt/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_apt/oval/shared.xml
@@ -1,0 +1,35 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+      {{{ oval_metadata("Group owner of /var/log/apt should be root or adm.") }}}
+    <criteria comment="Check group ownership of /var/log/apt">
+     <criterion test_ref="test_group_ownership_var_log_apt" />
+    </criteria>
+  </definition>
+  
+  <ind:textfilecontent54_object id="object_adm_gid" version="1" comment="gid of the dedicated adm group">
+    <ind:filepath>/etc/group</ind:filepath>
+    <ind:pattern operation="pattern match">^adm:\w+:(\w+):.*</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <local_variable id="var_adm_gid" datatype="int" version="1"
+                  comment="Retrieve the gid of adm group">
+    <object_component item_field="subexpression" object_ref="object_adm_gid"/>
+  </local_variable>
+
+  <unix:file_test check_existence="any_exist" check="all" comment="/var/log/apt group owner is root|adm"
+      id="test_group_ownership_var_log_apt" state_operator="OR" version="1">
+    <unix:object object_ref="object_group_ownership_var_log_apt" />
+    <unix:state state_ref="state_group_ownership_adm_var_log_apt"/>
+    <unix:state state_ref="state_group_ownership_root_var_log_apt"/>
+  </unix:file_test>
+  <unix:file_object comment="/var/log/apt" id="object_group_ownership_var_log_apt" version="1">
+    <unix:path>/var/log/apt</unix:path>
+    <unix:filename xsi:nil="true"/>
+  </unix:file_object>
+  <unix:file_state id="state_group_ownership_adm_var_log_apt" version="1">
+    <unix:group_id datatype="int" operation="equals" var_ref="var_adm_gid"/>
+  </unix:file_state>
+  <unix:file_state id="state_group_ownership_root_var_log_apt" version="1">
+    <unix:group_id datatype="int" operation="equals">0</unix:group_id>
+  </unix:file_state>
+ </def-group>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_apt/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_apt/rule.yml
@@ -1,0 +1,16 @@
+documentation_complete: true
+
+title: 'Verify Group Who Owns /var/log/apt Directory'
+
+description: '{{{ describe_file_group_owner(file="/var/log/apt", group="root|adm") }}}'
+
+rationale: |-
+    The <tt>/var/log/apt</tt> directory contains information about APT
+    and should only be accessed by authorized personnel.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/log/apt", group="root|adm") }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/var/log/apt", group="root|adm") }}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_apt/tests/no_file.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_apt/tests/no_file.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+rm -rf /var/log/apt
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_apt/tests/owned_by_adm.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_apt/tests/owned_by_adm.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+mkdir -p /var/log/apt
+chgrp adm /var/log/apt

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_apt/tests/owned_by_nogroup.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_apt/tests/owned_by_nogroup.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+mkdir -p /var/log/apt
+chgrp nogroup /var/log/apt

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_apt/tests/owned_by_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_apt/tests/owned_by_root.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+mkdir -p /var/log/apt
+chgrp root /var/log/apt

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_auth/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_auth/bash/shared.sh
@@ -1,0 +1,6 @@
+# platform = Ubuntu 24.04
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+find -L /var/log/ -maxdepth 1 ! -group root ! -group adm -type f -regextype posix-extended -name 'auth.log' -exec chgrp adm {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_auth/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_auth/oval/shared.xml
@@ -1,0 +1,34 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+      {{{ oval_metadata("Group owner of /var/log/auth should be root or adm.") }}}
+    <criteria comment="Check group ownership of /var/log/auth">
+     <criterion test_ref="test_group_ownership_var_log_auth" />
+    </criteria>
+  </definition>
+  
+  <ind:textfilecontent54_object id="object_adm_gid" version="1" comment="gid of the dedicated adm group">
+    <ind:filepath>/etc/group</ind:filepath>
+    <ind:pattern operation="pattern match">^adm:\w+:(\w+):.*</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <local_variable id="var_adm_gid" datatype="int" version="1"
+                  comment="Retrieve the gid of adm group">
+    <object_component item_field="subexpression" object_ref="object_adm_gid"/>
+  </local_variable>
+
+  <unix:file_test check_existence="any_exist" check="all" comment="/var/log/auth group owner is root|adm"
+      id="test_group_ownership_var_log_auth" state_operator="OR" version="1">
+    <unix:object object_ref="object_group_ownership_var_log_auth" />
+    <unix:state state_ref="state_group_ownership_adm_var_log_auth"/>
+    <unix:state state_ref="state_group_ownership_root_var_log_auth"/>
+  </unix:file_test>
+  <unix:file_object comment="/var/log/auth" id="object_group_ownership_var_log_auth" version="1">
+    <unix:filepath>/var/log/auth.log</unix:filepath>
+  </unix:file_object>
+  <unix:file_state id="state_group_ownership_adm_var_log_auth" version="1">
+    <unix:group_id datatype="int" operation="equals" var_ref="var_adm_gid"/>
+  </unix:file_state>
+  <unix:file_state id="state_group_ownership_root_var_log_auth" version="1">
+    <unix:group_id datatype="int" operation="equals">0</unix:group_id>
+  </unix:file_state>
+ </def-group>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_auth/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_auth/rule.yml
@@ -1,0 +1,17 @@
+documentation_complete: true
+
+title: 'Verify Group Who Owns /var/log/auth.log File'
+
+description: '{{{ describe_file_group_owner(file="/var/log/auth.log", group="root|adm") }}}'
+
+rationale: |-
+    The <tt>/var/log/auth.log</tt> file contains records information about user
+    login attempts and authentication processes and should only be accessed by
+    authorized personnel.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/log/auth.log", group="root|adm") }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/var/log/auth.log", group="root|adm") }}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_auth/tests/no_file.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_auth/tests/no_file.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+rm -f /var/log/auth.log
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_auth/tests/owned_by_adm.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_auth/tests/owned_by_adm.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/auth.log
+chgrp adm /var/log/auth.log

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_auth/tests/owned_by_nogroup.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_auth/tests/owned_by_nogroup.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/auth.log
+chgrp nogroup /var/log/auth.log

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_auth/tests/owned_by_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_auth/tests/owned_by_root.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/auth.log
+chgrp root /var/log/auth.log

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_cloud_init/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_cloud_init/bash/shared.sh
@@ -1,0 +1,6 @@
+# platform = Ubuntu 24.04
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+find -L /var/log/ -maxdepth 1 ! -group root ! -group adm -type f -regextype posix-extended -regex '.*cloud-init.log(.*)' -exec chgrp adm {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_cloud_init/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_cloud_init/oval/shared.xml
@@ -1,0 +1,34 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+      {{{ oval_metadata("Group owner of /var/log/cloud-init.log should be root or adm.") }}}
+    <criteria comment="Check group ownership of /var/log/cloud-init.log">
+     <criterion test_ref="test_group_ownership_var_log_cloud-init.log" />
+    </criteria>
+  </definition>
+  
+  <ind:textfilecontent54_object id="object_adm_gid" version="1" comment="gid of the dedicated adm group">
+    <ind:filepath>/etc/group</ind:filepath>
+    <ind:pattern operation="pattern match">^adm:\w+:(\w+):.*</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <local_variable id="var_adm_gid" datatype="int" version="1"
+                  comment="Retrieve the gid of adm group">
+    <object_component item_field="subexpression" object_ref="object_adm_gid"/>
+  </local_variable>
+
+  <unix:file_test check_existence="any_exist" check="all" comment="/var/log/cloud-init.log group owner is root|adm"
+      id="test_group_ownership_var_log_cloud-init.log" state_operator="OR" version="1">
+    <unix:object object_ref="object_group_ownership_var_log_cloud-init.log" />
+    <unix:state state_ref="state_group_ownership_adm_var_log_cloud-init.log"/>
+    <unix:state state_ref="state_group_ownership_root_var_log_cloud-init.log"/>
+  </unix:file_test>
+  <unix:file_object comment="/var/log/cloud-init.log" id="object_group_ownership_var_log_cloud-init.log" version="1">
+    <unix:filepath operation="pattern match">/var/log/cloud-init.log(.*)</unix:filepath>
+  </unix:file_object>
+  <unix:file_state id="state_group_ownership_adm_var_log_cloud-init.log" version="1">
+    <unix:group_id datatype="int" operation="equals" var_ref="var_adm_gid"/>
+  </unix:file_state>
+  <unix:file_state id="state_group_ownership_root_var_log_cloud-init.log" version="1">
+    <unix:group_id datatype="int" operation="equals">0</unix:group_id>
+  </unix:file_state>
+ </def-group>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_cloud_init/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_cloud_init/rule.yml
@@ -1,0 +1,16 @@
+documentation_complete: true
+
+title: 'Verify Group Who Owns /var/log/cloud-init.log File'
+
+description: '{{{ describe_file_group_owner(file="/var/log/cloud-init.log", group="root|adm") }}}'
+
+rationale: |-
+    The <tt>/var/log/cloud-init.log</tt> file contains detailed debugging information that
+    helps users troubleshoot cloud-init and should only be accessed by authorized personnel.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/log/cloud-init.log", group="root|adm") }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/var/log/cloud-init.log", group="root|adm") }}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_cloud_init/tests/no_file.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_cloud_init/tests/no_file.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+rm -f /var/log/loud-init.log*
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_cloud_init/tests/owned_by_adm.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_cloud_init/tests/owned_by_adm.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/cloud-init.log
+chgrp adm /var/log/cloud-init.log*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_cloud_init/tests/owned_by_nogroup.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_cloud_init/tests/owned_by_nogroup.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/cloud-init.log
+chgrp nogroup /var/log/cloud-init.log*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_cloud_init/tests/owned_by_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_cloud_init/tests/owned_by_root.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/cloud-init.log
+chgrp root /var/log/cloud-init.log*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_gdm/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_gdm/bash/shared.sh
@@ -1,0 +1,6 @@
+# platform = Ubuntu 24.04
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+find -L /var/log/ -maxdepth 1 ! -group root ! -group gdm -type d -regextype posix-extended -name 'gdm' -exec chgrp gdm {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_gdm/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_gdm/oval/shared.xml
@@ -1,0 +1,35 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+      {{{ oval_metadata("Group owner of /var/log/gdm should be root or gdm.") }}}
+    <criteria comment="Check group ownership of /var/log/gdm">
+     <criterion test_ref="test_group_ownership_var_log_gdm" />
+    </criteria>
+  </definition>
+  
+  <ind:textfilecontent54_object id="object_gdm_gid" version="1" comment="gid of the dedicated gdm group">
+    <ind:filepath>/etc/group</ind:filepath>
+    <ind:pattern operation="pattern match">^gdm:\w+:(\w+):.*</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <local_variable id="var_gdm_gid" datatype="int" version="1"
+                  comment="Retrieve the gid of gdm group">
+    <object_component item_field="subexpression" object_ref="object_gdm_gid"/>
+  </local_variable>
+
+  <unix:file_test check_existence="any_exist" check="all" comment="/var/log/gdm group owner is root|gdm"
+      id="test_group_ownership_var_log_gdm" state_operator="OR" version="1">
+    <unix:object object_ref="object_group_ownership_var_log_gdm" />
+    <unix:state state_ref="state_group_ownership_gdm_var_log_gdm"/>
+    <unix:state state_ref="state_group_ownership_root_var_log_gdm"/>
+  </unix:file_test>
+  <unix:file_object comment="/var/log/gdm" id="object_group_ownership_var_log_gdm" version="1">
+    <unix:path>/var/log/gdm</unix:path>
+    <unix:filename xsi:nil="true"/>
+  </unix:file_object>
+  <unix:file_state id="state_group_ownership_gdm_var_log_gdm" version="1">
+    <unix:group_id datatype="int" operation="equals" var_ref="var_gdm_gid"/>
+  </unix:file_state>
+  <unix:file_state id="state_group_ownership_root_var_log_gdm" version="1">
+    <unix:group_id datatype="int" operation="equals">0</unix:group_id>
+  </unix:file_state>
+ </def-group>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_gdm/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_gdm/rule.yml
@@ -1,0 +1,16 @@
+documentation_complete: true
+
+title: 'Verify Group Who Owns /var/log/gdm Directory'
+
+description: '{{{ describe_file_group_owner(file="/var/log/gdm", group="root|gdm") }}}'
+
+rationale: |-
+    The <tt>/var/log/gdm</tt> directory contains information about the GDM daemon
+    and should only be accessed by authorized personnel.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/log/gdm", group="root|gdm") }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/var/log/gdm", group="root|gdm") }}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_gdm/tests/no_file.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_gdm/tests/no_file.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+rm -rf /var/log/gdm
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_gdm/tests/owned_by_gdm.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_gdm/tests/owned_by_gdm.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = gdm
+
+mkdir -p /var/log/gdm
+chgrp gdm /var/log/gdm

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_gdm/tests/owned_by_nogroup.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_gdm/tests/owned_by_nogroup.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = gdm
+
+mkdir -p /var/log/gdm
+chgrp nogroup /var/log/gdm

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_gdm/tests/owned_by_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_gdm/tests/owned_by_root.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = gdm
+
+mkdir -p /var/log/gdm
+chgrp root /var/log/gdm

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_gdm3/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_gdm3/bash/shared.sh
@@ -1,0 +1,6 @@
+# platform = Ubuntu 24.04
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+find -L /var/log/ -maxdepth 1 ! -group root ! -group gdm -type d -regextype posix-extended -name 'gdm3' -exec chgrp gdm {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_gdm3/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_gdm3/oval/shared.xml
@@ -1,0 +1,35 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+      {{{ oval_metadata("Group owner of /var/log/gdm3 should be root or gdm.") }}}
+    <criteria comment="Check group ownership of /var/log/gdm3">
+     <criterion test_ref="test_group_ownership_var_log_gdm3" />
+    </criteria>
+  </definition>
+  
+  <ind:textfilecontent54_object id="object_gdm_gid" version="1" comment="gid of the dedicated gdm group">
+    <ind:filepath>/etc/group</ind:filepath>
+    <ind:pattern operation="pattern match">^gdm:\w+:(\w+):.*</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <local_variable id="var_gdm_gid" datatype="int" version="1"
+                  comment="Retrieve the gid of gdm group">
+    <object_component item_field="subexpression" object_ref="object_gdm_gid"/>
+  </local_variable>
+
+  <unix:file_test check_existence="any_exist" check="all" comment="/var/log/gdm3 group owner is root|gdm"
+      id="test_group_ownership_var_log_gdm3" state_operator="OR" version="1">
+    <unix:object object_ref="object_group_ownership_var_log_gdm3" />
+    <unix:state state_ref="state_group_ownership_gdm_var_log_gdm3"/>
+    <unix:state state_ref="state_group_ownership_root_var_log_gdm3"/>
+  </unix:file_test>
+  <unix:file_object comment="/var/log/gdm3" id="object_group_ownership_var_log_gdm3" version="1">
+    <unix:path>/var/log/gdm3</unix:path>
+    <unix:filename xsi:nil="true"/>
+  </unix:file_object>
+  <unix:file_state id="state_group_ownership_gdm_var_log_gdm3" version="1">
+    <unix:group_id datatype="int" operation="equals" var_ref="var_gdm_gid"/>
+  </unix:file_state>
+  <unix:file_state id="state_group_ownership_root_var_log_gdm3" version="1">
+    <unix:group_id datatype="int" operation="equals">0</unix:group_id>
+  </unix:file_state>
+ </def-group>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_gdm3/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_gdm3/rule.yml
@@ -1,0 +1,16 @@
+documentation_complete: true
+
+title: 'Verify Group Who Owns /var/log/gdm3 Directory'
+
+description: '{{{ describe_file_group_owner(file="/var/log/gdm3", group="root|gdm") }}}'
+
+rationale: |-
+    The <tt>/var/log/gdm3</tt> directory stores information about the GNOME Display Manager (GDM)
+    and should only be accessed by authorized personnel.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/log/gdm3", group="root|gdm") }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/var/log/gdm3", group="root|gdm") }}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_gdm3/tests/no_file.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_gdm3/tests/no_file.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+rm -rf /var/log/gdm3
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_gdm3/tests/owned_by_gdm.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_gdm3/tests/owned_by_gdm.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = gdm3
+
+mkdir -p /var/log/gdm3
+chgrp gdm /var/log/gdm3

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_gdm3/tests/owned_by_nogroup.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_gdm3/tests/owned_by_nogroup.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = gdm3
+
+mkdir -p /var/log/gdm3
+chgrp nogroup /var/log/gdm3

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_gdm3/tests/owned_by_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_gdm3/tests/owned_by_root.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = gdm3
+
+mkdir -p /var/log/gdm3
+chgrp root /var/log/gdm3

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_journal/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_journal/bash/shared.sh
@@ -1,0 +1,6 @@
+# platform = Ubuntu 24.04
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+find -L /var/log/ -maxdepth 1 ! -group root ! -group systemd-journal -type f -regextype posix-extended -regex ".*\.journal[~]?" -exec chgrp systemd-journal {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_journal/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_journal/oval/shared.xml
@@ -1,0 +1,34 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+      {{{ oval_metadata("Group owner of /var/log/*.journal-* should be root or systemd-journal.") }}}
+    <criteria comment="Check group ownership of /var/log/*.journal-*">
+     <criterion test_ref="test_group_ownership_var_log_journal" />
+    </criteria>
+  </definition>
+  
+  <ind:textfilecontent54_object id="object_systemd-journal_gid" version="1" comment="gid of the dedicated systemd-journal group">
+    <ind:filepath>/etc/group</ind:filepath>
+    <ind:pattern operation="pattern match">^systemd-journal:\w+:(\w+):.*</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <local_variable id="var_systemd-journal_gid" datatype="int" version="1"
+                  comment="Retrieve the gid of systemd-journal group">
+    <object_component item_field="subexpression" object_ref="object_systemd-journal_gid"/>
+  </local_variable>
+
+  <unix:file_test check_existence="any_exist" check="all" comment="/var/log/*.journal-* group owner is root|systemd-journal"
+      id="test_group_ownership_var_log_journal" state_operator="OR" version="1">
+    <unix:object object_ref="object_group_ownership_var_log_journal" />
+    <unix:state state_ref="state_group_ownership_systemd-journal_var_log_journal"/>
+    <unix:state state_ref="state_group_ownership_root_var_log_journal"/>
+  </unix:file_test>
+  <unix:file_object comment="/var/log/*.journal-*" id="object_group_ownership_var_log_journal" version="1">
+    <unix:filepath operation="pattern match">/var/log/.*\.journal(~)?$</unix:filepath>
+  </unix:file_object>
+  <unix:file_state id="state_group_ownership_systemd-journal_var_log_journal" version="1">
+    <unix:group_id datatype="int" operation="equals" var_ref="var_systemd-journal_gid"/>
+  </unix:file_state>
+  <unix:file_state id="state_group_ownership_root_var_log_journal" version="1">
+    <unix:group_id datatype="int" operation="equals">0</unix:group_id>
+  </unix:file_state>
+ </def-group>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_journal/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_journal/rule.yml
@@ -1,0 +1,15 @@
+documentation_complete: true
+
+title: 'Verify Group Who Owns /var/log/*.journal(~) File'
+
+description: '{{{ describe_file_group_owner(file="/var/log/*.journal(~)", group="root|systemd-journal") }}}'
+
+rationale: |-
+    The <tt>/var/log/*.journal(~)</tt> files are system logs managed by the "systemd" service.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/log/*.journal(~)", group="root|systemd-journal") }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/var/log/*.journal(~)", group="root|systemd-journal") }}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_journal/tests/no_file.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_journal/tests/no_file.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+rm -f /var/log/*.journal*
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_journal/tests/owned_by_nogroup.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_journal/tests/owned_by_nogroup.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = systemd
+
+
+touch /var/log/test.journal
+touch /var/log/test.journal~
+chgrp nogroup /var/log/test.journal
+chgrp nogroup /var/log/test.journal~
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_journal/tests/owned_by_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_journal/tests/owned_by_root.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = systemd
+
+
+touch /var/log/test.journal
+touch /var/log/test.journal~
+chgrp root /var/log/test.journal
+chgrp root /var/log/test.journal~
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_journal/tests/owned_by_systemd-journal.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_journal/tests/owned_by_systemd-journal.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = systemd
+
+touch /var/log/test.journal
+touch /var/log/test.journal~
+chgrp systemd-journal /var/log/test.journal
+chgrp systemd-journal /var/log/test.journal~

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_lastlog/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_lastlog/bash/shared.sh
@@ -1,0 +1,7 @@
+# platform = Ubuntu 24.04
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+
+find -L /var/log/ -maxdepth 1 ! -group root ! -group utmp -type f -regextype posix-extended -regex '.*lastlog(\.[^\/]+)?$' -exec chgrp utmp {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_lastlog/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_lastlog/oval/shared.xml
@@ -1,0 +1,34 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+      {{{ oval_metadata("Group owner of /var/log/lastlog should be root or utmp.") }}}
+    <criteria comment="Check group ownership of /var/log/lastlog">
+     <criterion test_ref="test_group_ownership_var_log_lastlog" />
+    </criteria>
+  </definition>
+  
+  <ind:textfilecontent54_object id="object_utmp_gid" version="1" comment="gid of the dedicated utmp group">
+    <ind:filepath>/etc/group</ind:filepath>
+    <ind:pattern operation="pattern match">^utmp:\w+:(\w+):.*</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <local_variable id="var_utmp_gid" datatype="int" version="1"
+                  comment="Retrieve the gid of utmp group">
+    <object_component item_field="subexpression" object_ref="object_utmp_gid"/>
+  </local_variable>
+
+  <unix:file_test check_existence="any_exist" check="all" comment="/var/log/lastlog group owner is root|utmp"
+      id="test_group_ownership_var_log_lastlog" state_operator="OR" version="1">
+    <unix:object object_ref="object_group_ownership_var_log_lastlog" />
+    <unix:state state_ref="state_group_ownership_utmp_var_log_lastlog"/>
+    <unix:state state_ref="state_group_ownership_root_var_log_lastlog"/>
+  </unix:file_test>
+  <unix:file_object comment="/var/log/lastlog" id="object_group_ownership_var_log_lastlog" version="1">
+    <unix:filepath operation="pattern match">/var/log/lastlog(\.[^\/]+)?</unix:filepath>
+  </unix:file_object>
+  <unix:file_state id="state_group_ownership_utmp_var_log_lastlog" version="1">
+    <unix:group_id datatype="int" operation="equals" var_ref="var_utmp_gid"/>
+  </unix:file_state>
+  <unix:file_state id="state_group_ownership_root_var_log_lastlog" version="1">
+    <unix:group_id datatype="int" operation="equals">0</unix:group_id>
+  </unix:file_state>
+ </def-group>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_lastlog/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_lastlog/rule.yml
@@ -1,0 +1,16 @@
+documentation_complete: true
+
+title: 'Verify Group Who Owns /var/log/lastlog File'
+
+description: '{{{ describe_file_group_owner(file="/var/log/lastlog", group="root|utmp") }}}'
+
+rationale: |-
+    The <tt>/var/log/lastlog</tt> file contains logs of reports the most recent login of all users
+    and should only be accessed by authorized personnel.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/log/lastlog", group="root|utmp") }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/var/log/lastlog", group="root|utmp") }}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_lastlog/tests/no_file.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_lastlog/tests/no_file.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+rm -f /var/log/lastlog*
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_lastlog/tests/owned_by_adm.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_lastlog/tests/owned_by_adm.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+
+touch /var/log/lastlog
+touch /var/log/lastlog.1
+chgrp utmp /var/log/lastlog*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_lastlog/tests/owned_by_nogroup.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_lastlog/tests/owned_by_nogroup.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+
+touch /var/log/lastlog
+touch /var/log/lastlog.1
+chgrp nogroup /var/log/lastlog*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_lastlog/tests/owned_by_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_lastlog/tests/owned_by_root.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+
+touch /var/log/lastlog
+touch /var/log/lastlog.1
+chgrp root /var/log/lastlog*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_localmessages/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_localmessages/bash/shared.sh
@@ -1,0 +1,6 @@
+# platform = Ubuntu 24.04
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+find -L /var/log/ -maxdepth 1 ! -group root ! -group adm -type f -regextype posix-extended -regex '.*localmessages(.*)' -exec chgrp adm {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_localmessages/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_localmessages/oval/shared.xml
@@ -1,0 +1,34 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+      {{{ oval_metadata("Group owner of /var/log/localmessages should be root or adm.") }}}
+    <criteria comment="Check group ownership of /var/log/localmessages">
+     <criterion test_ref="test_group_ownership_var_log_localmessages" />
+    </criteria>
+  </definition>
+  
+  <ind:textfilecontent54_object id="object_adm_gid" version="1" comment="gid of the dedicated adm group">
+    <ind:filepath>/etc/group</ind:filepath>
+    <ind:pattern operation="pattern match">^adm:\w+:(\w+):.*</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <local_variable id="var_adm_gid" datatype="int" version="1"
+                  comment="Retrieve the gid of adm group">
+    <object_component item_field="subexpression" object_ref="object_adm_gid"/>
+  </local_variable>
+
+  <unix:file_test check_existence="any_exist" check="all" comment="/var/log/localmessages group owner is root|adm"
+      id="test_group_ownership_var_log_localmessages" state_operator="OR" version="1">
+    <unix:object object_ref="object_group_ownership_var_log_localmessages" />
+    <unix:state state_ref="state_group_ownership_adm_var_log_localmessages"/>
+    <unix:state state_ref="state_group_ownership_root_var_log_localmessages"/>
+  </unix:file_test>
+  <unix:file_object comment="/var/log/localmessages" id="object_group_ownership_var_log_localmessages" version="1">
+    <unix:filepath operation="pattern match">/var/log/localmessages(.*)</unix:filepath>
+  </unix:file_object>
+  <unix:file_state id="state_group_ownership_adm_var_log_localmessages" version="1">
+    <unix:group_id datatype="int" operation="equals" var_ref="var_adm_gid"/>
+  </unix:file_state>
+  <unix:file_state id="state_group_ownership_root_var_log_localmessages" version="1">
+    <unix:group_id datatype="int" operation="equals">0</unix:group_id>
+  </unix:file_state>
+ </def-group>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_localmessages/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_localmessages/rule.yml
@@ -1,0 +1,16 @@
+documentation_complete: true
+
+title: 'Verify Group Who Owns /var/log/localmessages File'
+
+description: '{{{ describe_file_group_owner(file="/var/log/localmessages", group="root|adm") }}}'
+
+rationale: |-
+    The <tt>/var/log/localmessages</tt> file contains log messages from certain boot scripts,
+    including the DHCP client, and should only be accessed by authorized personnel.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/log/localmessages", group="root|adm") }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/var/log/localmessages", group="root|adm") }}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_localmessages/tests/no_file.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_localmessages/tests/no_file.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+rm -f /var/log/localmessages*
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_localmessages/tests/owned_by_adm.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_localmessages/tests/owned_by_adm.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/localmessages
+chgrp adm /var/log/localmessages*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_localmessages/tests/owned_by_nogroup.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_localmessages/tests/owned_by_nogroup.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/localmessages
+chgrp nogroup /var/log/localmessages*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_localmessages/tests/owned_by_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_localmessages/tests/owned_by_root.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/localmessages
+chgrp root /var/log/localmessages*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_messages/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_messages/bash/shared.sh
@@ -1,0 +1,6 @@
+# platform = Ubuntu 24.04
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+find -L /var/log/ -maxdepth 1 ! -group root ! -group adm -type f -regextype posix-extended -name 'messages' -exec chgrp adm {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_messages/oval/ubuntu.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_messages/oval/ubuntu.xml
@@ -1,0 +1,34 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+      {{{ oval_metadata("Group owner of /var/log/messages should be root or adm.") }}}
+    <criteria comment="Check group ownership of /var/log/messages">
+     <criterion test_ref="test_group_ownership_var_log_messages" />
+    </criteria>
+  </definition>
+  
+  <ind:textfilecontent54_object id="object_adm_gid" version="1" comment="gid of the dedicated adm group">
+    <ind:filepath>/etc/group</ind:filepath>
+    <ind:pattern operation="pattern match">^adm:\w+:(\w+):.*</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <local_variable id="var_adm_gid" datatype="int" version="1"
+                  comment="Retrieve the gid of adm group">
+    <object_component item_field="subexpression" object_ref="object_adm_gid"/>
+  </local_variable>
+
+  <unix:file_test check_existence="any_exist" check="all" comment="/var/log/messages group owner is root|adm"
+      id="test_group_ownership_var_log_messages" state_operator="OR" version="1">
+    <unix:object object_ref="object_group_ownership_var_log_messages" />
+    <unix:state state_ref="state_group_ownership_adm_var_log_messages"/>
+    <unix:state state_ref="state_group_ownership_root_var_log_messages"/>
+  </unix:file_test>
+  <unix:file_object comment="/var/log/messages" id="object_group_ownership_var_log_messages" version="1">
+    <unix:filepath>/var/log/messages</unix:filepath>
+  </unix:file_object>
+  <unix:file_state id="state_group_ownership_adm_var_log_messages" version="1">
+    <unix:group_id datatype="int" operation="equals" var_ref="var_adm_gid"/>
+  </unix:file_state>
+  <unix:file_state id="state_group_ownership_root_var_log_messages" version="1">
+    <unix:group_id datatype="int" operation="equals">0</unix:group_id>
+  </unix:file_state>
+ </def-group>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_messages/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_messages/rule.yml
@@ -2,7 +2,11 @@ documentation_complete: true
 
 title: 'Verify Group Who Owns /var/log/messages File'
 
-description: '{{{ describe_file_group_owner(file="/var/log/messages", group="root") }}}'
+{{%  if 'ubuntu2404' not in product %}}
+description: '{{{ describe_file_group_owner(file="/var/log/messages", group="adm") }}}'
+{{%- else %}}        
+description: '{{{ describe_file_group_owner(file="/var/log/messages", group="root|adm") }}}'
+{{%- endif %}}
 
 rationale: |-
     The <tt>/var/log/messages</tt> file contains logs of error messages in
@@ -21,6 +25,7 @@ references:
     stigid@ol8: OL08-00-010230
     stigid@rhel8: RHEL-08-010230
 
+{{%  if 'ubuntu2404' not in product %}}
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/log/messages", group="root") }}}'
 
 ocil: |-
@@ -35,3 +40,9 @@ fixtext: |-
     {{{ describe_file_group_owner(file="/var/log/messages", group="root") }}}
 
 srg_requirement: '{{{ srg_requirement_file_group_owner("/var/log/messages", group="root") }}}'
+{{%- else %}}        
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/log/messages", group="root|adm") }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/var/log/messages", group="root|adm") }}}
+{{%- endif %}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_messages/tests/no_file.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_messages/tests/no_file.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+rm -f /var/log/messages
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_messages/tests/owned_by_adm.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_messages/tests/owned_by_adm.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/messages
+chgrp adm /var/log/messages*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_messages/tests/owned_by_nogroup.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_messages/tests/owned_by_nogroup.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/messages
+chgrp nogroup /var/log/messages*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_messages/tests/owned_by_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_messages/tests/owned_by_root.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/messages
+chgrp root /var/log/messages*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_secure/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_secure/bash/shared.sh
@@ -1,0 +1,6 @@
+# platform = Ubuntu 24.04
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+find -L /var/log/ -maxdepth 1 ! -group root ! -group adm -type f -regextype posix-extended -regex '.*secure(.*)' -exec chgrp adm {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_secure/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_secure/oval/shared.xml
@@ -1,0 +1,34 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+      {{{ oval_metadata("Group owner of /var/log/secure should be root or adm.") }}}
+    <criteria comment="Check group ownership of /var/log/secure">
+     <criterion test_ref="test_group_ownership_var_log_secure" />
+    </criteria>
+  </definition>
+  
+  <ind:textfilecontent54_object id="object_adm_gid" version="1" comment="gid of the dedicated adm group">
+    <ind:filepath>/etc/group</ind:filepath>
+    <ind:pattern operation="pattern match">^adm:\w+:(\w+):.*</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <local_variable id="var_adm_gid" datatype="int" version="1"
+                  comment="Retrieve the gid of adm group">
+    <object_component item_field="subexpression" object_ref="object_adm_gid"/>
+  </local_variable>
+
+  <unix:file_test check_existence="any_exist" check="all" comment="/var/log/secure group owner is root|adm"
+      id="test_group_ownership_var_log_secure" state_operator="OR" version="1">
+    <unix:object object_ref="object_group_ownership_var_log_secure" />
+    <unix:state state_ref="state_group_ownership_adm_var_log_secure"/>
+    <unix:state state_ref="state_group_ownership_root_var_log_secure"/>
+  </unix:file_test>
+  <unix:file_object comment="/var/log/secure" id="object_group_ownership_var_log_secure" version="1">
+    <unix:filepath operation="pattern match">/var/log/secure(.*)</unix:filepath>
+  </unix:file_object>
+  <unix:file_state id="state_group_ownership_adm_var_log_secure" version="1">
+    <unix:group_id datatype="int" operation="equals" var_ref="var_adm_gid"/>
+  </unix:file_state>
+  <unix:file_state id="state_group_ownership_root_var_log_secure" version="1">
+    <unix:group_id datatype="int" operation="equals">0</unix:group_id>
+  </unix:file_state>
+ </def-group>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_secure/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_secure/rule.yml
@@ -1,0 +1,16 @@
+documentation_complete: true
+
+title: 'Verify Group Who Owns /var/log/secure File'
+
+description: '{{{ describe_file_group_owner(file="/var/log/secure", group="root|adm") }}}'
+
+rationale: |-
+    The <tt>/var/log/secure</tt> file contains information related to authentication
+    and authorization privileges and should only be accessed by authorized personnel.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/log/secure", group="root|adm") }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/var/log/secure", group="root|adm") }}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_secure/tests/no_file.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_secure/tests/no_file.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+rm -f /var/log/secure*
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_secure/tests/owned_by_adm.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_secure/tests/owned_by_adm.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/secure
+chgrp adm /var/log/secure*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_secure/tests/owned_by_nogroup.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_secure/tests/owned_by_nogroup.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/secure
+chgrp nogroup /var/log/secure*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_secure/tests/owned_by_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_secure/tests/owned_by_root.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/secure
+chgrp root /var/log/secure*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_sssd/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_sssd/bash/shared.sh
@@ -1,0 +1,6 @@
+# platform = Ubuntu 24.04
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+find -L /var/log/ -maxdepth 1 ! -group root ! -group sssd -type d -regextype posix-extended -name 'sssd' -exec chgrp root {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_sssd/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_sssd/oval/shared.xml
@@ -1,0 +1,35 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+      {{{ oval_metadata("Group owner of /var/log/sssd should be root or sssd.") }}}
+    <criteria comment="Check group ownership of /var/log/sssd">
+     <criterion test_ref="test_group_ownership_var_log_sssd" />
+    </criteria>
+  </definition>
+  
+  <ind:textfilecontent54_object id="object_sssd_gid" version="1" comment="gid of the dedicated sssd group">
+    <ind:filepath>/etc/group</ind:filepath>
+    <ind:pattern operation="pattern match">^sssd:\w+:(\w+):.*</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <local_variable id="var_sssd_gid" datatype="int" version="1"
+                  comment="Retrieve the gid of sssd group">
+    <object_component item_field="subexpression" object_ref="object_sssd_gid"/>
+  </local_variable>
+
+  <unix:file_test check_existence="any_exist" check="all" comment="/var/log/sssd group owner is root|sssd"
+      id="test_group_ownership_var_log_sssd" state_operator="OR" version="1">
+    <unix:object object_ref="object_group_ownership_var_log_sssd" />
+    <unix:state state_ref="state_group_ownership_sssd_var_log_sssd"/>
+    <unix:state state_ref="state_group_ownership_root_var_log_sssd"/>
+  </unix:file_test>
+  <unix:file_object comment="/var/log/sssd" id="object_group_ownership_var_log_sssd" version="1">
+    <unix:path>/var/log/sssd</unix:path>
+    <unix:filename xsi:nil="true"/>
+  </unix:file_object>
+  <unix:file_state id="state_group_ownership_sssd_var_log_sssd" version="1">
+    <unix:group_id datatype="int" operation="equals" var_ref="var_sssd_gid"/>
+  </unix:file_state>
+  <unix:file_state id="state_group_ownership_root_var_log_sssd" version="1">
+    <unix:group_id datatype="int" operation="equals">0</unix:group_id>
+  </unix:file_state>
+ </def-group>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_sssd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_sssd/rule.yml
@@ -1,0 +1,16 @@
+documentation_complete: true
+
+title: 'Verify Group Who Owns /var/log/apt Directory'
+
+description: '{{{ describe_file_group_owner(file="/var/log/apt", group="root|adm") }}}'
+
+rationale: |-
+    The <tt>/var/log/apt</tt> directory contains information about APT
+    and should only be accessed by authorized personnel.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/log/apt", group="root|adm") }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/var/log/apt", group="root|adm") }}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_sssd/tests/no_file.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_sssd/tests/no_file.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+rm -rf /var/log/sssd
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_sssd/tests/owned_by_nogroup.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_sssd/tests/owned_by_nogroup.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = sssd
+
+mkdir -p /var/log/sssd
+chgrp nogroup /var/log/sssd

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_sssd/tests/owned_by_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_sssd/tests/owned_by_root.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = sssd
+
+mkdir -p /var/log/sssd
+chgrp root /var/log/sssd

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_sssd/tests/owned_by_sssd.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_sssd/tests/owned_by_sssd.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = sssd
+
+mkdir -p /var/log/sssd
+chgrp sssd /var/log/sssd

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_syslog/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_syslog/bash/shared.sh
@@ -1,0 +1,6 @@
+# platform = Ubuntu 24.04
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+find -L /var/log/ -maxdepth 1 ! -group root ! -group adm -type f -regextype posix-extended -name 'syslog' -exec chgrp adm {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_syslog/oval/ubuntu.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_syslog/oval/ubuntu.xml
@@ -16,7 +16,7 @@
     <object_component item_field="subexpression" object_ref="object_adm_gid"/>
   </local_variable>
 
-  <unix:file_test check="all" comment="/var/log/syslog group owner is root|adm"
+  <unix:file_test check_existence="any_exist" check="all" comment="/var/log/syslog group owner is root|adm"
       id="test_group_ownership_var_log_syslog" state_operator="OR" version="1">
     <unix:object object_ref="object_group_ownership_var_log_syslog" />
     <unix:state state_ref="state_group_ownership_adm_var_log_syslog"/>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_syslog/oval/ubuntu.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_syslog/oval/ubuntu.xml
@@ -1,0 +1,34 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+      {{{ oval_metadata("Group owner of /var/log/syslog should be root or adm.") }}}
+    <criteria comment="Check group ownership of /var/log/syslog">
+     <criterion test_ref="test_group_ownership_var_log_syslog" />
+    </criteria>
+  </definition>
+  
+  <ind:textfilecontent54_object id="object_adm_gid" version="1" comment="gid of the dedicated adm group">
+    <ind:filepath>/etc/group</ind:filepath>
+    <ind:pattern operation="pattern match">^adm:\w+:(\w+):.*</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <local_variable id="var_adm_gid" datatype="int" version="1"
+                  comment="Retrieve the gid of adm group">
+    <object_component item_field="subexpression" object_ref="object_adm_gid"/>
+  </local_variable>
+
+  <unix:file_test check="all" comment="/var/log/syslog group owner is root|adm"
+      id="test_group_ownership_var_log_syslog" state_operator="OR" version="1">
+    <unix:object object_ref="object_group_ownership_var_log_syslog" />
+    <unix:state state_ref="state_group_ownership_adm_var_log_syslog"/>
+    <unix:state state_ref="state_group_ownership_root_var_log_syslog"/>
+  </unix:file_test>
+  <unix:file_object comment="/var/log/syslog" id="object_group_ownership_var_log_syslog" version="1">
+    <unix:filepath>/var/log/syslog</unix:filepath>
+  </unix:file_object>
+  <unix:file_state id="state_group_ownership_adm_var_log_syslog" version="1">
+    <unix:group_id datatype="int" operation="equals" var_ref="var_adm_gid"/>
+  </unix:file_state>
+  <unix:file_state id="state_group_ownership_root_var_log_syslog" version="1">
+    <unix:group_id datatype="int" operation="equals">0</unix:group_id>
+  </unix:file_state>
+ </def-group>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_syslog/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_syslog/rule.yml
@@ -2,7 +2,11 @@ documentation_complete: true
 
 title: 'Verify Group Who Owns /var/log/syslog File'
 
+{{%  if 'ubuntu2404' not in product %}}
 description: '{{{ describe_file_group_owner(file="/var/log/syslog", group="adm") }}}'
+{{%- else %}}        
+description: '{{{ describe_file_group_owner(file="/var/log/syslog", group="root|adm") }}}'
+{{%- endif %}}
 
 rationale: |-
     The <tt>/var/log/syslog</tt> file contains logs of error messages in
@@ -16,6 +20,7 @@ references:
     stigid@ubuntu2004: UBTU-20-010420
     stigid@ubuntu2204: UBTU-22-232135
 
+{{%  if 'ubuntu2404' not in product %}}
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/log/syslog", group="adm") }}}'
 
 ocil: |-
@@ -26,3 +31,9 @@ template:
     vars:
         filepath: /var/log/syslog
         gid_or_name: '4'
+{{%- else %}}        
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/log/syslog", group="root|adm") }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/var/log/syslog", group="root|adm") }}}
+{{%- endif %}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_syslog/tests/no_file.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_syslog/tests/no_file.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+rm -f /var/log/syslog
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_syslog/tests/owned_by_adm.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_syslog/tests/owned_by_adm.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/syslog
+chgrp adm /var/log/syslog*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_syslog/tests/owned_by_nogroup.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_syslog/tests/owned_by_nogroup.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/syslog
+chgrp nogroup /var/log/syslog*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_syslog/tests/owned_by_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_syslog/tests/owned_by_root.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/syslog
+chgrp root /var/log/syslog*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_waagent/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_waagent/bash/shared.sh
@@ -1,0 +1,6 @@
+# platform = Ubuntu 24.04
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+find -L /var/log/ -maxdepth 1 ! -group root ! -group adm -type f -regextype posix-extended -regex '.*waagent.log(.*)' -exec chgrp adm {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_waagent/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_waagent/oval/shared.xml
@@ -1,0 +1,34 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+      {{{ oval_metadata("Group owner of /var/log/waagent.log should be root or adm.") }}}
+    <criteria comment="Check group ownership of /var/log/waagent.log">
+     <criterion test_ref="test_group_ownership_var_log_waagent" />
+    </criteria>
+  </definition>
+  
+  <ind:textfilecontent54_object id="object_adm_gid" version="1" comment="gid of the dedicated adm group">
+    <ind:filepath>/etc/group</ind:filepath>
+    <ind:pattern operation="pattern match">^adm:\w+:(\w+):.*</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <local_variable id="var_adm_gid" datatype="int" version="1"
+                  comment="Retrieve the gid of adm group">
+    <object_component item_field="subexpression" object_ref="object_adm_gid"/>
+  </local_variable>
+
+  <unix:file_test check="all" comment="/var/log/waagent.log group owner is root|adm"
+      id="test_group_ownership_var_log_waagent" state_operator="OR" version="1">
+    <unix:object object_ref="object_group_ownership_var_log_waagent" />
+    <unix:state state_ref="state_group_ownership_adm_var_log_waagent"/>
+    <unix:state state_ref="state_group_ownership_root_var_log_waagent"/>
+  </unix:file_test>
+  <unix:file_object comment="/var/log/waagent.log" id="object_group_ownership_var_log_waagent" version="1">
+    <unix:filepath operation="pattern match">/var/log/waagent.log(.*)</unix:filepath>
+  </unix:file_object>
+  <unix:file_state id="state_group_ownership_adm_var_log_waagent" version="1">
+    <unix:group_id datatype="int" operation="equals" var_ref="var_adm_gid"/>
+  </unix:file_state>
+  <unix:file_state id="state_group_ownership_root_var_log_waagent" version="1">
+    <unix:group_id datatype="int" operation="equals">0</unix:group_id>
+  </unix:file_state>
+ </def-group>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_waagent/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_waagent/oval/shared.xml
@@ -16,7 +16,7 @@
     <object_component item_field="subexpression" object_ref="object_adm_gid"/>
   </local_variable>
 
-  <unix:file_test check="all" comment="/var/log/waagent.log group owner is root|adm"
+  <unix:file_test check_existence="any_exist" check="all" comment="/var/log/waagent.log group owner is root|adm"
       id="test_group_ownership_var_log_waagent" state_operator="OR" version="1">
     <unix:object object_ref="object_group_ownership_var_log_waagent" />
     <unix:state state_ref="state_group_ownership_adm_var_log_waagent"/>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_waagent/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_waagent/rule.yml
@@ -1,0 +1,16 @@
+documentation_complete: true
+
+title: 'Verify Group Who Owns /var/log/secure File'
+
+description: '{{{ describe_file_group_owner(file="/var/log/secure", group="root|adm") }}}'
+
+rationale: |-
+    The <tt>/var/log/waagent.log</tt> file contains Azure Linux Guest Agent records
+    events that can be used for troubleshooting and should only be accessed by authorized personnel.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/log/secure", group="root|adm") }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/var/log/secure", group="root|adm") }}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_waagent/tests/no_file.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_waagent/tests/no_file.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+rm -f /var/log/waagent*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_waagent/tests/owned_by_adm.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_waagent/tests/owned_by_adm.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/waagent.log
+chgrp adm /var/log/waagent.log*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_waagent/tests/owned_by_nogroup.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_waagent/tests/owned_by_nogroup.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/waagent.log
+chgrp nogroup /var/log/waagent.log*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_waagent/tests/owned_by_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_waagent/tests/owned_by_root.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/waagent.log
+chgrp root /var/log/waagent.log*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_wbtmp/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_wbtmp/bash/shared.sh
@@ -1,0 +1,7 @@
+# platform = Ubuntu 24.04
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+
+find -L /var/log/ -maxdepth 1 ! -group root ! -group utmp -type f -regextype posix-extended -regex '.*(b|w)tmp((\.|-)[^\/]+)?$' -exec chgrp utmp {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_wbtmp/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_wbtmp/oval/shared.xml
@@ -1,0 +1,34 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+      {{{ oval_metadata("Group owner of /var/log/(w|b)tmp should be root or utmp.") }}}
+    <criteria comment="Check group ownership of /var/log/(w|b)tmp">
+     <criterion test_ref="test_group_ownership_var_log_wbtmp" />
+    </criteria>
+  </definition>
+  
+  <ind:textfilecontent54_object id="object_utmp_gid" version="1" comment="gid of the dedicated utmp group">
+    <ind:filepath>/etc/group</ind:filepath>
+    <ind:pattern operation="pattern match">^utmp:\w+:(\w+):.*</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <local_variable id="var_utmp_gid" datatype="int" version="1"
+                  comment="Retrieve the gid of utmp group">
+    <object_component item_field="subexpression" object_ref="object_utmp_gid"/>
+  </local_variable>
+
+  <unix:file_test check="all" comment="/var/log/(w|b)tmp group owner is root|utmp"
+      id="test_group_ownership_var_log_wbtmp" state_operator="OR" version="1">
+    <unix:object object_ref="object_group_ownership_var_log_wbtmp" />
+    <unix:state state_ref="state_group_ownership_utmp_var_log_wbtmp"/>
+    <unix:state state_ref="state_group_ownership_root_var_log_wbtmp"/>
+  </unix:file_test>
+  <unix:file_object comment="/var/log/(w|b)tmp" id="object_group_ownership_var_log_wbtmp" version="1">
+    <unix:filepath operation="pattern match">/var/log/(b|w)tmp((\.|-)[^\/]+)?</unix:filepath>
+  </unix:file_object>
+  <unix:file_state id="state_group_ownership_utmp_var_log_wbtmp" version="1">
+    <unix:group_id datatype="int" operation="equals" var_ref="var_utmp_gid"/>
+  </unix:file_state>
+  <unix:file_state id="state_group_ownership_root_var_log_wbtmp" version="1">
+    <unix:group_id datatype="int" operation="equals">0</unix:group_id>
+  </unix:file_state>
+ </def-group>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_wbtmp/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_wbtmp/oval/shared.xml
@@ -16,7 +16,7 @@
     <object_component item_field="subexpression" object_ref="object_utmp_gid"/>
   </local_variable>
 
-  <unix:file_test check="all" comment="/var/log/(w|b)tmp group owner is root|utmp"
+  <unix:file_test check_existence="any_exist" check="all" comment="/var/log/(w|b)tmp group owner is root|utmp"
       id="test_group_ownership_var_log_wbtmp" state_operator="OR" version="1">
     <unix:object object_ref="object_group_ownership_var_log_wbtmp" />
     <unix:state state_ref="state_group_ownership_utmp_var_log_wbtmp"/>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_wbtmp/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_wbtmp/rule.yml
@@ -1,0 +1,16 @@
+documentation_complete: true
+
+title: 'Verify Group Who Owns /var/log/(b|w)tmp(.*|-*) File'
+
+description: '{{{ describe_file_group_owner(file="/var/log/(b|w)tmp(.*|-*)", group="root|utmp") }}}'
+
+rationale: |-
+    The <tt>/var/log/(b|w)tmp(.*|-*)</tt> file contains logs of reports the most recent login of all users
+    and should only be accessed by authorized personnel.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/log/(b|w)tmp(.*|-*)", group="root|utmp") }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/var/log/(b|w)tmp(.*|-*)", group="root|utmp") }}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_wbtmp/tests/no_file.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_wbtmp/tests/no_file.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+rm -f /var/log/btmp*
+rm -f /var/log/wtmp*
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_wbtmp/tests/owned_by_nogroup.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_wbtmp/tests/owned_by_nogroup.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+
+touch /var/log/btmp
+touch /var/log/btmp.1
+touch /var/log/btmp-1
+chgrp nogroup /var/log/btmp*
+touch /var/log/wtmp
+touch /var/log/wtmp.1
+touch /var/log/wtmp-1
+chgrp nogroup /var/log/wtmp*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_wbtmp/tests/owned_by_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_wbtmp/tests/owned_by_root.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+
+touch /var/log/btmp
+touch /var/log/btmp.1
+touch /var/log/btmp-1
+chgrp root /var/log/btmp*
+touch /var/log/wtmp
+touch /var/log/wtmp.1
+touch /var/log/wtmp-1
+chgrp root /var/log/wtmp*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_wbtmp/tests/owned_by_utmp.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_wbtmp/tests/owned_by_utmp.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+
+touch /var/log/btmp
+touch /var/log/btmp.1
+touch /var/log/btmp-1
+chgrp utmp /var/log/btmp*
+touch /var/log/wtmp
+touch /var/log/wtmp.1
+touch /var/log/wtmp-1
+chgrp utmp /var/log/wtmp*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_auth/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_auth/bash/shared.sh
@@ -1,0 +1,6 @@
+# platform = Ubuntu 24.04
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+find -L /var/log/ -maxdepth 1 ! -owner root ! -owner syslog -type f -regextype posix-extended -name 'auth.log' -exec chown syslog {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_auth/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_auth/bash/shared.sh
@@ -3,4 +3,4 @@
 # strategy = configure
 # complexity = low
 # disruption = low
-find -L /var/log/ -maxdepth 1 ! -owner root ! -owner syslog -type f -regextype posix-extended -name 'auth.log' -exec chown syslog {} \;
+find -L /var/log/ -maxdepth 1 ! -user root ! -user syslog -type f -regextype posix-extended -name 'auth.log' -exec chown syslog {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_auth/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_auth/oval/shared.xml
@@ -13,7 +13,7 @@
     <object_component item_field="user_id" object_ref="object_syslog_uid" />
   </local_variable>
 
-  <unix:file_test check="all" comment="/var/log/auth.log owner is root|syslog"
+  <unix:file_test check_existence="any_exist" check="all" comment="/var/log/auth.log owner is root|syslog"
       id="test_file_ownership_var_log_auth_log" state_operator="OR" version="1">
     <unix:object object_ref="object_file_ownership_var_log_auth_log" />
     <unix:state state_ref="state_file_ownership_syslog_var_log_auth_log"/>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_auth/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_auth/oval/shared.xml
@@ -1,0 +1,31 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+      {{{ oval_metadata("Owner of /var/log/auth.log should be root or syslog.") }}}
+    <criteria comment="Check file ownership of /var/log/auth.log">
+     <criterion test_ref="test_file_ownership_var_log_auth_log" />
+    </criteria>
+  </definition>
+
+  <unix:password_object id="object_syslog_uid" version="1">
+    <unix:username operation="pattern match">syslog</unix:username>
+  </unix:password_object>
+  <local_variable id="var_syslog_uid" comment="Retrieve the uid of syslog" datatype="int" version="1">
+    <object_component item_field="user_id" object_ref="object_syslog_uid" />
+  </local_variable>
+
+  <unix:file_test check="all" comment="/var/log/auth.log owner is root|syslog"
+      id="test_file_ownership_var_log_auth_log" state_operator="OR" version="1">
+    <unix:object object_ref="object_file_ownership_var_log_auth_log" />
+    <unix:state state_ref="state_file_ownership_syslog_var_log_auth_log"/>
+    <unix:state state_ref="state_file_ownership_root_var_log_auth_log"/>
+  </unix:file_test>
+  <unix:file_object comment="/var/log/auth.log" id="object_file_ownership_var_log_auth_log" version="1">
+    <unix:filepath>/var/log/auth.log</unix:filepath>
+  </unix:file_object>
+  <unix:file_state id="state_file_ownership_syslog_var_log_auth_log" version="1">
+    <unix:user_id datatype="int" operation="equals" var_ref="var_syslog_uid"/>
+  </unix:file_state>
+  <unix:file_state id="state_file_ownership_root_var_log_auth_log" version="1">
+    <unix:user_id datatype="int" operation="equals">0</unix:user_id>
+  </unix:file_state>
+ </def-group>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_auth/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_auth/rule.yml
@@ -1,0 +1,17 @@
+documentation_complete: true
+
+title: 'Verify User Who Owns /var/log/auth.log File'
+
+description: '{{{ describe_file_owner(file="/var/log/auth.log", owner="root|syslog") }}}'
+
+rationale: |-
+    The <tt>/var/log/auth.log</tt> file contains records information about user
+    login attempts and authentication processes and should only be accessed by
+    authorized personnel.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/log/auth.log", owner="root|syslog") }}}'
+
+ocil: |-
+    {{{ ocil_file_owner(file="/var/log/auth.log", owner="root|syslog") }}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_auth/tests/no_file.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_auth/tests/no_file.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+rm -f /var/log/auth.log
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_auth/tests/owned_by_nobody.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_auth/tests/owned_by_nobody.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/auth.log
+chown nobody /var/log/auth.log

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_auth/tests/owned_by_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_auth/tests/owned_by_root.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/auth.log
+chown root /var/log/auth.log

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_auth/tests/owned_by_syslog.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_auth/tests/owned_by_syslog.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/auth.log
+chown syslog /var/log/auth.log

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_cloud_init/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_cloud_init/bash/shared.sh
@@ -3,4 +3,4 @@
 # strategy = configure
 # complexity = low
 # disruption = low
-find -L /var/log/ -maxdepth 1 ! -owner root ! -owner syslog -type f -regextype posix-extended -regex '.*cloud-init.log(.*)' -exec chown syslog {} \;
+find -L /var/log/ -maxdepth 1 ! -user root ! -user syslog -type f -regextype posix-extended -regex '.*cloud-init.log(.*)' -exec chown syslog {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_cloud_init/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_cloud_init/bash/shared.sh
@@ -1,0 +1,6 @@
+# platform = Ubuntu 24.04
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+find -L /var/log/ -maxdepth 1 ! -owner root ! -owner syslog -type f -regextype posix-extended -regex '.*cloud-init.log(.*)' -exec chown syslog {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_cloud_init/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_cloud_init/oval/shared.xml
@@ -13,7 +13,7 @@
     <object_component item_field="user_id" object_ref="object_syslog_uid" />
   </local_variable>
 
-  <unix:file_test check="all" comment="/var/log/cloud-init.log owner is root|syslog"
+  <unix:file_test check_existence="any_exist" check="all" comment="/var/log/cloud-init.log owner is root|syslog"
       id="test_file_ownership_var_log_cloud-init_log" state_operator="OR" version="1">
     <unix:object object_ref="object_file_ownership_var_log_cloud-init_log" />
     <unix:state state_ref="state_file_ownership_syslog_var_log_cloud-init_log"/>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_cloud_init/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_cloud_init/oval/shared.xml
@@ -1,0 +1,31 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+      {{{ oval_metadata("Owner of /var/log/cloud-init.log should be root or syslog.") }}}
+    <criteria comment="Check file ownership of /var/log/cloud-init.log">
+     <criterion test_ref="test_file_ownership_var_log_cloud-init_log" />
+    </criteria>
+  </definition>
+
+  <unix:password_object id="object_syslog_uid" version="1">
+    <unix:username operation="pattern match">syslog</unix:username>
+  </unix:password_object>
+  <local_variable id="var_syslog_uid" comment="Retrieve the uid of syslog" datatype="int" version="1">
+    <object_component item_field="user_id" object_ref="object_syslog_uid" />
+  </local_variable>
+
+  <unix:file_test check="all" comment="/var/log/cloud-init.log owner is root|syslog"
+      id="test_file_ownership_var_log_cloud-init_log" state_operator="OR" version="1">
+    <unix:object object_ref="object_file_ownership_var_log_cloud-init_log" />
+    <unix:state state_ref="state_file_ownership_syslog_var_log_cloud-init_log"/>
+    <unix:state state_ref="state_file_ownership_root_var_log_cloud-init_log"/>
+  </unix:file_test>
+  <unix:file_object comment="/var/log/cloud-init.log" id="object_file_ownership_var_log_cloud-init_log" version="1">
+    <unix:filepath operation="pattern match">/var/log/cloud-init.log(.*)</unix:filepath>
+  </unix:file_object>
+  <unix:file_state id="state_file_ownership_syslog_var_log_cloud-init_log" version="1">
+    <unix:user_id datatype="int" operation="equals" var_ref="var_syslog_uid"/>
+  </unix:file_state>
+  <unix:file_state id="state_file_ownership_root_var_log_cloud-init_log" version="1">
+    <unix:user_id datatype="int" operation="equals">0</unix:user_id>
+  </unix:file_state>
+ </def-group>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_cloud_init/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_cloud_init/rule.yml
@@ -1,0 +1,16 @@
+documentation_complete: true
+
+title: 'Verify User Who Owns /var/log/cloud-init.log File'
+
+description: '{{{ describe_file_owner(file="/var/log/cloud-init.log", owner="root|syslog") }}}'
+
+rationale: |-
+    The <tt>/var/log/cloud-init.log</tt> file contains detailed debugging information that
+    helps users troubleshoot cloud-init and should only be accessed by authorized personnel.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/log/cloud-init.log", owner="root|syslog") }}}'
+
+ocil: |-
+    {{{ ocil_file_owner(file="/var/log/cloud-init.log", owner="root|syslog") }}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_cloud_init/tests/no_file.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_cloud_init/tests/no_file.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+rm -f /var/log/cloud-init.log
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_cloud_init/tests/owned_by_nobody.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_cloud_init/tests/owned_by_nobody.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/cloud-init.log
+chown nobody /var/log/cloud-init.log*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_cloud_init/tests/owned_by_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_cloud_init/tests/owned_by_root.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/cloud-init.log
+chown root /var/log/cloud-init.log*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_cloud_init/tests/owned_by_syslog.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_cloud_init/tests/owned_by_syslog.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/cloud-init.log
+chown syslog /var/log/cloud-init.log*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_gdm/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_gdm/rule.yml
@@ -1,0 +1,28 @@
+documentation_complete: true
+
+title: 'Verify User Who Owns /var/log/gdm directory'
+
+description: '{{{ describe_file_owner(file="/var/log/gdm", owner="root") }}}'
+
+rationale: |-
+    The <tt>/var/log/gdm</tt> directory contains information about the GDM daemon
+    and should only be accessed by authorized personnel.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/log/gdm", owner="root") }}}'
+
+ocil: |-
+    {{{ ocil_file_owner(file="/var/log/gdm", owner="root") }}}
+
+fixtext: |-
+    {{{ describe_file_owner(file="/var/log/gdm", owner="root") }}}
+
+srg_requirement: '{{{ srg_requirement_file_owner("/var/log/gdm", owner="root") }}}'
+
+template:
+    name: file_owner
+    vars:
+        filepath: /var/log/gdm/
+        fileuid: '0'
+        recursive: 'true'

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_gdm3/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_gdm3/rule.yml
@@ -1,0 +1,28 @@
+documentation_complete: true
+
+title: 'Verify User Who Owns /var/log/gdm3 directory'
+
+description: '{{{ describe_file_owner(file="/var/log/gdm3", owner="root") }}}'
+
+rationale: |-
+    The <tt>/var/log/gdm3</tt> directory stores information about the GNOME Display Manager (GDM)
+    and should only be accessed by authorized personnel.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/log/gdm3", owner="root") }}}'
+
+ocil: |-
+    {{{ ocil_file_owner(file="/var/log/gdm3", owner="root") }}}
+
+fixtext: |-
+    {{{ describe_file_owner(file="/var/log/gdm3", owner="root") }}}
+
+srg_requirement: '{{{ srg_requirement_file_owner("/var/log/gdm3", owner="root") }}}'
+
+template:
+    name: file_owner
+    vars:
+        filepath: /var/log/gdm3/
+        fileuid: '0'
+        recursive: 'true'

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_journal/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_journal/rule.yml
@@ -1,0 +1,27 @@
+documentation_complete: true
+
+title: 'Verify User Who Owns /var/log/*.journal(~) Files'
+
+description: '{{{ describe_file_owner(file="/var/log/*.journal(~)", owner="root") }}}'
+
+rationale: |-
+    The <tt>/var/log/*.journal(~)</tt> files are system logs managed by the "systemd" service.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/log/*.journal(~)", owner="root") }}}'
+
+ocil: |-
+    {{{ ocil_file_owner(file="/var/log/*.journal(~)", owner="root") }}}
+
+fixtext: |-
+    {{{ describe_file_owner(file="/var/log/*.journal(~)", owner="root") }}}
+
+srg_requirement: '{{{ srg_requirement_file_owner("/var/log/*.journal(~)", owner="root") }}}'
+
+template:
+    name: file_owner
+    vars:
+        filepath: /var/log/
+        file_regex: .*\.journal(~)?$
+        fileuid: '0'

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_journal/tests/incorrect_owner.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_journal/tests/incorrect_owner.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /var/log/my.journal
+chown nobody /var/log/my.journal

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_journal/tests/invalid_owner.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_journal/tests/invalid_owner.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /var/log/my.journal~
+chown nobody /var/log/my.journal~

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_journal/tests/valid_permissions.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_journal/tests/valid_permissions.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+touch touch /var/log/my.journal~
+chown root /var/log/my.journal~
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_lastlog/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_lastlog/rule.yml
@@ -1,0 +1,28 @@
+documentation_complete: true
+
+title: 'Verify User Who Owns /var/log/lastlog File'
+
+description: '{{{ describe_file_owner(file="/var/log/lastlog", owner="root") }}}'
+
+rationale: |-
+    The <tt>/var/log/lastlog</tt> file contains logs of reports the most recent login of all users
+    and should only be accessed by authorized personnel.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/log/lastlog", owner="root") }}}'
+
+ocil: |-
+    {{{ ocil_file_owner(file="/var/log/lastlog", owner="root") }}}
+
+fixtext: |-
+    {{{ describe_file_owner(file="/var/log/lastlog", owner="root") }}}
+
+srg_requirement: '{{{ srg_requirement_file_owner("/var/log/lastlog", owner="root") }}}'
+
+template:
+    name: file_owner
+    vars:
+        filepath: /var/log/
+        file_regex: .*lastlog(\.[^\/]+)?$
+        fileuid: '0'

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_lastlog/tests/incorrect_owner.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_lastlog/tests/incorrect_owner.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /var/log/lastlog
+chown syslog /var/log/lastlog

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_lastlog/tests/invalid_owner.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_lastlog/tests/invalid_owner.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /var/log/lastlog.1
+chown syslog /var/log/lastlog.1

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_lastlog/tests/valid_permissions.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_lastlog/tests/valid_permissions.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+touch /var/log/lastlog.1
+chown root /var/log/lastlog.1
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_localmessages/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_localmessages/bash/shared.sh
@@ -1,0 +1,6 @@
+# platform = Ubuntu 24.04
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+find -L /var/log/ -maxdepth 1 ! -owner root ! -owner syslog -type f -regextype posix-extended -regex '.*localmessages(.*)' -exec chown syslog {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_localmessages/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_localmessages/bash/shared.sh
@@ -3,4 +3,4 @@
 # strategy = configure
 # complexity = low
 # disruption = low
-find -L /var/log/ -maxdepth 1 ! -owner root ! -owner syslog -type f -regextype posix-extended -regex '.*localmessages(.*)' -exec chown syslog {} \;
+find -L /var/log/ -maxdepth 1 ! -user root ! -user syslog -type f -regextype posix-extended -regex '.*localmessages(.*)' -exec chown syslog {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_localmessages/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_localmessages/oval/shared.xml
@@ -13,7 +13,7 @@
     <object_component item_field="user_id" object_ref="object_syslog_uid" />
   </local_variable>
 
-  <unix:file_test check="all" comment="/var/log/localmessages owner is root|syslog"
+  <unix:file_test check_existence="any_exist" check="all" comment="/var/log/localmessages owner is root|syslog"
       id="test_file_ownership_var_log_localmessages" state_operator="OR" version="1">
     <unix:object object_ref="object_file_ownership_var_log_localmessages" />
     <unix:state state_ref="state_file_ownership_syslog_var_log_localmessages"/>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_localmessages/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_localmessages/oval/shared.xml
@@ -1,0 +1,31 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+      {{{ oval_metadata("Owner of /var/log/localmessages should be root or syslog.") }}}
+    <criteria comment="Check file ownership of /var/log/localmessages">
+     <criterion test_ref="test_file_ownership_var_log_localmessages" />
+    </criteria>
+  </definition>
+
+  <unix:password_object id="object_syslog_uid" version="1">
+    <unix:username operation="pattern match">syslog</unix:username>
+  </unix:password_object>
+  <local_variable id="var_syslog_uid" comment="Retrieve the uid of syslog" datatype="int" version="1">
+    <object_component item_field="user_id" object_ref="object_syslog_uid" />
+  </local_variable>
+
+  <unix:file_test check="all" comment="/var/log/localmessages owner is root|syslog"
+      id="test_file_ownership_var_log_localmessages" state_operator="OR" version="1">
+    <unix:object object_ref="object_file_ownership_var_log_localmessages" />
+    <unix:state state_ref="state_file_ownership_syslog_var_log_localmessages"/>
+    <unix:state state_ref="state_file_ownership_root_var_log_localmessages"/>
+  </unix:file_test>
+  <unix:file_object comment="/var/log/localmessages" id="object_file_ownership_var_log_localmessages" version="1">
+    <unix:filepath operation="pattern match">/var/log/localmessages(.*)</unix:filepath>
+  </unix:file_object>
+  <unix:file_state id="state_file_ownership_syslog_var_log_localmessages" version="1">
+    <unix:user_id datatype="int" operation="equals" var_ref="var_syslog_uid"/>
+  </unix:file_state>
+  <unix:file_state id="state_file_ownership_root_var_log_localmessages" version="1">
+    <unix:user_id datatype="int" operation="equals">0</unix:user_id>
+  </unix:file_state>
+ </def-group>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_localmessages/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_localmessages/rule.yml
@@ -1,0 +1,16 @@
+documentation_complete: true
+
+title: 'Verify User Who Owns /var/log/localmessages File'
+
+description: '{{{ describe_file_owner(file="/var/log/localmessages", owner="root|syslog") }}}'
+
+rationale: |-
+    The <tt>/var/log/localmessages</tt> file contains log messages from certain boot scripts,
+    including the DHCP client, and should only be accessed by authorized personnel.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/log/localmessages", owner="root|syslog") }}}'
+
+ocil: |-
+    {{{ ocil_file_owner(file="/var/log/localmessages", owner="root|syslog") }}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_localmessages/tests/no_file.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_localmessages/tests/no_file.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+rm -f /var/log/localmessages*
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_localmessages/tests/owned_by_nobody.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_localmessages/tests/owned_by_nobody.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/localmessages
+chown nobody /var/log/localmessages*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_localmessages/tests/owned_by_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_localmessages/tests/owned_by_root.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/localmessages
+chown root /var/log/localmessages*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_localmessages/tests/owned_by_syslog.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_localmessages/tests/owned_by_syslog.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/localmessages
+chown syslog /var/log/localmessages*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_messages/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_messages/bash/shared.sh
@@ -3,4 +3,4 @@
 # strategy = configure
 # complexity = low
 # disruption = low
-find -L /var/log/ -maxdepth 1 ! -owner root ! -owner syslog -type f -regextype posix-extended -name 'messages' -exec chown syslog {} \;
+find -L /var/log/ -maxdepth 1 ! -user root ! -user syslog -type f -regextype posix-extended -name 'messages' -exec chown syslog {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_messages/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_messages/bash/shared.sh
@@ -1,0 +1,6 @@
+# platform = Ubuntu 24.04
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+find -L /var/log/ -maxdepth 1 ! -owner root ! -owner syslog -type f -regextype posix-extended -name 'messages' -exec chown syslog {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_messages/oval/ubuntu.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_messages/oval/ubuntu.xml
@@ -1,0 +1,33 @@
+{{% if 'ubuntu2404' in product %}}
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+      {{{ oval_metadata("Owner of /var/log/messages should be root or syslog.") }}}
+    <criteria comment="Check file ownership of /var/log/messages">
+     <criterion test_ref="test_file_ownership_var_log_messages" />
+    </criteria>
+  </definition>
+
+  <unix:password_object id="object_syslog_uid" version="1">
+    <unix:username operation="pattern match">syslog</unix:username>
+  </unix:password_object>
+  <local_variable id="var_syslog_uid" comment="Retrieve the uid of syslog" datatype="int" version="1">
+    <object_component item_field="user_id" object_ref="object_syslog_uid" />
+  </local_variable>
+
+  <unix:file_test check="all" comment="/var/log/messages owner is root|syslog"
+      id="test_file_ownership_var_log_messages" state_operator="OR" version="1">
+    <unix:object object_ref="object_file_ownership_var_log_messages" />
+    <unix:state state_ref="state_file_ownership_syslog_var_log_messages"/>
+    <unix:state state_ref="state_file_ownership_root_var_log_messages"/>
+  </unix:file_test>
+  <unix:file_object comment="/var/log/messages" id="object_file_ownership_var_log_messages" version="1">
+    <unix:filepath>/var/log/messages</unix:filepath>
+  </unix:file_object>
+  <unix:file_state id="state_file_ownership_syslog_var_log_messages" version="1">
+    <unix:user_id datatype="int" operation="equals" var_ref="var_syslog_uid"/>
+  </unix:file_state>
+  <unix:file_state id="state_file_ownership_root_var_log_messages" version="1">
+    <unix:user_id datatype="int" operation="equals">0</unix:user_id>
+  </unix:file_state>
+ </def-group>
+ {{%- endif %}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_messages/oval/ubuntu.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_messages/oval/ubuntu.xml
@@ -14,7 +14,7 @@
     <object_component item_field="user_id" object_ref="object_syslog_uid" />
   </local_variable>
 
-  <unix:file_test check="all" comment="/var/log/messages owner is root|syslog"
+  <unix:file_test check_existence="any_exist" check="all" comment="/var/log/messages owner is root|syslog"
       id="test_file_ownership_var_log_messages" state_operator="OR" version="1">
     <unix:object object_ref="object_file_ownership_var_log_messages" />
     <unix:state state_ref="state_file_ownership_syslog_var_log_messages"/>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_messages/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_messages/rule.yml
@@ -2,7 +2,11 @@ documentation_complete: true
 
 title: 'Verify User Who Owns /var/log/messages File'
 
+{{%  if 'ubuntu2404' not in product %}}
 description: '{{{ describe_file_owner(file="/var/log/messages", owner="root") }}}'
+{{%- else %}}        
+description: '{{{ describe_file_owner(file="/var/log/messages", owner="root|syslog") }}}'
+{{%- endif %}}
 
 rationale: |-
     The <tt>/var/log/messages</tt> file contains logs of error messages in
@@ -21,18 +25,25 @@ references:
     stigid@ol8: OL08-00-010220
     stigid@rhel8: RHEL-08-010220
 
+{{%  if 'ubuntu2404' not in product %}}
 ocil_clause: '{{{ ocil_clause_file_owner(file="/var/log/messages", owner="root") }}}'
 
 ocil: |-
     {{{ ocil_file_owner(file="/var/log/messages", owner="root") }}}
+
+fixtext: |-
+    {{{ describe_file_owner(file="/var/log/messages", owner="root") }}}
+
+srg_requirement: '{{{ srg_requirement_file_owner("/var/log/messages", owner="root") }}}'
 
 template:
     name: file_owner
     vars:
         filepath: /var/log/messages
         fileuid: '0'
+{{%- else %}}        
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/log/messages", owner="root|syslog") }}}'
 
-fixtext: |-
-    {{{ describe_file_owner(file="/var/log/messages", owner="root") }}}
-
-srg_requirement: '{{{ srg_requirement_file_owner("/var/log/messages", owner="root") }}}'
+ocil: |-
+    {{{ ocil_file_owner(file="/var/log/messages", owner="root|syslog") }}}
+{{%- endif %}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_messages/tests/no_file.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_messages/tests/no_file.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+rm -f /var/log/messages
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_messages/tests/owned_by_nobody.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_messages/tests/owned_by_nobody.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/messages
+chown nobody /var/log/messages

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_messages/tests/owned_by_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_messages/tests/owned_by_root.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/messages
+chown root /var/log/messages

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_messages/tests/owned_by_syslog.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_messages/tests/owned_by_syslog.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/messages
+chown syslog /var/log/messages

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_secure/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_secure/bash/shared.sh
@@ -1,0 +1,6 @@
+# platform = Ubuntu 24.04
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+find -L /var/log/ -maxdepth 1 ! -owner root ! -owner syslog -type f -regextype posix-extended -regex '.*localmessages(.*)' -exec chown syslog {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_secure/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_secure/bash/shared.sh
@@ -3,4 +3,4 @@
 # strategy = configure
 # complexity = low
 # disruption = low
-find -L /var/log/ -maxdepth 1 ! -owner root ! -owner syslog -type f -regextype posix-extended -regex '.*localmessages(.*)' -exec chown syslog {} \;
+find -L /var/log/ -maxdepth 1 ! -user root ! -user syslog -type f -regextype posix-extended -name 'secure' -exec chown syslog {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_secure/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_secure/oval/shared.xml
@@ -13,7 +13,7 @@
     <object_component item_field="user_id" object_ref="object_syslog_uid" />
   </local_variable>
 
-  <unix:file_test check="all" comment="/var/log/secure owner is root|syslog"
+  <unix:file_test check_existence="any_exist" check="all" comment="/var/log/secure owner is root|syslog"
       id="test_file_ownership_var_log_secure" state_operator="OR" version="1">
     <unix:object object_ref="object_file_ownership_var_log_secure" />
     <unix:state state_ref="state_file_ownership_syslog_var_log_secure"/>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_secure/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_secure/oval/shared.xml
@@ -1,0 +1,31 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+      {{{ oval_metadata("Owner of /var/log/secure should be root or syslog.") }}}
+    <criteria comment="Check file ownership of /var/log/secure">
+     <criterion test_ref="test_file_ownership_var_log_secure" />
+    </criteria>
+  </definition>
+
+  <unix:password_object id="object_syslog_uid" version="1">
+    <unix:username operation="pattern match">syslog</unix:username>
+  </unix:password_object>
+  <local_variable id="var_syslog_uid" comment="Retrieve the uid of syslog" datatype="int" version="1">
+    <object_component item_field="user_id" object_ref="object_syslog_uid" />
+  </local_variable>
+
+  <unix:file_test check="all" comment="/var/log/secure owner is root|syslog"
+      id="test_file_ownership_var_log_secure" state_operator="OR" version="1">
+    <unix:object object_ref="object_file_ownership_var_log_secure" />
+    <unix:state state_ref="state_file_ownership_syslog_var_log_secure"/>
+    <unix:state state_ref="state_file_ownership_root_var_log_secure"/>
+  </unix:file_test>
+  <unix:file_object comment="/var/log/secure" id="object_file_ownership_var_log_secure" version="1">
+    <unix:filepath>/var/log/secure</unix:filepath>
+  </unix:file_object>
+  <unix:file_state id="state_file_ownership_syslog_var_log_secure" version="1">
+    <unix:user_id datatype="int" operation="equals" var_ref="var_syslog_uid"/>
+  </unix:file_state>
+  <unix:file_state id="state_file_ownership_root_var_log_secure" version="1">
+    <unix:user_id datatype="int" operation="equals">0</unix:user_id>
+  </unix:file_state>
+ </def-group>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_secure/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_secure/rule.yml
@@ -1,0 +1,16 @@
+documentation_complete: true
+
+title: 'Verify User Who Owns /var/log/secure File'
+
+description: '{{{ describe_file_owner(file="/var/log/secure", owner="root|syslog") }}}'
+
+rationale: |-
+    The <tt>/var/log/secure</tt> file contains information related to authentication
+    and authorization privileges and should only be accessed by authorized personnel.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/log/secure", owner="root|syslog") }}}'
+
+ocil: |-
+    {{{ ocil_file_owner(file="/var/log/secure", owner="root|syslog") }}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_secure/tests/no_file.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_secure/tests/no_file.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+rm -f /var/log/secure
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_secure/tests/owned_by_nobody.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_secure/tests/owned_by_nobody.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/secure
+chown nobody /var/log/secure*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_secure/tests/owned_by_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_secure/tests/owned_by_root.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/secure
+chown root /var/log/secure*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_secure/tests/owned_by_syslog.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_secure/tests/owned_by_syslog.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/secure
+chown syslog /var/log/secure*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_sssd/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_sssd/bash/shared.sh
@@ -1,0 +1,6 @@
+# platform = Ubuntu 24.04
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+find -L /var/log/ -maxdepth 1 ! -owner root ! -owner sssd -type d -regextype posix-extended -name 'sssd' -exec chown sssd {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_sssd/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_sssd/bash/shared.sh
@@ -3,4 +3,4 @@
 # strategy = configure
 # complexity = low
 # disruption = low
-find -L /var/log/ -maxdepth 1 ! -owner root ! -owner sssd -type d -regextype posix-extended -name 'sssd' -exec chown sssd {} \;
+find -L /var/log/ -maxdepth 1 ! -user root ! -user sssd -type d -regextype posix-extended -name 'sssd' -exec chown sssd {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_sssd/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_sssd/oval/shared.xml
@@ -13,7 +13,7 @@
     <object_component item_field="user_id" object_ref="object_sssd_uid" />
   </local_variable>
 
-  <unix:file_test check="all" comment="/var/log/sssd owner is root|sssd"
+  <unix:file_test check_existence="any_exist" check="all" comment="/var/log/sssd owner is root|sssd"
       id="test_file_ownership_var_log_sssd" state_operator="OR" version="1">
     <unix:object object_ref="object_file_ownership_var_log_sssd" />
     <unix:state state_ref="state_file_ownership_sssd_var_log_sssd"/>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_sssd/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_sssd/oval/shared.xml
@@ -1,0 +1,32 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+      {{{ oval_metadata("Owner of /var/log/sssd should be root or sssd.") }}}
+    <criteria comment="Check file ownership of /var/log/sssd">
+     <criterion test_ref="test_file_ownership_var_log_sssd" />
+    </criteria>
+  </definition>
+
+  <unix:password_object id="object_sssd_uid" version="1">
+    <unix:username operation="pattern match">sssd</unix:username>
+  </unix:password_object>
+  <local_variable id="var_sssd_uid" comment="Retrieve the uid of sssd" datatype="int" version="1">
+    <object_component item_field="user_id" object_ref="object_sssd_uid" />
+  </local_variable>
+
+  <unix:file_test check="all" comment="/var/log/sssd owner is root|sssd"
+      id="test_file_ownership_var_log_sssd" state_operator="OR" version="1">
+    <unix:object object_ref="object_file_ownership_var_log_sssd" />
+    <unix:state state_ref="state_file_ownership_sssd_var_log_sssd"/>
+    <unix:state state_ref="state_file_ownership_root_var_log_sssd"/>
+  </unix:file_test>
+  <unix:file_object comment="/var/log/sssd" id="object_file_ownership_var_log_sssd" version="1">
+    <unix:path>/var/log/sssd</unix:path>
+    <unix:filename xsi:nil="true"/>
+  </unix:file_object>
+  <unix:file_state id="state_file_ownership_sssd_var_log_sssd" version="1">
+    <unix:user_id datatype="int" operation="equals" var_ref="var_sssd_uid"/>
+  </unix:file_state>
+  <unix:file_state id="state_file_ownership_root_var_log_sssd" version="1">
+    <unix:user_id datatype="int" operation="equals">0</unix:user_id>
+  </unix:file_state>
+ </def-group>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_sssd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_sssd/rule.yml
@@ -1,0 +1,22 @@
+documentation_complete: true
+
+title: 'Verify User Who Owns /var/log/sssd Files'
+
+description: '{{{ describe_file_owner(file="/var/log/sssd", owner="root|sssd") }}}'
+
+rationale: |-
+    The <tt>/var/log/sssd</tt> directory contains debug logs for the System
+    Security Services Daemon (SSSD) and should only be accessed by authorized personnel.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/log/sssd", owner="root|sssd") }}}'
+
+ocil: |-
+    {{{ ocil_file_owner(file="/var/log/sssd", owner="root|sssd") }}}
+
+fixtext: |-
+    {{{ describe_file_owner(file="/var/log/sssd", owner="root|sssd") }}}
+
+srg_requirement: '{{{ srg_requirement_file_owner("/var/log/sssd", owner="root|sssd") }}}'
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_sssd/tests/no_file.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_sssd/tests/no_file.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = sssd
+
+rm -rf /var/log/sssd
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_sssd/tests/owned_by_nobody.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_sssd/tests/owned_by_nobody.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = sssd
+
+chown nobody /var/log/sssd

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_sssd/tests/owned_by_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_sssd/tests/owned_by_root.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = sssd
+
+chown root /var/log/sssd

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_sssd/tests/owned_by_sssd.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_sssd/tests/owned_by_sssd.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = sssd
+
+chown sssd /var/log/sssd

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_syslog/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_syslog/bash/shared.sh
@@ -3,4 +3,4 @@
 # strategy = configure
 # complexity = low
 # disruption = low
-find -L /var/log/ -maxdepth 1 ! -owner root ! -owner syslog -type f -regextype posix-extended -name 'syslog' -exec chown syslog {} \;
+find -L /var/log/ -maxdepth 1 ! -user root ! -user syslog -type f -regextype posix-extended -name 'syslog' -exec chown syslog {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_syslog/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_syslog/bash/shared.sh
@@ -1,0 +1,6 @@
+# platform = Ubuntu 24.04
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+find -L /var/log/ -maxdepth 1 ! -owner root ! -owner syslog -type f -regextype posix-extended -name 'syslog' -exec chown syslog {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_syslog/oval/ubuntu.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_syslog/oval/ubuntu.xml
@@ -14,7 +14,7 @@
     <object_component item_field="user_id" object_ref="object_syslog_uid" />
   </local_variable>
 
-  <unix:file_test check="all" comment="/var/log/syslog owner is root|syslog"
+  <unix:file_test check_existence="any_exist" check="all" comment="/var/log/syslog owner is root|syslog"
       id="test_file_ownership_var_log_syslog" state_operator="OR" version="1">
     <unix:object object_ref="object_file_ownership_var_log_syslog" />
     <unix:state state_ref="state_file_ownership_syslog_var_log_syslog"/>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_syslog/oval/ubuntu.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_syslog/oval/ubuntu.xml
@@ -1,0 +1,33 @@
+{{% if 'ubuntu2404' in product %}}
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+      {{{ oval_metadata("Owner of /var/log/syslog should be root or syslog.") }}}
+    <criteria comment="Check file ownership of /var/log/syslog">
+     <criterion test_ref="test_file_ownership_var_log_syslog" />
+    </criteria>
+  </definition>
+
+  <unix:password_object id="object_syslog_uid" version="1">
+    <unix:username operation="pattern match">syslog</unix:username>
+  </unix:password_object>
+  <local_variable id="var_syslog_uid" comment="Retrieve the uid of syslog" datatype="int" version="1">
+    <object_component item_field="user_id" object_ref="object_syslog_uid" />
+  </local_variable>
+
+  <unix:file_test check="all" comment="/var/log/syslog owner is root|syslog"
+      id="test_file_ownership_var_log_syslog" state_operator="OR" version="1">
+    <unix:object object_ref="object_file_ownership_var_log_syslog" />
+    <unix:state state_ref="state_file_ownership_syslog_var_log_syslog"/>
+    <unix:state state_ref="state_file_ownership_root_var_log_syslog"/>
+  </unix:file_test>
+  <unix:file_object comment="/var/log/syslog" id="object_file_ownership_var_log_syslog" version="1">
+    <unix:filepath>/var/log/syslog</unix:filepath>
+  </unix:file_object>
+  <unix:file_state id="state_file_ownership_syslog_var_log_syslog" version="1">
+    <unix:user_id datatype="int" operation="equals" var_ref="var_syslog_uid"/>
+  </unix:file_state>
+  <unix:file_state id="state_file_ownership_root_var_log_syslog" version="1">
+    <unix:user_id datatype="int" operation="equals">0</unix:user_id>
+  </unix:file_state>
+ </def-group>
+{{%- endif %}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_syslog/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_syslog/rule.yml
@@ -2,7 +2,11 @@ documentation_complete: true
 
 title: 'Verify User Who Owns /var/log/syslog File'
 
-description: '{{{ describe_file_owner(file="/var/log/syslog", owner="syslog") }}}'
+{{%  if 'ubuntu2404' not in product %}}
+description: '{{{ describe_file_owner(file="/var/log/syslog", owner="root") }}}'
+{{%- else %}}        
+description: '{{{ describe_file_owner(file="/var/log/syslog", owner="root|syslog") }}}'
+{{%- endif %}}
 
 rationale: |-
     The <tt>/var/log/syslog</tt> file contains logs of error messages in
@@ -16,13 +20,26 @@ references:
     stigid@ubuntu2004: UBTU-20-010421
     stigid@ubuntu2204: UBTU-22-232130
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/var/log/syslog", owner="syslog") }}}'
+{{%  if 'ubuntu2404' not in product %}}
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/log/syslog", owner="root") }}}'
 
 ocil: |-
-    {{{ ocil_file_owner(file="/var/log/syslog", owner="syslog") }}}
+    {{{ ocil_file_owner(file="/var/log/syslog", owner="root") }}}
+
+fixtext: |-
+    {{{ describe_file_owner(file="/var/log/syslog", owner="root") }}}
+
+srg_requirement: '{{{ srg_requirement_file_owner("/var/log/syslog", owner="root") }}}'
 
 template:
     name: file_owner
     vars:
         filepath: /var/log/syslog
-        fileuid: '104'
+        fileuid: '0'
+{{%- else %}}        
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/log/syslog", owner="root|syslog") }}}'
+
+ocil: |-
+    {{{ ocil_file_owner(file="/var/log/syslog", owner="root|syslog") }}}
+{{%- endif %}}
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_syslog/tests/no_file.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_syslog/tests/no_file.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+rm -f /var/log/syslog
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_syslog/tests/owned_by_nobody.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_syslog/tests/owned_by_nobody.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/syslog
+chown nobody /var/log/syslog*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_syslog/tests/owned_by_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_syslog/tests/owned_by_root.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/syslog
+chown root /var/log/syslog*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_syslog/tests/owned_by_syslog.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_syslog/tests/owned_by_syslog.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/syslog
+chown syslog /var/log/syslog*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_waagent/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_waagent/bash/shared.sh
@@ -1,0 +1,6 @@
+# platform = Ubuntu 24.04
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+find -L /var/log/ -maxdepth 1 ! -owner root ! -owner syslog -type f -regextype posix-extended -regex '.*waagent.log(.*)' -exec chown syslog {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_waagent/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_waagent/bash/shared.sh
@@ -3,4 +3,4 @@
 # strategy = configure
 # complexity = low
 # disruption = low
-find -L /var/log/ -maxdepth 1 ! -owner root ! -owner syslog -type f -regextype posix-extended -regex '.*waagent.log(.*)' -exec chown syslog {} \;
+find -L /var/log/ -maxdepth 1 ! -user root ! -user syslog -type f -regextype posix-extended -regex '.*waagent.log(.*)' -exec chown syslog {} \;

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_waagent/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_waagent/oval/shared.xml
@@ -1,0 +1,31 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+      {{{ oval_metadata("Owner of /var/log/waagent.log should be root or syslog.") }}}
+    <criteria comment="Check file ownership of /var/log/waagent.log">
+     <criterion test_ref="test_file_ownership_var_log_waagent_log" />
+    </criteria>
+  </definition>
+
+  <unix:password_object id="object_syslog_uid" version="1">
+    <unix:username operation="pattern match">syslog</unix:username>
+  </unix:password_object>
+  <local_variable id="var_syslog_uid" comment="Retrieve the uid of syslog" datatype="int" version="1">
+    <object_component item_field="user_id" object_ref="object_syslog_uid" />
+  </local_variable>
+
+  <unix:file_test check="all" comment="/var/log/waagent.log owner is root|syslog"
+      id="test_file_ownership_var_log_waagent_log" state_operator="OR" version="1">
+    <unix:object object_ref="object_file_ownership_var_log_waagent_log" />
+    <unix:state state_ref="state_file_ownership_syslog_var_log_waagent_log"/>
+    <unix:state state_ref="state_file_ownership_root_var_log_waagent_log"/>
+  </unix:file_test>
+  <unix:file_object comment="/var/log/waagent.log" id="object_file_ownership_var_log_waagent_log" version="1">
+    <unix:filepath operation="pattern match">/var/log/waagent.log(.*)</unix:filepath>
+  </unix:file_object>
+  <unix:file_state id="state_file_ownership_syslog_var_log_waagent_log" version="1">
+    <unix:user_id datatype="int" operation="equals" var_ref="var_syslog_uid"/>
+  </unix:file_state>
+  <unix:file_state id="state_file_ownership_root_var_log_waagent_log" version="1">
+    <unix:user_id datatype="int" operation="equals">0</unix:user_id>
+  </unix:file_state>
+ </def-group>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_waagent/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_waagent/oval/shared.xml
@@ -13,7 +13,7 @@
     <object_component item_field="user_id" object_ref="object_syslog_uid" />
   </local_variable>
 
-  <unix:file_test check="all" comment="/var/log/waagent.log owner is root|syslog"
+  <unix:file_test check_existence="any_exist" check="all" comment="/var/log/waagent.log owner is root|syslog"
       id="test_file_ownership_var_log_waagent_log" state_operator="OR" version="1">
     <unix:object object_ref="object_file_ownership_var_log_waagent_log" />
     <unix:state state_ref="state_file_ownership_syslog_var_log_waagent_log"/>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_waagent/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_waagent/rule.yml
@@ -1,0 +1,16 @@
+documentation_complete: true
+
+title: 'Verify User Who Owns /var/log/waagent.log File'
+
+description: '{{{ describe_file_owner(file="/var/log/waagent.log", owner="root|syslog") }}}'
+
+rationale: |-
+    The <tt>/var/log/waagent.log</tt> file contains Azure Linux Guest Agent records
+    events that can be used for troubleshooting and should only be accessed by authorized personnel.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/log/waagent.log", owner="sroot|yslog") }}}'
+
+ocil: |-
+    {{{ ocil_file_owner(file="/var/log/waagent.log", owner="root|syslog") }}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_waagent/tests/no_file.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_waagent/tests/no_file.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+rm -f /var/log/waagent.log
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_waagent/tests/owned_by_nobody.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_waagent/tests/owned_by_nobody.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/waagent.log
+chown nobody /var/log/waagent.log*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_waagent/tests/owned_by_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_waagent/tests/owned_by_root.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/waagent.log
+chown root /var/log/waagent.log*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_waagent/tests/owned_by_syslog.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_waagent/tests/owned_by_syslog.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+# packages = rsyslog
+
+touch /var/log/waagent.log
+chown syslog /var/log/waagent.log*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_wbtmp/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_wbtmp/rule.yml
@@ -1,0 +1,28 @@
+documentation_complete: true
+
+title: 'Verify User Who Owns /var/log/(b|w)tmp(.*|-*) File'
+
+description: '{{{ describe_file_owner(file="/var/log/(b|w)tmp(.*|-*)", owner="root") }}}'
+
+rationale: |-
+    The <tt>/var/log/(b|w)tmp(.*|-*)</tt> file contains logs of reports the most recent login of all users
+    and should only be accessed by authorized personnel.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/log/(b|w)tmp(.*|-*)", owner="root") }}}'
+
+ocil: |-
+    {{{ ocil_file_owner(file="/var/log/(b|w)tmp(.*|-*)", owner="root") }}}
+
+fixtext: |-
+    {{{ describe_file_owner(file="/var/log/(b|w)tmp(.*|-*)", owner="root") }}}
+
+srg_requirement: '{{{ srg_requirement_file_owner("/var/log/(b|w)tmp(.*|-*)", owner="root") }}}'
+
+template:
+    name: file_owner
+    vars:
+        filepath: /var/log/
+        file_regex: .*(b|w)tmp((\.|-)[^\/]+)?$
+        fileuid: '0'

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_wbtmp/tests/incorrect_owner.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_wbtmp/tests/incorrect_owner.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+touch /var/log/wtmp
+chown syslog /var/log/wtmp
+
+touch /var/log/btmp
+chown syslog /var/log/btmp

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_wbtmp/tests/invalid_owner.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_wbtmp/tests/invalid_owner.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+touch /var/log/wtmp.1
+chown syslog /var/log/wtmp.1
+touch /var/log/btmp.1
+chown syslog /var/log/btmp.1
+touch /var/log/wtmp-1
+chown syslog /var/log/wtmp-1
+touch /var/log/btmp-1
+chown syslog /var/log/btmp-1

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_wbtmp/tests/valid_permissions.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_wbtmp/tests/valid_permissions.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+touch /var/log/wtmp.1
+chown root /var/log/wtmp.1
+touch /var/log/btmp.1
+chown root /var/log/btmp.1
+touch /var/log/wtmp-1
+chown root /var/log/wtmp-1
+touch /var/log/btmp-1
+chown root /var/log/btmp-1
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_apt/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_apt/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+title: 'Verify Permissions on files in the /var/log/apt/.* directory'
+
+description: |-
+    {{{ describe_file_permissions(file="/var/log/apt/.*", perms="0644") }}}
+
+rationale: |-
+    The <tt>/var/log/apt</tt> directory contains information about APT
+    and should only be accessed by authorized personnel.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/log/apt/.*", perms="-rw-r--r--") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/var/log/apt/.*", perms="-rw-r--r--") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /var/log/apt/
+        file_regex: ^.*$
+        filemode: '0644'

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_apt/tests/lenient_permissions.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_apt/tests/lenient_permissions.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+mkdir -p /var/log/apt
+touch /var/log/apt/history.log
+chmod 777 /var/log/apt/history.log

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_auth/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_auth/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+title: 'Verify Permissions on /var/log/auth.log File'
+
+description: |-
+    {{{ describe_file_permissions(file="/var/log/auth.log", perms="0640") }}}
+
+rationale: |-
+    The <tt>/var/log/auth.log</tt> file contains records information about user
+    login attempts and authentication processes and should only be accessed by
+    authorized personnel.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/log/auth.log", perms="-rw-r-----") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/var/log/auth.log", perms="-rw-r-----") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /var/log/auth.log
+        filemode: '0640'

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_cloud-init/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_cloud-init/rule.yml
@@ -1,0 +1,29 @@
+documentation_complete: true
+
+title: 'Verify Permissions on /var/log/cloud-init.log(.*) Files'
+
+description: |-
+    {{{ describe_file_permissions(file="/var/log/cloud-init.log", perms="0664") }}}
+
+rationale: |-
+    The <tt>/var/log/cloud-init.log</tt> file contains detailed debugging information that
+    helps users troubleshoot cloud-init and should only be accessed by authorized personnel.
+
+severity: medium
+
+
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/log/cloud-init.log", perms="-rw-r--r--") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/var/log/cloud-init.log", perms="-rw-r--r--") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /var/log/
+        file_regex: .*cloud-init.log([^\/]+)?$
+        filemode: '0644'
+
+fixtext: |-
+    {{{ fixtext_file_permissions("/var/log/cloud-init.log", "0664") | indent(4) }}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_cloud-init/tests/invalid_permissions.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_cloud-init/tests/invalid_permissions.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /var/log/cloud-init.log1
+chmod a+x /var/log/cloud-init.log1

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_cloud-init/tests/lenient_permissions.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_cloud-init/tests/lenient_permissions.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /var/log/cloud-init.log
+chmod 777 /var/log/cloud-init.log

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_cloud-init/tests/valid_permissions.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_cloud-init/tests/valid_permissions.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+touch /var/log/cloud-init.log1
+chmod u+rw-x,g+r-wx,o+r-wx /var/log/cloud-init.log1
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_gdm/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_gdm/rule.yml
@@ -1,0 +1,23 @@
+documentation_complete: true
+
+title: 'Verify Permissions on /var/log/gdm directory'
+
+description: |-
+    {{{ describe_file_permissions(file="/var/log/gdm", perms="0770") }}}
+
+rationale: |-
+    The <tt>/var/log/gdm</tt> directory contains information about the GDM daemon
+    and should only be accessed by authorized personnel.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/log/gdm", perms="-rwxrwx---") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/var/log/gdm", perms="-rwxrwx---") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /var/log/gdm/
+        filemode: '0770'

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_gdm/tests/lenient_permissions.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_gdm/tests/lenient_permissions.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mkdir -p /var/log/gdm
+chmod 777 /var/log/gdm

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_gdm3/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_gdm3/rule.yml
@@ -1,0 +1,23 @@
+documentation_complete: true
+
+title: 'Verify Permissions on /var/log/gdm File'
+
+description: |-
+    {{{ describe_file_permissions(file="/var/log/gdm3", perms="0770") }}}
+
+rationale: |-
+    The <tt>/var/log/gdm3</tt> directory stores information about the GNOME Display Manager (GDM)
+    and should only be accessed by authorized personnel.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/log/gdm3", perms="-rwxrwx---") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/var/log/gdm3", perms="-rwxrwx---") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /var/log/gdm3/
+        filemode: '0770'

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_gdm3/tests/lenient_permissions.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_gdm3/tests/lenient_permissions.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mkdir -p /var/log/gdm3
+chmod 777 /var/log/gdm3

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_lastlog/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_lastlog/rule.yml
@@ -1,0 +1,29 @@
+documentation_complete: true
+
+title: 'Verify Permissions on /var/log/lastlog(.*) Files'
+
+description: |-
+    {{{ describe_file_permissions(file="/var/log/lastlog", perms="0664") }}}
+
+rationale: |-
+    The <tt>/var/log/lastlog</tt> file contains logs of reports the most recent login of all users
+    and should only be accessed by authorized personnel.
+
+severity: medium
+
+
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/log/lastlog", perms="-rw-rw-r--") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/var/log/lastlog", perms="-rw-rw-r--") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /var/log/
+        file_regex: .*lastlog(\.[^\/]+)?$
+        filemode: '0664'
+
+fixtext: |-
+    {{{ fixtext_file_permissions("/var/log/lastlog", "0664") | indent(4) }}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_lastlog/tests/invalid_permissions.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_lastlog/tests/invalid_permissions.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /var/log/lastlog.1
+chmod a+x /var/log/lastlog.1

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_lastlog/tests/lenient_permissions.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_lastlog/tests/lenient_permissions.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /var/log/lastlog
+chmod 777 /var/log/lastlog

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_lastlog/tests/valid_permissions.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_lastlog/tests/valid_permissions.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+touch /var/log/lastlog.1
+chmod u+rw-x,g+rw-x,o+r-wx /var/log/lastlog.1
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_localmessages/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_localmessages/rule.yml
@@ -1,0 +1,29 @@
+documentation_complete: true
+
+title: 'Verify Permissions on /var/log/localmessages(.*) Files'
+
+description: |-
+    {{{ describe_file_permissions(file="/var/log/localmessages", perms="0664") }}}
+
+rationale: |-
+    The <tt>/var/log/localmessages</tt> file contains log messages from certain boot scripts,
+    including the DHCP client, and should only be accessed by authorized personnel.
+
+severity: medium
+
+
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/log/localmessages", perms="-rw-r--r--") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/var/log/localmessages", perms="-rw-r--r--") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /var/log/
+        file_regex: .*localmessages([^\/]+)?$
+        filemode: '0644'
+
+fixtext: |-
+    {{{ fixtext_file_permissions("/var/log/localmessages", "0664") | indent(4) }}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_localmessages/tests/invalid_permissions.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_localmessages/tests/invalid_permissions.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /var/log/localmessages1
+chmod a+x /var/log/localmessages1

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_localmessages/tests/lenient_permissions.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_localmessages/tests/lenient_permissions.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /var/log/localmessages
+chmod 777 /var/log/localmessages

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_localmessages/tests/valid_permissions.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_localmessages/tests/valid_permissions.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+touch /var/log/localmessages1
+chmod u+rw-x,g+r-wx,o+r-wx /var/log/localmessages1
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_messages/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_messages/rule.yml
@@ -2,8 +2,16 @@ documentation_complete: true
 
 title: 'Verify Permissions on /var/log/messages File'
 
+{{%  if 'ubuntu2404' not in product %}}
+    {{% set target_perms_octal="0600" %}}
+    {{% set target_perms="-rw-------" %}}
+{{% else %}}
+    {{% set target_perms_octal="0640" %}}
+    {{% set target_perms="-rw-r-----" %}}
+{{% endif %}}
+
 description: |-
-    {{{ describe_file_permissions(file="/var/log/messages", perms="0600") }}}
+    {{{ describe_file_permissions(file="/var/log/messages", perms=target_perms_octal) }}}
 
 rationale: |-
     The <tt>/var/log/messages</tt> file contains logs of error messages in
@@ -22,18 +30,18 @@ references:
     stigid@ol8: OL08-00-010210
     stigid@rhel8: RHEL-08-010210
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/log/messages", perms="-rw-------") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/log/messages", perms=target_perms) }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/var/log/messages", perms="-rw-------") }}}
+    {{{ ocil_file_permissions(file="/var/log/messages", perms=target_perms) }}}
 
 template:
     name: file_permissions
     vars:
         filepath: /var/log/messages
-        filemode: '0600'
+        filemode: '{{{ target_perms_octal }}}'
 
 fixtext: |-
-    {{{ fixtext_file_permissions("/var/log/messages", "0640") | indent(4) }}}
+    {{{ fixtext_file_permissions("/var/log/messages", target_perms_octal) | indent(4) }}}
 
-srg_requirement: '{{{ srg_requirement_file_permission("/var/log/messages", "0600") }}}'
+srg_requirement: '{{{ srg_requirement_file_permission("/var/log/messages", target_perms_octal) }}}'

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_secure/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_secure/rule.yml
@@ -1,0 +1,23 @@
+documentation_complete: true
+
+title: 'Verify Permissions on /var/log/secure File'
+
+description: |-
+    {{{ describe_file_permissions(file="/var/log/secure", perms="0640") }}}
+
+rationale: |-
+    The <tt>/var/log/secure</tt> file contains information related to authentication
+    and authorization privileges and should only be accessed by authorized personnel.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/log/secure", perms="-rw-r-----") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/var/log/secure", perms="-rw-r-----") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /var/log/secure
+        filemode: '0640'

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_sssd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_sssd/rule.yml
@@ -1,0 +1,23 @@
+documentation_complete: true
+
+title: 'Verify Permissions on /var/log/sssd File'
+
+description: |-
+    {{{ describe_file_permissions(file="/var/log/sssd", perms="0770") }}}
+
+rationale: |-
+    The <tt>/var/log/sssd</tt> directory contains debug logs for the System
+    Security Services Daemon (SSSD) and should only be accessed by authorized personnel.
+
+severity: medium
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/log/sssd", perms="-rwxrwx---") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/var/log/sssd", perms="-rwxrwx---") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /var/log/sssd/
+        filemode: '0770'

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_sssd/tests/lenient_permissions.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_sssd/tests/lenient_permissions.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mkdir -p /var/log/sssd
+chmod 777 /var/log/sssd

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_waagent/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_waagent/rule.yml
@@ -1,0 +1,29 @@
+documentation_complete: true
+
+title: 'Verify Permissions on /var/log/waagent.log(.*) Files'
+
+description: |-
+    {{{ describe_file_permissions(file="/var/log/waagent.log", perms="0664") }}}
+
+rationale: |-
+    The <tt>/var/log/waagent.log</tt> file contains Azure Linux Guest Agent records
+    events that can be used for troubleshooting and should only be accessed by authorized personnel.
+
+severity: medium
+
+
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/log/waagent.log", perms="-rw-r--r--") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/var/log/waagent.log", perms="-rw-r--r--") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /var/log/
+        file_regex: .*waagent.log([^\/]+)?$
+        filemode: '0644'
+
+fixtext: |-
+    {{{ fixtext_file_permissions("/var/log/waagent.log", "0664") | indent(4) }}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_waagent/tests/invalid_permissions.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_waagent/tests/invalid_permissions.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /var/log/waagent.log1
+chmod a+x /var/log/waagent.log1

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_waagent/tests/lenient_permissions.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_waagent/tests/lenient_permissions.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+touch /var/log/waagent.log
+chmod 777 /var/log/waagent.log

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_waagent/tests/valid_permissions.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_waagent/tests/valid_permissions.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+touch /var/log/waagent.log1
+chmod u+rw-x,g+r-wx,o+r-wx /var/log/waagent.log1
+

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_wbtmp/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_wbtmp/rule.yml
@@ -1,0 +1,29 @@
+documentation_complete: true
+
+title: 'Verify Permissions on /var/log/wtmp(.*) Files'
+
+description: |-
+    {{{ describe_file_permissions(file="/var/log/(b|w)tmp(.*|-*)", perms="0664") }}}
+
+rationale: |-
+    The <tt>/var/log/(b|w)tmp(.*|-*)</tt> files contains logs of reports the most recent login of all users
+    and should only be accessed by authorized personnel.
+
+severity: medium
+
+
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/log/(b|w)tmp(.*|-*)", perms="-rw-rw-r--") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/var/log/(b|w)tmp(.*|-*)", perms="-rw-rw-r--") }}}
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /var/log/
+        file_regex: .*(b|w)tmp((\.|-)[^\/]+)?$
+        filemode: '0664'
+
+fixtext: |-
+    {{{ fixtext_file_permissions("/var/log/(b|w)tmp(.*|-*)", "0664") | indent(4) }}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_wbtmp/tests/invalid_permissions.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_wbtmp/tests/invalid_permissions.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+touch /var/log/wtmp.1
+touch /var/log/wtmp-1
+touch /var/log/btmp.1
+touch /var/log/btmp-1
+chmod a+x /var/log/wtmp.1
+chmod a+x /var/log/wtmp-1
+chmod a+x /var/log/btmp.1
+chmod a+x /var/log/btmp-1

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_wbtmp/tests/lenient_permissions.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_wbtmp/tests/lenient_permissions.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+touch /var/log/wtmp
+touch /var/log/btmp
+chmod 777 /var/log/wtmp
+chmod 777 /var/log/btmp

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_wbtmp/tests/valid_permissions.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log_wbtmp/tests/valid_permissions.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+touch /var/log/wtmp.s
+chmod u+rw-x,g+rw-x,o+r-wx /var/log/wtmp.1
+touch /var/log/wtmp-1
+chmod u+rw-x,g+rw-x,o+r-wx /var/log/wtmp-1
+touch /var/log/btmp.1
+chmod u+rw-x,g+rw-x,o+r-wx /var/log/btmp.1
+touch /var/log/btmp-1
+chmod u+rw-x,g+rw-x,o+r-wx /var/log/btmp-1
+


### PR DESCRIPTION
#### Description:

- Ubuntu 24.04 6.1.4.1 Ensure access to all logfiles has been configured

#### Rationale:

- Configure file permissions, owner, and group owner of all log files in the /var/log directory.
