### PR TITLE
OCPBUGS-52885: Exclude FIO notification check on ARM64

### DIFF
--- a/applications/openshift/general/file_integrity_notification_enabled/rule.yml
+++ b/applications/openshift/general/file_integrity_notification_enabled/rule.yml
@@ -1,11 +1,13 @@
 
 title: Ensure the notification is enabled for file integrity operator
 
+platform: x86_64_arch and not ocp4-on-hypershift
+
 description: |-
   The OpenShift platform provides the File Integrity Operator to monitor for unwanted
   file changes, and this control ensures proper notification alert is enabled so that system
   administrators and security personnel are notified about the alerts
-  
+
 rationale: |-
   File Integrity Operator is able to send out alerts
 
@@ -18,7 +20,6 @@ references:
   nist: SI-6,SI-7(2),SI-4(24)
   pcidss: Req-11.5.1,Req-12.10.5
 
-platform: not ocp4-on-hypershift
 
 {{% set jqfilter = '[.items[] | select(.metadata.name =="file-integrity") | .metadata.name]' %}}
 

--- a/applications/openshift/integrity/file_integrity_exists/rule.yml
+++ b/applications/openshift/integrity/file_integrity_exists/rule.yml
@@ -1,7 +1,7 @@
 
 title: Ensure that File Integrity Operator is scanning the cluster
 
-platform: not_aarch64_arch
+platform: x86_64_arch and not ocp4-on-hypershift
 
 description: |-
   {{{ weblink(link="https://docs.openshift.com/container-platform/4.7/security/file_integrity_operator/file-integrity-operator-understanding.html",
@@ -24,8 +24,6 @@ references:
   nist: SC-4(23),SI-6,SI-7,SI-7(1),CM-6(a),SI-7(2),SI-4(24)
   pcidss: Req-10.5.5,Req-11.5
   srg: SRG-APP-000516-CTR-001325
-
-platform: not ocp4-on-hypershift
 
 ocil_clause: 'File integrity Operator is not installed'
 

--- a/tests/assertions/ocp4/ocp4-high-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.12.yml
@@ -234,8 +234,8 @@ rule_results:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-file-integrity-notification-enabled:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-high-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.13.yml
@@ -229,8 +229,8 @@ rule_results:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-file-integrity-notification-enabled:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-high-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.14.yml
@@ -229,8 +229,8 @@ rule_results:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-file-integrity-notification-enabled:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-high-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.15.yml
@@ -233,8 +233,8 @@ rule_results:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-file-integrity-notification-enabled:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-high-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.16.yml
@@ -233,8 +233,8 @@ rule_results:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-file-integrity-notification-enabled:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-high-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.17.yml
@@ -234,8 +234,8 @@ rule_results:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-file-integrity-notification-enabled:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-high-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.18.yml
@@ -234,8 +234,8 @@ rule_results:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-file-integrity-notification-enabled:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-moderate-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.12.yml
@@ -228,8 +228,8 @@ rule_results:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-file-integrity-notification-enabled:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-moderate-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.13.yml
@@ -227,8 +227,8 @@ rule_results:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-file-integrity-notification-enabled:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-moderate-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.14.yml
@@ -227,8 +227,8 @@ rule_results:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-file-integrity-notification-enabled:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-moderate-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.15.yml
@@ -224,8 +224,8 @@ rule_results:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-file-integrity-notification-enabled:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-moderate-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.16.yml
@@ -227,8 +227,8 @@ rule_results:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-file-integrity-notification-enabled:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-moderate-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.17.yml
@@ -228,8 +228,8 @@ rule_results:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-file-integrity-notification-enabled:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-moderate-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.18.yml
@@ -228,8 +228,8 @@ rule_results:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-file-integrity-notification-enabled:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.12.yml
@@ -195,8 +195,8 @@ rule_results:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-file-integrity-notification-enabled:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.13.yml
@@ -195,8 +195,8 @@ rule_results:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-file-integrity-notification-enabled:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.14.yml
@@ -195,8 +195,8 @@ rule_results:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-file-integrity-notification-enabled:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.15.yml
@@ -195,8 +195,8 @@ rule_results:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-file-integrity-notification-enabled:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.16.yml
@@ -195,8 +195,8 @@ rule_results:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-file-integrity-notification-enabled:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.17.yml
@@ -195,8 +195,8 @@ rule_results:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-file-integrity-notification-enabled:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.18.yml
@@ -195,8 +195,8 @@ rule_results:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-file-integrity-notification-enabled:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.12.yml
@@ -189,8 +189,8 @@ rule_results:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-file-integrity-notification-enabled:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.13.yml
@@ -188,8 +188,8 @@ rule_results:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-file-integrity-notification-enabled:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.14.yml
@@ -188,8 +188,8 @@ rule_results:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-file-integrity-notification-enabled:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.15.yml
@@ -188,8 +188,8 @@ rule_results:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-file-integrity-notification-enabled:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.16.yml
@@ -188,8 +188,8 @@ rule_results:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-file-integrity-notification-enabled:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.17.yml
@@ -189,8 +189,8 @@ rule_results:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-file-integrity-notification-enabled:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.18.yml
@@ -189,8 +189,8 @@ rule_results:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-file-integrity-notification-enabled:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-file-owner-proxy-kubeconfig:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE


### PR DESCRIPTION
Since FIO isn't supported on ARM, we can disable the notification check
rule on that platform, too.
