### PR TITLE
Add missing RHEL8 stig id to rootfiles_configured

### DIFF
--- a/linux_os/guide/system/permissions/files/rootfiles/rootfiles_configured/rule.yml
+++ b/linux_os/guide/system/permissions/files/rootfiles/rootfiles_configured/rule.yml
@@ -27,6 +27,7 @@ identifiers:
 references:
     disa: CCI-000366
     srg: SRG-OS-000480-GPOS-00227
+    stigid@rhel8: RHEL-08-010770
 
 ocil_clause: 'that rootfiles are not configured correctly'
 


### PR DESCRIPTION
#### Description:

Fix issue with test that checks that all rules have STIG id assigned in RHEL8 where we don't use the auto stid id assignment from the control file.

```
 	8 	x86_64 	fail 	/static-checks/rule-identifiers/stig/rootfiles_configured 		missing https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
	8 	x86_64 	fail 	/static-checks/rule-identifiers 	output.txt 	
```
