### PR TITLE
[Ubuntu]: Override the /etc/dpkg path-exclude option

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/bash/ubuntu.sh
@@ -1,6 +1,6 @@
 # platform = multi_platform_ubuntu
 
-DEBIAN_FRONTEND=noninteractive apt-get install -y "libpam-pkcs11"
+DEBIAN_FRONTEND=noninteractive apt-get install -y -o Dpkg::Options::="--path-include=/usr/share/doc/libpam-pkcs11/*" "libpam-pkcs11"
 
 if [ ! -f /etc/pam_pkcs11/pam_pkcs11.conf ]; then
     cp /usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example /etc/pam_pkcs11/pam_pkcs11.conf


### PR DESCRIPTION
#### Description:

- Override the /etc/dpkg path-exclude option

#### Rationale:

- In AWS instance, there is `/etc/dpkg/dpkg.cfg.d/excludes:path-exclude=/usr/share/doc/*` option to exclude those files. And the rules smartcard_configure_ca smartcard_configure_cert_checking smartcard_configure_crl rely on `/usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example` if `/etc/pam_pkcs11/pam_pkcs11.conf` not exist