### PR TITLE
sysctl template: add new option no_remediation

### DIFF
--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -952,6 +952,9 @@ The selected value can be changed in the profile (consult the actual variable fo
     the remediation scripts will set the variable with correct value to a drop-in file in
     `/etc/sysctl.d/var_name.conf` file.
 
+    - **no_remediation** - this is a hint for templated test scenarios that the rule does not have remediation.
+        In this case, est scenarios are modified so that they do not expect the rule to be remediated.
+
 -   Languages: Ansible, Bash, OVAL, SCE
 
 #### systemd_dropin_configuration

--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -953,7 +953,7 @@ The selected value can be changed in the profile (consult the actual variable fo
     `/etc/sysctl.d/var_name.conf` file.
 
     - **no_remediation** - this is a hint for templated test scenarios that the rule does not have remediation.
-        In this case, est scenarios are modified so that they do not expect the rule to be remediated.
+        In this case, test scenarios are modified so that they do not expect the rule to be remediated.
 
 -   Languages: Ansible, Bash, OVAL, SCE
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_modules_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_modules_disabled/rule.yml
@@ -36,6 +36,7 @@ template:
         sysctlvar: kernel.modules_disabled
         sysctlval: '1'
         datatype: int
+        no_remediation: true
     backends:
         # Automated remediation of this rule during installations disrupts the first boot
         bash: 'off'

--- a/shared/templates/sysctl/tests/comment.fail.sh
+++ b/shared/templates/sysctl/tests/comment.fail.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+{{%- if NO_REMEDIATION %}}
+# remediation = none
+{{%- endif -%}}
 {{% if SYSCTLVAL == "" %}}
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}

--- a/shared/templates/sysctl/tests/correct_etc_ufw_wrong_rt.fail.sh
+++ b/shared/templates/sysctl/tests/correct_etc_ufw_wrong_rt.fail.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
+{{%- if NO_REMEDIATION %}}
+# remediation = none
+{{%- endif -%}}
 {{% if SYSCTLVAL == "" %}}
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}

--- a/shared/templates/sysctl/tests/line_not_there.fail.sh
+++ b/shared/templates/sysctl/tests/line_not_there.fail.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+{{%- if NO_REMEDIATION %}}
+# remediation = none
+{{%- endif -%}}
 {{% if SYSCTLVAL == "" %}}
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}

--- a/shared/templates/sysctl/tests/one_sysctl_conf_one_sysctl_d_conflicting.fail.sh
+++ b/shared/templates/sysctl/tests/one_sysctl_conf_one_sysctl_d_conflicting.fail.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+{{%- if NO_REMEDIATION %}}
+# remediation = none
+{{%- endif -%}}
 {{% if SYSCTLVAL == "" %}}
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}

--- a/shared/templates/sysctl/tests/symlink_conflicting.fail.sh
+++ b/shared/templates/sysctl/tests/symlink_conflicting.fail.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+{{%- if NO_REMEDIATION %}}
+# remediation = none
+{{%- endif -%}}
 {{% if SYSCTLVAL == "" %}}
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}

--- a/shared/templates/sysctl/tests/symlink_root_duplicate_conflicting.fail.sh
+++ b/shared/templates/sysctl/tests/symlink_root_duplicate_conflicting.fail.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+{{%- if NO_REMEDIATION %}}
+# remediation = none
+{{%- endif -%}}
 {{% if SYSCTLVAL == "" %}}
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}

--- a/shared/templates/sysctl/tests/symlink_root_incompliant.fail.sh
+++ b/shared/templates/sysctl/tests/symlink_root_incompliant.fail.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+{{%- if NO_REMEDIATION %}}
+# remediation = none
+{{%- endif -%}}
 {{% if SYSCTLVAL == "" %}}
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}

--- a/shared/templates/sysctl/tests/two_sysctls_on_d_conflicting.fail.sh
+++ b/shared/templates/sysctl/tests/two_sysctls_on_d_conflicting.fail.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+{{%- if NO_REMEDIATION %}}
+# remediation = none
+{{%- endif -%}}
 {{% if SYSCTLVAL == "" %}}
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}

--- a/shared/templates/sysctl/tests/two_sysctls_on_same_file_name_conflicting.fail.sh
+++ b/shared/templates/sysctl/tests/two_sysctls_on_same_file_name_conflicting.fail.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+{{%- if NO_REMEDIATION %}}
+# remediation = none
+{{%- endif -%}}
 {{% if SYSCTLVAL == "" %}}
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}

--- a/shared/templates/sysctl/tests/wrong_etc_ufw_correct_rt.fail.sh
+++ b/shared/templates/sysctl/tests/wrong_etc_ufw_correct_rt.fail.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
+{{%- if NO_REMEDIATION %}}
+# remediation = none
+{{%- endif -%}}
 {{% if SYSCTLVAL == "" %}}
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}

--- a/shared/templates/sysctl/tests/wrong_runtime.fail.sh
+++ b/shared/templates/sysctl/tests/wrong_runtime.fail.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+{{%- if NO_REMEDIATION %}}
+# remediation = none
+{{%- endif -%}}
 {{% if SYSCTLVAL == "" %}}
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}

--- a/shared/templates/sysctl/tests/wrong_usr_lib_wrong_etc.fail.sh
+++ b/shared/templates/sysctl/tests/wrong_usr_lib_wrong_etc.fail.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+{{%- if NO_REMEDIATION %}}
+# remediation = none
+{{%- endif -%}}
 {{% if SYSCTLVAL == "" %}}
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}

--- a/shared/templates/sysctl/tests/wrong_value.fail.sh
+++ b/shared/templates/sysctl/tests/wrong_value.fail.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+{{%- if NO_REMEDIATION %}}
+# remediation = none
+{{%- endif -%}}
 {{% if SYSCTLVAL == "" %}}
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}

--- a/shared/templates/sysctl/tests/wrong_value_d_directory.fail.sh
+++ b/shared/templates/sysctl/tests/wrong_value_d_directory.fail.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+{{%- if NO_REMEDIATION %}}
+# remediation = none
+{{%- endif -%}}
 {{% if SYSCTLVAL == "" %}}
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}

--- a/shared/templates/sysctl/tests/wrong_value_usr_local_lib.fail.sh
+++ b/shared/templates/sysctl/tests/wrong_value_usr_local_lib.fail.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+{{%- if NO_REMEDIATION %}}
+# remediation = none
+{{%- endif -%}}
 {{% if SYSCTLVAL == "" %}}
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}


### PR DESCRIPTION
#### Description:

- add new template option no_remediation which is set to false by default
- modify template test scenarios to honor this option
- use the new option in the rule sysctl_kernel_modules_disabled

#### Rationale:

- there might be rules which do not have remediation for a reason. However, this should be handled by a test scenario - the test then does not expect that the rule will get fixed in case the initial check reports fail.

#### Review Hints:

Use automatus to test the sysctl_kernel_modules_disabled and some other rule which uses sysctl template.