### PR TITLE
Improve snapshot handling in automatus

### DIFF
--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -302,7 +302,7 @@ class VMTestEnv(TestEnv):
         return state
 
     def _delete_saved_state(self, snapshot):
-        self.snapshot_stack.revert()
+        self.snapshot_stack.delete()
 
     def _local_oscap_check_base_arguments(self):
         return ['oscap-vm', "domain", self.domain_name, 'xccdf', 'eval']

--- a/tests/ssg_test_suite/virt.py
+++ b/tests/ssg_test_suite/virt.py
@@ -59,13 +59,13 @@ class SnapshotStack(object):
             self.domain.revertToSnapshot(snapshot,
                                          self.REVERT_FLAGS)
             if delete:
-                logging.debug(("Hard revert of snapshot "
+                logging.debug(("Hard revert to snapshot "
                                "'{0}' successful").format(snapshot.getName()))
                 snapshot.delete()
             else:
                 # this is soft revert - we are keeping the snapshot for
                 # another use
-                logging.debug(("Soft revert of snapshot "
+                logging.debug(("Soft revert to snapshot "
                                "'{0}' successful").format(snapshot.getName()))
                 self.snapshot_stack.append(snapshot)
 
@@ -85,7 +85,7 @@ class SnapshotStack(object):
         while self.snapshot_stack:
             snapshot = self.snapshot_stack.pop()
             snapshot_name = snapshot.getName()
-            logging.debug("Reverting of snapshot '{0}'".format(snapshot_name))
+            logging.debug("Reverting to snapshot '{0}'".format(snapshot_name))
             self.domain.revertToSnapshot(snapshot,
                                          self.REVERT_FLAGS)
             snapshot.delete()


### PR DESCRIPTION
#### Description:
1. Change wording of log message
Using "to" in "reverting to snapshot" better describes the actual
activity. The name of the function is also `revertToSnapshot`.
2. Don't revert to snapshot during deletion of snapshot
We revert to the snapshot after each test. When we want to delete
the snapshot, we don't have to revert to the snapshot again, because
we reverted to the snapshot right before it, so we can simply only
delete it. This can save some time.

