### PR TITLE
change rpm -q to dnf list for vsftp check

### DIFF
--- a/linux_os/guide/services/ftp/disabling_vsftpd/package_vsftpd_removed/policy/stig/shared.yml
+++ b/linux_os/guide/services/ftp/disabling_vsftpd/package_vsftpd_removed/policy/stig/shared.yml
@@ -11,7 +11,7 @@ vuldiscussion: |-
 checktext: |-
     Verify that {{{ full_name }}} does not have a File Transfer Protocol (FTP) server package installed with the following command:
 
-    $ rpm -q vsftpd
+    $ dnf list --installed vsftp
 
     package vsftpd is not installed
 


### PR DESCRIPTION
#### Description:

Change rpm -q to dnf list for vsftp check

#### Rationale:

Standardization with other package checks
