### PR TITLE
Add missing newline at end of chrony.conf

### DIFF
--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -731,6 +731,7 @@ if ! grep -q '#[[:space:]]*server' "{{{ config_file }}}" ; then
 else
   sed -i 's/#[ \t]*server/server/g' "{{{ config_file }}}"
 fi
+{{{ bash_ensure_nl_at_eof(config_file) }}}
 {{%- endmacro -%}}
 
 


### PR DESCRIPTION
#### Description:

- Fix macro `bash_ensure_there_are_servers_in_ntp_compatible_config_file` to ensure that chrony.conf ends with a newline

#### Rationale:

- Rule `chronyd_specify_remote_server` in Ubuntu 20.04 CIS writes to chrony.conf without adding a newline to the end which can cause issues with other rules or tooling that expect lines to end with a new line:
```
# cat /etc/chrony/chrony.conf | tail -3
server 0.ubuntu.pool.ntp.org
server 1.ubuntu.pool.ntp.org
server 2.ubuntu.pool.ntp.org# 
```
- Fixes https://bugs.launchpad.net/usg/+bug/2098303