### PR TITLE
Ubuntu 24.04 STIG rule UBTU-24-400360 

### DIFF
--- a/components/sssd.yml
+++ b/components/sssd.yml
@@ -15,6 +15,7 @@ rules:
 - package_sssd_installed
 - service_sssd_enabled
 - sssd_certificate_verification
+- sssd_certification_path_trust_anchor
 - sssd_enable_certmap
 - sssd_enable_pam_services
 - sssd_enable_smartcards

--- a/controls/stig_ubuntu2404.yml
+++ b/controls/stig_ubuntu2404.yml
@@ -846,8 +846,8 @@ controls:
       an accepted trust anchor.
     levels:
       - medium
-    related_rules:
-      - smartcard_configure_ca
+    rules:
+      - sssd_certification_path_trust_anchor
     status: planned
 
   - id: UBTU-24-400370

--- a/controls/stig_ubuntu2404.yml
+++ b/controls/stig_ubuntu2404.yml
@@ -848,6 +848,7 @@ controls:
       - medium
     rules:
       - sssd_enable_pam_services
+      - sssd_enable_smartcards
       - sssd_certification_path_trust_anchor
     status: automated
 

--- a/controls/stig_ubuntu2404.yml
+++ b/controls/stig_ubuntu2404.yml
@@ -847,6 +847,7 @@ controls:
     levels:
       - medium
     rules:
+      - sssd_enable_pam_services
       - sssd_certification_path_trust_anchor
     status: automated
 

--- a/controls/stig_ubuntu2404.yml
+++ b/controls/stig_ubuntu2404.yml
@@ -848,7 +848,7 @@ controls:
       - medium
     rules:
       - sssd_certification_path_trust_anchor
-    status: planned
+    status: automated
 
   - id: UBTU-24-400370
     title: Ubuntu 24.04 LTS must map the authenticated identity to the user or group

--- a/linux_os/guide/services/sssd/sssd_certification_path_trust_anchor/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_certification_path_trust_anchor/bash/shared.sh
@@ -11,9 +11,8 @@ umask u=rw,go=
 
 # find key in section and change value
 found=false
-# find key in section and change value
+# find key in section but don't change current value
 if grep -qzosP "[[:space:]]*\[domain/.*\]([^\n\[]*\n+)+?[[:space:]]*ca_cert" "/etc/sssd/sssd.conf"; then
-    sed -i "s/ca_cert[^(\n)]*/ca_cert = \/etc\/ssl\/certs\/ca-certificates.crt/" "/etc/sssd/sssd.conf"
     found=true
 
 # find section and add key = value to it
@@ -22,7 +21,7 @@ elif grep -qs "[[:space:]]*\[domain/.*\]" "/etc/sssd/sssd.conf"; then
     found=true
 fi
 
-# if section not in file, append section with key = value \
+# if section not in file, append section with key = value
 if ! $found ; then
     mkdir -p "/etc/sssd"
     echo -e "\n[domain/example.com]\nca_cert = /etc/ssl/certs/ca-certificates.crt" >> "/etc/sssd/sssd.conf"
@@ -34,15 +33,6 @@ if grep -qzosP "[[:space:]]*\[domain/.*\]([^\n\[]*\n+)+?[[:space:]]*certificate_
 # find section and add key = value to it
 else
     sed -i "/[[:space:]]*\[domain\/.*\]/a certificate_verification = ca_cert,ocsp" "/etc/sssd/sssd.conf"
-fi
-
-# find key in section and change value
-if grep -qzosP "[[:space:]]*\[domain/.*\]([^\n\[]*\n+)+?[[:space:]]*ldap_user_certificate" "/etc/sssd/sssd.conf"; then
-    sed -i "s/ldap_user_certificate[^(\n)]*/ldap_user_certificate = usercertificate;binary/" "/etc/sssd/sssd.conf"
-
-# find section and add key = value to it
-else
-    sed -i "/[[:space:]]*\[domain\/.*\]/a ldap_user_certificate = usercertificate;binary" "/etc/sssd/sssd.conf"
 fi
 
 umask $OLD_UMASK

--- a/linux_os/guide/services/sssd/sssd_certification_path_trust_anchor/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_certification_path_trust_anchor/bash/shared.sh
@@ -1,0 +1,48 @@
+# platform = multi_platform_ubuntu
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = medium
+
+# sssd configuration files must be created with 600 permissions if they don't exist
+# otherwise the sssd module fails to start
+OLD_UMASK=$(umask)
+umask u=rw,go=
+
+# find key in section and change value
+found=false
+# find key in section and change value
+if grep -qzosP "[[:space:]]*\[domain/.*\]([^\n\[]*\n+)+?[[:space:]]*ca_cert" "/etc/sssd/sssd.conf"; then
+    sed -i "s/ca_cert[^(\n)]*/ca_cert = \/etc\/ssl\/certs\/ca-certificates.crt/" "/etc/sssd/sssd.conf"
+    found=true
+
+# find section and add key = value to it
+elif grep -qs "[[:space:]]*\[domain/.*\]" "/etc/sssd/sssd.conf"; then
+    sed -i "/[[:space:]]*certificate_verification/a ca_cert = \/etc\/ssl\/certs\/ca-certificates.crt" "/etc/sssd/sssd.conf"
+    found=true
+fi
+
+# if section not in file, append section with key = value \
+if ! $found ; then
+    mkdir -p "/etc/sssd"
+    echo -e "\n[domain/example.com]\nca_cert = /etc/ssl/certs/ca-certificates.crt" >> "/etc/sssd/sssd.conf"
+fi
+
+if grep -qzosP "[[:space:]]*\[domain/.*\]([^\n\[]*\n+)+?[[:space:]]*certificate_verification" "/etc/sssd/sssd.conf"; then
+    sed -i "s/certificate_verification[^(\n)]*/certificate_verification = ca_cert,ocsp/" "/etc/sssd/sssd.conf"
+
+# find section and add key = value to it
+else
+    sed -i "/[[:space:]]*\[domain\/.*\]/a certificate_verification = ca_cert,ocsp" "/etc/sssd/sssd.conf"
+fi
+
+# find key in section and change value
+if grep -qzosP "[[:space:]]*\[domain/.*\]([^\n\[]*\n+)+?[[:space:]]*ldap_user_certificate" "/etc/sssd/sssd.conf"; then
+    sed -i "s/ldap_user_certificate[^(\n)]*/ldap_user_certificate = usercertificate;binary/" "/etc/sssd/sssd.conf"
+
+# find section and add key = value to it
+else
+    sed -i "/[[:space:]]*\[domain\/.*\]/a ldap_user_certificate = usercertificate;binary" "/etc/sssd/sssd.conf"
+fi
+
+umask $OLD_UMASK

--- a/linux_os/guide/services/sssd/sssd_certification_path_trust_anchor/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_certification_path_trust_anchor/oval/shared.xml
@@ -16,7 +16,7 @@
     <ind:textfilecontent54_object id="obj_{{{rule_id}}}" version="1">
         <ind:filepath operation="pattern match">^/etc/sssd/sssd.conf$</ind:filepath>
         <ind:pattern operation="pattern match">^[\s]*\[domain\/.*](?:[^\n\[]*\n+)+?[\s]*certificate_verification\s*=\s*([\w,]+)$</ind:pattern>
-        <ind:instance datatype="int">1</ind:instance>
+        <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
     </ind:textfilecontent54_object>
 
     <ind:textfilecontent54_state comment="value of certificate_verification" id="state_{{{rule_id}}}" version="1">

--- a/linux_os/guide/services/sssd/sssd_certification_path_trust_anchor/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_certification_path_trust_anchor/oval/shared.xml
@@ -1,0 +1,25 @@
+<def-group>
+    <definition class="compliance" id="{{{ rule_id }}}" version="1">
+           {{{ oval_metadata("SSSD should be configured with trust path to an accepted trust anchor.") }}}
+        <criteria>
+            <criterion comment="check value of certificate_verification in sssd configuration"
+                       test_ref="test_{{{rule_id}}}" />
+        </criteria>
+    </definition>
+
+    <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="test the value of
+        certificate_verification in sssd configuration" id="test_{{{rule_id}}}" version="1">
+        <ind:object object_ref="obj_{{{rule_id}}}" />
+        <ind:state state_ref="state_{{{rule_id}}}" />
+    </ind:textfilecontent54_test>
+
+    <ind:textfilecontent54_object id="obj_{{{rule_id}}}" version="1">
+        <ind:filepath operation="pattern match">^/etc/sssd/sssd.conf$</ind:filepath>
+        <ind:pattern operation="pattern match">^[\s]*\[domain\/.*](?:[^\n\[]*\n+)+?[\s]*certificate_verification\s*=\s*([\w,]+)$</ind:pattern>
+        <ind:instance datatype="int">1</ind:instance>
+    </ind:textfilecontent54_object>
+
+    <ind:textfilecontent54_state comment="value of certificate_verification" id="state_{{{rule_id}}}" version="1">
+        <ind:subexpression operation="equals">ca_cert,ocsp</ind:subexpression>
+    </ind:textfilecontent54_state>
+</def-group>

--- a/linux_os/guide/services/sssd/sssd_certification_path_trust_anchor/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_certification_path_trust_anchor/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+
+title: 'Certificate trust path in SSSD'
+
+description: |-
+    Enable certification trust path for SSSD to an accepted trust anchor.
+
+rationale: |-
+    Without path validation, an informed trust decision by the relying party cannot be made when 
+    presented with any certificate not already explicitly trusted.
+
+severity: medium
+
+
+ocil_clause: 'certificate_verification in sssd is not configured'
+
+ocil: |-
+    Ensure "ca" is enabled in "certificate_verification" with the following command:
+    <pre>$ sudo grep certificate_verification /etc/sssd/sssd.conf</pre>.
+    If configured properly, output should look like
+    <pre>
+        certificate_verification = ca_cert,ocsp
+    </pre>
+
+fixtext: |-
+    Configure SSSD for PKI-based authentication. To validate certificates by constructing a certification path
+    to an accepted trust anchor by checking the following configuration of the <pre>/etc/sssd/sssd.conf</pre> file.
+    <pre>
+        [domain/example.com]
+        ldap_user_certificate = usercertificate;binary
+        certificate_verification = ca_cert,ocsp
+        ca_cert = /etc/ssl/certs/ca-certificates.crt
+    </pre>

--- a/linux_os/guide/services/sssd/sssd_certification_path_trust_anchor/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/sssd/sssd_certification_path_trust_anchor/tests/correct_value.pass.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# packages = sssd-common
+
+mkdir -p /etc/sssd/conf.d
+touch /etc/sssd/sssd.conf
+echo -e "$ sudo vi /etc/sssd/sssd.conf
+[sssd]
+services = nss,pam,ssh
+config_file_version = 2
+
+[pam]
+pam_cert_auth = True
+
+[domain/example.com]
+ldap_user_certificate = usercertificate;binary
+certificate_verification = ca_cert,ocsp
+ca_cert = /etc/ssl/certs/ca-certificates.crt
+" >> /etc/sssd/sssd.conf

--- a/linux_os/guide/services/sssd/sssd_certification_path_trust_anchor/tests/not_configured.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_certification_path_trust_anchor/tests/not_configured.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = sssd-common
+
+mkdir -p /etc/sssd/conf.d
+touch /etc/sssd/sssd.conf

--- a/linux_os/guide/services/sssd/sssd_certification_path_trust_anchor/tests/partial_config.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_certification_path_trust_anchor/tests/partial_config.fail.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# packages = sssd-common
+
+mkdir -p /etc/sssd/conf.d
+touch /etc/sssd/sssd.conf
+echo -e "$ sudo vi /etc/sssd/sssd.conf
+[sssd]
+services = nss,pam,ssh
+config_file_version = 2
+
+[pam]
+pam_cert_auth = True
+
+[domain/test.com]
+ldap_user_certificate = usercertificate;binary
+certificate_verification = ca_cert
+ca_cert = /etc/ssl/certs/ca-certificates.crt
+" >> /etc/sssd/sssd.conf
+

--- a/linux_os/guide/services/sssd/sssd_certification_path_trust_anchor/tests/partial_config.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_certification_path_trust_anchor/tests/partial_config.fail.sh
@@ -15,5 +15,10 @@ pam_cert_auth = True
 ldap_user_certificate = usercertificate;binary
 certificate_verification = ca_cert
 ca_cert = /etc/ssl/certs/ca-certificates.crt
+
+[domain/test2.com]
+ldap_user_certificate = usercertificate;binary
+certificate_verification = ca_cert
+ca_cert = /etc/ssl/certs/ca-certificates.crt
 " >> /etc/sssd/sssd.conf
 

--- a/linux_os/guide/services/sssd/sssd_certification_path_trust_anchor/tests/partial_config2.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_certification_path_trust_anchor/tests/partial_config2.fail.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# packages = sssd-common
+
+mkdir -p /etc/sssd/conf.d
+touch /etc/sssd/sssd.conf
+echo -e "$ sudo vi /etc/sssd/sssd.conf
+[sssd]
+services = nss,pam,ssh
+config_file_version = 2
+
+[pam]
+pam_cert_auth = True
+
+[domain/test.com]
+ldap_user_certificate = usercertificate;binary
+certificate_verification = ca_cert
+ca_cert = /etc/ssl.crt
+" >> /etc/sssd/sssd.conf
+

--- a/linux_os/guide/services/sssd/sssd_certification_path_trust_anchor/tests/partial_config3.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_certification_path_trust_anchor/tests/partial_config3.fail.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# packages = sssd-common
+
+mkdir -p /etc/sssd/conf.d
+touch /etc/sssd/sssd.conf
+echo -e "$ sudo vi /etc/sssd/sssd.conf
+[sssd]
+services = nss,pam,ssh
+config_file_version = 2
+
+[pam]
+pam_cert_auth = True
+
+[domain/test.com]
+ldap_user_certificate = usercertificate;binary
+certificate_verification = ca_cert
+" >> /etc/sssd/sssd.conf
+

--- a/linux_os/guide/services/sssd/sssd_certification_path_trust_anchor/tests/wrong_section.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_certification_path_trust_anchor/tests/wrong_section.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# packages = sssd-common
+
+mkdir -p /etc/sssd/conf.d
+touch /etc/sssd/sssd.conf
+echo -e "[sssd]\ncertificate_verification = ca_cert,ocsp" >> /etc/sssd/sssd.conf

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_ol,multi_platform_almalinux
+# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_ol,multi_platform_almalinux,multi_platform_ubuntu
 
 
 

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/sssd_parameter_false.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/sssd_parameter_false.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = sssd
-# platform = multi_platform_fedora,Oracle Linux 7,Red Hat Virtualization 4
+# platform = multi_platform_fedora,Oracle Linux 7,Red Hat Virtualization 4,multi_platform_ubuntu
 
 SSSD_FILE="/etc/sssd/sssd.conf"
 echo "[pam]" > $SSSD_FILE

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/sssd_parameter_missing.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/sssd_parameter_missing.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = sssd
-# platform = multi_platform_fedora,Oracle Linux 7,Red Hat Virtualization 4
+# platform = multi_platform_fedora,Oracle Linux 7,Red Hat Virtualization 4,multi_platform_ubuntu
 
 SSSD_FILE="/etc/sssd/sssd.conf"
 echo "[pam]" > $SSSD_FILE

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/sssd_parameter_missing_file.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/sssd_parameter_missing_file.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = sssd
-# platform = multi_platform_fedora,Oracle Linux 7,Red Hat Virtualization 4
+# platform = multi_platform_fedora,Oracle Linux 7,Red Hat Virtualization 4,multi_platform_ubuntu
 
 SSSD_FILE="/etc/sssd/sssd.conf"
 rm -f $SSSD_FILE

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/sssd_parameter_true.pass.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/sssd_parameter_true.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = sssd
-# platform = multi_platform_fedora,Oracle Linux 7,Red Hat Virtualization 4
+# platform = multi_platform_fedora,Oracle Linux 7,Red Hat Virtualization 4,multi_platform_ubuntu
 
 SSSD_FILE="/etc/sssd/sssd.conf"
 echo "[pam]" > $SSSD_FILE


### PR DESCRIPTION
…nchor

#### Description:

- Implementation of Ubuntu 24.04 STIG UBTU-24-400460.

#### Rationale:

- Adds a sssd_certification_path_trust_anchor rule to enable certification trust anchors in the sssd.conf file.
- Enable rules sssd_enable_smartcards and sssd_enable_pam_services to complete the requirements for "SSSD must validate certificates by constructing a certification path to an
accepted trust anchor."
