### PR TITLE
OCPBUGS-54486: Use platform instead of platforms

### DIFF
--- a/applications/openshift/api-server/api_server_api_priority_v1_flowschema_catch_all/rule.yml
+++ b/applications/openshift/api-server/api_server_api_priority_v1_flowschema_catch_all/rule.yml
@@ -24,8 +24,7 @@ rationale: |-
 identifiers:
   cce@ocp4: CCE-86097-3
 
-platforms:
-  - ocp4.16
+platform: ocp4.16
 
 severity: medium
 

--- a/applications/openshift/api-server/api_server_api_priority_v1alpha1_flowschema_catch_all/rule.yml
+++ b/applications/openshift/api-server/api_server_api_priority_v1alpha1_flowschema_catch_all/rule.yml
@@ -26,8 +26,7 @@ identifiers:
   cce@ocp4: CCE-84002-5
 
 
-platforms:
-  - ocp4.6 or ocp4.7
+platform: ocp4.6 or ocp4.7
 
 severity: medium
 

--- a/applications/openshift/api-server/api_server_api_priority_v1beta1_flowschema_catch_all/rule.yml
+++ b/applications/openshift/api-server/api_server_api_priority_v1beta1_flowschema_catch_all/rule.yml
@@ -25,8 +25,7 @@ rationale: |-
 identifiers:
   cce@ocp4: CCE-83522-3
 
-platforms:
-  - ocp4.8 or ocp4.9 or ocp4.10
+platform: ocp4.8 or ocp4.9 or ocp4.10
 
 severity: medium
 

--- a/applications/openshift/api-server/api_server_api_priority_v1beta2_flowschema_catch_all/rule.yml
+++ b/applications/openshift/api-server/api_server_api_priority_v1beta2_flowschema_catch_all/rule.yml
@@ -25,8 +25,7 @@ rationale: |-
 identifiers:
   cce@ocp4: CCE-86390-2
 
-platforms:
-  - ocp4.11 or ocp4.12 or ocp4.13 or ocp4.14 or ocp4.15
+platform: ocp4.11 or ocp4.12 or ocp4.13 or ocp4.14 or ocp4.15
 
 severity: medium
 

--- a/applications/openshift/api-server/api_server_insecure_port/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_port/rule.yml
@@ -37,8 +37,7 @@ rationale: |-
 identifiers:
   cce@ocp4: CCE-83813-6
 
-platforms:
-  - (ocp4.6 or ocp4.7 or ocp4.8 or ocp4.9 or ocp4.10) and not ocp4-on-hypershift-hosted
+platform: (ocp4.6 or ocp4.7 or ocp4.8 or ocp4.9 or ocp4.10) and not ocp4-on-hypershift-hosted
 
 severity: medium
 

--- a/applications/openshift/etcd/etcd_unique_ca/rule.yml
+++ b/applications/openshift/etcd/etcd_unique_ca/rule.yml
@@ -27,8 +27,7 @@ references:
   nist: CM-6,CM-6(1)
   srg: SRG-APP-000516-CTR-001325
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
   - dependency: |-

--- a/applications/openshift/general/file_groupowner_pod_logs/rule.yml
+++ b/applications/openshift/general/file_groupowner_pod_logs/rule.yml
@@ -3,8 +3,7 @@ documentation_complete: true
 
 title: 'Kubernetes Pod Logs Must Be Group Owned By Root'
 
-platforms:
-  - ocp4-node
+platform: ocp4-node
 
 description: |-
     All logs must be owned by root user and group and have permissions

--- a/applications/openshift/general/file_owner_groupowner_permissions_pod_logs/rule.yml
+++ b/applications/openshift/general/file_owner_groupowner_permissions_pod_logs/rule.yml
@@ -3,8 +3,7 @@ documentation_complete: true
 
 title: 'Kubernetes Pod Logs Must Be Owned and Group Owned By Root and have permissions 755'
 
-platforms:
-  - ocp4-node
+platform: ocp4-node
 
 description: |-
     <p>

--- a/applications/openshift/general/file_owner_pod_logs/rule.yml
+++ b/applications/openshift/general/file_owner_pod_logs/rule.yml
@@ -3,8 +3,7 @@ documentation_complete: true
 
 title: 'Kubernetes Pod Logs Must Be Owned By Root'
 
-platforms:
-  - ocp4-node
+platform: ocp4-node
 
 description: |-
     All logs must be owned by root user and group. By default, the path for the Kubernetes audit log is <pre>/var/log/kube-apiserver/</pre>.

--- a/applications/openshift/general/file_permissions_pod_logs/rule.yml
+++ b/applications/openshift/general/file_permissions_pod_logs/rule.yml
@@ -3,8 +3,7 @@ documentation_complete: true
 
 title: 'Verify Permissions on the pod log files'
 
-platforms:
-  - ocp4-node
+platform: ocp4-node
 
 description: |-
     All logs must be owned by root user and group and have permissions

--- a/applications/openshift/integrity/crypto/azure_disk_encryption_enabled/rule.yml
+++ b/applications/openshift/integrity/crypto/azure_disk_encryption_enabled/rule.yml
@@ -1,8 +1,7 @@
 
 title: Ensure that the MachineSets provisioned by Azure have disk encryption enabled
 
-platforms:
-  - ocp4-on-azure
+platform: ocp4-on-azure
 
 description: |-
   OpenShift has an option to provide the Disk Encryption Set [1] when deploying
@@ -10,7 +9,7 @@ description: |-
   nodes have that enabled.
 
   [1] https://docs.openshift.com/container-platform/latest/machine_management/creating_machinesets/creating-machineset-azure.html#machineset-enabling-customer-managed-encryption-azure_creating-machineset-azure
-  
+
 rationale: |-
   The usage of disk encryption for the nodes protects the data at rest and
   ensures that an attacker cannot easily exfiltrate the machine contents which

--- a/applications/openshift/integrity/crypto/ebs_encryption_enabled_on_machinesets/rule.yml
+++ b/applications/openshift/integrity/crypto/ebs_encryption_enabled_on_machinesets/rule.yml
@@ -1,14 +1,13 @@
 
 title: Ensure that EBS volumes use by cluster nodes are encrypted
 
-platforms:
-  - ocp4-on-aws
+platform: ocp4-on-aws
 
 description: |-
-  OpenShift MachineSets can be configured to enable EBS encryption on 
-  EBS storage used by cluster nodes. By using EBS encryption, disk contents are 
+  OpenShift MachineSets can be configured to enable EBS encryption on
+  EBS storage used by cluster nodes. By using EBS encryption, disk contents are
   encrypted using a AWS KMS key.
-  
+
 rationale: |-
   Enabling encryption on EBS storage used by the cluster nodes, more specifically worker nodes,
   help protect any card holder data that might be persisted on those EBS volumes. Only authorized

--- a/applications/openshift/integrity/crypto/gcp_disk_encryption_enabled/rule.yml
+++ b/applications/openshift/integrity/crypto/gcp_disk_encryption_enabled/rule.yml
@@ -1,8 +1,7 @@
 
 title: Ensure that the MachineSets provisioned by GCP have disk encryption enabled
 
-platforms:
-  - ocp4-on-gcp
+platform: ocp4-on-gcp
 
 description: |-
   OpenShift has an option to provide the Disk Encryption Set [1] when deploying
@@ -10,7 +9,7 @@ description: |-
   nodes have that enabled.
 
   [1] https://docs.openshift.com/container-platform/latest/machine_management/creating_machinesets/creating-machineset-gcp.html#machineset-enabling-customer-managed-encryption_creating-machineset-gcp
-  
+
 rationale: |-
   The usage of disk encryption for the nodes protects the data at rest and
   ensures that an attacker cannot easily exfiltrate the machine contents which
@@ -29,7 +28,7 @@ ocil_clause: 'Disk encryption is not enabled on the GCP MachineSets'
 ocil: |-
     Run the following command to retrieve if the GCP disk encryption is enabled:
     <pre>$ oc get machineset --all-namespaces -o json | jq '{{{ jqfilter }}}'</pre>
-    Make sure that the result is an array MachineSet names. These MachineSets 
+    Make sure that the result is an array MachineSet names. These MachineSets
     have references to the GCP's KMS key names, which can be inspected by going through them
     with <pre>$ oc get machineset --all-namespaces -o yaml</pre>
 

--- a/applications/openshift/integrity/crypto/storageclass_encryption_enabled/rule.yml
+++ b/applications/openshift/integrity/crypto/storageclass_encryption_enabled/rule.yml
@@ -1,8 +1,7 @@
 
 title: Ensure that EBS volumes declared in storageclasses are encrypted
 
-platforms:
-- ocp4-on-aws
+platform: ocp4-on-aws
 
 description: |-
   OpenShift StorageClasses can be configured to enable EBS encryption on

--- a/applications/openshift/integrity/reject_unsigned_images_by_default/rule.yml
+++ b/applications/openshift/integrity/reject_unsigned_images_by_default/rule.yml
@@ -1,8 +1,7 @@
 
 title: Ensure the Container Runtime rejects unsigned images by default
 
-platforms:
-  - ocp4-node
+platform: ocp4-node
 
 description: |-
   <p>

--- a/applications/openshift/logging/directory_access_var_log_kube_audit/rule.yml
+++ b/applications/openshift/logging/directory_access_var_log_kube_audit/rule.yml
@@ -3,8 +3,7 @@ documentation_complete: true
 
 title: 'Record Access Events to Kubernetes Audit Log Directory'
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 description: |-
     The audit system should collect access events to read the Kubernetes audit log directory.

--- a/applications/openshift/logging/directory_access_var_log_oauth_audit/rule.yml
+++ b/applications/openshift/logging/directory_access_var_log_oauth_audit/rule.yml
@@ -3,8 +3,7 @@ documentation_complete: true
 
 title: 'Record Access Events to OAuth Audit Log Directory'
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 description: |-
     The audit system should collect access events to read the OAuth audit log directory.

--- a/applications/openshift/logging/directory_access_var_log_ocp_audit/rule.yml
+++ b/applications/openshift/logging/directory_access_var_log_ocp_audit/rule.yml
@@ -3,8 +3,7 @@ documentation_complete: true
 
 title: 'Record Access Events to OpenShift Audit Log Directory'
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 description: |-
     The audit system should collect access events to read the OpenShift audit log directory.

--- a/applications/openshift/logging/directory_permissions_var_log_kube_audit/rule.yml
+++ b/applications/openshift/logging/directory_permissions_var_log_kube_audit/rule.yml
@@ -3,8 +3,7 @@ documentation_complete: true
 
 title: 'The Kubernetes Audit Logs Directory Must Have Mode 0700'
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 description: |-
     {{{ describe_file_permissions(file="/var/log/kube-apiserver/", perms="0700") }}}

--- a/applications/openshift/logging/directory_permissions_var_log_oauth_audit/rule.yml
+++ b/applications/openshift/logging/directory_permissions_var_log_oauth_audit/rule.yml
@@ -3,8 +3,7 @@ documentation_complete: true
 
 title: 'The OAuth Audit Logs Directory Must Have Mode 0700'
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 description: |-
     {{{ describe_file_permissions(file="/var/log/oauth-apiserver/", perms="0700") }}}

--- a/applications/openshift/logging/directory_permissions_var_log_ocp_audit/rule.yml
+++ b/applications/openshift/logging/directory_permissions_var_log_ocp_audit/rule.yml
@@ -3,8 +3,7 @@ documentation_complete: true
 
 title: 'The OpenShift Audit Logs Directory Must Have Mode 0700'
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 description: |-
     {{{ describe_file_permissions(file="/var/log/openshift-apiserver/", perms="0700") }}}

--- a/applications/openshift/logging/file_ownership_var_log_kube_audit/rule.yml
+++ b/applications/openshift/logging/file_ownership_var_log_kube_audit/rule.yml
@@ -3,8 +3,7 @@ documentation_complete: true
 
 title: 'Kubernetes Audit Logs Must Be Owned By Root'
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 description: |-
     All audit logs must be owned by root user and group. By default, the path for the Kubernetes audit log is <pre>/var/log/kube-apiserver/</pre>.

--- a/applications/openshift/logging/file_ownership_var_log_oauth_audit/rule.yml
+++ b/applications/openshift/logging/file_ownership_var_log_oauth_audit/rule.yml
@@ -3,8 +3,7 @@ documentation_complete: true
 
 title: 'OAuth Audit Logs Must Be Owned By Root'
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 description: |-
     All audit logs must be owned by root user and group. By default, the path for the OAuth audit log is <pre>/var/log/oauth-apiserver/</pre>.

--- a/applications/openshift/logging/file_ownership_var_log_ocp_audit/rule.yml
+++ b/applications/openshift/logging/file_ownership_var_log_ocp_audit/rule.yml
@@ -3,8 +3,7 @@ documentation_complete: true
 
 title: 'OpenShift Audit Logs Must Be Owned By Root'
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 description: |-
     All audit logs must be owned by root user and group. By default, the path for the OpenShift audit log is <pre>/var/log/openshift-apiserver/</pre>.

--- a/applications/openshift/logging/file_permissions_var_log_kube_audit/rule.yml
+++ b/applications/openshift/logging/file_permissions_var_log_kube_audit/rule.yml
@@ -3,8 +3,7 @@ documentation_complete: true
 
 title: 'Kubernetes Audit Logs Must Have Mode 0600'
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 description: |-
     {{{ describe_file_permissions(file="/var/log/kube-apiserver/.*", perms="0600") }}}

--- a/applications/openshift/logging/file_permissions_var_log_oauth_audit/rule.yml
+++ b/applications/openshift/logging/file_permissions_var_log_oauth_audit/rule.yml
@@ -3,8 +3,7 @@ documentation_complete: true
 
 title: 'OAuth Audit Logs Must Have Mode 0600'
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 description: |-
     {{{ describe_file_permissions(file="/var/log/oauth-apiserver/.*", perms="0600") }}}

--- a/applications/openshift/logging/file_permissions_var_log_ocp_audit/rule.yml
+++ b/applications/openshift/logging/file_permissions_var_log_ocp_audit/rule.yml
@@ -3,8 +3,7 @@ documentation_complete: true
 
 title: 'OpenShift Audit Logs Must Have Mode 0600'
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 description: |-
     {{{ describe_file_permissions(file="/var/log/openshift-apiserver/.*", perms="0600") }}}

--- a/applications/openshift/logging/partition_for_var_log_kube_apiserver/rule.yml
+++ b/applications/openshift/logging/partition_for_var_log_kube_apiserver/rule.yml
@@ -3,8 +3,7 @@ documentation_complete: true
 title: 'Ensure /var/log/kube-apiserver Located On Separate Partition'
 
 
-platforms:
-    - ocp4-node
+platform: ocp4-node
 
 description: |-
     Kubernetes API server audit logs are stored in the

--- a/applications/openshift/logging/partition_for_var_log_oauth_apiserver/rule.yml
+++ b/applications/openshift/logging/partition_for_var_log_oauth_apiserver/rule.yml
@@ -3,8 +3,7 @@ documentation_complete: true
 title: 'Ensure /var/log/oauth-apiserver Located On Separate Partition'
 
 
-platforms:
-    - ocp4-node
+platform: ocp4-node
 
 description: |-
     OpenShift OAuth server audit logs are stored in the

--- a/applications/openshift/logging/partition_for_var_log_openshift_apiserver/rule.yml
+++ b/applications/openshift/logging/partition_for_var_log_openshift_apiserver/rule.yml
@@ -3,8 +3,7 @@ documentation_complete: true
 title: 'Ensure /var/log/openshift-apiserver Located On Separate Partition'
 
 
-platforms:
-    - ocp4-node
+platform: ocp4-node
 
 description: |-
     Openshift API server audit logs are stored in the

--- a/applications/openshift/master/file_groupowner_controller_manager_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_groupowner_controller_manager_kubeconfig/rule.yml
@@ -28,8 +28,7 @@ ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-
 ocil: |-
   {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/configmaps/controller-manager-kubeconfig/kubeconfig", group="root") }}}
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
   - dependency: |-

--- a/applications/openshift/master/file_groupowner_etcd_data_dir/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_dir/rule.yml
@@ -27,8 +27,7 @@ ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/lib/etcd/member/", gro
 ocil: |-
     {{{ ocil_file_group_owner(file="/var/lib/etcd/member/", group="root") }}}
 
-platforms:
-    - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
     - dependency: |-

--- a/applications/openshift/master/file_groupowner_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_files/rule.yml
@@ -27,8 +27,7 @@ ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/lib/etcd/member/wal/*"
 ocil: |-
     {{{ ocil_file_group_owner(file="/var/lib/etcd/member/wal/*", group="root") }}}
 
-platforms:
-    - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
     - dependency: |-

--- a/applications/openshift/master/file_groupowner_etcd_member/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_member/rule.yml
@@ -29,8 +29,7 @@ ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/manifests/e
 ocil: |-
     {{{ ocil_file_group_owner(file="/etc/kubernetes/manifests/etcd-pod.yaml", group="root") }}}
 
-platforms:
-    - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
     - dependency: |-

--- a/applications/openshift/master/file_groupowner_etcd_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_pki_cert_files/rule.yml
@@ -29,8 +29,7 @@ ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-
 ocil: |-
   {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/*.crt", group="root") }}}
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
   - dependency: |-

--- a/applications/openshift/master/file_groupowner_kube_apiserver/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_apiserver/rule.yml
@@ -26,8 +26,7 @@ ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-
 ocil: |-
     {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", group="root") }}}
 
-platforms:
-    - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
     - dependency: |-

--- a/applications/openshift/master/file_groupowner_kube_controller_manager/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_controller_manager/rule.yml
@@ -26,8 +26,7 @@ ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-
 ocil: |-
     {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", group="root") }}}
 
-platforms:
-    - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
     - dependency: |-

--- a/applications/openshift/master/file_groupowner_kube_scheduler/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_scheduler/rule.yml
@@ -26,8 +26,7 @@ ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-
 ocil: |-
     {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", group="root") }}}
 
-platforms:
-    - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
     - dependency: |-

--- a/applications/openshift/master/file_groupowner_master_admin_kubeconfigs/rule.yml
+++ b/applications/openshift/master/file_groupowner_master_admin_kubeconfigs/rule.yml
@@ -32,8 +32,7 @@ ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-
 ocil: |-
   {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/*.kubeconfig", group="root") }}}
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
     - dependency: |-

--- a/applications/openshift/master/file_groupowner_openshift_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_openshift_pki_cert_files/rule.yml
@@ -29,8 +29,7 @@ ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-
 ocil: |-
   {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/.*/.*/.*/tls.crt", group="root") }}}
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
   - dependency: |-

--- a/applications/openshift/master/file_groupowner_openshift_pki_key_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_openshift_pki_key_files/rule.yml
@@ -29,8 +29,7 @@ ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-
 ocil: |-
   {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/*.key", group="root") }}}
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
   - dependency: |-

--- a/applications/openshift/master/file_groupowner_scheduler_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_groupowner_scheduler_kubeconfig/rule.yml
@@ -28,8 +28,7 @@ ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/static-pod-
 ocil: |-
   {{{ ocil_file_group_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/configmaps/scheduler-kubeconfig/kubeconfig", group="root") }}}
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
   - dependency: |-

--- a/applications/openshift/master/file_owner_controller_manager_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_owner_controller_manager_kubeconfig/rule.yml
@@ -28,8 +28,7 @@ ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resour
 ocil: |-
   {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/configmaps/controller-manager-kubeconfig/kubeconfig", owner="root") }}}
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
   - dependency: |-

--- a/applications/openshift/master/file_owner_etcd_data_dir/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_data_dir/rule.yml
@@ -27,8 +27,7 @@ ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/etcd/member/", owner="ro
 ocil: |-
     {{{ ocil_file_owner(file="/var/lib/etcd/member/", owner="root") }}}
 
-platforms:
-    - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
     - dependency: |-

--- a/applications/openshift/master/file_owner_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_data_files/rule.yml
@@ -27,8 +27,7 @@ ocil_clause: '{{{ ocil_clause_file_owner(file="/var/lib/etcd/member/wal/*", owne
 ocil: |-
     {{{ ocil_file_owner(file="/var/lib/etcd/member/wal/*", owner="root") }}}
 
-platforms:
-    - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
     - dependency: |-

--- a/applications/openshift/master/file_owner_etcd_member/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_member/rule.yml
@@ -29,8 +29,7 @@ ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/manifests/etcd-po
 ocil: |-
     {{{ ocil_file_owner(file="/etc/kubernetes/manifests/etcd-pod.yaml", owner="root") }}}
 
-platforms:
-    - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
     - dependency: |-

--- a/applications/openshift/master/file_owner_etcd_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_owner_etcd_pki_cert_files/rule.yml
@@ -29,8 +29,7 @@ ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resour
 ocil: |-
   {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/*.crt", owner="root") }}}
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
   - dependency: |-

--- a/applications/openshift/master/file_owner_kube_apiserver/rule.yml
+++ b/applications/openshift/master/file_owner_kube_apiserver/rule.yml
@@ -26,8 +26,7 @@ ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resour
 ocil: |-
     {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", owner="root") }}}
 
-platforms:
-    - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
     - dependency: |-

--- a/applications/openshift/master/file_owner_kube_controller_manager/rule.yml
+++ b/applications/openshift/master/file_owner_kube_controller_manager/rule.yml
@@ -26,8 +26,7 @@ ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resour
 ocil: |-
     {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", owner="root") }}}
 
-platforms:
-    - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
     - dependency: |-

--- a/applications/openshift/master/file_owner_kube_scheduler/rule.yml
+++ b/applications/openshift/master/file_owner_kube_scheduler/rule.yml
@@ -26,8 +26,7 @@ ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resour
 ocil: |-
     {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", owner="root") }}}
 
-platforms:
-    - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
     - dependency: |-

--- a/applications/openshift/master/file_owner_master_admin_kubeconfigs/rule.yml
+++ b/applications/openshift/master/file_owner_master_admin_kubeconfigs/rule.yml
@@ -32,8 +32,7 @@ ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resour
 ocil: |-
   {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/*.kubeconfig", owner="root") }}}
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
   - dependency: |-

--- a/applications/openshift/master/file_owner_openshift_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_owner_openshift_pki_cert_files/rule.yml
@@ -28,8 +28,7 @@ ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resour
 ocil: |-
   {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/tls.crt", owner="root") }}}
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
   - dependency: |-

--- a/applications/openshift/master/file_owner_openshift_pki_key_files/rule.yml
+++ b/applications/openshift/master/file_owner_openshift_pki_key_files/rule.yml
@@ -29,8 +29,7 @@ ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resour
 ocil: |-
   {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/*/*/*/*.key", owner="root") }}}
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
   - dependency: |-

--- a/applications/openshift/master/file_owner_scheduler_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_owner_scheduler_kubeconfig/rule.yml
@@ -27,8 +27,7 @@ ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/static-pod-resour
 ocil: |-
   {{{ ocil_file_owner(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/configmaps/scheduler-kubeconfig/kubeconfig", owner="root") }}}
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
   - dependency: |-

--- a/applications/openshift/master/file_permissions_controller_manager_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_permissions_controller_manager_kubeconfig/rule.yml
@@ -29,8 +29,7 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-
 ocil: |-
   {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/configmaps/controller-manager-kubeconfig/kubeconfig", perms="-rw-------") }}}
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
   - dependency: |-

--- a/applications/openshift/master/file_permissions_etcd_data_dir/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_data_dir/rule.yml
@@ -28,8 +28,7 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/lib/etcd", perms="drwx
 ocil: |-
     {{{ ocil_file_permissions(file="/var/lib/etcd", perms="drwx------") }}}
 
-platforms:
-    - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
     - dependency: |-

--- a/applications/openshift/master/file_permissions_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_data_files/rule.yml
@@ -28,8 +28,7 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/var/lib/etcd/member/wal/*"
 ocil: |-
     {{{ ocil_file_permissions(file="/var/lib/etcd/member/wal/*", perms="-rw-------") }}}
 
-platforms:
-    - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
     - dependency: |-

--- a/applications/openshift/master/file_permissions_etcd_member/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_member/rule.yml
@@ -30,8 +30,7 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/manifests/e
 ocil: |-
     {{{ ocil_file_permissions(file="/etc/kubernetes/manifests/etcd-pod.yaml", perms="-rw-------") }}}
 
-platforms:
-    - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
     - dependency: |-

--- a/applications/openshift/master/file_permissions_etcd_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_pki_cert_files/rule.yml
@@ -28,8 +28,7 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-
 ocil: |-
   {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-*/secrets/*/*.crt", perms="-rw-------") }}}
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
   - dependency: |-

--- a/applications/openshift/master/file_permissions_kube_apiserver/rule.yml
+++ b/applications/openshift/master/file_permissions_kube_apiserver/rule.yml
@@ -28,8 +28,7 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-
 ocil: |-
     {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", perms="-rw-------") }}}
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
   - dependency: |-

--- a/applications/openshift/master/file_permissions_kube_controller_manager/rule.yml
+++ b/applications/openshift/master/file_permissions_kube_controller_manager/rule.yml
@@ -28,8 +28,7 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-
 ocil: |-
     {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", perms="-rw-------") }}}
 
-platforms:
-    - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
   - dependency: |-

--- a/applications/openshift/master/file_permissions_master_admin_kubeconfigs/rule.yml
+++ b/applications/openshift/master/file_permissions_master_admin_kubeconfigs/rule.yml
@@ -32,8 +32,7 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-
 ocil: |-
   {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/*.kubeconfig", perms="-rw-------") }}}
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
   - dependency: |-

--- a/applications/openshift/master/file_permissions_openshift_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_permissions_openshift_pki_cert_files/rule.yml
@@ -28,8 +28,7 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-
 ocil: |-
   {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-*/secrets/*/tls.crt", perms="-rw-------") }}}
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
   - dependency: |-

--- a/applications/openshift/master/file_permissions_openshift_pki_key_files/rule.yml
+++ b/applications/openshift/master/file_permissions_openshift_pki_key_files/rule.yml
@@ -28,8 +28,7 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-
 ocil: |-
   {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/*/*/*/*.key", perms="-rw-------") }}}
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
   - dependency: |-

--- a/applications/openshift/master/file_permissions_scheduler/rule.yml
+++ b/applications/openshift/master/file_permissions_scheduler/rule.yml
@@ -28,8 +28,7 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-
 ocil: |-
     {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/kube-scheduler-pod.yaml", perms="-rw-r--r--") }}}
 
-platforms:
-    - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
   - dependency: |-

--- a/applications/openshift/master/file_permissions_scheduler_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_permissions_scheduler_kubeconfig/rule.yml
@@ -29,8 +29,7 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-
 ocil: |-
   {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/configmaps/scheduler-kubeconfig/kubeconfig", perms="-rw-------") }}}
 
-platforms:
-  - ocp4-master-node
+platform: ocp4-master-node
 
 warnings:
   - dependency: |-

--- a/applications/openshift/worker/file_permissions_worker_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_permissions_worker_kubeconfig/rule.yml
@@ -1,8 +1,7 @@
 documentation_complete: true
 
 
-platforms:
-- {{{ product }}}-node
+platform: {{{ product }}}-node
 
 {{%- if product == "eks" %}}
 {{%- set octal_perms = "0644" %}}

--- a/products/ocp4/profiles/bsi-2022.profile
+++ b/products/ocp4/profiles/bsi-2022.profile
@@ -25,7 +25,7 @@ description: |-
     - Building-Block APP.4.4 Kubernetes
 
 
-filter_rules: '"ocp4-node" not in platforms and "ocp4-master-node" not in platforms and "ocp4-node-on-sdn" not in platforms and "ocp4-node-on-ovn" not in platforms'
+filter_rules: '"ocp4-node" not in platform and "ocp4-master-node" not in platform and "ocp4-node-on-sdn" not in platform and "ocp4-node-on-ovn" not in platform'
 
 selections:
     - bsi_app_4_4:all

--- a/products/ocp4/profiles/bsi-node-2022.profile
+++ b/products/ocp4/profiles/bsi-node-2022.profile
@@ -25,7 +25,7 @@ description: |-
     - Building-Block APP.4.4 Kubernetes
 
 
-filter_rules: '"ocp4-node" in platforms or "ocp4-master-node" in platforms or "ocp4-node-on-sdn" in platforms or "ocp4-node-on-ovn" in platforms'
+filter_rules: '"ocp4-node" in platform or "ocp4-master-node" in platform or "ocp4-node-on-sdn" in platform or "ocp4-node-on-ovn" in platform'
 
 selections:
     - bsi_app_4_4:all

--- a/products/ocp4/profiles/cis-1-4.profile
+++ b/products/ocp4/profiles/cis-1-4.profile
@@ -25,7 +25,7 @@ description: |-
 
     This profile is applicable to OpenShift versions 4.10 and greater.
 
-filter_rules: '"ocp4-node" not in platforms and "ocp4-master-node" not in platforms and "ocp4-node-on-sdn" not in platforms and "ocp4-node-on-ovn" not in platforms'
+filter_rules: '"ocp4-node" not in platform and "ocp4-master-node" not in platform and "ocp4-node-on-sdn" not in platform and "ocp4-node-on-ovn" not in platform'
 
 selections:
     - cis_ocp_1_4_0:all

--- a/products/ocp4/profiles/cis-1-5.profile
+++ b/products/ocp4/profiles/cis-1-5.profile
@@ -26,7 +26,7 @@ description: |-
 
     This profile is applicable to OpenShift versions 4.12 and greater.
 
-filter_rules: '"ocp4-node" not in platforms and "ocp4-master-node" not in platforms and "ocp4-node-on-sdn" not in platforms and "ocp4-node-on-ovn" not in platforms'
+filter_rules: '"ocp4-node" not in platform and "ocp4-master-node" not in platform and "ocp4-node-on-sdn" not in platform and "ocp4-node-on-ovn" not in platform'
 
 selections:
     - cis_ocp_1_4_0:all

--- a/products/ocp4/profiles/cis-1-7.profile
+++ b/products/ocp4/profiles/cis-1-7.profile
@@ -23,7 +23,7 @@ description: |-
 
     This profile is applicable to OpenShift versions 4.12 and greater.
 
-filter_rules: '"ocp4-node" not in platforms and "ocp4-master-node" not in platforms and "ocp4-node-on-sdn" not in platforms and "ocp4-node-on-ovn" not in platforms'
+filter_rules: '"ocp4-node" not in platform and "ocp4-master-node" not in platform and "ocp4-node-on-sdn" not in platform and "ocp4-node-on-ovn" not in platform'
 
 selections:
     - cis_ocp_1_4_0:all

--- a/products/ocp4/profiles/cis-node-1-4.profile
+++ b/products/ocp4/profiles/cis-node-1-4.profile
@@ -25,7 +25,7 @@ description: |-
 
     This profile is applicable to OpenShift versions 4.10 and greater.
 
-filter_rules: '"ocp4-node" in platforms or "ocp4-master-node" in platforms or "ocp4-node-on-sdn" in platforms or "ocp4-node-on-ovn" in platforms'
+filter_rules: '"ocp4-node" in platform or "ocp4-master-node" in platform or "ocp4-node-on-sdn" in platform or "ocp4-node-on-ovn" in platform'
 
 selections:
     - cis_ocp_1_4_0:all

--- a/products/ocp4/profiles/cis-node-1-5.profile
+++ b/products/ocp4/profiles/cis-node-1-5.profile
@@ -26,7 +26,7 @@ description: |-
 
     This profile is applicable to OpenShift versions 4.12 and greater.
 
-filter_rules: '"ocp4-node" in platforms or "ocp4-master-node" in platforms or "ocp4-node-on-sdn" in platforms or "ocp4-node-on-ovn" in platforms'
+filter_rules: '"ocp4-node" in platform or "ocp4-master-node" in platform or "ocp4-node-on-sdn" in platform or "ocp4-node-on-ovn" in platform'
 
 selections:
     - cis_ocp_1_4_0:all

--- a/products/ocp4/profiles/cis-node-1-7.profile
+++ b/products/ocp4/profiles/cis-node-1-7.profile
@@ -23,7 +23,7 @@ description: |-
 
     This profile is applicable to OpenShift versions 4.12 and greater.
 
-filter_rules: '"ocp4-node" in platforms or "ocp4-master-node" in platforms or "ocp4-node-on-sdn" in platforms or "ocp4-node-on-ovn" in platforms'
+filter_rules: '"ocp4-node" in platform or "ocp4-master-node" in platform or "ocp4-node-on-sdn" in platform or "ocp4-node-on-ovn" in platform'
 
 selections:
     - cis_ocp_1_4_0:all

--- a/products/ocp4/profiles/high-node-rev-4.profile
+++ b/products/ocp4/profiles/high-node-rev-4.profile
@@ -42,7 +42,7 @@ description: |-
 # CM-6(1) CONFIGURATION SETTINGS | AUTOMATED CENTRAL MANAGEMENT / APPLICATION / VERIFICATION
 extends: cis-node
 
-filter_rules: '"ocp4-node" in platforms or "ocp4-master-node" in platforms or "ocp4-node-on-sdn" in platforms or "ocp4-node-on-ovn" in platforms'
+filter_rules: '"ocp4-node" in platform or "ocp4-master-node" in platform or "ocp4-node-on-sdn" in platform or "ocp4-node-on-ovn" in platform'
 
 selections:
     - nist_ocp4:all:high

--- a/products/ocp4/profiles/high-rev-4.profile
+++ b/products/ocp4/profiles/high-rev-4.profile
@@ -38,7 +38,7 @@ description: |-
     content as minor divergences, such as bugfixes, work through the
     consensus and release processes.
 
-filter_rules: '"ocp4-node" not in platforms and "ocp4-master-node" not in platforms and "ocp4-node-on-sdn" not in platforms and "ocp4-node-on-ovn" not in platforms'
+filter_rules: '"ocp4-node" not in platform and "ocp4-master-node" not in platform and "ocp4-node-on-sdn" not in platform and "ocp4-node-on-ovn" not in platform'
 
 # CM-6 CONFIGURATION SETTINGS
 # CM-6(1) CONFIGURATION SETTINGS | AUTOMATED CENTRAL MANAGEMENT / APPLICATION / VERIFICATION

--- a/products/ocp4/profiles/moderate-node-rev-4.profile
+++ b/products/ocp4/profiles/moderate-node-rev-4.profile
@@ -40,7 +40,7 @@ description: |-
 # CM-6(1) CONFIGURATION SETTINGS | AUTOMATED CENTRAL MANAGEMENT / APPLICATION / VERIFICATION
 extends: cis-node
 
-filter_rules: '"ocp4-node" in platforms or "ocp4-master-node" in platforms or "ocp4-node-on-sdn" in platforms or "ocp4-node-on-ovn" in platforms'
+filter_rules: '"ocp4-node" in platform or "ocp4-master-node" in platform or "ocp4-node-on-sdn" in platform or "ocp4-node-on-ovn" in platform'
 
 selections:
     - nist_ocp4:all:moderate

--- a/products/ocp4/profiles/moderate-rev-4.profile
+++ b/products/ocp4/profiles/moderate-rev-4.profile
@@ -37,7 +37,7 @@ description: |-
     content as minor divergences, such as bugfixes, work through the
     consensus and release processes.
 
-filter_rules: '"ocp4-node" not in platforms and "ocp4-master-node" not in platforms and "ocp4-node-on-sdn" not in platforms and "ocp4-node-on-ovn" not in platforms'
+filter_rules: '"ocp4-node" not in platform and "ocp4-master-node" not in platform and "ocp4-node-on-sdn" not in platform and "ocp4-node-on-ovn" not in platform'
 
 # CM-6 CONFIGURATION SETTINGS
 # CM-6(1) CONFIGURATION SETTINGS | AUTOMATED CENTRAL MANAGEMENT / APPLICATION / VERIFICATION

--- a/products/ocp4/profiles/pci-dss-3-2.profile
+++ b/products/ocp4/profiles/pci-dss-3-2.profile
@@ -16,7 +16,7 @@ title: 'PCI-DSS v3.2.1 Control Baseline for Red Hat OpenShift Container Platform
 description: |-
     Ensures PCI-DSS v3.2.1 security configuration settings are applied.
 
-filter_rules: '"ocp4-node" not in platforms and "ocp4-master-node" not in platforms and "ocp4-node-on-sdn" not in platforms and "ocp4-node-on-ovn" not in platforms'
+filter_rules: '"ocp4-node" not in platform and "ocp4-master-node" not in platform and "ocp4-node-on-sdn" not in platform and "ocp4-node-on-ovn" not in platform'
 
 
 # Req-2.2

--- a/products/ocp4/profiles/pci-dss-4-0.profile
+++ b/products/ocp4/profiles/pci-dss-4-0.profile
@@ -16,7 +16,7 @@ title: 'PCI-DSS v4.0.0 Control Baseline for Red Hat OpenShift Container Platform
 description: |-
     Ensures PCI-DSS v4.0.0 security configuration settings are applied.
 
-filter_rules: '"ocp4-node" not in platforms and "ocp4-master-node" not in platforms and "ocp4-node-on-sdn" not in platforms and "ocp4-node-on-ovn" not in platforms'
+filter_rules: '"ocp4-node" not in platform and "ocp4-master-node" not in platform and "ocp4-node-on-sdn" not in platform and "ocp4-node-on-ovn" not in platform'
 
 
 selections:

--- a/products/ocp4/profiles/pci-dss-node-3-2.profile
+++ b/products/ocp4/profiles/pci-dss-node-3-2.profile
@@ -16,7 +16,7 @@ title: 'PCI-DSS v3.2.1 Control Baseline for Red Hat OpenShift Container Platform
 description: |-
     Ensures PCI-DSS v3.2.1 security configuration settings are applied.
 
-filter_rules: '"ocp4-node" in platforms or "ocp4-master-node" in platforms or "ocp4-node-on-sdn" in platforms or "ocp4-node-on-ovn" in platforms'
+filter_rules: '"ocp4-node" in platform or "ocp4-master-node" in platform or "ocp4-node-on-sdn" in platform or "ocp4-node-on-ovn" in platform'
 
 # Req-2.2
 extends: cis-node

--- a/products/ocp4/profiles/pci-dss-node-4-0.profile
+++ b/products/ocp4/profiles/pci-dss-node-4-0.profile
@@ -16,7 +16,7 @@ title: 'PCI-DSS v4.0.0 Control Baseline for Red Hat OpenShift Container Platform
 description: |-
     Ensures PCI-DSS v4.0.0 security configuration settings are applied.
 
-filter_rules: '"ocp4-node" in platforms or "ocp4-master-node" in platforms or "ocp4-node-on-sdn" in platforms or "ocp4-node-on-ovn" in platforms'
+filter_rules: '"ocp4-node" in platform or "ocp4-master-node" in platform or "ocp4-node-on-sdn" in platform or "ocp4-node-on-ovn" in platform'
 
 selections:
     - pcidss_4_ocp4:all:base

--- a/products/ocp4/profiles/stig-node-v1r1.profile
+++ b/products/ocp4/profiles/stig-node-v1r1.profile
@@ -19,7 +19,7 @@ description: |-
     This profile contains configuration checks that align to the DISA STIG for
     Red Hat OpenShift Container Platform 4.
 
-filter_rules: '"ocp4-node" in platforms or "ocp4-master-node" in platforms or "ocp4-node-on-sdn" in platforms or "ocp4-node-on-ovn" in platforms'
+filter_rules: '"ocp4-node" in platform or "ocp4-master-node" in platform or "ocp4-node-on-sdn" in platform or "ocp4-node-on-ovn" in platform'
 
 selections:
     - stig_ocp4:all

--- a/products/ocp4/profiles/stig-node-v2r1.profile
+++ b/products/ocp4/profiles/stig-node-v2r1.profile
@@ -17,7 +17,7 @@ description: |-
     This profile contains configuration checks that align to the DISA STIG for
     Red Hat OpenShift Container Platform 4.
 
-filter_rules: '"ocp4-node" in platforms or "ocp4-master-node" in platforms or "ocp4-node-on-sdn" in platforms or "ocp4-node-on-ovn" in platforms'
+filter_rules: '"ocp4-node" in platform or "ocp4-master-node" in platform or "ocp4-node-on-sdn" in platform or "ocp4-node-on-ovn" in platform'
 
 selections:
     - stig_ocp4:all

--- a/products/ocp4/profiles/stig-node-v2r2.profile
+++ b/products/ocp4/profiles/stig-node-v2r2.profile
@@ -17,7 +17,7 @@ description: |-
     This profile contains configuration checks that align to the DISA STIG for
     Red Hat OpenShift Container Platform 4.
 
-filter_rules: '"ocp4-node" in platforms or "ocp4-master-node" in platforms or "ocp4-node-on-sdn" in platforms or "ocp4-node-on-ovn" in platforms'
+filter_rules: '"ocp4-node" in platform or "ocp4-master-node" in platform or "ocp4-node-on-sdn" in platform or "ocp4-node-on-ovn" in platform'
 
 selections:
     - stig_ocp4:all

--- a/products/ocp4/profiles/stig-v1r1.profile
+++ b/products/ocp4/profiles/stig-v1r1.profile
@@ -19,7 +19,7 @@ description: |-
     This profile contains configuration checks that align to the DISA STIG for
     Red Hat OpenShift Container Platform 4.
 
-filter_rules: '"ocp4-node" not in platforms and "ocp4-master-node" not in platforms and "ocp4-node-on-sdn" not in platforms and "ocp4-node-on-ovn" not in platforms'
+filter_rules: '"ocp4-node" not in platform and "ocp4-master-node" not in platform and "ocp4-node-on-sdn" not in platform and "ocp4-node-on-ovn" not in platform'
 
 selections:
     - stig_ocp4:all

--- a/products/ocp4/profiles/stig-v2r1.profile
+++ b/products/ocp4/profiles/stig-v2r1.profile
@@ -17,7 +17,7 @@ description: |-
     This profile contains configuration checks that align to the DISA STIG for
     Red Hat OpenShift Container Platform 4.
 
-filter_rules: '"ocp4-node" not in platforms and "ocp4-master-node" not in platforms and "ocp4-node-on-sdn" not in platforms and "ocp4-node-on-ovn" not in platforms'
+filter_rules: '"ocp4-node" not in platform and "ocp4-master-node" not in platform and "ocp4-node-on-sdn" not in platform and "ocp4-node-on-ovn" not in platform'
 
 selections:
     - stig_ocp4:all

--- a/products/ocp4/profiles/stig-v2r2.profile
+++ b/products/ocp4/profiles/stig-v2r2.profile
@@ -17,7 +17,7 @@ description: |-
     This profile contains configuration checks that align to the DISA STIG for
     Red Hat OpenShift Container Platform 4.
 
-filter_rules: '"ocp4-node" not in platforms and "ocp4-master-node" not in platforms and "ocp4-node-on-sdn" not in platforms and "ocp4-node-on-ovn" not in platforms'
+filter_rules: '"ocp4-node" not in platform and "ocp4-master-node" not in platform and "ocp4-node-on-sdn" not in platform and "ocp4-node-on-ovn" not in platform'
 
 selections:
     - stig_ocp4:all


### PR DESCRIPTION
We can model the platform applicability checks using platform instead of
platforms, which has some additional logic that doesn't work as well
with boolean logic. It also only supports a list of one.

The subtle differences between the two is confusing, and we should be
able to do everything with platform.
