### PR TITLE
Align template audit_rules_privileged_commands with DISA

### DIFF
--- a/shared/macros/01-general.jinja
+++ b/shared/macros/01-general.jinja
@@ -1392,6 +1392,13 @@ Create a rule description for rules using the `audit_rules_privileged_commands` 
 {{% macro describe_arpc(path) %}}
 {{%- if product in ["almalinux9", "debian12", "fedora", "ol7", "ol8", "ol9", "ol10", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2004", "ubuntu2204", "ubuntu2404"] %}}
   {{%- set perm_x="-F perm=x " %}}
+{{%- endif -%}}
+{{%- if product == "rhel10" -%}}
+{{% set arch_clause=", setting ARCH to either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit" %}}
+{{% set rule="-a always,exit -F arch=ARCH -F path=" ~ path ~ " " ~ perm_x ~ "-F auid&gt;=" ~ auid ~ " -F auid!=unset -F key=privileged" %}}
+{{% else %}}
+{{% set arch_clause="" %}}
+{{% set rule="-a always,exit -F path=" ~ path ~ " " ~ perm_x ~ "-F auid&gt;=" ~ auid ~ " -F auid!=unset -F key=privileged" %}}
 {{%- endif %}}
     At a minimum, the audit system should collect the execution of privileged
     commands for all users and root.
@@ -1399,15 +1406,11 @@ Create a rule description for rules using the `audit_rules_privileged_commands` 
     If the <tt>auditd</tt> daemon is configured to use the <tt>augenrules</tt>
     program to read audit rules during daemon startup (the default), add
     a line of the following form to a file with suffix <tt>.rules</tt>
-    in the directory <tt>/etc/audit/rules.d</tt>, setting ARCH to either b32
-    for 32-bit system, or having two lines for both b32 and b64 in case your
-    system is 64-bit:
-    <pre>-a always,exit -F arch=ARCH -F path={{{ path }}} {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    in the directory <tt>/etc/audit/rules.d</tt>{{{ arch_clause }}}:
+    <pre>{{{ rule }}}</pre>
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add a line of the
-    following form to <tt>/etc/audit/audit.rules</tt>, setting ARCH to either
-    b32 for 32-bit system, or having two lines for both b32 and b64 in case
-    your system is 64-bit:
-    <pre>-a always,exit -F arch=ARCH -F path={{{ path }}} {{{ perm_x }}}-F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    following form to <tt>/etc/audit/audit.rules</tt>{{{ arch_clause }}}:
+    <pre>{{{ rule }}}</pre>
 {{%- endmacro -%}}

--- a/shared/templates/audit_rules_privileged_commands/ansible.template
+++ b/shared/templates/audit_rules_privileged_commands/ansible.template
@@ -7,6 +7,7 @@
 # complexity = low
 # disruption = low
 
+{{% if product == "rhel10" %}}
 - name: {{{ rule_title }}} - Set architecture for audit {{{ PATH }}}
   set_fact:
     audit_arch: "b64"
@@ -54,3 +55,23 @@
       syscall_grouping=SYSCALL_GROUPING,
       )|indent(4) }}}
   when: audit_arch == "b64"
+{{% else %}}
+- name: {{{ rule_title }}} - Perform remediation of Audit rules for {{{ PATH }}}
+  block:
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit",
+      other_filters="-F path="~PATH~perm_x,
+      auid_filters="-F auid>="~auid~" -F auid!=unset",
+      syscalls=SYSCALL,
+      key="privileged",
+      syscall_grouping=SYSCALL_GROUPING,
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit",
+      other_filters="-F path="~PATH~perm_x,
+      auid_filters="-F auid>="~auid~" -F auid!=unset",
+      syscalls=SYSCALL,
+      key="privileged",
+      syscall_grouping=SYSCALL_GROUPING,
+      )|indent(4) }}}
+{{% endif %}}

--- a/shared/templates/audit_rules_privileged_commands/bash.template
+++ b/shared/templates/audit_rules_privileged_commands/bash.template
@@ -11,6 +11,7 @@ SYSCALL=""
 KEY="privileged"
 SYSCALL_GROUPING="{{{ SYSCALL_GROUPING }}}"
 
+{{% if product == "rhel10" %}}
 for ARCH in "${RULE_ARCHS[@]}"
 do
   ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
@@ -18,3 +19,9 @@ do
   {{{ bash_fix_audit_syscall_rule("augenrules", "$ACTION_ARCH_FILTERS", "$OTHER_FILTERS", "$AUID_FILTERS", "$SYSCALL", "$SYSCALL_GROUPING", "$KEY") }}}
   {{{ bash_fix_audit_syscall_rule("auditctl", "$ACTION_ARCH_FILTERS", "$OTHER_FILTERS", "$AUID_FILTERS", "$SYSCALL", "$SYSCALL_GROUPING", "$KEY") }}}
 done
+{{% else %}}
+ACTION_ARCH_FILTERS="-a always,exit"
+# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
+{{{ bash_fix_audit_syscall_rule("augenrules", "$ACTION_ARCH_FILTERS", "$OTHER_FILTERS", "$AUID_FILTERS", "$SYSCALL", "$SYSCALL_GROUPING", "$KEY") }}}
+{{{ bash_fix_audit_syscall_rule("auditctl", "$ACTION_ARCH_FILTERS", "$OTHER_FILTERS", "$AUID_FILTERS", "$SYSCALL", "$SYSCALL_GROUPING", "$KEY") }}}
+{{% endif %}}

--- a/shared/templates/audit_rules_privileged_commands/bash.template
+++ b/shared/templates/audit_rules_privileged_commands/bash.template
@@ -4,7 +4,6 @@
 # platform = multi_platform_all
 
 # Retrieve hardware architecture of the underlying system
-[ "$(getconf LONG_BIT)" = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b32" "b64")
 OTHER_FILTERS="-F path={{{ PATH }}}{{{ perm_x }}}"
 AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
 SYSCALL=""
@@ -12,6 +11,7 @@ KEY="privileged"
 SYSCALL_GROUPING="{{{ SYSCALL_GROUPING }}}"
 
 {{% if product == "rhel10" %}}
+[ "$(getconf LONG_BIT)" = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b32" "b64")
 for ARCH in "${RULE_ARCHS[@]}"
 do
   ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"

--- a/shared/templates/audit_rules_privileged_commands/kubernetes.template
+++ b/shared/templates/audit_rules_privileged_commands/kubernetes.template
@@ -17,7 +17,11 @@ spec:
     storage:
       files:
       - contents:
+{{% if product == "rhel10" %}}
           source: data:,-a%20always%2Cexit%20-F%20arch%3Db32%20-F%20path%3D{{{ PATH }}}{{{ perm_x }}}%20-F%20auid%3E%3D{{{ auid }}}%20-F%20auid%21%3Dunset%20-F%20key%3Dprivileged%0A-a%20always%2Cexit%20-F%20arch%3Db64%20-F%20path%3D{{{ PATH }}}{{{ perm_x }}}%20-F%20auid%3E%3D{{{ auid }}}%20-F%20auid%21%3Dunset%20-F%20key%3Dprivileged%0A
+{{% else %}}
+          source: data:,-a%20always%2Cexit%20-F%20path%3D{{{ PATH }}}{{{ perm_x }}}%20-F%20auid%3E%3D{{{ auid }}}%20-F%20auid%21%3Dunset%20-F%20key%3Dprivileged%0A
+{{% endif %}}
         mode: 0644
         path: /etc/audit/rules.d/75-{{{ NORMALIZED_PATH }}}_execution.rules
         overwrite: true

--- a/shared/templates/audit_rules_privileged_commands/oval.template
+++ b/shared/templates/audit_rules_privileged_commands/oval.template
@@ -6,47 +6,55 @@
     {{{ oval_metadata("Audit rules about the information on the use of " + NAME + " is enabled.") }}}
 
     <criteria operator="OR">
-
-      <!-- Test the augenrules case -->
+{{% for audit_tool in ["augenrules", "auditctl"] %}}
+      <!-- Test the {{{ audit_tool }}} case -->
       <criteria operator="AND">
-        <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
-        <criterion comment="audit augenrules 32-bit {{{ NAME }}}" test_ref="test_{{{ rule_id }}}_augenrules_32bit" />
+        <extend_definition comment="audit {{{ audit_tool }}}" definition_ref="audit_rules_{{{ audit_tool }}}" />
+{{% if product == "rhel10" %}}
+        <criterion comment="audit {{{ audit_tool }}} 32-bit {{{ NAME }}}" test_ref="test_{{{ rule_id }}}_{{{ audit_tool }}}_32bit" />
         <criteria operator="OR">
           <!-- System either isn't 64-bit => we just check presence of 32-bit version of {{{ NAME }}} audit rule -->
           <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" negate="true" />
           <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of {{{ NAME }}} audit rule -->
-          <criterion comment="audit augenrules 64-bit {{{ NAME }}}" test_ref="test_{{{ rule_id }}}_augenrules_64bit" />
+          <criterion comment="audit {{{ audit_tool }}} 64-bit {{{ NAME }}}" test_ref="test_{{{ rule_id }}}_{{{ audit_tool }}}_64bit" />
         </criteria>
+{{% else %}}
+        <criterion comment="audit {{{ audit_tool }}} {{{ NAME }}}" test_ref="test_{{{ rule_id }}}_{{{ audit_tool }}}" />
+{{% endif %}}
       </criteria>
-
-      <!-- Test the auditctl case -->
-      <criteria operator="AND">
-        <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
-        <criterion comment="audit auditctl 32-bit {{{ NAME }}}" test_ref="test_{{{ rule_id }}}_auditctl_32bit" />
-        <criteria operator="OR">
-          <!-- System either isn't 64-bit => we just check presence of 32-bit version of the {{{ NAME }}} audit rule -->
-          <extend_definition comment="64-bit system" definition_ref="system_info_architecture_64bit" negate="true" />
-          <!-- Or system is 64-bit => in that case we also need to verify the presence of 64-bit version of {{{ NAME }}} audit rule -->
-          <criterion comment="audit auditctl 64-bit {{{ NAME }}}" test_ref="test_{{{ rule_id }}}_auditctl_64bit" />
-        </criteria>
-      </criteria>
+{{% endfor %}}
     </criteria>
   </definition>
 
-{{% macro arpc_tftst(audit_tool, filepath, bits) %}}
-  <ind:textfilecontent54_test check="all" check_existence="only_one_exists" comment="audit {{{ audit_tool }}} {{{ NAME }}}" id="test_{{{ rule_id }}}_{{{ audit_tool }}}_{{{ bits }}}bit" version="1">
-    <ind:object object_ref="object_{{{ rule_id }}}_{{{ audit_tool }}}_{{{ bits }}}bit" />
+{{% macro arpc_tftst(audit_tool, bits=None) %}}
+{{% set id_root = rule_id ~ "_" ~ audit_tool %}}
+{{% set arch_regex = "" %}}
+{{% if bits != None %}}
+{{% set id_root = id_root ~ "_" ~ bits ~ "bit" %}}
+{{% set arch_regex = "-F[\s]+arch=b" ~ bits ~ "[\s]+" %}}
+{{% endif %}}
+{{% if audit_tool == "augenrules" %}}
+{{% set filepath = "^/etc/audit/rules\.d/.*\.rules$" %}}
+{{% elif audit_tool == "auditctl" %}}
+{{% set filepath = "/etc/audit/audit.rules" %}}
+{{% endif %}}
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists" comment="audit {{{ audit_tool }}} {{{ NAME }}}" id="test_{{{ id_root }}}" version="1">
+    <ind:object object_ref="object_{{{ id_root }}}" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_{{{ rule_id }}}_{{{ audit_tool }}}_{{{ bits }}}bit" version="1">
+  <ind:textfilecontent54_object id="object_{{{ id_root }}}" version="1">
     <ind:filepath operation="pattern match">{{{ filepath }}}</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b{{{ bits }}}[\s]+-F[\s]+path={{{ PATH }}}{{{ perm_x }}}[\s]+-F[\s]+auid>={{{ auid }}}[\s]+-F[\s]+auid!=(?:4294967295|unset|-1)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+{{{ arch_regex }}}-F[\s]+path={{{ PATH }}}{{{ perm_x }}}[\s]+-F[\s]+auid>={{{ auid }}}[\s]+-F[\s]+auid!=(?:4294967295|unset|-1)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 {{% endmacro %}}
 
-{{{ arpc_tftst("augenrules", "^/etc/audit/rules\.d/.*\.rules$", "32") }}}
-{{{ arpc_tftst("augenrules", "^/etc/audit/rules\.d/.*\.rules$", "64") }}}
-{{{ arpc_tftst("auditctl", "/etc/audit/audit.rules", "32") }}}
-{{{ arpc_tftst("auditctl", "/etc/audit/audit.rules", "64") }}}
+{{% for audit_tool in ["augenrules", "auditctl"] %}}
+{{% if product == "rhel10" %}}
+{{{ arpc_tftst(audit_tool, "32") }}}
+{{{ arpc_tftst(audit_tool, "64") }}}
+{{% else %}}
+{{{ arpc_tftst(audit_tool) }}}
+{{% endif %}}
+{{% endfor %}}
 
 </def-group>

--- a/shared/templates/audit_rules_privileged_commands/tests/auditctl_correct_value.pass.sh
+++ b/shared/templates/audit_rules_privileged_commands/tests/auditctl_correct_value.pass.sh
@@ -4,5 +4,9 @@ source common.sh
 
 {{{ setup_auditctl_environment() }}}
 
+{{% if product == "rhel10" %}}
 echo "-a always,exit -F arch=b32 -F path={{{ PATH }}} ${perm_x} -F auid>={{{ auid }}} -F auid!=unset -k test_key" >> /etc/audit/audit.rules
 echo "-a always,exit -F arch=b64 -F path={{{ PATH }}} ${perm_x} -F auid>={{{ auid }}} -F auid!=unset -k test_key" >> /etc/audit/audit.rules
+{{% else %}}
+echo "-a always,exit -F path={{{ PATH }}} ${perm_x} -F auid>={{{ auid }}} -F auid!=unset -k test_key" >> /etc/audit/audit.rules
+{{% endif %}}

--- a/shared/templates/audit_rules_privileged_commands/tests/auditctl_missing_arch.fail.sh
+++ b/shared/templates/audit_rules_privileged_commands/tests/auditctl_missing_arch.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # packages = audit
+# platform = Red Hat Enterprise Linux 10
 source common.sh
 
 {{{ setup_auditctl_environment() }}}

--- a/shared/templates/audit_rules_privileged_commands/tests/auditctl_missing_perm_x.fail.sh
+++ b/shared/templates/audit_rules_privileged_commands/tests/auditctl_missing_perm_x.fail.sh
@@ -6,5 +6,9 @@ source common.sh
 
 {{{ setup_auditctl_environment() }}}
 
+{{% if product == "rhel10" %}}
 echo "-a always,exit -F arch=b32 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -k test_key" >> /etc/audit/audit.rules
 echo "-a always,exit -F arch=b64 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -k test_key" >> /etc/audit/audit.rules
+{{% else %}}
+echo "-a always,exit -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -k test_key" >> /etc/audit/audit.rules
+{{% endif %}}

--- a/shared/templates/audit_rules_privileged_commands/tests/augenrules_comented_value.fail.sh
+++ b/shared/templates/audit_rules_privileged_commands/tests/augenrules_comented_value.fail.sh
@@ -2,5 +2,9 @@
 
 source common.sh
 
+{{% if product == "rhel10" %}}
 echo "# -a always,exit -F arch=b32 -F path={{{ PATH }}} ${perm_x} -F auid>={{{ auid }}} -F auid!=unset -k test_key" >> /etc/audit/rules.d/test_key.rules
 echo "# -a always,exit -F arch=b64 -F path={{{ PATH }}} ${perm_x} -F auid>={{{ auid }}} -F auid!=unset -k test_key" >> /etc/audit/rules.d/test_key.rules
+{{% else %}}
+echo "# -a always,exit -F path={{{ PATH }}} ${perm_x} -F auid>={{{ auid }}} -F auid!=unset -k test_key" >> /etc/audit/rules.d/test_key.rules
+{{% endif %}}

--- a/shared/templates/audit_rules_privileged_commands/tests/augenrules_correct_value.pass.sh
+++ b/shared/templates/audit_rules_privileged_commands/tests/augenrules_correct_value.pass.sh
@@ -2,5 +2,9 @@
 
 source common.sh
 
+{{% if product == "rhel10" %}}
 echo "-a always,exit -F arch=b32 -F path={{{ PATH }}} ${perm_x} -F auid>={{{ auid }}} -F auid!=unset -k test_key" >> /etc/audit/rules.d/test_key.rules
 echo "-a always,exit -F arch=b64 -F path={{{ PATH }}} ${perm_x} -F auid>={{{ auid }}} -F auid!=unset -k test_key" >> /etc/audit/rules.d/test_key.rules
+{{% else %}}
+echo "-a always,exit -F path={{{ PATH }}} ${perm_x} -F auid>={{{ auid }}} -F auid!=unset -k test_key" >> /etc/audit/rules.d/test_key.rules
+{{% endif %}}

--- a/shared/templates/audit_rules_privileged_commands/tests/augenrules_missing_arch.fail.sh
+++ b/shared/templates/audit_rules_privileged_commands/tests/augenrules_missing_arch.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = Red Hat Enterprise Linux 10
 
 source common.sh
 

--- a/shared/templates/audit_rules_privileged_commands/tests/augenrules_missing_auid.fail.sh
+++ b/shared/templates/audit_rules_privileged_commands/tests/augenrules_missing_auid.fail.sh
@@ -2,5 +2,9 @@
 
 source common.sh
 
+{{% if product == "rhel10" %}}
 echo "-a always,exit -F arch=b32 -F path={{{ PATH }}} ${perm_x} -F auid!=unset -k test_key" >> /etc/audit/rules.d/test_key.rules
 echo "-a always,exit -F arch=b64 -F path={{{ PATH }}} ${perm_x} -F auid!=unset -k test_key" >> /etc/audit/rules.d/test_key.rules
+{{% else %}}
+echo "-a always,exit -F path={{{ PATH }}} ${perm_x} -F auid!=unset -k test_key" >> /etc/audit/rules.d/test_key.rules
+{{% endif %}}


### PR DESCRIPTION
Recently, we have updated the `audit_rules_privileged_commands` template to align the audit rules format with audit rules recommendations for RHEL 10. However, our productization test runs revealed that the new form isn't aligned with DISA STIG requirements.

The misalignment is that we expect 2 lines for each binary, the lines contain architecture filters `-F arch=b32` or `-F arch=b64`, but DISA expects a single line for each binary, without architecture filters.

Both our variant and DISA's variant are valid. Both of them work and could be accepted. But, our variant is better, because by having 2 rules each for different architecture we are telling audit which syscall table should be used. OTOH DISA's variant leaves everything up to the kernel's decision. As a result, our variant provides higher performance of the watched application than DISA's variant.

To solve the misalignment with DISA content, we will use the architecture specific two line rule only on RHEL 10 and we will use the architecture independent single line rule format on RHELs older than 10. The reason is that for RHEL 10 there is no DISA STIG yet, so on RHEL 10 we couldn't experience any misalignment with DISA content.

Fixes: https://github.com/ComplianceAsCode/content/issues/13272

#### Review Hints:

1. Run Automatus test on both RHEL 10 and RHEL 9 for any rule that uses the `audit_rules_privileged_commands` template, for example `audit_rules_execution_chacl` or `audit_rules_privileged_commands_chage`.
2. `./autocontest.sh test --distro rhel-9.5 --content-path /home/jcerny/work/git/scap-security-guide/ -t "/scanning/disa-alignment/oscap" -h <HOSTNAME>`