### PR TITLE
Update audit rules assertions for aarch64

### DIFF
--- a/tests/assertions/ocp4/rhcos4-e8-4.12.yml
+++ b/tests/assertions/ocp4/rhcos4-e8-4.12.yml
@@ -3,11 +3,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-e8-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-master-audit-rules-execution-chcon:
     default_result: FAIL
     result_after_remediation: PASS
@@ -63,8 +63,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-e8-master-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-master-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
@@ -153,11 +153,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-e8-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-worker-audit-rules-execution-chcon:
     default_result: FAIL
     result_after_remediation: PASS
@@ -213,8 +213,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-e8-worker-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-worker-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-e8-4.13.yml
+++ b/tests/assertions/ocp4/rhcos4-e8-4.13.yml
@@ -3,11 +3,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-e8-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-master-audit-rules-execution-chcon:
     default_result: FAIL
     result_after_remediation: PASS
@@ -63,8 +63,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-e8-master-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-master-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
@@ -153,11 +153,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-e8-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-worker-audit-rules-execution-chcon:
     default_result: FAIL
     result_after_remediation: PASS
@@ -213,8 +213,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-e8-worker-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-worker-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-e8-4.14.yml
+++ b/tests/assertions/ocp4/rhcos4-e8-4.14.yml
@@ -3,11 +3,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-e8-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-master-audit-rules-execution-chcon:
     default_result: FAIL
     result_after_remediation: PASS
@@ -63,8 +63,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-e8-master-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-master-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
@@ -153,11 +153,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-e8-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-worker-audit-rules-execution-chcon:
     default_result: FAIL
     result_after_remediation: PASS
@@ -213,8 +213,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-e8-worker-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-worker-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-e8-4.15.yml
+++ b/tests/assertions/ocp4/rhcos4-e8-4.15.yml
@@ -3,11 +3,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-e8-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-master-audit-rules-execution-chcon:
     default_result: FAIL
     result_after_remediation: PASS
@@ -63,8 +63,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-e8-master-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-master-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
@@ -153,11 +153,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-e8-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-worker-audit-rules-execution-chcon:
     default_result: FAIL
     result_after_remediation: PASS
@@ -213,8 +213,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-e8-worker-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-worker-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-e8-4.16.yml
+++ b/tests/assertions/ocp4/rhcos4-e8-4.16.yml
@@ -3,11 +3,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-e8-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-master-audit-rules-execution-chcon:
     default_result: FAIL
     result_after_remediation: PASS
@@ -63,8 +63,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-e8-master-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-master-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
@@ -153,11 +153,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-e8-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-worker-audit-rules-execution-chcon:
     default_result: FAIL
     result_after_remediation: PASS
@@ -213,8 +213,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-e8-worker-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-worker-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-e8-4.17.yml
+++ b/tests/assertions/ocp4/rhcos4-e8-4.17.yml
@@ -3,11 +3,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-e8-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-master-audit-rules-execution-chcon:
     default_result: FAIL
     result_after_remediation: PASS
@@ -63,8 +63,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-e8-master-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-master-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
@@ -153,11 +153,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-e8-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-worker-audit-rules-execution-chcon:
     default_result: FAIL
     result_after_remediation: PASS
@@ -213,8 +213,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-e8-worker-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-worker-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-e8-4.18.yml
+++ b/tests/assertions/ocp4/rhcos4-e8-4.18.yml
@@ -3,11 +3,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-e8-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-master-audit-rules-execution-chcon:
     default_result: FAIL
     result_after_remediation: PASS
@@ -63,8 +63,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-e8-master-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-master-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
@@ -153,11 +153,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-e8-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-worker-audit-rules-execution-chcon:
     default_result: FAIL
     result_after_remediation: PASS
@@ -213,8 +213,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-e8-worker-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-e8-worker-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-high-4.12.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.12.yml
@@ -3,11 +3,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-high-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -27,8 +27,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -42,8 +42,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -51,8 +51,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -60,8 +60,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -69,8 +69,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -96,17 +96,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -222,20 +222,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -258,8 +258,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -267,8 +267,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -282,14 +282,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -306,8 +306,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -318,8 +318,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -727,11 +727,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -751,8 +751,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -766,8 +766,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -775,8 +775,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -784,8 +784,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -793,8 +793,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -820,17 +820,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -946,20 +946,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -982,8 +982,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -991,8 +991,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1006,14 +1006,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1030,8 +1030,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1042,8 +1042,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-high-4.13.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.13.yml
@@ -3,11 +3,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-high-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -27,8 +27,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -42,8 +42,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -51,8 +51,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -60,8 +60,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -69,8 +69,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -96,17 +96,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -222,20 +222,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -258,8 +258,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -267,8 +267,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -282,14 +282,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -306,8 +306,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -318,8 +318,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -727,11 +727,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -751,8 +751,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -766,8 +766,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -775,8 +775,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -784,8 +784,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -793,8 +793,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -820,17 +820,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -946,20 +946,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -982,8 +982,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -991,8 +991,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1006,14 +1006,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1030,8 +1030,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1042,8 +1042,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-high-4.14.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.14.yml
@@ -3,11 +3,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-high-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -27,8 +27,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -42,8 +42,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -51,8 +51,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -60,8 +60,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -69,8 +69,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -96,17 +96,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -222,20 +222,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -258,8 +258,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -267,8 +267,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -282,14 +282,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -306,8 +306,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -318,8 +318,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -727,11 +727,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -751,8 +751,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -766,8 +766,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -775,8 +775,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -784,8 +784,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -793,8 +793,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -820,17 +820,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -946,20 +946,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -982,8 +982,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -991,8 +991,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1006,14 +1006,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1030,8 +1030,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1042,8 +1042,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-high-4.15.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.15.yml
@@ -3,11 +3,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-high-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -27,8 +27,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -42,8 +42,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -51,8 +51,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -60,8 +60,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -69,8 +69,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -96,17 +96,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -222,20 +222,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -258,8 +258,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -267,8 +267,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -282,14 +282,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -306,8 +306,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -318,8 +318,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -723,11 +723,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -747,8 +747,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -762,8 +762,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -771,8 +771,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -780,8 +780,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -789,8 +789,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -816,17 +816,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -942,20 +942,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -978,8 +978,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -987,8 +987,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1002,14 +1002,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1026,8 +1026,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1038,8 +1038,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-high-4.16.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.16.yml
@@ -3,11 +3,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-high-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -27,8 +27,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -42,8 +42,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -51,8 +51,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -60,8 +60,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -69,8 +69,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -96,17 +96,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -222,20 +222,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -258,8 +258,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -267,8 +267,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -282,14 +282,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -306,8 +306,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -318,8 +318,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -723,11 +723,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -747,8 +747,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -762,8 +762,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -771,8 +771,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -780,8 +780,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -789,8 +789,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -816,17 +816,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -942,20 +942,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -978,8 +978,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -987,8 +987,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1002,14 +1002,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1026,8 +1026,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1038,8 +1038,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-high-4.17.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.17.yml
@@ -3,11 +3,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-high-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -27,8 +27,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -42,8 +42,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -51,8 +51,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -60,8 +60,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -69,8 +69,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -96,17 +96,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -222,20 +222,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -258,8 +258,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -267,8 +267,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -282,14 +282,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -306,8 +306,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -318,8 +318,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -727,11 +727,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -751,8 +751,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -766,8 +766,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -775,8 +775,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -784,8 +784,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -793,8 +793,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -820,17 +820,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -946,20 +946,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -982,8 +982,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -991,8 +991,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1006,14 +1006,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1030,8 +1030,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1042,8 +1042,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-high-4.18.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.18.yml
@@ -3,11 +3,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-high-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -27,8 +27,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -42,8 +42,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -51,8 +51,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -60,8 +60,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -69,8 +69,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -96,17 +96,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -222,20 +222,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -258,8 +258,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -267,8 +267,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -282,14 +282,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -306,8 +306,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -318,8 +318,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -727,11 +727,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -751,8 +751,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -766,8 +766,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -775,8 +775,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -784,8 +784,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -793,8 +793,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -820,17 +820,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -946,20 +946,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -982,8 +982,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -991,8 +991,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1006,14 +1006,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1030,8 +1030,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1042,8 +1042,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-high-4.2.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.2.yml
@@ -3,11 +3,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-high-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -27,8 +27,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -42,8 +42,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -51,8 +51,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -60,8 +60,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -69,8 +69,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -96,17 +96,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -222,20 +222,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -258,8 +258,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -267,8 +267,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -282,14 +282,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -306,8 +306,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -318,8 +318,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-master-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-master-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -729,11 +729,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -753,8 +753,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -768,8 +768,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -777,8 +777,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -786,8 +786,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -795,8 +795,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -822,17 +822,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -948,20 +948,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -984,8 +984,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -993,8 +993,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1008,14 +1008,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1032,8 +1032,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1044,8 +1044,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-high-worker-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-high-worker-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-moderate-4.12.yml
+++ b/tests/assertions/ocp4/rhcos4-moderate-4.12.yml
@@ -3,11 +3,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -27,8 +27,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -42,8 +42,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -51,8 +51,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -60,8 +60,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -69,8 +69,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -96,17 +96,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -222,20 +222,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -258,8 +258,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -267,8 +267,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -282,14 +282,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -306,8 +306,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -318,8 +318,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -724,11 +724,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -748,8 +748,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -763,8 +763,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -772,8 +772,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -781,8 +781,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -790,8 +790,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -817,17 +817,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -943,20 +943,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -979,8 +979,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -988,8 +988,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1003,14 +1003,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1027,8 +1027,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1039,8 +1039,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-moderate-4.13.yml
+++ b/tests/assertions/ocp4/rhcos4-moderate-4.13.yml
@@ -3,11 +3,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-master-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -27,8 +27,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-master-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -42,8 +42,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-master-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -51,8 +51,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-master-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -60,8 +60,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-master-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -69,8 +69,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-master-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -96,17 +96,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-master-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-master-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-master-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -222,20 +222,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-master-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -258,8 +258,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -267,8 +267,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -282,14 +282,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -306,8 +306,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -318,8 +318,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -720,11 +720,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -744,8 +744,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -759,8 +759,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -768,8 +768,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -777,8 +777,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -786,8 +786,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -813,17 +813,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -939,20 +939,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -975,8 +975,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -984,8 +984,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -999,14 +999,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1023,8 +1023,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1035,8 +1035,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL OR NOT-APPLICABLE
+    result_after_remediation: PASS OR NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-moderate-4.14.yml
+++ b/tests/assertions/ocp4/rhcos4-moderate-4.14.yml
@@ -3,11 +3,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -27,8 +27,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -42,8 +42,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -51,8 +51,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -60,8 +60,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -69,8 +69,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -96,17 +96,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -222,20 +222,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -258,8 +258,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -267,8 +267,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -282,14 +282,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -306,8 +306,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -318,8 +318,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -720,11 +720,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -744,8 +744,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -759,8 +759,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -768,8 +768,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -777,8 +777,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -786,8 +786,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -813,17 +813,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -939,20 +939,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -975,8 +975,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -984,8 +984,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -999,14 +999,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1023,8 +1023,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1035,8 +1035,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-moderate-4.15.yml
+++ b/tests/assertions/ocp4/rhcos4-moderate-4.15.yml
@@ -3,11 +3,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -27,8 +27,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -42,8 +42,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -51,8 +51,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -60,8 +60,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -69,8 +69,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -96,17 +96,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -222,20 +222,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -258,8 +258,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -267,8 +267,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -282,14 +282,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -306,8 +306,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -318,8 +318,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -720,11 +720,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -744,8 +744,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -759,8 +759,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -768,8 +768,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -777,8 +777,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -786,8 +786,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -813,17 +813,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -939,20 +939,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -975,8 +975,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -984,8 +984,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -999,14 +999,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1023,8 +1023,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1035,8 +1035,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-moderate-4.16.yml
+++ b/tests/assertions/ocp4/rhcos4-moderate-4.16.yml
@@ -3,11 +3,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -27,8 +27,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -42,8 +42,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -51,8 +51,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -60,8 +60,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -69,8 +69,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -96,17 +96,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -222,20 +222,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -258,8 +258,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -267,8 +267,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -282,14 +282,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -306,8 +306,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -318,8 +318,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -720,11 +720,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -744,8 +744,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -759,8 +759,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -768,8 +768,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -777,8 +777,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -786,8 +786,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -813,17 +813,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -939,20 +939,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -975,8 +975,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -984,8 +984,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -999,14 +999,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1023,8 +1023,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1035,8 +1035,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-moderate-4.17.yml
+++ b/tests/assertions/ocp4/rhcos4-moderate-4.17.yml
@@ -3,11 +3,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -27,8 +27,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -42,8 +42,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -51,8 +51,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -60,8 +60,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -69,8 +69,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -96,17 +96,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -222,20 +222,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -258,8 +258,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -267,8 +267,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -282,14 +282,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -306,8 +306,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -318,8 +318,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -724,11 +724,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -748,8 +748,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -763,8 +763,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -772,8 +772,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -781,8 +781,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -790,8 +790,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -817,17 +817,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -943,20 +943,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -979,8 +979,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -988,8 +988,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1003,14 +1003,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1027,8 +1027,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1039,8 +1039,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-moderate-4.18.yml
+++ b/tests/assertions/ocp4/rhcos4-moderate-4.18.yml
@@ -3,11 +3,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -27,8 +27,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -42,8 +42,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -51,8 +51,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -60,8 +60,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -69,8 +69,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -96,17 +96,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -222,20 +222,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -258,8 +258,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -267,8 +267,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -282,14 +282,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -306,8 +306,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -318,8 +318,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-master-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -724,11 +724,11 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -748,8 +748,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -763,8 +763,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-etc-group-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-etc-group-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -772,8 +772,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-etc-gshadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-etc-gshadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -781,8 +781,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-etc-passwd-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-etc-passwd-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -790,8 +790,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-etc-shadow-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-etc-shadow-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -817,17 +817,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -943,20 +943,20 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-time-stime:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-time-watch-localtime:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -979,8 +979,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -988,8 +988,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1003,14 +1003,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-o-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-o-trunc-write:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-open-rule-order:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-openat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1027,8 +1027,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1039,8 +1039,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-moderate-worker-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-stig-4.12.yml
+++ b/tests/assertions/ocp4/rhcos4-stig-4.12.yml
@@ -15,11 +15,11 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -39,8 +39,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -72,17 +72,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -210,14 +210,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-unsuccessful-file-modification-ftruncate:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -225,8 +225,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -234,8 +234,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -372,11 +372,11 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -396,8 +396,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -429,17 +429,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -567,14 +567,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-ftruncate:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -582,8 +582,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -591,8 +591,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-stig-4.13.yml
+++ b/tests/assertions/ocp4/rhcos4-stig-4.13.yml
@@ -15,11 +15,11 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -39,8 +39,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -72,17 +72,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -210,14 +210,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-unsuccessful-file-modification-ftruncate:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -225,8 +225,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -234,8 +234,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -371,11 +371,11 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -395,8 +395,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -428,17 +428,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -566,14 +566,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-ftruncate:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -581,8 +581,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -590,8 +590,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-stig-4.14.yml
+++ b/tests/assertions/ocp4/rhcos4-stig-4.14.yml
@@ -15,11 +15,11 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -39,8 +39,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -72,17 +72,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -210,14 +210,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-unsuccessful-file-modification-ftruncate:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -225,8 +225,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -234,8 +234,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -371,11 +371,11 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -395,8 +395,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -428,17 +428,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -566,14 +566,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-ftruncate:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -581,8 +581,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -590,8 +590,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-stig-4.15.yml
+++ b/tests/assertions/ocp4/rhcos4-stig-4.15.yml
@@ -15,11 +15,11 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -39,8 +39,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -72,17 +72,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -210,14 +210,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-unsuccessful-file-modification-ftruncate:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -225,8 +225,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -234,8 +234,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -371,11 +371,11 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -395,8 +395,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -428,17 +428,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -566,14 +566,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-ftruncate:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -581,8 +581,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -590,8 +590,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-stig-4.16.yml
+++ b/tests/assertions/ocp4/rhcos4-stig-4.16.yml
@@ -15,11 +15,11 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -39,8 +39,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -72,17 +72,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -210,14 +210,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-unsuccessful-file-modification-ftruncate:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -225,8 +225,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -234,8 +234,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -371,11 +371,11 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -395,8 +395,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -428,17 +428,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -566,14 +566,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-ftruncate:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -581,8 +581,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -590,8 +590,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-stig-4.17.yml
+++ b/tests/assertions/ocp4/rhcos4-stig-4.17.yml
@@ -15,11 +15,11 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -39,8 +39,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -72,17 +72,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -210,14 +210,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-unsuccessful-file-modification-ftruncate:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -225,8 +225,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -234,8 +234,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -371,11 +371,11 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -395,8 +395,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -428,17 +428,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -566,14 +566,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-ftruncate:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -581,8 +581,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -590,8 +590,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-stig-4.18.yml
+++ b/tests/assertions/ocp4/rhcos4-stig-4.18.yml
@@ -15,11 +15,11 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -39,8 +39,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -72,17 +72,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -210,14 +210,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-unsuccessful-file-modification-ftruncate:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -225,8 +225,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -234,8 +234,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-master-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-master-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -371,11 +371,11 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-dac-modification-chmod:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-dac-modification-chown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-dac-modification-fchmod:
     default_result: FAIL
     result_after_remediation: PASS
@@ -395,8 +395,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-dac-modification-lchown:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-dac-modification-lremovexattr:
     default_result: FAIL
     result_after_remediation: PASS
@@ -428,17 +428,17 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-file-deletion-events-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-file-deletion-events-renameat:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-file-deletion-events-rmdir:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-file-deletion-events-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-file-deletion-events-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -566,14 +566,14 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-creat:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-ftruncate:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-open:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-open-by-handle-at:
     default_result: FAIL
     result_after_remediation: PASS
@@ -581,8 +581,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-rename:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-renameat:
     default_result: FAIL
     result_after_remediation: PASS
@@ -590,8 +590,8 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-unlink:
-    default_result: FAIL
-    result_after_remediation: PASS
+    default_result: FAIL or NOT-APPLICABLE
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-stig-worker-audit-rules-unsuccessful-file-modification-unlinkat:
     default_result: FAIL
     result_after_remediation: PASS


### PR DESCRIPTION
Update the following rules' e2e assertion files so that they will not fail on ARM clusters:

- [OCPBUGS-52893](https://issues.redhat.com/browse/OCPBUGS-52893) Rule audit_rules_dac_modification_chmod
- [OCPBUGS-52894](https://issues.redhat.com/browse/OCPBUGS-52894) Rule audit_rules_dac_modification_chown
- [OCPBUGS-52895](https://issues.redhat.com/browse/OCPBUGS-52895) Rule audit_rules_time_stime
- [OCPBUGS-52897](https://issues.redhat.com/browse/OCPBUGS-52897) Rule audit_rules_dac_modification_lchown
- [OCPBUGS-52898](https://issues.redhat.com/browse/OCPBUGS-52898) Rule audit_rules_etc_group_open
- [OCPBUGS-52900](https://issues.redhat.com/browse/OCPBUGS-52900) Rule audit_rules_etc_gshadow_open
- [OCPBUGS-52901](https://issues.redhat.com/browse/OCPBUGS-52901) Rule audit_rules_etc_passwd_open
- [OCPBUGS-52902](https://issues.redhat.com/browse/OCPBUGS-52902) Rule audit_rules_etc_shadow_open
- [OCPBUGS-52903](https://issues.redhat.com/browse/OCPBUGS-52903) Rule audit_rules_file_deletion_events_rename
- [OCPBUGS-52904](https://issues.redhat.com/browse/OCPBUGS-52904) Rule audit_rules_file_deletion_events_rmdir
- [OCPBUGS-52905](https://issues.redhat.com/browse/OCPBUGS-52905) Rule audit_rules_file_deletion_events_unlink
- [OCPBUGS-52907](https://issues.redhat.com/browse/OCPBUGS-52907) Rule audit_rules_unsuccessful_file_modification_chmod
- [OCPBUGS-52908](https://issues.redhat.com/browse/OCPBUGS-52908) Rule audit_rules_unsuccessful_file_modification_chown
- [OCPBUGS-52909](https://issues.redhat.com/browse/OCPBUGS-52909) Rule audit_rules_unsuccessful_file_modification_creat
- [OCPBUGS-52910](https://issues.redhat.com/browse/OCPBUGS-52910) Rule audit_rules_unsuccessful_file_modification_lchown
- [OCPBUGS-54358](https://issues.redhat.com/browse/OCPBUGS-54358) Rule audit_rules_unsuccessful_file_modification_open
- [OCPBUGS-54359](https://issues.redhat.com/browse/OCPBUGS-54359) Rule audit_rules_unsuccessful_file_modification_open_o_creat
- [OCPBUGS-54360](https://issues.redhat.com/browse/OCPBUGS-54360) Rule audit_rules_unsuccessful_file_modification_open_o_trunc_write
- [OCPBUGS-54361](https://issues.redhat.com/browse/OCPBUGS-54361) Rule audit_rules_unsuccessful_file_modification_open_rule_order
- [OCPBUGS-54363](https://issues.redhat.com/browse/OCPBUGS-54363) Rule audit_rules_unsuccessful_file_modification_rename
- [OCPBUGS-54364](https://issues.redhat.com/browse/OCPBUGS-54364) Rule audit_rules_unsuccessful_file_modification_unlink