### PR TITLE
dir_system_commands_* remediation fixes and applicability for all products

### DIFF
--- a/linux_os/guide/system/permissions/files/dir_system_commands_group_root_owned/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/dir_system_commands_group_root_owned/ansible/shared.yml
@@ -1,12 +1,14 @@
-# platform = multi_platform_sle,multi_platform_slmicro
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = medium
 # disruption = medium
 
-- name: "Retrive system commands directories and set its group owner to root"
-  command: "find -L {{ item }} ! -group root -type d -exec chgrp root '{}' \\;"
-  with_items: ['/bin', '/sbin', '/usr/bin', '/usr/sbin', '/usr/local/bin', '/usr/local/sbin'] 
-  changed_when: False
-  failed_when: False
-  check_mode: no
+-  name: "{{{ RULE_TITLE }}} - Set group ownership of directories that contain system commands to root"
+   file: 
+     path: "{{ item }}"
+     group: "root"
+     recurse: "yes"
+     state: "directory"
+     follow: "yes"
+   with_items: [ '/bin','/sbin','/usr/bin','/usr/sbin','/usr/local/bin','/usr/local/sbin'  ]

--- a/linux_os/guide/system/permissions/files/dir_system_commands_group_root_owned/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/dir_system_commands_group_root_owned/bash/shared.sh
@@ -1,4 +1,6 @@
-# platform = multi_platform_sle,multi_platform_slmicro
+# platform = multi_platform_all
+
+
 for SYSCMDDIRS in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin
 do
      find -L $SYSCMDDIRS ! -group root -type d -exec chgrp root '{}' \; 

--- a/linux_os/guide/system/permissions/files/dir_system_commands_root_owned/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/dir_system_commands_root_owned/ansible/shared.yml
@@ -1,14 +1,14 @@
-# platform = multi_platform_sle,multi_platform_slmicro
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = medium
 # disruption = medium
 
--  name: "Set ownership of directories that contain system commands to root"
+-  name: "{{{ RULE_TITLE }}} - Set ownership of directories that contain system commands to root"
    file: 
      path: "{{ item }}"
      owner: "root"
      recurse: "yes"
      state: "directory"
-     follow: "no"
-   with_items: [ '/bin','/sbin','/usr/bin','usr/sbin','usr/local/bin','/usr/local/sbin'  ]
+     follow: "yes"
+   with_items: [ '/bin','/sbin','/usr/bin','/usr/sbin','/usr/local/bin','/usr/local/sbin'  ]

--- a/linux_os/guide/system/permissions/files/dir_system_commands_root_owned/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/dir_system_commands_root_owned/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,multi_platform_slmicro
+# platform = multi_platform_all
 
 for SYSCMDDIRS in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin
 do


### PR DESCRIPTION
#### Description:

- make remediations applicable for all products
- fix Ansible remediaitons, see commits

#### Rationale:

- discovered while running per-rule test scenarios. It showed that rules are in rhel* products but remediations are not enabled for these products.


#### Review Hints:

- Use automatus.