### PR TITLE
Add audit_rules_mac_modification_etc_selinux to the PCI DSS 4 control file

### DIFF
--- a/controls/pcidss_4.yml
+++ b/controls/pcidss_4.yml
@@ -2877,6 +2877,7 @@ controls:
         - audit_rules_dac_modification_removexattr
         - audit_rules_dac_modification_setxattr
         - audit_rules_networkconfig_modification
+        - audit_rules_mac_modification_etc_selinux
 
   - id: '10.4'
     title: Audit logs are reviewed to identify anomalies or suspicious activity.

--- a/products/rhel8/profiles/pci-dss.profile
+++ b/products/rhel8/profiles/pci-dss.profile
@@ -61,3 +61,4 @@ selections:
     - '!aide_periodic_checking_systemd_timer'
     - '!package_cryptsetup-luks_installed'
     - '!audit_rules_file_deletion_events_renameat2'
+    - '!audit_rules_mac_modification_etc_selinux'

--- a/products/rhel9/profiles/pci-dss.profile
+++ b/products/rhel9/profiles/pci-dss.profile
@@ -70,3 +70,4 @@ selections:
     - '!ensure_shadow_group_empty'
     - '!service_timesyncd_enabled'
     - '!audit_rules_file_deletion_events_renameat2'
+    - '!audit_rules_mac_modification_etc_selinux'

--- a/products/sle12/profiles/pci-dss.profile
+++ b/products/sle12/profiles/pci-dss.profile
@@ -16,8 +16,8 @@ selections:
     - sshd_approved_macs=cis_sle12
     - sshd_approved_ciphers=cis_sle12
     - var_multiple_time_servers=suse
-    - var_multiple_time_pools=suse 
-# Exclude from PCI DISS profile all rules related to ntp and timesyncd and keep only 
+    - var_multiple_time_pools=suse
+# Exclude from PCI DISS profile all rules related to ntp and timesyncd and keep only
 # rules related to chrony
     - '!ntpd_specify_multiple_servers'
     - '!ntpd_specify_remote_server'
@@ -36,3 +36,4 @@ selections:
     - '!accounts_passwords_pam_faillock_unlock_time'
     - '!accounts_password_pam_ucredit'
     - '!accounts_password_pam_minlen'
+    - '!audit_rules_mac_modification_etc_selinux'

--- a/products/sle15/profiles/pci-dss-4.profile
+++ b/products/sle15/profiles/pci-dss-4.profile
@@ -65,3 +65,4 @@ selections:
     - '!network_nmcli_permissions'
     - '!package_cryptsetup-luks_installed'
     - '!audit_rules_file_deletion_events_renameat2'
+    - '!audit_rules_mac_modification_etc_selinux'


### PR DESCRIPTION



#### Description:
Only having it in the profile means it doesn't get reference.

#### Rationale:

Fixes #13265
