### PR TITLE
OCPBUGS-52295: Update testing assertions for partition-for-var-log-audit

### DIFF
--- a/tests/assertions/ocp4/rhcos4-high-4.12.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.12.yml
@@ -574,10 +574,8 @@ rule_results:
     result_after_remediation: PASS
   e2e-high-master-partition-for-var-log:
     default_result: MANUAL
-    result_after_remediation: MANUAL
   e2e-high-master-partition-for-var-log-audit:
     default_result: MANUAL
-    result_after_remediation: MANUAL
   e2e-high-master-require-singleuser-auth:
     default_result: PASS
     result_after_remediation: PASS
@@ -1300,10 +1298,8 @@ rule_results:
     result_after_remediation: PASS
   e2e-high-worker-partition-for-var-log:
     default_result: MANUAL
-    result_after_remediation: MANUAL
   e2e-high-worker-partition-for-var-log-audit:
     default_result: MANUAL
-    result_after_remediation: MANUAL
   e2e-high-worker-require-singleuser-auth:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-high-4.13.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.13.yml
@@ -574,10 +574,8 @@ rule_results:
     result_after_remediation: PASS
   e2e-high-master-partition-for-var-log:
     default_result: MANUAL
-    result_after_remediation: MANUAL
   e2e-high-master-partition-for-var-log-audit:
     default_result: MANUAL
-    result_after_remediation: MANUAL
   e2e-high-master-require-singleuser-auth:
     default_result: PASS
     result_after_remediation: PASS
@@ -1300,10 +1298,8 @@ rule_results:
     result_after_remediation: PASS
   e2e-high-worker-partition-for-var-log:
     default_result: MANUAL
-    result_after_remediation: MANUAL
   e2e-high-worker-partition-for-var-log-audit:
     default_result: MANUAL
-    result_after_remediation: MANUAL
   e2e-high-worker-require-singleuser-auth:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-high-4.14.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.14.yml
@@ -574,10 +574,8 @@ rule_results:
     result_after_remediation: PASS
   e2e-high-master-partition-for-var-log:
     default_result: MANUAL
-    result_after_remediation: MANUAL
   e2e-high-master-partition-for-var-log-audit:
     default_result: MANUAL
-    result_after_remediation: MANUAL
   e2e-high-master-require-singleuser-auth:
     default_result: PASS
     result_after_remediation: PASS
@@ -1300,10 +1298,8 @@ rule_results:
     result_after_remediation: PASS
   e2e-high-worker-partition-for-var-log:
     default_result: MANUAL
-    result_after_remediation: MANUAL
   e2e-high-worker-partition-for-var-log-audit:
     default_result: MANUAL
-    result_after_remediation: MANUAL
   e2e-high-worker-require-singleuser-auth:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-high-4.16.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.16.yml
@@ -572,9 +572,9 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-partition-for-var-log:
-    default_result: NOT-APPLICABLE
+    default_result: MANUAL
   e2e-high-master-partition-for-var-log-audit:
-    default_result: NOT-APPLICABLE
+    default_result: MANUAL
   e2e-high-master-require-singleuser-auth:
     default_result: PASS
     result_after_remediation: PASS
@@ -1292,9 +1292,9 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-partition-for-var-log:
-    default_result: NOT-APPLICABLE
+    default_result: MANUAL
   e2e-high-worker-partition-for-var-log-audit:
-    default_result: NOT-APPLICABLE
+    default_result: MANUAL
   e2e-high-worker-require-singleuser-auth:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-high-4.17.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.17.yml
@@ -573,11 +573,9 @@ rule_results:
    default_result: FAIL
    result_after_remediation: PASS
  e2e-high-master-partition-for-var-log:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: MANUAL
  e2e-high-master-partition-for-var-log-audit:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: MANUAL
  e2e-high-master-require-singleuser-auth:
    default_result: PASS
    result_after_remediation: PASS
@@ -1299,11 +1297,9 @@ rule_results:
    default_result: FAIL
    result_after_remediation: PASS
  e2e-high-worker-partition-for-var-log:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: MANUAL
  e2e-high-worker-partition-for-var-log-audit:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: MANUAL
  e2e-high-worker-require-singleuser-auth:
    default_result: PASS
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-high-4.18.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.18.yml
@@ -573,11 +573,9 @@ rule_results:
    default_result: FAIL
    result_after_remediation: PASS
  e2e-high-master-partition-for-var-log:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: MANUAL
  e2e-high-master-partition-for-var-log-audit:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: MANUAL
  e2e-high-master-require-singleuser-auth:
    default_result: PASS
    result_after_remediation: PASS
@@ -1299,11 +1297,9 @@ rule_results:
    default_result: FAIL
    result_after_remediation: PASS
  e2e-high-worker-partition-for-var-log:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: MANUAL
  e2e-high-worker-partition-for-var-log-audit:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: MANUAL
  e2e-high-worker-require-singleuser-auth:
    default_result: PASS
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-moderate-4.12.yml
+++ b/tests/assertions/ocp4/rhcos4-moderate-4.12.yml
@@ -574,10 +574,8 @@ rule_results:
     result_after_remediation: PASS
   e2e-moderate-master-partition-for-var-log:
     default_result: MANUAL
-    result_after_remediation: MANUAL
   e2e-moderate-master-partition-for-var-log-audit:
     default_result: MANUAL
-    result_after_remediation: MANUAL
   e2e-moderate-master-require-singleuser-auth:
     default_result: PASS
     result_after_remediation: PASS
@@ -1297,10 +1295,8 @@ rule_results:
     result_after_remediation: PASS
   e2e-moderate-worker-partition-for-var-log:
     default_result: MANUAL
-    result_after_remediation: MANUAL
   e2e-moderate-worker-partition-for-var-log-audit:
     default_result: MANUAL
-    result_after_remediation: MANUAL
   e2e-moderate-worker-require-singleuser-auth:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-moderate-4.16.yml
+++ b/tests/assertions/ocp4/rhcos4-moderate-4.16.yml
@@ -572,9 +572,9 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-partition-for-var-log:
-    default_result: NOT-APPLICABLE
+    default_result: MANUAL
   e2e-moderate-master-partition-for-var-log-audit:
-    default_result: NOT-APPLICABLE
+    default_result: MANUAL
   e2e-moderate-master-require-singleuser-auth:
     default_result: PASS
     result_after_remediation: PASS
@@ -1289,9 +1289,9 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-partition-for-var-log:
-    default_result: NOT-APPLICABLE
+    default_result: MANUAL
   e2e-moderate-worker-partition-for-var-log-audit:
-    default_result: NOT-APPLICABLE
+    default_result: MANUAL
   e2e-moderate-worker-require-singleuser-auth:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-moderate-4.17.yml
+++ b/tests/assertions/ocp4/rhcos4-moderate-4.17.yml
@@ -573,11 +573,9 @@ rule_results:
    default_result: FAIL
    result_after_remediation: PASS
  e2e-moderate-master-partition-for-var-log:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: MANUAL
  e2e-moderate-master-partition-for-var-log-audit:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: MANUAL
  e2e-moderate-master-require-singleuser-auth:
    default_result: PASS
    result_after_remediation: PASS
@@ -1296,11 +1294,9 @@ rule_results:
    default_result: FAIL
    result_after_remediation: PASS
  e2e-moderate-worker-partition-for-var-log:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: MANUAL
  e2e-moderate-worker-partition-for-var-log-audit:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: MANUAL
  e2e-moderate-worker-require-singleuser-auth:
    default_result: PASS
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-moderate-4.18.yml
+++ b/tests/assertions/ocp4/rhcos4-moderate-4.18.yml
@@ -573,11 +573,9 @@ rule_results:
    default_result: FAIL
    result_after_remediation: PASS
  e2e-moderate-master-partition-for-var-log:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: MANUAL
  e2e-moderate-master-partition-for-var-log-audit:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: MANUAL
  e2e-moderate-master-require-singleuser-auth:
    default_result: PASS
    result_after_remediation: PASS
@@ -1296,11 +1294,9 @@ rule_results:
    default_result: FAIL
    result_after_remediation: PASS
  e2e-moderate-worker-partition-for-var-log:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: MANUAL
  e2e-moderate-worker-partition-for-var-log-audit:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: MANUAL
  e2e-moderate-worker-require-singleuser-auth:
    default_result: PASS
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-stig-4.16.yml
+++ b/tests/assertions/ocp4/rhcos4-stig-4.16.yml
@@ -324,7 +324,7 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-partition-for-var-log-audit:
-    default_result: NOT-APPLICABLE
+    default_result: MANUAL
   e2e-stig-master-selinux-policytype:
     default_result: PASS
     result_after_remediation: PASS
@@ -680,7 +680,7 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-partition-for-var-log-audit:
-    default_result: NOT-APPLICABLE
+    default_result: MANUAL
   e2e-stig-worker-selinux-policytype:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-stig-4.17.yml
+++ b/tests/assertions/ocp4/rhcos4-stig-4.17.yml
@@ -324,8 +324,7 @@ rule_results:
    default_result: FAIL
    result_after_remediation: PASS
  e2e-stig-master-partition-for-var-log-audit:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: MANUAL
  e2e-stig-master-selinux-policytype:
    default_result: PASS
    result_after_remediation: PASS
@@ -681,8 +680,7 @@ rule_results:
    default_result: FAIL
    result_after_remediation: PASS
  e2e-stig-worker-partition-for-var-log-audit:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: MANUAL
  e2e-stig-worker-selinux-policytype:
    default_result: PASS
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-stig-4.18.yml
+++ b/tests/assertions/ocp4/rhcos4-stig-4.18.yml
@@ -324,8 +324,7 @@ rule_results:
    default_result: FAIL
    result_after_remediation: PASS
  e2e-stig-master-partition-for-var-log-audit:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: MANUAL
  e2e-stig-master-selinux-policytype:
    default_result: PASS
    result_after_remediation: PASS
@@ -681,8 +680,7 @@ rule_results:
    default_result: FAIL
    result_after_remediation: PASS
  e2e-stig-worker-partition-for-var-log-audit:
-   default_result: NOT-APPLICABLE
-   result_after_remediation: NOT-APPLICABLE
+   default_result: MANUAL
  e2e-stig-worker-selinux-policytype:
    default_result: PASS
    result_after_remediation: PASS


### PR DESCRIPTION
https://github.com/ComplianceAsCode/content/pull/12910 converted the
partition-for-var-log-audit rule to MANUAL. This commit updates the
testing assertions for RHCOS to match.
