### PR TITLE
OCPBUGS-55030: Only exclude FIO rules on ARM64

### DIFF
--- a/applications/openshift/general/file_integrity_notification_enabled/rule.yml
+++ b/applications/openshift/general/file_integrity_notification_enabled/rule.yml
@@ -1,7 +1,7 @@
 
 title: Ensure the notification is enabled for file integrity operator
 
-platform: x86_64_arch and not ocp4-on-hypershift
+platform: not aarch64_arch and not ocp4-on-hypershift
 
 description: |-
   The OpenShift platform provides the File Integrity Operator to monitor for unwanted

--- a/applications/openshift/integrity/file_integrity_exists/rule.yml
+++ b/applications/openshift/integrity/file_integrity_exists/rule.yml
@@ -1,7 +1,7 @@
 
 title: Ensure that File Integrity Operator is scanning the cluster
 
-platform: x86_64_arch and not ocp4-on-hypershift
+platform: not aarch64_arch and not ocp4-on-hypershift
 
 description: |-
   {{{ weblink(link="https://docs.openshift.com/container-platform/4.7/security/file_integrity_operator/file-integrity-operator-understanding.html",


### PR DESCRIPTION
These rules should run fine on Power, but the logic to only include them
for x86_64 meant they weren't included on those platforms.

This commit updates the platform condition to exclude them only on
aarch64 and hypershift, which should include them on x64 and power
installs.
