### PR TITLE
Revert argument name for file_existence template

### DIFF
--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_at_allow_exists/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_at_allow_exists/rule.yml
@@ -28,5 +28,5 @@ template:
     vars:
         filepath: /etc/at.allow
         exists: true
-        uid_or_name: "0"
+        fileuid: "0"
         filemode: "0640"

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_cron_allow_exists/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_cron_allow_exists/rule.yml
@@ -35,5 +35,5 @@ template:
     vars:
         filepath: /etc/cron.allow
         exists: true
-        uid_or_name: "0"
+        fileuid: "0"
         filemode: "0600"


### PR DESCRIPTION

#### Description:

- Revert argument name for file_existence template in rules `file_at_allow_exists` and `file_cron_allow_exists` from .`uid_or_name` to `fileuid`
- Temporary fix, the template should ideally also support uid_or_name, same as file_owner and file_groupowner.

#### Rationale:

- uid_or_name argument was recently introduced to the file_owner template, replacing fileuid
