### PR TITLE
Fix ansible platform in  `network_nmcli_permissions` for RHEL 9

### DIFF
--- a/linux_os/guide/system/network/network_nmcli_permissions/ansible/shared.yml
+++ b/linux_os/guide/system/network/network_nmcli_permissions/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 10,multi_platform_ol,multi_platform_rhv,multi_platform_fedora,multi_platform_almalinux
+# platform = multi_platform_ol,multi_platform_rhv,multi_platform_fedora,multi_platform_almalinux,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = low


### PR DESCRIPTION
#### Description:

Add `network_nmcli_permissions` to RHEL 9.

#### Rationale:

Fixes #13128
