### PR TITLE
[template]: Capture exact options

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/bash/shared.sh
@@ -20,12 +20,12 @@ for hash_option in "${HASHING_ALGORITHMS_OPTIONS[@]}"; do
   {{% if 'ubuntu' in product -%}}
     sed -i -E '/^Password:/,/^[^[:space:]]/ {
     /pam_unix\.so/ {
-      s/\s*'"$hash_option"'//g
+      s/\s*\b'"$hash_option"'\b//g
     }
     }' "$PAM_FILE_PATH"
     sed -i -E '/^Password-Initial:/,/^[^[:space:]]/ {
     /pam_unix\.so/ {
-      s/\s*'"$hash_option"'//g
+      s/\s*\b'"$hash_option"'\b//g
     }
     }' "$PAM_FILE_PATH"
     DEBIAN_FRONTEND=noninteractive pam-auth-update

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/bash/shared.sh
@@ -53,6 +53,8 @@ if ! grep -qzP "Password-Initial:\s*\n\s+.*\s+pam_unix.so\s+.*\b$var_password_ha
 }' "$PAM_FILE_PATH"
 fi
 
+DEBIAN_FRONTEND=noninteractive pam-auth-update
+
 {{%- else -%}}
 {{{ bash_ensure_pam_module_configuration("$PAM_FILE_PATH", 'password', control, 'pam_unix.so', "$var_password_hashing_algorithm_pam", '', '') }}}
 {{%- endif %}}

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/bash/shared.sh
@@ -13,6 +13,29 @@ PAM_FILE_PATH="/etc/pam.d/system-auth"
 {{% set control = "sufficient" %}}
 {{%- endif %}}
 
+# Ensure all the hashing algorithm option is removed.
+declare -a HASHING_ALGORITHMS_OPTIONS=("sha512" "yescrypt" "gost_yescrypt" "blowfish" "sha256" "md5" "bigcrypt")
+
+for hash_option in "${HASHING_ALGORITHMS_OPTIONS[@]}"; do
+  {{% if 'ubuntu' in product -%}}
+    sed -i -E '/^Password:/,/^[^[:space:]]/ {
+    /pam_unix\.so/ {
+      s/\s*'"$hash_option"'//g
+    }
+    }' "$PAM_FILE_PATH"
+    sed -i -E '/^Password-Initial:/,/^[^[:space:]]/ {
+    /pam_unix\.so/ {
+      s/\s*'"$hash_option"'//g
+    }
+    }' "$PAM_FILE_PATH"
+    DEBIAN_FRONTEND=noninteractive pam-auth-update
+  {{%- else -%}}
+  if grep -qP "^\s*password\s+.*\s+pam_unix.so\s+.*\b$hash_option\b" "$PAM_FILE_PATH"; then
+    {{{ bash_remove_pam_module_option_configuration("$PAM_FILE_PATH", 'password', ".*", 'pam_unix.so', "$hash_option") }}}
+  fi
+  {{%- endif %}}
+done
+
 {{% if 'ubuntu' in product -%}}
 if ! grep -qzP "Password:\s*\n\s+.*\s+pam_unix.so\s+.*\b$var_password_hashing_algorithm_pam\b" "$PAM_FILE_PATH"; then
   sed -i -E '/^Password:/,/^[^[:space:]]/ {
@@ -33,28 +56,3 @@ fi
 {{%- else -%}}
 {{{ bash_ensure_pam_module_configuration("$PAM_FILE_PATH", 'password', control, 'pam_unix.so', "$var_password_hashing_algorithm_pam", '', '') }}}
 {{%- endif %}}
-
-# Ensure only the correct hashing algorithm option is used.
-declare -a HASHING_ALGORITHMS_OPTIONS=("sha512" "yescrypt" "gost_yescrypt" "blowfish" "sha256" "md5" "bigcrypt")
-
-for hash_option in "${HASHING_ALGORITHMS_OPTIONS[@]}"; do
-  if [ "$hash_option" != "$var_password_hashing_algorithm_pam" ]; then
-    {{% if 'ubuntu' in product -%}}
-      sed -i -E '/^Password:/,/^[^[:space:]]/ {
-      /pam_unix\.so/ {
-        s/\s*'"$hash_option"'//g
-      }
-      }' "$PAM_FILE_PATH"
-      sed -i -E '/^Password-Initial:/,/^[^[:space:]]/ {
-      /pam_unix\.so/ {
-        s/\s*'"$hash_option"'//g
-      }
-      }' "$PAM_FILE_PATH"
-      DEBIAN_FRONTEND=noninteractive pam-auth-update
-    {{%- else -%}}
-    if grep -qP "^\s*password\s+.*\s+pam_unix.so\s+.*\b$hash_option\b" "$PAM_FILE_PATH"; then
-      {{{ bash_remove_pam_module_option_configuration("$PAM_FILE_PATH", 'password', ".*", 'pam_unix.so', "$hash_option") }}}
-    fi
-    {{%- endif %}}
-  fi
-done

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/wrong_value_concat.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/wrong_value_concat.fail.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 # variables = var_password_hashing_algorithm_pam=sha512
+# remediation = none
 
 config_file=/usr/share/pam-configs/tmpunix
 cat << EOF > "$config_file"

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -2415,7 +2415,7 @@ if grep -qP "^\s*{{{ group }}}\s.*\b{{{ module }}}\s.*\b{{{ option }}}\b" "{{{ p
     sed -i -E --follow-symlinks "s/(.*{{{ group }}}.*{{{ module }}}.*)\b{{{ option }}}\b=?[[:alnum:]]*(.*)/\1\2/g" "{{{ pam_file }}}"
 {{%- else %}}
 if grep -qP "^\s*{{{ group }}}\s+{{{ control }}}\s+{{{ module }}}\s.*\b{{{ option }}}\b" "{{{ pam_file }}}"; then
-    sed -i -E --follow-symlinks "s/(.*{{{ group }}}.*{{{ control }}}.*{{{ module }}}.*)\s{{{ option }}}=?[[:alnum:]]*(.*)/\1\2/g" "{{{ pam_file }}}"
+    sed -i -E --follow-symlinks "s/(.*{{{ group }}}.*{{{ control }}}.*{{{ module }}}.*)\b{{{ option }}}\b=?[[:alnum:]]*(.*)/\1\2/g" "{{{ pam_file }}}"
 {{%- endif %}}
 fi
 {{%- endmacro -%}}


### PR DESCRIPTION
#### Description:

- In bash macro bash_remove_pam_module_option, remove **exact** options
- Remove all hash option in advance for rule `set_password_hashing_algorithm_systemauth`

#### Rationale:

- Remove first is cleaner
