### PR TITLE
OCPBUGS-54212: Adjust api-server-tls-cipher-suite to include 4.18 suites

### DIFF
--- a/applications/openshift/api-server/api_server_tls_cipher_suites/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_cipher_suites/rule.yml
@@ -19,6 +19,9 @@ description: |-
     "servingInfo":{
       ...
       "cipherSuites": [
+        "TLS_AES_128_GCM_SHA256",
+        "TLS_AES_256_GCM_SHA384",
+        "TLS_CHACHA20_POLY1305_SHA256",
         "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
         "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
         "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
@@ -45,13 +48,16 @@ references:
 
 platform: not ocp4-on-hypershift-hosted
 
-ocil_clause: '<tt>cipherSuites</tt> is not configured, or contains ciphers (possibly insecure) other than TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, or TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 in servingInfo'
+ocil_clause: '<tt>cipherSuites</tt> is not configured, or contains ciphers (possibly insecure) other than  TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, or TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 in servingInfo'
 
 ocil: |-
     Run the following command:
     <pre>$ oc get configmap config -n openshift-kube-apiserver -ojson | jq -r '.data["config.yaml"]' | jq '.servingInfo["cipherSuites"]'</pre>
     Verify that the set of ciphers contains only the following:
     <pre>
+    "TLS_AES_128_GCM_SHA256",
+    "TLS_AES_256_GCM_SHA384",
+    "TLS_CHACHA20_POLY1305_SHA256",
     "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
     "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
     "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
@@ -76,6 +82,6 @@ template:
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.servingInfo.cipherSuites[:]'
     values:
-    - value: 'TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256|TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256|TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256|TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384|TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256|TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384'
+    - value: 'TLS_AES_128_GCM_SHA256|TLS_AES_256_GCM_SHA384|TLS_CHACHA20_POLY1305_SHA256|TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256|TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256|TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256|TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384|TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256|TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384'
       operation: "pattern match"
       type: "string"

--- a/tests/assertions/ocp4/ocp4-cis-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.18.yml
@@ -111,7 +111,7 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-cis-api-server-tls-cipher-suites:
-    default_result: FAIL
+    default_result: PASS
     result_after_remediation: PASS
   e2e-cis-api-server-tls-private-key:
     default_result: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.18.yml
@@ -126,7 +126,7 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-high-api-server-tls-cipher-suites:
-    default_result: FAIL
+    default_result: PASS
     result_after_remediation: PASS
   e2e-high-api-server-tls-private-key:
     default_result: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.18.yml
@@ -123,7 +123,7 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-moderate-api-server-tls-cipher-suites:
-    default_result: FAIL
+    default_result: PASS
     result_after_remediation: PASS
   e2e-moderate-api-server-tls-private-key:
     default_result: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.18.yml
@@ -111,7 +111,7 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-pci-dss-4-0-api-server-tls-cipher-suites:
-    default_result: FAIL
+    default_result: PASS
     result_after_remediation: PASS
   e2e-pci-dss-4-0-api-server-tls-private-key:
     default_result: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.18.yml
@@ -111,7 +111,7 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-pci-dss-api-server-tls-cipher-suites:
-    default_result: FAIL
+    default_result: PASS
     result_after_remediation: PASS
   e2e-pci-dss-api-server-tls-private-key:
     default_result: PASS

--- a/tests/assertions/ocp4/ocp4-stig-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.18.yml
@@ -114,7 +114,7 @@ rule_results:
     default_result: PASS
     result_after_remediation: PASS
   e2e-stig-api-server-tls-cipher-suites:
-    default_result: FAIL
+    default_result: PASS
     result_after_remediation: PASS
   e2e-stig-api-server-tls-security-profile:
     default_result: PASS


### PR DESCRIPTION
OCP 4.18 comes with some updated ciphers in for the OpenShift API
server. The rule we have for check these ciphers failed because the new
ciphers were not in a blessed list of ciphers.

However, they are recommended and were introduced with RFC 8446:

https://datatracker.ietf.org/doc/html/rfc8446

This commit updates the rule to check for three additional ciphers:

    TLS_AES_128_GCM_SHA256
    TLS_AES_256_GCM_SHA384
    TLS_CHACHA20_POLY1305_SHA256

References:

https://ciphersuite.info/cs/TLS_AES_128_GCM_SHA256/
https://ciphersuite.info/cs/TLS_AES_256_GCM_SHA384/
https://ciphersuite.info/cs/TLS_CHACHA20_POLY1305_SHA256/
