### PR TITLE
package_pam_pwquality_installed: add custom test scenarios

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/package_pam_pwquality_installed/tests/custom-package-removed.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/package_pam_pwquality_installed/tests/custom-package-removed.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# platform = multi_platform_rhel,multi_platform_fedora
+
+# Package libpwquality cannot be uninstalled normally
+# as it would cause removal of sudo package which is
+# protected and package manager returns error in such
+# case. If the package would be removed forcefully it
+# would make the system unusable. Therefore, we will
+# remove the package only from RPM database
+rpm -e --nodeps --justdb libpwquality

--- a/linux_os/guide/system/accounts/accounts-pam/package_pam_pwquality_installed/tests/test_config.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/package_pam_pwquality_installed/tests/test_config.yml
@@ -1,0 +1,2 @@
+allow_templated_scenarios:
+  - package-installed.pass.sh


### PR DESCRIPTION
#### Description:

- do not remove the package, just fake it

#### Rationale:

- the sudo package depends on libpwquality and therefore libpwquality cannot be removed without rendering the system unusable


#### Review Hints:

Use Automatus.