### PR TITLE
sebool_deny_execmem: add custom test scenario

### DIFF
--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_deny_execmem/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_deny_execmem/tests/wrong_value.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# variables = var_deny_execmem=true
+# remediation = none
+
+setsebool -P deny_execmem false


### PR DESCRIPTION
#### Description:

- add custom test scenario which declares that the rule does not have remediation

#### Rationale:

- this aligns expectation of the test result
- before it was expected that the rule will be fixed in case the .fail.sh test scenario is executed


#### Review Hints:

Use automatus.