### PR TITLE
Build thin data streams alongside normal data stream

### DIFF
--- a/build-scripts/build_xccdf.py
+++ b/build-scripts/build_xccdf.py
@@ -60,6 +60,7 @@ def parse_args():
     )
     parser.add_argument(
         "--thin-ds-components-dir",
+        default="off",
         help="Directory to store XCCDF, OVAL, OCIL, for thin data stream. (off: to disable)"
         "e.g.: ~/scap-security-guide/build/rhel9/thin_ds_component/"
         "Fake profiles are used to create thin DS. Components are generated for each profile.",
@@ -168,14 +169,15 @@ def main():
     _, xccdftree = get_linked_xccdf(loader, loader.get_benchmark_xml(), args)
     var_ids = get_rules_with_variables(xccdftree)
 
+    build_thin_ds_for_each_rule = args.thin_ds_components_dir != "off"
     oval_linker, xccdftree = get_linked_xccdf(
-        loader, loader.export_benchmark_to_xml(var_ids), args
+        loader, loader.export_benchmark_to_xml(var_ids, build_thin_ds_for_each_rule), args
     )
 
     ssg.xml.ElementTree.ElementTree(xccdftree).write(
         args.xccdf, xml_declaration=True, encoding="utf-8")
 
-    if args.thin_ds_components_dir is not None and args.thin_ds_components_dir != "off":
+    if build_thin_ds_for_each_rule:
         if not os.path.exists(args.thin_ds_components_dir):
             os.makedirs(args.thin_ds_components_dir)
         store_xccdf_per_profile(loader, oval_linker, var_ids, args.thin_ds_components_dir)

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -3209,10 +3209,11 @@ class LinearLoader(object):
             )
 
         for profile in self.benchmark.profiles:
-            profiles_ids, benchmark = self.benchmark.get_benchmark_xml_for_profiles(
-                self.env_yaml, [profile], rule_and_variables_dict
-            )
-            yield profiles_ids.pop(), benchmark
+            if profile.single_rule_profile == "true":
+                profiles_ids, benchmark = self.benchmark.get_benchmark_xml_for_profiles(
+                    self.env_yaml, [profile], rule_and_variables_dict
+                )
+                yield profiles_ids.pop(), benchmark
 
     def load_compiled_content(self):
         """
@@ -3262,18 +3263,23 @@ class LinearLoader(object):
         for g in self.groups.values():
             g.load_entities(self.rules, self.values, self.groups)
 
-    def export_benchmark_to_xml(self, rule_and_variables_dict):
+    def export_benchmark_to_xml(self, rule_and_variables_dict, ignore_single_rule_profiles):
         """
         Exports the benchmark data to an XML format.
 
         Args:
             rule_and_variables_dict (dict): A dictionary containing rules and variables.
+            ignore_single_rule_profiles (bool): All profiles that contain "single_rule_profile: true" will be skipping.
 
         Returns:
             str: The benchmark data in XML format.
         """
+        if ignore_single_rule_profiles:
+            profiles = [p for p in self.benchmark.profiles if p.single_rule_profile == "false"]
+        else:
+            profiles = self.benchmark.profiles
         _, benchmark = self.benchmark.get_benchmark_xml_for_profiles(
-            self.env_yaml, self.benchmark.profiles, rule_and_variables_dict
+            self.env_yaml, profiles, rule_and_variables_dict
         )
         return benchmark
 

--- a/ssg/entities/profile_base.py
+++ b/ssg/entities/profile_base.py
@@ -48,6 +48,7 @@ class Profile(XCCDFEntity, SelectionHandler):
         platform=lambda: None,
         filter_rules=lambda: "",
         policies=lambda: list(),
+        single_rule_profile=lambda: False,
         ** XCCDFEntity.KEYS
     )
 


### PR DESCRIPTION
Fixes: #13163

#### Description:


Build thin data streams alongside normal data stream

To build thin data streams we are internally using special "single rule profiles". For each rule, we build a special
profile that contains just that rule.

Until now, when thin data streams were build, only these special single rule profiles were created internally
and actual (normal) profiles weren't created internally. As a result, we didn't build a normal data stream and
that prevented building HTML guides, playbooks and other artifacts in the same build command with thin data streams. This is a problem that caused #13163.

We will address this problem by creating both normal and single rule profiles during build of thin data streams.

It's internally implemented by adding a flag `single_rule_profile` to the resolved profiles and then reacting on this flag during XCCDF creation.
