### PR TITLE
Remove rule enable_authselect from RHEL10

### DIFF
--- a/controls/cis_rhel10.yml
+++ b/controls/cis_rhel10.yml
@@ -28,18 +28,6 @@ controls:
     rules:
       - dconf_db_up_to_date
 
-  - id: enable_authselect
-    title: Enable Authselect
-    levels:
-      - l1_server
-      - l1_workstation
-    notes: <-
-      We need this in all CIS versions, but the policy doesn't have any section where this would fit better.
-    status: automated
-    rules:
-      - var_authselect_profile=sssd
-      - enable_authselect
-
   - id: 1.1.1.6
     title: Ensure squashfs kernel module is not available (Automated)
     levels:

--- a/products/rhel10/profiles/anssi_bp28_enhanced.profile
+++ b/products/rhel10/profiles/anssi_bp28_enhanced.profile
@@ -23,6 +23,7 @@ description: |-
 selections:
     - anssi:all:enhanced
     # Following rules are incompatible with rhel10 product
+    - '!enable_authselect'
     # tally2 is deprecated, replaced by faillock
     - '!accounts_passwords_pam_tally2_deny_root'
     - '!accounts_passwords_pam_tally2'

--- a/products/rhel10/profiles/anssi_bp28_high.profile
+++ b/products/rhel10/profiles/anssi_bp28_high.profile
@@ -25,6 +25,7 @@ selections:
     # the following rule renders UEFI systems unbootable
     - '!sebool_secure_mode_insmod'
     # Following rules are incompatible with rhel10 product
+    - '!enable_authselect'
     # tally2 is deprecated, replaced by faillock
     - '!accounts_passwords_pam_tally2_deny_root'
     - '!accounts_passwords_pam_tally2'

--- a/products/rhel10/profiles/anssi_bp28_intermediary.profile
+++ b/products/rhel10/profiles/anssi_bp28_intermediary.profile
@@ -23,6 +23,7 @@ description: |-
 selections:
     - anssi:all:intermediary
     # Following rules are incompatible with rhel10 product
+    - '!enable_authselect'
     # tally2 is deprecated, replaced by faillock
     - '!accounts_passwords_pam_tally2_deny_root'
     - '!accounts_passwords_pam_tally2'

--- a/products/rhel10/profiles/anssi_bp28_minimal.profile
+++ b/products/rhel10/profiles/anssi_bp28_minimal.profile
@@ -23,6 +23,7 @@ description: |-
 selections:
     - anssi:all:minimal
     # Following rules are incompatible with rhel10 product
+    - '!enable_authselect'
     # tally2 is deprecated, replaced by faillock
     - '!accounts_passwords_pam_tally2_deny_root'
     - '!accounts_passwords_pam_tally2'

--- a/products/rhel10/profiles/default.profile
+++ b/products/rhel10/profiles/default.profile
@@ -21,3 +21,4 @@ selections:
   - configure_tmux_lock_command
   - configure_tmux_lock_keybinding
   - audit_rules_session_events
+  - enable_authselect

--- a/products/rhel10/profiles/e8.profile
+++ b/products/rhel10/profiles/e8.profile
@@ -22,6 +22,7 @@ description: |-
 
 selections:
     - e8:all
+    - '!enable_authselect'
     # nosha1 crypto policy does not exist in RHEL 10
     - var_system_crypto_policy=default_policy
     # More tests are needed to identify which rule is conflicting with rpm_verify_permissions.

--- a/products/rhel10/profiles/hipaa.profile
+++ b/products/rhel10/profiles/hipaa.profile
@@ -36,6 +36,7 @@ selections:
     - '!coreos_enable_selinux_kernel_argument'
     - '!dconf_gnome_remote_access_credential_prompt'
     - '!dconf_gnome_remote_access_encryption'
+    - '!enable_authselect'
     - '!ensure_suse_gpgkey_installed'
     - '!ensure_fedora_gpgkey_installed'
     - '!ensure_almalinux_gpgkey_installed'

--- a/products/rhel10/profiles/ism_o.profile
+++ b/products/rhel10/profiles/ism_o.profile
@@ -29,6 +29,7 @@ extends: e8
 selections:
     - ism_o:all:base
     # these rules do not work properly on RHEL 10 for now
+    - '!enable_authselect'
     - '!enable_dracut_fips_module'
     - '!firewalld_sshd_port_enabled'
     - '!require_singleuser_auth'

--- a/products/rhel10/profiles/ism_o_secret.profile
+++ b/products/rhel10/profiles/ism_o_secret.profile
@@ -31,6 +31,7 @@ extends: e8
 selections:
     - ism_o:all:secret
     # these rules do not work properly on RHEL 10 for now
+    - '!enable_authselect'
     - '!enable_dracut_fips_module'
     - '!firewalld_sshd_port_enabled'
     - '!require_singleuser_auth'

--- a/products/rhel10/profiles/ism_o_top_secret.profile
+++ b/products/rhel10/profiles/ism_o_top_secret.profile
@@ -29,6 +29,7 @@ extends: e8
 selections:
     - ism_o:all:top_secret
     # these rules do not work properly on RHEL 10 for now
+    - '!enable_authselect'
     - '!enable_dracut_fips_module'
     - '!firewalld_sshd_port_enabled'
     - '!require_singleuser_auth'

--- a/products/rhel10/profiles/ospp.profile
+++ b/products/rhel10/profiles/ospp.profile
@@ -24,3 +24,4 @@ selections:
     - '!package_dnf-plugin-subscription-manager_installed'
     # Currently not working RHEL 10, changes are being made to FIPS mode. Investigation is recommended.
     - '!enable_dracut_fips_module'
+    - '!enable_authselect'

--- a/products/rhel10/profiles/pci-dss.profile
+++ b/products/rhel10/profiles/pci-dss.profile
@@ -36,6 +36,7 @@ selections:
     - '!rpm_verify_permissions'
 
     # these rules do not apply to RHEL 10
+    - '!enable_authselect'
     - '!package_audit-audispd-plugins_installed'
     - '!package_dhcp_removed'
     - '!package_ypserv_removed'

--- a/products/rhel10/profiles/stig.profile
+++ b/products/rhel10/profiles/stig.profile
@@ -20,5 +20,6 @@ description: |-
 
 selections:
     - srg_gpos:all
+    - '!enable_authselect'
     # Currently not working RHEL 10, changes are being made to FIPS mode. Investigation is recommended.
     - '!enable_dracut_fips_module'

--- a/products/rhel10/profiles/stig_gui.profile
+++ b/products/rhel10/profiles/stig_gui.profile
@@ -27,6 +27,7 @@ selections:
 
     - '!package_nfs-utils_removed'
 
+    - '!enable_authselect'
     # Limiting user namespaces cause issues with user apps, such as Firefox and Cheese
     # https://issues.redhat.com/browse/RHEL-10416
     - '!sysctl_user_max_user_namespaces'

--- a/tests/data/profile_stability/rhel10/anssi_bp28_enhanced.profile
+++ b/tests/data/profile_stability/rhel10/anssi_bp28_enhanced.profile
@@ -121,7 +121,6 @@ selections:
 - directory_permissions_etc_sysctld
 - dnf-automatic_apply_updates
 - dnf-automatic_security_updates_only
-- enable_authselect
 - enable_pam_namespace
 - ensure_gpgcheck_globally_activated
 - ensure_gpgcheck_local_packages

--- a/tests/data/profile_stability/rhel10/anssi_bp28_high.profile
+++ b/tests/data/profile_stability/rhel10/anssi_bp28_high.profile
@@ -125,7 +125,6 @@ selections:
 - directory_permissions_etc_sysctld
 - dnf-automatic_apply_updates
 - dnf-automatic_security_updates_only
-- enable_authselect
 - enable_pam_namespace
 - ensure_gpgcheck_globally_activated
 - ensure_gpgcheck_local_packages

--- a/tests/data/profile_stability/rhel10/anssi_bp28_intermediary.profile
+++ b/tests/data/profile_stability/rhel10/anssi_bp28_intermediary.profile
@@ -63,7 +63,6 @@ selections:
 - directory_permissions_etc_sysctld
 - dnf-automatic_apply_updates
 - dnf-automatic_security_updates_only
-- enable_authselect
 - enable_pam_namespace
 - ensure_gpgcheck_globally_activated
 - ensure_gpgcheck_local_packages

--- a/tests/data/profile_stability/rhel10/anssi_bp28_minimal.profile
+++ b/tests/data/profile_stability/rhel10/anssi_bp28_minimal.profile
@@ -33,7 +33,6 @@ selections:
 - dir_perms_world_writable_sticky_bits
 - dnf-automatic_apply_updates
 - dnf-automatic_security_updates_only
-- enable_authselect
 - ensure_gpgcheck_globally_activated
 - ensure_gpgcheck_local_packages
 - ensure_gpgcheck_never_disabled

--- a/tests/data/profile_stability/rhel10/cis.profile
+++ b/tests/data/profile_stability/rhel10/cis.profile
@@ -137,7 +137,6 @@ selections:
 - dir_perms_world_writable_sticky_bits
 - directory_permissions_var_log_audit
 - disable_host_auth
-- enable_authselect
 - ensure_gpgcheck_globally_activated
 - ensure_pam_wheel_group_empty
 - ensure_root_password_configured
@@ -442,7 +441,6 @@ selections:
 - cis_banner_text=cis
 - var_system_crypto_policy=default_policy
 - var_selinux_policy_name=targeted
-- var_authselect_profile=sssd
 - var_accounts_passwords_pam_faillock_dir=run
 - var_auditd_action_mail_acct=root
 - var_auditd_admin_space_left_action=cis_rhel8

--- a/tests/data/profile_stability/rhel10/cis_server_l1.profile
+++ b/tests/data/profile_stability/rhel10/cis_server_l1.profile
@@ -70,7 +70,6 @@ selections:
 - dconf_gnome_session_idle_user_locks
 - dir_perms_world_writable_sticky_bits
 - disable_host_auth
-- enable_authselect
 - ensure_gpgcheck_globally_activated
 - ensure_pam_wheel_group_empty
 - ensure_root_password_configured
@@ -346,7 +345,6 @@ selections:
 - cis_banner_text=cis
 - var_system_crypto_policy=default_policy
 - var_selinux_policy_name=targeted
-- var_authselect_profile=sssd
 unselected_groups: []
 platforms: !!set {}
 cpe_names: !!set {}

--- a/tests/data/profile_stability/rhel10/cis_workstation_l1.profile
+++ b/tests/data/profile_stability/rhel10/cis_workstation_l1.profile
@@ -68,7 +68,6 @@ selections:
 - dconf_gnome_session_idle_user_locks
 - dir_perms_world_writable_sticky_bits
 - disable_host_auth
-- enable_authselect
 - ensure_gpgcheck_globally_activated
 - ensure_pam_wheel_group_empty
 - ensure_root_password_configured
@@ -338,7 +337,6 @@ selections:
 - cis_banner_text=cis
 - var_system_crypto_policy=default_policy
 - var_selinux_policy_name=targeted
-- var_authselect_profile=sssd
 unselected_groups: []
 platforms: !!set {}
 cpe_names: !!set {}

--- a/tests/data/profile_stability/rhel10/cis_workstation_l2.profile
+++ b/tests/data/profile_stability/rhel10/cis_workstation_l2.profile
@@ -137,7 +137,6 @@ selections:
 - dir_perms_world_writable_sticky_bits
 - directory_permissions_var_log_audit
 - disable_host_auth
-- enable_authselect
 - ensure_gpgcheck_globally_activated
 - ensure_pam_wheel_group_empty
 - ensure_root_password_configured
@@ -437,7 +436,6 @@ selections:
 - cis_banner_text=cis
 - var_system_crypto_policy=default_policy
 - var_selinux_policy_name=targeted
-- var_authselect_profile=sssd
 - var_accounts_passwords_pam_faillock_dir=run
 - var_auditd_action_mail_acct=root
 - var_auditd_admin_space_left_action=cis_rhel8

--- a/tests/data/profile_stability/rhel10/e8.profile
+++ b/tests/data/profile_stability/rhel10/e8.profile
@@ -57,7 +57,6 @@ selections:
 - configure_ssh_crypto_policy
 - dir_perms_world_writable_sticky_bits
 - dnf-automatic_security_updates_only
-- enable_authselect
 - ensure_gpgcheck_globally_activated
 - ensure_gpgcheck_local_packages
 - ensure_gpgcheck_never_disabled

--- a/tests/data/profile_stability/rhel10/hipaa.profile
+++ b/tests/data/profile_stability/rhel10/hipaa.profile
@@ -125,7 +125,6 @@ selections:
 - disable_ctrlaltdel_burstaction
 - disable_ctrlaltdel_reboot
 - disable_host_auth
-- enable_authselect
 - encrypt_partitions
 - ensure_gpgcheck_globally_activated
 - ensure_gpgcheck_local_packages

--- a/tests/data/profile_stability/rhel10/ism_o.profile
+++ b/tests/data/profile_stability/rhel10/ism_o.profile
@@ -101,7 +101,6 @@ selections:
 - disable_host_auth
 - dnf-automatic_apply_updates
 - dnf-automatic_security_updates_only
-- enable_authselect
 - enable_fips_mode
 - enable_ldap_client
 - ensure_gpgcheck_globally_activated

--- a/tests/data/profile_stability/rhel10/ism_o_secret.profile
+++ b/tests/data/profile_stability/rhel10/ism_o_secret.profile
@@ -104,7 +104,6 @@ selections:
 - disable_host_auth
 - dnf-automatic_apply_updates
 - dnf-automatic_security_updates_only
-- enable_authselect
 - enable_fips_mode
 - enable_ldap_client
 - ensure_gpgcheck_globally_activated

--- a/tests/data/profile_stability/rhel10/ism_o_top_secret.profile
+++ b/tests/data/profile_stability/rhel10/ism_o_top_secret.profile
@@ -101,7 +101,6 @@ selections:
 - disable_host_auth
 - dnf-automatic_apply_updates
 - dnf-automatic_security_updates_only
-- enable_authselect
 - enable_fips_mode
 - enable_ldap_client
 - ensure_gpgcheck_globally_activated

--- a/tests/data/profile_stability/rhel10/ospp.profile
+++ b/tests/data/profile_stability/rhel10/ospp.profile
@@ -82,7 +82,6 @@ selections:
 - disable_ctrlaltdel_reboot
 - disable_host_auth
 - dnf-automatic_apply_updates
-- enable_authselect
 - enable_fips_mode
 - ensure_gpgcheck_globally_activated
 - ensure_gpgcheck_local_packages

--- a/tests/data/profile_stability/rhel10/pci-dss.profile
+++ b/tests/data/profile_stability/rhel10/pci-dss.profile
@@ -116,7 +116,6 @@ selections:
 - disable_host_auth
 - disable_users_coredumps
 - display_login_attempts
-- enable_authselect
 - ensure_gpgcheck_globally_activated
 - ensure_gpgcheck_never_disabled
 - ensure_pam_wheel_group_empty

--- a/tests/data/profile_stability/rhel10/stig.profile
+++ b/tests/data/profile_stability/rhel10/stig.profile
@@ -219,7 +219,6 @@ selections:
 - disallow_bypass_password_sudo
 - display_login_attempts
 - dnf-automatic_apply_updates
-- enable_authselect
 - enable_fips_mode
 - encrypt_partitions
 - ensure_gpgcheck_globally_activated

--- a/tests/data/profile_stability/rhel10/stig_gui.profile
+++ b/tests/data/profile_stability/rhel10/stig_gui.profile
@@ -219,7 +219,6 @@ selections:
 - disallow_bypass_password_sudo
 - display_login_attempts
 - dnf-automatic_apply_updates
-- enable_authselect
 - enable_fips_mode
 - encrypt_partitions
 - ensure_gpgcheck_globally_activated


### PR DESCRIPTION
Authselect is the default package to configure PAM service files, and it's enabled by default and at the same time it's impossible to disable. Therefore, the rule enable_authselect is superfluous and we will remove it from all RHEL 10 profiles. We will keep the rule as a part of the hidden default profile.

Resolves: https://issues.redhat.com/browse/OPENSCAP-4691

