### PR TITLE
Make overrding tests work in built tests

### DIFF
--- a/build-scripts/build_tests.py
+++ b/build-scripts/build_tests.py
@@ -181,13 +181,10 @@ def _process_rules(env_yaml: Dict, output_path: pathlib.Path,
 
         rule_tests_root = rule_root / "tests"
         rule_output_path = output_path / rule_id
-
-        if rule_tests_root.exists():
-            _process_local_tests(product, env_yaml, rule_output_path, rule_tests_root)
         if rendered_rule_obj["template"] is not None:
             _process_templated_tests(env_yaml, rendered_rule_obj, templates_root, rule_output_path)
-
-
+        if rule_tests_root.exists():
+            _process_local_tests(product, env_yaml, rule_output_path, rule_tests_root)
 
 
 def _get_rules_in_profile(built_profiles_root) -> Generator[str, None, None]:

--- a/build-scripts/build_tests.py
+++ b/build-scripts/build_tests.py
@@ -188,12 +188,6 @@ def _process_rules(env_yaml: Dict, output_path: pathlib.Path,
             _process_templated_tests(env_yaml, rendered_rule_obj, templates_root, rule_output_path)
 
 
-def _get_benchmark_cpes(env_yaml) -> Set[str]:
-    benchmark_cpes = set()
-    for cpe in env_yaml["cpes"]:
-        for _, data in cpe.items():
-            benchmark_cpes.add(data["name"])
-    return benchmark_cpes
 
 
 def _get_rules_in_profile(built_profiles_root) -> Generator[str, None, None]:


### PR DESCRIPTION
#### Description:

Make overriding templated tests work for built tests by making the templated tests be built first. This allow the local tests to override the template tests.

#### Rationale:

Make the built tests work as expected.

#### Review Hints:

Build the tests (`export ADDITIONAL_CMAKE_OPTIONS="-DSSG_BUILT_TESTS_ENABLED:BOOL=ON"
`) on master and this branch. See that overridden test scenario, the rule `dconf_gnome_lock_screen_on_smartcard_removal` has one, now work correctly.