### PR TITLE
Update bash_sudo_remove_config macro

### DIFF
--- a/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/tests/wrong_value_specific_commands.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/tests/wrong_value_specific_commands.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "%wheel        ALL=(ALL)       NOPASSWD:  /bin/systemctl, /bin/lsof, /bin/date" >> /etc/sudoers
+chmod 440 /etc/sudoers
+
+mkdir -p /etc/sudoers.d
+echo "%wheel        ALL=(ALL)       NOPASSWD:  /bin/systemctl, /bin/lsof, /bin/date" >> /etc/sudoers.d/sudoers
+chmod 440 /etc/sudoers.d/sudoers

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1409,7 +1409,7 @@ for f in /etc/sudoers /etc/sudoers.d/* ; do
   if ! test -z "$matching_list"; then
     while IFS= read -r entry; do
       # comment out "{{{ parameter }}}" matches to preserve user data
-      sed -i "s/^${entry}$/# &/g" $f
+      sed -i "s|^${entry}$|# &|g" $f
     done <<< "$matching_list"
 
     /usr/sbin/visudo -cf $f &> /dev/null || echo "Fail to validate $f with visudo"


### PR DESCRIPTION
#### Description:

Update bash_sudo_remove_config macro

Add new test for sudo_remove_nopasswd

#### Rationale:

This update modifies the command delimiter in bash_sudo_remove_config to handle cases where the user's commands in the file include the "/" character.