### PR TITLE
Improve description in accounts_passwords_pam_faillock_dir

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/rule.yml
@@ -17,6 +17,9 @@ description: |-
 
     The chosen profile expects the directory to be <tt>{{{ xccdf_value("var_accounts_passwords_pam_faillock_dir") }}}</tt>.
 
+    To configure the tally directory, add the following line to <tt>/etc/security/faillock.conf</tt>:
+    <pre>dir = {{{ xccdf_value("var_accounts_passwords_pam_faillock_dir") }}}</pre>
+
 rationale: |-
     Locking out user accounts after a number of incorrect attempts prevents direct password
     guessing attacks. In combination with the <tt>silent</tt> option, user enumeration attacks


### PR DESCRIPTION
We should mention that the directory is changed by setting the "dir" option in /etc/security/faillock.conf.

Resolves: https://issues.redhat.com/browse/OPENSCAP-4714

