### PR TITLE
[ubuntu2404] Add ubuntu specific configuration path

### DIFF
--- a/linux_os/guide/services/ntp/service_timesyncd_configured/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/service_timesyncd_configured/ansible/shared.yml
@@ -17,7 +17,11 @@
 
 - name: {{{ rule_title }}} - Add missing / update wrong records for NTP servers
   ansible.builtin.lineinfile:
+    {{% if "ubuntu" in product %}}
+    path: /etc/systemd/timesyncd.conf.d/oscap-remedy.conf
+    {{% else %}}
     path: /etc/systemd/timesyncd.d/oscap-remedy.conf
+    {{% endif %}}
     regexp: '^\s*NTP\s*='
     state: present
     line: 'NTP={{ preferred_ntp_servers }}'
@@ -25,7 +29,11 @@
 
 - name: {{{ rule_title }}} - Add missing / update wrong records for fallback servers
   ansible.builtin.lineinfile:
+    {{% if "ubuntu" in product %}}
+    path: /etc/systemd/timesyncd.conf.d/oscap-remedy.conf
+    {{% else %}}
     path: /etc/systemd/timesyncd.d/oscap-remedy.conf
+    {{% endif %}}
     regexp: '^\s*FallbackNTP\s*='
     state: present
     line: 'FallbackNTP={{ fallback_ntp_servers }}'

--- a/linux_os/guide/services/ntp/service_timesyncd_configured/bash/shared.sh
+++ b/linux_os/guide/services/ntp/service_timesyncd_configured/bash/shared.sh
@@ -11,8 +11,12 @@ preferred_ntp_servers=$( echo "${preferred_ntp_servers_array[@]}"|sed -e 's/\s\+
 fallback_ntp_servers_array=("${time_servers_array[@]:2}")
 fallback_ntp_servers=$( echo "${fallback_ntp_servers_array[@]}"|sed -e 's/\s\+/,/g' )
 
-IFS=" " mapfile -t current_cfg_arr < <(ls -1 /etc/systemd/timesyncd.d/* 2>/dev/null)
+IFS=" " mapfile -t current_cfg_arr < <(ls -1 /etc/systemd/timesyncd.d/* /etc/systemd/timesyncd.conf.d/* 2>/dev/null)
+{{% if "ubuntu" in product %}}
+config_file="/etc/systemd/timesyncd.conf.d/oscap-remedy.conf"
+{{% else %}}
 config_file="/etc/systemd/timesyncd.d/oscap-remedy.conf"
+{{% endif %}}
 current_cfg_arr+=( "/etc/systemd/timesyncd.conf" )
 # Comment existing NTP FallbackNTP settings
 for current_cfg in "${current_cfg_arr[@]}"
@@ -20,11 +24,19 @@ do
     sed -i 's/^NTP/#&/g' "$current_cfg"
     sed -i 's/^FallbackNTP/#&/g' "$current_cfg"
 done
+{{% if "ubuntu" in product %}}
+if [ ! -d "/etc/systemd/timesyncd.conf.d" ]
+then 
+    mkdir /etc/systemd/timesyncd.conf.d
+fi
+{{% else %}}
 # Create /etc/systemd/timesyncd.d if it doesn't exist
 if [ ! -d "/etc/systemd/timesyncd.d" ]
 then 
     mkdir /etc/systemd/timesyncd.d
 fi
+{{% endif %}}
+
 # Set primary fallback NTP servers in drop-in configuration
 echo "NTP=$preferred_ntp_servers" >> "$config_file"
 echo "FallbackNTP=$fallback_ntp_servers" >> "$config_file"

--- a/linux_os/guide/services/ntp/service_timesyncd_configured/oval/shared.xml
+++ b/linux_os/guide/services/ntp/service_timesyncd_configured/oval/shared.xml
@@ -30,7 +30,11 @@
 
   <ind:textfilecontent54_object comment="Ensure at least one NTP server is set"
     id="{{{ rule_id }}}_object_systemd_timesyncd_dropin_configuration" version="1">
+{{% if "ubuntu" in product %}}
+    <ind:path>/etc/systemd/timesyncd.conf.d</ind:path>
+{{% else %}}
     <ind:path>/etc/systemd/timesyncd.d</ind:path>
+{{% endif %}}
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
     <ind:pattern operation="pattern match" var_ref="{{{ rule_id }}}_variable_test_servers"/>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>

--- a/linux_os/guide/services/ntp/service_timesyncd_configured/tests/common.sh
+++ b/linux_os/guide/services/ntp/service_timesyncd_configured/tests/common.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+{{% if "ubuntu" in product %}}
+mkdir -p /etc/systemd/timesyncd.conf.d/
+echo "" > /etc/systemd/timesyncd.conf.d/oscap-remedy.conf
+{{% else %}}
 mkdir -p /etc/systemd/timesyncd.d/
-echo "" > /etc/systemd/timesyncd.conf
 echo "" > /etc/systemd/timesyncd.d/oscap-remedy.conf
+{{% endif %}}
+echo "" > /etc/systemd/timesyncd.conf

--- a/linux_os/guide/services/ntp/service_timesyncd_configured/tests/dropin_config.pass.sh
+++ b/linux_os/guide/services/ntp/service_timesyncd_configured/tests/dropin_config.pass.sh
@@ -3,8 +3,14 @@
 # variables = var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
 
 source common.sh
-
+{{% if "ubuntu" in product %}}
+cat <<EOF >/etc/systemd/timesyncd.conf.d/oscap-remedy.conf
+NTP=0.suse.pool.ntp.org,1.suse.pool.ntp.org
+FallbackNTP=2.suse.pool.ntp.org,3.suse.pool.ntp.org
+EOF
+{{% else %}}
 cat <<EOF >/etc/systemd/timesyncd.d/oscap-remedy.conf
 NTP=0.suse.pool.ntp.org,1.suse.pool.ntp.org
 FallbackNTP=2.suse.pool.ntp.org,3.suse.pool.ntp.org
 EOF
+{{% endif %}}


### PR DESCRIPTION
#### Description:

- correct the configuration path on ubuntu

#### Rationale:

- Satisfy the rule 2.3.2.1 Ensure systemd-timesyncd configured with authorized timeserver