### PR TITLE
Revert the uid back to rsyslog for the rule file_owner_var_log_syslog

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_syslog/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_syslog/rule.yml
@@ -5,7 +5,7 @@ title: 'Verify User Who Owns /var/log/syslog File'
 {{%  if product in ['ubuntu2404'] %}}
 description: '{{{ describe_file_owner(file="/var/log/syslog", owner="root|syslog") }}}'
 {{%- else %}}
-description: '{{{ describe_file_owner(file="/var/log/syslog", owner="root") }}}'
+description: '{{{ describe_file_owner(file="/var/log/syslog", owner="syslog") }}}'
 {{%- endif %}}
 
 rationale: |-
@@ -27,15 +27,15 @@ ocil: |-
     {{{ ocil_file_owner(file="/var/log/syslog", owner="root|syslog") }}}
 
 {{%- else %}}
-ocil_clause: '{{{ ocil_clause_file_owner(file="/var/log/syslog", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file="/var/log/syslog", owner="syslog") }}}'
 
 ocil: |-
-    {{{ ocil_file_owner(file="/var/log/syslog", owner="root") }}}
+    {{{ ocil_file_owner(file="/var/log/syslog", owner="syslog") }}}
 
 fixtext: |-
-    {{{ describe_file_owner(file="/var/log/syslog", owner="root") }}}
+    {{{ describe_file_owner(file="/var/log/syslog", owner="syslog") }}}
 
-srg_requirement: '{{{ srg_requirement_file_owner("/var/log/syslog", owner="root") }}}'
+srg_requirement: '{{{ srg_requirement_file_owner("/var/log/syslog", owner="syslog") }}}'
 
 platform: package[rsyslog]
 

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_syslog/tests/correct_owner.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_syslog/tests/correct_owner.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_ubuntu
 # packages = rsyslog
 
 if [ ! -f /var/log/syslog ]; then

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_syslog/tests/incorrect_owner.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_syslog/tests/incorrect_owner.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_ubuntu
 # packages = rsyslog
 
 if [ ! -f /var/log/syslog ]; then

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_syslog/tests/owned_by_syslog.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_syslog/tests/owned_by_syslog.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # platform = Ubuntu 24.04
-# platform = Ubuntu 24.04
 # packages = rsyslog
 
 touch /var/log/syslog


### PR DESCRIPTION
#### Description:

- Change the uid of rule file_owner_var_log_syslog back to syslog
- Make customized tests only applicable on Ubuntu 

### Rationale

- The uid required by stig for Ubuntu 20.04 and 22.04 is syslog
