### PR TITLE
[Ubuntu] Drop pam config for faillock audit tests

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/rule.yml
@@ -45,3 +45,5 @@ fixtext: |-
     audit
 
 srg_requirement: '{{{ full_name }}} must log user name information when unsuccessful logon attempts occur.'
+
+platform: package[pam]

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/ubuntu_common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/ubuntu_common.sh
@@ -22,3 +22,4 @@ Account:
 EOF
 
 DEBIAN_FRONTEND=noninteractive pam-auth-update
+rm /usr/share/pam-configs/tmp_faillock /usr/share/pam-configs/tmp_faillock_notify

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/ubuntu_common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/ubuntu_common.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cat << EOF > /usr/share/pam-configs/faillock
+cat << EOF > /usr/share/pam-configs/tmp_faillock
 Name: Enable pam_faillock to deny access
 Default: yes
 Priority: 0
@@ -9,7 +9,7 @@ Auth:
     [default=die]                   pam_faillock.so authfail
 EOF
 
-cat << EOF > /usr/share/pam-configs/faillock_notify
+cat << EOF > /usr/share/pam-configs/tmp_faillock_notify
 Name: Notify of failed login attempts and reset count upon success
 Default: yes
 Priority: 1024

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/ubuntu_correct_pamd.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/ubuntu_correct_pamd.pass.sh
@@ -23,3 +23,4 @@ Account:
 EOF
 
 DEBIAN_FRONTEND=noninteractive pam-auth-update
+rm /usr/share/pam-configs/tmp_faillock /usr/share/pam-configs/tmp_faillock_notify

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/ubuntu_correct_pamd.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/ubuntu_correct_pamd.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 
-cat << EOF > /usr/share/pam-configs/faillock
+cat << EOF > /usr/share/pam-configs/tmp_faillock
 Name: Enable pam_faillock to deny access
 Default: yes
 Priority: 0
@@ -10,7 +10,7 @@ Auth:
     [default=die]                   pam_faillock.so authfail audit
 EOF
 
-cat << EOF > /usr/share/pam-configs/faillock_notify
+cat << EOF > /usr/share/pam-configs/tmp_faillock_notify
 Name: Notify of failed login attempts and reset count upon success
 Default: yes
 Priority: 1024


### PR DESCRIPTION
#### Description:

- Drop pam config for tests of accounts_passwords_pam_faillock_audit
- Add package[pam] applicability to accounts_passwords_pam_faillock_audit

#### Rationale:

- Delete the pam configs of faillock in case they affect the remediation.