### PR TITLE
OCPBUGS-52884: Exclude file integrity operator checks from ARM clusters

### DIFF
--- a/applications/openshift/integrity/file_integrity_exists/rule.yml
+++ b/applications/openshift/integrity/file_integrity_exists/rule.yml
@@ -1,6 +1,8 @@
 
 title: Ensure that File Integrity Operator is scanning the cluster
 
+platform: not_aarch64_arch
+
 description: |-
   {{{ weblink(link="https://docs.openshift.com/container-platform/4.7/security/file_integrity_operator/file-integrity-operator-understanding.html",
               text="The File Integrity Operator") }}}

--- a/tests/assertions/ocp4/ocp4-high-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.12.yml
@@ -231,8 +231,8 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-high-file-integrity-exists:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-file-integrity-notification-enabled:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.13.yml
@@ -226,8 +226,8 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-high-file-integrity-exists:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-file-integrity-notification-enabled:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.14.yml
@@ -226,8 +226,8 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-high-file-integrity-exists:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-file-integrity-notification-enabled:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.15.yml
@@ -230,8 +230,8 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-high-file-integrity-exists:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-file-integrity-notification-enabled:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.16.yml
@@ -230,8 +230,8 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-high-file-integrity-exists:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-file-integrity-notification-enabled:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.17.yml
@@ -231,8 +231,8 @@ rule_results:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE
  e2e-high-file-integrity-exists:
-   default_result: FAIL
-   result_after_remediation: PASS
+   default_result: FAIL or NOT-APPLICABLE
+   result_after_remediation: PASS or NOT-APPLICABLE
  e2e-high-file-integrity-notification-enabled:
    default_result: FAIL
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.18.yml
@@ -231,8 +231,8 @@ rule_results:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE
  e2e-high-file-integrity-exists:
-   default_result: FAIL
-   result_after_remediation: PASS
+   default_result: FAIL or NOT-APPLICABLE
+   result_after_remediation: PASS or NOT-APPLICABLE
  e2e-high-file-integrity-notification-enabled:
    default_result: FAIL
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.12.yml
@@ -225,8 +225,8 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-moderate-file-integrity-exists:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-file-integrity-notification-enabled:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.13.yml
@@ -224,8 +224,8 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-moderate-file-integrity-exists:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-file-integrity-notification-enabled:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.14.yml
@@ -224,8 +224,8 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-moderate-file-integrity-exists:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-file-integrity-notification-enabled:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.15.yml
@@ -221,8 +221,8 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-moderate-file-integrity-exists:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-file-integrity-notification-enabled:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.16.yml
@@ -224,8 +224,8 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-moderate-file-integrity-exists:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-file-integrity-notification-enabled:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.17.yml
@@ -225,8 +225,8 @@ rule_results:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE
  e2e-moderate-file-integrity-exists:
-   default_result: FAIL
-   result_after_remediation: PASS
+   default_result: FAIL or NOT-APPLICABLE
+   result_after_remediation: PASS or NOT-APPLICABLE
  e2e-moderate-file-integrity-notification-enabled:
    default_result: FAIL
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.18.yml
@@ -225,8 +225,8 @@ rule_results:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE
  e2e-moderate-file-integrity-exists:
-   default_result: FAIL
-   result_after_remediation: PASS
+   default_result: FAIL or NOT-APPLICABLE
+   result_after_remediation: PASS or NOT-APPLICABLE
  e2e-moderate-file-integrity-notification-enabled:
    default_result: FAIL
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.12.yml
@@ -192,8 +192,8 @@ rule_results:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE
  e2e-pci-dss-4-0-file-integrity-exists:
-   default_result: FAIL
-   result_after_remediation: PASS
+   default_result: FAIL or NOT-APPLICABLE
+   result_after_remediation: PASS or NOT-APPLICABLE
  e2e-pci-dss-4-0-file-integrity-notification-enabled:
    default_result: FAIL
    result_after_remediation: PASS
@@ -352,4 +352,4 @@ rule_results:
    result_after_remediation: PASS
  e2e-pci-dss-4-0-tls-version-check-router:
    default_result: PASS
-   result_after_remediation: PASS 
+   result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.13.yml
@@ -192,8 +192,8 @@ rule_results:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE
  e2e-pci-dss-4-0-file-integrity-exists:
-   default_result: FAIL
-   result_after_remediation: PASS
+   default_result: FAIL or NOT-APPLICABLE
+   result_after_remediation: PASS or NOT-APPLICABLE
  e2e-pci-dss-4-0-file-integrity-notification-enabled:
    default_result: FAIL
    result_after_remediation: PASS
@@ -352,4 +352,4 @@ rule_results:
    result_after_remediation: PASS
  e2e-pci-dss-4-0-tls-version-check-router:
    default_result: PASS
-   result_after_remediation: PASS 
+   result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.14.yml
@@ -192,8 +192,8 @@ rule_results:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE
  e2e-pci-dss-4-0-file-integrity-exists:
-   default_result: FAIL
-   result_after_remediation: PASS
+   default_result: FAIL or NOT-APPLICABLE
+   result_after_remediation: PASS or NOT-APPLICABLE
  e2e-pci-dss-4-0-file-integrity-notification-enabled:
    default_result: FAIL
    result_after_remediation: PASS
@@ -352,4 +352,4 @@ rule_results:
    result_after_remediation: PASS
  e2e-pci-dss-4-0-tls-version-check-router:
    default_result: PASS
-   result_after_remediation: PASS 
+   result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.15.yml
@@ -192,8 +192,8 @@ rule_results:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE
  e2e-pci-dss-4-0-file-integrity-exists:
-   default_result: FAIL
-   result_after_remediation: PASS
+   default_result: FAIL or NOT-APPLICABLE
+   result_after_remediation: PASS or NOT-APPLICABLE
  e2e-pci-dss-4-0-file-integrity-notification-enabled:
    default_result: FAIL
    result_after_remediation: PASS
@@ -352,4 +352,4 @@ rule_results:
    result_after_remediation: PASS
  e2e-pci-dss-4-0-tls-version-check-router:
    default_result: PASS
-   result_after_remediation: PASS 
+   result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.16.yml
@@ -192,8 +192,8 @@ rule_results:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE
  e2e-pci-dss-4-0-file-integrity-exists:
-   default_result: FAIL
-   result_after_remediation: PASS
+   default_result: FAIL or NOT-APPLICABLE
+   result_after_remediation: PASS or NOT-APPLICABLE
  e2e-pci-dss-4-0-file-integrity-notification-enabled:
    default_result: FAIL
    result_after_remediation: PASS
@@ -352,4 +352,4 @@ rule_results:
    result_after_remediation: PASS
  e2e-pci-dss-4-0-tls-version-check-router:
    default_result: PASS
-   result_after_remediation: PASS 
+   result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.17.yml
@@ -192,8 +192,8 @@ rule_results:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE
  e2e-pci-dss-4-0-file-integrity-exists:
-   default_result: FAIL
-   result_after_remediation: PASS
+   default_result: FAIL or NOT-APPLICABLE
+   result_after_remediation: PASS or NOT-APPLICABLE
  e2e-pci-dss-4-0-file-integrity-notification-enabled:
    default_result: FAIL
    result_after_remediation: PASS
@@ -352,4 +352,4 @@ rule_results:
    result_after_remediation: PASS
  e2e-pci-dss-4-0-tls-version-check-router:
    default_result: PASS
-   result_after_remediation: PASS 
+   result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.18.yml
@@ -192,8 +192,8 @@ rule_results:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE
  e2e-pci-dss-4-0-file-integrity-exists:
-   default_result: FAIL
-   result_after_remediation: PASS
+   default_result: FAIL or NOT-APPLICABLE
+   result_after_remediation: PASS or NOT-APPLICABLE
  e2e-pci-dss-4-0-file-integrity-notification-enabled:
    default_result: FAIL
    result_after_remediation: PASS
@@ -352,4 +352,4 @@ rule_results:
    result_after_remediation: PASS
  e2e-pci-dss-4-0-tls-version-check-router:
    default_result: PASS
-   result_after_remediation: PASS 
+   result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.12.yml
@@ -186,8 +186,8 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-pci-dss-file-integrity-exists:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-file-integrity-notification-enabled:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.13.yml
@@ -185,8 +185,8 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-pci-dss-file-integrity-exists:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-file-integrity-notification-enabled:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.14.yml
@@ -185,8 +185,8 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-pci-dss-file-integrity-exists:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-file-integrity-notification-enabled:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.15.yml
@@ -185,8 +185,8 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-pci-dss-file-integrity-exists:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-file-integrity-notification-enabled:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.16.yml
@@ -185,8 +185,8 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-pci-dss-file-integrity-exists:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-file-integrity-notification-enabled:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.17.yml
@@ -186,8 +186,8 @@ rule_results:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE
  e2e-pci-dss-file-integrity-exists:
-   default_result: FAIL
-   result_after_remediation: PASS
+   default_result: FAIL or NOT-APPLICABLE
+   result_after_remediation: PASS or NOT-APPLICABLE
  e2e-pci-dss-file-integrity-notification-enabled:
    default_result: FAIL
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.18.yml
@@ -186,8 +186,8 @@ rule_results:
    default_result: NOT-APPLICABLE
    result_after_remediation: NOT-APPLICABLE
  e2e-pci-dss-file-integrity-exists:
-   default_result: FAIL
-   result_after_remediation: PASS
+   default_result: FAIL or NOT-APPLICABLE
+   result_after_remediation: PASS or NOT-APPLICABLE
  e2e-pci-dss-file-integrity-notification-enabled:
    default_result: FAIL
    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-stig-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.12.yml
@@ -195,8 +195,8 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-stig-file-integrity-exists:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-stig-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.13.yml
@@ -194,8 +194,8 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-stig-file-integrity-exists:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-stig-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.14.yml
@@ -194,8 +194,8 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-stig-file-integrity-exists:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-stig-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.15.yml
@@ -194,8 +194,8 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-stig-file-integrity-exists:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-stig-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.16.yml
@@ -194,8 +194,8 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-stig-file-integrity-exists:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-stig-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.17.yml
@@ -195,8 +195,8 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-stig-file-integrity-exists:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-stig-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.18.yml
@@ -195,8 +195,8 @@ rule_results:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
   e2e-stig-file-integrity-exists:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE


### PR DESCRIPTION
FIO isn't supported on ARM, yet. Updating the file_integrity_exists rule
to make it not applicable for ARM64 clusters.
