### PR TITLE
Improve match patterns in CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,9 @@
+# Global Owners
+/ssg/ @vojtapolasek @jan-cerny @mab879 @ggbecker
+/tests/ @matusmarhefka @mab879 @vojtapolasek @jan-cerny
+/linux_os/**/tests @matusmarhefka @mab879 @vojtapolasek @jan-cerny
+/shared/**/tests @matusmarhefka @mab879 @vojtapolasek @jan-cerny
+
 # Products
 
 /tests/data/product_stability/rhel*.yml @ComplianceAsCode/red-hatters
@@ -19,7 +25,3 @@
 /controls/cis_sle12.yml @ComplianceAsCode/suse-maintainers
 /controls/cis_sle15.yml @ComplianceAsCode/suse-maintainers
 /controls/cis_ubuntu2404.yml @ComplianceAsCode/ubuntu-maintainers
-
-# Global Owners
-/ssg @vojtapolasek @jan-cerny @mab879 @ggbecker
-/tests @matusmarhefka @mab879 @vojtapolasek @jan-cerny


### PR DESCRIPTION
The patterns in the CODEOWNERS needed a reshuffle because the last matching pattern takes the most precedence, see
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
This is needed because, for example, right now https://github.com/ComplianceAsCode/content/blob/master/tests/data/product_stability/ubuntu2404.yml is not owned by Ubuntu maintainers and that is incorrect.

Also added owners for test scenarios under `linux_os` and templated test scenarios under `shared` directory.

Follow-up of https://github.com/ComplianceAsCode/content/pull/13333