### PR TITLE
Update owner macros to allow | between owners

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_security_opasswd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_security_opasswd/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 title: 'Verify Group Who Owns /etc/security/opasswd File'
 
-description: '{{{ describe_file_group_owner(file="/etc/security/opasswd", group=root) }}}'
+description: '{{{ describe_file_group_owner(file="/etc/security/opasswd", group="root") }}}'
 
 rationale: |-
     The <tt>/etc/security/opasswd</tt> file stores old passwords to prevent
@@ -10,14 +10,14 @@ rationale: |-
 
 severity: medium
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/security/opasswd", group=root) }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/security/opasswd", group="root") }}}'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="/etc/security/opasswd", group=root) }}}
+    {{{ ocil_file_group_owner(file="/etc/security/opasswd", group="root") }}}
 
-fixtext: '{{{ fixtext_file_group_owner(file="/etc/security/opasswd", group=root) }}}'
+fixtext: '{{{ fixtext_file_group_owner(file="/etc/security/opasswd", group="root") }}}'
 
-srg_requirement: '{{{ srg_requirement_file_group_owner(file="/etc/security/opasswd", group=root) }}}'
+srg_requirement: '{{{ srg_requirement_file_group_owner(file="/etc/security/opasswd", group="root") }}}'
 
 template:
     name: file_groupowner

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_security_opasswd_old/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_security_opasswd_old/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 title: 'Verify Group Who Owns /etc/security/opasswd.old File'
 
-description: '{{{ describe_file_group_owner(file="/etc/security/opasswd.old", group=root) }}}'
+description: '{{{ describe_file_group_owner(file="/etc/security/opasswd.old", group="root") }}}'
 
 rationale: |-
     The <tt>/etc/security/opasswd.old</tt> file stores backups of old passwords to prevent
@@ -10,14 +10,14 @@ rationale: |-
 
 severity: medium
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/security/opasswd.old", group=root) }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/security/opasswd.old", group="root") }}}'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="/etc/security/opasswd.old", group=root) }}}
+    {{{ ocil_file_group_owner(file="/etc/security/opasswd.old", group="root") }}}
 
-fixtext: '{{{ fixtext_file_group_owner(file="/etc/security/opasswd.old", group=root) }}}'
+fixtext: '{{{ fixtext_file_group_owner(file="/etc/security/opasswd.old", group="root") }}}'
 
-srg_requirement: '{{{ srg_requirement_file_group_owner(file="/etc/security/opasswd.old", group=root) }}}'
+srg_requirement: '{{{ srg_requirement_file_group_owner(file="/etc/security/opasswd.old", group="root") }}}'
 
 template:
     name: file_groupowner

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log/tests/ubuntu_correct.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log/tests/ubuntu_correct.pass.sh
@@ -1,0 +1,10 @@
+# platform = multi_platform_ubuntu
+# packages = rsyslog
+
+# purpose of this scenario is to install the rsyslog package
+# and thus configure the syslog group. The group is required
+# for the Ubuntu check and remediations but is missing
+# in podman containers by default.
+
+chgrp syslog /var/log
+

--- a/shared/macros/01-general.jinja
+++ b/shared/macros/01-general.jinja
@@ -836,7 +836,10 @@ substituting the correct package management software.
 #}}
 {{%- macro describe_file_owner(file, owner) %}}
     To properly set the owner of <code>{{{ file }}}</code>, run the command:
-    <pre>$ sudo chown {{{ owner }}} {{{ file }}} </pre>
+    {{% for own in owner.split("|") %}}
+      <pre>$ sudo chown {{{ own }}} {{{ file }}} </pre>
+      {{% if not loop.last %}} or {{% endif %}}
+    {{% endfor %}}
 {{%- endmacro %}}
 
 {{#
@@ -850,7 +853,10 @@ substituting the correct package management software.
 #}}
 {{%- macro describe_directory_owner(directory, owner) %}}
     To properly set the owner of <code>{{{ directory }}}</code>, run the command:
-    <pre>$ sudo chown {{{ owner }}} {{{ directory }}}</pre>
+    {{% for own in owner.split("|") %}}
+      <pre>$ sudo chown {{{ own }}} {{{ directory }}} </pre>
+      {{% if not loop.last %}} or {{% endif %}}
+    {{% endfor %}}
 {{%- endmacro %}}
 
 {{#
@@ -879,7 +885,10 @@ substituting the correct package management software.
 #}}
 {{%- macro describe_file_group_owner(file, group) %}}
     To properly set the group owner of <code>{{{ file }}}</code>, run the command:
-    <pre>$ sudo chgrp {{{ group }}} {{{ file }}}</pre>
+    {{% for grp in group.split("|") %}}
+      <pre>$ sudo chgrp {{{ grp }}} {{{ file }}}</pre>
+      {{% if not loop.last %}} or {{% endif %}}
+    {{% endfor %}}
 {{%- endmacro %}}
 
 {{#
@@ -893,7 +902,10 @@ substituting the correct package management software.
 #}}
 {{%- macro describe_directory_group_owner(directory, group) %}}
     To properly set the group owner of <code>{{{ directory }}}</code>, run the command:
-    <pre>$ sudo chgrp {{{ group }}} {{{ directory }}}</pre>
+    {{% for grp in group.split("|") %}}
+      <pre>$ sudo chgrp {{{ grp }}} {{{ directory }}}</pre>
+      {{% if not loop.last %}} or {{% endif %}}
+    {{% endfor %}}
 {{%- endmacro %}}
 
 {{#

--- a/shared/macros/10-ocil.jinja
+++ b/shared/macros/10-ocil.jinja
@@ -1124,7 +1124,10 @@ JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
     run the command:
     <pre>$ ls -lL {{{ file }}}</pre>
     If properly configured, the output should indicate the following group-owner:
-    <code>{{{ group }}}</code>
+    {{% for grp in group.split("|") %}}
+      <code>{{{ grp }}}</code> 
+      {{% if not loop.last %}} or {{% endif %}}
+    {{% endfor %}}
 {{%- endmacro %}}
 
 {{#
@@ -1182,7 +1185,11 @@ JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
 
 #}}
 {{%- macro ocil_clause_file_group_owner(file, group) -%}}
-    {{{ file }}} does not have a group owner of {{{ group }}}
+    {{{ file }}} does not have a group owner of 
+    {{% for grp in group.split("|") %}}
+      {{{ grp }}} 
+      {{% if not loop.last %}} or {{% endif %}}
+    {{% endfor %}}
 {{%- endmacro %}}
 
 {{#


### PR DESCRIPTION
#### Description:

- Update describe_file_group_owner and describe_file_owner too allow multiple owners and properly show the chgrp or chown command with only one owner.

#### Rationale:

- Allow multiple owners and only shown one owner in the command
