### PR TITLE
OPENSCAP-4816: Remove grub2_nousb_argument from RHEL10 HIPAA profile

### DIFF
--- a/controls/hipaa.yml
+++ b/controls/hipaa.yml
@@ -206,7 +206,6 @@ controls:
             - addressable
         rules:
             - coreos_nousb_kernel_argument
-            - grub2_nousb_argument
             - kernel_module_usb-storage_disabled
             - service_autofs_disabled
         status: automated
@@ -305,7 +304,6 @@ controls:
             - audit_rules_time_watch_localtime
             - auditd_data_retention_flush
             - coreos_nousb_kernel_argument
-            - grub2_nousb_argument
             - kernel_module_usb-storage_disabled
             - service_autofs_disabled
         status: automated
@@ -1039,7 +1037,6 @@ controls:
             - grub2_uefi_admin_username
             - grub2_uefi_password
             - coreos_nousb_kernel_argument
-            - grub2_nousb_argument
             - kernel_module_usb-storage_disabled
             - service_autofs_disabled
         status: automated
@@ -1054,7 +1051,6 @@ controls:
             - base
         rules:
             - coreos_nousb_kernel_argument
-            - grub2_nousb_argument
             - kernel_module_usb-storage_disabled
             - service_autofs_disabled
         status: automated
@@ -1133,7 +1129,6 @@ controls:
             - base
         rules:
             - coreos_nousb_kernel_argument
-            - grub2_nousb_argument
             - kernel_module_usb-storage_disabled
             - service_autofs_disabled
             - encrypt_partitions
@@ -1273,7 +1268,6 @@ controls:
             - addressable
         rules:
             - coreos_nousb_kernel_argument
-            - grub2_nousb_argument
             - kernel_module_usb-storage_disabled
             - service_autofs_disabled
             - encrypt_partitions
@@ -1382,7 +1376,6 @@ controls:
             - service_auditd_enabled
             - rsyslog_remote_loghost
             - coreos_nousb_kernel_argument
-            - grub2_nousb_argument
             - kernel_module_usb-storage_disabled
             - service_autofs_disabled
             - encrypt_partitions

--- a/products/rhel10/profiles/default.profile
+++ b/products/rhel10/profiles/default.profile
@@ -11,4 +11,5 @@ description: |-
   this profile is to keep a rule in the product's XCCDF Benchmark.
 
 selections:
+  - grub2_nousb_argument
   - audit_rules_kernel_module_loading_create

--- a/tests/data/profile_stability/rhel10/hipaa.profile
+++ b/tests/data/profile_stability/rhel10/hipaa.profile
@@ -139,7 +139,6 @@ selections:
 - grub2_audit_argument
 - grub2_disable_interactive_boot
 - grub2_enable_selinux
-- grub2_nousb_argument
 - grub2_password
 - grub2_uefi_password
 - kernel_module_usb-storage_disabled


### PR DESCRIPTION
#### Description:
- Remove grub2_nousb_argument from RHEL10 HIPAA profile.
- This rule was only applicable to RHEL<=8.
