### PR TITLE
Fix build due to setuptools 78.0.1

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,4 @@ myst-parser
 sphinx
 sphinx-rtd-theme
 sphinxcontrib-apidoc
-git+https://github.com/sphinx-contrib/napoleon.git#egg=sphinxcontrib-napoleon
 git+https://github.com/ggbecker/sphinxcontrib.jinjadomain.git#egg=sphinxcontrib-jinjadomain


### PR DESCRIPTION
#### Description:

Adds `setuptools==77.0.3` to the base packages.

#### Rationale:

So we can install our packages. 78.0.1 breaks things.