### PR TITLE
OPENSCAP-4959 - Add arch filter to directory_access_var_log_audit

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/ansible/shared.yml
@@ -3,10 +3,23 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: Perform remediation of Audit rules for /var/log/audit
+
+# What architecture are we on?
+
+- name: "{{{ rule_title }}} - Set architecture for audit tasks"
+  set_fact:
+    audit_arch: "b64"
+  when:
+  - ansible_architecture == "aarch64" or
+    ansible_architecture == "ppc64" or
+    ansible_architecture == "ppc64le" or
+    ansible_architecture == "s390x" or
+    ansible_architecture == "x86_64"
+
+- name: "{{{ rule_title }}} - Perform remediation of Audit rules for /var/log/audit"
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
-      action_arch_filters="-a always,exit",
+      action_arch_filters="-a always,exit -F arch=b32",
       other_filters="-F dir=/var/log/audit/ -F perm=r",
       auid_filters="-F auid>="~auid~" -F auid!=unset",
       syscalls=[],
@@ -14,10 +27,30 @@
       syscall_grouping=[],
       )|indent(4) }}}
     {{{ ansible_audit_auditctl_add_syscall_rule(
-      action_arch_filters="-a always,exit",
+      action_arch_filters="-a always,exit -F arch=b32",
       other_filters="-F dir=/var/log/audit/ -F perm=r",
       auid_filters="-F auid>="~auid~" -F auid!=unset",
       syscalls=[],
       key="access-audit-trail",
       syscall_grouping=[],
       )|indent(4) }}}
+
+- name: "{{{ rule_title }}} - Perform remediation of Audit rules for /var/log/audit for x86_64 platform"
+  block:
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="-F dir=/var/log/audit/ -F perm=r",
+      auid_filters="-F auid>="~auid~" -F auid!=unset",
+      syscalls=[],
+      key="access-audit-trail",
+      syscall_grouping=[],
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="-F dir=/var/log/audit/ -F perm=r",
+      auid_filters="-F auid>="~auid~" -F auid!=unset",
+      syscalls=[],
+      key="access-audit-trail",
+      syscall_grouping=[],
+      )|indent(4) }}}
+  when: audit_arch == "b64"

--- a/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/bash/shared.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/bash/shared.sh
@@ -1,11 +1,16 @@
 # platform = multi_platform_all
 
-ACTION_ARCH_FILTERS="-a always,exit"
 OTHER_FILTERS="-F dir=/var/log/audit/ -F perm=r"
 AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
 SYSCALL=""
 KEY="access-audit-trail"
 SYSCALL_GROUPING=""
+[ "$(getconf LONG_BIT)" = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b32" "b64")
+
+for ARCH in "${RULE_ARCHS[@]}"
+do
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
-{{{ bash_fix_audit_syscall_rule("augenrules", "$ACTION_ARCH_FILTERS", "$OTHER_FILTERS", "$AUID_FILTERS", "$SYSCALL", "$SYSCALL_GROUPING", "$KEY") }}}
-{{{ bash_fix_audit_syscall_rule("auditctl", "$ACTION_ARCH_FILTERS", "$OTHER_FILTERS", "$AUID_FILTERS", "$SYSCALL", "$SYSCALL_GROUPING", "$KEY") }}}
+    ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
+    {{{ bash_fix_audit_syscall_rule("augenrules", "$ACTION_ARCH_FILTERS", "$OTHER_FILTERS", "$AUID_FILTERS", "$SYSCALL", "$SYSCALL_GROUPING", "$KEY") }}}
+    {{{ bash_fix_audit_syscall_rule("auditctl", "$ACTION_ARCH_FILTERS", "$OTHER_FILTERS", "$AUID_FILTERS", "$SYSCALL", "$SYSCALL_GROUPING", "$KEY") }}}
+done

--- a/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/oval/shared.xml
+++ b/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/oval/shared.xml
@@ -7,44 +7,43 @@
       <!-- Test the augenrules case -->
       <criteria operator="AND">
         <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
-        <criterion comment="audit rule to record read access events to /var/log/audit" test_ref="test_directory_acccess_var_log_audit_augenrules" />
+        <criterion comment="audit augenrules 32-bit rule to record read access events to /var/log/audit" test_ref="test_{{{ rule_id }}}_augenrules_32bit" />
+        <criteria operator="OR">
+          <!-- System either isn't 64-bit => we just check presence of 32-bit version of audit rule -->
+          <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" negate="true" />
+          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of audit rule -->
+          <criterion comment="audit augenrules 64-bit rule to record read access events to /var/log/audit" test_ref="test_{{{ rule_id }}}_augenrules_64bit" />
+        </criteria>
       </criteria>
 
-      <!-- OR test the auditctl case -->
+      <!-- Test the auditctl case -->
       <criteria operator="AND">
         <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
-        <criterion comment="audit rule to record read access events to /var/log/audit" test_ref="test_directory_acccess_var_log_audit_auditctl" />
+        <criterion comment="audit auditctl 32-bit rule to record read access events to /var/log/audit" test_ref="test_{{{ rule_id }}}_auditctl_32bit" />
+        <criteria operator="OR">
+          <!-- System either isn't 64-bit => we just check presence of 32-bit version of the audit rule -->
+          <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" negate="true" />
+          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of audit rule -->
+          <criterion comment="audit auditctl 64-bit rule to record read access events to /var/log/audit" test_ref="test_{{{ rule_id }}}_auditctl_64bit" />
+        </criteria>
       </criteria>
-
     </criteria>
   </definition>
 
-  <!-- Access to /var/log/audit rule regex-->
-  <constant_variable id="var_audit_rule_access_var_log_audit_regex" version="1" datatype="string" comment="audit rule arch and syscal">
-      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+dir=/var/log/audit/)[\s]+(?:-F[\s]+perm=r)[\s]+(?:-F\s+auid>={{{ auid }}}[\s]+)(?:-F\s+auid!=(unset|4294967295)[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</value>
-  </constant_variable>
-
-  <!-- directory access /var/log/audit augenrule -->
-  <ind:textfilecontent54_test check="all" check_existence="only_one_exists"
- comment="defined audit rule must exist" id="test_directory_acccess_var_log_audit_augenrules" version="1">
-    <ind:object object_ref="object_directory_acccess_var_log_audit_augenrules" />
+{{% macro test_directory_acccess_var_log_audit(audit_tool, filepath, bits) %}}
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists" comment="audit {{{ audit_tool }}} {{{ NAME }}}" id="test_{{{ rule_id }}}_{{{ audit_tool }}}_{{{ bits }}}bit" version="1">
+    <ind:object object_ref="object_{{{ rule_id }}}_{{{ audit_tool }}}_{{{ bits }}}bit" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_directory_acccess_var_log_audit_augenrules" version="1">
-    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match" var_ref="var_audit_rule_access_var_log_audit_regex" />
-    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  <ind:textfilecontent54_object id="object_{{{ rule_id }}}_{{{ audit_tool }}}_{{{ bits }}}bit" version="1">
+    <ind:filepath operation="pattern match">{{{ filepath }}}</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b{{{ bits }}}[\s]+(?:-F[\s]+dir=/var/log/audit/)[\s]+(?:-F[\s]+perm=r)[\s]+(?:-F\s+auid>={{{ auid }}}[\s]+)(?:-F\s+auid!=(unset|4294967295)[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+{{% endmacro %}}
 
-
-  <!-- directory access /var/log/audit auditctl -->
-  <ind:textfilecontent54_test check="all" check_existence="only_one_exists"
- comment="defined audit rule must exist" id="test_directory_acccess_var_log_audit_auditctl" version="1">
-    <ind:object object_ref="object_directory_acccess_var_log_audit_auditctl" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_directory_acccess_var_log_audit_auditctl" version="1">
-    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match" var_ref="var_audit_rule_access_var_log_audit_regex" />
-    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
-  </ind:textfilecontent54_object>
+{{{ test_directory_acccess_var_log_audit("augenrules", "^/etc/audit/rules\.d/.*\.rules$", "32") }}}
+{{{ test_directory_acccess_var_log_audit("augenrules", "^/etc/audit/rules\.d/.*\.rules$", "64") }}}
+{{{ test_directory_acccess_var_log_audit("auditctl", "/etc/audit/audit.rules", "32") }}}
+{{{ test_directory_acccess_var_log_audit("auditctl", "/etc/audit/audit.rules", "64") }}}
 
 </def-group>

--- a/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/rule.yml
@@ -7,7 +7,8 @@ description: |-
     The audit system should collect access events to read audit log directory.
     The following audit rule will assure that access to audit log directory are
     collected.
-    <pre>-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>={{{ auid }}} -F auid!=unset -F key=access-audit-trail</pre>
+    Set ARCH to either b32 for 32-bit system, or have two lines for both b32 and b64 in case your system is 64-bit.
+    <pre>-a always,exit -F arch=ARCH -F dir=/var/log/audit/ -F perm=r -F auid>={{{ auid }}} -F auid!=unset -F key=access-audit-trail</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>augenrules</tt>
     program to read audit rules during daemon startup (the default), add the
     rule to a file with suffix <tt>.rules</tt> in the directory

--- a/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/auditctl_missing_arch.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/auditctl_missing_arch.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+
+{{{ setup_auditctl_environment() }}}
+
+echo "-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>={{{ uid_min }}} -F auid!=unset -F key=access-audit-trail" >> /etc/audit/audit.rules
+echo "-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>={{{ uid_min }}} -F auid!=unset -F key=access-audit-trail" >> /etc/audit/audit.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/auditctl_only_b64_arch.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/auditctl_only_b64_arch.fail.sh
@@ -3,5 +3,4 @@
 
 {{{ setup_auditctl_environment() }}}
 
-echo "-a always,exit -F arch=b32 -F dir=/var/log/audit/ -F perm=r -F auid>={{{ uid_min }}} -F auid!=unset -F key=access-audit-trail" >> /etc/audit/audit.rules
 echo "-a always,exit -F arch=b64 -F dir=/var/log/audit/ -F perm=r -F auid>={{{ uid_min }}} -F auid!=unset -F key=access-audit-trail" >> /etc/audit/audit.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/auditctl_wrong_dir.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/auditctl_wrong_dir.fail.sh
@@ -3,4 +3,5 @@
 
 {{{ setup_auditctl_environment() }}}
 
-echo "-a always,exit -F dir=/var/log/auditd/ -F perm=r -F auid>={{{ uid_min }}} -F auid!=unset -F key=access-audit-trail" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b32 -F dir=/var/log/auditd/ -F perm=r -F auid>={{{ uid_min }}} -F auid!=unset -F key=access-audit-trail" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b64 -F dir=/var/log/auditd/ -F perm=r -F auid>={{{ uid_min }}} -F auid!=unset -F key=access-audit-trail" >> /etc/audit/audit.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_correct_rule.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_correct_rule.pass.sh
@@ -2,4 +2,5 @@
 # packages = audit
 
 
-echo "-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>={{{ uid_min }}} -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F arch=b32 -F dir=/var/log/audit/ -F perm=r -F auid>={{{ uid_min }}} -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F arch=b64 -F dir=/var/log/audit/ -F perm=r -F auid>={{{ uid_min }}} -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_missing_arch.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_missing_arch.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# packages = audit
+
+
+echo "-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>={{{ uid_min }}} -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>={{{ uid_min }}} -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_wrong_dir.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_wrong_dir.fail.sh
@@ -2,4 +2,5 @@
 # packages = audit
 
 
-echo "-a always,exit -F dir=/var/log/auditd/ -F perm=r -F auid>={{{ uid_min }}} -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F arch=b32 -F dir=/var/log/auditd/ -F perm=r -F auid>={{{ uid_min }}} -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F arch=b64 -F dir=/var/log/auditd/ -F perm=r -F auid>={{{ uid_min }}} -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_wrong_perm.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_wrong_perm.fail.sh
@@ -2,4 +2,5 @@
 # packages = audit
 
 
-echo "-a always,exit -F dir=/var/log/audit/ -F perm=w -F auid>={{{ uid_min }}} -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F arch=b32 -F dir=/var/log/audit/ -F perm=w -F auid>={{{ uid_min }}} -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F arch=b64 -F dir=/var/log/audit/ -F perm=w -F auid>={{{ uid_min }}} -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules


### PR DESCRIPTION
We should have the `-F arch=` filter in the rule `directory_access_var_log_audit`. If the system is 64-bit, there should be 2 rules, one with `-F arch=b32` and one with `-F arch=b64`.
