### PR TITLE
Fix sshd oval check for SLE15, SLEM5 and opensuse

### DIFF
--- a/shared/macros/10-oval.jinja
+++ b/shared/macros/10-oval.jinja
@@ -1059,7 +1059,7 @@ datatype="{{{ datatype }}}" version="1">
      <criteria comment="sshd is not installed" operator="AND">
         <extend_definition comment="sshd is not required or requirement is unset"
           definition_ref="sshd_not_required_or_unset" />
-          {{% if product in ['opensuse', 'sle12','sle15', 'slmicro5'] %}}
+          {{% if product in ['sle12','sle15', 'slmicro5'] %}}
           <extend_definition definition_ref="package_openssh_removed"
           comment="rpm package openssh removed"/>
           {{% else %}}
@@ -1070,7 +1070,7 @@ datatype="{{{ datatype }}}" version="1">
      <criteria comment="sshd is installed and configured" operator="AND">
         <extend_definition comment="sshd is required or requirement is unset"
           definition_ref="sshd_required_or_unset" />
-        {{% if product in ['opensuse', 'sle12','sle15', 'slmicro5'] %}}
+        {{% if product in ['sle12','sle15', 'slmicro5'] %}}
         <extend_definition comment="rpm package openssh installed"
           definition_ref="package_openssh_installed" />
         {{% else %}}

--- a/shared/macros/10-oval.jinja
+++ b/shared/macros/10-oval.jinja
@@ -1059,7 +1059,7 @@ datatype="{{{ datatype }}}" version="1">
      <criteria comment="sshd is not installed" operator="AND">
         <extend_definition comment="sshd is not required or requirement is unset"
           definition_ref="sshd_not_required_or_unset" />
-          {{% if product in ['sle12'] %}}
+          {{% if product == "sle12" %}}
           <extend_definition definition_ref="package_openssh_removed"
           comment="rpm package openssh removed"/>
           {{% else %}}
@@ -1070,7 +1070,7 @@ datatype="{{{ datatype }}}" version="1">
      <criteria comment="sshd is installed and configured" operator="AND">
         <extend_definition comment="sshd is required or requirement is unset"
           definition_ref="sshd_required_or_unset" />
-        {{% if product in ['sle12'] %}}
+        {{% if product == "sle12" %}}
         <extend_definition comment="rpm package openssh installed"
           definition_ref="package_openssh_installed" />
         {{% else %}}

--- a/shared/macros/10-oval.jinja
+++ b/shared/macros/10-oval.jinja
@@ -1059,7 +1059,7 @@ datatype="{{{ datatype }}}" version="1">
      <criteria comment="sshd is not installed" operator="AND">
         <extend_definition comment="sshd is not required or requirement is unset"
           definition_ref="sshd_not_required_or_unset" />
-          {{% if product in ['sle12', 'slmicro5'] %}}
+          {{% if product in ['sle12'] %}}
           <extend_definition definition_ref="package_openssh_removed"
           comment="rpm package openssh removed"/>
           {{% else %}}
@@ -1070,7 +1070,7 @@ datatype="{{{ datatype }}}" version="1">
      <criteria comment="sshd is installed and configured" operator="AND">
         <extend_definition comment="sshd is required or requirement is unset"
           definition_ref="sshd_required_or_unset" />
-        {{% if product in ['sle12', 'slmicro5'] %}}
+        {{% if product in ['sle12'] %}}
         <extend_definition comment="rpm package openssh installed"
           definition_ref="package_openssh_installed" />
         {{% else %}}

--- a/shared/macros/10-oval.jinja
+++ b/shared/macros/10-oval.jinja
@@ -1059,7 +1059,7 @@ datatype="{{{ datatype }}}" version="1">
      <criteria comment="sshd is not installed" operator="AND">
         <extend_definition comment="sshd is not required or requirement is unset"
           definition_ref="sshd_not_required_or_unset" />
-          {{% if product in ['sle12','sle15', 'slmicro5'] %}}
+          {{% if product in ['sle12', 'slmicro5'] %}}
           <extend_definition definition_ref="package_openssh_removed"
           comment="rpm package openssh removed"/>
           {{% else %}}
@@ -1070,7 +1070,7 @@ datatype="{{{ datatype }}}" version="1">
      <criteria comment="sshd is installed and configured" operator="AND">
         <extend_definition comment="sshd is required or requirement is unset"
           definition_ref="sshd_required_or_unset" />
-        {{% if product in ['sle12','sle15', 'slmicro5'] %}}
+        {{% if product in ['sle12', 'slmicro5'] %}}
         <extend_definition comment="rpm package openssh installed"
           definition_ref="package_openssh_installed" />
         {{% else %}}


### PR DESCRIPTION
#### Description:

- _Fix sshd oval check for SLE15, SLEM5 and opensuse_

#### Rationale:

- _It will be much better to check explicitly for the openssh-server pkg not implicitly_
