### PR TITLE
OPENSCAP-5470: sysctl_user_max_user_namespaces: align all RHEL STIG profiles

### DIFF
--- a/products/rhel10/profiles/stig.profile
+++ b/products/rhel10/profiles/stig.profile
@@ -22,3 +22,7 @@ selections:
     - srg_gpos:all
     # Currently not working RHEL 10, changes are being made to FIPS mode. Investigation is recommended.
     - '!enable_dracut_fips_module'
+    # the following rule prevents system from running containers and it prevents also other relatively common workloads.
+    # Therefore, the rule is not enforced.
+    - sysctl_user_max_user_namespaces.role=unscored
+    - sysctl_user_max_user_namespaces.severity=info

--- a/products/rhel10/profiles/stig_gui.profile
+++ b/products/rhel10/profiles/stig_gui.profile
@@ -22,14 +22,9 @@ extends: stig
 
 selections:
     - '!xwindows_remove_packages'
-
     - '!xwindows_runlevel_target'
-
     - '!package_nfs-utils_removed'
 
-    # Limiting user namespaces cause issues with user apps, such as Firefox and Cheese
-    # https://issues.redhat.com/browse/RHEL-10416
-    - '!sysctl_user_max_user_namespaces'
     # locking of idle sessions is handled by screensaver when GUI is present, the following rule is therefore redundant
     - '!logind_session_timeout'
     # Currently not working RHEL 10, changes are being made to FIPS mode. Investigation is recommended.

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -1172,6 +1172,10 @@ selections:
 
     # RHEL-08-040284
     - sysctl_user_max_user_namespaces
+    # the rule prevents system from running containers and it prevents also other relatively common workloads.
+    # Therefore, the rule is not enforced.
+    - sysctl_user_max_user_namespaces.role=unscored
+    - sysctl_user_max_user_namespaces.severity=info
 
     # RHEL-08-040285
     - sysctl_net_ipv4_conf_all_rp_filter

--- a/products/rhel8/profiles/stig_gui.profile
+++ b/products/rhel8/profiles/stig_gui.profile
@@ -42,10 +42,5 @@ selections:
     # RHEL-08-040001
     - '!package_libreport-plugin-rhtsupport_removed'
 
-    # RHEL-08-040284
-    # Limiting user namespaces cause issues with user apps, such as Firefox and Cheese
-    # https://issues.redhat.com/browse/RHEL-10416
-    - '!sysctl_user_max_user_namespaces'
-
     # locking of idle sessions is handled by screensaver when GUI is present, the following rule is therefore redundant
     - '!logind_session_timeout'

--- a/tests/data/profile_stability/rhel10/stig.profile
+++ b/tests/data/profile_stability/rhel10/stig.profile
@@ -508,6 +508,8 @@ selections:
 - sysctl_net_ipv6_conf_default_accept_redirects
 - sysctl_net_ipv6_conf_default_accept_source_route
 - sysctl_user_max_user_namespaces
+- sysctl_user_max_user_namespaces.role=unscored
+- sysctl_user_max_user_namespaces.severity=info
 - system_booted_in_fips_mode
 - tftp_uses_secure_mode_systemd
 - usbguard_generate_policy

--- a/tests/data/profile_stability/rhel10/stig_gui.profile
+++ b/tests/data/profile_stability/rhel10/stig_gui.profile
@@ -505,6 +505,9 @@ selections:
 - sysctl_net_ipv6_conf_default_accept_ra
 - sysctl_net_ipv6_conf_default_accept_redirects
 - sysctl_net_ipv6_conf_default_accept_source_route
+- sysctl_user_max_user_namespaces
+- sysctl_user_max_user_namespaces.role=unscored
+- sysctl_user_max_user_namespaces.severity=info
 - system_booted_in_fips_mode
 - tftp_uses_secure_mode_systemd
 - usbguard_generate_policy

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -423,6 +423,8 @@ selections:
 - sysctl_net_ipv6_conf_default_accept_redirects
 - sysctl_net_ipv6_conf_default_accept_source_route
 - sysctl_user_max_user_namespaces
+- sysctl_user_max_user_namespaces.role=unscored
+- sysctl_user_max_user_namespaces.severity=info
 - tftpd_uses_secure_mode
 - usbguard_generate_policy
 - wireless_disable_interfaces

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -431,6 +431,9 @@ selections:
 - sysctl_net_ipv6_conf_default_accept_ra
 - sysctl_net_ipv6_conf_default_accept_redirects
 - sysctl_net_ipv6_conf_default_accept_source_route
+- sysctl_user_max_user_namespaces
+- sysctl_user_max_user_namespaces.role=unscored
+- sysctl_user_max_user_namespaces.severity=info
 - tftpd_uses_secure_mode
 - usbguard_generate_policy
 - wireless_disable_interfaces


### PR DESCRIPTION
#### Description:

- modify stig profiles for rhel8 and rhel10 products including profile stability data
- make rule sysctl_user_max_user_namespaces not scored and informational in the same way as for rhel9 product

#### Rationale:

https://issues.redhat.com/browse/RHEL-76750

#### Review Hints:

- build rhel8 and rhel10 and check stig profiles in the datastream