### PR TITLE
[ubuntu2404] New rule: remove pkg inetutils-telnet

### DIFF
--- a/components/inetutils-telnet.yml
+++ b/components/inetutils-telnet.yml
@@ -1,0 +1,5 @@
+name: inetutils-telnet
+packages:
+- inetutils-telnet
+rules:
+- package_inetutils-telnet_removed

--- a/components/inetutils-telnetd.yml
+++ b/components/inetutils-telnetd.yml
@@ -2,5 +2,4 @@ name: inetutils-telnetd
 packages:
 - inetutils-telnetd
 rules:
-- package_inetutils-telnet_removed
 - package_inetutils-telnetd_removed

--- a/components/inetutils-telnetd.yml
+++ b/components/inetutils-telnetd.yml
@@ -2,4 +2,5 @@ name: inetutils-telnetd
 packages:
 - inetutils-telnetd
 rules:
+- package_inetutils-telnet_removed
 - package_inetutils-telnetd_removed

--- a/components/telnet.yml
+++ b/components/telnet.yml
@@ -7,6 +7,7 @@ packages:
 - telnetd
 - telnetd-ssl
 rules:
+- package_inetutils-telnet_removed
 - package_telnet-server_removed
 - package_telnet_removed
 - package_telnetd-ssl_removed

--- a/components/telnet.yml
+++ b/components/telnet.yml
@@ -7,7 +7,6 @@ packages:
 - telnetd
 - telnetd-ssl
 rules:
-- package_inetutils-telnet_removed
 - package_telnet-server_removed
 - package_telnet_removed
 - package_telnetd-ssl_removed

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -912,6 +912,7 @@ controls:
       - l1_server
       - l1_workstation
     rules:
+      - package_inetutils-telnet_removed
       - package_telnet_removed
     status: automated
 

--- a/linux_os/guide/services/obsolete/telnet/package_inetutils-telnet_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/telnet/package_inetutils-telnet_removed/rule.yml
@@ -1,0 +1,21 @@
+documentation_complete: true
+
+
+title: 'Remove telnet Clients'
+
+description: |-
+    The telnet client allows users to start connections to other systems via
+    the telnet protocol.
+
+rationale: |-
+    The <tt>telnet</tt> protocol is insecure and unencrypted. The use
+    of an unencrypted transmission medium could allow an unauthorized user
+    to steal credentials. The <tt>ssh</tt> package provides an
+    encrypted session and stronger security and is included in {{{ full_name }}}.
+
+severity: low
+
+template:
+    name: package_removed
+    vars:
+        pkgname: inetutils-telnet


### PR DESCRIPTION
#### Description:

- Implement a new rule to remove pkg inetutils-telnet

#### Rationale:

-  telnet is a transitional dummy package for inetutils-telnet default switch
- Satisfy rule 2.2.4 Ensure telnet client is not installed which requires inetutils-telnet & telnet are not installed
