### PR TITLE
OPENSCAP-4951: Support modern watches in audit_rules_sysadmin_actions

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/ansible/shared.yml
@@ -4,7 +4,18 @@
 # complexity = low
 # disruption = low
 
+{{% if audit_watches_style == "modern" %}}
+{{{ ansible_audit_augenrules_add_watch_rule(path='/etc/sudoers', permissions='wa', key='actions', style='modern', arch='b32', filter_type='path') }}}
+{{{ ansible_audit_augenrules_add_watch_rule(path='/etc/sudoers', permissions='wa', key='actions', style='modern', arch='b64', filter_type='path') }}}
+{{{ ansible_audit_auditctl_add_watch_rule(path='/etc/sudoers', permissions='wa', key='actions', style='modern', arch='b32', filter_type='path') }}}
+{{{ ansible_audit_auditctl_add_watch_rule(path='/etc/sudoers', permissions='wa', key='actions', style='modern', arch='b64', filter_type='path') }}}
+{{{ ansible_audit_augenrules_add_watch_rule(path='/etc/sudoers.d/', permissions='wa', key='actions', style='modern', arch='b32', filter_type='dir') }}}
+{{{ ansible_audit_augenrules_add_watch_rule(path='/etc/sudoers.d/', permissions='wa', key='actions', style='modern', arch='b64', filter_type='dir') }}}
+{{{ ansible_audit_auditctl_add_watch_rule(path='/etc/sudoers.d/', permissions='wa', key='actions', style='modern', arch='b32', filter_type='dir') }}}
+{{{ ansible_audit_auditctl_add_watch_rule(path='/etc/sudoers.d/', permissions='wa', key='actions', style='modern', arch='b64', filter_type='dir') }}}
+{{% else %}}
 {{{ ansible_audit_auditctl_add_watch_rule(path='/etc/sudoers', permissions='wa', key='actions') }}}
 {{{ ansible_audit_augenrules_add_watch_rule(path='/etc/sudoers', permissions='wa', key='actions') }}}
 {{{ ansible_audit_auditctl_add_watch_rule(path='/etc/sudoers.d/', permissions='wa', key='actions') }}}
 {{{ ansible_audit_augenrules_add_watch_rule(path='/etc/sudoers.d/', permissions='wa', key='actions') }}}
+{{% endif %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/bash/shared.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/bash/shared.sh
@@ -2,7 +2,18 @@
 
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 
+{{% if audit_watches_style == "modern" %}}
+{{{ bash_fix_audit_watch_rule("auditctl", "/etc/sudoers", "wa", "actions", "modern", "b32", "path") }}}
+{{{ bash_fix_audit_watch_rule("auditctl", "/etc/sudoers", "wa", "actions", "modern", "b64", "path") }}}
+{{{ bash_fix_audit_watch_rule("augenrules", "/etc/sudoers", "wa", "actions", "modern", "b32", "path") }}}
+{{{ bash_fix_audit_watch_rule("augenrules", "/etc/sudoers", "wa", "actions", "modern", "b64", "path") }}}
+{{{ bash_fix_audit_watch_rule("auditctl", "/etc/sudoers.d/", "wa", "actions", "modern", "b32", "dir") }}}
+{{{ bash_fix_audit_watch_rule("auditctl", "/etc/sudoers.d/", "wa", "actions", "modern", "b64", "dir") }}}
+{{{ bash_fix_audit_watch_rule("augenrules", "/etc/sudoers.d/", "wa", "actions", "modern", "b32", "dir") }}}
+{{{ bash_fix_audit_watch_rule("augenrules", "/etc/sudoers.d/", "wa", "actions", "modern", "b64", "dir") }}}
+{{% else %}}
 {{{ bash_fix_audit_watch_rule("auditctl", "/etc/sudoers", "wa", "actions") }}}
 {{{ bash_fix_audit_watch_rule("augenrules", "/etc/sudoers", "wa", "actions") }}}
 {{{ bash_fix_audit_watch_rule("auditctl", "/etc/sudoers.d/", "wa", "actions") }}}
 {{{ bash_fix_audit_watch_rule("augenrules", "/etc/sudoers.d/", "wa", "actions") }}}
+{{% endif %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/oval/shared.xml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/oval/shared.xml
@@ -1,54 +1,9 @@
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}"  version="1">
     {{{ oval_metadata("Audit actions taken by system administrators on the system.") }}}
-    <criteria operator="OR">
-      <criteria operator="AND">
-        <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
-        <criterion comment="audit augenrules sudoers" test_ref="test_audit_rules_sysadmin_actions_sudoers_augenrules" />
-        <criterion comment="audit augenrules sudoers_d" test_ref="test_audit_rules_sysadmin_actions_sudoers_d_augenrules" />
-      </criteria>
-      <criteria operator="AND">
-        <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
-        <criterion comment="audit auditctl sudoers" test_ref="test_audit_rules_sysadmin_actions_sudoers_auditctl" />
-        <criterion comment="audit auditctl sudoers_d" test_ref="test_audit_rules_sysadmin_actions_sudoers_d_auditctl" />
-      </criteria>
+    <criteria operator="AND">
+        <extend_definition comment="audit augenrules" definition_ref="audit_rules_sudoers" />
+        <extend_definition comment="audit augenrules" definition_ref="audit_rules_sudoers_d" />
     </criteria>
   </definition>
-
-  <ind:textfilecontent54_test check="all" comment="audit augenrules sudoers" id="test_audit_rules_sysadmin_actions_sudoers_augenrules" version="1">
-    <ind:object object_ref="object_audit_rules_sysadmin_actions_sudoers_augenrules" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_audit_rules_sysadmin_actions_sudoers_augenrules" version="1">
-    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w[\s]+/etc/sudoers[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-
-  <ind:textfilecontent54_test check="all" comment="audit augenrules sudoers" id="test_audit_rules_sysadmin_actions_sudoers_d_augenrules" version="1">
-    <ind:object object_ref="object_audit_rules_sysadmin_actions_sudoers_d_augenrules" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_audit_rules_sysadmin_actions_sudoers_d_augenrules" version="1">
-    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w[\s]+/etc/sudoers\.d/[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-
-  <ind:textfilecontent54_test check="all" comment="audit auditctl sudoers" id="test_audit_rules_sysadmin_actions_sudoers_auditctl" version="1">
-    <ind:object object_ref="object_audit_rules_sysadmin_actions_sudoers_auditctl" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_audit_rules_sysadmin_actions_sudoers_auditctl" version="1">
-    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w[\s]+/etc/sudoers[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-
-  <ind:textfilecontent54_test check="all" comment="audit auditctl sudoers" id="test_audit_rules_sysadmin_actions_sudoers_d_auditctl" version="1">
-    <ind:object object_ref="object_audit_rules_sysadmin_actions_sudoers_d_auditctl" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_audit_rules_sysadmin_actions_sudoers_d_auditctl" version="1">
-    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w[\s]+/etc/sudoers\.d/[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-
 </def-group>

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/rule.yml
@@ -3,18 +3,8 @@ documentation_complete: true
 title: 'Ensure auditd Collects System Administrator Actions'
 
 description: |-
-    At a minimum, the audit system should collect administrator actions
-    for all users and root. If the <tt>auditd</tt> daemon is configured to use the
-    <tt>augenrules</tt> program to read audit rules during daemon startup (the default),
-    add the following line to a file with suffix <tt>.rules</tt> in the directory
-    <tt>/etc/audit/rules.d</tt>:
-    <pre>-w /etc/sudoers -p wa -k actions
-    -w /etc/sudoers.d/ -p wa -k actions</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add the following line to
-    <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-w /etc/sudoers -p wa -k actions
-    -w /etc/sudoers.d/ -p wa -k actions</pre>
+    {{{ describe_audit_rules_watch("/etc/sudoers", "actions") }}}
+    {{{ describe_audit_rules_watch("/etc/sudoers.d/", "actions") }}}
 
 rationale: |-
     The actions taken by system administrators should be audited to keep a record
@@ -57,5 +47,5 @@ references:
 ocil_clause: 'there is not output'
 
 ocil: |-
-    To verify that auditing is configured for system administrator actions, run the following command:
-    <pre>$ sudo auditctl -l | grep "watch=/etc/sudoers\|watch=/etc/sudoers.d\|-w /etc/sudoers\|-w /etc/sudoers.d"</pre>
+    {{{ ocil_audit_rules_watch("/etc/sudoers", "actions") }}}
+    {{{ ocil_audit_rules_watch("/etc/sudoers.d/", "actions") }}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/tests/correct.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/tests/correct.pass.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
 # packages = audit
+
+{{% if audit_watches_style == "modern" %}}
+echo "-a always,exit -F arch=b32 -F path=/etc/sudoers -F perm=wa -F key=actions" >> /etc/audit/rules.d/actions.rules
+echo "-a always,exit -F arch=b64 -F path=/etc/sudoers -F perm=wa -F key=actions" >> /etc/audit/rules.d/actions.rules
+echo "-a always,exit -F arch=b32 -F dir=/etc/sudoers.d/ -F perm=wa -F key=actions" >> /etc/audit/rules.d/actions.rules
+echo "-a always,exit -F arch=b64 -F dir=/etc/sudoers.d/ -F perm=wa -F key=actions" >> /etc/audit/rules.d/actions.rules
+{{% else %}}
 echo "-w /etc/sudoers -p wa -k actions" >> /etc/audit/rules.d/actions.rules
 echo "-w /etc/sudoers.d/ -p wa -k actions" >> /etc/audit/rules.d/actions.rules
+{{% endif %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/tests/correct_without_key.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/tests/correct_without_key.pass.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
 # packages = audit
+
+{{% if audit_watches_style == "modern" %}}
+echo "-a always,exit -F arch=b32 -F path=/etc/sudoers -F perm=wa" >> /etc/audit/rules.d/actions.rules
+echo "-a always,exit -F arch=b64 -F path=/etc/sudoers -F perm=wa" >> /etc/audit/rules.d/actions.rules
+echo "-a always,exit -F arch=b32 -F dir=/etc/sudoers.d/ -F perm=wa" >> /etc/audit/rules.d/actions.rules
+echo "-a always,exit -F arch=b64 -F dir=/etc/sudoers.d/ -F perm=wa" >> /etc/audit/rules.d/actions.rules
+{{% else %}}
 echo "-w /etc/sudoers -p wa" >> /etc/audit/rules.d/actions.rules
 echo "-w /etc/sudoers.d/ -p wa" >> /etc/audit/rules.d/actions.rules
+{{% endif %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/tests/missing_slash.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/tests/missing_slash.fail.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
 # packages = audit
+
+{{% if audit_watches_style == "modern" %}}
+echo "-a always,exit -F arch=b32 -F path=/etc/sudoers -F perm=wa -F key=actions" >> /etc/audit/rules.d/actions.rules
+echo "-a always,exit -F arch=b64 -F path=/etc/sudoers -F perm=wa -F key=actions" >> /etc/audit/rules.d/actions.rules
+echo "-a always,exit -F arch=b32 -F dir=/etc/sudoers.d -F perm=wa -F key=actions" >> /etc/audit/rules.d/actions.rules
+echo "-a always,exit -F arch=b64 -F dir=/etc/sudoers.d -F perm=wa -F key=actions" >> /etc/audit/rules.d/actions.rules
+{{% else %}}
 echo "-w /etc/sudoers -p wa -k actions" >> /etc/audit/rules.d/actions.rules
 echo "-w /etc/sudoers.d -p wa -k actions" >> /etc/audit/rules.d/actions.rules
+{{% endif %}}


### PR DESCRIPTION
#### Description:

OVAL is done by reusing existing OVAL form other rules audit_rules_sudoers and audit_rules_sudoers_d that are templated. Remediations will reuse macros.