### PR TITLE
OCPBUGS-53041: Add missing assertions for OVS rules

### DIFF
--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.12.yml
@@ -353,22 +353,6 @@ rule_results:
   e2e-pci-dss-4-0-tls-version-check-router:
     default_result: PASS
     result_after_remediation: PASS
-  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-api-server-tls-security-profile-custom-min-tls-version:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.13.yml
@@ -353,22 +353,6 @@ rule_results:
   e2e-pci-dss-4-0-tls-version-check-router:
     default_result: PASS
     result_after_remediation: PASS
-  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-api-server-tls-security-profile-custom-min-tls-version:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.14.yml
@@ -353,22 +353,6 @@ rule_results:
   e2e-pci-dss-4-0-tls-version-check-router:
     default_result: PASS
     result_after_remediation: PASS
-  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-api-server-tls-security-profile-custom-min-tls-version:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.15.yml
@@ -353,22 +353,6 @@ rule_results:
   e2e-pci-dss-4-0-tls-version-check-router:
     default_result: PASS
     result_after_remediation: PASS
-  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-api-server-tls-security-profile-custom-min-tls-version:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.16.yml
@@ -353,22 +353,6 @@ rule_results:
   e2e-pci-dss-4-0-tls-version-check-router:
     default_result: PASS
     result_after_remediation: PASS
-  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-api-server-tls-security-profile-custom-min-tls-version:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.17.yml
@@ -353,22 +353,6 @@ rule_results:
   e2e-pci-dss-4-0-tls-version-check-router:
     default_result: PASS
     result_after_remediation: PASS
-  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-api-server-tls-security-profile-custom-min-tls-version:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.18.yml
@@ -353,22 +353,6 @@ rule_results:
   e2e-pci-dss-4-0-tls-version-check-router:
     default_result: PASS
     result_after_remediation: PASS
-  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-api-server-tls-security-profile-custom-min-tls-version:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.12.yml
@@ -368,22 +368,6 @@ rule_results:
   e2e-pci-dss-security-profiles-operator-exists:
     default_result: FAIL
     result_after_remediation: PASS
-  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
   e2e-pci-dss-api-server-tls-security-profile-custom-min-tls-version:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.13.yml
@@ -367,22 +367,6 @@ rule_results:
   e2e-pci-dss-security-profiles-operator-exists:
     default_result: FAIL
     result_after_remediation: PASS
-  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
   e2e-pci-dss-api-server-tls-security-profile-custom-min-tls-version:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.14.yml
@@ -367,22 +367,6 @@ rule_results:
   e2e-pci-dss-security-profiles-operator-exists:
     default_result: FAIL
     result_after_remediation: PASS
-  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
   e2e-pci-dss-api-server-tls-security-profile-custom-min-tls-version:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.15.yml
@@ -367,22 +367,6 @@ rule_results:
   e2e-pci-dss-security-profiles-operator-exists:
     default_result: FAIL
     result_after_remediation: PASS
-  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
   e2e-pci-dss-api-server-tls-security-profile-custom-min-tls-version:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.16.yml
@@ -367,22 +367,6 @@ rule_results:
   e2e-pci-dss-security-profiles-operator-exists:
     default_result: FAIL
     result_after_remediation: PASS
-  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
   e2e-pci-dss-api-server-tls-security-profile-custom-min-tls-version:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.17.yml
@@ -368,22 +368,6 @@ rule_results:
   e2e-pci-dss-security-profiles-operator-exists:
     default_result: FAIL
     result_after_remediation: PASS
-  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
   e2e-pci-dss-api-server-tls-security-profile-custom-min-tls-version:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.18.yml
@@ -368,22 +368,6 @@ rule_results:
   e2e-pci-dss-security-profiles-operator-exists:
     default_result: FAIL
     result_after_remediation: PASS
-  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-hugetlbfs:
-    default_result: PASS or NOT-APPLICABLE
-  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
-    default_result: PASS or NOT-APPLICABLE
   e2e-pci-dss-api-server-tls-security-profile-custom-min-tls-version:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.12.yml
@@ -686,3 +686,19 @@ rule_results:
   e2e-pci-dss-node-4-0-worker-tls-version-check-masters-workers:
     default_result: PASS
     result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
+    default_result: PASS or NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.13.yml
@@ -686,3 +686,19 @@ rule_results:
   e2e-pci-dss-node-4-0-worker-tls-version-check-masters-workers:
     default_result: PASS
     result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
+    default_result: PASS or NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.14.yml
@@ -685,3 +685,19 @@ rule_results:
   e2e-pci-dss-node-4-0-worker-tls-version-check-masters-workers:
     default_result: PASS
     result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
+    default_result: PASS or NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.15.yml
@@ -685,3 +685,19 @@ rule_results:
   e2e-pci-dss-node-4-0-worker-tls-version-check-masters-workers:
     default_result: PASS
     result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
+    default_result: PASS or NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.16.yml
@@ -685,3 +685,19 @@ rule_results:
   e2e-pci-dss-node-4-0-worker-tls-version-check-masters-workers:
     default_result: PASS
     result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
+    default_result: PASS or NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.17.yml
@@ -685,3 +685,19 @@ rule_results:
   e2e-pci-dss-node-4-0-worker-tls-version-check-masters-workers:
     default_result: PASS
     result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
+    default_result: PASS or NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4-0-4.18.yml
@@ -685,3 +685,19 @@ rule_results:
   e2e-pci-dss-node-4-0-worker-tls-version-check-masters-workers:
     default_result: PASS
     result_after_remediation: PASS
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-conf-db-lock-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-master-file-groupowner-ovs-sys-id-conf-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-conf-db-lock-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-4-0-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
+    default_result: PASS or NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4.12.yml
@@ -480,3 +480,19 @@ rule_results:
   e2e-pci-dss-node-worker-kubelet-configure-tls-min-version:
     default_result: PASS
     result_after_remediation: PASS
+  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
+    default_result: PASS or NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4.13.yml
@@ -480,3 +480,19 @@ rule_results:
   e2e-pci-dss-node-worker-kubelet-configure-tls-min-version:
     default_result: PASS
     result_after_remediation: PASS
+  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
+    default_result: PASS or NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4.14.yml
@@ -480,3 +480,19 @@ rule_results:
   e2e-pci-dss-node-worker-kubelet-configure-tls-min-version:
     default_result: PASS
     result_after_remediation: PASS
+  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
+    default_result: PASS or NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4.15.yml
@@ -480,3 +480,19 @@ rule_results:
   e2e-pci-dss-node-worker-kubelet-configure-tls-min-version:
     default_result: PASS
     result_after_remediation: PASS
+  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
+    default_result: PASS or NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4.16.yml
@@ -480,3 +480,19 @@ rule_results:
   e2e-pci-dss-node-worker-kubelet-configure-tls-min-version:
     default_result: PASS
     result_after_remediation: PASS
+  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
+    default_result: PASS or NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4.17.yml
@@ -479,3 +479,19 @@ rule_results:
   e2e-pci-dss-node-worker-kubelet-configure-tls-min-version:
     default_result: PASS
     result_after_remediation: PASS
+  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
+    default_result: PASS or NOT-APPLICABLE

--- a/tests/assertions/ocp4/ocp4-pci-dss-node-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-node-4.18.yml
@@ -479,3 +479,19 @@ rule_results:
   e2e-pci-dss-node-worker-kubelet-configure-tls-min-version:
     default_result: PASS
     result_after_remediation: PASS
+  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-master-file-groupowner-ovs-conf-db-lock-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-master-file-groupowner-ovs-sys-id-conf-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovs-conf-db-lock-openvswitch:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-hugetlbfs:
+    default_result: PASS or NOT-APPLICABLE
+  e2e-pci-dss-node-worker-file-groupowner-ovs-sys-id-conf-openvswitch:
+    default_result: PASS or NOT-APPLICABLE


### PR DESCRIPTION
There were added initially in
https://github.com/ComplianceAsCode/content/pull/13201 but were added
for the platform profiles in addition to the node profiles.
