### PR TITLE
Add tar.gz file of the build data streams

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
         working-directory: ./build
       - name: Set Version
         id: set_version
-        run: |- 
+        run: |-
           echo "tag=${GITHUB_REF/refs\/tags\//}"  >> $GITHUB_OUTPUT
           echo "ver=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_OUTPUT
         env:
@@ -56,5 +56,7 @@ jobs:
             build/scap-security-guide-*.tar.bz2.sha512
             build/zipfile/scap-security-guide-*.zip
             build/zipfile/scap-security-guide-*.zip.sha512
+            build/zipfile/scap-security-guide-*.tar.gz
+            build/zipfile/scap-security-guide-*.tar.gz.sha512
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -1285,6 +1285,7 @@ endmacro()
 macro(ssg_build_zipfile ZIPNAME)
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/zipfile/${ZIPNAME}.zip"
+        OUTPUT "${CMAKE_BINARY_DIR}/zipfile/${ZIPNAME}.tar.gz"
         COMMAND ${CMAKE_COMMAND} -E remove_directory "zipfile/"
         COMMAND ${CMAKE_COMMAND} -E make_directory "zipfile/${ZIPNAME}"
         COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_SOURCE_DIR}/README.md" "zipfile/${ZIPNAME}"
@@ -1304,7 +1305,9 @@ macro(ssg_build_zipfile ZIPNAME)
         COMMAND ${CMAKE_COMMAND} -E make_directory "zipfile/${ZIPNAME}/manifests"
         COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/*/manifest-*.json" -DDEST="zipfile/${ZIPNAME}/manifests" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
         COMMAND ${CMAKE_COMMAND} -E chdir "zipfile" ${CMAKE_COMMAND} -E tar "cvf" "${ZIPNAME}.zip" --format=zip "${ZIPNAME}"
+        COMMAND ${CMAKE_COMMAND} -E chdir "zipfile" ${CMAKE_COMMAND} -E tar "czvf" "${ZIPNAME}.tar.gz" "${ZIPNAME}"
         COMMAND ${CMAKE_COMMAND} -E chdir "zipfile" ${CMAKE_COMMAND} -E sha512sum "${ZIPNAME}.zip" > "zipfile/${ZIPNAME}.zip.sha512"
+        COMMAND ${CMAKE_COMMAND} -E chdir "zipfile" ${CMAKE_COMMAND} -E sha512sum "${ZIPNAME}.tar.gz" > "zipfile/${ZIPNAME}.tar.gz.sha512"
         COMMENT "Building zipfile at ${CMAKE_BINARY_DIR}/zipfile/${ZIPNAME}.zip"
     )
 endmacro()
@@ -1312,5 +1315,6 @@ macro(ssg_build_zipfile_target ZIPNAME)
     add_custom_target(
         zipfile
         DEPENDS "${CMAKE_BINARY_DIR}/zipfile/${ZIPNAME}.zip"
+        DEPENDS "${CMAKE_BINARY_DIR}/zipfile/${ZIPNAME}.tar.gz"
     )
 endmacro()


### PR DESCRIPTION

#### Description:

This PR adds tar.gz file of the built data streams. These will be part of the release artifacts.

Something to think about is file naming. I'm open to suggestions.

After this change we will a `tar.gz` and `.zip` with the built content. Then we also also have a `.tar.bz2` with the source. All of these files start with `scap-security-guide-0.1.77`. The only way to tell what is what (this is even true without this change) is by file size. The 100+ MB file is the built data streams and the smaller (~8.0 MB) is the source. Even today our release pages don't make that very clear.

#### Rationale:

Addresses #13305

#### Review Hints:
These might take while.

1. `rm -rf build/*`
2. `cd build`
3. `cmake -G Ninja ..`
4. `ninja -j$(nproc) zipfile`
