### PR TITLE
Bug fix - version number changed from 1.5.0 to 1.7.0

### DIFF
--- a/products/ocp4/profiles/cis-node.profile
+++ b/products/ocp4/profiles/cis-node.profile
@@ -9,7 +9,7 @@ metadata:
         - rhmdnd
         - Vincent056
         - yuumasato
-    version: 1.5.0
+    version: 1.7.0
 
 description: |-
     This profile defines a baseline that aligns to the Center for Internet Security®


### PR DESCRIPTION
#### Description:

- Just a simple fix of a little typo in the profile version in metadata section

#### Rationale:

-  Section is describing section 1.7.0, instead of 1.5.0 originally menitoned

