### PR TITLE
SLE15 nfs and dhcp disable service fixes

### DIFF
--- a/linux_os/guide/services/dhcp/disabling_dhcp_server/service_dhcpd_disabled/rule.yml
+++ b/linux_os/guide/services/dhcp/disabling_dhcp_server/service_dhcpd_disabled/rule.yml
@@ -55,3 +55,4 @@ template:
         packagename@rhel8: dhcp-server
         packagename@rhel9: dhcp-server
         packagename@ubuntu2404: isc-dhcp-server
+        packagename@sle15: dhcp-server

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/disabling_nfsd/service_nfs_disabled/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/disabling_nfsd/service_nfs_disabled/rule.yml
@@ -46,3 +46,4 @@ template:
         servicename: nfs-server
         packagename: nfs-utils
         packagename@ubuntu2404: nfs-kernel-server
+        packagename@sle15: nfs-kernel-server

--- a/products/sle15/profiles/default.profile
+++ b/products/sle15/profiles/default.profile
@@ -14,7 +14,6 @@ description: |-
 selections:
     - var_network_filtering_service=firewalld
     - accounts_user_dot_user_ownership
-    - service_timesyncd_enabled
     - gnome_gdm_disable_xdmcp
     - configure_user_data_backups
     - dir_ownership_binary_dirs
@@ -34,7 +33,6 @@ selections:
     - configure_etc_hosts_deny
     - sudoers_no_root_target
     - auditd_write_logs
-    - service_ntpd_enabled
     - accounts_users_home_files_groupownership
     - dconf_gnome_disable_user_list
     - coreos_enable_selinux_kernel_argument
@@ -51,7 +49,6 @@ selections:
     - directory_permissions_var_log_audit
     - service_tftp_disabled
     - file_permissions_var_log
-    - service_timesyncd_configured
     - file_ownership_sshd_private_key
     - sshd_enable_warning_banner_net
     - file_groupowner_var_log_syslog
@@ -102,7 +99,6 @@ selections:
     - auditd_log_format
     - service_syslogng_enabled
     - account_passwords_pam_faillock_audit
-    - ntpd_specify_remote_server
     - file_owner_var_log
     - service_sshd_disabled
     - sshd_disable_rhosts_rsa


### PR DESCRIPTION
#### Description:

- Some fixes related with disable service rules

#### Rationale:

- Fix package name for SLE15 for NFS server
- Fix package name for SLE15 for DHCP server
- Drop timesync rules from default profile
  - this is needed since rules get *accidently* run if the rule gets specified explicitely but the rule is not in the profile specified