### PR TITLE
enable_dracut_fips_module: test scenario does not expect remediation on rhel

### DIFF
--- a/linux_os/guide/system/software/integrity/fips/enable_dracut_fips_module/tests/fips_dracut_module_missing.fail.sh
+++ b/linux_os/guide/system/software/integrity/fips/enable_dracut_fips_module/tests/fips_dracut_module_missing.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = crypto-policies-scripts
 # platform = multi_platform_rhel,Red Hat Virtualization 4,multi_platform_ol
-    {{% if 'rhel' in product %}}
+{{% if 'rhel' in product %}}
 # remediation = none
 {{% endif %}}
 

--- a/linux_os/guide/system/software/integrity/fips/enable_dracut_fips_module/tests/fips_dracut_module_missing.fail.sh
+++ b/linux_os/guide/system/software/integrity/fips/enable_dracut_fips_module/tests/fips_dracut_module_missing.fail.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # packages = crypto-policies-scripts
 # platform = multi_platform_rhel,Red Hat Virtualization 4,multi_platform_ol
+    {{% if 'rhel' in product %}}
+# remediation = none
+{{% endif %}}
 
 fips-mode-setup --enable
 FIPS_CONF="/etc/dracut.conf.d/40-fips.conf"


### PR DESCRIPTION
#### Description:

- reflect the rule state on rhel product in the test scenario

#### Rationale:

- align expectation of the test

#### Review Hints:

Use automatus and see that there is no warning about nonexisting remediation.