### PR TITLE
build_product: add --render-test-scenarios option

### DIFF
--- a/build_product
+++ b/build_product
@@ -82,6 +82,7 @@ _arg_profiling="off"
 _arg_log="off"
 _arg_thin_datastream="off"
 _arg_rule_id="off"
+_arg_render_test_scenarios="off"
 
 print_help()
 {
@@ -99,6 +100,7 @@ print_help()
 	printf '\t%s\n' "-t, --thin, --no-thin: Build thin data streams for each rule. Do not build any of the guides, tables, etc (off by default)"
 	printf '\t%s\n' "-r, --rule-id: Rule ID: Build a thin data stream with the specified rule. Do not build any of the guides, tables, etc (off by default)"
 	printf '\t%s\n' "-d, --datastream-only, --no-datastream-only: Build the data stream only. Do not build any of the guides, tables, etc (off by default)"
+	printf '\t%s\n' "--render-test-scenarios: render Automatus test scenarios for specified product and put them into the build directory (off by default)"
 	printf '\t%s\n' "-p, --profiling, --no-profiling: Use ninja and call the build_profiler.sh util (off by default)"
 	printf '\t%s\n' "-l, --log, --no-log: Logs all debugging messages (off by default)"
 	printf '\t%s\n' "-h, --help: Prints help"
@@ -226,6 +228,9 @@ parse_commandline()
 				then
 					{ begins_with_short_option "$_next" && shift && set -- "-l" "-${_next}" "$@"; } || die "The short option '$_key' can't be decomposed to ${_key:0:2} and -${_key:2}, because ${_key:0:2} doesn't accept value and '-${_key:2:1}' doesn't correspond to a short option."
 				fi
+				;;
+			--render-test-scenarios)
+				_arg_render_test_scenarios="on"
 				;;
 			-h|--help)
 				print_help
@@ -473,6 +478,13 @@ if [ "$_arg_thin_datastream" = on ] ; then
 else
 	CMAKE_OPTIONS+=("-DSSG_THIN_DS:BOOL=OFF")
 fi
+
+if [ "$_arg_render_test_scenarios" = on ] ; then
+	CMAKE_OPTIONS+=("-DSSG_BUILT_TESTS_ENABLED:BOOL=ON")
+else
+	CMAKE_OPTIONS+=("-DSSG_BUILT_TESTS_ENABLED:BOOL=OFF")
+fi
+
 
 set -e
 [ -d build ] || mkdir build

--- a/docs/manual/developer/02_building_complianceascode.md
+++ b/docs/manual/developer/02_building_complianceascode.md
@@ -527,6 +527,8 @@ You can build the Automatus tests so they can be run directly.
 To enable build with `-DSSG_BUILT_TESTS_ENABLED:BOOL=ON`
 The tests will be `$PRODUCT/tests/` with directory for each rule.
 
+you can also use the `build_product` script together with `--render-test-scenarios` option.
+
 ## Testing
 
 To ensure validity of built artifacts prior to installation, we recommend


### PR DESCRIPTION
#### Description:

- add --render-test-scenarios option to build_product script

#### Rationale:

- this builds rendered test scenarios as introduced in #13029 


#### Review Hints:

- use build_product with --render-test-scenarios option and without it