### PR TITLE
OCPBUGS-38312: Add auto-remediation for rule service_systemd-coredump_disabled

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/coredumps/service_systemd-coredump_disabled/kubernetes/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/service_systemd-coredump_disabled/kubernetes/shared.yml
@@ -1,0 +1,19 @@
+# platform = multi_platform_rhcos
+# reboot = true
+# strategy = disable
+# complexity = low
+# disruption = medium
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+spec:
+  config:
+    ignition:
+      version: 3.1.0
+    systemd:
+      units:
+      - name: systemd-coredump.socket
+        enabled: false
+        mask: true
+      - name: systemd-coredump.service
+        enabled: false
+        mask: true

--- a/tests/assertions/ocp4/rhcos4-high-4.12.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.12.yml
@@ -605,7 +605,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-high-master-service-systemd-coredump-disabled:
     default_result: FAIL
-    result_after_remediation: FAIL
+    result_after_remediation: PASS
   e2e-high-master-service-usbguard-enabled:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1329,7 +1329,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-high-worker-service-systemd-coredump-disabled:
     default_result: FAIL
-    result_after_remediation: FAIL
+    result_after_remediation: PASS
   e2e-high-worker-service-usbguard-enabled:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-high-4.13.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.13.yml
@@ -605,7 +605,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-high-master-service-systemd-coredump-disabled:
     default_result: FAIL
-    result_after_remediation: FAIL
+    result_after_remediation: PASS
   e2e-high-master-service-usbguard-enabled:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1329,7 +1329,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-high-worker-service-systemd-coredump-disabled:
     default_result: FAIL
-    result_after_remediation: FAIL
+    result_after_remediation: PASS
   e2e-high-worker-service-usbguard-enabled:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-high-4.14.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.14.yml
@@ -605,7 +605,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-high-master-service-systemd-coredump-disabled:
     default_result: FAIL
-    result_after_remediation: FAIL
+    result_after_remediation: PASS
   e2e-high-master-service-usbguard-enabled:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1329,7 +1329,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-high-worker-service-systemd-coredump-disabled:
     default_result: FAIL
-    result_after_remediation: FAIL
+    result_after_remediation: PASS
   e2e-high-worker-service-usbguard-enabled:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-high-4.15.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.15.yml
@@ -604,6 +604,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-high-master-service-systemd-coredump-disabled:
     default_result: FAIL
+    result_after_remediation: PASS
   e2e-high-master-service-usbguard-enabled:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1324,6 +1325,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-high-worker-service-systemd-coredump-disabled:
     default_result: FAIL
+    result_after_remediation: PASS
   e2e-high-worker-service-usbguard-enabled:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-high-4.16.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.16.yml
@@ -604,6 +604,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-high-master-service-systemd-coredump-disabled:
     default_result: FAIL
+    result_after_remediation: PASS
   e2e-high-master-service-usbguard-enabled:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1324,6 +1325,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-high-worker-service-systemd-coredump-disabled:
     default_result: FAIL
+    result_after_remediation: PASS
   e2e-high-worker-service-usbguard-enabled:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-high-4.17.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.17.yml
@@ -605,7 +605,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-high-master-service-systemd-coredump-disabled:
     default_result: FAIL
-    result_after_remediation: FAIL
+    result_after_remediation: PASS
   e2e-high-master-service-usbguard-enabled:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1329,7 +1329,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-high-worker-service-systemd-coredump-disabled:
     default_result: FAIL
-    result_after_remediation: FAIL
+    result_after_remediation: PASS
   e2e-high-worker-service-usbguard-enabled:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-high-4.18.yml
+++ b/tests/assertions/ocp4/rhcos4-high-4.18.yml
@@ -605,7 +605,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-high-master-service-systemd-coredump-disabled:
     default_result: FAIL
-    result_after_remediation: FAIL
+    result_after_remediation: PASS
   e2e-high-master-service-usbguard-enabled:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1329,7 +1329,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-high-worker-service-systemd-coredump-disabled:
     default_result: FAIL
-    result_after_remediation: FAIL
+    result_after_remediation: PASS
   e2e-high-worker-service-usbguard-enabled:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-moderate-4.12.yml
+++ b/tests/assertions/ocp4/rhcos4-moderate-4.12.yml
@@ -602,7 +602,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-moderate-master-service-systemd-coredump-disabled:
     default_result: FAIL
-    result_after_remediation: FAIL
+    result_after_remediation: PASS
   e2e-moderate-master-service-usbguard-enabled:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1323,7 +1323,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-moderate-worker-service-systemd-coredump-disabled:
     default_result: FAIL
-    result_after_remediation: FAIL
+    result_after_remediation: PASS
   e2e-moderate-worker-service-usbguard-enabled:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-moderate-4.13.yml
+++ b/tests/assertions/ocp4/rhcos4-moderate-4.13.yml
@@ -601,6 +601,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-moderate-master-service-systemd-coredump-disabled:
     default_result: FAIL
+    result_after_remediation: PASS
   e2e-moderate-master-service-usbguard-enabled:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1318,6 +1319,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-moderate-worker-service-systemd-coredump-disabled:
     default_result: FAIL
+    result_after_remediation: PASS
   e2e-moderate-worker-service-usbguard-enabled:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-moderate-4.14.yml
+++ b/tests/assertions/ocp4/rhcos4-moderate-4.14.yml
@@ -601,6 +601,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-moderate-master-service-systemd-coredump-disabled:
     default_result: FAIL
+    result_after_remediation: PASS
   e2e-moderate-master-service-usbguard-enabled:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1318,6 +1319,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-moderate-worker-service-systemd-coredump-disabled:
     default_result: FAIL
+    result_after_remediation: PASS
   e2e-moderate-worker-service-usbguard-enabled:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-moderate-4.15.yml
+++ b/tests/assertions/ocp4/rhcos4-moderate-4.15.yml
@@ -601,6 +601,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-moderate-master-service-systemd-coredump-disabled:
     default_result: FAIL
+    result_after_remediation: PASS
   e2e-moderate-master-service-usbguard-enabled:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1318,6 +1319,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-moderate-worker-service-systemd-coredump-disabled:
     default_result: FAIL
+    result_after_remediation: PASS
   e2e-moderate-worker-service-usbguard-enabled:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-moderate-4.16.yml
+++ b/tests/assertions/ocp4/rhcos4-moderate-4.16.yml
@@ -601,6 +601,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-moderate-master-service-systemd-coredump-disabled:
     default_result: FAIL
+    result_after_remediation: PASS
   e2e-moderate-master-service-usbguard-enabled:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1318,6 +1319,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-moderate-worker-service-systemd-coredump-disabled:
     default_result: FAIL
+    result_after_remediation: PASS
   e2e-moderate-worker-service-usbguard-enabled:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-moderate-4.17.yml
+++ b/tests/assertions/ocp4/rhcos4-moderate-4.17.yml
@@ -601,7 +601,7 @@ rule_results:
     default_result: FAIL
     result_after_remediation: PASS
   e2e-moderate-master-service-systemd-coredump-disabled:
-    default_result: FAIL
+    default_result: PASS
     result_after_remediation: FAIL
   e2e-moderate-master-service-usbguard-enabled:
     default_result: FAIL
@@ -1323,7 +1323,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-moderate-worker-service-systemd-coredump-disabled:
     default_result: FAIL
-    result_after_remediation: FAIL
+    result_after_remediation: PASS
   e2e-moderate-worker-service-usbguard-enabled:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/rhcos4-moderate-4.18.yml
+++ b/tests/assertions/ocp4/rhcos4-moderate-4.18.yml
@@ -602,7 +602,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-moderate-master-service-systemd-coredump-disabled:
     default_result: FAIL
-    result_after_remediation: FAIL
+    result_after_remediation: PASS
   e2e-moderate-master-service-usbguard-enabled:
     default_result: FAIL
     result_after_remediation: PASS
@@ -1323,7 +1323,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-moderate-worker-service-systemd-coredump-disabled:
     default_result: FAIL
-    result_after_remediation: FAIL
+    result_after_remediation: PASS
   e2e-moderate-worker-service-usbguard-enabled:
     default_result: FAIL
     result_after_remediation: PASS


### PR DESCRIPTION
#### Description:
Add auto-remediation for rule service_systemd-coredump_disabled

#### Rationale:

- _Rationale here. Replace this text. Don't use the italics format!_
1. add auto-remediation for rule service_systemd-coredump_disabled
The rule rule service_systemd-coredump_disabled with below machineconfig for ocp:
`apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfig
spec:
  config:
    ignition:
      version: 3.1.0
    systemd:
      units:
      - name: systemd-coredump.socket
        enabled: false
        mask: true
      - name: systemd-coredump.service
        enabled: false
        mask: true`
 2. update e2e test results


#### Review Hints:

