### PR TITLE
systemd_mount_enabled template: enable mount in passing test scenario

### DIFF
--- a/shared/templates/systemd_mount_enabled/tests/mount_enabled.pass.sh
+++ b/shared/templates/systemd_mount_enabled/tests/mount_enabled.pass.sh
@@ -2,4 +2,5 @@
 
 SYSTEMCTL_EXEC='/usr/bin/systemctl'
 "$SYSTEMCTL_EXEC" unmask '{{{ MOUNTNAME }}}.mount'
+"$SYSTEMCTL_EXEC" enable '{{{ MOUNTNAME }}}.mount'
 "$SYSTEMCTL_EXEC" start '{{{ MOUNTNAME }}}.mount'


### PR DESCRIPTION
#### Description:

- run the enable systemd command in the passing test scenario

#### Rationale:

- the OVAL expect the unit to b enabled, but the test scenario did not do this in the past


#### Review Hints:

Use automatus.