### PR TITLE
Fix typos and exclude symlinks in file_(group)ownerships_var_log rules

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupownerships_var_log/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupownerships_var_log/oval/shared.xml
@@ -26,6 +26,7 @@
     <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="all" />
     <unix:path>/var/log</unix:path>
     <unix:filename operation="pattern match">.*</unix:filename>
+    <filter action="exclude">{{{ rule_id }}}_exclude_symlinks</filter>
     <filter action="exclude">{{{ rule_id }}}_exclude_files_apt</filter>
     <filter action="exclude">{{{ rule_id }}}_exclude_files_auth_log</filter>
     <filter action="exclude">{{{ rule_id }}}_exclude_files_bwtmp</filter>
@@ -40,6 +41,9 @@
     <filter action="exclude">{{{ rule_id }}}_exclude_files_syslog</filter>
     <filter action="exclude">{{{ rule_id }}}_exclude_files_waagent</filter>
   </unix:file_object>
+  <unix:file_state id="{{{ rule_id }}}_exclude_symlinks" version="1">
+    <unix:type operation="equals">symbolic link</unix:type>
+  </unix:file_state>
   <unix:file_state id="state_group_ownership_adm_var_log_auth_log" version="1">
     <unix:group_id datatype="int" operation="equals" var_ref="var_adm_gid"/>
   </unix:file_state>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupownerships_var_log/tests/symlink.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupownerships_var_log/tests/symlink.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+
+chgrp root -R /var/log/*
+
+ln -s /etc/issue /var/log/test.log.symlink
+chgrp -h nogroup /var/log/test.log.symlink

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_ownerships_var_log/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_ownerships_var_log/oval/shared.xml
@@ -23,6 +23,7 @@
     <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="all" />
     <unix:path>/var/log</unix:path>
     <unix:filename operation="pattern match">.*</unix:filename>
+    <filter action="exclude">{{{ rule_id }}}_exclude_symlinks</filter>
     <filter action="exclude">{{{ rule_id }}}_exclude_files_apt</filter>
     <filter action="exclude">{{{ rule_id }}}_exclude_files_auth_log</filter>
     <filter action="exclude">{{{ rule_id }}}_exclude_files_bwtmp</filter>
@@ -37,6 +38,9 @@
     <filter action="exclude">{{{ rule_id }}}_exclude_files_syslog</filter>
     <filter action="exclude">{{{ rule_id }}}_exclude_files_waagent</filter>
   </unix:file_object>
+  <unix:file_state id="{{{ rule_id }}}_exclude_symlinks" version="1">
+    <unix:type operation="equals">symbolic link</unix:type>
+  </unix:file_state>
   <unix:file_state id="state_file_ownership_syslog_var_log_auth_log" version="1">
     <unix:user_id datatype="int" operation="equals" var_ref="var_syslog_uid"/>
   </unix:file_state>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_ownerships_var_log/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_ownerships_var_log/oval/shared.xml
@@ -40,8 +40,8 @@
   <unix:file_state id="state_file_ownership_syslog_var_log_auth_log" version="1">
     <unix:user_id datatype="int" operation="equals" var_ref="var_syslog_uid"/>
   </unix:file_state>
-  <unix:file_state id="state_group_ownership_root_var_log_auth_log" version="1">
-    <unix:group_id datatype="int" operation="equals">0</unix:group_id>
+  <unix:file_state id="state_file_ownership_root_var_log_auth_log" version="1">
+    <unix:user_id datatype="int" operation="equals">0</unix:user_id>
   </unix:file_state>
   <unix:file_state id="{{{ rule_id }}}_exclude_files_apt" version="1">
     <unix:filepath operation="pattern match">^/var/log/apt/.*</unix:filepath>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_ownerships_var_log/tests/symlink.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_ownerships_var_log/tests/symlink.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = Ubuntu 24.04
+
+chown root -R /var/log/*
+
+ln -s /etc/issue /var/log/test.log.symlink
+chown -h nobody /var/log/test.log.symlink


### PR DESCRIPTION
#### Description:

- Fix typos in file_ownerships_var_log
- Exclude symlinks in oval of file_(group)ownerships_var_log, analogous to file_owner/file_groupowner templates

