### PR TITLE
Fix Docs Build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,6 +48,7 @@ extensions = ['myst_parser',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',
+    'sphinx.ext.napoleon',
     'sphinxcontrib.jinjadomain',
     'sphinxcontrib.autojinja.jinja',
 ]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,4 +4,4 @@ myst-parser
 sphinx
 sphinx-rtd-theme
 sphinxcontrib-apidoc
-git+https://github.com/ggbecker/sphinxcontrib.jinjadomain.git#egg=sphinxcontrib-jinjadomain
+git+https://github.com/mab879/sphinxcontrib.jinjadomain.git#egg=sphinxcontrib-jinjadomain


### PR DESCRIPTION
#### Description:

See each commit for details

#### Rationale:

So the docs build

#### Review Hints:
Try to build on master and this branch. See that this branch does build. Remember to clean up the venv after you switch branches.

1. Checkout this PR 
1. `python -m venv venv` (use python 3.11 or newer)
1. `source venv/bin/activeate`
1. `pip install -r docs/requirements.txt`
1. `cd docs`
1. `make html`

