### PR TITLE
OPENSCAP-5455: Add GitHub codespaces development environment configurations + workshop env

### DIFF
--- a/.devcontainer/cac-container_fedora/devcontainer.json
+++ b/.devcontainer/cac-container_fedora/devcontainer.json
@@ -1,0 +1,24 @@
+{
+	"name": "ComplianceAsCode Dev (Ubuntu+Fedora)",
+	"image": "ghcr.io/ggbecker/cac-dev:latest",
+
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
+	},
+
+	"postCreateCommand": "bash utils/setup_dev.sh fedora",
+
+	// Configure tool-specific properties.
+	"customizations": {
+        "vscode":{
+            "extensions": [
+                "ggbecker.content-navigator", // useful extension for the ComplianceAsCode/content project
+                "ms-vscode.live-server", // HTML preview
+                "rogalmic.bash-debug", // support bashdb debug configurations
+                "eamodio.gitlens", // cool git extension with a bunch of extra features
+                "twxs.cmake", // support to CMakeLists.txt syntax highlighting and more
+                "ms-python.python" // running python configurations
+            ]
+        }
+    }
+}

--- a/.devcontainer/cac-container_rhel/devcontainer.json
+++ b/.devcontainer/cac-container_rhel/devcontainer.json
@@ -1,0 +1,24 @@
+{
+	"name": "ComplianceAsCode Dev (Ubuntu+RHEL)",
+	"image": "ghcr.io/ggbecker/cac-dev:latest",
+
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
+	},
+
+	"postCreateCommand": "bash utils/setup_dev.sh rhel9",
+
+	// Configure tool-specific properties.
+	"customizations": {
+        "vscode":{
+            "extensions": [
+                "ggbecker.content-navigator", // useful extension for the ComplianceAsCode/content project
+                "ms-vscode.live-server", // HTML preview
+                "rogalmic.bash-debug", // support bashdb debug configurations
+                "eamodio.gitlens", // cool git extension with a bunch of extra features
+                "twxs.cmake", // support to CMakeLists.txt syntax highlighting and more
+                "ms-python.python" // running python configurations
+            ]
+        }
+    }
+}

--- a/.devcontainer/cac-workshop1/devcontainer.json
+++ b/.devcontainer/cac-workshop1/devcontainer.json
@@ -1,0 +1,24 @@
+{
+	"name": "ComplianceAsCode Workshop Exercise 1",
+	"image": "ghcr.io/ggbecker/cac-dev:latest",
+
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
+	},
+
+	"postCreateCommand": "bash utils/setup_dev.sh fedora lab1_introduction",
+
+	// Configure tool-specific properties.
+	"customizations": {
+        "vscode":{
+            "extensions": [
+                "ggbecker.content-navigator", // useful extension for the ComplianceAsCode/content project
+                "ms-vscode.live-server", // HTML preview
+                "rogalmic.bash-debug", // support bashdb debug configurations
+                "eamodio.gitlens", // cool git extension with a bunch of extra features
+                "twxs.cmake", // support to CMakeLists.txt syntax highlighting and more
+                "ms-python.python" // running python configurations
+            ]
+        }
+    }
+}

--- a/.devcontainer/cac-workshop2/devcontainer.json
+++ b/.devcontainer/cac-workshop2/devcontainer.json
@@ -1,0 +1,24 @@
+{
+	"name": "ComplianceAsCode Workshop Exercise 2",
+	"image": "ghcr.io/ggbecker/cac-dev:latest",
+
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
+	},
+
+	"postCreateCommand": "bash utils/setup_dev.sh fedora lab2_openscap",
+
+	// Configure tool-specific properties.
+	"customizations": {
+        "vscode":{
+            "extensions": [
+                "ggbecker.content-navigator", // useful extension for the ComplianceAsCode/content project
+                "ms-vscode.live-server", // HTML preview
+                "rogalmic.bash-debug", // support bashdb debug configurations
+                "eamodio.gitlens", // cool git extension with a bunch of extra features
+                "twxs.cmake", // support to CMakeLists.txt syntax highlighting and more
+                "ms-python.python" // running python configurations
+            ]
+        }
+    }
+}

--- a/.devcontainer/cac-workshop3/devcontainer.json
+++ b/.devcontainer/cac-workshop3/devcontainer.json
@@ -1,0 +1,24 @@
+{
+	"name": "ComplianceAsCode Workshop Exercise 3",
+	"image": "ghcr.io/ggbecker/cac-dev:latest",
+
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
+	},
+
+	"postCreateCommand": "bash utils/setup_dev.sh fedora lab3_profiles",
+
+	// Configure tool-specific properties.
+	"customizations": {
+        "vscode":{
+            "extensions": [
+                "ggbecker.content-navigator", // useful extension for the ComplianceAsCode/content project
+                "ms-vscode.live-server", // HTML preview
+                "rogalmic.bash-debug", // support bashdb debug configurations
+                "eamodio.gitlens", // cool git extension with a bunch of extra features
+                "twxs.cmake", // support to CMakeLists.txt syntax highlighting and more
+                "ms-python.python" // running python configurations
+            ]
+        }
+    }
+}

--- a/.devcontainer/cac-workshop4/devcontainer.json
+++ b/.devcontainer/cac-workshop4/devcontainer.json
@@ -1,0 +1,24 @@
+{
+	"name": "ComplianceAsCode Workshop Exercise 4",
+	"image": "ghcr.io/ggbecker/cac-dev:latest",
+
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
+	},
+
+	"postCreateCommand": "bash utils/setup_dev.sh fedora lab4_ansible",
+
+	// Configure tool-specific properties.
+	"customizations": {
+        "vscode":{
+            "extensions": [
+                "ggbecker.content-navigator", // useful extension for the ComplianceAsCode/content project
+                "ms-vscode.live-server", // HTML preview
+                "rogalmic.bash-debug", // support bashdb debug configurations
+                "eamodio.gitlens", // cool git extension with a bunch of extra features
+                "twxs.cmake", // support to CMakeLists.txt syntax highlighting and more
+                "ms-python.python" // running python configurations
+            ]
+        }
+    }
+}

--- a/.devcontainer/cac-workshop5/devcontainer.json
+++ b/.devcontainer/cac-workshop5/devcontainer.json
@@ -1,0 +1,24 @@
+{
+	"name": "ComplianceAsCode Workshop Exercise 5",
+	"image": "ghcr.io/ggbecker/cac-dev:latest",
+
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
+	},
+
+	"postCreateCommand": "bash utils/setup_dev.sh fedora lab5_oval",
+
+	// Configure tool-specific properties.
+	"customizations": {
+        "vscode":{
+            "extensions": [
+                "ggbecker.content-navigator", // useful extension for the ComplianceAsCode/content project
+                "ms-vscode.live-server", // HTML preview
+                "rogalmic.bash-debug", // support bashdb debug configurations
+                "eamodio.gitlens", // cool git extension with a bunch of extra features
+                "twxs.cmake", // support to CMakeLists.txt syntax highlighting and more
+                "ms-python.python" // running python configurations
+            ]
+        }
+    }
+}

--- a/docs/workshop/lab1_introduction.adoc
+++ b/docs/workshop/lab1_introduction.adoc
@@ -46,8 +46,13 @@ The `ComplianceAsCode` project consists of human-readable files that are compile
 For your convenience, the environment is already set up, so the content is built and ready to be used.
 No worries, though--you get to rebuild it later in the exercise.
 
-To start the hands-on section, take the following steps:
+To start the hands-on section, take one of the following steps:
 
+=== Github Codespaces
+. Go to: link:https://github.com/codespaces/new?hide_repo_select=true&ref=master&repo=19279458&skip_quickstart=true[Github Codespaces]
+. Select `ComplianceAsCode Workshop Exercise 1` in the `Dev container configuration` option.
+
+=== Gitpod
 . Go to: link:https://gitpod.io/#WORKSHOP=lab1_introduction/https://github.com/ComplianceAsCode/content[Lab 1 Environment]
 . Wait until all the steps being executed in the terminal are complete.
 

--- a/docs/workshop/lab2_openscap.adoc
+++ b/docs/workshop/lab2_openscap.adoc
@@ -44,11 +44,15 @@ The `ComplianceAsCode` project consists of human-readable files that are compile
 For your convenience, the environment is already set up, so the content is built and ready to be used.
 No worries, though--you get to rebuild it later in the exercise.
 
-To start the hands-on section, take the following steps:
+To start the hands-on section, take one of the following steps:
 
+=== Github Codespaces
+. Go to: link:https://github.com/codespaces/new?hide_repo_select=true&ref=master&repo=19279458&skip_quickstart=true[Github Codespaces]
+. Select `ComplianceAsCode Workshop Exercise 2` in the `Dev container configuration` option.
+
+=== Gitpod
 . Go to: link:https://gitpod.io/#WORKSHOP=lab2_openscap/https://github.com/ComplianceAsCode/content[Lab 2 Environment]
 . Wait until all the steps being executed in the terminal are complete.
-
 
 == Introduction to OpenSCAP Command Line Tool
 

--- a/docs/workshop/lab3_profiles.adoc
+++ b/docs/workshop/lab3_profiles.adoc
@@ -42,8 +42,13 @@ The `ComplianceAsCode` project consists of human-readable files that are compile
 For your convenience, the environment is already set up, so the content is built and ready to be used.
 No worries, though--you get to rebuild it later in the exercise.
 
-To start the hands-on section, take the following steps:
+To start the hands-on section, take one of the following steps:
 
+=== Github Codespaces
+. Go to: link:https://github.com/codespaces/new?hide_repo_select=true&ref=master&repo=19279458&skip_quickstart=true[Github Codespaces]
+. Select `ComplianceAsCode Workshop Exercise 3` in the `Dev container configuration` option.
+
+=== Gitpod
 . Go to: link:https://gitpod.io/#WORKSHOP=lab3_profiles/https://github.com/ComplianceAsCode/content[Lab 3 Environment]
 . Wait until all the steps being executed in the terminal are complete.
 

--- a/docs/workshop/lab4_ansible.adoc
+++ b/docs/workshop/lab4_ansible.adoc
@@ -48,8 +48,13 @@ The `ComplianceAsCode` project consists of human-readable files that are compile
 For your convenience, the environment is already set up, so the content is built and ready to be used.
 No worries, though--you get to rebuild it later in the exercise.
 
-To start the hands-on section, take the following steps:
+To start the hands-on section, take one of the following steps:
 
+=== Github Codespaces
+. Go to: link:https://github.com/codespaces/new?hide_repo_select=true&ref=master&repo=19279458&skip_quickstart=true[Github Codespaces]
+. Select `ComplianceAsCode Workshop Exercise 4` in the `Dev container configuration` option.
+
+=== Gitpod
 . Go to: link:https://gitpod.io/#WORKSHOP=lab4_ansible/https://github.com/ComplianceAsCode/content[Lab 4 Environment]
 . Wait until all the steps being executed in the terminal are complete.
 

--- a/docs/workshop/lab5_oval.adoc
+++ b/docs/workshop/lab5_oval.adoc
@@ -57,8 +57,13 @@ The `ComplianceAsCode` project consists of human-readable files that are compile
 For your convenience, the environment is already set up, so the content is built and ready to be used.
 No worries, though--you get to rebuild it later in the exercise.
 
-To start the hands-on section, take the following steps:
+To start the hands-on section, take one of the following steps:
 
+=== Github Codespaces
+. Go to: link:https://github.com/codespaces/new?hide_repo_select=true&ref=master&repo=19279458&skip_quickstart=true[Github Codespaces]
+. Select `ComplianceAsCode Workshop Exercise 5` in the `Dev container configuration` option.
+
+=== Gitpod
 . Go to: link:https://gitpod.io/#WORKSHOP=lab5_oval/https://github.com/ComplianceAsCode/content[Lab 5 Environment]
 . Wait until all the steps being executed in the terminal are complete.
 

--- a/utils/setup_dev.sh
+++ b/utils/setup_dev.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+PRODUCT=$1 # parameter passed from .devcontainer.json files
+WORKSHOP=$2 # parameter passed from .devcontainer.json files
+[ -z "$PRODUCT" ] && PRODUCT="fedora"
+[ -z "$CONTAINER" ] && CONTAINER=$PRODUCT
+[ -z "$CONTAINER_VERSION" ] && CONTAINER_VERSION="$CONTAINER"
+mkdir -p .vscode && cp .gitpod.launch.json .vscode/launch.json
+CONTAINER_NAME=${CONTAINER}_container
+sed -i "s/&&CONTAINER_NAME&&/$CONTAINER_NAME/g" .vscode/launch.json
+sed -i "s/&&DEFAULT_PRODUCT&&/$PRODUCT/g" .vscode/launch.json
+PRIVATE_KEY_FOLDER=.ssh
+PRIVATE_KEY_FILEPATH=$PRIVATE_KEY_FOLDER/id_rsa
+sed -i "s,&&PRIVATE_KEY_FILEPATH&&,$PRIVATE_KEY_FILEPATH,g" .vscode/launch.json
+mkdir -p $PRIVATE_KEY_FOLDER
+ssh-keygen -N '' -f $PRIVATE_KEY_FILEPATH
+# set correct SSH permissions
+chmod 600 $PRIVATE_KEY_FILEPATH
+docker build --build-arg "CLIENT_PUBLIC_KEY=$(cat $PRIVATE_KEY_FILEPATH.pub)" -t $CONTAINER_NAME --build-arg IMAGE=$CONTAINER_VERSION -f Dockerfiles/test_suite-$CONTAINER .
+[ -n "$WORKSHOP" ] && ansible-playbook -i 127.0.0.1, docs/workshop/labs_setup.yml -e EXERCISE="$WORKSHOP" -e LAB_DIR="$(pwd)" --connection=local -u vscode --ssh-extra-args '-F docs/workshop/data/ssh_config'
+[ -z "$WORKSHOP" ] && ./build_product $PRODUCT --datastream-only
+
+exit 0


### PR DESCRIPTION
#### Description:

- Add GitHub codespaces configuration
  - This configuration allows to spin up a Github Codespaces environment that contains the development environment for ComplianceAsCode project.
  - It uses a custom image containing latest built OpenSCAP and other dependencies to speed up the environment deployment time. https://github.com/ggbecker/cac-dev
    - This container image can later be brought into the ComplianceAsCode organization.

#### Rationale:

- Fixes OPENSCAP-5455

#### Review Hints:

- Spin up an environment using the config from my fork's master branch containing exactly this same code: https://github.com/codespaces/new?hide_repo_select=true&ref=master&repo=158392512&skip_quickstart=true&machine=basicLinux32gb&devcontainer_path=.devcontainer%2Fcac-container_rhel%2Fdevcontainer.json&geo=EuropeWest
- Try to run automatus for rule `file_permissions_var_log` using the Ctrl+F5 command (Run Without Debugging option)
