### PR TITLE
Update regex to support RainerScript in rsyslog_cron_logging 

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/ansible/shared.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/ansible/shared.yml
@@ -5,7 +5,11 @@
 # disruption = low
 
 -   name: "{{{ rule_title }}} - Search if cron configuration exists"
-    ansible.builtin.command: 'grep -s "^\s*cron\.\*\s*/var/log/cron$" /etc/rsyslog.conf /etc/rsyslog.d/*.conf'
+    {{% if 'ol' in families %}}
+    ansible.builtin.command: grep -Pzo '(?m)^\s*(cron|\*)\.\*\s*(/var/log/(cron|messages)|action\(\s*.*(?i:\btype\b)="omfile"\s*.*(?i:\bfile\b)="/var/log/(cron|messages)"\s*\))\s*$' /etc/rsyslog.conf /etc/rsyslog.d/*.conf
+    {{% else %}}
+    ansible.builtin.command: grep -Pzo '(?m)^\s*cron\.\*\s*(/var/log/cron|action\(\s*.*(?i:\btype\b)="omfile"\s*.*(?i:\bfile\b)="/var/log/cron"\s*\))\s*$' /etc/rsyslog.conf /etc/rsyslog.d/*.conf
+    {{% endif %}}
     register: cron_log_config_exists
     failed_when: false
 

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/bash/shared.sh
@@ -1,6 +1,10 @@
 # platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux
 
-if ! grep -s "^\s*cron\.\*\s*/var/log/cron$" /etc/rsyslog.conf /etc/rsyslog.d/*.conf; then
+{{% if 'ol' in families %}}
+if ! grep -Pzo '(?m)^\s*(cron|\*)\.\*\s*(/var/log/(cron|messages)|action\(\s*.*(?i:\btype\b)="omfile"\s*.*(?i:\bfile\b)="/var/log/(cron|messages)"\s*\))\s*$' /etc/rsyslog.conf /etc/rsyslog.d/*.conf; then
+{{% else %}}
+if ! grep -Pzo '(?m)^\s*cron\.\*\s*(/var/log/cron|action\(\s*.*(?i:\btype\b)="omfile"\s*.*(?i:\bfile\b)="/var/log/cron"\s*\))\s*$' /etc/rsyslog.conf /etc/rsyslog.d/*.conf; then
+{{% endif %}}
 	mkdir -p /etc/rsyslog.d
 	echo "cron.*	/var/log/cron" >> /etc/rsyslog.d/cron.conf
 fi

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/oval/shared.xml
@@ -22,7 +22,7 @@
 
 {{% set legacy_regex = "^[\\s]*cron\\.\\*[\\s]+/var/log/cron\\s*(?:#.*)?$" %}}
 {{# RainerScript keys are case-insensitive #}}
-{{% set rainer_script_regex = "^\\s*cron\\.\\*\\s+action\\(.*(?i)\\btype\\b(?-i)=\"omfile\".*(?i)\\bfile\\b(?-i)=\"/var/log/cron\".*\\)\\s*$" %}}
+{{% set rainer_script_regex = "(?m)^\\s*cron\\.\\*\\s+action\\(\\s*.*(?i)\\btype\\b(?-i)=\"omfile\"\\s*.*(?i)\\bfile\\b(?-i)=\"/var/log/cron\"\\s*.*\\)\\s*$" %}}
 
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
   comment="cron is configured in /etc/rsyslog.conf"
@@ -78,7 +78,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_cron_logging_rsyslog_logging_all_facilities" version="1">
     <ind:filepath>/etc/rsyslog.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*\*\.\*[\s]+/var/log/messages\s*(?:#.*)?$</ind:pattern>
+    <ind:pattern operation="pattern match">(?m)^[\s]*\*\.\*[\s]+(/var/log/messages|action\(\s*.*(?i:\btype\b)="omfile"\s*.*(?i:\bfile\b)="/var/log/messages"\s*\))\s*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -90,7 +90,7 @@
   <ind:textfilecontent54_object id="obj_cron_logging_rsyslog_dir_logging_all_facilities" version="1">
     <ind:path>/etc/rsyslog.d</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
-    <ind:pattern operation="pattern match">^[\s]*\*\.\*[\s]+/var/log/messages\s*(?:#.*)?$</ind:pattern>
+    <ind:pattern operation="pattern match">(?m)^[\s]*\*\.\*[\s]+(/var/log/messages|action\(\s*.*(?i:\btype\b)="omfile"\s*.*(?i:\bfile\b)="/var/log/messages"\s*\))\s*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   {{% endif %}}

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/tests/cron_set_rainer_rsyslog_conf_multiline.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/tests/cron_set_rainer_rsyslog_conf_multiline.pass.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# packages = rsyslog
+
+RSYSLOG_CONF='/etc/rsyslog.conf'
+RSYSLOG_D_FILES='/etc/rsyslog.d/*'
+
+# Ensure that rsyslog.conf exists and rsyslog.d folder doesn't contain any file with cron.*
+touch $RSYSLOG_CONF
+for rsyslog_d_file in $RSYSLOG_D_FILES
+do
+	sed -i '/^[[:space:]]*cron\.\*/d' $rsyslog_d_file
+done
+
+cat << EOF >> "$RSYSLOG_CONF"
+cron.* action(
+    name="local-cron"
+    type="omfile"
+    fileCreateMode="0600"
+    fileOwner="root"
+    fileGroup="root"
+    file="/var/log/cron"
+)
+EOF

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/tests/wrong_log_rainer_rsyslog_conf_multiline.fail.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/tests/wrong_log_rainer_rsyslog_conf_multiline.fail.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# packages = rsyslog
+
+RSYSLOG_CONF='/etc/rsyslog.conf'
+RSYSLOG_D_FILES='/etc/rsyslog.d/*'
+
+# Ensure that rsyslog.conf exists and rsyslog.d folder doesn't contain any file with cron.*
+touch $RSYSLOG_CONF
+for rsyslog_d_file in $RSYSLOG_D_FILES
+do
+	sed -i '/^[[:space:]]*cron\.\*/d' $rsyslog_d_file
+done
+
+# If there's cron.* line, then remove it
+sed -i '/^[[:space:]]*cron\.\*/d' $RSYSLOG_CONF
+# Add cron.* that logs into wrong file
+cat << EOF >> "$RSYSLOG_CONF"
+cron.* action(
+    name="local-cron"
+    type="omfile"
+    fileCreateMode="0600"
+    fileOwner="root"
+    fileGroup="root"
+    file="/tmp/log/cron"
+)
+EOF


### PR DESCRIPTION
#### Description:

- Upgraded regex remediations to fully support RainerScript syntax in multiline format
- Enhanced OVAL regex to support multiline detection
- Adjusted remediations to include OL-specific conditional
- Added new tests to check RainerScript multiline

#### Rationale:

The current regex only checks for the legacy configuration and does not include support for RainerScript. Additionally, the OVAL file contains a condition for OL products that redirects all facility logs to /var/log/messages. This scenario is not currently supported by the remediation scripts.
The RainerScript accepts multi-line configurations, we need to ensure the correct behavior of the rule.
