### PR TITLE
Disable remediations for set_iptables_default_rule and set_ip6tables_default_rule on Ubuntu products

### DIFF
--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/bash/shared.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/bash/shared.sh
@@ -1,8 +1,6 @@
-# platform = multi_platform_all
 {{% if 'ubuntu' in product %}}
-{{{ bash_package_install("iptables-persistent") }}}
-sed -i 's/^:INPUT ACCEPT.*/:INPUT DROP [0:0]/g' /etc/iptables/rules.v6
+# platform = Not Applicable
 {{% else %}}
-sed -i 's/^:INPUT ACCEPT.*/:INPUT DROP [0:0]/g' /etc/sysconfig/ip6tables
+# platform = multi_platform_all
 {{% endif %}}
-
+sed -i 's/^:INPUT ACCEPT.*/:INPUT DROP [0:0]/g' /etc/sysconfig/ip6tables

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/rule.yml
@@ -57,3 +57,11 @@ ocil: |-
     Inspect the file <tt>/etc/sysconfig/ip6tables</tt> to determine
     the default policy for the INPUT chain. It should be set to DROP:
     <pre>$ sudo grep ":INPUT" /etc/sysconfig/ip6tables</pre>
+
+{{% if 'ubuntu' in product %}}
+warnings:
+    - general: |-
+        Automated remediation for this rule is disabled.
+        Changing firewall settings while connected over network can
+        result in being locked out of the system.
+{{% endif %}}

--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/set_iptables_default_rule/bash/shared.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/set_iptables_default_rule/bash/shared.sh
@@ -1,2 +1,6 @@
+{{% if 'ubuntu' in product %}}
+# platform = Not Applicable
+{{% else %}}
 # platform = multi_platform_all
+{{% endif %}}
 sed -i 's/^:INPUT ACCEPT.*/:INPUT DROP [0:0]/g' /etc/sysconfig/iptables

--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/set_iptables_default_rule/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/set_iptables_default_rule/rule.yml
@@ -6,7 +6,11 @@ description: |-
     To set the default policy to DROP (instead of ACCEPT) for
     the built-in INPUT chain which processes incoming packets,
     add or correct the following line in
+    {{% if 'ubuntu' in product %}}
+    <tt>/etc/iptables/rules.v4</tt>:
+    {{% else %}}
     <tt>/etc/sysconfig/iptables</tt>:
+    {{% endif %}}
     <pre>:INPUT DROP [0:0]</pre>
 
 rationale: |-
@@ -47,3 +51,11 @@ ocil: |-
     Inspect the file <tt>/etc/sysconfig/iptables</tt> to determine
     the default policy for the INPUT chain. It should be set to DROP:
     <pre>$ sudo grep ":INPUT" /etc/sysconfig/iptables</pre>
+
+{{% if 'ubuntu' in product %}}
+warnings:
+    - general: |-
+        Automated remediation for this rule is disabled.
+        Changing firewall settings while connected over network can
+        result in being locked out of the system.
+{{% endif %}}

--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/set_iptables_default_rule/tests/correct.pass.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/set_iptables_default_rule/tests/correct.pass.sh
@@ -1,0 +1,11 @@
+# platform = multi_platform_ubuntu
+# packages = iptables,iptables-persistent
+
+apt purge -y nftables ufw
+
+iptables -A INPUT -m conntrack --ctstate NEW,ESTABLISHED,RELATED -j ACCEPT
+iptables -A OUTPUT -m conntrack --ctstate NEW,ESTABLISHED,RELATED -j ACCEPT
+
+iptables -P INPUT DROP
+iptables -P FORWARD DROP
+iptables -P OUTPUT DROP

--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/set_iptables_default_rule/tests/wrong.fail.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/set_iptables_default_rule/tests/wrong.fail.sh
@@ -1,0 +1,12 @@
+# platform = multi_platform_ubuntu
+# remediation = none
+# packages = iptables,iptables-persistent
+
+apt purge -y nftables ufw
+
+iptables -A INPUT -m conntrack --ctstate NEW,ESTABLISHED,RELATED -j ACCEPT
+iptables -A OUTPUT -m conntrack --ctstate NEW,ESTABLISHED,RELATED -j ACCEPT
+
+iptables -P INPUT ACCEPT
+iptables -P FORWARD DROP
+iptables -P OUTPUT DROP


### PR DESCRIPTION
#### Description:

- Disable remediations for `set_iptables_default_rule` and `set_ip6tables_default_rule` on Ubuntu products
- Fix path for iptables config in rule descriptions

#### Rationale:

- Remediations are disabled to avoid network lockout
- New behavior is consistent with analogous nftables and ufw rules nftables_ensure_default_deny_policy and set_ufw_default_rule.
