### PR TITLE
OPENSCAP-4930, OPENSCAP-4931, OPENSCAP-4932, OPENSCAP-4933, OPENSCAP-4934, OPENSCAP-4935, OPENSCAP-4936, OPENSCAP-4937, OPENSCAP-4938, OPENSCAP-4939, OPENSCAP-4940, OPENSCAP-4941, OPENSCAP-4942, OPENSCAP-4943, OPENSCAP-4944, OPENSCAP-4945, OPENSCAP-4946, OPENSCAP-4947: Add arch filter to ARPC

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_execution_acl_commands/audit_rules_execution_chacl/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_execution_acl_commands/audit_rules_execution_chacl/rule.yml
@@ -4,16 +4,7 @@ documentation_complete: true
 title: 'Record Any Attempts to Run chacl'
 
 description: |-
-    At a minimum, the audit system should collect any execution attempt
-    of the <tt>chacl</tt> command for all users and root. If the <tt>auditd</tt>
-    daemon is configured to use the <tt>augenrules</tt> program to read audit rules
-    during daemon startup (the default), add the following lines to a file with suffix
-    <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/chacl -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add the following lines to
-    <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F path=/usr/bin/chacl -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/bin/chacl")}}}
 
 rationale: |-
     Without generating audit records that are specific to the security and

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_execution_acl_commands/audit_rules_execution_chmod/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_execution_acl_commands/audit_rules_execution_chmod/rule.yml
@@ -4,16 +4,7 @@ documentation_complete: true
 title: 'Record Any Attempts to Run chmod'
 
 description: |-
-    At a minimum, the audit system should collect any execution attempt
-    of the <tt>chmod</tt> command for all users and root. If the <tt>auditd</tt>
-    daemon is configured to use the <tt>augenrules</tt> program to read audit rules
-    during daemon startup (the default), add the following lines to a file with suffix
-    <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/chmod -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add the following lines to
-    <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F path=/usr/bin/chmod -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/bin/chmod")}}}
 
 rationale: |-
     Without generating audit records that are specific to the security and

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_execution_acl_commands/audit_rules_execution_setfacl/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_execution_acl_commands/audit_rules_execution_setfacl/rule.yml
@@ -3,16 +3,7 @@ documentation_complete: true
 title: 'Record Any Attempts to Run setfacl'
 
 description: |-
-    At a minimum, the audit system should collect any execution attempt
-    of the <tt>setfacl</tt> command for all users and root. If the <tt>auditd</tt>
-    daemon is configured to use the <tt>augenrules</tt> program to read audit rules
-    during daemon startup (the default), add the following lines to a file with suffix
-    <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/setfacl -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add the following lines to
-    <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F path=/usr/bin/setfacl -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/bin/setfacl")}}}
 
 rationale: |-
     Without generating audit records that are specific to the security and

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_chcon/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_chcon/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Record Any Attempts to Run chcon'
 
 description: |-
-    At a minimum, the audit system should collect any execution attempt
-    of the <tt>chcon</tt> command for all users and root. If the <tt>auditd</tt>
-    daemon is configured to use the <tt>augenrules</tt> program to read audit rules
-    during daemon startup (the default), add the following lines to a file with suffix
-    <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/chcon {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add the following lines to
-    <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F path=/usr/bin/chcon {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/bin/chcon")}}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_restorecon/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_restorecon/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Record Any Attempts to Run restorecon'
 
 description: |-
-    At a minimum, the audit system should collect any execution attempt
-    of the <tt>restorecon</tt> command for all users and root. If the <tt>auditd</tt>
-    daemon is configured to use the <tt>augenrules</tt> program to read audit rules
-    during daemon startup (the default), add the following lines to a file with suffix
-    <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/restorecon {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add the following lines to
-    <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F path=/usr/sbin/restorecon {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/sbin/restorecon")}}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_rm/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_rm/rule.yml
@@ -4,16 +4,7 @@ documentation_complete: true
 title: 'Record Any Attempts to Run rm'
 
 description: |-
-    At a minimum, the audit system should collect any execution attempt
-    of the <tt>rm</tt> command for all users and root. If the <tt>auditd</tt>
-    daemon is configured to use the <tt>augenrules</tt> program to read audit rules
-    during daemon startup (the default), add the following lines to a file with suffix
-    <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/rm -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add the following lines to
-    <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F path=/usr/bin/rm -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/bin/rm")}}}
 
 rationale: |-
     Without generating audit records that are specific to the security and

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_semanage/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_semanage/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Record Any Attempts to Run semanage'
 
 description: |-
-    At a minimum, the audit system should collect any execution attempt
-    of the <tt>semanage</tt> command for all users and root. If the <tt>auditd</tt>
-    daemon is configured to use the <tt>augenrules</tt> program to read audit rules
-    during daemon startup (the default), add the following lines to a file with suffix
-    <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/semanage {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add the following lines to
-    <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F path=/usr/sbin/semanage {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/sbin/semanage")}}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setfiles/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setfiles/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Record Any Attempts to Run setfiles'
 
 description: |-
-    At a minimum, the audit system should collect any execution attempt
-    of the <tt>setfiles</tt> command for all users and root. If the <tt>auditd</tt>
-    daemon is configured to use the <tt>augenrules</tt> program to read audit rules
-    during daemon startup (the default), add the following lines to a file with suffix
-    <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/setfiles {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add the following lines to
-    <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F path=/usr/sbin/setfiles {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/sbin/setfiles")}}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setsebool/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setsebool/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Record Any Attempts to Run setsebool'
 
 description: |-
-    At a minimum, the audit system should collect any execution attempt
-    of the <tt>setsebool</tt> command for all users and root. If the <tt>auditd</tt>
-    daemon is configured to use the <tt>augenrules</tt> program to read audit rules
-    during daemon startup (the default), add the following lines to a file with suffix
-    <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/setsebool {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add the following lines to
-    <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F path=/usr/sbin/setsebool {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/sbin/setsebool")}}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_seunshare/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_seunshare/rule.yml
@@ -1,24 +1,9 @@
-{{%- if product in ["fedora", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
-
 documentation_complete: true
-
 
 title: 'Record Any Attempts to Run seunshare'
 
 description: |-
-    At a minimum, the audit system should collect any execution attempt
-    of the <tt>seunshare</tt> command for all users and root. If the <tt>auditd</tt>
-    daemon is configured to use the <tt>augenrules</tt> program to read audit rules
-    during daemon startup (the default), add the following lines to a file with suffix
-    <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/seunshare {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add the following lines to
-    <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F path=/usr/sbin/seunshare {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/sbin/seunshare")}}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_privileged_commands_init/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_privileged_commands_init/rule.yml
@@ -9,16 +9,7 @@ documentation_complete: true
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - init'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path={{{ path }}}/init {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path={{{ path }}}/init {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc(path + "/init") }}}
 
 rationale:
     Misuse of the init command may cause availability issues for the system.

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_privileged_commands_poweroff/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_privileged_commands_poweroff/rule.yml
@@ -9,16 +9,7 @@ documentation_complete: true
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - poweroff'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path={{{ path }}}/poweroff {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/poweroff {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc(path + "/poweroff") }}}
 
 rationale:
     Misuse of the poweroff command may cause availability issues for the system.

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_privileged_commands_reboot/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_privileged_commands_reboot/rule.yml
@@ -9,16 +9,7 @@ documentation_complete: true
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - reboot'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path={{{ path }}}/reboot {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path={{{ path }}}/reboot {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc(path + "/reboot") }}}
 
 rationale:
     Misuse of the reboot command may cause availability issues for the system.

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_privileged_commands_shutdown/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_privileged_commands_shutdown/rule.yml
@@ -9,16 +9,7 @@ documentation_complete: true
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - shutdown'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path={{{ path }}}/shutdown {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path={{{ path }}}/shutdown {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc(path + "/shutdown") }}}
 
 rationale:
     Misuse of the shutdown command may cause availability issues for the system.

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
@@ -14,8 +14,9 @@ description: |-
     <pre>$ sudo find <i>PARTITION</i> -xdev -perm /6000 -type f 2&gt;/dev/null</pre>
 
     For each setuid / setgid program identified by the previous command, an audit rule must be
-    present in the appropriate place using the following line structure:
-    <pre>-a always,exit -F path=<i>PROG_PATH</i> -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    present in the appropriate place using the following line structure, setting ARCH to either b32 for 32-bit
+    system, or having two lines for both b32 and b64 in case your system is 64-bit:
+    <pre>-a always,exit -F arch=ARCH -F path=<i>PROG_PATH</i> -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>augenrules</tt> program to read
     audit rules during daemon startup, add the line to a file with suffix <tt>.rules</tt> in the

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_apparmor_parser/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_apparmor_parser/rule.yml
@@ -4,17 +4,7 @@ documentation_complete: true
 title: 'Record Any Attempts to Run apparmor_parser'
 
 description: |-
-    At a minimum, the audit system should collect any execution attempt
-    of the <tt>apparmor_parser</tt> command for all users and root. If
-    the <tt>auditd</tt> daemon is configured to use the <tt>augenrules</tt>
-    program to read audit rules during daemon startup (the default), add
-    the following lines to a file with suffix <tt>.rules</tt> in the
-    directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/sbin/apparmor_parser -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add the following
-    lines to <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F path=/sbin/apparmor_parser -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/sbin/apparmor_parser") }}}
 
 rationale: |-
     Without generating audit records that are specific to the security and

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_at/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_at/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in products %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - at'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/at {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/at {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/bin/at") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chage/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chage/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - chage'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/chage {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/chage {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/bin/chage") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chfn/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chfn/rule.yml
@@ -4,16 +4,7 @@ documentation_complete: true
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - chfn'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/chfn -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/chfn -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/bin/chfn") }}}
 
 rationale: |-
     Without generating audit records that are specific to the security and

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chsh/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chsh/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - chsh'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/chsh {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/chsh {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/bin/chsh") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_crontab/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_crontab/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - crontab'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/crontab {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/crontab {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/bin/crontab") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_dbus_daemon_launch_helper/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_dbus_daemon_launch_helper/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - dbus helper'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path= /usr/libexec/dbus-1/dbus-daemon-launch-helper-1 {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path= /usr/libexec/dbus-1/dbus-daemon-launch-helper-1 {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/libexec/dbus-1/dbus-daemon-launch-helper-1") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fusermount/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fusermount/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - fusermount'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/fusermount {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/fusermount {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/bin/fusermount") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fusermount3/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fusermount3/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - fusermount3'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/fusermount3 {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/fusermount3 {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/bin/fusermount3") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_gpasswd/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_gpasswd/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "slmicro5" ,"ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - gpasswd'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/gpasswd {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/gpasswd {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/bin/gpasswd") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_grub2_set_bootflag/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_grub2_set_bootflag/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - grub2_set_bootflag'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/grub2-set-bootflag {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path= /usr/sbin/grub2-set-bootflag{{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/sbin/grub2-set-bootflag") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/rule.yml
@@ -1,25 +1,9 @@
-{{%- if 'ol' in families or 'rhel' in product %}}
-    {{%- set kmod_audit="-a always,exit -F path=/usr/bin/kmod -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=privileged" %}}
-{{%- else %}}
-    {{%- set kmod_audit="-w /usr/bin/kmod -p x -k modules" %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - kmod'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>{{{ kmod_audit }}}</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>{{{ kmod_audit }}}</pre>
+    {{{ describe_arpc("/usr/bin/kmod") }}}
 
 rationale: |-
     Without generating audit records that are specific to the security and

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_mount/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_mount/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - mount'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/mount {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/mount {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/bin/mount") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_mount_nfs/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_mount_nfs/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - mount.nfs'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/mount.nfs {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path= /usr/sbin/mount.nfs perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/sbin/mount.mfs") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgidmap/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgidmap/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora",  "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - newgidmap'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/newgidmap {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/newgidmap {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/bin/newgidmap") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgrp/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgrp/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - newgrp'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/newgrp {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/newgrp {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/bin/newgrp") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newuidmap/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newuidmap/rule.yml
@@ -1,23 +1,9 @@
- {{%- if product in ["fedora", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - newuidmap'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/newuidmap {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/newuidmap {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/bin/newuidmap") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pam_timestamp_check/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pam_timestamp_check/rule.yml
@@ -1,6 +1,3 @@
-{{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 {{% if product in ["sle12", "sle15", "slmicro5"] %}}
 {{% set pam_bin_path = "/sbin/pam_timestamp_check" %}}
 {{% else %}}
@@ -9,22 +6,10 @@
 
 documentation_complete: true
 
-
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - pam_timestamp_check'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path={{{ pam_bin_path }}}
-    {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path={{{ pam_bin_path }}}
-    {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc(pam_bin_path) }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passmass/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passmass/rule.yml
@@ -4,16 +4,7 @@ documentation_complete: true
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - passmass'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/passmass -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/passmass -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/bin/passmass") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passwd/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passwd/rule.yml
@@ -1,22 +1,9 @@
-{{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - passwd'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/passwd {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/passwd {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/bin/passwd") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pkexec/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pkexec/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - pkexec'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/pkexec {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/pkexec {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/bin/pkexec") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_polkit_helper/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_polkit_helper/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - polkit helper'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path= /usr/lib/polkit-1/polkit-agent-helper-1{{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path= /usr/lib/polkit-1/polkit-agent-helper-1{{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/lib/polkit-1/polkit-agent-helper-1") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postdrop/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postdrop/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - postdrop'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/postdrop {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/postdrop {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/sbin/postdrop") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postqueue/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postqueue/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - postqueue'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/postqueue {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/postqueue {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/sbin/postqueue") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pt_chown/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pt_chown/rule.yml
@@ -1,23 +1,9 @@
- {{%- if product in ["fedora", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - pt_chown'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/libexec/pt_chown {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/libexec/pt_chown {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/libexec/pt_chown") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_agent/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_agent/rule.yml
@@ -4,16 +4,7 @@ documentation_complete: true
 title: 'Record Any Attempts to Run ssh-agent'
 
 description: |-
-    At a minimum, the audit system should collect any execution attempt
-    of the <tt>ssh-agent</tt> command for all users and root. If the <tt>auditd</tt>
-    daemon is configured to use the <tt>augenrules</tt> program to read audit rules
-    during daemon startup (the default), add the following lines to a file with suffix
-    <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -k privileged-ssh-agent</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add the following lines to
-    <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -k privileged-ssh-agent</pre>
+    {{{ describe_arpc("/usr/bin/ssh-agent") }}}
 
 rationale: |-
     Without generating audit records that are specific to the security and

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/rule.yml
@@ -1,7 +1,3 @@
-{{%- if product in ["fedora", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 {{%- if product in ["sle12", "sle15", "slmicro5"] %}}
   {{%- set ssh_keysign_path="/usr/lib/ssh/ssh-keysign" %}}
 {{%- elif 'ubuntu' in product %}}
@@ -16,16 +12,7 @@ documentation_complete: true
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - ssh-keysign'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path={{{ ssh_keysign_path }}} {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path={{{ ssh_keysign_path }}} {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc(ssh_keysign_path) }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by
@@ -72,14 +59,9 @@ references:
     stigid@ubuntu2004: UBTU-20-010141
     stigid@ubuntu2204: UBTU-22-654095
 
-{{{ ocil_fix_srg_privileged_command("ssh-keysign", "/usr/libexec/openssh/") }}}
+{{{ ocil_fix_srg_privileged_command("ssh-keysign", ssh_keysign_path) }}}
 
 template:
     name: audit_rules_privileged_commands
     vars:
-        path: /usr/libexec/openssh/ssh-keysign
-        path@sle12: /usr/lib/ssh/ssh-keysign
-        path@sle15: /usr/lib/ssh/ssh-keysign
-        path@slmicro5: /usr/lib/ssh/ssh-keysign
-        path@ubuntu2004: /usr/lib/openssh/ssh-keysign
-        path@ubuntu2204: /usr/lib/openssh/ssh-keysign
+        path: {{{ ssh_keysign_path }}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sssd_krb5_child/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sssd_krb5_child/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - sssd_krb5_child'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/libexec/sssd/krb5_child {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/libexec/sssd/krb5_child {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/libexec/sssd/krb5_child") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sssd_ldap_child/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sssd_ldap_child/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - sssd_ldap_child'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/libexec/sssd/ldap_child {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/libexec/sssd/ldap_child {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/libexec/sssd/ldap_child") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sssd_proxy_child/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sssd_proxy_child/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - sssd_proxy_child'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/libexec/sssd/proxy_child {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/libexec/sssd/proxy_child {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/libexec/sssd/proxy_child") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sssd_selinux_child/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sssd_selinux_child/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - sssd_selinux_child'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/libexec/sssd/selinux_child {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/libexec/sssd/selinux_child {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/libexec/sssd/selinux_child") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_su/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_su/rule.yml
@@ -1,22 +1,9 @@
-{{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - su'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/su {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/su {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/bin/su") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404", "debian12"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - sudo'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/sudo {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/sudo {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/bin/sudo") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudoedit/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudoedit/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "sle12", "sle15", "slmicro5" ,"ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - sudoedit'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/sudoedit {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/sudoedit {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/bin/sudoedit") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - umount'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/umount {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/umount {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/bin/umount") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix2_chkpwd/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix2_chkpwd/rule.yml
@@ -1,6 +1,5 @@
 {{%- set unix2_chkpwd_binary="/usr/sbin/unix2_chkpwd" %}}
 {{%- if product in ["sle15"] %}}
-  {{%- set perm_x="-F perm=x " %}}
   {{%- set unix2_chkpwd_binary="/sbin/unix2_chkpwd" %}}
 {{%- endif %}}
 
@@ -10,16 +9,7 @@ documentation_complete: true
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - unix2_chkpwd'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path={{{ unix2_chkpwd_binary }}} {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path={{{ unix2_chkpwd_binary }}} {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc(unix2_chkpwd_binary) }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/rule.yml
@@ -1,6 +1,5 @@
 {{%- set unix_chkpwd_binary="/usr/sbin/unix_chkpwd" %}}
 {{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}  
-    {{%- set perm_x="-F perm=x " %}}
     {{%- set unix_chkpwd_binary="/sbin/unix_chkpwd" %}}
 {{%- endif %}}
 
@@ -10,16 +9,7 @@ documentation_complete: true
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - unix_chkpwd'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path={{{ unix_chkpwd_binary }}} {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path={{{ unix_chkpwd_binary }}} {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc(unix_chkpwd_binary) }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_update/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_update/rule.yml
@@ -4,16 +4,7 @@ documentation_complete: true
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - unix_update'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/unix_update -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/unix_update -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/sbin/unix_update") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_userhelper/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_userhelper/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - userhelper'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/userhelper {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/userhelper {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/sbin/userhelper") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_usermod/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_usermod/rule.yml
@@ -4,16 +4,7 @@ documentation_complete: true
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - usermod'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/usermod -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/usermod -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/sbin/usermod") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_usernetctl/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_usernetctl/rule.yml
@@ -1,23 +1,9 @@
- {{%- if product in ["fedora", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - usernetctl'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/usernetctl {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/sbin/usernetctl {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/sbin/usernetctl") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_utempter/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_utempter/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - utempter'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path= /usr/libexec/utempter {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path= /usr/libexec/utempter {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/libexec/utempter") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_write/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_write/rule.yml
@@ -1,23 +1,9 @@
-{{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
-  {{%- set perm_x="-F perm=x " %}}
-{{%- endif %}}
-
 documentation_complete: true
-
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - write'
 
 description: |-
-    At a minimum, the audit system should collect the execution of
-    privileged commands for all users and root. If the <tt>auditd</tt> daemon is
-    configured to use the <tt>augenrules</tt> program to read audit rules during
-    daemon startup (the default), add a line of the following form to a file with
-    suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-a always,exit -F path=/usr/bin/write {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt>:
-    <pre>-a always,exit -F path=/usr/bin/write {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    {{{ describe_arpc("/usr/bin/write") }}}
 
 rationale: |-
     Misuse of privileged functions, either intentionally or unintentionally by

--- a/shared/macros/01-general.jinja
+++ b/shared/macros/01-general.jinja
@@ -1390,7 +1390,7 @@ Create a rule description for rules using the `audit_rules_privileged_commands` 
 #}}
 
 {{% macro describe_arpc(path) %}}
-{{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
+{{%- if product in ["almalinux9", "debian12", "fedora", "ol7", "ol8", "ol9", "ol10", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
     At a minimum, the audit system should collect the execution of privileged

--- a/shared/macros/01-general.jinja
+++ b/shared/macros/01-general.jinja
@@ -1381,3 +1381,33 @@ Create a rule description text for rules that use the audit_rules_watch platform
     <pre>-w {{{ path }}} -p wa -k {{{ key }}}</pre>
 {{% endif %}}
 {{% endmacro %}}
+
+{{#
+Create a rule description for rules using the `audit_rules_privileged_commands` template.
+
+:param path: path of the privileged command for which the audit rule should be defined
+:type path: str
+#}}
+
+{{% macro describe_arpc(path) %}}
+{{%- if product in ["fedora", "rhcos4", "sle12", "sle15", "ubuntu2004", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product %}}
+  {{%- set perm_x="-F perm=x " %}}
+{{%- endif %}}
+    At a minimum, the audit system should collect the execution of privileged
+    commands for all users and root.
+
+    If the <tt>auditd</tt> daemon is configured to use the <tt>augenrules</tt>
+    program to read audit rules during daemon startup (the default), add
+    a line of the following form to a file with suffix <tt>.rules</tt>
+    in the directory <tt>/etc/audit/rules.d</tt>, setting ARCH to either b32
+    for 32-bit system, or having two lines for both b32 and b64 in case your
+    system is 64-bit:
+    <pre>-a always,exit -F arch=ARCH -F path={{{ path }}} {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add a line of the
+    following form to <tt>/etc/audit/audit.rules</tt>, setting ARCH to either
+    b32 for 32-bit system, or having two lines for both b32 and b64 in case
+    your system is 64-bit:
+    <pre>-a always,exit -F arch=ARCH -F path={{{ path }}} {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+{{%- endmacro -%}}

--- a/shared/templates/audit_rules_privileged_commands/ansible.template
+++ b/shared/templates/audit_rules_privileged_commands/ansible.template
@@ -1,4 +1,4 @@
-{{%- if product in ["almalinux9", "fedora", "ol7", "ol8", "ol9", "ol10", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] %}}
+{{%- if product in ["almalinux9", "debian12", "fedora", "ol7", "ol8", "ol9", "ol10", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] %}}
   {{%- set perm_x=" -F perm=x" %}}
 {{%- endif %}}
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle,multi_platform_slmicro,multi_platform_ubuntu,multi_platform_almalinux
@@ -7,10 +7,20 @@
 # complexity = low
 # disruption = low
 
-- name: Perform remediation of Audit rules for {{{ PATH }}}
+- name: {{{ rule_title }}} - Set architecture for audit {{{ PATH }}}
+  set_fact:
+    audit_arch: "b64"
+  when:
+  - ansible_architecture == "aarch64" or
+    ansible_architecture == "ppc64" or
+    ansible_architecture == "ppc64le" or
+    ansible_architecture == "s390x" or
+    ansible_architecture == "x86_64"
+
+- name: {{{ rule_title }}} - Perform remediation of Audit rules for {{{ PATH }}} 32 bit
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
-      action_arch_filters="-a always,exit",
+      action_arch_filters="-a always,exit -F arch=b32",
       other_filters="-F path="~PATH~perm_x,
       auid_filters="-F auid>="~auid~" -F auid!=unset",
       syscalls=SYSCALL,
@@ -18,10 +28,29 @@
       syscall_grouping=SYSCALL_GROUPING,
       )|indent(4) }}}
     {{{ ansible_audit_auditctl_add_syscall_rule(
-      action_arch_filters="-a always,exit",
+      action_arch_filters="-a always,exit -F arch=b32",
       other_filters="-F path="~PATH~perm_x,
       auid_filters="-F auid>="~auid~" -F auid!=unset",
       syscalls=SYSCALL,
       key="privileged",
       syscall_grouping=SYSCALL_GROUPING,
       )|indent(4) }}}
+- name: {{{ rule_title }}} - Perform remediation of Audit rules for {{{ PATH }}} 64 bit
+  block:
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="-F path="~PATH~perm_x,
+      auid_filters="-F auid>="~auid~" -F auid!=unset",
+      syscalls=SYSCALL,
+      key="privileged",
+      syscall_grouping=SYSCALL_GROUPING,
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="-F path="~PATH~perm_x,
+      auid_filters="-F auid>="~auid~" -F auid!=unset",
+      syscalls=SYSCALL,
+      key="privileged",
+      syscall_grouping=SYSCALL_GROUPING,
+      )|indent(4) }}}
+  when: audit_arch == "b64"

--- a/shared/templates/audit_rules_privileged_commands/bash.template
+++ b/shared/templates/audit_rules_privileged_commands/bash.template
@@ -1,14 +1,20 @@
-{{%- if product in ["fedora", "ol7", "ol8", "ol9", "ol10", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404", "debian12"] %}}
+{{%- if product in ["almalinux9", "debian12", "fedora", "ol7", "ol8", "ol9", "ol10", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] %}}
   {{%- set perm_x=" -F perm=x" %}}
 {{%- endif %}}
 # platform = multi_platform_all
 
-ACTION_ARCH_FILTERS="-a always,exit"
+# Retrieve hardware architecture of the underlying system
+[ "$(getconf LONG_BIT)" = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b32" "b64")
 OTHER_FILTERS="-F path={{{ PATH }}}{{{ perm_x }}}"
 AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
 SYSCALL=""
 KEY="privileged"
 SYSCALL_GROUPING="{{{ SYSCALL_GROUPING }}}"
-# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
-{{{ bash_fix_audit_syscall_rule("augenrules", "$ACTION_ARCH_FILTERS", "$OTHER_FILTERS", "$AUID_FILTERS", "$SYSCALL", "$SYSCALL_GROUPING", "$KEY") }}}
-{{{ bash_fix_audit_syscall_rule("auditctl", "$ACTION_ARCH_FILTERS", "$OTHER_FILTERS", "$AUID_FILTERS", "$SYSCALL", "$SYSCALL_GROUPING", "$KEY") }}}
+
+for ARCH in "${RULE_ARCHS[@]}"
+do
+  ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
+  # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
+  {{{ bash_fix_audit_syscall_rule("augenrules", "$ACTION_ARCH_FILTERS", "$OTHER_FILTERS", "$AUID_FILTERS", "$SYSCALL", "$SYSCALL_GROUPING", "$KEY") }}}
+  {{{ bash_fix_audit_syscall_rule("auditctl", "$ACTION_ARCH_FILTERS", "$OTHER_FILTERS", "$AUID_FILTERS", "$SYSCALL", "$SYSCALL_GROUPING", "$KEY") }}}
+done

--- a/shared/templates/audit_rules_privileged_commands/kubernetes.template
+++ b/shared/templates/audit_rules_privileged_commands/kubernetes.template
@@ -4,6 +4,10 @@
 # complexity = low
 # disruption = medium
 
+{{%- if product in ["almalinux9", "debian12", "fedora", "ol7", "ol8", "ol9", "ol10", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] %}}
+  {{%- set perm_x="%20-F%20perm%3Dx" %}}
+{{%- endif %}}
+
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:
@@ -13,7 +17,7 @@ spec:
     storage:
       files:
       - contents:
-          source: data:,-a%20always%2Cexit%20-F%20arch%3Db32%20-F%20path%3D{{{ PATH }}}%20-F%20auid%3E%3D{{{ auid }}}%20-F%20auid%21%3Dunset%20-F%20key%3Dprivileged%0A-a%20always%2Cexit%20-F%20arch%3Db64%20-F%20path%3D{{{ PATH }}}%20-F%20auid%3E%3D{{{ auid }}}%20-F%20auid%21%3Dunset%20-F%20key%3Dprivileged%0A
+          source: data:,-a%20always%2Cexit%20-F%20arch%3Db32%20-F%20path%3D{{{ PATH }}}{{{ perm_x }}}%20-F%20auid%3E%3D{{{ auid }}}%20-F%20auid%21%3Dunset%20-F%20key%3Dprivileged%0A-a%20always%2Cexit%20-F%20arch%3Db64%20-F%20path%3D{{{ PATH }}}{{{ perm_x }}}%20-F%20auid%3E%3D{{{ auid }}}%20-F%20auid%21%3Dunset%20-F%20key%3Dprivileged%0A
         mode: 0644
         path: /etc/audit/rules.d/75-{{{ NORMALIZED_PATH }}}_execution.rules
         overwrite: true

--- a/shared/templates/audit_rules_privileged_commands/kubernetes.template
+++ b/shared/templates/audit_rules_privileged_commands/kubernetes.template
@@ -4,10 +4,6 @@
 # complexity = low
 # disruption = medium
 
-{{%- if product in ["almalinux9", "debian12", "fedora", "ol7", "ol8", "ol9", "ol10", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] %}}
-  {{%- set perm_x="%20-F%20perm%3Dx" %}}
-{{%- endif %}}
-
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:
@@ -17,7 +13,7 @@ spec:
     storage:
       files:
       - contents:
-          source: data:,-a%20always%2Cexit%20-F%20arch%3Db32%20-F%20path%3D{{{ PATH }}}{{{ perm_x }}}%20-F%20auid%3E%3D{{{ auid }}}%20-F%20auid%21%3Dunset%20-F%20key%3Dprivileged%0A-a%20always%2Cexit%20-F%20arch%3Db64%20-F%20path%3D{{{ PATH }}}{{{ perm_x }}}%20-F%20auid%3E%3D{{{ auid }}}%20-F%20auid%21%3Dunset%20-F%20key%3Dprivileged%0A
+          source: data:,-a%20always%2Cexit%20-F%20path%3D{{{ PATH }}}%20-F%20auid%3E%3D{{{ auid }}}%20-F%20auid%21%3Dunset%20-F%20key%3Dprivileged%0A
         mode: 0644
         path: /etc/audit/rules.d/75-{{{ NORMALIZED_PATH }}}_execution.rules
         overwrite: true

--- a/shared/templates/audit_rules_privileged_commands/kubernetes.template
+++ b/shared/templates/audit_rules_privileged_commands/kubernetes.template
@@ -13,7 +13,7 @@ spec:
     storage:
       files:
       - contents:
-          source: data:,-a%20always%2Cexit%20-F%20path%3D{{{ PATH }}}%20-F%20auid%3E%3D{{{ auid }}}%20-F%20auid%21%3Dunset%20-F%20key%3Dprivileged%0A
+          source: data:,-a%20always%2Cexit%20-F%20arch%3Db32%20-F%20path%3D{{{ PATH }}}%20-F%20auid%3E%3D{{{ auid }}}%20-F%20auid%21%3Dunset%20-F%20key%3Dprivileged%0A-a%20always%2Cexit%20-F%20arch%3Db64%20-F%20path%3D{{{ PATH }}}%20-F%20auid%3E%3D{{{ auid }}}%20-F%20auid%21%3Dunset%20-F%20key%3Dprivileged%0A
         mode: 0644
         path: /etc/audit/rules.d/75-{{{ NORMALIZED_PATH }}}_execution.rules
         overwrite: true

--- a/shared/templates/audit_rules_privileged_commands/oval.template
+++ b/shared/templates/audit_rules_privileged_commands/oval.template
@@ -1,8 +1,8 @@
-{{%- if product in [ "debian12", "fedora", "ol7", "ol8", "ol9", "ol10", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] %}}
+{{%- if product in ["almalinux9", "debian12", "fedora", "ol7", "ol8", "ol9", "ol10", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] %}}
   {{%- set perm_x="(?:[\s]+-F[\s]+perm=x)" %}}
 {{%- endif %}}
 <def-group>
-  <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("Audit rules about the information on the use of " + NAME + " is enabled.") }}}
 
     <criteria operator="OR">
@@ -10,33 +10,43 @@
       <!-- Test the augenrules case -->
       <criteria operator="AND">
         <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
-        <criterion comment="audit augenrules {{{ NAME }}}" test_ref="test_{{{ ID }}}_augenrules" />
+        <criterion comment="audit augenrules 32-bit {{{ NAME }}}" test_ref="test_{{{ rule_id }}}_augenrules_32bit" />
+        <criteria operator="OR">
+          <!-- System either isn't 64-bit => we just check presence of 32-bit version of {{{ NAME }}} audit rule -->
+          <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" negate="true" />
+          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of {{{ NAME }}} audit rule -->
+          <criterion comment="audit augenrules 64-bit {{{ NAME }}}" test_ref="test_{{{ rule_id }}}_augenrules_64bit" />
+        </criteria>
       </criteria>
 
       <!-- Test the auditctl case -->
       <criteria operator="AND">
         <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
-        <criterion comment="audit auditctl {{{ NAME }}}" test_ref="test_{{{ ID }}}_auditctl" />
+        <criterion comment="audit auditctl 32-bit {{{ NAME }}}" test_ref="test_{{{ rule_id }}}_auditctl_32bit" />
+        <criteria operator="OR">
+          <!-- System either isn't 64-bit => we just check presence of 32-bit version of the {{{ NAME }}} audit rule -->
+          <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" negate="true" />
+          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of {{{ NAME }}} audit rule -->
+          <criterion comment="audit auditctl 64-bit {{{ NAME }}}" test_ref="test_{{{ rule_id }}}_auditctl_64bit" />
+        </criteria>
       </criteria>
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" check_existence="only_one_exists" comment="audit augenrules {{{ NAME }}}" id="test_{{{ ID }}}_augenrules" version="1">
-    <ind:object object_ref="object_{{{ ID }}}_augenrules" />
+{{% macro arpc_tftst(audit_tool, filepath, bits) %}}
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists" comment="audit {{{ audit_tool }}} {{{ NAME }}}" id="test_{{{ rule_id }}}_{{{ audit_tool }}}_{{{ bits }}}bit" version="1">
+    <ind:object object_ref="object_{{{ rule_id }}}_{{{ audit_tool }}}_{{{ bits }}}bit" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_{{{ ID }}}_augenrules" version="1">
-    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+path={{{ PATH }}}{{{ perm_x }}}[\s]+-F[\s]+auid>={{{ auid }}}[\s]+-F[\s]+auid!=(?:4294967295|unset|-1)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+  <ind:textfilecontent54_object id="object_{{{ rule_id }}}_{{{ audit_tool }}}_{{{ bits }}}bit" version="1">
+    <ind:filepath operation="pattern match">{{{ filepath }}}</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b{{{ bits }}}[\s]+-F[\s]+path={{{ PATH }}}{{{ perm_x }}}[\s]+-F[\s]+auid>={{{ auid }}}[\s]+-F[\s]+auid!=(?:4294967295|unset|-1)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+{{% endmacro %}}
 
-  <ind:textfilecontent54_test check="all" check_existence="only_one_exists" comment="audit auditctl {{{ NAME }}}" id="test_{{{ ID }}}_auditctl" version="1">
-    <ind:object object_ref="object_{{{ ID }}}_auditctl" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_{{{ ID }}}_auditctl" version="1">
-    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+path={{{ PATH }}}{{{ perm_x }}}[\s]+-F[\s]+auid>={{{ auid }}}[\s]+-F[\s]+auid!=(?:4294967295|unset|-1)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
-    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
+{{{ arpc_tftst("augenrules", "^/etc/audit/rules\.d/.*\.rules$", "32") }}}
+{{{ arpc_tftst("augenrules", "^/etc/audit/rules\.d/.*\.rules$", "64") }}}
+{{{ arpc_tftst("auditctl", "/etc/audit/audit.rules", "32") }}}
+{{{ arpc_tftst("auditctl", "/etc/audit/audit.rules", "64") }}}
 
 </def-group>

--- a/shared/templates/audit_rules_privileged_commands/tests/auditctl_correct_value.pass.sh
+++ b/shared/templates/audit_rules_privileged_commands/tests/auditctl_correct_value.pass.sh
@@ -4,6 +4,5 @@ source common.sh
 
 {{{ setup_auditctl_environment() }}}
 
-echo \
-"-a always,exit -F path={{{ PATH }}} ${perm_x} -F auid>={{{ auid }}} -F auid!=unset -k test_key" \
->> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b32 -F path={{{ PATH }}} ${perm_x} -F auid>={{{ auid }}} -F auid!=unset -k test_key" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b64 -F path={{{ PATH }}} ${perm_x} -F auid>={{{ auid }}} -F auid!=unset -k test_key" >> /etc/audit/audit.rules

--- a/shared/templates/audit_rules_privileged_commands/tests/auditctl_missing_arch.fail.sh
+++ b/shared/templates/audit_rules_privileged_commands/tests/auditctl_missing_arch.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# packages = audit
+source common.sh
+
+{{{ setup_auditctl_environment() }}}
+
+echo "-a always,exit -F path={{{ PATH }}} ${perm_x} -F auid>={{{ auid }}} -F auid!=unset -k test_key" >> /etc/audit/audit.rules
+echo "-a always,exit -F path={{{ PATH }}} ${perm_x} -F auid>={{{ auid }}} -F auid!=unset -k test_key" >> /etc/audit/audit.rules

--- a/shared/templates/audit_rules_privileged_commands/tests/auditctl_missing_perm_x.fail.sh
+++ b/shared/templates/audit_rules_privileged_commands/tests/auditctl_missing_perm_x.fail.sh
@@ -6,5 +6,5 @@ source common.sh
 
 {{{ setup_auditctl_environment() }}}
 
-echo "-a always,exit -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -k test_key" \
->> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b32 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -k test_key" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b64 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -k test_key" >> /etc/audit/audit.rules

--- a/shared/templates/audit_rules_privileged_commands/tests/augenrules_comented_value.fail.sh
+++ b/shared/templates/audit_rules_privileged_commands/tests/augenrules_comented_value.fail.sh
@@ -2,6 +2,5 @@
 
 source common.sh
 
-echo \
-"# -a always,exit -F path={{{ PATH }}} ${perm_x} -F auid>={{{ auid }}} -F auid!=unset -k test_key" \
->> /etc/audit/rules.d/test_key.rules
+echo "# -a always,exit -F arch=b32 -F path={{{ PATH }}} ${perm_x} -F auid>={{{ auid }}} -F auid!=unset -k test_key" >> /etc/audit/rules.d/test_key.rules
+echo "# -a always,exit -F arch=b64 -F path={{{ PATH }}} ${perm_x} -F auid>={{{ auid }}} -F auid!=unset -k test_key" >> /etc/audit/rules.d/test_key.rules

--- a/shared/templates/audit_rules_privileged_commands/tests/augenrules_correct_value.pass.sh
+++ b/shared/templates/audit_rules_privileged_commands/tests/augenrules_correct_value.pass.sh
@@ -2,6 +2,5 @@
 
 source common.sh
 
-echo \
-"-a always,exit -F path={{{ PATH }}} ${perm_x} -F auid>={{{ auid }}} -F auid!=unset -k test_key" \
->> /etc/audit/rules.d/test_key.rules
+echo "-a always,exit -F arch=b32 -F path={{{ PATH }}} ${perm_x} -F auid>={{{ auid }}} -F auid!=unset -k test_key" >> /etc/audit/rules.d/test_key.rules
+echo "-a always,exit -F arch=b64 -F path={{{ PATH }}} ${perm_x} -F auid>={{{ auid }}} -F auid!=unset -k test_key" >> /etc/audit/rules.d/test_key.rules

--- a/shared/templates/audit_rules_privileged_commands/tests/augenrules_missing_arch.fail.sh
+++ b/shared/templates/audit_rules_privileged_commands/tests/augenrules_missing_arch.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+source common.sh
+
+echo "-a always,exit -F path={{{ PATH }}} ${perm_x} -F auid>={{{ auid }}} -F auid!=unset -k test_key" >> /etc/audit/rules.d/test_key.rules
+echo "-a always,exit -F path={{{ PATH }}} ${perm_x} -F auid>={{{ auid }}} -F auid!=unset -k test_key" >> /etc/audit/rules.d/test_key.rules

--- a/shared/templates/audit_rules_privileged_commands/tests/augenrules_missing_auid.fail.sh
+++ b/shared/templates/audit_rules_privileged_commands/tests/augenrules_missing_auid.fail.sh
@@ -2,4 +2,5 @@
 
 source common.sh
 
-echo "-a always,exit -F path={{{ PATH }}} ${perm_x} -k test_key" >> /etc/audit/rules.d/test_key.rules
+echo "-a always,exit -F arch=b32 -F path={{{ PATH }}} ${perm_x} -F auid!=unset -k test_key" >> /etc/audit/rules.d/test_key.rules
+echo "-a always,exit -F arch=b64 -F path={{{ PATH }}} ${perm_x} -F auid!=unset -k test_key" >> /etc/audit/rules.d/test_key.rules


### PR DESCRIPTION
#### Description:

We should have the `-F arch=` filter in rules that use the `audit_rules_privileged_commands` template. If the system is 64-bit, there should be 2 rules, one with  `-F arch=b32` and one with  `-F arch=b64`.

In this PR we update the  `audit_rules_privileged_commands`  template to have the `-F arch=` filter there. This consist of updating OVAL, remediations and also test scenarios.

Also, we will unify the descriptions of all rules that use this template. This reduces code duplication.

#### Rationale:

Update for RHEL 10.

#### Review Hints:

Use Automatus tests.


