### PR TITLE
SLE Add dependency to crypto-policies-scripts package

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/ansible/shared.yml
@@ -5,6 +5,14 @@
 # disruption = low
 {{{ ansible_instantiate_variables("var_system_crypto_policy") }}}
 
+{{% if product == "sle15" %}}
+- name: "{{{ rule_title }}} - Ensure crypto-policies-scripts package installed"
+  become: yes
+  package:
+    name: crypto-policies-scripts
+    state: present
+{{% endif %}}
+
 - name: "{{{ rule_title }}}"
   lineinfile:
     path: /etc/crypto-policies/config

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/bash/shared.sh
@@ -1,6 +1,14 @@
 # platform = multi_platform_all
+# reboot = false
+# strategy = enable
+# complexity = low
+# disruption = low
 
 {{{ bash_instantiate_variables("var_system_crypto_policy") }}}
+
+{{% if product == "sle15" %}}
+{{{ bash_package_install("crypto-policies-scripts") }}}
+{{% endif %}}
 
 stderr_of_call=$(update-crypto-policies --set ${var_system_crypto_policy} 2>&1 > /dev/null)
 rc=$?

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/oval/shared.xml
@@ -2,6 +2,10 @@
   <definition class="compliance" id="configure_crypto_policy" version="1">
     {{{ oval_metadata("Ensure crypto policy is correctly configured in /etc/crypto-policies/config, and the policy is current.") }}}
     <criteria operator="AND">
+{{% if product == "sle15" %}}
+      <criterion comment="package crypto-policies-scripts is installed"
+      test_ref="test_package_crypto-policies-scripts_installed" />
+{{% endif %}}
       <criterion comment="check for crypto policy correctly configured in /etc/crypto-policy/config"
       test_ref="test_configure_crypto_policy" />
       <criterion comment="check for crypto policy correctly configured in /etc/crypto-policy/state/current"
@@ -10,6 +14,10 @@
       <criterion comment="Check if /etc/crypto-policies/back-ends/nss.config exists" test_ref="test_crypto_policy_nss_config" />
     </criteria>
   </definition>
+
+{{% if product == "sle15" %}}
+  {{{ oval_test_package_installed(package="crypto-policies-scripts", test_id="test_package_crypto-policies-scripts_installed") }}}
+{{% endif %}}
 
   <unix:file_object id="crypto_policies_current_file" comment="crypto-policies current state" version="1">
     <unix:filepath>/etc/crypto-policies/state/current</unix:filepath>
@@ -85,7 +93,6 @@ id="object_crypto_policies_config_file_modified_time" version="1">
     <unix:filepath>/etc/crypto-policies/back-ends/nss.config</unix:filepath>
   </unix:file_object>
 
-  <external_variable comment="defined crypto policy" datatype="string"
-  id="var_system_crypto_policy" version="1" />
+  <external_variable comment="defined crypto policy" datatype="string" id="var_system_crypto_policy" version="1" />
 
 </def-group>


### PR DESCRIPTION

#### Description:

- Add dependency in configure_crypto_policy rule to crypto-policies-scripts package for SLE platform

#### Rationale:

- The remediation scripts depend on the utility from crypto-policies-scripts package

