### PR TITLE
Remove tmux rules from RHEL 10 STIG

### DIFF
--- a/controls/srg_gpos/SRG-OS-000028-GPOS-00009.yml
+++ b/controls/srg_gpos/SRG-OS-000028-GPOS-00009.yml
@@ -3,9 +3,6 @@ controls:
         title: {{{ full_name }}} must retain a users session lock until that user reestablishes
             access using established identification and authentication procedures.
         rules:
-            - configure_tmux_lock_command
-            - no_tmux_in_shells
-            - package_tmux_installed
             - dconf_gnome_lock_screen_on_smartcard_removal
             - dconf_gnome_screensaver_lock_enabled
             - dconf_gnome_screensaver_lock_locked

--- a/controls/srg_gpos/SRG-OS-000029-GPOS-00010.yml
+++ b/controls/srg_gpos/SRG-OS-000029-GPOS-00010.yml
@@ -5,7 +5,6 @@ controls:
         title: {{{ full_name }}} must initiate a session lock after a 15-minute period
             of inactivity for all connection types.
         rules:
-            - configure_tmux_lock_after_time
             - dconf_gnome_screensaver_idle_delay
             - dconf_gnome_session_idle_user_locks
             - inactivity_timeout_value=15_minutes

--- a/controls/srg_gpos/SRG-OS-000030-GPOS-00011.yml
+++ b/controls/srg_gpos/SRG-OS-000030-GPOS-00011.yml
@@ -5,9 +5,7 @@ controls:
         title: {{{ full_name }}} must provide the capability for users to directly initiate
             a session lock for all connection types.
         rules:
-            - package_tmux_installed
             - dconf_gnome_lock_screen_on_smartcard_removal
             - dconf_gnome_screensaver_lock_enabled
             - dconf_gnome_screensaver_lock_locked
-            - configure_tmux_lock_keybinding
         status: automated

--- a/controls/srg_gpos/SRG-OS-000031-GPOS-00012.yml
+++ b/controls/srg_gpos/SRG-OS-000031-GPOS-00012.yml
@@ -5,6 +5,5 @@ controls:
         title: {{{ full_name }}} must conceal, via the session lock, information previously
             visible on the display with a publicly viewable image.
         rules:
-            - configure_tmux_lock_after_time
             - dconf_gnome_screensaver_mode_blank
         status: automated

--- a/controls/srg_gpos/SRG-OS-000324-GPOS-00125.yml
+++ b/controls/srg_gpos/SRG-OS-000324-GPOS-00125.yml
@@ -8,7 +8,6 @@ controls:
         rules:
             - disable_ctrlaltdel_burstaction
             - disable_ctrlaltdel_reboot
-            - no_tmux_in_shells
             - service_debug-shell_disabled
             - sysctl_fs_protected_hardlinks
             - sysctl_fs_protected_symlinks

--- a/products/rhel10/profiles/default.profile
+++ b/products/rhel10/profiles/default.profile
@@ -15,3 +15,8 @@ selections:
   - audit_rules_kernel_module_loading_create
   - grub2_uefi_admin_username
   - grub2_uefi_password
+  - no_tmux_in_shells
+  - package_tmux_installed
+  - configure_tmux_lock_after_time
+  - configure_tmux_lock_command
+  - configure_tmux_lock_keybinding

--- a/tests/data/profile_stability/rhel10/stig.profile
+++ b/tests/data/profile_stability/rhel10/stig.profile
@@ -184,9 +184,6 @@ selections:
 - configure_libreswan_crypto_policy
 - configure_opensc_card_drivers
 - configure_ssh_crypto_policy
-- configure_tmux_lock_after_time
-- configure_tmux_lock_command
-- configure_tmux_lock_keybinding
 - configure_usbguard_auditbackend
 - configured_firewalld_default_deny
 - coredump_disable_backtraces
@@ -364,7 +361,6 @@ selections:
 - no_files_unowned_by_user
 - no_host_based_files
 - no_shelllogin_for_systemaccounts
-- no_tmux_in_shells
 - no_user_host_based_files
 - package_aide_installed
 - package_audispd-plugins_installed
@@ -396,7 +392,6 @@ selections:
 - package_telnet-server_removed
 - package_tftp-server_removed
 - package_tftp_removed
-- package_tmux_installed
 - package_tuned_removed
 - package_unbound_removed
 - package_usbguard_installed

--- a/tests/data/profile_stability/rhel10/stig_gui.profile
+++ b/tests/data/profile_stability/rhel10/stig_gui.profile
@@ -184,9 +184,6 @@ selections:
 - configure_libreswan_crypto_policy
 - configure_opensc_card_drivers
 - configure_ssh_crypto_policy
-- configure_tmux_lock_after_time
-- configure_tmux_lock_command
-- configure_tmux_lock_keybinding
 - configure_usbguard_auditbackend
 - configured_firewalld_default_deny
 - coredump_disable_backtraces
@@ -364,7 +361,6 @@ selections:
 - no_files_unowned_by_user
 - no_host_based_files
 - no_shelllogin_for_systemaccounts
-- no_tmux_in_shells
 - no_user_host_based_files
 - package_aide_installed
 - package_audispd-plugins_installed
@@ -394,7 +390,6 @@ selections:
 - package_telnet-server_removed
 - package_tftp-server_removed
 - package_tftp_removed
-- package_tmux_installed
 - package_tuned_removed
 - package_unbound_removed
 - package_usbguard_installed


### PR DESCRIPTION
#### Description:

Remove tmux rules from RHEL 10 STIG profile.

#### Rationale:

No longer in the RHEL 9 STIG, shouldn't be in the RHEL 10.