### PR TITLE
Fix dconf key for idle-delay lock on Ubuntu

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/bash/shared.sh
@@ -3,7 +3,7 @@
 {{% if 'ubuntu' in product %}}
 {{{ bash_enable_dconf_user_profile(profile="user", database="local") }}}
 {{{ bash_enable_dconf_user_profile(profile="gdm", database="gdm") }}}
-{{{ bash_dconf_lock("org/gnome/desktop/screensaver", "idle-delay", "local.d", "00-security-settings-lock") }}}
+{{{ bash_dconf_lock("org/gnome/desktop/session", "idle-delay", "local.d", "00-security-settings-lock") }}}
 {{% endif %}}
 
 {{{ bash_instantiate_variables("inactivity_timeout_value") }}}


### PR DESCRIPTION
#### Description:

- Fix dconf key for idle-delay lock on Ubuntu
