### PR TITLE
RHEL: remove talk related rules

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -1298,8 +1298,10 @@ controls:
     - package_rsh_removed
     - package_rsh-server_removed
     - package_sendmail_removed
+    {{%- if "rhel" not in product %}}
     - package_talk_removed
     - package_talk-server_removed
+    {{%- endif %}}
     - package_telnet_removed
     - package_telnet-server_removed
     - package_tftp_removed

--- a/controls/e8.yml
+++ b/controls/e8.yml
@@ -11,8 +11,10 @@ controls:
             - base
         title: 'Application and operating system patching'
         rules:
+            {{%- if "rhel" not in product %}}
             - package_talk_removed
             - package_talk-server_removed
+            {{%- endif %}}
             - package_ypbind_removed
             - package_telnet_removed
             - service_telnet_disabled

--- a/controls/hipaa.yml
+++ b/controls/hipaa.yml
@@ -354,8 +354,10 @@ controls:
             - service_rexec_disabled
             - service_rlogin_disabled
             - service_rsh_disabled
+            {{%- if "rhel" not in product %}}
             - package_talk-server_removed
             - package_talk_removed
+           {{%- endif %}}
             - package_telnet-server_removed
             - package_telnet_removed
             - service_telnet_disabled

--- a/products/rhel8/profiles/e8.profile
+++ b/products/rhel8/profiles/e8.profile
@@ -21,8 +21,6 @@ description: |-
 selections:
 
   ### Remove obsolete packages
-  - package_talk_removed
-  - package_talk-server_removed
   - package_xinetd_removed
   - service_xinetd_disabled
   - package_ypbind_removed

--- a/products/rhel8/profiles/hipaa.profile
+++ b/products/rhel8/profiles/hipaa.profile
@@ -41,8 +41,6 @@ selections:
     - sshd_disable_root_login
     - libreswan_approved_tunnels
     - no_rsh_trust_files
-    - package_talk_removed
-    - package_talk-server_removed
     - package_telnet_removed
     - package_telnet-server_removed
     - package_xinetd_removed

--- a/products/rhel9/profiles/e8.profile
+++ b/products/rhel9/profiles/e8.profile
@@ -21,8 +21,6 @@ description: |-
 selections:
 
   ### Remove obsolete packages
-  - package_talk_removed
-  - package_talk-server_removed
   - package_telnet_removed
   - service_telnet_disabled
   - package_telnet-server_removed

--- a/products/rhel9/profiles/hipaa.profile
+++ b/products/rhel9/profiles/hipaa.profile
@@ -45,8 +45,6 @@ selections:
     - sshd_disable_root_login
     - libreswan_approved_tunnels
     - no_rsh_trust_files
-    - package_talk_removed
-    - package_talk-server_removed
     - package_telnet_removed
     - package_telnet-server_removed
     - package_cron_installed

--- a/tests/data/profile_stability/rhel8/e8.profile
+++ b/tests/data/profile_stability/rhel8/e8.profile
@@ -76,8 +76,6 @@ selections:
 - package_rear_installed
 - package_rsyslog_installed
 - package_squid_removed
-- package_talk-server_removed
-- package_talk_removed
 - package_telnet-server_removed
 - package_telnet_removed
 - package_xinetd_removed


### PR DESCRIPTION
#### Description:

- remove rules related to talk and talk-server package from all RHEL profiles

#### Rationale:

- these packages do not exist in rhel* products in this repo



#### Review Hints:

- build the content and inspect rules in pofiles