### PR TITLE
OCPBUGS-54605: Set architecture in directory-access-var-log-audit remediation

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/kubernetes/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/directory_access_var_log_audit/kubernetes/shared.yml
@@ -6,6 +6,7 @@
 # disruption = medium
 #
 {{% macro rhcos_access_var_log_audit_rules() -%}}
--a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>={{{ auid }}} -F auid!=unset -F key=access-audit-trail
+-a always,exit -F arch=b64 -F dir=/var/log/audit/ -F perm=r -F auid>={{{ auid }}} -F auid!=unset -F key=access-audit-trail
+-a always,exit -F arch=b32 -F dir=/var/log/audit/ -F perm=r -F auid>={{{ auid }}} -F auid!=unset -F key=access-audit-trail
 {{% endmacro %}}
 {{{ kubernetes_machine_config_file(path='/etc/audit/rules.d/30-access-var-log-audit.rules', file_permissions_mode='0600', source=rhcos_access_var_log_audit_rules()) }}}


### PR DESCRIPTION
A recent change refactored the directory-access-var-log-audit rule to
check for 32 and 64 bit systems.

  https://github.com/ComplianceAsCode/content/pull/13215

This commit updates the OpenShift remediation so that it will update the
argument that the rule is now looking for.
