### PR TITLE
[ubuntu2404] Install the pacakge libpam-sss

### DIFF
--- a/components/pam.yml
+++ b/components/pam.yml
@@ -11,6 +11,7 @@ packages:
 - pam_apparmor
 - libpam-runtime
 - libpam-modules
+- libpam-sss
 rules:
 - account_disable_inactivity_password_auth
 - account_disable_inactivity_system_auth
@@ -153,6 +154,7 @@ rules:
 - package_pam_modules_installed
 - package_pam_pwquality_installed
 - package_pam_runtime_installed
+- package_pam_sss_installed
 - package_pcsc-lite_installed
 - package_screen_installed
 - pam_disable_automatic_configuration

--- a/components/sssd.yml
+++ b/components/sssd.yml
@@ -6,7 +6,9 @@ packages:
 - sssd
 - sssd-common
 - sssd-ipa
+- libpam-sss
 rules:
+- package_pam_sss_installed
 - package_sssd-ipa_installed
 - package_sssd_installed
 - service_sssd_enabled

--- a/controls/stig_ubuntu2404.yml
+++ b/controls/stig_ubuntu2404.yml
@@ -163,9 +163,10 @@ controls:
     title: Ubuntu 24.04 LTS must have the "SSSD" package installed.
     levels:
       - medium
-    related_rules:
+    rules:
+      - package_pam_sss_installed
       - package_sssd_installed
-    status: planned
+    status: automated
 
   - id: UBTU-24-100660
     title: Ubuntu 24.04 LTS must use the "SSSD" package for multifactor authentication

--- a/linux_os/guide/system/accounts/accounts-pam/package_pam_sss_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/package_pam_sss_installed/rule.yml
@@ -1,0 +1,18 @@
+documentation_complete: true
+
+title: 'Install pam-sss Package'
+
+description: |-
+    {{{ describe_package_install(package="libpam-sss") }}}
+
+rationale: |-
+    libpam-sss has pam module for the SSSD
+    (System Security Services Daemon).
+
+severity: medium
+
+template:
+    name: package_installed
+    vars:
+        pkgname: libpam-sss
+        pkgname@ubuntu2404: libpam-sss


### PR DESCRIPTION
#### Description:

- Add new rule package_pam_sss_installed to stig ubnutu2404
- Assign package_pam_sss_installed to pam.yml and sssd.yml component 

#### Rationale:

- Rule UBTU-24-100650 needs to install sssd, libpam-sss and libnss-sss