### PR TITLE
Add /sbin/audisp-syslog to audit binary rules

### DIFF
--- a/linux_os/guide/auditing/file_permissions_auditd/file_groupownership_audit_binaries/rule.yml
+++ b/linux_os/guide/auditing/file_permissions_auditd/file_groupownership_audit_binaries/rule.yml
@@ -17,6 +17,9 @@ description: |-
     /sbin/auditd root
     {{% if 'rhel' not in product %}}/sbin/audispd root{{% endif %}}
     /sbin/augenrules root
+    {{%- if 'rhel' in product %}}
+    /sbin/audisp-syslog root
+    {{%- endif %}}
     </pre>
 
     Audit tools needed to successfully view and manipulate audit information
@@ -48,7 +51,7 @@ references:
 
 ocil: |-
     Verify it by running the following command:
-    <pre>$ stat -c "%n %G" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace /sbin/auditd /sbin/audispd /sbin/augenrules
+    <pre>$ stat -c "%n %G" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace /sbin/auditd /sbin/audispd /sbin/augenrules /sbin/audisp-syslog
 
     /sbin/auditctl root
     /sbin/aureport root
@@ -57,6 +60,7 @@ ocil: |-
     /sbin/auditd root
     {{% if 'rhel' not in product %}}/sbin/audispd root{{% endif %}}
     /sbin/augenrules root
+    {{% if 'rhel' in product %}}/sbin/audisp-syslog root{{% endif %}}
     </pre>
 
     If the command does not return all the above lines, the missing ones
@@ -79,4 +83,5 @@ template:
             - /sbin/auditd
             {{% if 'rhel' not in product %}}- /sbin/audispd{{% endif %}}
             - /sbin/augenrules
+            {{% if 'rhel' in product %}}- /sbin/audisp-syslog{{% endif %}}
         gid_or_name: '0'

--- a/linux_os/guide/auditing/file_permissions_auditd/file_ownership_audit_binaries/rule.yml
+++ b/linux_os/guide/auditing/file_permissions_auditd/file_ownership_audit_binaries/rule.yml
@@ -8,7 +8,7 @@ description: |-
     ownership configured to protected against unauthorized access.
 
     Verify it by running the following command:
-    <pre>$ stat -c "%n %U" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace /sbin/auditd /sbin/audispd /sbin/augenrules
+    <pre>$ stat -c "%n %U" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace /sbin/auditd /sbin/audispd /sbin/augenrules /sbin/audisp-syslog
 
     /sbin/auditctl root
     /sbin/aureport root
@@ -17,6 +17,7 @@ description: |-
     /sbin/auditd root
     {{% if 'rhel' not in product %}}/sbin/audispd root{{% endif %}}
     /sbin/augenrules root
+    {{% if 'rhel' in product %}}/sbin/audisp-syslog root{{% endif %}}
     </pre>
 
     Audit tools needed to successfully view and manipulate audit information
@@ -80,4 +81,5 @@ template:
             - /sbin/auditd
             {{% if 'rhel' not in product %}}- /sbin/audispd{{% endif %}}
             - /sbin/augenrules
+            {{% if 'rhel' in product %}}- /sbin/audisp-syslog{{% endif %}}
         uid_or_name: '0'

--- a/linux_os/guide/auditing/file_permissions_auditd/file_permissions_audit_binaries/rule.yml
+++ b/linux_os/guide/auditing/file_permissions_auditd/file_permissions_audit_binaries/rule.yml
@@ -21,6 +21,9 @@ description: |-
     /sbin/audispd 755
     {{%- endif %}}
     /sbin/augenrules 755
+    {{%- if 'rhel' in product %}}
+    /sbin/audisp-syslog 755
+    {{%- endif %}}
     </pre>
 
     Audit tools needed to successfully view and manipulate audit information
@@ -85,4 +88,5 @@ template:
             - /sbin/auditd
             {{% if 'rhel' not in product %}}- /sbin/audispd{{% endif %}}
             - /sbin/augenrules
+            {{% if 'rhel' in product %}}- /sbin/audisp-syslog{{% endif %}}
         filemode: '0755'


### PR DESCRIPTION
It appears this is in RHEL 8+

#### Description:

Add /sbin/audisp-syslog to audit binary rules.

It appears this is in RHEL 8+ based on my quick checking.

#### Rationale:

Fixes OPENSCAP-4818

