### PR TITLE
Remove Napoleon as is no longer needed

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,5 +4,4 @@ myst-parser
 sphinx
 sphinx-rtd-theme
 sphinxcontrib-apidoc
-git+https://github.com/sphinx-contrib/napoleon.git#egg=sphinxcontrib-napoleon
 git+https://github.com/ggbecker/sphinxcontrib.jinjadomain.git#egg=sphinxcontrib-jinjadomain


### PR DESCRIPTION
#### Description:

Remove Napoleon from docs requirement as is no longer needed

#### Rationale:

Removing old, used dependencies. 

#### Review Hints:

Build the docs with a fresh venv.