### PR TITLE
build: use a formatting construct that can use an older python3

### DIFF
--- a/ssg/jinja.py
+++ b/ssg/jinja.py
@@ -255,7 +255,7 @@ def _load_macros(macros_directory, substitutions_dict=None):
     add_python_functions(substitutions_dict)
 
     if not os.path.isdir(macros_directory):
-        msg = (f"The directory '{macros_directory}' does not exist.")
+        msg = ("The directory '{1}' does not exist.").format(macros_directory)
         raise RuntimeError(msg)
 
     _load_macros_from_directory(macros_directory, substitutions_dict)

--- a/ssg/jinja.py
+++ b/ssg/jinja.py
@@ -255,7 +255,7 @@ def _load_macros(macros_directory, substitutions_dict=None):
     add_python_functions(substitutions_dict)
 
     if not os.path.isdir(macros_directory):
-        msg = ("The directory '{1}' does not exist.").format(macros_directory)
+        msg = ("The directory '{}' does not exist.").format(macros_directory)
         raise RuntimeError(msg)
 
     _load_macros_from_directory(macros_directory, substitutions_dict)


### PR DESCRIPTION
One small fix to still build it on python 3.4.

#### Description:

The formatting construct is not valid syntax for python 3.4.

#### Rationale:

Use string format which can be used by older python3.