### PR TITLE
[Ubuntu] Remove UBTU-22-412015 in align with ubuntu 22.04 stig v2r3

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/rule.yml
@@ -58,7 +58,6 @@ references:
     stigid@sle12: SLES-12-010390
     stigid@sle15: SLES-15-020080
     stigid@ubuntu2004: UBTU-20-010453
-    stigid@ubuntu2204: UBTU-22-412015
 
 platform: package[pam]
 

--- a/products/ubuntu2204/profiles/stig.profile
+++ b/products/ubuntu2204/profiles/stig.profile
@@ -532,9 +532,6 @@ selections:
     # UBTU-22-651015 The Ubuntu operating system must use a file integrity tool to verify correct operation of all security functions.
     - aide_build_database
 
-    # UBTU-22-412015 The Ubuntu operating system must display the date and time of the last successful account logon upon logon.
-    - display_login_attempts
-
     # UBTU-22-251015 The Ubuntu operating system must enable and run the Uncomplicated Firewall (ufw).
     - check_ufw_active
 


### PR DESCRIPTION
#### Description:

- Remove UBTU-22-412015 in align with Ubuntu 22.04 stig v2r3

#### Rationale:

- Ubuntu 22.04 stig v2r3 delete this rule