### PR TITLE
[ubuntu2404] Fix rule 6.2.3.19 Ensure kernel module loading unloading and modification is collected

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2780,9 +2780,10 @@ controls:
     rules:
       - audit_rules_kernel_module_loading_delete
       - audit_rules_kernel_module_loading_init
-      - audit_rules_privileged_commands_insmod
-      - audit_rules_privileged_commands_modprobe
-      - audit_rules_privileged_commands_rmmod
+      - audit_rules_kernel_module_loading_finit
+      - audit_rules_kernel_module_loading_create
+      - audit_rules_kernel_module_loading_query
+      - audit_rules_privileged_commands_kmod
     status: automated
 
   - id: 6.2.3.20


### PR DESCRIPTION
#### Description:

- Correct the filters for audit rule

#### Rationale:

- Satisfy rule 6.2.3.19 Ensure kernel module loading unloading and modification is collected
