### PR TITLE
rsyslog_remote_loghost: support Rainer Script in OVAL

### DIFF
--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/oval/shared.xml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/oval/shared.xml
@@ -7,6 +7,8 @@
     </criteria>
   </definition>
 
+{{% set rsyslog_remote_loghost_old_regex="^\*\.\*[\s]+(?:@|\:omrelp\:)" %}}
+
   <!-- NIST scapval validation tool complains that a variable passed to
   rsyslog_remote_loghost OVAL check from the XCCDF Rule doesn't have
   the correct type according to the SCAP specifications.
@@ -33,14 +35,14 @@
 
   <ind:textfilecontent54_object id="object_remote_loghost_rsyslog_conf" version="1">
     <ind:filepath>/etc/rsyslog.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^\*\.\*[\s]+(?:@|\:omrelp\:)</ind:pattern>
+    <ind:pattern operation="pattern match">{{{ rsyslog_remote_loghost_old_regex }}}</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_object id="object_remote_loghost_rsyslog_d" version="1">
     <ind:path>/etc/rsyslog.d</ind:path>
     <ind:filename operation="pattern match">^.+\.conf$</ind:filename>
-    <ind:pattern operation="pattern match">^\*\.\*[\s]+(?:@|\:omrelp\:)</ind:pattern>
+    <ind:pattern operation="pattern match">{{{ rsyslog_remote_loghost_old_regex }}}</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/oval/shared.xml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/oval/shared.xml
@@ -4,10 +4,13 @@
     <criteria operator="OR">
       <criterion comment="Remote logging set within /etc/rsyslog.conf" test_ref="test_remote_rsyslog_conf" />
       <criterion comment="Remote logging set within /etc/rsyslog.d" test_ref="test_remote_rsyslog_d" />
+      <criterion comment="Remote logging set within /etc/rsyslog.conf in RainerScript" test_ref="test_remote_rsyslog_conf_rainer" />
+      <criterion comment="Remote logging set within /etc/rsyslog.d through RainerScript" test_ref="test_remote_rsyslog_d_rainer" />
     </criteria>
   </definition>
 
 {{% set rsyslog_remote_loghost_old_regex="^\*\.\*[\s]+(?:@|\:omrelp\:)" %}}
+{{% set rsyslog_remote_loghost_rainer_regex="(?m)^\\s*\\*\\.\\*\\s+action\\(\\s*.*(?i)\\btype\\b(?-i)=\"omfwd\"\\s*.*(?i)\\btarget\\b(?-i)=\"\\S+\"\\s*.*\\)\\s*$" %}}
 
   <!-- NIST scapval validation tool complains that a variable passed to
   rsyslog_remote_loghost OVAL check from the XCCDF Rule doesn't have
@@ -43,6 +46,31 @@
     <ind:path>/etc/rsyslog.d</ind:path>
     <ind:filename operation="pattern match">^.+\.conf$</ind:filename>
     <ind:pattern operation="pattern match">{{{ rsyslog_remote_loghost_old_regex }}}</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="Ensures system configured to export logs to remote host using Rainer syntax"
+  id="test_remote_rsyslog_conf_rainer" version="1">
+    <ind:object object_ref="object_remote_loghost_rsyslog_conf_rainer" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="Ensures system configured to export logs to remote host using Rainer"
+  id="test_remote_rsyslog_d_rainer" version="1">
+    <ind:object object_ref="object_remote_loghost_rsyslog_d_rainer" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_remote_loghost_rsyslog_conf_rainer" version="1">
+    <ind:filepath>/etc/rsyslog.conf</ind:filepath>
+    <ind:pattern operation="pattern match">{{{ rsyslog_remote_loghost_rainer_regex }}}</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="object_remote_loghost_rsyslog_d_rainer" version="1">
+    <ind:path>/etc/rsyslog.d</ind:path>
+    <ind:filename operation="pattern match">^.+\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">{{{ rsyslog_remote_loghost_rainer_regex }}}</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/rule.yml
@@ -18,11 +18,20 @@ description: |-
     To use UDP for log message delivery:
     <pre>*.* @<i>{{{ xccdf_value("rsyslog_remote_loghost_address") }}}</i></pre>
     <br />
+    Or in RainerScript:
+    <pre>*.* action(type="omfwd" ... target="<i>{{{ xccdf_value("rsyslog_remote_loghost_address") }}}</i>" protocol="udp")</pre>
+    <br />
     To use TCP for log message delivery:
     <pre>*.* @@<i>{{{ xccdf_value("rsyslog_remote_loghost_address") }}}</i></pre>
     <br />
+    Or in RainerScript:
+    <pre>*.* action(type="omfwd" ... target="<i>{{{ xccdf_value("rsyslog_remote_loghost_address") }}}</i>" protocol="tcp")</pre>
+    <br />
     To use RELP for log message delivery:
     <pre>*.* :omrelp:<i>{{{ xccdf_value("rsyslog_remote_loghost_address") }}}</i></pre>
+    <br />
+    Or in RainerScript:
+    <pre>*.* action(type="omfwd" ... target="<i>{{{ xccdf_value("rsyslog_remote_loghost_address") }}}</i>" protocol="relp")</pre>
     <br />
     There must be a resolvable DNS CNAME or Alias record set to "{{{ xccdf_value("rsyslog_remote_loghost_address") }}}" for logs to be sent correctly to the centralized logging utility.
 
@@ -72,15 +81,23 @@ ocil: |-
     <tt>/etc/rsyslog.conf</tt>.
     If using UDP, a line similar to the following should be present:
     <pre> *.* @<i>{{{ xccdf_value("rsyslog_remote_loghost_address") }}}</i></pre>
+    or
+    <pre>*.* action(type="omfwd" ... target="<i>{{{ xccdf_value("rsyslog_remote_loghost_address") }}}</i>" protocol="udp")</pre>
     If using TCP, a line similar to the following should be present:
     <pre> *.* @@<i>{{{ xccdf_value("rsyslog_remote_loghost_address") }}}</i></pre>
+    or
+    <pre>*.* action(type="omfwd" ... target="<i>{{{ xccdf_value("rsyslog_remote_loghost_address") }}}</i>" protocol="tcp")</pre>
     If using RELP, a line similar to the following should be present:
     <pre> *.* :omrelp:<i>{{{ xccdf_value("rsyslog_remote_loghost_address") }}}</i></pre>
+    or
+    <pre>*.* action(type="omfwd" ... target="<i>{{{ xccdf_value("rsyslog_remote_loghost_address") }}}</i>" protocol="relp")</pre>
 
 fixtext: |-
     Configure {{{ full_name }}} to off-load audit records onto a different system or media from the system being audited by specifying the remote logging server in "/etc/rsyslog.conf" or "/etc/rsyslog.d/[customfile].conf" with the name or IP address of the log aggregation server.
 
     *.* @@[remoteloggingserver]:[port]"
+    or
+    <pre>*.* action(type="omfwd" ... target="<i>{{{ xccdf_value("rsyslog_remote_loghost_address") }}}</i>" protocol="relp")</pre>
 
 srg_requirement: 'The {{{ full_name }}} audit records must be off-loaded onto a different system or storage media from the system being audited.'
 
@@ -100,3 +117,5 @@ warnings:
         $ActionQueueSaveOnShutdown on
         $ActionResumeRetryCount -1
         </pre>
+        Or if using Rainer Script syntax, it could be:
+        <pre>*.* action(type="omfwd" queue.type="linkedlist" queue.filename="example_fwd" action.resumeRetryCount="-1" queue.saveOnShutdown="on" target="example.com" port="30514" protocol="tcp")</pre>

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/tests/remote_configured_rainer.pass.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/tests/remote_configured_rainer.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# packages = rsyslog
+
+CONF_FILE="/etc/rsyslog.conf"
+LOGHOST_LINE='*.* action(type="omfwd" queue.type="linkedlist" queue.filename="example_fwd" action.resumeRetryCount="-1" queue.saveOnShutdown="on" target="192.168.122.1" port="30514" protocol="tcp")'
+
+if grep -q "^\*\.\*" "$CONF_FILE"; then
+	sed -i "s|^\*\.\*.*|$LOGHOST_LINE|" "$CONF_FILE"
+else
+	echo "$LOGHOST_LINE" >> "$CONF_FILE"
+fi


### PR DESCRIPTION
#### Description:

- extend OVAL check to support Rainer Script syntax
- add Rainer Script examples to rule.yml next to the old syntax
- Note that I did not change remediations... I think this is out of scope of the reported issue. Also the old and new syntax should work together in Rsyslog and it will be probably quite complex to decide what syntax to use.

#### Rationale:

- new syntax is definitely valid and we should not discourage users from using it

fixes: OPENSCAP-5467

#### Review Hints:

- use Automatus