### PR TITLE
remove scapval test from gating

### DIFF
--- a/tests/tmt-plans/main.fmf
+++ b/tests/tmt-plans/main.fmf
@@ -108,6 +108,10 @@ report:
           - /static-checks/html-links
           # these always fail, meant for manual review
           - /static-checks/diff
+          # The value of this test is debatable and therefore it should not delay upstream gating.
+          # Our SCAP datastream is often noncompliant from the start, for example by containing SCE checks.
+          - /static-checks/nist-validation
+
 
 # Fedora specific plan
 /rpmbuild-ctest-fedora:


### PR DESCRIPTION
#### Description:

- exclude the /static-tests/nist-validation from tests being run as gating for PRs

#### Rationale:

- This test is often failing because of unrelated reasons such as third party sites not being available
- also usefulness of such a test in PR gating is small because our datastreams will always fail some parts of the SCAP validation process

#### Review Hints:

- check gating tests and ensure that the /static-tests/nist-validation test is not executed
