### PR TITLE
Fix `variables=` for `chronyd_configure_pool_and_server` tests

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/correct_chrony_configuration.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/correct_chrony_configuration.pass.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = chrony
-# variables = var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
-# variables = var_multiple_time_pools=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
+# variables = var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org,var_multiple_time_pools=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
 
 var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
 var_multiple_time_pools=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org

--- a/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/file_empty.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/file_empty.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # packages = chrony
-# variables = var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
-# variables = var_multiple_time_pools=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
+# variables = var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org,var_multiple_time_pools=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
 
 echo "" > {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/file_missing.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/file_missing.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # packages = chrony
-# variables = var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
-# variables = var_multiple_time_pools=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
+# variables = var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org,var_multiple_time_pools=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
 
 rm -f {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/incorrect_line1.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/incorrect_line1.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = chrony
-# variables = var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
-# variables = var_multiple_time_pools=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
+# variables = var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org,var_multiple_time_pools=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
 
 echo "" > {{{ chrony_conf_path }}}
 echo "server0.suse.pool.ntp.org" >> {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/incorrect_line2.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/incorrect_line2.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = chrony
-# variables = var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
-# variables = var_multiple_time_pools=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
+# variables = var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org,var_multiple_time_pools=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
 
 echo "" > {{{ chrony_conf_path }}}
 echo "server   0.suse.pool.ntp.org" >> {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/incorrect_line3.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/incorrect_line3.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = chrony
-# variables = var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
-# variables = var_multiple_time_pools=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
+# variables = var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org,var_multiple_time_pools=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
 
 echo "" > {{{ chrony_conf_path }}}
 echo " server   0.suse.pool.ntp.org" >> {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/incorrect_line4.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/incorrect_line4.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = chrony
-# variables = var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
-# variables = var_multiple_time_pools=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
+# variables = var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org,var_multiple_time_pools=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
 
 echo "" > {{{ chrony_conf_path }}}
 echo " server 0.suse.pool.ntp.org" >> {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/multiple_servers.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/tests/multiple_servers.pass.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = chrony
-# variables = var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
-# variables = var_multiple_time_pools=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
+# variables = var_multiple_time_servers=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org,var_multiple_time_pools=0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org
 
 echo "" > {{{ chrony_conf_path }}}
 echo "server 0.suse.pool.ntp.org" >> {{{ chrony_conf_path }}}


### PR DESCRIPTION
#### Description:

This fixes multiple lines of `# variables = ` metadata in `chronyd_configure_pool_and_server` by putting them on a single line, which the `ssg_test_suite` should be able to deal with (comma separation with `=`).

#### Rationale:

Multi-line `variables` are not supported, see [relevant code in Automatus](https://github.com/ComplianceAsCode/content/blob/8b4019cc/tests/ssg_test_suite/rule.py#L620-L634).

The `variables = []` array is re-set to empty when a new line is encountered, which is consistent with every other test metadata type.

Any proper future multi-line support in `ssg_test_suite` should probably be consistently done across all metadata (parameter) types.