### PR TITLE
[Ubuntu 24.04]: Implement rule UBTU-24-400220

### DIFF
--- a/components/pam.yml
+++ b/components/pam.yml
@@ -225,6 +225,7 @@ rules:
 - securetty_root_login_console_only
 - service_debug-shell_disabled
 - service_pcscd_enabled
+- set_password_hashing_algorithm_auth_stig
 - set_password_hashing_algorithm_commonauth
 - set_password_hashing_algorithm_libuserconf
 - set_password_hashing_algorithm_logindefs

--- a/controls/stig_ubuntu2404.yml
+++ b/controls/stig_ubuntu2404.yml
@@ -747,9 +747,11 @@ controls:
     title: Ubuntu 24.04 LTS must store only encrypted representations of passwords.
     levels:
       - medium
-    related_rules:
-      - set_password_hashing_algorithm_systemauth
-    status: planned
+    rules:
+      - var_password_pam_unix_rounds=100000
+      - set_password_hashing_algorithm_auth_stig
+      - accounts_password_pam_unix_rounds_password_auth
+    status: automated
 
   - id: UBTU-24-400260
     title: Ubuntu 24.04 LTS must enforce password complexity by requiring that at

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_auth_stig/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_auth_stig/bash/shared.sh
@@ -9,12 +9,12 @@ declare -a HASHING_ALGORITHMS_OPTIONS=("sha512" "yescrypt" "gost_yescrypt" "blow
 for hash_option in "${HASHING_ALGORITHMS_OPTIONS[@]}"; do
   sed -i -E '/^Password:/,/^[^[:space:]]/ {
     /pam_unix\.so/ {
-      s/\s*\b\S*'"$hash_option"'\S*\b//g
+      s/\s*\b'"$hash_option"'\b//g
     }
 }' "$PAM_FILE_PATH"
   sed -i -E '/^Password-Initial:/,/^[^[:space:]]/ {
     /pam_unix\.so/ {
-      s/\s*\b\S*'"$hash_option"'\S*\b//g
+      s/\s*\b'"$hash_option"'\b//g
     }
 }' "$PAM_FILE_PATH"
 done

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_auth_stig/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_auth_stig/bash/shared.sh
@@ -1,0 +1,38 @@
+# platform = multi_platform_ubuntu
+
+{{{ bash_pam_unix_enable() }}}
+PAM_FILE_PATH=/usr/share/pam-configs/cac_unix
+
+# Ensure only the correct hashing algorithm option is used.
+declare -a HASHING_ALGORITHMS_OPTIONS=("sha512" "yescrypt" "gost_yescrypt" "blowfish" "sha256" "md5" "bigcrypt")
+
+for hash_option in "${HASHING_ALGORITHMS_OPTIONS[@]}"; do
+  sed -i -E '/^Password:/,/^[^[:space:]]/ {
+    /pam_unix\.so/ {
+      s/\s*\b\S*'"$hash_option"'\S*\b//g
+    }
+}' "$PAM_FILE_PATH"
+  sed -i -E '/^Password-Initial:/,/^[^[:space:]]/ {
+    /pam_unix\.so/ {
+      s/\s*\b\S*'"$hash_option"'\S*\b//g
+    }
+}' "$PAM_FILE_PATH"
+done
+
+if ! grep -qzP "Password:\s*\n\s+.*\s+pam_unix.so\s+.*\bsha512\b" "$PAM_FILE_PATH"; then
+  sed -i -E '/^Password:/,/^[^[:space:]]/ {
+    /pam_unix\.so/ {
+        s/$/ sha512/g
+    }
+}' "$PAM_FILE_PATH"
+fi
+
+if ! grep -qzP "Password-Initial:\s*\n\s+.*\s+pam_unix.so\s+.*\bsha512\b" "$PAM_FILE_PATH"; then
+  sed -i -E '/^Password-Initial:/,/^[^[:space:]]/ {
+    /pam_unix\.so/ {
+        s/$/ sha512/g
+    }
+}' "$PAM_FILE_PATH"
+fi
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_auth_stig/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_auth_stig/oval/shared.xml
@@ -1,0 +1,40 @@
+{{% set pam_file = "/etc/pam.d/common-password" %}}
+{{% set line_pattern = "^[\s]*password[\s]+(?:\[success=\d+\s+default=ignore\])[\s]+pam_unix\.so[\s]+" %}}
+
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="2">
+    {{{ oval_metadata("The password hashing algorithm should be set correctly in {{{ pam_file }}}.") }}}
+    <criteria operator="AND">
+      <criterion test_ref="test_pam_unix_hashing_algorithm_commonauth" />
+    </criteria>
+  </definition>
+
+  {{% set pam_unix_algorithms = "\\b(sha512|yescrypt|gost_yescrypt|blowfish|sha256|md5|bigcrypt)\\b" %}}
+  {{% set hashing_pattern = line_pattern + "(?!.*" + pam_unix_algorithms + "[^#]*" + pam_unix_algorithms + ")[^#]*" + pam_unix_algorithms + ".*$" %}}
+
+  <!--
+    This regex will only match if any of the hashing algorithm options is defined only once.
+    If two options for hashing algorithms are defined, the system behavior may be unexpected.
+    Therefore, the regex won't match and the rule check will fail. If only one option is defined,
+    it will be comprared with the value defined.
+  -->
+
+  <ind:textfilecontent54_test id="test_pam_unix_hashing_algorithm_commonauth" version="2"
+    check="all" check_existence="at_least_one_exists"
+    comment="check if pam_unix.so hashing algorithm option is correct and specified only once in {{{ pam_file }}}">
+    <ind:object object_ref="object_pam_unix_hashing_algorithm_commonauth"/>
+    <ind:state state_ref="state_pam_unix_hashing_algorithm_commonauth"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_pam_unix_hashing_algorithm_commonauth" version="1"
+    comment="only one hashing algorithm option for pam_unix.so is found in {{{ pam_file }}}">
+    <ind:filepath>{{{ pam_file }}}</ind:filepath>
+    <ind:pattern operation="pattern match">{{{ hashing_pattern }}}</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_pam_unix_hashing_algorithm_commonauth" version="1">
+    <ind:subexpression operation="equals" datatype="string">sha512</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_auth_stig/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_auth_stig/rule.yml
@@ -1,0 +1,30 @@
+documentation_complete: true
+
+title: "Set Password Hashing Algorithm for PAM"
+
+{{% set pam_passwd_file_path = "/etc/pam.d/common-password" %}}
+
+description: |-
+    The PAM system service can be configured to only store encrypted representations of passwords.
+    In "{{{ pam_passwd_file_path }}}", the <tt>password</tt> section of the file controls which
+    PAM modules to execute during a password change.
+
+    Set the <tt>pam_unix.so</tt> module in the <tt>password</tt> section to include the option
+    <tt>sha512</tt> and no other hashing algorithms as shown below:
+    <br />
+    <pre>password    [success=1 default=ignore]   pam_unix.so sha512 <i>other arguments...</i></pre>
+    <br />
+    This will help ensure that new passwords for local users will be stored using the sha512 algorithm.
+
+rationale: |-
+    Passwords need to be protected at all times, and encryption is the standard method for
+    protecting passwords. If passwords are not encrypted, they can be plainly read
+    (i.e., clear text) and easily compromised. Passwords that are encrypted with a weak algorithm
+    are no more protected than if they are kept in plain text.
+    <br /><br />
+    This setting ensures user and group account administration utilities are configured to store
+    only encrypted representations of passwords.
+
+severity: medium
+
+platform: package[pam]

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_auth_stig/tests/commented_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_auth_stig/tests/commented_value.fail.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+config_file=/usr/share/pam-configs/tmp_unix
+cat << EOF > "$config_file"
+Name: Unix authentication
+Default: yes
+Priority: 256
+Auth-Type: Primary
+Auth:
+        [success=end default=ignore]    pam_unix.so try_first_pass
+Auth-Initial:
+        [success=end default=ignore]    pam_unix.so
+Account-Type: Primary
+Account:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Account-Initial:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Session-Type: Additional
+Session:
+        required        pam_unix.so
+Session-Initial:
+        required        pam_unix.so
+Password-Type: Primary
+Password:
+        [success=end default=ignore]    pam_unix.so obscure use_authtok try_first_pass # sha512
+Password-Initial:
+        [success=end default=ignore]    pam_unix.so obscure # sha512
+EOF
+DEBIAN_FRONTEND=noninteractive pam-auth-update
+rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_auth_stig/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_auth_stig/tests/correct.pass.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+config_file=/usr/share/pam-configs/tmp_unix
+cat << EOF > "$config_file"
+Name: Unix authentication
+Default: yes
+Priority: 256
+Auth-Type: Primary
+Auth:
+        [success=end default=ignore]    pam_unix.so try_first_pass
+Auth-Initial:
+        [success=end default=ignore]    pam_unix.so
+Account-Type: Primary
+Account:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Account-Initial:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Session-Type: Additional
+Session:
+        required        pam_unix.so
+Session-Initial:
+        required        pam_unix.so
+Password-Type: Primary
+Password:
+        [success=end default=ignore]    pam_unix.so obscure use_authtok try_first_pass sha512
+Password-Initial:
+        [success=end default=ignore]    pam_unix.so obscure sha512
+EOF
+DEBIAN_FRONTEND=noninteractive pam-auth-update
+rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_auth_stig/tests/missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_auth_stig/tests/missing.fail.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+config_file=/usr/share/pam-configs/tmp_unix
+cat << EOF > "$config_file"
+Name: Unix authentication
+Default: yes
+Priority: 256
+Auth-Type: Primary
+Auth:
+        [success=end default=ignore]    pam_unix.so try_first_pass
+Auth-Initial:
+        [success=end default=ignore]    pam_unix.so
+Account-Type: Primary
+Account:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Account-Initial:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Session-Type: Additional
+Session:
+        required        pam_unix.so
+Session-Initial:
+        required        pam_unix.so
+Password-Type: Primary
+Password:
+        [success=end default=ignore]    pam_unix.so obscure use_authtok try_first_pass
+Password-Initial:
+        [success=end default=ignore]    pam_unix.so obscure
+EOF
+DEBIAN_FRONTEND=noninteractive pam-auth-update
+rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_auth_stig/tests/wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_auth_stig/tests/wrong_control.fail.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+config_file=/usr/share/pam-configs/tmp_unix
+cat << EOF > "$config_file"
+Name: Unix authentication
+Default: yes
+Priority: 256
+Auth-Type: Primary
+Auth:
+        [success=end default=ignore]    pam_unix.so try_first_pass
+Auth-Initial:
+        [success=end default=ignore]    pam_unix.so
+Account-Type: Primary
+Account:
+        optional      pam_unix.so
+Account-Initial:
+        optional      pam_unix.so
+Session-Type: Additional
+Session:
+        required        pam_unix.so
+Session-Initial:
+        required        pam_unix.so
+Password-Type: Primary
+Password:
+        [success=end default=ignore]    pam_unix.so obscure use_authtok try_first_pass
+Password-Initial:
+        [success=end default=ignore]    pam_unix.so obscure
+EOF
+DEBIAN_FRONTEND=noninteractive pam-auth-update
+rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_auth_stig/tests/wrong_value_concat.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_auth_stig/tests/wrong_value_concat.fail.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+config_file=/usr/share/pam-configs/tmp_unix
+cat << EOF > "$config_file"
+Name: Unix authentication
+Default: yes
+Priority: 256
+Auth-Type: Primary
+Auth:
+        [success=end default=ignore]    pam_unix.so try_first_pass
+Auth-Initial:
+        [success=end default=ignore]    pam_unix.so
+Account-Type: Primary
+Account:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Account-Initial:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Session-Type: Additional
+Session:
+        required        pam_unix.so
+Session-Initial:
+        required        pam_unix.so
+Password-Type: Primary
+Password:
+        [success=end default=ignore]    pam_unix.so obscure use_authtok try_first_pass sha5122
+Password-Initial:
+        [success=end default=ignore]    pam_unix.so obscure sha5122
+EOF
+DEBIAN_FRONTEND=noninteractive pam-auth-update
+rm "$config_file"

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle,multi_platform_debian,multi_platform_almalinux
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle,multi_platform_debian,multi_platform_almalinux,multi_platform_ubuntu
 
 {{{ bash_instantiate_variables("var_password_pam_unix_rounds") }}}
 
@@ -6,6 +6,25 @@
 {{{ bash_ensure_pam_module_configuration('/etc/pam.d/common-password', 'password', 'sufficient', 'pam_unix.so', 'rounds', "$var_password_pam_unix_rounds", '') }}}
 {{% elif product in ["debian12"] %}}
 {{{ bash_ensure_pam_module_configuration('/etc/pam.d/common-password', 'password', '\[success=1 default=ignore\]', 'pam_unix.so', 'rounds', "$var_password_pam_unix_rounds", '') }}}
+{{% elif product in ["ubuntu2404"] %}}
+config_file="/usr/share/pam-configs/cac_unix"
+{{{ bash_pam_unix_enable() }}}
+sed -i -E '/^Password:/,/^[^[:space:]]/ {
+    /pam_unix\.so/ {
+        s/\s*rounds=[^[:space:]]*//g
+        s/$/ rounds='"$var_password_pam_unix_rounds"'/g
+    }
+}' "$config_file"
+
+sed -i -E '/^Password-Initial:/,/^[^[:space:]]/ {
+    /pam_unix\.so/ {
+        s/\s*rounds=[^[:space:]]*//g
+        s/$/ rounds='"$var_password_pam_unix_rounds"'/g
+    }
+}' "$config_file"
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update
+
 {{% else %}}
 {{{ bash_ensure_pam_module_configuration('/etc/pam.d/password-auth', 'password', 'sufficient', 'pam_unix.so', 'rounds', "$var_password_pam_unix_rounds", '') }}}
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/oval/shared.xml
@@ -20,9 +20,9 @@
   <ind:textfilecontent54_object id="object_password_auth_pam_unix_rounds" version="1">
     <ind:filepath operation="pattern match">^{{{ pam_passwd_file_path }}}$</ind:filepath>
     {{% if product in ["debian12", 'ubuntu2404'] %}}
-    <ind:pattern operation="pattern match">^\s*password\s+.*\s+pam_unix\.so.*rounds=([0-9]*).*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*password\s+.*\s+pam_unix\.so[^#]*rounds=([0-9]*).*$</ind:pattern>
     {{% else %}}
-    <ind:pattern operation="pattern match">^\s*password\s+(?:(?:sufficient)|(?:required))\s+pam_unix\.so.*rounds=([0-9]*).*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*password\s+(?:(?:sufficient)|(?:required))\s+pam_unix\.so[^#]*rounds=([0-9]*).*$</ind:pattern>
     {{% endif %}}
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/oval/shared.xml
@@ -1,4 +1,4 @@
-{{% if product in ["sle12", "sle15", "debian12"] %}}
+{{% if product in ["sle12", "sle15", "debian12", 'ubuntu2404'] %}}
 {{% set pam_passwd_file_path = "/etc/pam.d/common-password" %}}
 {{% else %}}
 {{% set pam_passwd_file_path = "/etc/pam.d/password-auth" %}}
@@ -19,7 +19,7 @@
 
   <ind:textfilecontent54_object id="object_password_auth_pam_unix_rounds" version="1">
     <ind:filepath operation="pattern match">^{{{ pam_passwd_file_path }}}$</ind:filepath>
-    {{% if product in ["debian12"] %}}
+    {{% if product in ["debian12", 'ubuntu2404'] %}}
     <ind:pattern operation="pattern match">^\s*password\s+.*\s+pam_unix\.so.*rounds=([0-9]*).*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^\s*password\s+(?:(?:sufficient)|(?:required))\s+pam_unix\.so.*rounds=([0-9]*).*$</ind:pattern>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/rule.yml
@@ -3,7 +3,7 @@ documentation_complete: true
 
 title: 'Set number of Password Hashing Rounds - password-auth'
 
-{{% if product in ["sle12", "sle15", "debian12"] %}}
+{{% if product in ["sle12", "sle15", "debian12", 'ubuntu2404'] %}}
 {{% set pam_passwd_file_path = "/etc/pam.d/common-password" %}}
 {{% else %}}
 {{% set pam_passwd_file_path = "/etc/pam.d/password-auth" %}}
@@ -15,7 +15,7 @@ description: |-
     <br /><br />
     In file <tt>{{{ pam_passwd_file_path }}}</tt> append <tt>rounds={{{ xccdf_value("var_password_pam_unix_rounds") }}}</tt>
     to the <tt>pam_unix.so</tt> entry, as shown below:
-    {{% if product in ["debian12"] %}}  
+    {{% if product in ["debian12", 'ubuntu2404'] %}}  
     <pre>password [success=1 default=ignore] pam_unix.so <i>...existing_options...</i> rounds={{{ xccdf_value("var_password_pam_unix_rounds") }}}</pre>
     {{% else %}}
     <pre>password sufficient pam_unix.so <i>...existing_options...</i> rounds={{{ xccdf_value("var_password_pam_unix_rounds") }}}</pre>
@@ -50,7 +50,7 @@ ocil: |-
     To verify the number of rounds for the password hashing algorithm is configured, run the following command:
     <pre>$ sudo grep rounds {{{ pam_passwd_file_path }}}</pre>
     The output should show the following match:
-    {{% if product in ["debian12"] %}} 
+    {{% if product in ["debian12", 'ubuntu2404'] %}} 
     <pre>password [sucess=1 default=ignore] pam_unix.so sha512 rounds={{{ xccdf_value("var_password_pam_unix_rounds") }}}</pre>
     {{% else %}}
     <pre>password sufficient pam_unix.so sha512 rounds={{{ xccdf_value("var_password_pam_unix_rounds") }}}</pre>
@@ -63,7 +63,7 @@ fixtext: |-
 
     Add or modify the following line in "{{{ pam_passwd_file_path }}}" and set "rounds" to {{{ xccdf_value("var_password_pam_unix_rounds") }}}.
     For example:
-    {{% if product in ["debian12"] %}} 
+    {{% if product in ["debian12", 'ubuntu2404'] %}} 
     password [sucess=1 default=ignore] pam_unix.so sha512 rounds=5000
     {{% else %}}
     password sufficient pam_unix.so sha512 rounds=5000

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/pamupdate_argument_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/pamupdate_argument_missing.fail.sh
@@ -8,7 +8,8 @@ config_file=/usr/share/pam-configs/tmp_unix
 cat << EOF > "$config_file"
 Name: Unix authentication
 Default: yes
-Priority: 256
+Priority: 257
+Conflicts: unix
 Auth-Type: Primary
 Auth:
         [success=end default=ignore]    pam_unix.so try_first_pass

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/pamupdate_argument_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/pamupdate_argument_missing.fail.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = pam
+# variables = var_password_pam_unix_rounds=65536
+
+config_file=/usr/share/pam-configs/tmp_unix
+
+cat << EOF > "$config_file"
+Name: Unix authentication
+Default: yes
+Priority: 256
+Auth-Type: Primary
+Auth:
+        [success=end default=ignore]    pam_unix.so try_first_pass
+Auth-Initial:
+        [success=end default=ignore]    pam_unix.so
+Account-Type: Primary
+Account:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Account-Initial:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Session-Type: Additional
+Session:
+        required        pam_unix.so
+Session-Initial:
+        required        pam_unix.so
+Password-Type: Primary
+Password:
+        [success=end default=ignore]    pam_unix.so obscure sha512 shadow remember=5
+Password-Initial:
+        [success=end default=ignore]    pam_unix.so obscure sha512 shadow remember=5
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update
+rm $config_file

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/pamupdate_commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/pamupdate_commented.fail.sh
@@ -8,7 +8,8 @@ config_file=/usr/share/pam-configs/tmp_unix
 cat << EOF > "$config_file"
 Name: Unix authentication
 Default: yes
-Priority: 256
+Priority: 257
+Conflicts: unix
 Auth-Type: Primary
 Auth:
         [success=end default=ignore]    pam_unix.so try_first_pass

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/pamupdate_commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/pamupdate_commented.fail.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = pam
+# variables = var_password_pam_unix_rounds=65536
+
+config_file=/usr/share/pam-configs/tmp_unix
+
+cat << EOF > "$config_file"
+Name: Unix authentication
+Default: yes
+Priority: 256
+Auth-Type: Primary
+Auth:
+        [success=end default=ignore]    pam_unix.so try_first_pass
+Auth-Initial:
+        [success=end default=ignore]    pam_unix.so
+Account-Type: Primary
+Account:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Account-Initial:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Session-Type: Additional
+Session:
+        required        pam_unix.so
+Session-Initial:
+        required        pam_unix.so
+Password-Type: Primary
+Password:
+        [success=end default=ignore]    pam_unix.so obscure sha512 shadow remember=5 #rounds=65536
+Password-Initial:
+        [success=end default=ignore]    pam_unix.so obscure sha512 shadow remember=5 #rounds=65536
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update
+rm $config_file

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/pamupdate_correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/pamupdate_correct_value.pass.sh
@@ -10,7 +10,8 @@ config_file=/usr/share/pam-configs/tmp_unix
 cat << EOF > "$config_file"
 Name: Unix authentication
 Default: yes
-Priority: 256
+Priority: 257
+Conflicts: unix
 Auth-Type: Primary
 Auth:
         [success=end default=ignore]    pam_unix.so try_first_pass

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/pamupdate_correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/pamupdate_correct_value.pass.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = pam
+# variables = var_password_pam_unix_rounds=65536
+
+ROUNDS=65536
+
+config_file=/usr/share/pam-configs/tmp_unix
+
+cat << EOF > "$config_file"
+Name: Unix authentication
+Default: yes
+Priority: 256
+Auth-Type: Primary
+Auth:
+        [success=end default=ignore]    pam_unix.so try_first_pass
+Auth-Initial:
+        [success=end default=ignore]    pam_unix.so
+Account-Type: Primary
+Account:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Account-Initial:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Session-Type: Additional
+Session:
+        required        pam_unix.so
+Session-Initial:
+        required        pam_unix.so
+Password-Type: Primary
+Password:
+        [success=end default=ignore]    pam_unix.so obscure sha512 shadow remember=5 rounds=$ROUNDS
+Password-Initial:
+        [success=end default=ignore]    pam_unix.so obscure sha512 shadow remember=5 rounds=$ROUNDS
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update
+rm $config_file

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/pamupdate_less_rounds.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/pamupdate_less_rounds.fail.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = pam
+# variables = var_password_pam_unix_rounds=65536
+
+ROUNDS=6553
+
+config_file=/usr/share/pam-configs/tmp_unix
+
+cat << EOF > "$config_file"
+Name: Unix authentication
+Default: yes
+Priority: 256
+Auth-Type: Primary
+Auth:
+        [success=end default=ignore]    pam_unix.so try_first_pass
+Auth-Initial:
+        [success=end default=ignore]    pam_unix.so
+Account-Type: Primary
+Account:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Account-Initial:
+        [success=end new_authtok_reqd=done default=ignore]      pam_unix.so
+Session-Type: Additional
+Session:
+        required        pam_unix.so
+Session-Initial:
+        required        pam_unix.so
+Password-Type: Primary
+Password:
+        [success=end default=ignore]    pam_unix.so obscure sha512 shadow remember=5 rounds=$ROUNDS
+Password-Initial:
+        [success=end default=ignore]    pam_unix.so obscure sha512 shadow remember=5 rounds=$ROUNDS
+EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update
+rm $config_file

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/pamupdate_less_rounds.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/pamupdate_less_rounds.fail.sh
@@ -10,7 +10,8 @@ config_file=/usr/share/pam-configs/tmp_unix
 cat << EOF > "$config_file"
 Name: Unix authentication
 Default: yes
-Priority: 256
+Priority: 257
+Conflicts: unix
 Auth-Type: Primary
 Auth:
         [success=end default=ignore]    pam_unix.so try_first_pass


### PR DESCRIPTION
#### Description:

- Implement stig rule UBTU-24-400220
- Implement rule set_password_hashing_algorithm_auth_stig
- Use pam-auth-update to update the rounds value in remediation of rule `accounts_password_pam_unix_rounds_password_auth` for ubuntu
- Make Ubuntu applicable in oval check while ignoring the control type of pam nodule
-  Flag commented parameter in oval: Change regex `.` to `[^#]` 
-  Add tests for pam-auth-update remediation of rule `accounts_password_pam_unix_rounds_password_auth`

#### Rationale:

- STIG v1r1 requires only sha512 can pass the audit. So existing rule set_password_hashing_algorithm_systemauth won't work unless we blindly trust users not modify the variable
- In current oval implementation, `password sufficient pam_unix.so sha512 #rounds=100000` will pass the oval check