### PR TITLE
Update rule package_bind_removed for RHEL 9.6

### DIFF
--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -579,7 +579,7 @@ The only way to remediate is to recompile and reinstall the kernel, so no remedi
 -   Languages: Anaconda, Ansible, Bash, OVAL, Puppet, Blueprint, Kickstart, Bootc
 
 #### package_removed
--   Checks if the given package is not installed.
+-   Checks if the given package(s) are not installed.
 
 -   Parameters:
 

--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -583,7 +583,8 @@ The only way to remediate is to recompile and reinstall the kernel, so no remedi
 
 -   Parameters:
 
-    -   **pkgname** - name of the RPM or DEB package, eg. `tmux`
+    -   **pkgname** - name of the RPM or DEB package, eg. `tmux`.
+        Can be either a name of a single package or a list of names.
 
 -   Languages: Anaconda, Ansible, Bash, OVAL, Puppet, Kickstart, Bootc
 

--- a/linux_os/guide/services/dns/disabling_dns_server/package_bind_removed/rule.yml
+++ b/linux_os/guide/services/dns/disabling_dns_server/package_bind_removed/rule.yml
@@ -5,6 +5,10 @@ title: 'Uninstall bind Package'
 description: |-
     The <tt>named</tt> service is provided by the <tt>bind</tt> package.
     {{{ describe_package_remove(package="bind") }}}
+    {{% if product == "rhel9" %}}
+    On Red Hat Enterprise Linux 9.6 and newer, the <tt>bind</tt> command is also provided by the <tt>bind9.18</tt> package.
+    {{{ describe_package_remove(package="bind9.18") }}}
+    {{% endif %}}
 
 rationale: |-
     If there is no need to make DNS server software available,

--- a/linux_os/guide/services/dns/disabling_dns_server/package_bind_removed/rule.yml
+++ b/linux_os/guide/services/dns/disabling_dns_server/package_bind_removed/rule.yml
@@ -41,6 +41,9 @@ template:
     name: package_removed
     vars:
         pkgname: bind
+        pkgname@rhel9:
+            - bind
+            - bind9.18
         pkgname@ubuntu1604: bind9
         pkgname@ubuntu1804: bind9
         pkgname@ubuntu2004: bind9

--- a/shared/templates/package_removed/anaconda.template
+++ b/shared/templates/package_removed/anaconda.template
@@ -4,4 +4,6 @@
 # complexity = low
 # disruption = low
 
-package --remove={{{ PKGNAME }}}
+{{% for package in PACKAGES %}}
+package --remove={{{ package }}}
+{{% endfor %}}

--- a/shared/templates/package_removed/ansible.template
+++ b/shared/templates/package_removed/ansible.template
@@ -3,8 +3,10 @@
 # strategy = disable
 # complexity = low
 # disruption = low
-- name: Ensure {{{ PKGNAME }}} is removed
-  package:
-    name: "{{{ PKGNAME }}}"
-    state: absent
 
+{{% for package in PACKAGES %}}
+- name: "{{{ rule_title }}}: Ensure {{{ package }}} is removed"
+  package:
+    name: "{{{ package }}}"
+    state: absent
+{{% endfor %}}

--- a/shared/templates/package_removed/bash.template
+++ b/shared/templates/package_removed/bash.template
@@ -4,10 +4,12 @@
 # complexity = low
 # disruption = low
 
-# CAUTION: This remediation script will remove {{{ PKGNAME }}}
-#	   from the system, and may remove any packages
-#	   that depend on {{{ PKGNAME }}}. Execute this
-#	   remediation AFTER testing on a non-production
-#	   system!
+# CAUTION: This remediation script will remove {{{ PACKAGES | join(" and ") }}}
+# from the system, and may remove any packages
+# that depend on {{{ PACKAGES | join(" and ") }}}. Execute this
+# remediation AFTER testing on a non-production
+# system!
 
-{{{ bash_package_remove(package=PKGNAME) }}}
+{{% for package in PACKAGES %}}
+{{{ bash_package_remove(package=package) }}}
+{{% endfor %}}

--- a/shared/templates/package_removed/bootc.template
+++ b/shared/templates/package_removed/bootc.template
@@ -4,4 +4,6 @@
 # complexity = low
 # disruption = low
 
-dnf remove {{{ PKGNAME }}}
+{{% for package in PACKAGES %}}
+dnf remove {{{ package }}}
+{{% endfor %}}

--- a/shared/templates/package_removed/kickstart.template
+++ b/shared/templates/package_removed/kickstart.template
@@ -4,4 +4,6 @@
 # complexity = low
 # disruption = low
 
-package remove {{{ PKGNAME }}}
+{{% for package in PACKAGES %}}
+package remove {{{ package }}}
+{{% endfor %}}

--- a/shared/templates/package_removed/oval.template
+++ b/shared/templates/package_removed/oval.template
@@ -1,11 +1,14 @@
 <def-group>
-  <definition class="compliance" id="{{{ _RULE_ID }}}"
-  version="1">
-    {{{ oval_metadata("The " + pkg_system|upper + " package " + PKGNAME + " should be removed.", affected_platforms=["multi_platform_all"]) }}}
-    <criteria>
-      <criterion comment="package {{{ PKGNAME }}} is removed"
-      test_ref="test_package_{{{ PKGNAME }}}_removed" />
-    </criteria>
-  </definition>
-{{{ oval_test_package_removed(package=PKGNAME, test_id="test_package_"+PKGNAME+"_removed") }}}
+<definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
+  {{{ oval_metadata("The " + pkg_system|upper + " package " + PACKAGES | join(" and ") + " should be removed.", affected_platforms=["multi_platform_all"]) }}}
+  <criteria>
+  {{% for package in PACKAGES %}}
+    <criterion comment="package {{{ package }}} is removed" test_ref="test_package_{{{ package }}}_removed" />
+  {{% endfor %}}
+  </criteria>
+</definition>
+{{% for package in PACKAGES %}}
+{{{ oval_test_package_removed(package=package, test_id="test_package_"+package+"_removed") }}}
+{{% endfor %}}
+
 </def-group>

--- a/shared/templates/package_removed/puppet.template
+++ b/shared/templates/package_removed/puppet.template
@@ -3,10 +3,12 @@
 # strategy = disable
 # complexity = low
 # disruption = low
-include remove_{{{ PKGNAME }}}
+{{% for package in PACKAGES %}}
+include remove_{{{ package }}}
 
-class remove_{{{ PKGNAME }}} {
-  package { '{{{ PKGNAME }}}':
+class remove_{{{ package }}} {
+  package { '{{{ package }}}':
     ensure => 'purged',
   }
 }
+{{% endfor %}}

--- a/shared/templates/package_removed/template.py
+++ b/shared/templates/package_removed/template.py
@@ -1,0 +1,6 @@
+def preprocess(data, lang):
+    if isinstance(data["pkgname"], list):
+        data["packages"] = data["pkgname"]
+    else:
+        data["packages"] = [data["pkgname"]]
+    return data


### PR DESCRIPTION
#### Description:
We have productization issue https://github.com/ComplianceAsCode/content/issues/13107 that test scenario `package-installed.fail` fails for rule `package_bind_removed` on RHEL 9.6. I have discovered that if `dnf install bind` is run on RHEL 9.6 the actual package that it installs is `bind9.18`, not `bind`. This is a difference from RHEL 9.5.

We will fix this issue by making sure both `bind` and `bind9.18` RPM packages are removed by the rule.

To do this, we will add a feature to the `package_removed` template that allows you specify multiple package names instead of only single package name.

Fixes: https://github.com/ComplianceAsCode/content/issues/13107