### PR TITLE
Fix description in accounts_set_post_pw_existing

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_set_post_pw_existing/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_set_post_pw_existing/rule.yml
@@ -6,7 +6,7 @@ title: 'Set existing passwords a period of inactivity before they been locked'
 description: |-
     Configure user accounts that have been inactive for over a given period of time
     to be automatically disabled by running the following command:
-    <pre>$ sudo chage --inactive 30<i>USER</i></pre>
+    <pre>$ sudo chage --inactive 30 USER</pre>
 
 rationale: |-
     Inactive accounts pose a threat to system security since the users are not logging in to


### PR DESCRIPTION
There should be a space in the example command between 30 and USER.

Resolves: https://issues.redhat.com/browse/OPENSCAP-4715
