### PR TITLE
Remove newlines from dpkg-query showformat

### DIFF
--- a/shared/applicability/system_with_kernel.yml
+++ b/shared/applicability/system_with_kernel.yml
@@ -25,9 +25,9 @@ bash_conditional: "rpm --quiet -q kernel"
 {{% endif %}}
 {{% else %}}
 {{% if "debian" in product or "ubuntu" in product %}}
-bash_conditional: "dpkg-query --show --showformat='${db:Status-Status}\n' 'linux-base' 2>/dev/null | grep -q ^installed"
+bash_conditional: "dpkg-query --show --showformat='${db:Status-Status}' 'linux-base' 2>/dev/null | grep -q '^installed$'"
 {{% else %}}
-bash_conditional: "dpkg-query --show --showformat='${db:Status-Status}\n' 'kernel' 2>/dev/null | grep -q ^installed"
+bash_conditional: "dpkg-query --show --showformat='${db:Status-Status}' 'kernel' 2>/dev/null | grep -q '^installed$'"
 {{% endif %}}
 {{% endif %}}
 {{% if "debian" in product or "ubuntu" in product %}}

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1456,7 +1456,7 @@ done
 #}}
 {{%- macro bash_package_installed(pkgname) -%}}
 {{%- if pkg_manager == "apt_get" -%}}
-dpkg-query --show --showformat='${db:Status-Status}\n' "{{{ pkgname }}}" 2>/dev/null | grep -q ^installed
+dpkg-query --show --showformat='${db:Status-Status}' "{{{ pkgname }}}" 2>/dev/null | grep -q '^installed$'
 {{%- else -%}}
 rpm --quiet -q "{{{ pkgname }}}"
 {{%- endif -%}}
@@ -2147,9 +2147,9 @@ This macro creates a Bash conditional which uses dpkg to check if a package pass
 #}}
 {{%- macro bash_pkg_conditional_dpkg(package, op=None, ver=None) -%}}
 {{%- if ver -%}}
-dpkg-query --show --showformat='${db:Status-Status}\n' '{{{ package }}}' 2>/dev/null | grep -q '^installed' && {{{ bash_compare_version_dpkg(package, op, ver) }}}
+dpkg-query --show --showformat='${db:Status-Status}' '{{{ package }}}' 2>/dev/null | grep -q '^installed$' && {{{ bash_compare_version_dpkg(package, op, ver) }}}
 {{%- else -%}}
-dpkg-query --show --showformat='${db:Status-Status}\n' '{{{ package }}}' 2>/dev/null | grep -q '^installed'
+dpkg-query --show --showformat='${db:Status-Status}' '{{{ package }}}' 2>/dev/null | grep -q '^installed$'
 {{%- endif -%}}
 {{%- endmacro -%}}
 


### PR DESCRIPTION
#### Description:

- Remove newline characters from command `dpkg-query --show --showformat='${db:Status-Status}\n'`

#### Rationale:

- The newline character is not necessary and introduces broken lines in remediation scripts https://github.com/ComplianceAsCode/content/pull/13052#discussion_r1957814160