### PR TITLE
OPENSCAP-4816: Update grub2_nousb_argument to use coreusb.nousb on RHEL10

### DIFF
--- a/linux_os/guide/system/permissions/mounting/grub2_nousb_argument/bash/shared.sh
+++ b/linux_os/guide/system/permissions/mounting/grub2_nousb_argument/bash/shared.sh
@@ -1,12 +1,16 @@
-# platform = multi_platform_fedora
+{{%- set nousb_argument = 'nousb' %}}
+{{%- if product in ["rhel10"] %}}
+{{%- set nousb_argument = 'coreusb.nousb' %}}
+{{%- endif %}}
+# platform = multi_platform_fedora,multi_platform_rhel
 
 # Correct the form of default kernel command line in /etc/default/grub
-if ! grep -q '^GRUB_CMDLINE_LINUX=".*nousb.*"' /etc/default/grub;
+if ! grep -q '^GRUB_CMDLINE_LINUX=".*{{{ nousb_argument }}}.*"' /etc/default/grub;
 then
   # Edit configuration setting
-  # Append 'nousb' argument to /etc/default/grub (if not present yet)
-  sed -i "s/\(GRUB_CMDLINE_LINUX=\)\"\(.*\)\"/\1\"\2 nousb\"/" /etc/default/grub
+  # Append '{{{ nousb_argument }}}' argument to /etc/default/grub (if not present yet)
+  sed -i "s/\(GRUB_CMDLINE_LINUX=\)\"\(.*\)\"/\1\"\2 {{{ nousb_argument }}}\"/" /etc/default/grub
   # Edit runtime setting
   # Correct the form of kernel command line for each installed kernel in the bootloader
-  /sbin/grubby --update-kernel=ALL --args="nousb"
+  /sbin/grubby --update-kernel=ALL --args="{{{ nousb_argument }}}"
 fi

--- a/linux_os/guide/system/permissions/mounting/grub2_nousb_argument/oval/shared.xml
+++ b/linux_os/guide/system/permissions/mounting/grub2_nousb_argument/oval/shared.xml
@@ -1,1 +1,5 @@
-{{{ oval_grub_config(parameter="GRUB_CMDLINE_LINUX", value="nousb") }}}
+{{%- set nousb_argument = 'nousb' %}}
+{{%- if product in ["rhel10"] %}}
+{{%- set nousb_argument = 'coreusb.nousb' %}}
+{{%- endif %}}
+{{{ oval_grub_config(parameter="GRUB_CMDLINE_LINUX", value=nousb_argument) }}}

--- a/linux_os/guide/system/permissions/mounting/grub2_nousb_argument/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/grub2_nousb_argument/rule.yml
@@ -1,13 +1,16 @@
+{{%- set nousb_argument = 'nousb' %}}
+{{%- if product in ["rhel10"] %}}
+{{%- set nousb_argument = 'coreusb.nousb' %}}
+{{%- endif %}}
 documentation_complete: true
-
 
 title: 'Disable Kernel Support for USB via Bootloader Configuration'
 
 description: |-
-    All USB support can be disabled by adding the <tt>nousb</tt>
+    All USB support can be disabled by adding the <tt>{{{ nousb_argument }}}</tt>
     argument to the kernel's boot loader configuration. To do so,
-    append "nousb" to the kernel line in <tt>/etc/default/grub</tt> as shown:
-    <pre>kernel /vmlinuz-<i>VERSION</i> ro vga=ext root=/dev/VolGroup00/LogVol00 rhgb quiet nousb</pre>
+    append "{{{ nousb_argument }}}" to the kernel line in <tt>/etc/default/grub</tt> as shown:
+    <pre>kernel /vmlinuz-<i>VERSION</i> ro vga=ext root=/dev/VolGroup00/LogVol00 rhgb quiet {{{ nousb_argument }}}</pre>
 
 rationale: |-
     Disabling the USB subsystem within the Linux kernel at system boot will

--- a/linux_os/guide/system/permissions/mounting/grub2_nousb_argument/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/permissions/mounting/grub2_nousb_argument/tests/correct_value.pass.sh
@@ -1,5 +1,9 @@
+{{%- set nousb_argument = 'nousb' %}}
+{{%- if product in ["rhel10"] %}}
+{{%- set nousb_argument = 'coreusb.nousb' %}}
+{{%- endif %}}
 #!/bin/bash
-# platform = multi_platform_fedora
+# platform = multi_platform_fedora,multi_platform_rhel
 
 cat <<EOF > /etc/default/grub
 GRUB_TIMEOUT=5
@@ -8,7 +12,7 @@ GRUB_DEFAULT=saved
 GRUB_DISABLE_SUBMENU=true
 GRUB_TERMINAL="serial console"
 GRUB_SERIAL_COMMAND="serial --speed=115200"
-GRUB_CMDLINE_LINUX="nousb audit=1 audit_backlog_limit=8192 slub_debug=P page_poison=1 vsyscall=none crashkernel=auto resume=/dev/mapper/VolGroup-lv_swap rd.lvm.lv=VolGroup/root rd.lvm.lv=VolGroup/lv_swap net.ifnames=0 console=ttyS0,115200"
+GRUB_CMDLINE_LINUX="{{{ nousb_argument }}} audit=1 audit_backlog_limit=8192 slub_debug=P page_poison=1 vsyscall=none crashkernel=auto resume=/dev/mapper/VolGroup-lv_swap rd.lvm.lv=VolGroup/root rd.lvm.lv=VolGroup/lv_swap net.ifnames=0 console=ttyS0,115200"
 GRUB_DISABLE_RECOVERY="true"
 GRUB_ENABLE_BLSCFG=true
 EOF

--- a/linux_os/guide/system/permissions/mounting/grub2_nousb_argument/tests/missing_value.fail.sh
+++ b/linux_os/guide/system/permissions/mounting/grub2_nousb_argument/tests/missing_value.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora
+# platform = multi_platform_fedora,multi_platform_rhel
 
 cat <<EOF > /etc/default/grub
 GRUB_TIMEOUT=5


### PR DESCRIPTION
#### Description:

- Update grub2_nousb_argument to use coreusb.nousb on RHEL10.

#### Rationale:
- This rule has remediation only enabled in Fedora
- This rule is only present in the HIPAA control file and only present in the RHEL10 HIPAA Profile
- Additionally the Fedora Standard profile selects this rule.
- I'm divided if we really want to include this change in the repository, since it can cause issues for HIPAA users in case they use USB devices on RHEL10
- I don't know for how long the `nousb` value will be supported alongside `coreusb.nousb`.
- Please, share any additional info you might have.