### PR TITLE
OPENSCAP-4815: Remove grub2_uefi_password from ANSSI intermediary in RHEL10

### DIFF
--- a/products/rhel10/profiles/anssi_bp28_intermediary.profile
+++ b/products/rhel10/profiles/anssi_bp28_intermediary.profile
@@ -56,3 +56,5 @@ selections:
     - '!sssd_enable_pam_services'
     - '!sssd_ldap_configure_tls_reqcert'
     - '!sssd_ldap_start_tls'
+    # RHEL 10 unified the paths for grub2 files. This rule is selected in control file by R5.
+    - '!grub2_uefi_password'

--- a/tests/data/profile_stability/rhel10/anssi_bp28_intermediary.profile
+++ b/tests/data/profile_stability/rhel10/anssi_bp28_intermediary.profile
@@ -131,7 +131,6 @@ selections:
 - grub2_slub_debug_argument
 - grub2_spec_store_bypass_disable_argument
 - grub2_spectre_v2_argument
-- grub2_uefi_password
 - logind_session_timeout
 - mount_option_boot_noexec
 - mount_option_boot_nosuid


### PR DESCRIPTION
#### Description:
- Remove grub2_uefi_password from ANSSI intermediary in RHEL10.
  - Rule is not applicable in RHEL10 anymore since UEFI/BIOS paths were unified.

Fixes OPENSCAP-4815