### PR TITLE
Fix double `mknod`, expect `PATH` entries not existing in tests

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/root_paths/accounts_root_path_dirs_no_write/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/accounts_root_path_dirs_no_write/tests/correct.pass.sh
@@ -2,6 +2,8 @@
 
 ( IFS=:
   for p in $PATH; do
-    chmod go-w $p
+    if [ -d "$p" ]; then
+      chmod go-w $p
+    fi
   done
 )

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/accounts_root_path_dirs_no_write/tests/wrong.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/accounts_root_path_dirs_no_write/tests/wrong.fail.sh
@@ -2,6 +2,8 @@
 
 ( IFS=:
   for p in $PATH; do
-    chmod go+w $p
+    if [ -d "$p" ]; then
+      chmod go+w $p
+    fi
   done
 )

--- a/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/tests/char_device_unlabeled_t.fail.sh
+++ b/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/tests/char_device_unlabeled_t.fail.sh
@@ -8,7 +8,3 @@ semodule -i /tmp/unlabeled_t.cil
 
 mknod /dev/foo c 1 5
 chcon -t unlabeled_t /dev/foo
-
-
-mknod /dev/foo c 1 5
-chcon -t device_t /dev/foo


### PR DESCRIPTION
#### Description:

These are just two additional small fixes that didn't make it to https://github.com/ComplianceAsCode/content/pull/13220

#### Rationale:

This fixes the modified tests - they silently PASS via `automatus.py` probably because that script (logic) ignores test script exit code.

#### Review Hints:

Go commit by commit, there's extra details in descriptions.