### PR TITLE
Add required to controlseval.py --product switch

### DIFF
--- a/utils/controleval.py
+++ b/utils/controleval.py
@@ -334,7 +334,7 @@ def parse_arguments():
         help="The output format of the result")
     stats_parser.add_argument(
         '-p', '--product',
-        help="product to check has required references")
+        help="product to check has required references", required=True)
     stats_parser.add_argument(
         '--show-controls', action='store_true',
         help="list the controls and their respective status")


### PR DESCRIPTION
#### Description:
Add required to controlseval.py --product switch

#### Rationale:

The script wouldn't run without it.
#### Review Hints:
Run the script on master and this branch with and without `-p rhel10`.
`./utils/controleval.py stats --id srg_gpos -l medium -s pending --show-controls -p rhel10`