### PR TITLE
CMP-3264: Update OCP assertions for TLS rules

### DIFF
--- a/tests/assertions/ocp4/ocp4-cis-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.12.yml
@@ -296,3 +296,7 @@ rule_results:
   e2e-cis-secrets-no-environment-variables:
     default_result: MANUAL
     result_after_remediation: MANUAL
+  e2e-cis-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+  e2e-cis-api-server-tls-security-profile-not-old:
+    default_result: PASS

--- a/tests/assertions/ocp4/ocp4-cis-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.13.yml
@@ -271,3 +271,7 @@ rule_results:
     default_result: MANUAL
   e2e-cis-secrets-no-environment-variables:
     default_result: MANUAL
+  e2e-cis-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+  e2e-cis-api-server-tls-security-profile-not-old:
+    default_result: PASS

--- a/tests/assertions/ocp4/ocp4-cis-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.14.yml
@@ -271,3 +271,7 @@ rule_results:
     default_result: MANUAL
   e2e-cis-secrets-no-environment-variables:
     default_result: MANUAL
+  e2e-cis-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+  e2e-cis-api-server-tls-security-profile-not-old:
+    default_result: PASS

--- a/tests/assertions/ocp4/ocp4-cis-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.15.yml
@@ -295,3 +295,7 @@ rule_results:
   e2e-cis-secrets-no-environment-variables:
     default_result: MANUAL
     result_after_remediation: MANUAL
+  e2e-cis-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+  e2e-cis-api-server-tls-security-profile-not-old:
+    default_result: PASS

--- a/tests/assertions/ocp4/ocp4-cis-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.16.yml
@@ -271,3 +271,7 @@ rule_results:
     default_result: MANUAL
   e2e-cis-secrets-no-environment-variables:
     default_result: MANUAL
+  e2e-cis-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+  e2e-cis-api-server-tls-security-profile-not-old:
+    default_result: PASS


### PR DESCRIPTION
https://github.com/ComplianceAsCode/content/pull/12863 made some
adjustments to the TLS rules, and the assertions weren't propagated all
the way back to 4.12.

This commit updates the assertion files so we're checking those rules on
CI runs, and making sure they pass.
