### PR TITLE
Apply 1.1.1.8 to server_l1 to match the benchmark on RHEL 8

### DIFF
--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -106,7 +106,7 @@ controls:
   - id: 1.1.1.8
     title: Ensure usb-storage kernel module is not available (Automated)
     levels:
-      - l2_server
+      - l1_server
       - l2_workstation
     status: automated
     rules:

--- a/tests/data/profile_stability/rhel8/cis_server_l1.profile
+++ b/tests/data/profile_stability/rhel8/cis_server_l1.profile
@@ -178,6 +178,7 @@ selections:
 - journald_forward_to_syslog
 - journald_storage
 - kernel_module_cramfs_disabled
+- kernel_module_usb-storage_disabled
 - mount_option_dev_shm_nodev
 - mount_option_dev_shm_noexec
 - mount_option_dev_shm_nosuid


### PR DESCRIPTION
#### Description:

- Apply kernel_module_usb-storage_disabled to l1_server to match the benchmark

#### Rationale:

- The benchmark specifies that this applies to l1 server and l2 workstation. Match that here.

- Fixes #13102

#### Review Hints:


