### PR TITLE
OCPBUGS-38310: Remove the 1.3.1 references for the OCP garbage collection rules

### DIFF
--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_available/rule.yml
@@ -55,7 +55,7 @@ identifiers:
   cce@ocp4: CCE-84144-5
 
 references:
-  cis@ocp4: 1.3.1,4.2.1
+  cis@ocp4: 4.2.1
   nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
   nist: CM-6,CM-6(1)
   srg: SRG-APP-000516-CTR-001325

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_memory_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_memory_available/rule.yml
@@ -54,7 +54,7 @@ identifiers:
   cce@ocp4: CCE-84135-3
 
 references:
-  cis@ocp4: 1.3.1,4.2.1
+  cis@ocp4: 4.2.1
   nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
   nist: CM-6,CM-6(1)
   srg: SRG-APP-000516-CTR-001325

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_available/rule.yml
@@ -54,7 +54,7 @@ identifiers:
   cce@ocp4: CCE-84138-7
 
 references:
-  cis@ocp4: 1.3.1,4.2.1
+  cis@ocp4: 4.2.1
   nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
   nist: CM-6,CM-6(1)
   srg: SRG-APP-000516-CTR-001325

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_inodesfree/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_inodesfree/rule.yml
@@ -54,7 +54,7 @@ identifiers:
   cce@ocp4: CCE-84141-1
 
 references:
-  cis@ocp4: 1.3.1,4.2.1
+  cis@ocp4: 4.2.1
   nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
   nist: CM-6,CM-6(1)
   srg: SRG-APP-000516-CTR-001325


### PR DESCRIPTION
#### Description:

Remove the 1.3.1 references for the OCP garbage collection rules
