### PR TITLE
OPENSCAP-5464: Use more fine granular audit rules for E8 and ISM profiles in RHEL

### DIFF
--- a/controls/e8.yml
+++ b/controls/e8.yml
@@ -124,7 +124,11 @@ controls:
             - audit_rules_execution_seunshare
             - audit_rules_sysadmin_actions
             - audit_rules_networkconfig_modification
-            - audit_rules_usergroup_modification
+            - audit_rules_usergroup_modification_group
+            - audit_rules_usergroup_modification_gshadow
+            - audit_rules_usergroup_modification_opasswd
+            - audit_rules_usergroup_modification_passwd
+            - audit_rules_usergroup_modification_shadow
             - audit_rules_dac_modification_chmod
             - audit_rules_dac_modification_chown
             - audit_rules_kernel_module_loading

--- a/controls/e8.yml
+++ b/controls/e8.yml
@@ -110,7 +110,6 @@ controls:
             - audit_rules_login_events_tallylog
             - audit_rules_login_events_faillock
             - audit_rules_login_events_lastlog
-            - audit_rules_login_events
             - audit_rules_time_adjtimex
             - audit_rules_time_clock_settime
             - audit_rules_time_watch_localtime

--- a/controls/ism_o.yml
+++ b/controls/ism_o.yml
@@ -126,7 +126,12 @@ controls:
             - audit_access_success_ppc64le
             - audit_rules_privileged_commands
             - audit_rules_session_events
-            - audit_rules_unsuccessful_file_modification
+            - audit_rules_unsuccessful_file_modification_creat
+            - audit_rules_unsuccessful_file_modification_open
+            - audit_rules_unsuccessful_file_modification_openat
+            - audit_rules_unsuccessful_file_modification_open_by_handle_at
+            - audit_rules_unsuccessful_file_modification_truncate
+            - audit_rules_unsuccessful_file_modification_ftruncate
             - package_audit_installed
             - sshd_print_last_log
             - sebool_auditadm_exec_content
@@ -145,7 +150,12 @@ controls:
             - audit_access_success_ppc64le
             - audit_rules_privileged_commands
             - audit_rules_session_events
-            - audit_rules_unsuccessful_file_modification
+            - audit_rules_unsuccessful_file_modification_creat
+            - audit_rules_unsuccessful_file_modification_open
+            - audit_rules_unsuccessful_file_modification_openat
+            - audit_rules_unsuccessful_file_modification_open_by_handle_at
+            - audit_rules_unsuccessful_file_modification_truncate
+            - audit_rules_unsuccessful_file_modification_ftruncate
             - package_audit_installed
             - sshd_print_last_log
             - sebool_auditadm_exec_content

--- a/products/rhel10/profiles/e8.profile
+++ b/products/rhel10/profiles/e8.profile
@@ -36,5 +36,3 @@ selections:
     - '!package_rsh_removed'
     - '!package_rsh-server_removed'
     - '!security_patches_up_to_date'
-    # this rule fails after being remediated through Ansible
-    - '!audit_rules_usergroup_modification'

--- a/products/rhel8/profiles/e8.profile
+++ b/products/rhel8/profiles/e8.profile
@@ -123,7 +123,11 @@ selections:
   - audit_rules_execution_seunshare
   - audit_rules_sysadmin_actions
   - audit_rules_networkconfig_modification
-  - audit_rules_usergroup_modification
+  - audit_rules_usergroup_modification_group
+  - audit_rules_usergroup_modification_gshadow
+  - audit_rules_usergroup_modification_opasswd
+  - audit_rules_usergroup_modification_passwd
+  - audit_rules_usergroup_modification_shadow
   - audit_rules_dac_modification_chmod
   - audit_rules_dac_modification_chown
   - audit_rules_kernel_module_loading

--- a/products/rhel8/profiles/e8.profile
+++ b/products/rhel8/profiles/e8.profile
@@ -109,7 +109,6 @@ selections:
   - audit_rules_login_events_tallylog
   - audit_rules_login_events_faillock
   - audit_rules_login_events_lastlog
-  - audit_rules_login_events
   - audit_rules_time_adjtimex
   - audit_rules_time_clock_settime
   - audit_rules_time_watch_localtime

--- a/products/rhel8/profiles/ism_o.profile
+++ b/products/rhel8/profiles/ism_o.profile
@@ -105,7 +105,11 @@ selections:
   - sebool_auditadm_exec_content
   - audit_rules_privileged_commands
   - audit_rules_session_events
-  - audit_rules_unsuccessful_file_modification
+  - audit_rules_usergroup_modification_group
+  - audit_rules_usergroup_modification_gshadow
+  - audit_rules_usergroup_modification_opasswd
+  - audit_rules_usergroup_modification_passwd
+  - audit_rules_usergroup_modification_shadow
   - audit_access_failed
   - audit_access_success
 

--- a/products/rhel9/profiles/default.profile
+++ b/products/rhel9/profiles/default.profile
@@ -574,3 +574,6 @@ selections:
     - file_permissions_etc_audit_rulesd
     - configure_openssl_tls_crypto_policy
     - configure_openssl_crypto_policy
+    - audit_rules_login_events
+    - audit_rules_usergroup_modification
+    - audit_rules_unsuccessful_file_modification

--- a/products/rhel9/profiles/e8.profile
+++ b/products/rhel9/profiles/e8.profile
@@ -107,7 +107,6 @@ selections:
   - audit_rules_login_events_tallylog
   - audit_rules_login_events_faillock
   - audit_rules_login_events_lastlog
-  - audit_rules_login_events
   - audit_rules_time_adjtimex
   - audit_rules_time_clock_settime
   - audit_rules_time_watch_localtime

--- a/products/rhel9/profiles/e8.profile
+++ b/products/rhel9/profiles/e8.profile
@@ -121,7 +121,11 @@ selections:
   - audit_rules_execution_seunshare
   - audit_rules_sysadmin_actions
   - audit_rules_networkconfig_modification
-  - audit_rules_usergroup_modification
+  - audit_rules_usergroup_modification_group
+  - audit_rules_usergroup_modification_gshadow
+  - audit_rules_usergroup_modification_opasswd
+  - audit_rules_usergroup_modification_passwd
+  - audit_rules_usergroup_modification_shadow
   - audit_rules_dac_modification_chmod
   - audit_rules_dac_modification_chown
   - audit_rules_kernel_module_loading

--- a/products/rhel9/profiles/ism_o.profile
+++ b/products/rhel9/profiles/ism_o.profile
@@ -105,7 +105,11 @@ selections:
   - sebool_auditadm_exec_content
   - audit_rules_privileged_commands
   - audit_rules_session_events
-  - audit_rules_unsuccessful_file_modification
+  - audit_rules_usergroup_modification_group
+  - audit_rules_usergroup_modification_gshadow
+  - audit_rules_usergroup_modification_opasswd
+  - audit_rules_usergroup_modification_passwd
+  - audit_rules_usergroup_modification_shadow
   - audit_access_failed
   - audit_access_success
 

--- a/tests/data/profile_stability/rhel10/e8.profile
+++ b/tests/data/profile_stability/rhel10/e8.profile
@@ -32,7 +32,6 @@ selections:
 - audit_rules_execution_setsebool
 - audit_rules_execution_seunshare
 - audit_rules_kernel_module_loading
-- audit_rules_login_events
 - audit_rules_login_events_faillock
 - audit_rules_login_events_lastlog
 - audit_rules_login_events_tallylog
@@ -43,6 +42,11 @@ selections:
 - audit_rules_time_settimeofday
 - audit_rules_time_stime
 - audit_rules_time_watch_localtime
+- audit_rules_usergroup_modification_group
+- audit_rules_usergroup_modification_gshadow
+- audit_rules_usergroup_modification_opasswd
+- audit_rules_usergroup_modification_passwd
+- audit_rules_usergroup_modification_shadow
 - auditd_data_retention_flush
 - auditd_freq
 - auditd_local_events

--- a/tests/data/profile_stability/rhel10/ism_o.profile
+++ b/tests/data/profile_stability/rhel10/ism_o.profile
@@ -60,7 +60,6 @@ selections:
 - audit_rules_execution_setsebool
 - audit_rules_execution_seunshare
 - audit_rules_kernel_module_loading
-- audit_rules_login_events
 - audit_rules_login_events_faillock
 - audit_rules_networkconfig_modification
 - audit_rules_privileged_commands
@@ -71,7 +70,17 @@ selections:
 - audit_rules_time_settimeofday
 - audit_rules_time_stime
 - audit_rules_time_watch_localtime
-- audit_rules_unsuccessful_file_modification
+- audit_rules_unsuccessful_file_modification_creat
+- audit_rules_unsuccessful_file_modification_ftruncate
+- audit_rules_unsuccessful_file_modification_open
+- audit_rules_unsuccessful_file_modification_open_by_handle_at
+- audit_rules_unsuccessful_file_modification_openat
+- audit_rules_unsuccessful_file_modification_truncate
+- audit_rules_usergroup_modification_group
+- audit_rules_usergroup_modification_gshadow
+- audit_rules_usergroup_modification_opasswd
+- audit_rules_usergroup_modification_passwd
+- audit_rules_usergroup_modification_shadow
 - auditd_data_retention_flush
 - auditd_freq
 - auditd_local_events

--- a/tests/data/profile_stability/rhel10/ism_o_secret.profile
+++ b/tests/data/profile_stability/rhel10/ism_o_secret.profile
@@ -63,7 +63,6 @@ selections:
 - audit_rules_execution_setsebool
 - audit_rules_execution_seunshare
 - audit_rules_kernel_module_loading
-- audit_rules_login_events
 - audit_rules_login_events_faillock
 - audit_rules_networkconfig_modification
 - audit_rules_privileged_commands
@@ -74,7 +73,17 @@ selections:
 - audit_rules_time_settimeofday
 - audit_rules_time_stime
 - audit_rules_time_watch_localtime
-- audit_rules_unsuccessful_file_modification
+- audit_rules_unsuccessful_file_modification_creat
+- audit_rules_unsuccessful_file_modification_ftruncate
+- audit_rules_unsuccessful_file_modification_open
+- audit_rules_unsuccessful_file_modification_open_by_handle_at
+- audit_rules_unsuccessful_file_modification_openat
+- audit_rules_unsuccessful_file_modification_truncate
+- audit_rules_usergroup_modification_group
+- audit_rules_usergroup_modification_gshadow
+- audit_rules_usergroup_modification_opasswd
+- audit_rules_usergroup_modification_passwd
+- audit_rules_usergroup_modification_shadow
 - auditd_data_retention_flush
 - auditd_freq
 - auditd_local_events

--- a/tests/data/profile_stability/rhel10/ism_o_top_secret.profile
+++ b/tests/data/profile_stability/rhel10/ism_o_top_secret.profile
@@ -60,7 +60,6 @@ selections:
 - audit_rules_execution_setsebool
 - audit_rules_execution_seunshare
 - audit_rules_kernel_module_loading
-- audit_rules_login_events
 - audit_rules_login_events_faillock
 - audit_rules_networkconfig_modification
 - audit_rules_privileged_commands
@@ -71,7 +70,17 @@ selections:
 - audit_rules_time_settimeofday
 - audit_rules_time_stime
 - audit_rules_time_watch_localtime
-- audit_rules_unsuccessful_file_modification
+- audit_rules_unsuccessful_file_modification_creat
+- audit_rules_unsuccessful_file_modification_ftruncate
+- audit_rules_unsuccessful_file_modification_open
+- audit_rules_unsuccessful_file_modification_open_by_handle_at
+- audit_rules_unsuccessful_file_modification_openat
+- audit_rules_unsuccessful_file_modification_truncate
+- audit_rules_usergroup_modification_group
+- audit_rules_usergroup_modification_gshadow
+- audit_rules_usergroup_modification_opasswd
+- audit_rules_usergroup_modification_passwd
+- audit_rules_usergroup_modification_shadow
 - auditd_data_retention_flush
 - auditd_freq
 - auditd_local_events

--- a/tests/data/profile_stability/rhel8/e8.profile
+++ b/tests/data/profile_stability/rhel8/e8.profile
@@ -9,8 +9,15 @@ description: 'This profile contains configuration checks for Red Hat Enterprise 
     ACSC website:
 
 
-    https://www.cyber.gov.au/publications/essential-eight-in-linux-environments'
-documentation_complete: true
+    https://www.cyber.gov.au/acsc/view-all-content/publications/hardening-linux-workstations-and-servers'
+extends: null
+hidden: ''
+status: ''
+metadata:
+    SMEs:
+    - shaneboulden
+    - tjbutt58
+reference: https://www.cyber.gov.au/acsc/view-all-content/publications/hardening-linux-workstations-and-servers
 selections:
 - accounts_no_uid_except_zero
 - audit_rules_dac_modification_chmod
@@ -22,7 +29,6 @@ selections:
 - audit_rules_execution_setsebool
 - audit_rules_execution_seunshare
 - audit_rules_kernel_module_loading
-- audit_rules_login_events
 - audit_rules_login_events_faillock
 - audit_rules_login_events_lastlog
 - audit_rules_login_events_tallylog
@@ -33,7 +39,11 @@ selections:
 - audit_rules_time_settimeofday
 - audit_rules_time_stime
 - audit_rules_time_watch_localtime
-- audit_rules_usergroup_modification
+- audit_rules_usergroup_modification_group
+- audit_rules_usergroup_modification_gshadow
+- audit_rules_usergroup_modification_opasswd
+- audit_rules_usergroup_modification_passwd
+- audit_rules_usergroup_modification_shadow
 - auditd_data_retention_flush
 - auditd_freq
 - auditd_local_events
@@ -115,4 +125,11 @@ selections:
 - var_authselect_profile=sssd
 - var_auditd_flush=incremental_async
 - var_system_crypto_policy=default_nosha1
+unselected_groups: []
+platforms: !!set {}
+cpe_names: !!set {}
+platform: null
+filter_rules: ''
+policies: []
 title: Australian Cyber Security Centre (ACSC) Essential Eight
+documentation_complete: true


### PR DESCRIPTION
#### Description:

- Use more fine granular audit rules for E8 and ISM profiles in RHEL

#### Rationale:

- These fine granular rules contain Ansible remediation which makes the content more complete.

Fixes #13125
