### PR TITLE
Change the way in which applicability of selinux platform is determined

### DIFF
--- a/linux_os/guide/system/selinux/selinux-booleans/group.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/group.yml
@@ -2,7 +2,14 @@ documentation_complete: true
 
 title: 'SELinux - Booleans'
 
-platform: selinux
+
+# Please note that the `sebool` template used in this group is a bit special.
+# The Bash remediation of the template can remediate even if selinux is totally disabled, because it uses `setsebool -P`.
+# But OVAL check and Ansible remediation will not work with disabled selinux.
+# When hardening in Imagebuilder or Bootc environment, Bash remediations are used, no checks are performed.
+# therefore, the `selinux` platform guards against running OVAL or Ansible on system with selinux disabled / not present.
+# The `osbuild` and `bootc` platform allows to run Bash remediations in these environments.
+platform: selinux or bootc or osbuild
 
 description: |-
     Enable or Disable runtime customization of SELinux system policies

--- a/shared/applicability/selinux.yml
+++ b/shared/applicability/selinux.yml
@@ -1,3 +1,5 @@
 name: cpe:/a:selinux
 title: SELinux enabled on system
 check_id: selinux_is_enabled
+bash_conditional: selinuxenabled
+ansible_conditional: 'ansible_facts.selinux.status != "disabled"'

--- a/shared/templates/sebool/ansible.template
+++ b/shared/templates/sebool/ansible.template
@@ -35,7 +35,6 @@
     name: "{{{ SEBOOLID }}}"
     state: "{{{ SEBOOL_BOOL }}}"
     persistent: yes
-  when: ansible_facts.selinux.status == 'enabled'  
 {{% else %}}
 - (xccdf-var var_{{{ SEBOOLID }}})
 - name: "{{{ rule_title }}} - Set SELinux Boolean {{{ SEBOOLID }}} Accordingly"
@@ -43,5 +42,4 @@
     name: {{{ SEBOOLID }}}
     state: "{{ var_{{{ SEBOOLID }}} }}"
     persistent: yes
-  when: ansible_facts.selinux.status == 'enabled'  
 {{% endif %}}

--- a/shared/templates/sebool/bash.template
+++ b/shared/templates/sebool/bash.template
@@ -16,14 +16,9 @@
 {{{ bash_package_install("libsemanage-python") }}}
 {{% endif %}}
 
-if selinuxenabled || {{{ bash_bootc_build() }}} ; then
 {{% if SEBOOL_BOOL %}}
     setsebool -P {{{ SEBOOLID }}} {{{ SEBOOL_BOOL }}}
 {{% else %}}
     {{{ bash_instantiate_variables("var_" + SEBOOLID) }}}
     setsebool -P {{{ SEBOOLID }}} $var_{{{ SEBOOLID }}}
 {{% endif %}}
-else
-    echo "Skipping remediation, SELinux is disabled";
-    false
-fi


### PR DESCRIPTION
#### Description:

- remove applicability checks from sebool template remediations
- add conditionals to the selinux platform
- expand applicability of the selinux-sebool group

#### Rationale:

The main reason for this change was the issue #13127  . It showed that remediations of selinux booleans could work when using Imabeguilder or building Bootc images. However, these remediations were not applied in the case of Imagebuilder.
There were conditionals in Bash remediation of the sebool template which let the remediation to happen in some cases. One way of solving the problem was to expand the conditional.
But I did not like that the conditional is specific to the template, it was also quite hidden and I feel it could cause problems in the future.
Therefore, I rather enhanced conditionals for the selinux template it self and I also allowed rules within the  selinux-booleans group to be used in Imagebuilder and Bootc. I think this makes everything more transparent.

#### Review Hints:

- I suggest testing some profiles with sebool rules (ANSSI, HIPAA) on bare metal, Imagebuilder and Bootc.