### PR TITLE
SLE15 Use socket disable template for telnet

### DIFF
--- a/linux_os/guide/services/obsolete/telnet/service_telnet_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/telnet/service_telnet_disabled/rule.yml
@@ -42,8 +42,16 @@ warnings:
        is disabled by the following line: <tt>disable = yes</tt>. Note that the xinetd file for
        telnet is not created automatically, therefore it might have different names.
 
+{{% if "sle15" in product %}}
+template:
+    name: socket_disabled
+    vars:
+        socketname: telnet
+        packagename: telnet-server
+{{% else %}}
 template:
     name: service_disabled
     vars:
         servicename: telnet
         packagename: telnet-server
+{{% endif %}}


### PR DESCRIPTION
#### Description:

- Use telnet.socket , since it is the way to enable/disable/start/stop telnet server on the system

#### Rationale:

- Use socket_disable template