### PR TITLE
Add product_properties to open_environment for build tests

### DIFF
--- a/build-scripts/build_tests.py
+++ b/build-scripts/build_tests.py
@@ -209,7 +209,9 @@ def _get_rules_in_profile(built_profiles_root) -> Generator[str, None, None]:
 def main() -> int:
     args = _create_arg_parser().parse_args()
     logging.basicConfig(level=logging.getLevelName(args.log_level))
-    env_yaml = ssg.environment.open_environment(args.build_config_yaml, args.product_yaml)
+    env_yaml = ssg.environment.open_environment(args.build_config_yaml, args.product_yaml,
+                                                os.path.join(args.root, "product_properties"))
+
     root_path = pathlib.Path(args.root).resolve()
     output_path = pathlib.Path(args.output).resolve()
     resolved_rules_dir = pathlib.Path(args.resolved_rules_dir)


### PR DESCRIPTION
#### Description:

Add product_properties to open_environment for build tests.

#### Rationale:
Make tests build.

#### Review Hints:

Build with `export ADDITIONAL_CMAKE_OPTIONS="-DSSG_BUILT_TESTS_ENABLED:BOOL=ON"` on RHEL 10 (can be any RHEL version if change the path below).

Compare the content from master in the file `build/rhel10/tests/grub2_mds_argument/correct_value_remediated.pass.sh`
