### PR TITLE
Remove audit_rules_kernel_module_loading_create from RHEL 10

### DIFF
--- a/controls/cis_rhel10.yml
+++ b/controls/cis_rhel10.yml
@@ -2684,7 +2684,6 @@ controls:
       - l2_workstation
     status: automated
     rules:
-      - audit_rules_kernel_module_loading_create
       - audit_rules_kernel_module_loading_delete
       - audit_rules_kernel_module_loading_finit
       - audit_rules_kernel_module_loading_init

--- a/products/rhel10/profiles/default.profile
+++ b/products/rhel10/profiles/default.profile
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+hidden: true
+
+title: Default Profile for Red Hat Enterprise Linux 10
+
+description: |-
+  This profile contains all the rules that once belonged to the rhel10
+  product. This profile won't be rendered into an XCCDF Profile entity,
+  nor it will select any of these rules by default. The only purpose of
+  this profile is to keep a rule in the product's XCCDF Benchmark.
+
+selections:
+  - audit_rules_kernel_module_loading_create

--- a/tests/data/profile_stability/rhel10/cis.profile
+++ b/tests/data/profile_stability/rhel10/cis.profile
@@ -72,7 +72,6 @@ selections:
 - audit_rules_file_deletion_events_unlink
 - audit_rules_file_deletion_events_unlinkat
 - audit_rules_immutable
-- audit_rules_kernel_module_loading_create
 - audit_rules_kernel_module_loading_delete
 - audit_rules_kernel_module_loading_finit
 - audit_rules_kernel_module_loading_init

--- a/tests/data/profile_stability/rhel10/cis_workstation_l2.profile
+++ b/tests/data/profile_stability/rhel10/cis_workstation_l2.profile
@@ -72,7 +72,6 @@ selections:
 - audit_rules_file_deletion_events_unlink
 - audit_rules_file_deletion_events_unlinkat
 - audit_rules_immutable
-- audit_rules_kernel_module_loading_create
 - audit_rules_kernel_module_loading_delete
 - audit_rules_kernel_module_loading_finit
 - audit_rules_kernel_module_loading_init


### PR DESCRIPTION
The rule `audit_rules_kernel_module_loading_create` checks for auditing the `create_module` syscall. This syscall has been deprecated and has been removed since Linux 2.6.
