### PR TITLE
Fix SLE15 CIS Ensure AppArmor is installed

### DIFF
--- a/controls/cis_sle15.yml
+++ b/controls/cis_sle15.yml
@@ -415,7 +415,7 @@ controls:
       - l1_workstation
     status: automated
     rules:
-      - package_pam_apparmor_installed
+      - package_apparmor_installed
 
   - id: 1.7.1.2
     title: Ensure AppArmor is enabled in the bootloader configuration (Automated)

--- a/linux_os/guide/system/apparmor/package_apparmor_installed/rule.yml
+++ b/linux_os/guide/system/apparmor/package_apparmor_installed/rule.yml
@@ -23,4 +23,4 @@ template:
     name: package_installed
     vars:
         pkgname: apparmor
-        pkgname@sle15: apparmor-profiles
+        pkgname@sle15: patterns-base-apparmor


### PR DESCRIPTION
#### Description:

- _Fix SLE15 CIS profile and rule package_apparmor_installed_

#### Rationale:

- _The correct rule for SLE15 CIS profile is package_apparmor_installed and pkg patterns-base-apparmor_
