### PR TITLE
Fix file_groupowner_etc_chrony_keys OVAL check

### DIFF
--- a/linux_os/guide/services/ntp/file_groupowner_etc_chrony_keys/oval/shared.xml
+++ b/linux_os/guide/services/ntp/file_groupowner_etc_chrony_keys/oval/shared.xml
@@ -59,7 +59,7 @@
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_object id="object_file_groupowner_etc_chrony_keys_usr_lib_group" version="1">
     <ind:filepath>/usr/lib/group</ind:filepath>
-    <ind:pattern operation="pattern match">^chrony:\w+:(\w+):.*</ind:pattern>
+    <ind:pattern operation="pattern match">^chrony:[\w!]+:(\w+):.*</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <unix:file_state id="state_file_groupowner_etc_chrony_keys_gid_chrony_with_usrlib" version="1" operator="AND">

--- a/linux_os/guide/services/ntp/file_groupowner_etc_chrony_keys/oval/shared.xml
+++ b/linux_os/guide/services/ntp/file_groupowner_etc_chrony_keys/oval/shared.xml
@@ -30,7 +30,7 @@
   </unix:file_object>
   <ind:textfilecontent54_object id="object_file_groupowner_etc_chrony_keys_etc_group" version="1" comment="gid of the dedicated chrony group">
     <ind:filepath>/etc/group</ind:filepath>
-    <ind:pattern operation="pattern match">^chrony:[^:]*:(\w+):.*</ind:pattern>
+    <ind:pattern operation="pattern match">^chrony:[\w!]+:(\w+):.*</ind:pattern>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
   <unix:file_state id="state_file_groupowner_etc_chrony_keys_gid_chrony" version="1" operator="AND">
@@ -59,7 +59,7 @@
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_object id="object_file_groupowner_etc_chrony_keys_usr_lib_group" version="1">
     <ind:filepath>/usr/lib/group</ind:filepath>
-    <ind:pattern operation="pattern match">^chrony:[^:]*:(\w+):.*</ind:pattern>
+    <ind:pattern operation="pattern match">^chrony:[\w!]+:(\w+):.*</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <unix:file_state id="state_file_groupowner_etc_chrony_keys_gid_chrony_with_usrlib" version="1" operator="AND">

--- a/linux_os/guide/services/ntp/file_groupowner_etc_chrony_keys/oval/shared.xml
+++ b/linux_os/guide/services/ntp/file_groupowner_etc_chrony_keys/oval/shared.xml
@@ -30,7 +30,7 @@
   </unix:file_object>
   <ind:textfilecontent54_object id="object_file_groupowner_etc_chrony_keys_etc_group" version="1" comment="gid of the dedicated chrony group">
     <ind:filepath>/etc/group</ind:filepath>
-    <ind:pattern operation="pattern match">^chrony:\w+:(\w+):.*</ind:pattern>
+    <ind:pattern operation="pattern match">^chrony:[\w!]+:(\w+):.*</ind:pattern>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
   <unix:file_state id="state_file_groupowner_etc_chrony_keys_gid_chrony" version="1" operator="AND">

--- a/linux_os/guide/services/ntp/file_groupowner_etc_chrony_keys/oval/shared.xml
+++ b/linux_os/guide/services/ntp/file_groupowner_etc_chrony_keys/oval/shared.xml
@@ -30,7 +30,7 @@
   </unix:file_object>
   <ind:textfilecontent54_object id="object_file_groupowner_etc_chrony_keys_etc_group" version="1" comment="gid of the dedicated chrony group">
     <ind:filepath>/etc/group</ind:filepath>
-    <ind:pattern operation="pattern match">^chrony:[\w!]+:(\w+):.*</ind:pattern>
+    <ind:pattern operation="pattern match">^chrony:\w+:(\w+):.*</ind:pattern>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
   <unix:file_state id="state_file_groupowner_etc_chrony_keys_gid_chrony" version="1" operator="AND">
@@ -59,7 +59,7 @@
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_object id="object_file_groupowner_etc_chrony_keys_usr_lib_group" version="1">
     <ind:filepath>/usr/lib/group</ind:filepath>
-    <ind:pattern operation="pattern match">^chrony:[\w!]+:(\w+):.*</ind:pattern>
+    <ind:pattern operation="pattern match">^chrony:\w+:(\w+):.*</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <unix:file_state id="state_file_groupowner_etc_chrony_keys_gid_chrony_with_usrlib" version="1" operator="AND">

--- a/linux_os/guide/services/ntp/file_groupowner_etc_chrony_keys/oval/shared.xml
+++ b/linux_os/guide/services/ntp/file_groupowner_etc_chrony_keys/oval/shared.xml
@@ -30,7 +30,7 @@
   </unix:file_object>
   <ind:textfilecontent54_object id="object_file_groupowner_etc_chrony_keys_etc_group" version="1" comment="gid of the dedicated chrony group">
     <ind:filepath>/etc/group</ind:filepath>
-    <ind:pattern operation="pattern match">^chrony:\w+:(\w+):.*</ind:pattern>
+    <ind:pattern operation="pattern match">^chrony:[^:]*:(\w+):.*</ind:pattern>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
   <unix:file_state id="state_file_groupowner_etc_chrony_keys_gid_chrony" version="1" operator="AND">
@@ -59,7 +59,7 @@
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_object id="object_file_groupowner_etc_chrony_keys_usr_lib_group" version="1">
     <ind:filepath>/usr/lib/group</ind:filepath>
-    <ind:pattern operation="pattern match">^chrony:\w+:(\w+):.*</ind:pattern>
+    <ind:pattern operation="pattern match">^chrony:[^:]*:(\w+):.*</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <unix:file_state id="state_file_groupowner_etc_chrony_keys_gid_chrony_with_usrlib" version="1" operator="AND">

--- a/linux_os/guide/services/ntp/file_groupowner_etc_chrony_keys/tests/correct_chrony_keys_groupowner.pass.sh
+++ b/linux_os/guide/services/ntp/file_groupowner_etc_chrony_keys/tests/correct_chrony_keys_groupowner.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# packages = chrony
+if [ ! -f /etc/chrony.keys ]; then
+    touch /etc/chrony.keys
+fi
+chgrp chrony /etc/chrony.keys

--- a/linux_os/guide/services/ntp/file_groupowner_etc_chrony_keys/tests/correct_chrony_keys_locked_groupowner.pass.sh
+++ b/linux_os/guide/services/ntp/file_groupowner_etc_chrony_keys/tests/correct_chrony_keys_locked_groupowner.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# packages = chrony
+
+# make sure the test passes also for locked groups
+sed -ir 's/^chrony\:.*\:(.*)\:/chrony:!:\1/g' /etc/group
+if [ ! -f /etc/chrony.keys ]; then
+    touch /etc/chrony.keys
+fi
+chgrp chrony /etc/chrony.keys

--- a/linux_os/guide/services/ntp/file_groupowner_etc_chrony_keys/tests/incorrect_chrony_keys_groupowner.fail.sh
+++ b/linux_os/guide/services/ntp/file_groupowner_etc_chrony_keys/tests/incorrect_chrony_keys_groupowner.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = chrony
+groupadd group_test
+if [ ! -f /etc/chrony.keys ]; then
+    touch /etc/chrony.keys
+fi
+chgrp group_test /etc/chrony.keys

--- a/linux_os/guide/services/ntp/file_groupowner_etc_chrony_keys/tests/test_config.yml
+++ b/linux_os/guide/services/ntp/file_groupowner_etc_chrony_keys/tests/test_config.yml
@@ -1,0 +1,5 @@
+deny_templated_scenarios:
+  # this rule uses chrony package originated user and group
+  # so we cannot use the template tests, since they are not per package limited
+  - incorrect_groupowner.fail.sh
+  - correct_groupowner.pass.sh

--- a/shared/templates/file_groupowner/oval.template
+++ b/shared/templates/file_groupowner/oval.template
@@ -58,7 +58,7 @@
   {{%- else %}}
     <ind:filepath>/etc/group</ind:filepath>
   {{%- endif %}}
-    <ind:pattern operation="pattern match">^{{{ GID_OR_NAME }}}:[\w!]+:(\w+):.*</ind:pattern>
+    <ind:pattern operation="pattern match">^{{{ GID_OR_NAME }}}:\w+:(\w+):.*</ind:pattern>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/shared/templates/file_groupowner/oval.template
+++ b/shared/templates/file_groupowner/oval.template
@@ -58,7 +58,7 @@
   {{%- else %}}
     <ind:filepath>/etc/group</ind:filepath>
   {{%- endif %}}
-    <ind:pattern operation="pattern match">^{{{ GID_OR_NAME }}}:\w+:(\w+):.*</ind:pattern>
+    <ind:pattern operation="pattern match">^{{{ GID_OR_NAME }}}:[\w!]+:(\w+):.*</ind:pattern>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 


### PR DESCRIPTION
#### Description:

- _Fix file_groupowner_etc_chrony_keys OVAL check_

#### Rationale:

- _improved the pattern match_
