### PR TITLE
Switch to using hardcoded sshd algorithms in Ubuntu STIGs

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/bash/shared.sh
@@ -1,12 +1,7 @@
-# platform = Oracle Linux 7,multi_platform_sle,multi_platform_slmicro,multi_platform_ubuntu
+# platform = Oracle Linux 7,multi_platform_sle,multi_platform_slmicro
 
-{{%- if 'ubuntu' in product %}}
-{{{ bash_instantiate_variables('sshd_approved_ciphers') }}}
-{{{ bash_sshd_remediation(parameter="Ciphers", value="$sshd_approved_ciphers", config_is_distributed=sshd_distributed_config) }}}
-{{%- else %}}
 if grep -q -P '^\s*[Cc]iphers\s+' /etc/ssh/sshd_config; then
   sed -i 's/^\s*[Cc]iphers.*/Ciphers aes256-ctr,aes192-ctr,aes128-ctr/' /etc/ssh/sshd_config
 else
   echo "Ciphers aes256-ctr,aes192-ctr,aes128-ctr" >> /etc/ssh/sshd_config
 fi
-{{%- endif %}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/bash/ubuntu.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/bash/ubuntu.sh
@@ -1,0 +1,9 @@
+# platform = multi_platform_ubuntu
+
+{{%- if product == 'ubuntu2204' %}}
+sshd_approved_ciphers="aes256-ctr,aes256-gcm@openssh.com,aes192-ctr,aes128-ctr,aes128-gcm@openssh.com"
+{{%- else %}}
+sshd_approved_ciphers="aes256-ctr,aes192-ctr,aes128-ctr"
+{{%- endif %}}
+
+{{{ bash_sshd_remediation(parameter="Ciphers", value="$sshd_approved_ciphers", config_is_distributed=sshd_distributed_config) }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/oval/ubuntu.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/oval/ubuntu.xml
@@ -1,3 +1,8 @@
+{{%- if product == 'ubuntu2204' %}}
+{{%- set sshd_approved_ciphers = "aes256-ctr,aes256-gcm@openssh.com,aes192-ctr,aes128-ctr,aes128-gcm@openssh.com" %}}
+{{%- else %}}
+{{%- set sshd_approved_ciphers = "aes256-ctr,aes192-ctr,aes128-ctr" %}}
+{{%- endif %}}
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("Limit the ciphers to those which are FIPS-approved.") }}}
@@ -59,10 +64,8 @@
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_{{{ rule_id }}}" version="1">
-    <ind:subexpression datatype="string" operation="pattern match" var_ref="sshd_approved_ciphers"/>
+    <ind:subexpression datatype="string" operation="equals">{{{ sshd_approved_ciphers }}}</ind:subexpression>
   </ind:textfilecontent54_state>
-
-  <external_variable comment="sshd approved ciphers" datatype="string" id="sshd_approved_ciphers" version="1" />
 
   <ind:textfilecontent54_object comment="All confs collection" id="obj_collection_obj_{{{ rule_id }}}" version="1">
     <set>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/rule.yml
@@ -1,3 +1,8 @@
+{{%- if product == 'ubuntu2204' %}}
+{{%- set sshd_approved_ciphers = "aes256-ctr,aes256-gcm@openssh.com,aes192-ctr,aes128-ctr,aes128-gcm@openssh.com" %}}
+{{%- else %}}
+{{%- set sshd_approved_ciphers = "aes256-ctr,aes192-ctr,aes128-ctr" %}}
+{{%- endif %}}
 documentation_complete: true
 
 title: 'Use Only FIPS 140-2 Validated Ciphers'
@@ -7,7 +12,7 @@ description: |-
     The following line in <tt>/etc/ssh/sshd_config</tt>
     demonstrates use of FIPS-approved ciphers:
     {{%- if 'ubuntu' in product %}}
-    <pre>Ciphers {{{ xccdf_value("sshd_approved_ciphers") }}}</pre>
+    <pre>Ciphers {{{ sshd_approved_ciphers }}}</pre>
     If this line does not contain these ciphers in exact order,
     is commented out, or is missing, this is a finding.
     {{%- else %}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/tests/comment.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/tests/comment.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-{{% if product == "ubuntu2204", "ubuntu2404" %}}
+{{% if product == "ubuntu2204" %}}
 sshd_approved_ciphers="aes256-ctr,aes256-gcm@openssh.com,aes192-ctr,aes128-ctr,aes128-gcm@openssh.com"
 {{% else %}}
 sshd_approved_ciphers="aes256-ctr,aes192-ctr,aes128-ctr"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/tests/correct_scrambled.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/tests/correct_scrambled.fail.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
+{{% if product == "ubuntu2204" %}}
+sshd_scrambled_ciphers="aes128-gcm@openssh.com,aes256-ctr,aes256-gcm@openssh.com,aes192-ctr,aes128-ctr"
+{{% else %}}
+sshd_scrambled_ciphers="aes128-ctr,aes192-ctr,aes256-ctr"
+{{% endif %}}
+
 if grep -q "^Ciphers" /etc/ssh/sshd_config; then
-	sed -i "s/^Ciphers.*/Ciphers aes128-ctr,aes192-ctr,aes256-ctr/" /etc/ssh/sshd_config
+	sed -i "s/^Ciphers.*/Ciphers $sshd_scrambled_ciphers/" /etc/ssh/sshd_config
 else
-	echo "Ciphers aes128-ctr,aes192-ctr,aes256-ctr" >> /etc/ssh/sshd_config
+	echo "Ciphers $sshd_scrambled_ciphers" >> /etc/ssh/sshd_config
 fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/tests/correct_value.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-{{% if product == "ubuntu2204", "ubuntu2404" %}}
+{{% if product == "ubuntu2204" %}}
 sshd_approved_ciphers="aes256-ctr,aes256-gcm@openssh.com,aes192-ctr,aes128-ctr,aes128-gcm@openssh.com"
 {{% else %}}
 sshd_approved_ciphers="aes256-ctr,aes192-ctr,aes128-ctr"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/bash/shared.sh
@@ -1,12 +1,7 @@
-# platform = Oracle Linux 7,multi_platform_sle,multi_platform_slmicro,multi_platform_ubuntu
+# platform = Oracle Linux 7,multi_platform_sle,multi_platform_slmicro
 
-{{%- if 'ubuntu' in product %}}
-{{{ bash_instantiate_variables('sshd_approved_macs') }}}
-{{{ bash_sshd_remediation(parameter="MACs", value="$sshd_approved_macs", config_is_distributed=sshd_distributed_config) }}}
-{{%- else %}}
 if grep -q -P '^\s*MACs\s+' /etc/ssh/sshd_config; then
   sed -i 's/^\s*MACs.*/MACs hmac-sha2-512,hmac-sha2-256/' /etc/ssh/sshd_config
 else
   echo "MACs hmac-sha2-512,hmac-sha2-256" >> /etc/ssh/sshd_config
 fi
-{{%- endif %}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/bash/ubuntu.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/bash/ubuntu.sh
@@ -1,0 +1,9 @@
+# platform = multi_platform_ubuntu
+
+{{%- if product == 'ubuntu2204' %}}
+sshd_approved_macs="hmac-sha2-512,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-256-etm@openssh.com"
+{{%- else %}}
+sshd_approved_macs="hmac-sha2-512,hmac-sha2-256"
+{{%- endif %}}
+
+{{{ bash_sshd_remediation(parameter="MACs", value="$sshd_approved_macs", config_is_distributed=sshd_distributed_config) }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/oval/ubuntu.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/oval/ubuntu.xml
@@ -1,3 +1,8 @@
+{{%- if product == 'ubuntu2204' %}}
+{{%- set sshd_approved_macs = "hmac-sha2-512,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-256-etm@openssh.com" %}}
+{{%- else %}}
+{{%- set sshd_approved_macs = "hmac-sha2-512,hmac-sha2-256" %}}
+{{%- endif %}}
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("Limit the Message Authentication Codes (MACs) to those which are FIPS-approved.") }}}
@@ -59,10 +64,8 @@
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_{{{ rule_id }}}" version="1">
-    <ind:subexpression datatype="string" operation="pattern match" var_ref="sshd_approved_macs"/>
+    <ind:subexpression datatype="string" operation="equals">{{{ sshd_approved_macs }}}</ind:subexpression>
   </ind:textfilecontent54_state>
-
-  <external_variable comment="sshd approved MACs" datatype="string" id="sshd_approved_macs" version="1" />
 
   <ind:textfilecontent54_object comment="All confs collection" id="obj_collection_obj_{{{ rule_id }}}" version="1">
     <set>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/rule.yml
@@ -1,3 +1,8 @@
+{{%- if product == 'ubuntu2204' %}}
+{{%- set sshd_approved_macs = "hmac-sha2-512,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-256-etm@openssh.com" %}}
+{{%- else %}}
+{{%- set sshd_approved_macs = "hmac-sha2-512,hmac-sha2-256" %}}
+{{%- endif %}}
 documentation_complete: true
 
 title: 'Use Only FIPS 140-2 Validated MACs'
@@ -7,7 +12,7 @@ description: |-
     The following line in <tt>/etc/ssh/sshd_config</tt>
     demonstrates use of FIPS-approved MACs:
     {{%- if 'ubuntu' in product %}}
-    <pre>MACs {{{ xccdf_value("sshd_approved_macs") }}}</pre>
+    <pre>MACs {{{ sshd_approved_macs }}}</pre>
     If this line does not contain these MACs in exact order,
     is commented out, or is missing, this is a finding.
     {{%- else %}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/tests/comment.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/tests/comment.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-{{% if product == "ubuntu2204", "ubuntu2404" %}}
+{{% if product == "ubuntu2204" %}}
 sshd_approved_macs="hmac-sha2-512,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-256-etm@openssh.com"
 {{% else %}}
 sshd_approved_macs="hmac-sha2-512,hmac-sha2-256"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/tests/correct_scrambled.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/tests/correct_scrambled.fail.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
+{{% if product == "ubuntu2204" %}}
+sshd_scrambled_macs="hmac-sha2-256,hmac-sha2-512,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com"
+{{% else %}}
+sshd_scrambled_macs="hmac-sha2-256,hmac-sha2-512"
+{{% endif %}}
+
 if grep -q "^MACs" /etc/ssh/sshd_config; then
-	sed -i "s/^MACs.*/MACs hmac-sha2-256,hmac-sha2-512/" /etc/ssh/sshd_config
+	sed -i "s/^MACs.*/MACs $sshd_scrambled_macs/" /etc/ssh/sshd_config
 else
-	echo "MACs hmac-sha2-256,hmac-sha2-512" >> /etc/ssh/sshd_config
+	echo "MACs $sshd_scrambled_macs" >> /etc/ssh/sshd_config
 fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/tests/correct_value.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-{{% if product == "ubuntu2204", "ubuntu2404" %}}
+{{% if product == "ubuntu2204" %}}
 sshd_approved_macs="hmac-sha2-512,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-256-etm@openssh.com"
 {{% else %}}
 sshd_approved_macs="hmac-sha2-512,hmac-sha2-256"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/tests/correct_value_config_dir.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/tests/correct_value_config_dir.pass.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 
+{{% if product == "ubuntu2204" %}}
 sshd_approved_macs="hmac-sha2-512,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-256-etm@openssh.com"
+{{% else %}}
+sshd_approved_macs="hmac-sha2-512,hmac-sha2-256"
+{{% endif %}}
 
 sed -i "/^MACs.*/d" /etc/ssh/sshd_config
 sed -i "/^MACs.*/d" /etc/ssh/sshd_config.d/*

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/tests/wrong_value.fail.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
+{{% if product == "ubuntu2204" %}}
+sshd_approved_macs="hmac-sha2-512,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-256-etm@openssh.com"
+{{% else %}}
+sshd_approved_macs="hmac-sha2-512,hmac-sha2-256"
+{{% endif %}}
+
 if grep -q "^MACs" /etc/ssh/sshd_config; then
-	sed -i "s/^MACs.*/MACs hmac-sha2-512,hmac-sha2-256,blahblah/" /etc/ssh/sshd_config
+	sed -i "s/^MACs.*/MACs ${sshd_approved_macs},blahblah/" /etc/ssh/sshd_config
 else
-	echo "MACs hmac-sha2-512,hmac-sha2-256,blahblah" >> /etc/ssh/sshd_config
+	echo "MACs ${sshd_approved_macs},blahblah" >> /etc/ssh/sshd_config
 fi

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -83,11 +83,9 @@ selections:
     - service_sshd_enabled
 
     # UBTU-20-010043 The Ubuntu operating system must configure the SSH daemon to use Message Authentication Codes (MACs) employing FIPS 140-2 approved cryptographic hashes to prevent the unauthorized disclosure of information and/or detect changes to information during transmission.
-    - sshd_approved_macs=stig
     - sshd_use_approved_macs_ordered_stig
 
     # UBTU-20-010044 The Ubuntu operating system must configure the SSH daemon to use FIPS 140-2 approved ciphers to prevent the unauthorized disclosure of information and/or detect changes to information during transmission.
-    - sshd_approved_ciphers=stig
     - sshd_use_approved_ciphers_ordered_stig
 
     # UBTU-20-010045 The Ubuntu operating system SSH server must be configured to use only FIPS-validated key exchange algorithms.

--- a/products/ubuntu2204/profiles/stig.profile
+++ b/products/ubuntu2204/profiles/stig.profile
@@ -85,11 +85,9 @@ selections:
     - sshd_enable_warning_banner_net
 
     # UBTU-22-255055 The Ubuntu operating system must configure the SSH daemon to use Message Authentication Codes (MACs) employing FIPS 140-3 approved cryptographic hashes to prevent the unauthorized disclosure of information and/or detect changes to information during transmission.
-    - sshd_approved_macs=stig_ubuntu2204
     - sshd_use_approved_macs_ordered_stig
 
     # UBTU-22-255050 The Ubuntu operating system must configure the SSH daemon to use FIPS 140-3 approved ciphers to prevent the unauthorized disclosure of information and/or detect changes to information during transmission.
-    - sshd_approved_ciphers=stig_ubuntu2204
     - sshd_use_approved_ciphers_ordered_stig
 
     # UBTU-22-255060 The Ubuntu operating system SSH server must be configured to use only FIPS-validated key exchange algorithms.


### PR DESCRIPTION
#### Description:

- Switch to using hardcoded sshd ciphers in Ubuntu STIGs instead of XCCDF var `sshd_approved_ciphers`
- Switch to using hardcoded sshd MACs in Ubuntu STIGs instead of XCCDF var `sshd_approved_macs`

#### Rationale:

- The list of FIPS-ceritified ssh algorithms is critical and should always match exactly the STIG document.
- Currently, the list of approved sshd ciphers and macs are defined using XCCDF vars, which are user-modifiable via the tailoring file.