### PR TITLE
Fix accounts_password_pam_retry

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
@@ -8,21 +8,24 @@
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="2">
     {{{ oval_metadata("The password retry should meet minimum requirements") }}}
-    <criteria operator="OR" comment="Conditions for retry are satisfied">
-      <criteria operator="AND" comment="Conditions for retry in PAM files are satisfied">
-        {{% for file in configuration_files %}}
-        <criterion comment="pam_pwquality has correctly set the retry argument in  {{{ file }}}"
-        test_ref="test_password_pam_pwquality_retry_{{{ file | escape_id }}}" />
-        {{% endfor %}}
-      </criteria>
-      <criteria operator="AND" comment="Conditions for retry in pwquality.conf file are satisfied">
-        {{% for file in configuration_files %}}
-        <criterion
-        comment="retry value not set in PAM files"
-        test_ref="test_password_pam_pwquality_retry_{{{ (file | escape_id) }}}_not_set"/>
-        {{% endfor %}}
-        <criterion comment="check retry parameter in pwquality.conf"
-        test_ref="test_password_pam_pwquality_retry_pwquality_conf"/>
+    <criteria operator="AND" comment="The password retry should meet minimum requirements">
+      <extend_definition definition_ref="enable_authselect"/>
+      <criteria operator="OR" comment="Conditions for retry are satisfied">
+        <criteria operator="AND" comment="Conditions for retry in PAM files are satisfied">
+          {{% for file in configuration_files %}}
+          <criterion comment="pam_pwquality has correctly set the retry argument in  {{{ file }}}"
+          test_ref="test_password_pam_pwquality_retry_{{{ file | escape_id }}}" />
+          {{% endfor %}}
+        </criteria>
+        <criteria operator="AND" comment="Conditions for retry in pwquality.conf file are satisfied">
+          {{% for file in configuration_files %}}
+          <criterion
+          comment="retry value not set in PAM files"
+          test_ref="test_password_pam_pwquality_retry_{{{ (file | escape_id) }}}_not_set"/>
+          {{% endfor %}}
+          <criterion comment="check retry parameter in pwquality.conf"
+          test_ref="test_password_pam_pwquality_retry_pwquality_conf"/>
+        </criteria>
       </criteria>
     </criteria>
   </definition>


### PR DESCRIPTION
The rule `accounts_password_pam_retry` failed after kickstart or Anaconda installation. The problem is that the rule passes in the initial scan but fails in the final scan because in the initial scan the rule `enable_authselect` fails and the remediation for `enable_authselect` made `accounts_password_pam_retry` fail but remediation for `accounts_password_pam_retry` isn't executed because it passed in the initial scan.

Fixes: #12277

Used test: `/hardening/anaconda/anssi_bp28_high` on RHEL 9

