### PR TITLE
Remove `sysctl_user_max_user_namespaces` from RHEL 10 STIG

### DIFF
--- a/controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml
+++ b/controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml
@@ -163,7 +163,6 @@ controls:
             - sysctl_kernel_unprivileged_bpf_disabled
             - sysctl_kernel_yama_ptrace_scope
             - sysctl_net_core_bpf_jit_harden
-            - sysctl_user_max_user_namespaces
             - sysctl_kernel_kptr_restrict
             - sysctl_kernel_randomize_va_space
 

--- a/tests/data/profile_stability/rhel10/stig.profile
+++ b/tests/data/profile_stability/rhel10/stig.profile
@@ -503,7 +503,6 @@ selections:
 - sysctl_net_ipv6_conf_default_accept_ra
 - sysctl_net_ipv6_conf_default_accept_redirects
 - sysctl_net_ipv6_conf_default_accept_source_route
-- sysctl_user_max_user_namespaces
 - system_booted_in_fips_mode
 - tftp_uses_secure_mode_systemd
 - usbguard_generate_policy


### PR DESCRIPTION
#### Description:

Remove `sysctl_user_max_user_namespaces` from RHEL 10 STIG

#### Rationale:

Causes more pain that it is worth.


