### PR TITLE
Mark wireless_disable_interfaces as notapplicable to containers

### DIFF
--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/rule.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/rule.yml
@@ -138,4 +138,4 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} wireless network adapters must be disabled.'
 
-platform: wifi-iface
+platform: wifi-iface and not container


### PR DESCRIPTION
Rule wireless_disable_interfaces is currently applicable during bootable container image build, on a deployed Image Mode RHEL system and also if the image is run as a podman container. In this commit, we will change this applicability situation. The reason is that during the image build the environment doesn't have the wireless network interface that it will have if deployed as Image Mode RHEL system. The rule won't be applicable during bootable container image build and also won't be applicable if the image is run as a podman container. On the other hand, the rule will stay applicable on a deployed Image Mode RHEL system.

Fixes: https://issues.redhat.com/browse/OPENSCAP-5323
