### PR TITLE
OCPBUGS-47485: Only list CLO ouput urls when they exist

### DIFF
--- a/applications/openshift/logging/audit_log_forwarding_uses_tls/rule.yml
+++ b/applications/openshift/logging/audit_log_forwarding_uses_tls/rule.yml
@@ -32,7 +32,7 @@ ocil_clause: 'Logs are not forwarded outside the cluster using TLS'
 
 ocil: |-
     Run the following command:
-    <pre>{{{ ocil_oc_pipe_jq_filter('clusterlogforwarders', 'try [.items[].spec.outputs[][]|objects|.url] catch []', namespace="openshift-logging") }}}</pre>
+    <pre>{{{ ocil_oc_pipe_jq_filter('clusterlogforwarders', 'try [.items[].spec.outputs[][]|objects|selece(.url != null).url] catch []', namespace="openshift-logging") }}}</pre>
     The output should return a list of URL entries with <pre>https://</pre> or <pre>tls://</pre> transport.
 
 warnings:
@@ -40,5 +40,5 @@ warnings:
     {{{ openshift_cluster_setting() | indent(4) }}}
     {{{ openshift_filtered_cluster_setting_suppressed({
             "/apis/logging.openshift.io/v1/namespaces/openshift-logging/clusterlogforwarders/instance": 'try [.spec.outputs[].url] catch []',
-            "/apis/observability.openshift.io/v1/namespaces/openshift-logging/clusterlogforwarders": 'try [.items[].spec.outputs[][]|objects|.url] catch []',
+            "/apis/observability.openshift.io/v1/namespaces/openshift-logging/clusterlogforwarders": 'try [.items[].spec.outputs[][]|objects|select(.url != null).url] catch []',
         }) | indent(4) }}}

--- a/applications/openshift/logging/audit_log_forwarding_uses_tls_observability_api/rule.yml
+++ b/applications/openshift/logging/audit_log_forwarding_uses_tls_observability_api/rule.yml
@@ -39,7 +39,7 @@ warnings:
 - general: |-
     {{{ openshift_cluster_setting() | indent(4) }}}
     {{{ openshift_filtered_cluster_setting_suppressed({
-            "/apis/observability.openshift.io/v1/namespaces/openshift-logging/clusterlogforwarders": 'try [.items[].spec.outputs[][]|objects|.url] catch []',
+            "/apis/observability.openshift.io/v1/namespaces/openshift-logging/clusterlogforwarders": 'try [.items[].spec.outputs[][]|objects|(select(.url != null).url] catch []',
         }) | indent(4) }}}
 
 template:
@@ -50,7 +50,7 @@ template:
     # The log forwarder outputs consist of an object and two strings (name and type).
     # The url is part of the object and its name will vary depending on its type.
     # By using the objects filter we ensure we are getting the object to query for its url.
-    filepath: "{{{ openshift_filtered_path('/apis/observability.openshift.io/v1/namespaces/openshift-logging/clusterlogforwarders', 'try [.items[].spec.outputs[][]|objects|.url] catch []') }}}"
+    filepath: "{{{ openshift_filtered_path('/apis/observability.openshift.io/v1/namespaces/openshift-logging/clusterlogforwarders', 'try [.items[].spec.outputs[][]|objects|select(.url != null).url] catch []') }}}"
     yamlpath: "[:]"
     entity_check: "all"
     values:


### PR DESCRIPTION


#### Description:

- This changes the jq filter to grab on the maps that have a url key.
#### Rationale:

- When the output had more than one map, it would try to list the url of all them.
- Fixes: https://issues.redhat.com/browse/OCPBUGS-47485