### PR TITLE
Update enable_authselect remediation on bootable containers

### DIFF
--- a/linux_os/guide/system/accounts/enable_authselect/bash/shared.sh
+++ b/linux_os/guide/system/accounts/enable_authselect/bash/shared.sh
@@ -5,7 +5,11 @@
 authselect current
 
 if test "$?" -ne 0; then
-    authselect select "$var_authselect_profile"
+    if {{{ bash_bootc_build() }}}; then
+        authselect select --force "$var_authselect_profile"
+    else
+        authselect select "$var_authselect_profile"
+    fi
 
     if test "$?" -ne 0; then
         if rpm --quiet --verify pam; then


### PR DESCRIPTION
The `authselect` has been added into RHEL 9 bootable containers in https://issues.redhat.com/browse/RHEL-76811 but there is no default authselect profile selected and that is causing the remediation of the rule `enable_authselect` to fail:

```
[root]# authselect current
No existing configuration detected.

[root]# authselect select sssd
No existing configuration detected.
[error] File [/etc/pam.d/system-auth] exists but it needs to be overwritten!
[error] File [/etc/pam.d/password-auth] exists but it needs to be overwritten!
[error] File [/etc/pam.d/fingerprint-auth] exists but it needs to be overwritten!
[error] File [/etc/pam.d/smartcard-auth] exists but it needs to be overwritten!
[error] File [/etc/pam.d/postlogin] exists but it needs to be overwritten!
[error] File [/etc/nsswitch.conf] exists but it needs to be overwritten!
[error] File that needs to be overwritten was found
[error] Refusing to activate profile unless this file is removed or overwrite is requested.

Some unexpected changes to the configuration were detected.
Use --force parameter if you want to overwrite these changes.
authselect is not used but files from the 'pam' package have been altered, so the authselect configuration won't be forced.
```

Therefore, we update the remediation to run `authselect select` command with the `--force` parameter when running on a bootable container which resolves this issue.