### PR TITLE
Align audit OSPP rules with audit upstream

### DIFF
--- a/linux_os/guide/auditing/policy_rules/audit_ospp_general/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_ospp_general/rule.yml
@@ -1,5 +1,12 @@
 documentation_complete: true
 
+{{% if product == "rhel10" %}}
+{{# This path shouldn't contain trailing slash #}}
+{{% set original_copies_path="/usr/share/audit-rules" %}}
+{{% else %}}
+{{# This path should contain trailing slash #}}
+{{% set original_copies_path="/usr/share/audit/sample-rules/" %}}
+{{% endif %}}
 
 title: 'Perform general configuration of Audit for OSPP'
 
@@ -18,7 +25,7 @@ title: 'Perform general configuration of Audit for OSPP'
 ## 30-ospp-v42-6-owner-change-failed.rules,
 ## 30-ospp-v42-6-owner-change-success.rules
 ##
-## original copies may be found in /usr/share/audit-rules
+## original copies may be found in " ~ original_copies_path ~ "
 
 
 ## User add delete modify. This is covered by pam. However, someone could

--- a/linux_os/guide/auditing/policy_rules/audit_ospp_general/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_ospp_general/rule.yml
@@ -17,6 +17,9 @@ title: 'Perform general configuration of Audit for OSPP'
 ## 30-ospp-v42-5-perm-change-success.rules,
 ## 30-ospp-v42-6-owner-change-failed.rules,
 ## 30-ospp-v42-6-owner-change-success.rules
+##
+## original copies may be found in /usr/share/audit-rules
+
 
 ## User add delete modify. This is covered by pam. However, someone could
 ## open a file and directly create or modify a user, so we'll watch passwd and

--- a/linux_os/guide/auditing/policy_rules/audit_ospp_general_aarch64/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_ospp_general_aarch64/rule.yml
@@ -1,5 +1,12 @@
 documentation_complete: true
 
+{{% if product == "rhel10" %}}
+{{# This path shouldn't contain trailing slash #}}
+{{% set original_copies_path="/usr/share/audit-rules" %}}
+{{% else %}}
+{{# This path should contain trailing slash #}}
+{{% set original_copies_path="/usr/share/audit/sample-rules/" %}}
+{{% endif %}}
 
 title: 'Perform general configuration of Audit for OSPP (AArch64)'
 
@@ -18,7 +25,7 @@ title: 'Perform general configuration of Audit for OSPP (AArch64)'
 ## 30-ospp-v42-6-owner-change-failed.rules,
 ## 30-ospp-v42-6-owner-change-success.rules
 ##
-## original copies may be found in /usr/share/audit-rules
+## original copies may be found in " ~ original_copies_path ~ "
 
 
 ## User add delete modify. This is covered by pam. However, someone could

--- a/linux_os/guide/auditing/policy_rules/audit_ospp_general_aarch64/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_ospp_general_aarch64/rule.yml
@@ -17,6 +17,9 @@ title: 'Perform general configuration of Audit for OSPP (AArch64)'
 ## 30-ospp-v42-5-perm-change-success.rules,
 ## 30-ospp-v42-6-owner-change-failed.rules,
 ## 30-ospp-v42-6-owner-change-success.rules
+##
+## original copies may be found in /usr/share/audit-rules
+
 
 ## User add delete modify. This is covered by pam. However, someone could
 ## open a file and directly create or modify a user, so we'll watch passwd and

--- a/linux_os/guide/auditing/policy_rules/audit_ospp_general_ppc64le/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_ospp_general_ppc64le/rule.yml
@@ -17,6 +17,9 @@ title: 'Perform general configuration of Audit for OSPP (ppc64le)'
 ## 30-ospp-v42-5-perm-change-success.rules,
 ## 30-ospp-v42-6-owner-change-failed.rules,
 ## 30-ospp-v42-6-owner-change-success.rules
+##
+## original copies may be found in /usr/share/audit-rules
+
 
 ## User add delete modify. This is covered by pam. However, someone could
 ## open a file and directly create or modify a user, so we'll watch passwd and

--- a/linux_os/guide/auditing/policy_rules/audit_ospp_general_ppc64le/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_ospp_general_ppc64le/rule.yml
@@ -1,5 +1,12 @@
 documentation_complete: true
 
+{{% if product == "rhel10" %}}
+{{# This path shouldn't contain trailing slash #}}
+{{% set original_copies_path="/usr/share/audit-rules" %}}
+{{% else %}}
+{{# This path should contain trailing slash #}}
+{{% set original_copies_path="/usr/share/audit/sample-rules/" %}}
+{{% endif %}}
 
 title: 'Perform general configuration of Audit for OSPP (ppc64le)'
 
@@ -18,7 +25,7 @@ title: 'Perform general configuration of Audit for OSPP (ppc64le)'
 ## 30-ospp-v42-6-owner-change-failed.rules,
 ## 30-ospp-v42-6-owner-change-success.rules
 ##
-## original copies may be found in /usr/share/audit-rules
+## original copies may be found in " ~ original_copies_path ~ "
 
 
 ## User add delete modify. This is covered by pam. However, someone could


### PR DESCRIPTION
This commit changes the contents of the audit rules file to be the same as the latest file provided by audit:
https://raw.githubusercontent.com/linux-audit/audit-userspace/refs/heads/master/rules/30-ospp-v42.rules
