### PR TITLE
OCPBUGS-54486: Ensure platform is set appropriately when filtering rules

### DIFF
--- a/ssg/entities/profile_base.py
+++ b/ssg/entities/profile_base.py
@@ -1,3 +1,5 @@
+import copy
+
 from xml.sax.saxutils import escape
 
 from ..build_cpe import CPEDoesNotExist
@@ -25,9 +27,12 @@ def rule_filter_from_def(filterdef):
         return noop_rule_filterfunc
 
     def filterfunc(rule):
+        c = copy.copy(rule)
+        if c.platform is None:
+            c.platform = ''
         # Remove globals for security and only expose
         # variables relevant to the rule
-        return eval(filterdef, {"__builtins__": None}, rule.__dict__)
+        return eval(filterdef, {"__builtins__": None}, c.__dict__)
     return filterfunc
 
 


### PR DESCRIPTION
The filter_rules construct evaluates python to help organize profiles
based on a set of criteria, like `platform`. However, if you set
platform in the profile filter_rules and also use it in the rule, you'll
get an error like the following:

  TypeError: argument of type 'NoneType' is not iterable

This is because the rule.platform is None, and should at least be an
empty list. This commit checks that condition on a copy of the rule
while doing the evaluation.
