### PR TITLE
fix accounts_password_pan_rety oval check for Debian

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
@@ -9,7 +9,9 @@
   <definition class="compliance" id="{{{ rule_id }}}" version="2">
     {{{ oval_metadata("The password retry should meet minimum requirements") }}}
     <criteria operator="AND" comment="The password retry should meet minimum requirements">
+      {{% if 'debian' not in product %}}
       <extend_definition definition_ref="enable_authselect"/>
+      {{% endif %}}
       <criteria operator="OR" comment="Conditions for retry are satisfied">
         <criteria operator="AND" comment="Conditions for retry in PAM files are satisfied">
           {{% for file in configuration_files %}}


### PR DESCRIPTION
Deactivate the authselect extend_definition for debian.

#### Description:

- Deactivate the authselect extend_definition for debian in the oval check


#### Rationale:

- Debian 12 doesn't use authselect, so the authselect check criterion fails.


