### PR TITLE
Add new rules for rootfiles package

### DIFF
--- a/components/rootfiles.yml
+++ b/components/rootfiles.yml
@@ -1,0 +1,5 @@
+name: rootfiles
+packages:
+- rootfiles
+rules:
+- rootfiles_root_bash_bash_profile

--- a/components/rootfiles.yml
+++ b/components/rootfiles.yml
@@ -3,3 +3,4 @@ packages:
 - rootfiles
 rules:
 - rootfiles_root_bash_bash_profile
+- rootfiles_root_bash_bashrc

--- a/components/rootfiles.yml
+++ b/components/rootfiles.yml
@@ -4,3 +4,4 @@ packages:
 rules:
 - rootfiles_root_bash_bash_profile
 - rootfiles_root_bash_bashrc
+- rootfiles_root_bash_cshrc

--- a/components/rootfiles.yml
+++ b/components/rootfiles.yml
@@ -5,3 +5,4 @@ rules:
 - rootfiles_root_bash_bash_profile
 - rootfiles_root_bash_bashrc
 - rootfiles_root_bash_cshrc
+- rootfiles_root_bash_logout

--- a/components/rootfiles.yml
+++ b/components/rootfiles.yml
@@ -6,3 +6,4 @@ rules:
 - rootfiles_root_bash_bashrc
 - rootfiles_root_bash_cshrc
 - rootfiles_root_bash_logout
+- rootfiles_root_bash_tcshrc

--- a/controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml
+++ b/controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml
@@ -70,6 +70,15 @@ controls:
             - file_permission_user_init_files_root
             - var_user_initialization_files_regex=all_dotfiles
 
+            # rootfiles
+            - rootfiles_root_bash_bash_profile
+            - rootfiles_root_bash_bashrc
+            - rootfiles_root_bash_cshrc
+            - rootfiles_root_bash_logout
+            - rootfiles_root_bash_tcshrc
+
+
+
             # service disabled
             - service_kdump_disabled
             - service_debug-shell_disabled

--- a/controls/stig_rhel9.yml
+++ b/controls/stig_rhel9.yml
@@ -994,6 +994,11 @@ controls:
         rules:
             - file_permission_user_init_files_root
             - var_user_initialization_files_regex=all_dotfiles
+            - rootfiles_root_bash_bash_profile
+            - rootfiles_root_bash_bashrc
+            - rootfiles_root_bash_cshrc
+            - rootfiles_root_bash_logout
+            - rootfiles_root_bash_tcshrc
         status: automated
 
     -   id: RHEL-09-232050

--- a/linux_os/guide/system/permissions/files/rootfiles/group.yml
+++ b/linux_os/guide/system/permissions/files/rootfiles/group.yml
@@ -1,0 +1,6 @@
+documentation_complete: true
+
+title: rootfiles
+
+description: |-
+    Configure the rootfiles package so the root user's files are correctly secured.

--- a/linux_os/guide/system/permissions/files/rootfiles/rootfiles_root_bash_bash_profile/rule.yml
+++ b/linux_os/guide/system/permissions/files/rootfiles/rootfiles_root_bash_bash_profile/rule.yml
@@ -1,0 +1,32 @@
+documentation_complete: true
+
+title: "Ensure rootfiles Sets /root/.bash_profile Permissions Correctly"
+
+description: |-
+    To set the mode of the root user initialization file <tt>/root/.bash_profile</tt>,
+    ensure the following line is is included in a file ending in <tt>.conf</tt> under
+    <tt>/etc/tmpfiles.d/</tt>.
+    <pre>
+        C /root/.bash_profile   600 root root - /usr/share/rootfiles/.bash_profile
+    </pre>
+
+rationale: |-
+    Local initialization files are used to configure the user's shell environment
+    upon logon. Malicious modification of these files could compromise accounts upon
+    logon.
+
+severity: medium
+
+platform: package[rootfiles]
+
+template:
+    name: tmpfile_config
+    vars:
+        tmp_action: 'C'
+        dest_path: '/root/.bash_profile'
+        mode: '600'
+        wrong_mode: '777'
+        owner: 'root'
+        group_owner: 'root'
+        source_path: '/usr/share/rootfiles/.bash_profile'
+        remedation_file: '/etc/tmpfiles.d/rootconf.conf'

--- a/linux_os/guide/system/permissions/files/rootfiles/rootfiles_root_bash_bashrc/rule.yml
+++ b/linux_os/guide/system/permissions/files/rootfiles/rootfiles_root_bash_bashrc/rule.yml
@@ -1,0 +1,32 @@
+documentation_complete: true
+
+title: "Ensure rootfiles Sets /root/.bashrc Permissions Correctly"
+
+description: |-
+    To set the mode of the root user initialization file <tt>/root/.bashrc</tt>,
+    ensure the following line is is included in a file ending in <tt>.conf</tt> under
+    <tt>/etc/tmpfiles.d/</tt>.
+    <pre>
+        C /root/.bashrc   600 root root - /usr/share/rootfiles/.bashrc
+    </pre>
+
+rationale: |-
+    Local initialization files are used to configure the user's shell environment
+    upon logon. Malicious modification of these files could compromise accounts upon
+    logon.
+
+severity: medium
+
+platform: package[rootfiles]
+
+template:
+    name: tmpfile_config
+    vars:
+        tmp_action: 'C'
+        dest_path: '/root/.bashrc'
+        mode: '600'
+        wrong_mode: '777'
+        owner: 'root'
+        group_owner: 'root'
+        source_path: '/usr/share/rootfiles/.bashrc'
+        remedation_file: '/etc/tmpfiles.d/rootconf.conf'

--- a/linux_os/guide/system/permissions/files/rootfiles/rootfiles_root_bash_cshrc/rule.yml
+++ b/linux_os/guide/system/permissions/files/rootfiles/rootfiles_root_bash_cshrc/rule.yml
@@ -1,0 +1,32 @@
+documentation_complete: true
+
+title: "Ensure rootfiles Sets /root/.cshrc Permissions Correctly"
+
+description: |-
+    To set the mode of the root user initialization file <tt>/root/.cshrc</tt>,
+    ensure the following line is is included in a file ending in <tt>.conf</tt> under
+    <tt>/etc/tmpfiles.d/</tt>.
+    <pre>
+        C /root/.cshrc   600 root root - /usr/share/rootfiles/.cshrc
+    </pre>
+
+rationale: |-
+    Local initialization files are used to configure the user's shell environment
+    upon logon. Malicious modification of these files could compromise accounts upon
+    logon.
+
+severity: medium
+
+platform: package[rootfiles]
+
+template:
+    name: tmpfile_config
+    vars:
+        tmp_action: 'C'
+        dest_path: '/root/.cshrc'
+        mode: '600'
+        wrong_mode: '777'
+        owner: 'root'
+        group_owner: 'root'
+        source_path: '/usr/share/rootfiles/.cshrc'
+        remedation_file: '/etc/tmpfiles.d/rootconf.conf'

--- a/linux_os/guide/system/permissions/files/rootfiles/rootfiles_root_bash_logout/rule.yml
+++ b/linux_os/guide/system/permissions/files/rootfiles/rootfiles_root_bash_logout/rule.yml
@@ -1,0 +1,32 @@
+documentation_complete: true
+
+title: "Ensure rootfiles Sets /root/.bash_logout Permissions Correctly"
+
+description: |-
+    To set the mode of the root user initialization file <tt>/root/.bash_logout</tt>,
+    ensure the following line is is included in a file ending in <tt>.conf</tt> under
+    <tt>/etc/tmpfiles.d/</tt>.
+    <pre>
+        C /root/.bash_logout   600 root root - /usr/share/rootfiles/.bash_logout
+    </pre>
+
+rationale: |-
+    Local initialization files are used to configure the user's shell environment
+    upon logon. Malicious modification of these files could compromise accounts upon
+    logon.
+
+severity: medium
+
+platform: package[rootfiles]
+
+template:
+    name: tmpfile_config
+    vars:
+        tmp_action: 'C'
+        dest_path: '/root/.bash_logout'
+        mode: '600'
+        wrong_mode: '777'
+        owner: 'root'
+        group_owner: 'root'
+        source_path: '/usr/share/rootfiles/.bash_logout'
+        remedation_file: '/etc/tmpfiles.d/rootconf.conf'

--- a/linux_os/guide/system/permissions/files/rootfiles/rootfiles_root_bash_tcshrc/rule.yml
+++ b/linux_os/guide/system/permissions/files/rootfiles/rootfiles_root_bash_tcshrc/rule.yml
@@ -1,0 +1,32 @@
+documentation_complete: true
+
+title: "Ensure rootfiles Sets /root/.tcshrc Permissions Correctly"
+
+description: |-
+    To set the mode of the root user initialization file <tt>/root/.tcshrc</tt>,
+    ensure the following line is is included in a file ending in <tt>.conf</tt> under
+    <tt>/etc/tmpfiles.d/</tt>.
+    <pre>
+        C /root/.tcshrc   600 root root - /usr/share/rootfiles/.tcshrc
+    </pre>
+
+rationale: |-
+    Local initialization files are used to configure the user's shell environment
+    upon logon. Malicious modification of these files could compromise accounts upon
+    logon.
+
+severity: medium
+
+platform: package[rootfiles]
+
+template:
+    name: tmpfile_config
+    vars:
+        tmp_action: 'C'
+        dest_path: '/root/.tcshrc'
+        mode: '600'
+        wrong_mode: '777'
+        owner: 'root'
+        group_owner: 'root'
+        source_path: '/usr/share/rootfiles/.tcshrc'
+        remedation_file: '/etc/tmpfiles.d/rootconf.conf'

--- a/shared/applicability/package.yml
+++ b/shared/applicability/package.yml
@@ -140,3 +140,5 @@ args:
     pkgname: apt
   rsyslog:
     pkgname: rsyslog
+  rootfiles:
+    pkgname: rootfiles

--- a/shared/templates/tmpfile_config/ansible.template
+++ b/shared/templates/tmpfile_config/ansible.template
@@ -1,0 +1,9 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+{{% set new_line = TMP_ACTION ~ " " ~ DEST_PATH ~ " " ~  MODE ~ " " ~ OWNER ~ " " ~ GROUP_OWNER ~ " - " ~ SOURCE_PATH  %}}
+
+{{{ ansible_lineinfile(msg='', path=REMEDATION_FILE, new_line=new_line, create='yes', state='present', insert_after='', insert_before='') -}}}
+

--- a/shared/templates/tmpfile_config/bash.template
+++ b/shared/templates/tmpfile_config/bash.template
@@ -1,0 +1,8 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+{{% set new_line = TMP_ACTION ~ " " ~ DEST_PATH ~ " " ~  MODE ~ " " ~ OWNER ~ " " ~ GROUP_OWNER ~ " - " ~ SOURCE_PATH  %}}
+
+{{{ set_config_file(REMEDATION_FILE, new_line, value="", create='yes', insert_after="", insert_before="", separator="", separator_regex="", prefix_regex="^\s*", sed_path_separator='#') -}}}

--- a/shared/templates/tmpfile_config/oval.template
+++ b/shared/templates/tmpfile_config/oval.template
@@ -1,0 +1,22 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("Check presence of " + TMP_ACTION + " in " + DEST_PATH) }}}
+    <criteria operator="AND" comment="Test conditions - presence of the file plus {{{ OVAL_EXTEND_DEFINITIONS | length }}} extra definitions.">
+      <criterion comment="Check that {{{ PATH }}} contains a line with certain text" test_ref="test_{{{ rule_id }}}" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all"
+  comment="tests the presence of '{{{ DEST_PATH }}}' setting in the tmpfile config"
+  id="test_{{{ rule_id }}}" version="1">
+    <ind:object object_ref="obj_{{{ rule_id }}}" />
+  </ind:textfilecontent54_test>
+
+
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}" version="1">
+    <ind:path>/etc/tmpfiles.d/</ind:path>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^{{{ TMP_ACTION }}}[[:blank:]]+{{{ DEST_PATH | replace("/", "\\/") }}}[[:blank:]]+{{{ MODE }}}[[:blank:]]+{{{ OWNER }}}[[:blank:]]+{{{ GROUP_OWNER }}}[[:blank:]]+-[[:blank:]]+{{{ SOURCE_PATH | replace("/", "\\/") }}}$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/shared/templates/tmpfile_config/template.yml
+++ b/shared/templates/tmpfile_config/template.yml
@@ -1,0 +1,4 @@
+supported_languages:
+  - ansible
+  - bash
+  - oval

--- a/shared/templates/tmpfile_config/tests/correct.pass.sh
+++ b/shared/templates/tmpfile_config/tests/correct.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+mkdir /etc/tmpfiles.d/
+echo '{{{ TMP_ACTION }}} {{{ DEST_PATH }}} {{{ MODE }}} {{{ OWNER }}} {{{ GROUP_OWNER }}} - {{{ SOURCE_PATH }}}' >> {{{ REMEDATION_FILE }}}

--- a/shared/templates/tmpfile_config/tests/default.fail.sh
+++ b/shared/templates/tmpfile_config/tests/default.fail.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+touch /root/.bashrc

--- a/shared/templates/tmpfile_config/tests/wrong_mode.fail.sh
+++ b/shared/templates/tmpfile_config/tests/wrong_mode.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+mkdir /etc/tmpfiles.d/
+echo '{{{ TMP_ACTION }}} {{{ DEST_PATH }}} {{{ WRONG_MODE }}} {{{ OWNER }}} {{{ GROUP_OWNER }}} - {{{ SOURCE_PATH }}}' >> {{{ REMEDATION_FILE }}}

--- a/tests/data/profile_stability/rhel10/stig.profile
+++ b/tests/data/profile_stability/rhel10/stig.profile
@@ -413,6 +413,11 @@ selections:
 - postfix_prevent_unrestricted_relay
 - require_singleuser_auth
 - root_permissions_syslibrary_files
+- rootfiles_root_bash_bash_profile
+- rootfiles_root_bash_bashrc
+- rootfiles_root_bash_cshrc
+- rootfiles_root_bash_logout
+- rootfiles_root_bash_tcshrc
 - rsyslog_cron_logging
 - rsyslog_encrypt_offload_actionsendstreamdriverauthmode
 - rsyslog_encrypt_offload_actionsendstreamdrivermode

--- a/tests/data/profile_stability/rhel10/stig_gui.profile
+++ b/tests/data/profile_stability/rhel10/stig_gui.profile
@@ -411,6 +411,11 @@ selections:
 - postfix_prevent_unrestricted_relay
 - require_singleuser_auth
 - root_permissions_syslibrary_files
+- rootfiles_root_bash_bash_profile
+- rootfiles_root_bash_bashrc
+- rootfiles_root_bash_cshrc
+- rootfiles_root_bash_logout
+- rootfiles_root_bash_tcshrc
 - rsyslog_cron_logging
 - rsyslog_encrypt_offload_actionsendstreamdriverauthmode
 - rsyslog_encrypt_offload_actionsendstreamdrivermode

--- a/tests/data/profile_stability/rhel9/stig.profile
+++ b/tests/data/profile_stability/rhel9/stig.profile
@@ -421,6 +421,11 @@ selections:
 - require_emergency_target_auth
 - require_singleuser_auth
 - root_permissions_syslibrary_files
+- rootfiles_root_bash_bash_profile
+- rootfiles_root_bash_bashrc
+- rootfiles_root_bash_cshrc
+- rootfiles_root_bash_logout
+- rootfiles_root_bash_tcshrc
 - rsyslog_cron_logging
 - rsyslog_encrypt_offload_actionsendstreamdriverauthmode
 - rsyslog_encrypt_offload_actionsendstreamdrivermode

--- a/tests/data/profile_stability/rhel9/stig_gui.profile
+++ b/tests/data/profile_stability/rhel9/stig_gui.profile
@@ -431,6 +431,11 @@ selections:
 - require_emergency_target_auth
 - require_singleuser_auth
 - root_permissions_syslibrary_files
+- rootfiles_root_bash_bash_profile
+- rootfiles_root_bash_bashrc
+- rootfiles_root_bash_cshrc
+- rootfiles_root_bash_logout
+- rootfiles_root_bash_tcshrc
 - rsyslog_cron_logging
 - rsyslog_encrypt_offload_actionsendstreamdriverauthmode
 - rsyslog_encrypt_offload_actionsendstreamdrivermode


### PR DESCRIPTION
#### Description:

Add rules to ensure that root's init files created by the `rootfiles` package are correctly configured.
#### Rationale:

Fixes #13100 