### PR TITLE
Change checks for rexec and rlogin to use xinetd configuration

### DIFF
--- a/linux_os/guide/services/obsolete/r_services/service_rexec_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/service_rexec_disabled/rule.yml
@@ -38,9 +38,16 @@ references:
 {{{ complete_ocil_entry_socket_and_service_disabled("rexec") }}}
 
 platform: system_with_kernel
-
+{{% if product == "sle15" %}}
+template:
+    name: xinetd_service_disabled
+    vars:
+        servicename: rexec
+        packagename: rsh-server
+{{% else %}}
 template:
     name: service_disabled
     vars:
         servicename: rexec
         packagename: rsh-server
+{{% endif %}}

--- a/linux_os/guide/services/obsolete/r_services/service_rlogin_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/service_rlogin_disabled/rule.yml
@@ -41,8 +41,16 @@ references:
 
 platform: system_with_kernel
 
+{{% if product == "sle15" %}}
+template:
+    name: xinetd_service_disabled
+    vars:
+        servicename: rlogin
+        packagename: rsh-server
+{{% else %}}
 template:
     name: service_disabled
     vars:
         servicename: rlogin
         packagename: rsh-server
+{{% endif %}}

--- a/shared/templates/xinetd_service_disabled/ansible.template
+++ b/shared/templates/xinetd_service_disabled/ansible.template
@@ -1,0 +1,27 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+
+- name: Disable xinetd service {{{ SERVICENAME }}}
+  block:
+  - name: Gather the package facts
+    package_facts:
+      manager: auto
+
+  - name: "{{{ rule_title }}} - Ensure /etc/xinetd.d/{{{ SERVICENAME }}} exists"
+    stat:
+      path: "/etc/xinetd.d/{{{ SERVICENAME }}}"
+    register: xinetd_service
+
+  - name: "{{{ rule_title }}} - Configure 'disable = yes' in /etc/xinetd.d/{{{ SERVICENAME }}}"
+    lineinfile:
+      dest: "/etc/xinetd.d/{{{ SERVICENAME }}}"
+      regexp: '^[\s]*disable[\s]*=[\s]*no'
+      line: "disable = yes"
+      insertbefore: "}"
+      state: present
+    when:
+    - '"{{{ PACKAGENAME }}}" in ansible_facts.packages'
+    - xinetd_service.stat.exists

--- a/shared/templates/xinetd_service_disabled/bash.template
+++ b/shared/templates/xinetd_service_disabled/bash.template
@@ -1,0 +1,8 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+
+grep -qi disable "/etc/xinetd.d/{{{ SERVICENAME }}}" && \
+sed -i "s/disable.*/disable = yes/gI" "/etc/xinetd.d/{{{ SERVICENAME }}}"

--- a/shared/templates/xinetd_service_disabled/oval.template
+++ b/shared/templates/xinetd_service_disabled/oval.template
@@ -1,0 +1,28 @@
+<def-group>
+
+{{%- set package_removed_test_id = _RULE_ID + "_test_service_" + SERVICENAME + "_package_" + PACKAGENAME + "_removed" -%}}
+{{%- set xinetd_disabled_test_id = _RULE_ID + "_test_xinetd_service_" + SERVICENAME + "_disabled" -%}}
+{{%- set xinetd_disabled_object_id = _RULE_ID + "_object_xinetd_service_" + SERVICENAME + "_disabled" -%}}
+{{%- set service_path = "/etc/xinetd.d/" + SERVICENAME -%}}
+
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
+    {{{ oval_metadata("The xinetd " + SERVICENAME + " service should be disabled.", affected_platforms=["multi_platform_sle"]) }}}
+    <criteria comment="package {{{ PACKAGENAME }}} removed or service {{{ SERVICENAME }}} is not configured to start" operator="OR">
+      <criterion comment="{{{ PACKAGENAME }}} removed" test_ref="{{{ package_removed_test_id }}}" />
+        <criterion comment="check for disable = yes in {{{ service_path }}}" test_ref="{{{ xinetd_disabled_test_id }}}" />
+    </criteria>
+  </definition>
+  {{{- oval_test_package_removed(package=PACKAGENAME, test_id=package_removed_test_id) }}}
+
+  <ind:textfilecontent54_test check="all" check_existence="none_exist"
+  comment="check for disable = yes in {{{ service_path }}}" id="{{{ xinetd_disabled_test_id }}}" version="1">
+    <ind:object object_ref="{{{ xinetd_disabled_object_id }}}" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="{{{ xinetd_disabled_object_id }}}" version="1">
+    <ind:filepath>{{{ service_path }}}</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*disable[\s]*=[\s]*no</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/shared/templates/xinetd_service_disabled/template.py
+++ b/shared/templates/xinetd_service_disabled/template.py
@@ -1,0 +1,4 @@
+def preprocess(data, lang):
+    if "packagename" not in data:
+        data["packagename"] = data["servicename"]
+    return data

--- a/shared/templates/xinetd_service_disabled/template.yml
+++ b/shared/templates/xinetd_service_disabled/template.yml
@@ -1,0 +1,4 @@
+supported_languages:
+  - ansible
+  - bash
+  - oval

--- a/shared/templates/xinetd_service_disabled/tests/service_disabled.pass.sh
+++ b/shared/templates/xinetd_service_disabled/tests/service_disabled.pass.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# packages = xinetd,{{{ PACKAGENAME }}}
+
+XINETD_SERVICE="/etc/xinetd.d/{{{ SERVICENAME }}}"
+SERVICENAME="{{{ SERVICENAME }}}"
+
+if [ -f "$XINETD_SERVICE" ]; then
+    if grep -q 'disable' "$XINETD_SERVICE"; then
+        sed -i "s/disable.*/disable = yes/gI" "$XINETD_SERVICE"
+    else
+        sed -i "s/}/disable = yes\n}/gI" "$XINETD_SERVICE"
+    fi
+else
+cat > "$XINETD_SERVICE" << EOF
+service $SERVICENAME
+{
+        disable         = yes
+}
+EOF
+fi

--- a/shared/templates/xinetd_service_disabled/tests/service_enabled.fail.sh
+++ b/shared/templates/xinetd_service_disabled/tests/service_enabled.fail.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# packages = xinetd,{{{ PACKAGENAME }}}
+
+XINETD_SERVICE="/etc/xinetd.d/{{{ SERVICENAME }}}"
+SERVICENAME="{{{ SERVICENAME }}}"
+
+if [ -f "$XINETD_SERVICE" ]; then
+    if grep -q 'disable' "$XINETD_SERVICE"; then
+        sed -i "s/disable.*/disable = no/gI" "$XINETD_SERVICE"
+    else
+        sed -i "s/}/disable = no\n}/gI" "$XINETD_SERVICE"
+    fi
+else
+cat > "$XINETD_SERVICE" << EOF
+service $SERVICENAME
+{
+        disable         = no
+}
+EOF
+fi


### PR DESCRIPTION
#### Description:

- Add template for xinetd service disable and use it for rexec and rlogin

#### Rationale:

-  For SLE15 platform where rexec and rlogin are enabled via xinetd use new template that checks/disables service in xinetd super-daemon
