### PR TITLE
Add `mount[boot-efi]` platform to mount_option_boot_efi_nosuid rule

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/rule.yml
@@ -28,6 +28,8 @@ references:
     stigid@ol8: OL08-00-010572
     stigid@rhel8: RHEL-08-010572
 
+platform: mount[boot-efi]
+
 template:
     name: mount_option
     vars:

--- a/shared/applicability/mount.yml
+++ b/shared/applicability/mount.yml
@@ -7,18 +7,20 @@ template:
   name: platform_mount
 args:
   home:
-      mountpoint: /home
+    mountpoint: /home
   opt:
-      mountpoint: /opt
+    mountpoint: /opt
   srv:
-      mountpoint: /srv
+    mountpoint: /srv
   tmp:
     mountpoint: /tmp
   var:
-      mountpoint: /var
+    mountpoint: /var
   var-log:
-      mountpoint: /var/log
+    mountpoint: /var/log
   var-log-audit:
-      mountpoint: /var/log/audit
+    mountpoint: /var/log/audit
   var-tmp:
     mountpoint: /var/tmp
+  boot-efi:
+    mountpoint: /boot/efi


### PR DESCRIPTION
#### Description:

- Make the rule explicitly not applicable.

#### Rationale:

- In order to get closer to the DISA understanding of the applicability for this rule, let's make it not applicable when there is no mountpoint present.

- Fixes #13006.

#### Review Hints:

- While platform does not exactly follow the DISA applicability criteria, it'd match the behavior in general. For the cases when it won't it actually would be very useful to check the presence of the mount option (e.g. in double-boot systems, when partition is present, but the system is currently in BIOS mode).