### PR TITLE
[Ubuntu] Enable sssd service

### DIFF
--- a/controls/stig_ubuntu2404.yml
+++ b/controls/stig_ubuntu2404.yml
@@ -172,9 +172,9 @@ controls:
       services.
     levels:
       - medium
-    related_rules:
+    rules:
       - service_sssd_enabled
-    status: planned
+    status: automated
 
   - id: UBTU-24-100700
     title: Ubuntu 24.04 LTS must have the "chrony" package installed.

--- a/linux_os/guide/services/sssd/service_sssd_enabled/rule.yml
+++ b/linux_os/guide/services/sssd/service_sssd_enabled/rule.yml
@@ -16,7 +16,7 @@ identifiers:
     cce@rhel9: CCE-86088-2
     cce@rhel10: CCE-87447-9
 
-platform: system_with_kernel
+platform: system_with_kernel and package[sssd]
 
 references:
     cis-csc: 1,12,15,16,5

--- a/shared/applicability/package.yml
+++ b/shared/applicability/package.yml
@@ -111,7 +111,7 @@ args:
   squid:
     pkgname: squid
   sssd:
-    {{% if product in ["sle12", "sle15"] %}}
+    {{% if product in ["sle12", "sle15"] or 'ubuntu' in product %}}
       pkgname: sssd
     {{% else %}}
       pkgname: sssd-common


### PR DESCRIPTION
#### Description:

- Enable sssd service for STIG Ubuntu2404
- Set sssd package name for Ubuntu in applicability
- Set package applicability for rule service_sssd_enabled 

#### Rationale:

- UBTU-24-100660 rule requires sssd service enabled 