### PR TITLE
Correct the CIS reference for rule ocp4-api-server-api-priority-flowschema-catch-all

### DIFF
--- a/applications/openshift/api-server/api_server_api_priority_flowschema_catch_all/rule.yml
+++ b/applications/openshift/api-server/api_server_api_priority_flowschema_catch_all/rule.yml
@@ -28,7 +28,7 @@ identifiers:
 severity: medium
 
 references:
-  cis@ocp4: 1.2.10
+  cis@ocp4: 1.2.9
   nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
   nist: CM-6,CM-6(1)
   pcidss: Req-2.2


### PR DESCRIPTION
#### Description:
This PR fixes the CIS reference for rule ocp4-api-server-api-priority-flowschema-catch-all to 1.2.9
Jira: https://issues.redhat.com/browse/OCPBUGS-49951