### PR TITLE
[Ubuntu2404]: Fix rule set_nftables_loopback_traffic

### DIFF
--- a/linux_os/guide/system/network/network-nftables/set_nftables_loopback_traffic/bash/shared.sh
+++ b/linux_os/guide/system/network/network-nftables/set_nftables_loopback_traffic/bash/shared.sh
@@ -28,5 +28,5 @@ if [ "$disabled" = false ] ; then
 fi
 
 {{% if "ubuntu" in product %}}
-nft list ruleset > "/etc/${var_nftables_family}-filter.rules"
+nft list ruleset > /etc/nftables.conf
 {{% endif %}}

--- a/linux_os/guide/system/network/network-nftables/set_nftables_loopback_traffic/bash/shared.sh
+++ b/linux_os/guide/system/network/network-nftables/set_nftables_loopback_traffic/bash/shared.sh
@@ -1,9 +1,5 @@
 # platform = multi_platform_all
 
-{{% if "ubuntu" in product %}}
-{{{ bash_instantiate_variables("var_nftables_family") }}}
-{{% endif %}}
-
 grubfile="{{{ grub2_boot_path }}}/grub.cfg"
 
 # Implement the loopback rules:


### PR DESCRIPTION
#### Description:

- Write to the correct configuration file

#### Rationale:

- The original path is wrong which cause the ntf reset the ruleset after each reboot
