### PR TITLE
Fail if the build causes empty OCIL

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -3357,6 +3357,9 @@ class LinearLoader(object):
             test_actions.append(action)
             questions.append(boolean_question)
 
+        if len(questionnaires) == 0:
+            raise ValueError("No OCIL content found in the provided rules.")
+
     def _get_rules_from_benchmark(self, benchmark):
         """
         Retrieves a list of rules from the benchmark that are selected in all profiles.


### PR DESCRIPTION
If building a single rule data stream we need to check if the OCIL in that rule isn't empty otherwise we would build an invalid single rule data stream because it would have empty questionnaires element.



#### Review Hints:

1. Remove `ocil` and `ocil_clause` from your favorite rule (or create a new rule that doesn't have these keys).
2. Build a single rule thin data stream: `./build_product -r your_favorite_rule product_id`
