### PR TITLE
Fix accounts_user_dot_user/group_ownership to only remediate regular files

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/ansible/shared.yml
@@ -7,4 +7,4 @@
 - name: Ensure interactive local users are the group-owners of their respective initialization files
   ansible.builtin.shell:
     cmd: |
-      awk -F: '{if ($4 >= {{{ gid_min }}} && $4 != {{{ nobody_gid }}}) print $4":"$6}' /etc/passwd | while IFS=: read -r gid home; do find "$home" -maxdepth 1 -name "\.[^.]*" -exec chgrp -f $gid "{}" \;; done
+      awk -F: '{if ($4 >= {{{ gid_min }}} && $4 != {{{ nobody_gid }}}) print $4":"$6}' /etc/passwd | while IFS=: read -r gid home; do find -P "$home" -maxdepth 1 -type f -name "\.[^.]*" -exec chgrp -f --no-dereference -- $gid "{}" \;; done

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/bash/shared.sh
@@ -4,4 +4,4 @@
 # complexity = low
 # disruption = low
 
-awk -F: '{if ($4 >= {{{ gid_min }}} && $4 != {{{ nobody_gid }}}) print $4":"$6}' /etc/passwd | while IFS=: read -r gid home; do find "$home" -maxdepth 1 -name "\.[^.]*" -exec chgrp -f $gid "{}" \;; done
+awk -F: '{if ($4 >= {{{ gid_min }}} && $4 != {{{ nobody_gid }}}) print $4":"$6}' /etc/passwd | while IFS=: read -r gid home; do find -P "$home" -maxdepth 1 -type f -name "\.[^.]*" -exec chgrp -f --no-dereference -- $gid "{}" \;; done

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/ansible/shared.yml
@@ -7,4 +7,4 @@
 - name: Ensure interactive local users are the owners of their respective initialization files
   ansible.builtin.shell:
     cmd: |
-      awk -F: '{if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) print $3":"$6}' /etc/passwd | while IFS=: read -r uid home; do find "$home" -maxdepth 1 -name "\.[^.]*" -exec chown -f $uid "{}" \;; done
+      awk -F: '{if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) print $3":"$6}' /etc/passwd | while IFS=: read -r uid home; do find -P "$home" -maxdepth 1 -type f -name "\.[^.]*" -exec chown -f --no-dereference -- $uid "{}" \;; done

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/bash/shared.sh
@@ -4,4 +4,4 @@
 # complexity = low
 # disruption = low
 
-awk -F: '{if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) print $3":"$6}' /etc/passwd | while IFS=: read -r uid home; do find "$home" -maxdepth 1 -name "\.[^.]*" -exec chown -f $uid "{}" \;; done
+awk -F: '{if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) print $3":"$6}' /etc/passwd | while IFS=: read -r uid home; do find -P "$home" -maxdepth 1 -type f -name "\.[^.]*" -exec chown -f --no-dereference -- $uid "{}" \;; done


### PR DESCRIPTION
#### Description:

- Fix `accounts_user_dot_user_ownership` and `accounts_user_dot_group_ownership` to only remediate regular files

#### Rationale:

- Prevents a possible symlink attack where a malicious user creates a symlink in their home directory pointing to sensitive system files