### PR TITLE
Fix refinements removal

### DIFF
--- a/products/ol10/profiles/ospp.profile
+++ b/products/ol10/profiles/ospp.profile
@@ -20,6 +20,12 @@ selections:
     - '!enable_dracut_fips_module'
     - '!package_subscription-manager_installed'
 
+    - '!audit_access_success_aarch64.role=unscored'
+    - '!audit_access_success_aarch64.severity=info'
+    - '!audit_access_success_aarch64'
+    - '!audit_access_success_ppc64le.role=unscored'
+    - '!audit_access_success_ppc64le.severity=info'
+    - '!audit_access_success_ppc64le'
     - '!audit_access_failed_aarch64'
     - '!audit_access_failed_ppc64le'
     - '!audit_create_failed_aarch64'

--- a/ssg/entities/common.py
+++ b/ssg/entities/common.py
@@ -372,17 +372,17 @@ class SelectionHandler(object):
         else:
             self.selected.append(item)
 
-    def _subtract_refinements(self, extended_refinements):
+    def _subtract_refinements(self):
         """
-        Given a dict of rule refinements from the extended profile,
-        "undo" every refinement prefixed with '!' in this profile.
+        From the resolved profile, "undo" every refinement prefixed with '!' in this profile.
         """
         for rule, refinements in list(self.refine_rules.items()):
             if rule.startswith("!"):
                 for prop, val in refinements:
-                    extended_refinements[rule[1:]].remove((prop, val))
+                    self.refine_rules[rule[1:]].remove((prop, val))
                 del self.refine_rules[rule]
-        return extended_refinements
+                if not self.refine_rules[rule[1:]]:
+                    del self.refine_rules[rule[1:]]
 
     def update_with(self, rhs):
         extended_selects = set(rhs.selected)
@@ -394,9 +394,8 @@ class SelectionHandler(object):
         self.variables = updated_variables
 
         extended_refinements = deepcopy(rhs.refine_rules)
-        updated_refinements = self._subtract_refinements(extended_refinements)
-        updated_refinements.update(self.refine_rules)
-        self.refine_rules = updated_refinements
+        extended_refinements.update(self.refine_rules)
+        self.refine_rules = extended_refinements
 
 
 class Templatable(object):

--- a/ssg/entities/profile.py
+++ b/ssg/entities/profile.py
@@ -102,3 +102,4 @@ class ProfileWithInlinePolicies(ResolvableProfile):
 
             for c in controls:
                 self.update_with(c)
+        self._subtract_refinements()


### PR DESCRIPTION
#### Description:

- Update how refinements are removed. Instead of remove them on each control update, do it at the end of applying all controls. With current implementation this error occurs when building the update in OSPP profile included in this PR
```
[  1%] [ol10-content] compiling everything
Traceback (most recent call last):
  File "content/build-scripts/compile_all.py", line 241, in <module>
    main()
  File "content/build-scripts/compile_all.py", line 224, in main
    normal_profiles = get_all_resolved_profiles_by_id(
  File "content/build-scripts/compile_all.py", line 100, in get_all_resolved_profiles_by_id
    profiles_by_id = load_resolve_and_validate_profiles(
  File "content/build-scripts/compile_all.py", line 113, in load_resolve_and_validate_profiles
    p.resolve(profiles_by_id, loader.all_rules, controls_manager)
  File "content/ssg/entities/profile.py", line 35, in resolve
    self.resolve_controls(controls_manager)
  File "content/ssg/entities/profile.py", line 104, in resolve_controls
    self.update_with(c)
  File "content/ssg/entities/common.py", line 397, in update_with
    updated_refinements = self._subtract_refinements(extended_refinements)
  File "content/ssg/entities/common.py", line 383, in _subtract_refinements
    extended_refinements[rule[1:]].remove((prop, val))
ValueError: list.remove(x): x not in list
make[2]: *** [ol10/CMakeFiles/ol10-compile-all.dir/build.make:75: ol10/ssg_build_compile_all-ol10] Error 1
make[1]: *** [CMakeFiles/Makefile2:429: ol10/CMakeFiles/ol10-compile-all.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```

#### Rationale:

- Allow remove rules with refinements from profile, when they were included from a control file



