### PR TITLE
Adjust titles for SRG GPS to use {{{ full_name }}} in place of the os

### DIFF
--- a/controls/srg_gpos/SRG-OS-000228-GPOS-00088.yml
+++ b/controls/srg_gpos/SRG-OS-000228-GPOS-00088.yml
@@ -1,6 +1,6 @@
 controls:
     -   id: SRG-OS-000228-GPOS-00088
-        title: Any publically accessible connection to the operating system must display
+        title: Any publically accessible connection to {{{ full_name }}} must display
             the Standard Mandatory DoD Notice and Consent Banner before granting access to
             the system.
 

--- a/controls/srg_gpos/SRG-OS-000269-GPOS-00103.yml
+++ b/controls/srg_gpos/SRG-OS-000269-GPOS-00103.yml
@@ -1,6 +1,6 @@
 controls:
     -   id: SRG-OS-000269-GPOS-00103
-        title: In the event of a system failure, the operating system must preserve any
+        title: In the event of a system failure, {{{ full_name }}} must preserve any
             information necessary to determine cause of failure and any information necessary
             to return to operations with least disruption to mission processes.
         levels:

--- a/controls/srg_gpos/SRG-OS-000384-GPOS-00167.yml
+++ b/controls/srg_gpos/SRG-OS-000384-GPOS-00167.yml
@@ -2,7 +2,7 @@ controls:
     -   id: SRG-OS-000384-GPOS-00167
         levels:
             - medium
-        title: The operating system, for PKI-based authentication, must implement a local
+        title: {{{ full_name }}}, for PKI-based authentication, must implement a local
             cache of revocation data to support path discovery and validation in case of the
             inability to access revocation information via the network.
         status: manual

--- a/controls/srg_gpos/SRG-OS-000439-GPOS-00195.yml
+++ b/controls/srg_gpos/SRG-OS-000439-GPOS-00195.yml
@@ -2,7 +2,7 @@ controls:
     -   id: SRG-OS-000439-GPOS-00195
         levels:
             - medium
-        title: The operating system must install security-relevant software updates within
+        title: {{{ full_name }}} must install security-relevant software updates within
             the time period directed by an authoritative source (e.g., IAVM, CTOs, DTMs, and
             STIGs).
         status: pending


### PR DESCRIPTION
#### Description:

Adjust titles for SRG GPS to use {{{ full_name }}} in place of the os

#### Rationale:

Clean up for RHEL 10.