### PR TITLE
Fix  Memory Usage for file_(group)owner

### DIFF
--- a/shared/templates/file_groupowner/oval.template
+++ b/shared/templates/file_groupowner/oval.template
@@ -52,7 +52,7 @@
       {{%- else %}}
         <unix:filepath{{% if FILEPATH_IS_REGEX %}} operation="pattern match"{{% endif %}}>{{{ filepath }}}</unix:filepath>
       {{%- endif %}}
-      <filter action="exclude">symlink_file_groupowner{{{ FILEID }}}_{{{ loop.index0 }}}</filter>
+      <filter action="exclude">symlink_file_groupowner</filter>
       {{% for grp in GROUPS %}}
       <filter action="exclude">state_file_groupowner{{{ FILEID }}}_{{{ loop.index0 }}}_{{{ grp }}}</filter>
       {{% endfor %}}
@@ -63,10 +63,8 @@
         <unix:group_id datatype="int" operation="equals" var_ref="var_file_groupowner{{{ FILEID }}}_{{{grp}}}_gid"></unix:group_id>
       </unix:file_state>
     {{% endfor %}}
-
-    <unix:file_state id="symlink_file_groupowner{{{ FILEID }}}_{{{ loop.index0  }}}" version="1">
+  {{% endfor %}}
+    <unix:file_state id="symlink_file_groupowner" version="1">
       <unix:type operation="equals">symbolic link</unix:type>
     </unix:file_state>
-  {{% endfor %}}
-
 </def-group>

--- a/shared/templates/file_groupowner/oval.template
+++ b/shared/templates/file_groupowner/oval.template
@@ -13,7 +13,7 @@
    {{% endif %}}
     </criteria>
   </definition>
-  
+
   {{%- set GROUPS=GID_OR_NAME.split("|") %}}
   {{%- if GROUP_REPRESENTED_WITH_GID %}}
   <local_variable id="var_file_groupowner{{{ FILEID }}}_{{{ GID_OR_NAME }}}_gid" comment="Set the gid to {{{ GID_OR_NAME }}}" datatype="int" version="1">
@@ -32,13 +32,10 @@
     </local_variable>
   {{% endfor %}}
   {{% endif %}}
-  
+
   {{% for filepath in FILEPATH %}}
-    <unix:file_test check="all" check_existence="any_exist" comment="Testing group ownership of {{{ filepath }}}" id="test_file_groupowner{{{ FILEID }}}_{{{ loop.index0 }}}" state_operator="OR" version="1">
+    <unix:file_test check="all" check_existence="none_exist" comment="Testing group ownership of {{{ filepath }}}" id="test_file_groupowner{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
       <unix:object object_ref="object_file_groupowner{{{ FILEID }}}_{{{ loop.index0 }}}" />
-      {{% for grp in GROUPS %}}
-        <unix:state state_ref="state_file_groupowner{{{ FILEID }}}_{{{ loop.index0 }}}_{{{ grp }}}"/>
-      {{% endfor %}}
     </unix:file_test>
 
     <unix:file_object comment="{{{ filepath }}}" id="object_file_groupowner{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
@@ -56,14 +53,14 @@
         <unix:filepath{{% if FILEPATH_IS_REGEX %}} operation="pattern match"{{% endif %}}>{{{ filepath }}}</unix:filepath>
       {{%- endif %}}
       <filter action="exclude">symlink_file_groupowner{{{ FILEID }}}_{{{ loop.index0 }}}</filter>
+      {{% for grp in GROUPS %}}
+      <filter action="exclude">state_file_groupowner{{{ FILEID }}}_{{{ loop.index0 }}}_{{{ grp }}}</filter>
+      {{% endfor %}}
     </unix:file_object>
 
     {{% for grp in GROUPS %}}
       <unix:file_state id="state_file_groupowner{{{ FILEID }}}_{{{ loop.index0 }}}_{{{ grp }}}" version="1">
         <unix:group_id datatype="int" operation="equals" var_ref="var_file_groupowner{{{ FILEID }}}_{{{grp}}}_gid"></unix:group_id>
-      </unix:file_state>
-      <unix:file_state id="symlink_file_groupowner{{{ FILEID }}}_{{{ loop.index0  }}}" version="1">
-        <unix:type operation="equals">symbolic link</unix:type>
       </unix:file_state>
     {{% endfor %}}
 

--- a/shared/templates/file_owner/oval.template
+++ b/shared/templates/file_owner/oval.template
@@ -31,11 +31,8 @@
   {{%- endif %}}
 
   {{% for filepath in FILEPATH %}}
-  <unix:file_test check="all" check_existence="any_exist" comment="Testing user ownership of {{{ filepath }}}" id="test_file_owner{{{ FILEID }}}_{{{ loop.index0 }}}" state_operator="OR" version="1">
+  <unix:file_test check="all" check_existence="none_exist" comment="Testing user ownership of {{{ filepath }}}" id="test_file_owner{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
     <unix:object object_ref="object_file_owner{{{ FILEID }}}_{{{ loop.index0 }}}" />
-    {{% for own in OWNERS %}}
-      <unix:state state_ref="state_file_owner{{{ FILEID }}}_{{{ loop.index0 }}}_{{{ own }}}"/>
-    {{% endfor %}}
   </unix:file_test>
 
   <unix:file_object comment="{{{ filepath }}}" id="object_file_owner{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
@@ -47,20 +44,21 @@
       {{%- if FILE_REGEX %}}
       <unix:filename operation="pattern match">{{{ FILE_REGEX[loop.index0] }}}</unix:filename>
       {{%- else %}}
-      <unix:filename xsi:nil="true" /> 
+      <unix:filename xsi:nil="true" />
       {{%- endif %}}
     {{%- else %}}
       <unix:filepath{{% if FILEPATH_IS_REGEX %}} operation="pattern match"{{% endif %}}>{{{ filepath }}}</unix:filepath>
     {{%- endif %}}
     <filter action="exclude">symlink_file_owner{{{ FILEID }}}_{{{ loop.index0 }}}</filter>
+    {{% for own in OWNERS %}}
+      <filter action="exclude">state_file_owner{{{ FILEID }}}_{{{ loop.index0 }}}_{{{ own }}}</filter>
+    {{% endfor %}}
   </unix:file_object>
-
   {{% for own in OWNERS %}}
     <unix:file_state id="state_file_owner{{{ FILEID }}}_{{{ loop.index0 }}}_{{{ own }}}" version="1">
       <unix:user_id datatype="int" operation="equals" var_ref="var_file_owner{{{ FILEID }}}_{{{ own }}}_uid"></unix:user_id>
     </unix:file_state>
   {{% endfor %}}
-
   <unix:file_state id="symlink_file_owner{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
     <unix:type operation="equals">symbolic link</unix:type>
   </unix:file_state>

--- a/shared/templates/file_owner/oval.template
+++ b/shared/templates/file_owner/oval.template
@@ -49,7 +49,7 @@
     {{%- else %}}
       <unix:filepath{{% if FILEPATH_IS_REGEX %}} operation="pattern match"{{% endif %}}>{{{ filepath }}}</unix:filepath>
     {{%- endif %}}
-    <filter action="exclude">symlink_file_owner{{{ FILEID }}}_{{{ loop.index0 }}}</filter>
+    <filter action="exclude">symlink_file_owner</filter>
     {{% for own in OWNERS %}}
       <filter action="exclude">state_file_owner{{{ FILEID }}}_{{{ loop.index0 }}}_{{{ own }}}</filter>
     {{% endfor %}}
@@ -59,9 +59,8 @@
       <unix:user_id datatype="int" operation="equals" var_ref="var_file_owner{{{ FILEID }}}_{{{ own }}}_uid"></unix:user_id>
     </unix:file_state>
   {{% endfor %}}
-  <unix:file_state id="symlink_file_owner{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
+  {{% endfor %}}
+  <unix:file_state id="symlink_file_owner" version="1">
     <unix:type operation="equals">symbolic link</unix:type>
   </unix:file_state>
-  {{% endfor %}}
-
 </def-group>


### PR DESCRIPTION
#### Description:

Filter out complaint files help reduce memory footprint when scanning.

#### Rationale:

Make the content usable on all systems. 
Fixes #13297

#### Review Hints:
Use Automatus on system that has <2000 MB of RAM.

