### PR TITLE
Fix not-applicable tests in template pam_account_password_faillock

### DIFF
--- a/shared/macros/20-test-scenarios.jinja
+++ b/shared/macros/20-test-scenarios.jinja
@@ -67,6 +67,7 @@ TEST_VALUE=4
 TEST_VALUE=6
 {{% elif state == "lenient_low" %}}
 # there is no lower limit so the test should be not-applicable
+# platform = Not Applicable (rule does not set a lower boundary for '{{{ PRM_NAME }}}')
 {{% endif %}}
 
 {{% elif VARIABLE_LOWER_BOUND == "use_ext_variable" and VARIABLE_UPPER_BOUND is number %}}
@@ -93,6 +94,7 @@ TEST_VALUE=5
 TEST_VALUE=6
 {{% elif state == "lenient_high" %}}
 # there is no upper limit so the test should be not-applicable
+# platform = Not Applicable (rule does not set an upper boundary for '{{{ PRM_NAME }}}')
 {{% elif state == "lenient_low" %}}
 # variables = {{{ EXT_VARIABLE }}}=5
 TEST_VALUE=4

--- a/shared/templates/pam_account_password_faillock/tests/pam_faillock_lenient_high_faillock_conf.fail.sh
+++ b/shared/templates/pam_account_password_faillock/tests/pam_faillock_lenient_high_faillock_conf.fail.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
+{{{ tests_init_faillock_vars("lenient_high") }}}
 # packages = authselect
 # platform = multi_platform_fedora,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,Oracle Linux 8
 
-{{{ tests_init_faillock_vars("lenient_high") }}}
 
 authselect select sssd --force
 authselect enable-feature with-faillock

--- a/shared/templates/pam_account_password_faillock/tests/pam_faillock_lenient_high_pam_files.fail.sh
+++ b/shared/templates/pam_account_password_faillock/tests/pam_faillock_lenient_high_pam_files.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+{{{ tests_init_faillock_vars("lenient_high") }}}
 # packages = authconfig
 # platform = Oracle Linux 7,multi_platform_fedora
 
-{{{ tests_init_faillock_vars("lenient_high") }}}
 
 authconfig --enablefaillock --faillockargs="$PRM_NAME=$TEST_VALUE" --update

--- a/shared/templates/pam_account_password_faillock/tests/pam_faillock_lenient_low_faillock_conf.fail.sh
+++ b/shared/templates/pam_account_password_faillock/tests/pam_faillock_lenient_low_faillock_conf.fail.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
+{{{ tests_init_faillock_vars("lenient_low") }}}
 # packages = authselect
 # platform = multi_platform_fedora,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,Oracle Linux 8
 
-{{{ tests_init_faillock_vars("lenient_low") }}}
 
 authselect select sssd --force
 authselect enable-feature with-faillock

--- a/shared/templates/pam_account_password_faillock/tests/pam_faillock_lenient_low_pam_files.fail.sh
+++ b/shared/templates/pam_account_password_faillock/tests/pam_faillock_lenient_low_pam_files.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+{{{ tests_init_faillock_vars("lenient_low") }}}
 # packages = authconfig
 # platform = Oracle Linux 7,multi_platform_fedora
 
-{{{ tests_init_faillock_vars("lenient_low") }}}
 
 authconfig --enablefaillock --faillockargs="$PRM_NAME=$TEST_VALUE" --update

--- a/shared/templates/pam_account_password_faillock/tests/ubuntu_lenient_high.fail.sh
+++ b/shared/templates/pam_account_password_faillock/tests/ubuntu_lenient_high.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+{{{ tests_init_faillock_vars("lenient_high") }}}
 # platform = multi_platform_ubuntu
 
-{{{ tests_init_faillock_vars("lenient_high") }}}
 
 {{{ bash_enable_pam_faillock_directly_in_pam_files() }}}
 

--- a/shared/templates/pam_account_password_faillock/tests/ubuntu_lenient_low.fail.sh
+++ b/shared/templates/pam_account_password_faillock/tests/ubuntu_lenient_low.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
+{{{ tests_init_faillock_vars("lenient_low") }}}
 # platform = multi_platform_ubuntu
 
-{{{ tests_init_faillock_vars("lenient_low") }}}
 
 {{{ bash_enable_pam_faillock_directly_in_pam_files() }}}
 


### PR DESCRIPTION
#### Description:

Tests in template `pam_account_password_faillock` use the macro `tests_init_faillock_vars` to define individual test parameters and values based on the required state (correct, strict, lenient_high, lenient_low).

Two test scenarios, which should result in not-applicable, were not properly implemented and resulted in error:
- lenient_high + no upper boundary
- lenient_low + no lower boundary

This fix inserts an additional `# platform = Not Applicable` to the top of the test script for those cases.

#### Rationale:

- Fixes #13319