### PR TITLE
Add recommendation about authselect

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/rule.yml
@@ -8,6 +8,11 @@ description: |-
     Edit the <tt>password</tt> section in
     <tt>/etc/pam.d/password-auth</tt> to show
     <tt>password    requisite                                    pam_pwquality.so</tt>.
+    {{% if product == "rhel10" %}}
+    The <tt>pam_pwquality</tt> module should be enabled using the <tt>authselect</tt> tool.
+    By default, <tt>authselect</tt> always configures <tt>pam_pwquality local_users_only</tt> as a part of <tt>local</tt>, <tt>sssd</tt>, and <tt>winbind</tt> profiles.
+    No additional authselect feature is needed to be enabled.
+    {{% endif %}}
 
 rationale: |-
     Enabling PAM password complexity permits to enforce strong passwords and consequently

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_system_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_system_auth/rule.yml
@@ -8,6 +8,11 @@ description: |-
     Edit the <tt>password</tt> section in
     <tt>/etc/pam.d/system-auth</tt> to show
     <tt>password    requisite                                    pam_pwquality.so</tt>.
+    {{% if product == "rhel10" %}}
+    The <tt>pam_pwquality</tt> module should be enabled using the <tt>authselect</tt> tool.
+    By default, <tt>authselect</tt> always configures <tt>pam_pwquality local_users_only</tt> as a part of <tt>local</tt>, <tt>sssd</tt>, and <tt>winbind</tt> profiles.
+    No additional authselect feature is needed to be enabled.
+    {{% endif %}}
 
 rationale: |-
     Enabling PAM password complexity permits to enforce strong passwords and consequently


### PR DESCRIPTION
In RHEL 10, people should preferably be using authselect to enable pwquality.so.

Resolves:
https://issues.redhat.com/browse/OPENSCAP-4707
https://issues.redhat.com/browse/OPENSCAP-4708

