### PR TITLE
sssd_enable_certmap: notify test scenario that there is no remediation

### DIFF
--- a/linux_os/guide/services/sssd/sssd_enable_certmap/tests/default.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_certmap/tests/default.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# remediation = none
 
 touch /etc/sssd/sssd.conf
 sed -i "s/\[certmap.*//g" /etc/sssd/sssd.conf


### PR DESCRIPTION
#### Description:

- do not expect that the rule will be remediated when testing

#### Rationale:

- align test scenario expectations


#### Review Hints:

Use automatus.