### PR TITLE
gid_passwd_group_same: test scenario does not expect remediation

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/gid_passwd_group_same/tests/user_with_nonexistent_group.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/gid_passwd_group_same/tests/user_with_nonexistent_group.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# remediation = none
 
 groupdel 888888 || true
 echo "testuser:x:8000:888888:testuser:/home/testuser:/bin/bash" >> /etc/passwd


### PR DESCRIPTION
#### Description:

- add a proper option to the failing test scenario

#### Rationale:

- align test expectations with the reality



#### Review Hints:

Test with automatus and ensure that there is no warning about missing remediation.