### PR TITLE
Change the algorithm to yescript

### DIFF
--- a/products/rhel10/profiles/anssi_bp28_enhanced.profile
+++ b/products/rhel10/profiles/anssi_bp28_enhanced.profile
@@ -22,6 +22,7 @@ description: |-
 
 selections:
     - anssi:all:enhanced
+    - var_password_hashing_algorithm_pam=yescrypt
     # Following rules are incompatible with rhel10 product
     - '!enable_authselect'
     # tally2 is deprecated, replaced by faillock

--- a/products/rhel10/profiles/anssi_bp28_high.profile
+++ b/products/rhel10/profiles/anssi_bp28_high.profile
@@ -22,6 +22,7 @@ description: |-
 
 selections:
     - anssi:all:high
+    - var_password_hashing_algorithm_pam=yescrypt
     # the following rule renders UEFI systems unbootable
     - '!sebool_secure_mode_insmod'
     # Following rules are incompatible with rhel10 product

--- a/products/rhel10/profiles/anssi_bp28_intermediary.profile
+++ b/products/rhel10/profiles/anssi_bp28_intermediary.profile
@@ -22,6 +22,7 @@ description: |-
 
 selections:
     - anssi:all:intermediary
+    - var_password_hashing_algorithm_pam=yescrypt
     # Following rules are incompatible with rhel10 product
     - '!enable_authselect'
     # tally2 is deprecated, replaced by faillock

--- a/products/rhel10/profiles/anssi_bp28_minimal.profile
+++ b/products/rhel10/profiles/anssi_bp28_minimal.profile
@@ -22,6 +22,7 @@ description: |-
 
 selections:
     - anssi:all:minimal
+    - var_password_hashing_algorithm_pam=yescrypt
     # Following rules are incompatible with rhel10 product
     - '!enable_authselect'
     # tally2 is deprecated, replaced by faillock

--- a/tests/data/profile_stability/rhel10/anssi_bp28_enhanced.profile
+++ b/tests/data/profile_stability/rhel10/anssi_bp28_enhanced.profile
@@ -328,7 +328,7 @@ selections:
 - timer_dnf-automatic_enabled
 - timer_logrotate_enabled
 - var_password_hashing_algorithm=yescrypt
-- var_password_hashing_algorithm_pam=sha512
+- var_password_hashing_algorithm_pam=yescrypt
 - var_password_pam_unix_rounds=11
 - var_password_pam_minclass=4
 - var_accounts_maximum_age_root=365

--- a/tests/data/profile_stability/rhel10/anssi_bp28_high.profile
+++ b/tests/data/profile_stability/rhel10/anssi_bp28_high.profile
@@ -398,7 +398,7 @@ selections:
 - timer_dnf-automatic_enabled
 - timer_logrotate_enabled
 - var_password_hashing_algorithm=yescrypt
-- var_password_hashing_algorithm_pam=sha512
+- var_password_hashing_algorithm_pam=yescrypt
 - var_password_pam_unix_rounds=11
 - var_password_pam_minclass=4
 - var_accounts_maximum_age_root=365

--- a/tests/data/profile_stability/rhel10/anssi_bp28_intermediary.profile
+++ b/tests/data/profile_stability/rhel10/anssi_bp28_intermediary.profile
@@ -241,7 +241,7 @@ selections:
 - systemd_tmp_mount_enabled
 - timer_dnf-automatic_enabled
 - var_password_hashing_algorithm=yescrypt
-- var_password_hashing_algorithm_pam=sha512
+- var_password_hashing_algorithm_pam=yescrypt
 - var_password_pam_unix_rounds=11
 - var_password_pam_minclass=4
 - var_accounts_maximum_age_root=365

--- a/tests/data/profile_stability/rhel10/anssi_bp28_minimal.profile
+++ b/tests/data/profile_stability/rhel10/anssi_bp28_minimal.profile
@@ -51,7 +51,7 @@ selections:
 - set_password_hashing_algorithm_systemauth
 - timer_dnf-automatic_enabled
 - var_password_hashing_algorithm=yescrypt
-- var_password_hashing_algorithm_pam=sha512
+- var_password_hashing_algorithm_pam=yescrypt
 - var_password_pam_unix_rounds=11
 - var_password_pam_minclass=4
 - var_accounts_maximum_age_root=365


### PR DESCRIPTION
This commit will change the algorithm used in RHEL 10 in rules set_password_hashing_algorithm_passwordauth and
set_password_hashing_algorithm_systemauth to yescrypt.

Resolves: https://issues.redhat.com/browse/OPENSCAP-4761 https://issues.redhat.com/browse/OPENSCAP-4762


