### PR TITLE
Add several rules and vars to Ubuntu 24.04 STIG

### DIFF
--- a/controls/stig_ubuntu2404.yml
+++ b/controls/stig_ubuntu2404.yml
@@ -311,12 +311,12 @@ controls:
       of inactivity.
     levels:
       - medium
-    related_rules:
-      - inactivity_timeout_value=15_minutes
+    rules:
+      - inactivity_timeout_value=10_minutes
       - var_screensaver_lock_delay=immediate
       - dconf_gnome_screensaver_idle_delay
       - dconf_gnome_screensaver_lock_delay
-    status: planned
+    status: automated
 
   - id: UBTU-24-200040
     title: Ubuntu 24.04 LTS must retain a user's session lock until the user reestablishes
@@ -332,10 +332,10 @@ controls:
       timeouts have expired.
     levels:
       - medium
-    related_rules:
-      - var_accounts_tmout=15_min
+    rules:
+      - var_accounts_tmout=10_min
       - accounts_tmout
-    status: planned
+    status: automated
 
   - id: UBTU-24-200090
     title: Ubuntu 24.04 LTS must monitor remote access methods.
@@ -1666,9 +1666,9 @@ controls:
     title: Ubuntu 24.04 LTS must configure the audit tools to be group-owned by root.
     levels:
       - medium
-    related_rules:
+    rules:
       - file_groupownership_audit_binaries
-    status: planned
+    status: automated
 
   - id: UBTU-24-901260
     title: Ubuntu 24.04 LTS must have directories that contain system commands set
@@ -1748,6 +1748,6 @@ controls:
       change.
     levels:
       - medium
-    related_rules:
+    rules:
       - audit_rules_immutable
-    status: planned
+    status: automated

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/comment_profile.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/comment_profile.fail.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+{{% if 'ubuntu' in product %}}
+# platform = Not Applicable
+{{% endif %}}
+
 # variables = var_accounts_tmout=600
 
 sed -i "/.*TMOUT.*/d" /etc/profile.d/*.sh

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/conflicting_values_diff_file.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/conflicting_values_diff_file.fail.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+{{% if 'ubuntu' in product %}}
+# platform = Not Applicable
+{{% endif %}}
+
 # variables = var_accounts_tmout=700
 
 sed -i "/.*TMOUT.*/d" /etc/profile /etc/profile.d/*.sh /etc/bashrc

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/conflicting_values_same_file.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/conflicting_values_same_file.fail.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+{{% if 'ubuntu' in product %}}
+# platform = Not Applicable
+{{% endif %}}
+
 # variables = var_accounts_tmout=700
 
 sed -i "/.*TMOUT.*/d" /etc/profile /etc/profile.d/*.sh /etc/bashrc

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/correct_value_profile.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/correct_value_profile.pass.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+{{% if 'ubuntu' in product %}}
+# platform = Not Applicable
+{{% endif %}}
+
 # variables = var_accounts_tmout=700
 
 sed -i "/.*TMOUT.*/d" /etc/profile.d/*.sh

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/correct_value_profile_d.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/correct_value_profile_d.pass.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+{{% if 'ubuntu' in product %}}
+# platform = Not Applicable
+{{% endif %}}
+
 # variables = var_accounts_tmout=700
 
 TEST_FILE=/etc/profile.d/tmout.sh

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/correct_value_profile_declare.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/correct_value_profile_declare.pass.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+{{% if 'ubuntu' in product %}}
+# platform = Not Applicable
+{{% endif %}}
+
 # variables = var_accounts_tmout=700
 
 sed -i "/.*TMOUT.*/d" /etc/profile.d/*.sh

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/duplicate_correct_value_diff_files.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/duplicate_correct_value_diff_files.pass.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+{{% if 'ubuntu' in product %}}
+# platform = Not Applicable
+{{% endif %}}
+
 # variables = var_accounts_tmout=700
 
 sed -i "/.*TMOUT.*/d" /etc/profile /etc/profile.d/*.sh

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/duplicate_correct_value_profile.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/duplicate_correct_value_profile.pass.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+{{% if 'ubuntu' in product %}}
+# platform = Not Applicable
+{{% endif %}}
+
 # variables = var_accounts_tmout=700
 
 sed -i "/.*TMOUT.*/d" /etc/profile.d/*.sh

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/duplicate_correct_value_profile_d.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/duplicate_correct_value_profile_d.pass.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+{{% if 'ubuntu' in product %}}
+# platform = Not Applicable
+{{% endif %}}
+
 # variables = var_accounts_tmout=700
 
 sed -i "/.*TMOUT.*/d" /etc/profile

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/multiline.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/multiline.pass.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-# platform = multi_platform_sle
+# platform = multi_platform_sle,multi_platform_ubuntu
 # variables = var_accounts_tmout=700
 
 if grep -q "TMOUT" /etc/profile; then
-	sed -i "s/.*TMOUT.*/TMOUT=700; readonly TMOUT; export TMOUT/" /etc/profile
+	sed -i "s/.*TMOUT.*/TMOUT=700\nreadonly TMOUT\nexport TMOUT/" /etc/profile
 else
-	echo "TMOUT=700; readonly TMOUT; export TMOUT" >> /etc/profile
+	echo -e "TMOUT=700\nreadonly TMOUT\nexport TMOUT" >> /etc/profile
 fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/multiline_profile.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/multiline_profile.fail.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-# platform = multi_platform_sle
+# platform = multi_platform_sle,multi_platform_ubuntu
 # variables = var_accounts_tmout=900
 
 sed -i "/.*TMOUT.*/d" /etc/profile.d/*.sh
 
 if grep -q "TMOUT" /etc/profile; then
-	sed -i "s/.*TMOUT.*/TMOUT=950; readonly TMOUT; export TMOUT/" /etc/profile
+	sed -i "s/.*TMOUT.*/TMOUT=950\nreadonly TMOUT\nexport TMOUT/" /etc/profile
 else
-	echo "TMOUT=950; readonly TMOUT; export TMOUT" >> /etc/profile
+	echo -e "TMOUT=950\nreadonly TMOUT\nexport TMOUT" >> /etc/profile
 fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/multiline_profile_d.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/multiline_profile_d.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# platform = multi_platform_sle
+# platform = multi_platform_sle,multi_platform_ubuntu
 # variables = var_accounts_tmout=900
 
 TEST_FILE=/etc/profile.d/tmout.sh
@@ -10,7 +10,7 @@ sed -i "/.*TMOUT.*/d" /etc/profile
 test -f $TEST_FILE || touch $TEST_FILE
 
 if grep -q "TMOUT" $TEST_FILE; then
-	sed -i "s/.*TMOUT.*/TMOUT=950; readonly TMOUT; export TMOUT/" $TEST_FILE
+	sed -i "s/.*TMOUT.*/TMOUT=950\nreadonly TMOUT\nexport TMOUT/" $TEST_FILE
 else
-	echo "TMOUT=950; readonly TMOUT; export TMOUT" >> $TEST_FILE
+	echo -e "TMOUT=950\nreadonly TMOUT\nexport TMOUT" >> $TEST_FILE
 fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/multiline_profile_d.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/multiline_profile_d.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# platform = multi_platform_sle
+# platform = multi_platform_sle,multi_platform_ubuntu
 # variables = var_accounts_tmout=700
 
 TEST_FILE=/etc/profile.d/tmout.sh
@@ -10,7 +10,7 @@ sed -i "/.*TMOUT.*/d" /etc/profile
 test -f $TEST_FILE || touch $TEST_FILE
 
 if grep -q "TMOUT" $TEST_FILE; then
-	sed -i "s/.*TMOUT.*/TMOUT=700; readonly TMOUT; export TMOUT/" $TEST_FILE
+	sed -i "s/.*TMOUT.*/TMOUT=700\nreadonly TMOUT\nexport TMOUT/" $TEST_FILE
 else
-	echo "TMOUT=700; readonly TMOUT; export TMOUT" >> $TEST_FILE
+	echo -e "TMOUT=700\nreadonly TMOUT\nexport TMOUT" >> $TEST_FILE
 fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/supercompliance_profile.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/supercompliance_profile.pass.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+{{% if 'ubuntu' in product %}}
+# platform = Not Applicable
+{{% endif %}}
+
 # variables = var_accounts_tmout=900
 
 sed -i "/.*TMOUT.*/d" /etc/profile.d/*.sh

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/supercompliance_profile_d.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/supercompliance_profile_d.pass.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+{{% if 'ubuntu' in product %}}
+# platform = Not Applicable
+{{% endif %}}
+
 # variables = var_accounts_tmout=900
 
 TEST_FILE=/etc/profile.d/tmout.sh


### PR DESCRIPTION
#### Description:

- Add rules and vars for Ubuntu 24.04 STIG controls UBTU-24-200020, UBTU-24-200060, UBTU-24-901250, UBTU-24-909000.
- Fix tests for rule `accounts_tmout`

