### PR TITLE
Align chronyd makestep value with Ubuntu STIGs

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_sync_clock/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_sync_clock/rule.yml
@@ -1,10 +1,6 @@
 documentation_complete: true
 
-{{% if product in ['ubuntu2204', 'ubuntu2404'] -%}}
-{{% set step_value = '1 1' -%}}
-{{% else -%}}
 {{% set step_value = '1 -1' -%}}
-{{% endif -%}}
 
 title: 'Synchronize internal information system clocks'
 


### PR DESCRIPTION
#### Description:

- Align chrony makestep value with Ubuntu STIGs 22.04 V2R3 and 24.04 V1R1

