### PR TITLE
Disable remediation for all_apparmor_profiles_in_enforce_complain_mode on Ubuntu

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -387,7 +387,7 @@ controls:
       - l1_server
       - l1_workstation
     rules:
-      - var_apparmor_mode=enforce
+      - var_apparmor_mode=keep_existing_mode
       - all_apparmor_profiles_in_enforce_complain_mode
     status: automated
     notes: |
@@ -395,7 +395,9 @@ controls:
       of various profiles, including disabled, force-complain,
       and unconfined. Currently, the control changes the default apparmor
       mode for all profiles in /etc/apparmor.d which can
-      break certain applications.
+      break certain applications. See https://workbench.cisecurity.org/benchmarks/18959/tickets/23987
+      The remediation for this rule is currently disabled via
+      var_apparmor_mode=keep_existing_mode
 
   - id: 1.3.1.4
     title: Ensure all AppArmor Profiles are enforcing (Automated)
@@ -403,7 +405,6 @@ controls:
       - l2_server
       - l2_workstation
     rules:
-      - var_apparmor_mode=enforce
       - all_apparmor_profiles_enforced
     status: automated
     notes: |
@@ -411,7 +412,7 @@ controls:
       of various profiles, including disabled, force-complain,
       and unconfined. Currently, the control changes the default apparmor
       mode for all profiles in /etc/apparmor.d which can
-      break certain applications.
+      break certain applications. See https://workbench.cisecurity.org/benchmarks/18959/tickets/23987
 
   - id: 1.4.1
     title: Ensure bootloader password is set (Automated)

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/bash/shared.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/bash/shared.sh
@@ -34,6 +34,11 @@ then
   {{% endif %}}
 fi
 
+if [ "$APPARMOR_MODE" = "keep_existing_mode" ]
+then
+  echo "***WARNING***: This remediation will not modify any existing AppArmor profiles."
+fi
+
 {{% if 'ubuntu' in product %}}
 UNCONFINED=$(aa-status | grep "processes are unconfined" | awk '{print $1;}')
 if [ $UNCONFINED -ne 0 ];

--- a/linux_os/guide/system/apparmor/var_apparmor_mode.var
+++ b/linux_os/guide/system/apparmor/var_apparmor_mode.var
@@ -4,7 +4,8 @@ title: 'AppArmor profiles mode'
 
 description: |-
     enforce - Set all AppArmor profiles to enforce mode<br />
-    complain - Set all AppArmor profiles to complain mode
+    complain - Set all AppArmor profiles to complain mode<br />
+    keep_existing_mode - Don't change existing modes of AppArmor profiles.
 
 type: string
 
@@ -16,3 +17,4 @@ options:
     default: enforce
     complain: complain
     enforce: enforce
+    keep_existing_mode: keep_existing_mode


### PR DESCRIPTION
#### Description:

- Introduce option `keep_existing_mode` for variable `var_apparmor_mode`:  the option does not change the mode of existing apparmor profiles 
- Disable remediation for `all_apparmor_profiles_in_enforce_complain_mode ` on Ubuntu 24.04 by setting the variable `var_apparmor_mode=keep_existing_mode`
- The audit is unaffected and will always fail unless the user manually removes or enforces all the unconfined profiles.
- This change affects only Level 1 profiles. Level 2 profiles are always set to enforce in rule `all_apparmor_profiles_enforced`

#### Rationale:

- CIS apparmor rules require that all profiles must be either in enforce or in complain mode, which breaks `unconfined` profiles on Ubuntu 24.04  https://workbench.cisecurity.org/benchmarks/18959/tickets/23987
