### PR TITLE
Fix dconf key for idle-delay lock on Ubuntu

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/oval/shared.xml
@@ -64,7 +64,7 @@
   version="1">
     <ind:path>/etc/dconf/db/local.d/locks/</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
-    <ind:pattern operation="pattern match">^/org/gnome/desktop/screensaver/idle-delay$</ind:pattern>
+    <ind:pattern operation="pattern match">^/org/gnome/desktop/session/idle-delay$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 {{% endif %}}

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/tests/comment.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/tests/comment.fail.sh
@@ -8,5 +8,5 @@ add_dconf_profiles
 add_dconf_setting "org/gnome/desktop/session" "#idle-delay" "uint32 900" "local.d" "00-security-settings"
 
 {{% if 'ubuntu' in product %}}
-add_dconf_lock "org/gnome/desktop/screensaver" "idle-delay" "local.d" "00-security-settings"
+add_dconf_lock "org/gnome/desktop/session" "idle-delay" "local.d" "00-security-settings"
 {{% endif %}}

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/tests/correct_value.pass.sh
@@ -10,5 +10,5 @@ add_dconf_profiles
 add_dconf_setting "org/gnome/desktop/session" "idle-delay" "uint32 900" "local.d" "00-security-settings"
 
 {{% if 'ubuntu' in product %}}
-add_dconf_lock "org/gnome/desktop/screensaver" "idle-delay" "local.d" "00-security-settings"
+add_dconf_lock "org/gnome/desktop/session" "idle-delay" "local.d" "00-security-settings"
 {{% endif %}}

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/tests/correct_value_wrong_db.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/tests/correct_value_wrong_db.fail.sh
@@ -10,5 +10,5 @@ add_dconf_profiles
 add_dconf_setting "org/gnome/desktop/session" "idle-delay" "uint32 900" "dummy.d" "00-security-settings"
 
 {{% if 'ubuntu' in product %}}
-add_dconf_lock "org/gnome/desktop/screensaver" "idle-delay" "local.d" "00-security-settings"
+add_dconf_lock "org/gnome/desktop/session" "idle-delay" "local.d" "00-security-settings"
 {{% endif %}}

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/tests/missing_profiles.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/tests/missing_profiles.fail.sh
@@ -8,4 +8,4 @@
 clean_dconf_settings
 
 add_dconf_setting "org/gnome/desktop/session" "idle-delay" "uint32 900" "local.d" "00-security-settings"
-add_dconf_lock "org/gnome/desktop/screensaver" "idle-delay" "local.d" "00-security-settings"
+add_dconf_lock "org/gnome/desktop/session" "idle-delay" "local.d" "00-security-settings"

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/tests/setting_not_there.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/tests/setting_not_there.fail.sh
@@ -7,5 +7,5 @@ clean_dconf_settings
 add_dconf_profiles
 
 {{% if 'ubuntu' in product %}}
-add_dconf_lock "org/gnome/desktop/screensaver" "idle-delay" "local.d" "00-security-settings"
+add_dconf_lock "org/gnome/desktop/session" "idle-delay" "local.d" "00-security-settings"
 {{% endif %}}

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/tests/wrong_value.fail.sh
@@ -9,5 +9,5 @@ add_dconf_profiles
 add_dconf_setting "org/gnome/desktop/session" "idle-delay" "uint32 2900" "local.d" "00-security-settings"
 
 {{% if 'ubuntu' in product %}}
-add_dconf_lock "org/gnome/desktop/screensaver" "idle-delay" "local.d" "00-security-settings"
+add_dconf_lock "org/gnome/desktop/session" "idle-delay" "local.d" "00-security-settings"
 {{% endif %}}


### PR DESCRIPTION
#### Description:

- Fix dconf key for idle-delay lock on Ubuntu
- Extends #13112 

