### PR TITLE
OPENSCAP-4927 - Update audit_rules_media_export

### DIFF
--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -40,6 +40,7 @@
 -   Parameters:
 
     -   **attr** - value of `-S` argument in Audit rule, eg. `chmod`
+    -   **key** - audit key. If this isn't specified then the default value `perm_mod` is used.
 
 -   Languages: Ansible, Bash, OVAL, Kubernetes
 

--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -40,6 +40,7 @@
 -   Parameters:
 
     -   **attr** - value of `-S` argument in Audit rule, eg. `chmod`
+
     -   **key** - audit key. If this isn't specified then the default value `perm_mod` is used.
 
 -   Languages: Ansible, Bash, OVAL, Kubernetes

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_media_export/policy/stig/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_media_export/policy/stig/shared.yml
@@ -13,15 +13,17 @@ vuldiscussion: |-
 checktext: |-
     Verify that {{{ full_name }}} is configured to audit the execution of the "mount" command with the following command:
 
-    $ sudo auditctl -l | grep /usr/bin/mount
+    $ sudo auditctl -l | grep mount
 
-    -a always,exit -F path=/usr/bin/mount -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-mount
+    -a always,exit -F arch=b32 -S mount -F auid&gt;={{{ uid_min }}} -F auid!=unset -k export
+    -a always,exit -F arch=b64 -S mount -F auid&gt;={{{ uid_min }}} -F auid!=unset -k export
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "mount" command by adding or updating the following rule in "/etc/audit/rules.d/audit.rules":
 
-    --a always,exit -F path=/usr/bin/mount -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-mount
+    -a always,exit -F arch=b32 -S mount -F auid&gt;={{{ uid_min }}} -F auid!=unset -k export
+    -a always,exit -F arch=b64 -S mount -F auid&gt;={{{ uid_min }}} -F auid!=unset -k export
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_media_export/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_media_export/rule.yml
@@ -7,13 +7,15 @@ description: |-
     events for all users and root. If the <tt>auditd</tt> daemon is configured to
     use the <tt>augenrules</tt> program to read audit rules during daemon startup
     (the default), add the following line to a file with suffix <tt>.rules</tt> in
-    the directory <tt>/etc/audit/rules.d</tt>, setting ARCH to either b32 or b64 as
-    appropriate for your system:
+    the directory <tt>/etc/audit/rules.d</tt>, setting ARCH to either b32 for
+    32-bit system, or having two lines for both b32 and b64 in case your
+    system is 64-bit:
     <pre>-a always,exit -F arch=ARCH -S mount -F auid&gt;={{{ auid }}} -F auid!=unset -F key=export</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
-    <tt>/etc/audit/audit.rules</tt> file, setting ARCH to either b32 or b64 as
-    appropriate for your system:
+    <tt>/etc/audit/audit.rules</tt> file, setting ARCH to either b32 for
+    32-bit system, or having two lines for both b32 and b64 in case your
+    system is 64-bit:
     <pre>-a always,exit -F arch=ARCH -S mount -F auid&gt;={{{ auid }}} -F auid!=unset -F key=export</pre>
 
 rationale: |-
@@ -60,7 +62,7 @@ references:
 {{{ complete_ocil_entry_audit_syscall(syscall="mount") }}}
 
 fixtext: |-
-    {{{ fixtext_audit_rules_dac_modification_attr("mount") | indent(4) }}}
+    {{{ fixtext_audit_rules("mount", "export", None) | indent(4) }}}
 
 srg_requirement: '{{{ srg_requirement_audit_syscall("mount") }}}'
 
@@ -68,3 +70,4 @@ template:
     name: audit_rules_dac_modification
     vars:
         attr: mount
+        key: export

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_media_export/tests/correct_rules.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_media_export/tests/correct_rules.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # packages = audit
 
-echo "-a always,exit -F arch=b32 -S mount -F auid>={{{ uid_min }}} -F auid!=unset -k mount" >> /etc/audit/rules.d/mount.rules
-echo "-a always,exit -F arch=b64 -S mount -F auid>={{{ uid_min }}} -F auid!=unset -k mount" >> /etc/audit/rules.d/mount.rules
+echo "-a always,exit -F arch=b32 -S mount -F auid>={{{ uid_min }}} -F auid!=unset -k export" >> /etc/audit/rules.d/export.rules
+echo "-a always,exit -F arch=b64 -S mount -F auid>={{{ uid_min }}} -F auid!=unset -k export" >> /etc/audit/rules.d/export.rules

--- a/shared/templates/audit_rules_dac_modification/ansible.template
+++ b/shared/templates/audit_rules_dac_modification/ansible.template
@@ -24,7 +24,7 @@
       other_filters="",
       auid_filters="-F auid>="~auid~" -F auid!=unset",
       syscalls=ATTR,
-      key="perm_mod",
+      key=KEY,
       syscall_grouping=SYSCALL_GROUPING,
       )|indent(4) }}}
     {{{ ansible_audit_auditctl_add_syscall_rule(
@@ -32,7 +32,7 @@
       other_filters="",
       auid_filters="-F auid>="~auid~" -F auid!=unset",
       syscalls=ATTR,
-      key="perm_mod",
+      key=KEY,
       syscall_grouping=SYSCALL_GROUPING,
       )|indent(4) }}}
 {{%- if CHECK_ROOT_USER %}}
@@ -41,7 +41,7 @@
       other_filters="",
       auid_filters="-F auid=0",
       syscalls=ATTR,
-      key="perm_mod",
+      key=KEY,
       syscall_grouping=SYSCALL_GROUPING,
       )|indent(4) }}}
     {{{ ansible_audit_auditctl_add_syscall_rule(
@@ -49,7 +49,7 @@
       other_filters="",
       auid_filters="-F auid=0",
       syscalls=ATTR,
-      key="perm_mod",
+      key=KEY,
       syscall_grouping=SYSCALL_GROUPING,
       )|indent(4) }}}
 {{%- endif %}}
@@ -61,7 +61,7 @@
       other_filters="",
       auid_filters="-F auid>="~auid~" -F auid!=unset",
       syscalls=ATTR,
-      key="perm_mod",
+      key=KEY,
       syscall_grouping=SYSCALL_GROUPING,
       )|indent(4) }}}
     {{{ ansible_audit_auditctl_add_syscall_rule(
@@ -69,7 +69,7 @@
       other_filters="",
       auid_filters="-F auid>="~auid~" -F auid!=unset",
       syscalls=ATTR,
-      key="perm_mod",
+      key=KEY,
       syscall_grouping=SYSCALL_GROUPING,
       )|indent(4) }}}
 {{%- if CHECK_ROOT_USER %}}
@@ -78,7 +78,7 @@
       other_filters="",
       auid_filters="-F auid=0",
       syscalls=ATTR,
-      key="perm_mod",
+      key=KEY,
       syscall_grouping=SYSCALL_GROUPING,
       )|indent(4) }}}
     {{{ ansible_audit_auditctl_add_syscall_rule(
@@ -86,7 +86,7 @@
       other_filters="",
       auid_filters="-F auid=0",
       syscalls=ATTR,
-      key="perm_mod",
+      key=KEY,
       syscall_grouping=SYSCALL_GROUPING,
       )|indent(4) }}}
 {{%- endif %}}

--- a/shared/templates/audit_rules_dac_modification/bash.template
+++ b/shared/templates/audit_rules_dac_modification/bash.template
@@ -10,7 +10,7 @@ do
 	OTHER_FILTERS=""
 	AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
 	SYSCALL="{{{ ATTR }}}"
-	KEY="perm_mod"
+	KEY="{{{ KEY }}}"
 	SYSCALL_GROUPING="{{{ SYSCALL_GROUPING }}}"
 
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
@@ -26,7 +26,7 @@ do
 	OTHER_FILTERS=""
 	AUID_FILTERS="-F auid=0"
 	SYSCALL="{{{ ATTR }}}"
-	KEY="perm_mod"
+	KEY="{{{ KEY }}}"
 	SYSCALL_GROUPING="{{{ SYSCALL_GROUPING }}}"
 
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'

--- a/shared/templates/audit_rules_dac_modification/kubernetes.template
+++ b/shared/templates/audit_rules_dac_modification/kubernetes.template
@@ -13,7 +13,7 @@ spec:
     storage:
       files:
       - contents:
-          source: data:,-a%20always%2Cexit%20-F%20arch%3Db32%20-S%20{{{ ATTR }}}%20-F%20auid%3E%3D1000%20-F%20auid%21%3Dunset%20-F%20key%3Dperm_mod%0A-a%20always%2Cexit%20-F%20arch%3Db64%20-S%20{{{ ATTR }}}%20-F%20auid%3E%3D1000%20-F%20auid%21%3Dunset%20-F%20key%3Dperm_mod%0A
+          source: data:,-a%20always%2Cexit%20-F%20arch%3Db32%20-S%20{{{ ATTR }}}%20-F%20auid%3E%3D1000%20-F%20auid%21%3Dunset%20-F%20key%3D{{{ KEY }}}%0A-a%20always%2Cexit%20-F%20arch%3Db64%20-S%20{{{ ATTR }}}%20-F%20auid%3E%3D1000%20-F%20auid%21%3Dunset%20-F%20key%3D{{{ KEY }}}%0A
         mode: 0644
         path: /etc/audit/rules.d/75-{{{ ATTR }}}_dac_modification.rules
         overwrite: true

--- a/shared/templates/audit_rules_dac_modification/template.py
+++ b/shared/templates/audit_rules_dac_modification/template.py
@@ -3,6 +3,8 @@ from ssg.utils import parse_template_boolean_value
 
 def preprocess(data, lang):
     data["check_root_user"] = parse_template_boolean_value(data, parameter="check_root_user", default_value=False)
+    if "key" not in data:
+        data["key"] = "perm_mod"
     if lang == "bash":
         if "syscall_grouping" in data:
             # Make it easier to tranform the syscall_grouping into a Bash array

--- a/shared/templates/audit_rules_dac_modification/tests/correct_rules.pass.sh
+++ b/shared/templates/audit_rules_dac_modification/tests/correct_rules.pass.sh
@@ -5,10 +5,10 @@
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules
 
-echo "-a always,exit -F arch=b32 -S {{{ ATTR }}} -F auid>={{{ uid_min }}} -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
-echo "-a always,exit -F arch=b64 -S {{{ ATTR }}} -F auid>={{{ uid_min }}} -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
+echo "-a always,exit -F arch=b32 -S {{{ ATTR }}} -F auid>={{{ uid_min }}} -F auid!=unset -F key={{{ KEY }}}" >> /etc/audit/rules.d/{{{ KEY }}}.rules
+echo "-a always,exit -F arch=b64 -S {{{ ATTR }}} -F auid>={{{ uid_min }}} -F auid!=unset -F key={{{ KEY }}}" >> /etc/audit/rules.d/{{{ KEY }}}.rules
 
 {{% if CHECK_ROOT_USER %}}
-    echo "-a always,exit -F arch=b32 -S {{{ ATTR }}} -F auid=0 -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
-    echo "-a always,exit -F arch=b64 -S {{{ ATTR }}} -F auid=0 -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
+    echo "-a always,exit -F arch=b32 -S {{{ ATTR }}} -F auid=0 -F auid!=unset -F key={{{ KEY }}}" >> /etc/audit/rules.d/{{{ KEY }}}.rules
+    echo "-a always,exit -F arch=b64 -S {{{ ATTR }}} -F auid=0 -F auid!=unset -F key={{{ KEY }}}" >> /etc/audit/rules.d/{{{ KEY }}}.rules
 {{% endif %}}

--- a/shared/templates/audit_rules_dac_modification/tests/wrong_list_action.fail.sh
+++ b/shared/templates/audit_rules_dac_modification/tests/wrong_list_action.fail.sh
@@ -4,10 +4,10 @@
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules
-echo "-a never,exit -F arch=b32 -S {{{ ATTR }}} -F auid>={{{ uid_min }}} -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
-echo "-a never,exit -F arch=b64 -S {{{ ATTR }}} -F auid>={{{ uid_min }}} -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
+echo "-a never,exit -F arch=b32 -S {{{ ATTR }}} -F auid>={{{ uid_min }}} -F auid!=unset -F key={{{ KEY }}}" >> /etc/audit/rules.d/{{{ KEY }}}.rules
+echo "-a never,exit -F arch=b64 -S {{{ ATTR }}} -F auid>={{{ uid_min }}} -F auid!=unset -F key={{{ KEY }}}" >> /etc/audit/rules.d/{{{ KEY }}}.rules
 
 {{% if CHECK_ROOT_USER %}}
-    echo "-a never,exit -F arch=b32 -S {{{ ATTR }}} -F auid=0 -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
-    echo "-a never,exit -F arch=b64 -S {{{ ATTR }}} -F auid=0 -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
+    echo "-a never,exit -F arch=b32 -S {{{ ATTR }}} -F auid=0 -F auid!=unset -F key={{{ KEY }}}" >> /etc/audit/rules.d/{{{ KEY }}}.rules
+    echo "-a never,exit -F arch=b64 -S {{{ ATTR }}} -F auid=0 -F auid!=unset -F key={{{ KEY }}}" >> /etc/audit/rules.d/{{{ KEY }}}.rules
 {{% endif %}}

--- a/shared/templates/audit_rules_dac_modification/tests/wrong_syscall.fail.sh
+++ b/shared/templates/audit_rules_dac_modification/tests/wrong_syscall.fail.sh
@@ -4,10 +4,10 @@
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules
-echo "-a always,exit -F arch=b32 -S pipe -F auid>={{{ uid_min }}} -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
-echo "-a always,exit -F arch=b64 -S pipe -F auid>={{{ uid_min }}} -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
+echo "-a always,exit -F arch=b32 -S pipe -F auid>={{{ uid_min }}} -F auid!=unset -F key={{{ KEY }}}" >> /etc/audit/rules.d/{{{ KEY }}}.rules
+echo "-a always,exit -F arch=b64 -S pipe -F auid>={{{ uid_min }}} -F auid!=unset -F key={{{ KEY }}}" >> /etc/audit/rules.d/{{{ KEY }}}.rules
 
 {{% if CHECK_ROOT_USER %}}
-    echo "-a always,exit -F arch=b32 -S pipe -F auid=0 -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
-    echo "-a always,exit -F arch=b64 -S pipe -F auid=0 -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
+    echo "-a always,exit -F arch=b32 -S pipe -F auid=0 -F auid!=unset -F key={{{ KEY }}}" >> /etc/audit/rules.d/{{{ KEY }}}.rules
+    echo "-a always,exit -F arch=b64 -S pipe -F auid=0 -F auid!=unset -F key={{{ KEY }}}" >> /etc/audit/rules.d/{{{ KEY }}}.rules
 {{% endif %}}


### PR DESCRIPTION
- Update rule description because if you are on 64 bit architecture you should add 2 lines of audit rules - one with b32 and one with b64.
- Align remediations, checks, tests, etc. with the rule description
- Resolve inconsistencies with audit key.

