### PR TITLE
Fix applicability for file_permissions_var_log on Ubuntu

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log/rule.yml
@@ -31,6 +31,10 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/log", perms="drwxr-xr-
 ocil: |-
     {{{ ocil_file_permissions(file="/var/log", perms="drwxr-xr-x") }}}
 
+{{% if 'ubuntu' in product %}}
+platform: service_disabled[rsyslog]
+{{% endif %}}
+
 template:
     name: file_permissions
     vars:


### PR DESCRIPTION
#### Description:

- Make file_permissions_var_log applicable only when rsyslog is not active

#### Rationale:

- The rule sets /var/log permissions to 0755 which prevents rsyslog from being able to create new files in that directory.
- According to UBTU-20-010419, UBTU-22-232025, this rule should not be applicable when rsyslog is installed and active.