### PR TITLE
[Ubuntu] Insert to beginning of file in Ubuntu

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/bash/shared.sh
@@ -2,7 +2,11 @@
 
 {{%- if "sle" in product or "slmicro" in product or "ubuntu" in product %}}
 {{%- set pam_lastlog_path = "/etc/pam.d/login" %}}
+{{%- if "ubuntu" in product %}}
+{{%- set after_match = "BOF" %}}
+{{%- else %}}
 {{%- set after_match = "^\s*session.*include\s+common-session$" %}}
+{{%- endif %}}
 {{%- else %}}
 {{%- set pam_lastlog_path = "/etc/pam.d/postlogin" %}}
 {{%- set after_match = "^\s*session\s+.*pam_succeed_if\.so.*" %}}


### PR DESCRIPTION
#### Description:

- Insert to beginning of file in Ubuntu

#### Rationale:

- STIG requires that if there is no matching line exist, add to the top of the file