### PR TITLE
add variable to network providers and add cilium per default

### DIFF
--- a/applications/openshift/networking/configure_network_policies/rule.yml
+++ b/applications/openshift/networking/configure_network_policies/rule.yml
@@ -50,6 +50,5 @@ template:
     yamlpath: "[:]"
     check_existence: "any_exist"
     entity_check: "all"
-    values:
-      - value: "OpenShiftSDN|OVN|Calico"
-        operation: "pattern match"
+    regex_data: "true"
+    xccdf_variable: var_configure_network_policies_regex

--- a/applications/openshift/networking/var_configure_network_policies_regex.var
+++ b/applications/openshift/networking/var_configure_network_policies_regex.var
@@ -1,0 +1,20 @@
+documentation_complete: true
+
+title: 'Network Provider which provide Support for Network Policies'
+
+description: |-
+    Regular expression explicitly describing
+    which CNI plugins provide the cluster with the
+    network policies feature/capability
+    You can chose to either allow multiple providers
+    by adding them like "Provider1|Provider2" or only
+    allow one, by overwriting the value
+
+type: string
+
+operator: equals
+
+interactive: true
+
+options:
+  default: "OpenShiftSDN|OVN|Calico|Cilium"


### PR DESCRIPTION
#### Description:

This PR adds Cilium to the default regex which is checked to see if the CNI Plugin used provides support for network-policies. This PR also makes this value configurable

#### Rationale:

Cilium does support Network Policies in different styles: https://docs.cilium.io/en/latest/security/policy/index.html
Also making it configurable, allows people to define their own values in the variable without changing sourcecode

#### Review Hints:

I did not have a Cilium Cluster at Hand. Therefore I checked with default CIS Profile

and a tailored profile which changes the regex and creates a false result in my environment (as expected)
```
apiVersion: compliance.openshift.io/v1alpha1
kind: TailoredProfile
metadata:
  name: test-tailoredprofile-ciliumonly
spec:
  description: Example of a tailoredProfile that extends OCP4 FedRAMP Moderate
  extends: ocp4-cis
  setValues:
    - name: ocp4-var-configure-network-policies-regex
      rationale: testing Cilium
      value: Cilium
  title: My little profile
```
