### PR TITLE
Remove from OL8 STIG not STIG related rules

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/rule.yml
@@ -30,7 +30,6 @@ references:
     disa: CCI-001453
     nist: AC-17(2)
     srg: SRG-OS-000033-GPOS-00014,SRG-OS-000125-GPOS-00065,SRG-OS-000250-GPOS-00093,SRG-OS-000393-GPOS-00173,SRG-OS-000394-GPOS-00174,SRG-OS-000423-GPOS-00187
-    stigid@ol8: OL08-00-010020
     stigid@rhel8: RHEL-08-010020
 
 ocil_clause: 'Crypto Policy for OpenSSH client is not configured correctly'

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/rule.yml
@@ -28,7 +28,6 @@ references:
     disa: CCI-000877,CCI-001453
     nist: AC-17(2)
     srg: SRG-OS-000125-GPOS-00065,SRG-OS-000250-GPOS-00093
-    stigid@ol8: OL08-00-010290
     stigid@rhel8: RHEL-08-010020
 
 ocil_clause: 'Crypto Policy for OpenSSH client is not configured correctly'

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -88,8 +88,6 @@ selections:
 
     # OL08-00-010020
     - sysctl_crypto_fips_enabled
-    - harden_sshd_ciphers_openssh_conf_crypto_policy
-    - harden_sshd_ciphers_openssh_conf_crypto_policy.severity=high
 
     # OL08-00-010030
     - encrypt_partitions
@@ -197,7 +195,6 @@ selections:
     - configure_ssh_crypto_policy
 
     # OL08-00-010290
-    - harden_sshd_macs_openssh_conf_crypto_policy
     - harden_sshd_macs_opensshserver_conf_crypto_policy
 
     # OL08-00-010291


### PR DESCRIPTION
#### Description:

- Remove rules `harden_sshd_ciphers_openssh_conf_crypto_policy` & `harden_sshd_macs_openssh_conf_crypto_policy` from STIG profile

#### Rationale:

- The STIG ids they reference don't actually have the requirements that these rules cover
