### PR TITLE
Fix Kubernetes Test Content Parsing Workflow

### DIFF
--- a/.github/workflows/k8s-content-pr-test.yaml
+++ b/.github/workflows/k8s-content-pr-test.yaml
@@ -7,6 +7,11 @@ on:
     - opened
     - reopened
     - synchronize
+  workflow_run:
+    workflows: ['Kubernetes content image for PR']
+    branches: ['master']
+    types:
+      - completed
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.run_id }}


### PR DESCRIPTION
This workflow parses the content built in a PR in the same way the
Compliance Operator parses the content. This is useful for making sure
we don't inadvertently breaking content parsing.

However, this workflow has a dependency on another workflow responsible
for building the image. Often times, the initial run of the workflow
will fail because the content hasn't been built, yet:

  Warning: Attempt 2 failed. Reason: Child_process exited with error code 125
  Error response from daemon: manifest unknown
  Unable to find image 'ghcr.io/complianceascode/k8scontent:13083' locally
  docker: Error response from daemon: manifest unknown.
  See 'docker run --help'.
  Error: Final attempt failed. Child_process exited with error code 125

This commit adds a dependency relationship between the content parsing
workflow and the content building workflow so that parsing won't start
until the content is built.
