### PR TITLE
[Ubuntu] Exclude system accounts in check and remediation

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/bash/shared.sh
@@ -1,20 +1,6 @@
 # platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_ol,multi_platform_sle,multi_platform_slmicro,multi_platform_almalinux,multi_platform_ubuntu
 {{% if 'ubuntu' in product %}}
-find /bin/ \
-/usr/bin/ \
-/usr/local/bin/ \
-/sbin/ \
-/usr/sbin/ \
-/usr/local/sbin/ \
-/usr/libexec \
-\! -uid -100 -execdir chown root {} \;
+find /bin/ /usr/bin/ /usr/local/bin/ /sbin/ /usr/sbin/ /usr/local/sbin/ /usr/libexec \! -uid -100 -execdir chown root {} \;
 {{% else %}}
-find /bin/ \
-/usr/bin/ \
-/usr/local/bin/ \
-/sbin/ \
-/usr/sbin/ \
-/usr/local/sbin/ \
-/usr/libexec \
-\! -user root -execdir chown root {} \;
+find /bin/ /usr/bin/ /usr/local/bin/ /sbin/ /usr/sbin/ /usr/local/sbin/ /usr/libexec \! -user root -execdir chown root {} \;
 {{% endif %}}

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_ol,multi_platform_sle,multi_platform_slmicro,multi_platform_almalinux
+# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_ol,multi_platform_sle,multi_platform_slmicro,multi_platform_almalinux,multi_platform_ubuntu
 {{% if 'ubuntu' in product %}}
 find /bin/ \
 /usr/bin/ \

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/bash/shared.sh
@@ -1,4 +1,14 @@
 # platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_ol,multi_platform_sle,multi_platform_slmicro,multi_platform_almalinux
+{{% if 'ubuntu' in product %}}
+find /bin/ \
+/usr/bin/ \
+/usr/local/bin/ \
+/sbin/ \
+/usr/sbin/ \
+/usr/local/sbin/ \
+/usr/libexec \
+\! -user root \! \( -user daemon -a -name "at" \) -execdir chown root {} \;
+{{% else %}}
 find /bin/ \
 /usr/bin/ \
 /usr/local/bin/ \
@@ -7,3 +17,4 @@ find /bin/ \
 /usr/local/sbin/ \
 /usr/libexec \
 \! -user root -execdir chown root {} \;
+{{% endif %}}

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/bash/shared.sh
@@ -7,7 +7,7 @@ find /bin/ \
 /usr/sbin/ \
 /usr/local/sbin/ \
 /usr/libexec \
-\! -user root \! \( -user daemon -a -name "at" \) -execdir chown root {} \;
+\! -uid -100 -execdir chown root {} \;
 {{% else %}}
 find /bin/ \
 /usr/bin/ \

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/bash/shared.sh
@@ -1,6 +1,6 @@
 # platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_ol,multi_platform_sle,multi_platform_slmicro,multi_platform_almalinux,multi_platform_ubuntu
 {{% if 'ubuntu' in product %}}
-find /bin/ /usr/bin/ /usr/local/bin/ /sbin/ /usr/sbin/ /usr/local/sbin/ /usr/libexec \! -uid -100 -execdir chown root {} \;
+find /bin/ /usr/bin/ /usr/local/bin/ /sbin/ /usr/sbin/ /usr/local/sbin/ \! -uid -100 -execdir chown root {} \;
 {{% else %}}
 find /bin/ /usr/bin/ /usr/local/bin/ /sbin/ /usr/sbin/ /usr/local/sbin/ /usr/libexec \! -user root -execdir chown root {} \;
 {{% endif %}}

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/oval/shared.xml
@@ -31,9 +31,10 @@
          /usr/local/sbin, and /usr/libexec directories belong to user with uid 0 (root) -->
     <unix:path operation="pattern match">^\/(|s)bin|^\/usr\/(|local\/)(|s)bin|^\/usr\/libexec</unix:path>
     <unix:filename operation="pattern match">^.*$</unix:filename>
+{{% if 'ubuntu' not in product %}}
    <filter action="include">state_owner_binaries_not_root</filter>
-{{% if 'ubuntu' in product %}}
-   <filter action="exclude">state_at_owner_binaries_daemon</filter>
+{{% else %}}
+   <filter action="include">state_owner_binaries_not_system_accounts</filter>
 {{% endif %}}
   </unix:file_object>
 
@@ -42,9 +43,8 @@
   </unix:file_state>
 
 {{% if 'ubuntu' in product %}}
-  <!-- Exclude owners with less than 100 uid -->
-  <unix:file_state id="state_at_owner_binaries_daemon" version="1" operator="AND">
-    <unix:user_id datatype="int" operation="less than">100</unix:user_id>
+  <unix:file_state id="state_owner_binaries_not_system_accounts" version="1" operator="AND">
+    <unix:user_id datatype="int" operation="greater than or equal">100</unix:user_id>
   </unix:file_state>
 {{% endif %}}
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/oval/shared.xml
@@ -42,10 +42,9 @@
   </unix:file_state>
 
 {{% if 'ubuntu' in product %}}
-  <!-- Exclude /bin/at -->
+  <!-- Exclude owners with less than 100 uid -->
   <unix:file_state id="state_at_owner_binaries_daemon" version="1" operator="AND">
-    <unix:filename operation="pattern match">^at$</unix:filename>
-    <unix:user_id datatype="int" operation="equals">1</unix:user_id>
+    <unix:user_id datatype="int" operation="less than">100</unix:user_id>
   </unix:file_state>
 {{% endif %}}
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/oval/shared.xml
@@ -32,10 +32,21 @@
     <unix:path operation="pattern match">^\/(|s)bin|^\/usr\/(|local\/)(|s)bin|^\/usr\/libexec</unix:path>
     <unix:filename operation="pattern match">^.*$</unix:filename>
    <filter action="include">state_owner_binaries_not_root</filter>
+{{% if 'ubuntu' in product %}}
+   <filter action="exclude">state_at_owner_binaries_daemon</filter>
+{{% endif %}}
   </unix:file_object>
 
   <unix:file_state id="state_owner_binaries_not_root" version="1" operator="OR">
     <unix:user_id datatype="int" operation="not equal">0</unix:user_id>
   </unix:file_state>
+
+{{% if 'ubuntu' in product %}}
+  <!-- Exclude /bin/at -->
+  <unix:file_state id="state_at_owner_binaries_daemon" version="1" operator="AND">
+    <unix:filename operation="pattern match">^at$</unix:filename>
+    <unix:user_id datatype="int" operation="equals">1</unix:user_id>
+  </unix:file_state>
+{{% endif %}}
 
 </def-group>

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/oval/shared.xml
@@ -19,34 +19,34 @@
   </unix:file_test>
 
   <unix:file_object comment="binary directories" id="object_file_ownership_binary_directories" version="1">
-{{% if 'ubuntu' not in product %}}
-    <!-- Check that /bin, /sbin, /usr/sbin, /usr/sbin, /usr/local/bin,
-         /usr/local/sbin, and /usr/libexec directories belong to user with uid 0 (root) -->
-    <unix:path operation="pattern match">^\/(|s)bin|^\/usr\/(|local\/)(|s)bin|^\/usr\/libexec</unix:path>
-{{% else %}}
+{{% if 'ubuntu' in product %}}
     <!-- Check that files within /bin, /sbin, /usr/bin, /usr/sbin, /usr/local/bin,
          /usr/local/sbin directories belong to user with uid < 100 (system accounts) -->
     <unix:path operation="pattern match">^\/(|s)bin|^\/usr\/(|local\/)(|s)bin</unix:path>
+{{% else %}}
+    <!-- Check that /bin, /sbin, /usr/sbin, /usr/sbin, /usr/local/bin,
+         /usr/local/sbin, and /usr/libexec directories belong to user with uid 0 (root) -->
+    <unix:path operation="pattern match">^\/(|s)bin|^\/usr\/(|local\/)(|s)bin|^\/usr\/libexec</unix:path>
 {{% endif %}}
     <unix:filename xsi:nil="true" />
     <filter action="include">state_owner_binaries_not_root</filter>
   </unix:file_object>
 
   <unix:file_object comment="binary files" id="object_file_ownership_binary_files" version="1">
-{{% if 'ubuntu' not in product %}}
-    <!-- Check that files within /bin, /sbin, /usr/bin, /usr/sbin, /usr/local/bin,
-         /usr/local/sbin, and /usr/libexec directories belong to user with uid 0 (root) -->
-    <unix:path operation="pattern match">^\/(|s)bin|^\/usr\/(|local\/)(|s)bin|^\/usr\/libexec</unix:path>
-{{% else %}}
+{{% if 'ubuntu' in product %}}
     <!-- Check that files within /bin, /sbin, /usr/bin, /usr/sbin, /usr/local/bin,
          /usr/local/sbin directories belong to user with uid < 100 (system accounts) -->
     <unix:path operation="pattern match">^\/(|s)bin|^\/usr\/(|local\/)(|s)bin</unix:path>
+{{% else %}}
+    <!-- Check that files within /bin, /sbin, /usr/bin, /usr/sbin, /usr/local/bin,
+         /usr/local/sbin, and /usr/libexec directories belong to user with uid 0 (root) -->
+    <unix:path operation="pattern match">^\/(|s)bin|^\/usr\/(|local\/)(|s)bin|^\/usr\/libexec</unix:path>
 {{% endif %}}
     <unix:filename operation="pattern match">^.*$</unix:filename>
-{{% if 'ubuntu' not in product %}}
-   <filter action="include">state_owner_binaries_not_root</filter>
-{{% else %}}
+{{% if 'ubuntu' in product %}}
    <filter action="include">state_owner_binaries_not_system_accounts</filter>
+{{% else %}}
+   <filter action="include">state_owner_binaries_not_root</filter>
 {{% endif %}}
   </unix:file_object>
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/oval/shared.xml
@@ -19,17 +19,29 @@
   </unix:file_test>
 
   <unix:file_object comment="binary directories" id="object_file_ownership_binary_directories" version="1">
+{{% if 'ubuntu' not in product %}}
     <!-- Check that /bin, /sbin, /usr/sbin, /usr/sbin, /usr/local/bin,
          /usr/local/sbin, and /usr/libexec directories belong to user with uid 0 (root) -->
     <unix:path operation="pattern match">^\/(|s)bin|^\/usr\/(|local\/)(|s)bin|^\/usr\/libexec</unix:path>
+{{% else %}}
+    <!-- Check that files within /bin, /sbin, /usr/bin, /usr/sbin, /usr/local/bin,
+         /usr/local/sbin directories belong to user with uid < 100 (system accounts) -->
+    <unix:path operation="pattern match">^\/(|s)bin|^\/usr\/(|local\/)(|s)bin</unix:path>
+{{% endif %}}
     <unix:filename xsi:nil="true" />
     <filter action="include">state_owner_binaries_not_root</filter>
   </unix:file_object>
 
   <unix:file_object comment="binary files" id="object_file_ownership_binary_files" version="1">
+{{% if 'ubuntu' not in product %}}
     <!-- Check that files within /bin, /sbin, /usr/bin, /usr/sbin, /usr/local/bin,
          /usr/local/sbin, and /usr/libexec directories belong to user with uid 0 (root) -->
     <unix:path operation="pattern match">^\/(|s)bin|^\/usr\/(|local\/)(|s)bin|^\/usr\/libexec</unix:path>
+{{% else %}}
+    <!-- Check that files within /bin, /sbin, /usr/bin, /usr/sbin, /usr/local/bin,
+         /usr/local/sbin directories belong to user with uid < 100 (system accounts) -->
+    <unix:path operation="pattern match">^\/(|s)bin|^\/usr\/(|local\/)(|s)bin</unix:path>
+{{% endif %}}
     <unix:filename operation="pattern match">^.*$</unix:filename>
 {{% if 'ubuntu' not in product %}}
    <filter action="include">state_owner_binaries_not_root</filter>

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/tests/right_owner.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/tests/right_owner.pass.sh
@@ -8,7 +8,7 @@ find /bin/ \
 /usr/sbin/ \
 /usr/local/sbin/ \
 /usr/libexec \
-\! -user root \! \( -user daemon -a -name "at" \) -execdir chown root {} \;
+\! -uid -100 -execdir chown root {} \;
 {{% else %}}
 find /bin/ \
 /usr/bin/ \

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/tests/right_owner.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/tests/right_owner.pass.sh
@@ -1,21 +1,7 @@
 #!/bin/bash
 
 {{% if 'ubuntu' in product %}}
-find /bin/ \
-/usr/bin/ \
-/usr/local/bin/ \
-/sbin/ \
-/usr/sbin/ \
-/usr/local/sbin/ \
-/usr/libexec \
-\! -uid -100 -execdir chown root {} \;
+find /bin/ /usr/bin/ /usr/local/bin/ /sbin/ /usr/sbin/ /usr/local/sbin/ /usr/libexec \! -uid -100 -execdir chown root {} \;
 {{% else %}}
-find /bin/ \
-/usr/bin/ \
-/usr/local/bin/ \
-/sbin/ \
-/usr/sbin/ \
-/usr/local/sbin/ \
-/usr/libexec \
-\! -user root -execdir chown root {} \;
+find /bin/ /usr/bin/ /usr/local/bin/ /sbin/ /usr/sbin/ /usr/local/sbin/ /usr/libexec \! -user root -execdir chown root {} \;
 {{% endif %}}

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/tests/right_owner.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/tests/right_owner.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 {{% if 'ubuntu' in product %}}
-find /bin/ /usr/bin/ /usr/local/bin/ /sbin/ /usr/sbin/ /usr/local/sbin/ /usr/libexec \! -uid -100 -execdir chown root {} \;
+find /bin/ /usr/bin/ /usr/local/bin/ /sbin/ /usr/sbin/ /usr/local/sbin/ \! -uid -100 -execdir chown root {} \;
 {{% else %}}
 find /bin/ /usr/bin/ /usr/local/bin/ /sbin/ /usr/sbin/ /usr/local/sbin/ /usr/libexec \! -user root -execdir chown root {} \;
 {{% endif %}}

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/tests/right_owner.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/tests/right_owner.pass.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+{{% if 'ubuntu' in product %}}
+find /bin/ \
+/usr/bin/ \
+/usr/local/bin/ \
+/sbin/ \
+/usr/sbin/ \
+/usr/local/sbin/ \
+/usr/libexec \
+\! -user root \! \( -user daemon -a -name "at" \) -execdir chown root {} \;
+{{% else %}}
 find /bin/ \
 /usr/bin/ \
 /usr/local/bin/ \
@@ -8,3 +18,4 @@ find /bin/ \
 /usr/local/sbin/ \
 /usr/libexec \
 \! -user root -execdir chown root {} \;
+{{% endif %}}

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/tests/wrong_owner.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/tests/wrong_owner.fail.sh
@@ -2,7 +2,10 @@
 
 useradd testUser
 
-dirs=("/bin" "/sbin" "/usr/bin" "/usr/sbin" "/usr/libexec" "/usr/local/bin" "/usr/local/sbin")
+dirs=("/bin" "/sbin" "/usr/bin" "/usr/sbin" "/usr/local/bin" "/usr/local/sbin")
+{{% if 'ubuntu' not in product %}}
+dirs+=("/usr/libexec")
+{{% endif %}}
 
 for directory in "${dirs[@]}"; do
 


### PR DESCRIPTION
#### Description:

- Exclude accounts with uid < 100 in check and remediation for Ubuntu
- Exclude directory `/usr/libexec` for Ubuntu according to STIG v2r1 UBTU-20-010457
- Formatted the find lines

#### Rationale:

- It aligns with the STIG rule UBTU-20-010429: Rule Title: The Ubuntu operating system must have system commands owned by root or a system account.
- If the file_ownership_binary_dirs audit remediation is executed after the file_groupownership_system_commands_dirs audit remediation, the chown will clear the setuid/setgid bits of `-rwsr-sr-x 1 daemon daemon 55560 Nov 12  2018 /usr/bin/at` which will cause the check of file_groupownership_system_commands_dirs on the next run fail since the oval will flag files not group owned by root and not with setgid:
```
  <unix:file_state id="state_groupowner_system_commands_dirs_not_root_not_sgid" version="1">
    <unix:group_id datatype="int" operation="not equal">0</unix:group_id>
    <unix:sgid datatype="boolean">false</unix:sgid>
  </unix:file_state>
  ```
- After discussion we decided to regard users with uid < 100 as system account so it can be ignored 

