### PR TITLE
[Ubuntu]: Ensure single line of pam_unix exist during testing

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/ubuntu_arg_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/ubuntu_arg_missing.fail.sh
@@ -5,7 +5,8 @@ config_file=/usr/share/pam-configs/tmpunix
 cat << EOF > "$config_file"
 Name: Unix authentication
 Default: yes
-Priority: 256
+Priority: 257
+Conflicts: unix
 Auth-Type: Primary
 Auth:
         [success=end default=ignore]    pam_unix.so try_first_pass

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/ubuntu_correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/ubuntu_correct_value.pass.sh
@@ -8,7 +8,8 @@ remember_cnt=5
 cat << EOF > "$config_file"
 Name: Unix authentication
 Default: yes
-Priority: 256
+Priority: 257
+Conflicts: unix
 Auth-Type: Primary
 Auth:
         [success=end default=ignore]    pam_unix.so try_first_pass

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/ubuntu_wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/ubuntu_wrong_value.fail.sh
@@ -8,7 +8,8 @@ remember_cnt=3
 cat << EOF > "$config_file"
 Name: Unix authentication
 Default: yes
-Priority: 256
+Priority: 257
+Conflicts: unix
 Auth-Type: Primary
 Auth:
         [success=end default=ignore]    pam_unix.so try_first_pass

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/commented_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/commented_value.fail.sh
@@ -7,7 +7,8 @@ config_file=/usr/share/pam-configs/tmpunix
 cat << EOF > "$config_file"
 Name: Unix authentication
 Default: yes
-Priority: 256
+Priority: 257
+Conflicts: unix
 Auth-Type: Primary
 Auth:
         [success=end default=ignore]    pam_unix.so try_first_pass

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/correct.pass.sh
@@ -7,7 +7,8 @@ config_file=/usr/share/pam-configs/tmpunix
 cat << EOF > "$config_file"
 Name: Unix authentication
 Default: yes
-Priority: 256
+Priority: 257
+Conflicts: unix
 Auth-Type: Primary
 Auth:
         [success=end default=ignore]    pam_unix.so try_first_pass

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/missing.fail.sh
@@ -7,7 +7,8 @@ config_file=/usr/share/pam-configs/tmpunix
 cat << EOF > "$config_file"
 Name: Unix authentication
 Default: yes
-Priority: 256
+Priority: 257
+Conflicts: unix
 Auth-Type: Primary
 Auth:
         [success=end default=ignore]    pam_unix.so try_first_pass

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/wrong_value_concat.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/wrong_value_concat.fail.sh
@@ -6,7 +6,8 @@ config_file=/usr/share/pam-configs/tmpunix
 cat << EOF > "$config_file"
 Name: Unix authentication
 Default: yes
-Priority: 256
+Priority: 257
+Conflicts: unix
 Auth-Type: Primary
 Auth:
         [success=end default=ignore]    pam_unix.so try_first_pass

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/tests/no_remember.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/tests/no_remember.pass.sh
@@ -7,7 +7,8 @@ config_file=/usr/share/pam-configs/tmpunix
 cat << EOF > "$config_file"
 Name: Unix authentication
 Default: yes
-Priority: 256
+Priority: 257
+Conflicts: unix
 Auth-Type: Primary
 Auth:
         [success=end default=ignore]    pam_unix.so try_first_pass

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/tests/remember_commented.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/tests/remember_commented.pass.sh
@@ -7,7 +7,8 @@ config_file=/usr/share/pam-configs/tmpunix
 cat << EOF > "$config_file"
 Name: Unix authentication
 Default: yes
-Priority: 256
+Priority: 257
+Conflicts: unix
 Auth-Type: Primary
 Auth:
         [success=end default=ignore]    pam_unix.so try_first_pass

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/tests/remember_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_no_remember/tests/remember_present.fail.sh
@@ -7,7 +7,8 @@ config_file=/usr/share/pam-configs/tmpunix
 cat << EOF > "$config_file"
 Name: Unix authentication
 Default: yes
-Priority: 256
+Priority: 257
+Conflicts: unix
 Auth-Type: Primary
 Auth:
         [success=end default=ignore]    pam_unix.so try_first_pass

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/no_nullok.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/no_nullok.pass.sh
@@ -8,7 +8,8 @@ config_file=/usr/share/pam-configs/tmp_unix
 cat << EOF > "$config_file"
 Name: Unix authentication
 Default: yes
-Priority: 256
+Priority: 257
+Conflicts: unix
 Auth-Type: Primary
 Auth:
 	[success=end default=ignore]	pam_unix.so nullok try_first_pass

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_commented.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_commented.pass.sh
@@ -8,7 +8,8 @@ config_file=/usr/share/pam-configs/tmp_unix
 cat << EOF > "$config_file"
 Name: Unix authentication
 Default: yes
-Priority: 256
+Priority: 257
+Conflicts: unix
 Auth-Type: Primary
 Auth:
 	[success=end default=ignore]	pam_unix.so nullok try_first_pass

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_present.fail.sh
@@ -8,7 +8,8 @@ config_file=/usr/share/pam-configs/tmp_unix
 cat << EOF > "$config_file"
 Name: Unix authentication
 Default: yes
-Priority: 256
+Priority: 257
+Conflicts: unix
 Auth-Type: Primary
 Auth:
 	[success=end default=ignore]	pam_unix.so nullok try_first_pass

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_unix/tests/no_nullok.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_unix/tests/no_nullok.pass.sh
@@ -8,7 +8,8 @@ cat << EOF > "$config_file"
 Name: Unix authentication
 Conflicts: unix
 Default: yes
-Priority: 256
+Priority: 257
+Conflicts: unix
 Auth-Type: Primary
 Auth:
 	[success=end default=ignore]	pam_unix.so try_first_pass

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_unix/tests/nullok_commented.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_unix/tests/nullok_commented.pass.sh
@@ -8,7 +8,8 @@ cat << EOF > "$config_file"
 Name: Unix authentication
 Conflicts: unix
 Default: yes
-Priority: 256
+Priority: 257
+Conflicts: unix
 Auth-Type: Primary
 Auth:
 	[success=end default=ignore]	pam_unix.so try_first_pass # nullok

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_unix/tests/nullok_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_unix/tests/nullok_present.fail.sh
@@ -8,7 +8,8 @@ cat << EOF > "$config_file"
 Name: Unix authentication
 Conflicts: unix
 Default: yes
-Priority: 256
+Priority: 257
+Conflicts: unix
 Auth-Type: Primary
 Auth:
 	[success=end default=ignore]	pam_unix.so nullok try_first_pass


### PR DESCRIPTION
#### Description:

- Declare Conflicts field for Ubuntu rule that related to pam_unix

#### Rationale:

- The clean Ubuntu will have unix conf already which will cause duplicate lines with test scripts. 
- Another default configure for pam_pwquality already has conflicts field setup