### PR TITLE
network_configure_name_resolution: test scenarios know there is no remediation

### DIFF
--- a/linux_os/guide/system/network/network_configure_name_resolution/tests/commented_nameservers.fail.sh
+++ b/linux_os/guide/system/network/network_configure_name_resolution/tests/commented_nameservers.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # platform = multi_platform_all
+# remediation = none
 
 source common.sh
 

--- a/linux_os/guide/system/network/network_configure_name_resolution/tests/dns_not_in_nsswitch_and_resolv_isnt_empty.fail.sh
+++ b/linux_os/guide/system/network/network_configure_name_resolution/tests/dns_not_in_nsswitch_and_resolv_isnt_empty.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # platform = multi_platform_ol,multi_platform_rhel,multi_platform_almalinux
+# remediation = none
 
 source common.sh
 

--- a/linux_os/guide/system/network/network_configure_name_resolution/tests/one_nameserver.fail.sh
+++ b/linux_os/guide/system/network/network_configure_name_resolution/tests/one_nameserver.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # platform = multi_platform_all
+# remediation = none
 
 source common.sh
 


### PR DESCRIPTION
#### Description:

- signal to test scenarios that the rule has no remediation

#### Rationale:

- aligning test scenario expectations


#### Review Hints:

Run automatus on the rule.