### PR TITLE
postfix_client_configure_mail_alias: adjust test scenario

### DIFF
--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/tests/correct.pass.sh
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/tests/correct.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 # packages = postfix
+# variables = var_postfix_root_mail_alias=change_me@localhost
 
 echo "root: change_me@localhost" > /etc/aliases

--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/tests/correct.pass.sh
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/tests/correct.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # packages = postfix
 
-echo "root: system.administrator@mail.mil" > /etc/aliases
+echo "root: change_me@localhost" > /etc/aliases

--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/tests/wrong.fail.sh
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/tests/wrong.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 # packages = postfix
+# variables = var_postfix_root_mail_alias=change_me@localhost
 
 echo "root: invalid_address" > /etc/aliases


### PR DESCRIPTION
#### Description:

- correct test scenario: use the same text which is used in the default variable

#### Rationale:

- the text which was there before was aligned with a different variable


#### Review Hints:

Use automatus to test the rule.