### PR TITLE
CMP-3264: Update TLS assertions in moderate, high, pci-dss

### DIFF
--- a/tests/assertions/ocp4/ocp4-high-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.12.yml
@@ -406,3 +406,9 @@ rule_results:
   e2e-high-kubelet-configure-tls-cipher-suites-ingresscontroller:
     default_result: FAIL
     result_after_remediation: PASS
+  e2e-high-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-tls-security-profile-not-old:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.13.yml
@@ -378,3 +378,9 @@ rule_results:
   e2e-high-kubelet-configure-tls-cipher-suites-ingresscontroller:
     default_result: FAIL
     result_after_remediation: PASS
+  e2e-high-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-tls-security-profile-not-old:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.14.yml
@@ -378,3 +378,9 @@ rule_results:
   e2e-high-kubelet-configure-tls-cipher-suites-ingresscontroller:
     default_result: FAIL
     result_after_remediation: PASS
+  e2e-high-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-tls-security-profile-not-old:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.15.yml
@@ -405,3 +405,9 @@ rule_results:
   e2e-high-kubelet-configure-tls-cipher-suites-ingresscontroller:
     default_result: FAIL
     result_after_remediation: PASS
+  e2e-high-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-tls-security-profile-not-old:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.16.yml
@@ -405,3 +405,9 @@ rule_results:
   e2e-high-kubelet-configure-tls-cipher-suites-ingresscontroller:
     default_result: FAIL
     result_after_remediation: PASS
+  e2e-high-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-tls-security-profile-not-old:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.17.yml
@@ -407,3 +407,9 @@ rule_results:
   e2e-high-kubelet-configure-tls-cipher-suites-ingresscontroller:
     default_result: FAIL
     result_after_remediation: PASS
+  e2e-high-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-tls-security-profile-not-old:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.18.yml
@@ -407,3 +407,9 @@ rule_results:
   e2e-high-kubelet-configure-tls-cipher-suites-ingresscontroller:
     default_result: FAIL
     result_after_remediation: PASS
+  e2e-high-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-high-api-server-tls-security-profile-not-old:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.12.yml
@@ -397,3 +397,9 @@ rule_results:
   e2e-moderate-kubelet-configure-tls-cipher-suites-ingresscontroller:
     default_result: FAIL
     result_after_remediation: PASS
+  e2e-moderate-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-tls-security-profile-not-old:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.13.yml
@@ -396,3 +396,9 @@ rule_results:
   e2e-moderate-kubelet-configure-tls-cipher-suites-ingresscontroller:
     default_result: FAIL
     result_after_remediation: PASS
+  e2e-moderate-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-tls-security-profile-not-old:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.14.yml
@@ -396,3 +396,9 @@ rule_results:
   e2e-moderate-kubelet-configure-tls-cipher-suites-ingresscontroller:
     default_result: FAIL
     result_after_remediation: PASS
+  e2e-moderate-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-tls-security-profile-not-old:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.15.yml
@@ -370,3 +370,9 @@ rule_results:
   e2e-moderate-kubelet-configure-tls-cipher-suites-ingresscontroller:
     default_result: FAIL
     result_after_remediation: PASS
+  e2e-moderate-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-tls-security-profile-not-old:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.16.yml
@@ -396,3 +396,9 @@ rule_results:
   e2e-moderate-kubelet-configure-tls-cipher-suites-ingresscontroller:
     default_result: FAIL
     result_after_remediation: PASS
+  e2e-moderate-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-moderate-api-server-tls-security-profile-not-old:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.12.yml
@@ -369,3 +369,9 @@ rule_results:
     default_result: PASS or NOT-APPLICABLE
   e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
     default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-4-0-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-4-0-api-server-tls-security-profile-not-old:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.13.yml
@@ -369,3 +369,9 @@ rule_results:
     default_result: PASS or NOT-APPLICABLE
   e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
     default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-4-0-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-4-0-api-server-tls-security-profile-not-old:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.14.yml
@@ -369,3 +369,9 @@ rule_results:
     default_result: PASS or NOT-APPLICABLE
   e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
     default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-4-0-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-4-0-api-server-tls-security-profile-not-old:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.15.yml
@@ -369,3 +369,9 @@ rule_results:
     default_result: PASS or NOT-APPLICABLE
   e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
     default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-4-0-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-4-0-api-server-tls-security-profile-not-old:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.16.yml
@@ -369,3 +369,9 @@ rule_results:
     default_result: PASS or NOT-APPLICABLE
   e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
     default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-4-0-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-4-0-api-server-tls-security-profile-not-old:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.17.yml
@@ -369,3 +369,9 @@ rule_results:
     default_result: PASS or NOT-APPLICABLE
   e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
     default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-4-0-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-4-0-api-server-tls-security-profile-not-old:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.18.yml
@@ -369,3 +369,9 @@ rule_results:
     default_result: PASS or NOT-APPLICABLE
   e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
     default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-4-0-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-4-0-api-server-tls-security-profile-not-old:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.12.yml
@@ -384,3 +384,9 @@ rule_results:
     default_result: PASS or NOT-APPLICABLE
   e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
     default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-tls-security-profile-not-old:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.13.yml
@@ -383,3 +383,9 @@ rule_results:
     default_result: PASS or NOT-APPLICABLE
   e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
     default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-tls-security-profile-not-old:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.14.yml
@@ -383,3 +383,9 @@ rule_results:
     default_result: PASS or NOT-APPLICABLE
   e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
     default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-tls-security-profile-not-old:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.15.yml
@@ -383,3 +383,9 @@ rule_results:
     default_result: PASS or NOT-APPLICABLE
   e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
     default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-tls-security-profile-not-old:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.16.yml
@@ -383,3 +383,9 @@ rule_results:
     default_result: PASS or NOT-APPLICABLE
   e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
     default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-tls-security-profile-not-old:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.17.yml
@@ -384,3 +384,9 @@ rule_results:
     default_result: PASS or NOT-APPLICABLE
   e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
     default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-tls-security-profile-not-old:
+    default_result: PASS
+    result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.18.yml
@@ -384,3 +384,9 @@ rule_results:
     default_result: PASS or NOT-APPLICABLE
   e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
     default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-api-server-tls-security-profile-custom-min-tls-version:
+    default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-api-server-tls-security-profile-not-old:
+    default_result: PASS
+    result_after_remediation: PASS


### PR DESCRIPTION
We updated the assertions for CIS profiles in
https://github.com/ComplianceAsCode/content/pull/13196 but because the
CIS profile is extended for high, moderate, and pci-dss platform
profiles, we need to update it there, too.

  $ grep -R "extends: cis" products/ocp4
  products/ocp4/profiles/cis.profile:extends: cis-1-7
  products/ocp4/profiles/high-rev-4.profile:extends: cis
  products/ocp4/profiles/moderate-rev-4.profile:extends: cis
  products/ocp4/profiles/pci-dss-3-2.profile:extends: cis
