### PR TITLE
fix typo lapd-utils

### DIFF
--- a/linux_os/guide/services/ldap/openldap_client/package_openldap-clients_removed/rule.yml
+++ b/linux_os/guide/services/ldap/openldap_client/package_openldap-clients_removed/rule.yml
@@ -1,7 +1,7 @@
 {{% if product in ["sle12", "sle15"] %}}
 {{% set package_name = "openldap2-client" %}}
 {{% elif "ubuntu" in product %}}
-{{% set package_name = "lapd-utils" %}}
+{{% set package_name = "ldap-utils" %}}
 {{% else %}}
 {{% set package_name = "openldap-clients" %}}
 {{% endif %}}


### PR DESCRIPTION
#### Description:

- This MR fixes a typo. From lapd to ldap.

#### Rationale:

- We don't want to unistall anything with the LAPD but remove the LDAP-client ;)