### PR TITLE
CMP-3146,CMP-3147,CMP-3148: Deprecate old OCP STIG profiles and OCP CIS 1.5

### DIFF
--- a/products/ocp4/profiles/cis-1-5.profile
+++ b/products/ocp4/profiles/cis-1-5.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'CIS Red Hat OpenShift Container Platform 4 Benchmark'
 
 platform: ocp4
-
+status: deprecated
 metadata:
     SMEs:
         - JAORMX

--- a/products/ocp4/profiles/cis-node-1-5.profile
+++ b/products/ocp4/profiles/cis-node-1-5.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'CIS Red Hat OpenShift Container Platform 4 Benchmark'
 
 platform: ocp4-node
-
+status: deprecated
 metadata:
     SMEs:
         - JAORMX

--- a/products/ocp4/profiles/stig-node-v1r1.profile
+++ b/products/ocp4/profiles/stig-node-v1r1.profile
@@ -1,7 +1,7 @@
 documentation_complete: true
 
 platform: ocp4-node
-
+status: deprecated
 metadata:
     version: V1R1
     SMEs:

--- a/products/ocp4/profiles/stig-node-v2r1.profile
+++ b/products/ocp4/profiles/stig-node-v2r1.profile
@@ -1,7 +1,7 @@
 documentation_complete: true
 
 platform: ocp4-node
-
+status: deprecated
 metadata:
     version: V2R1
     SMEs:

--- a/products/ocp4/profiles/stig-v1r1.profile
+++ b/products/ocp4/profiles/stig-v1r1.profile
@@ -1,7 +1,7 @@
 documentation_complete: true
 
 platform: ocp4
-
+status: deprecated
 metadata:
     version: V1R1
     SMEs:

--- a/products/ocp4/profiles/stig-v2r1.profile
+++ b/products/ocp4/profiles/stig-v2r1.profile
@@ -1,7 +1,7 @@
 documentation_complete: true
 
 platform: ocp4
-
+status: deprecated
 metadata:
     version: V2R1
     SMEs:

--- a/products/rhcos4/profiles/stig-v1r1.profile
+++ b/products/rhcos4/profiles/stig-v1r1.profile
@@ -1,5 +1,6 @@
 documentation_complete: true
 
+status: deprecated
 metadata:
     version: V1R1
     SMEs:

--- a/products/rhcos4/profiles/stig-v2r1.profile
+++ b/products/rhcos4/profiles/stig-v2r1.profile
@@ -1,5 +1,6 @@
 documentation_complete: true
 
+status: deprecated
 metadata:
     version: V2R1
     SMEs:


### PR DESCRIPTION
#### Description:

- Deprecate OCP CIS 1.5 Profile
  - Newer OCP CIS 1.7 Profile is available
- Deprecate OCP STIG V1R1 and OCP STIG V2R1
   - Newer OCP STIG V2R2 Profile is available

#### Rationale:

- Removing outdated profile makes it easier to find relevant and valid profiles
- Deprecating profiles signals to users that they should change their scan configs