### PR TITLE
Enable ansible macro for faillock

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/common.sh
@@ -1,11 +1,6 @@
 pam_files=("password-auth" "system-auth")
 
-{{%- if ('rhel' in product or 'ol' in families) and product not in ['ol8', 'ol9', 'rhel8', 'rhel9']%}}
-# rhel>=10 default profile is now called local
-authselect create-profile testingProfile --base-on local
-{{%- else %}}
-authselect create-profile testingProfile --base-on minimal
-{{%- endif %}}
+authselect create-profile testingProfile --base-on local || authselect create-profile testingProfile --base-on minimal
 
 CUSTOM_PROFILE_DIR="/etc/authselect/custom/testingProfile"
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/ansible/shared.yml
@@ -21,8 +21,8 @@
 
 - name: {{{ rule_title }}} - Ensure the pam_faillock.so silent parameter not in PAM files
   block:
-    {{{ ansible_remove_pam_module_option_configuration('/etc/pam.d/system-auth','auth','','pam_faillock.so',silent, rule_title=rule_title) | indent(4) }}}
-    {{{ ansible_remove_pam_module_option_configuration('/etc/pam.d/password-auth','auth','','pam_faillock.so',silent, rule_title=rule_title) | indent(4) }}}
+    {{{ ansible_remove_pam_module_option_configuration('/etc/pam.d/system-auth','auth','','pam_faillock.so','silent', rule_title=rule_title) | indent(4) }}}
+    {{{ ansible_remove_pam_module_option_configuration('/etc/pam.d/password-auth','auth','','pam_faillock.so','silent', rule_title=rule_title) | indent(4) }}}
   when:
     - result_faillock_conf_check.stat.exists
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/ansible/shared.yml
@@ -3,34 +3,6 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+
 {{{ ansible_pam_faillock_enable(rule_title=rule_title) }}}
-
-- name: {{{ rule_title }}} - Check the presence of /etc/security/faillock.conf file
-  ansible.builtin.stat:
-    path: /etc/security/faillock.conf
-  register: result_faillock_conf_check
-
-- name: {{{ rule_title }}} - Ensure the pam_faillock.so silent parameter in /etc/security/faillock.conf
-  ansible.builtin.lineinfile:
-    path: /etc/security/faillock.conf
-    regexp: ^\s*silent
-    line: silent
-    state: present
-  when:
-    - result_faillock_conf_check.stat.exists
-
-- name: {{{ rule_title }}} - Ensure the pam_faillock.so silent parameter in PAM files
-  block:
-
-    - name: {{{ rule_title }}} - Ensure the inclusion of pam_faillock.so preauth silent parameter in auth section
-      ansible.builtin.lineinfile:
-        path: "{{ item }}"
-        backrefs: true
-        regexp: (^\s*auth\s+)([\w\[].*\b)(\s+pam_faillock.so preauth(:?(?!silent).)*)
-        line: \1required\3 silent
-        state: present
-      loop:
-        - /etc/pam.d/system-auth
-        - /etc/pam.d/password-auth
-  when:
-    - not result_faillock_conf_check.stat.exists
+{{{ ansible_pam_faillock_parameter_value("silent", authfail=False, rule_title=rule_title)}}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/ansible/shared.yml
@@ -3,6 +3,34 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-
 {{{ ansible_pam_faillock_enable(rule_title=rule_title) }}}
-{{{ ansible_pam_faillock_parameter_value("silent", authfail=False, rule_title=rule_title)}}}
+
+- name: {{{ rule_title }}} - Check the presence of /etc/security/faillock.conf file
+  ansible.builtin.stat:
+    path: /etc/security/faillock.conf
+  register: result_faillock_conf_check
+
+- name: {{{ rule_title }}} - Ensure the pam_faillock.so silent parameter in /etc/security/faillock.conf
+  ansible.builtin.lineinfile:
+    path: /etc/security/faillock.conf
+    regexp: ^\s*silent
+    line: silent
+    state: present
+  when:
+    - result_faillock_conf_check.stat.exists
+
+- name: {{{ rule_title }}} - Ensure the pam_faillock.so silent parameter in PAM files
+  block:
+
+    - name: {{{ rule_title }}} - Ensure the inclusion of pam_faillock.so preauth silent parameter in auth section
+      ansible.builtin.lineinfile:
+        path: "{{ item }}"
+        backrefs: true
+        regexp: (^\s*auth\s+)([\w\[].*\b)(\s+pam_faillock.so preauth(:?(?!silent).)*)
+        line: \1required\3 silent
+        state: present
+      loop:
+        - /etc/pam.d/system-auth
+        - /etc/pam.d/password-auth
+  when:
+    - not result_faillock_conf_check.stat.exists

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/ansible/shared.yml
@@ -19,6 +19,13 @@
   when:
     - result_faillock_conf_check.stat.exists
 
+- name: {{{ rule_title }}} - Ensure the pam_faillock.so silent parameter not in PAM files
+  block:
+    {{{ ansible_remove_pam_module_option_configuration('/etc/pam.d/system-auth','auth','','pam_faillock.so',silent, rule_title=rule_title) | indent(4) }}}
+    {{{ ansible_remove_pam_module_option_configuration('/etc/pam.d/password-auth','auth','','pam_faillock.so',silent, rule_title=rule_title) | indent(4) }}}
+  when:
+    - result_faillock_conf_check.stat.exists
+
 - name: {{{ rule_title }}} - Ensure the pam_faillock.so silent parameter in PAM files
   block:
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/bash/shared.sh
@@ -1,25 +1,5 @@
 # platform = multi_platform_all
 
 {{{ bash_pam_faillock_enable() }}}
-
-{{% if "ubuntu" in product %}}
 {{{ bash_pam_faillock_parameter_value("silent", authfail=False)}}}
 
-{{% else %}}
-AUTH_FILES=("/etc/pam.d/system-auth" "/etc/pam.d/password-auth")
-FAILLOCK_CONF="/etc/security/faillock.conf"
-if [ -f $FAILLOCK_CONF ]; then
-    regex="^\s*silent"
-    line="silent"
-    if ! grep -q $regex $FAILLOCK_CONF; then
-        echo $line >> $FAILLOCK_CONF
-    fi
-else
-    for pam_file in "${AUTH_FILES[@]}"
-    do
-        if ! grep -qE '^\s*auth.*pam_faillock\.so\s*preauth.*silent' "$pam_file"; then
-            sed -i --follow-symlinks '/^\s*auth.*pam_faillock\.so.*preauth/ s/$/ silent/' "$pam_file"
-        fi
-    done
-fi
-{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/oval/shared.xml
@@ -18,6 +18,9 @@
                 <criterion
                 test_ref="test_pam_faillock_silent_parameter_password_auth"
                 comment="Check the silent parameter in auth section of password-auth file"/>
+                <criterion
+                test_ref="test_pam_faillock_silent_parameter_no_faillock_conf"
+                comment="Ensure /etc/security/faillock.conf is not used together with pam files"/>
             </criteria>
             <criteria operator="AND"
             comment="Check expected pam_faillock.so silent parameter in faillock.conf">
@@ -100,4 +103,9 @@
         <ind:object object_ref="object_pam_faillock_silent_parameter_faillock_conf"/>
     </ind:textfilecontent54_test>
 
+      <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
+      id="test_pam_faillock_silent_parameter_no_faillock_conf"
+      comment="Check the absence of silent parameter in /etc/security/faillock.conf">
+            <ind:object object_ref="object_pam_faillock_silent_parameter_faillock_conf"/>
+      </ind:textfilecontent54_test>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/oval/ubuntu.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/oval/ubuntu.xml
@@ -57,7 +57,7 @@
   <constant_variable id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_auth_regex"
                 datatype="string" version="1"
                 comment="regex to identify pam_faillock.so entries in auth section of pam files">
-      <value>^\s*auth\s+required\s+pam_faillock\.so.*preauth.*[\s\S]*^\s*auth.*pam_unix\.so[\s\S]*^\s*auth\s+\[default=die\]\s+pam_faillock\.so\s+authfail[\s\S]*^\s*auth\s+sufficient\s+pam_faillock\.so\s+authsucc</value>
+      <value>^\s*auth\s+(requisite|required)\s+pam_faillock\.so.*preauth.*[\s\S]*^\s*auth.*pam_unix\.so[\s\S]*^\s*auth\s+\[default=die\]\s+pam_faillock\.so\s+authfail[\s\S]*^\s*auth\s+sufficient\s+pam_faillock\.so\s+authsucc</value>
   </constant_variable>
 
   <constant_variable id="var_accounts_passwords_pam_faillock_{{{ prm_name }}}_pam_faillock_account_regex"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/common.sh
@@ -1,6 +1,6 @@
 pam_files=("password-auth" "system-auth")
 
-authselect create-profile testingProfile --base-on minimal
+authselect create-profile testingProfile --base-on local || authselect create-profile testingProfile --base-on minimal
 
 CUSTOM_PROFILE_DIR="/etc/authselect/custom/testingProfile"
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_commented_values.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_commented_values.fail.sh
@@ -3,7 +3,4 @@
 
 source ubuntu_common.sh
 
-sed -i 's/\(^.*pam_faillock\.so.*\)/# \1/' /etc/pam.d/common-auth
-sed -i 's/\(^.*pam_faillock\.so.*\)/# \1/' /etc/pam.d/common-account
-
 echo "#silent" > /etc/security/faillock.conf

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_common.sh
@@ -1,50 +1,26 @@
 #!/bin/bash
 
-# Create passing pam.d files based on defaults from a clean installation of Ubuntu 22.04 LTS
-# Extra comments and whitespaces were added to test for edge cases
-
-cat >/etc/pam.d/common-auth <<EOF
- ## Leading and trailing whitespaces should be ok
- auth required  pam_faillock.so     preauth 
-# here are the per-package modules (the "Primary" block)
-auth    [success=2 default=ignore]      pam_unix.so nullok
-## Several lines of comments should not
-## break faillock remediation logic
-## Nor should commented pam_unix
-#auth    [success=2 default=ignore]      pam_unix.so nullok
-
-auth    [success=1 default=ignore]      pam_sss.so use_first_pass
-
- ## Some more user comments
- auth [default=die]  pam_faillock.so authfail 
- ## and some more
- auth sufficient     pam_faillock.so authsucc 
-
-# here's the fallback if no module succeeds
-auth    requisite                       pam_deny.so
-# prime the stack with a positive return value if there isn't one already;
-# this avoids us returning an error just because nothing sets a success code
-# since the modules above will each just jump around
-auth    required                        pam_permit.so
-# and here are more per-package modules (the "Additional" block)
-auth    optional                        pam_cap.so 
-# end of pam-auth-update config
+cat << EOF > /usr/share/pam-configs/tmp_faillock
+Name: Enable pam_faillock to deny access
+Default: yes
+Priority: 0
+Auth-Type: Primary
+Auth:
+    [default=die]                   pam_faillock.so authfail
+    sufficient                      pam_faillock.so authsucc
 EOF
 
-
-cat >/etc/pam.d/common-account <<EOF
-# here are the per-package modules (the "Primary" block)
-account [success=1 new_authtok_reqd=done default=ignore]        pam_unix.so 
-# here's the fallback if no module succeeds
-account requisite                       pam_deny.so
-# prime the stack with a positive return value if there isn't one already;
-# this avoids us returning an error just because nothing sets a success code
-# since the modules above will each just jump around
-account required                        pam_permit.so
-# and here are more per-package modules (the "Additional" block)
-account sufficient                      pam_localuser.so 
-account [default=bad success=ok user_unknown=ignore]    pam_sss.so 
-# end of pam-auth-update config
-
-  account required  pam_faillock.so 
+cat << EOF > /usr/share/pam-configs/tmp_faillock_notify
+Name: Notify of failed login attempts and reset count upon success
+Default: yes
+Priority: 1024
+Auth-Type: Primary
+Auth:
+    requisite                       pam_faillock.so preauth
+Account-Type: Primary
+Account:
+    required                        pam_faillock.so
 EOF
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update
+rm /usr/share/pam-configs/tmp_faillock /usr/share/pam-configs/tmp_faillock_notify

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_correct_pamd.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_correct_pamd.pass.sh
@@ -1,7 +1,27 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 
-source ubuntu_common.sh
+cat << EOF > /usr/share/pam-configs/tmp_faillock
+Name: Enable pam_faillock to deny access
+Default: yes
+Priority: 0
+Auth-Type: Primary
+Auth:
+    [default=die]                   pam_faillock.so authfail silent
+    sufficient                      pam_faillock.so authsucc silent
+EOF
 
-sed -i 's/\(.*pam_faillock.so.*\)/\1 silent/g' /etc/pam.d/common-auth
+cat << EOF > /usr/share/pam-configs/tmp_faillock_notify
+Name: Notify of failed login attempts and reset count upon success
+Default: yes
+Priority: 1024
+Auth-Type: Primary
+Auth:
+    requisite                       pam_faillock.so preauth silent
+Account-Type: Primary
+Account:
+    required                        pam_faillock.so
+EOF
 
+DEBIAN_FRONTEND=noninteractive pam-auth-update
+rm /usr/share/pam-configs/tmp_faillock /usr/share/pam-configs/tmp_faillock_notify

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_missing_pamd.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_missing_pamd.fail.sh
@@ -1,9 +1,4 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 
-source ubuntu_common.sh
-
-sed -i '/pam_faillock\.so/d' /etc/pam.d/common-auth
-sed -i '/pam_faillock\.so/d' /etc/pam.d/common-account
-
 echo "silent" > /etc/security/faillock.conf

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_multiple_pam_unix.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/ubuntu_multiple_pam_unix.fail.sh
@@ -8,4 +8,4 @@
 
 source ubuntu_common.sh
 
-echo "auth        sufficient       pam_unix.so" >> /etc/pam.d/common-auth
+sed -i '/# end of pam-auth-update config/i\auth        sufficient       pam_unix.so' /etc/pam.d/common-auth

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/tests/common.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/tests/common.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-authselect create-profile testingProfile --base-on minimal
+authselect create-profile testingProfile --base-on local || authselect create-profile testingProfile --base-on minimal
 
 CUSTOM_PAM_FILE="/etc/authselect/custom/testingProfile/password-auth"
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/tests/common.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/tests/common.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-authselect create-profile testingProfile --base-on minimal
+authselect create-profile testingProfile --base-on local || authselect create-profile testingProfile --base-on minimal
 
 CUSTOM_PAM_FILE="/etc/authselect/custom/testingProfile/system-auth"
 

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1305,7 +1305,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
       ansible.builtin.lineinfile:
         path: "{{ item }}"
         backrefs: true
-        regexp: (^\s*auth\s+)(.+)(\s+pam_faillock.so preauth.*)
+        regexp: (^\s*auth\s+)([\w\[].*\b)(\s+pam_faillock.so preauth.*)
         {{%- if faillock_var_name == '' %}}
         line: \1required\3 {{{ parameter }}}
         {{%- else %}}
@@ -1323,7 +1323,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
       ansible.builtin.lineinfile:
         path: "{{ item }}"
         backrefs: true
-        regexp: (^\s*auth\s+)(.+)(\s+pam_faillock.so authfail.*)
+        regexp: (^\s*auth\s+)([\w\[].*\b)(\s+pam_faillock.so authfail.*)
         {{%- if faillock_var_name == '' %}}
         line: \1required\3 {{{ parameter }}}
         {{%- else %}}
@@ -1342,7 +1342,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
       ansible.builtin.lineinfile:
         path: "{{ item }}"
         backrefs: true
-        regexp: (^\s*auth\s+)(.+)(\s+pam_faillock.so preauth.*)({{{ parameter }}})=\S+\b(.*)
+        regexp: (^\s*auth\s+)([\w\[].*\b)(\s+pam_faillock.so preauth.*)({{{ parameter }}})=[0-9]+(.*)
         line: \1required\3\4={{ {{{ faillock_var_name }}} }}\5
         state: present
       loop:
@@ -1356,7 +1356,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
       ansible.builtin.lineinfile:
         path: "{{ item }}"
         backrefs: true
-        regexp: (^\s*auth\s+)(.+)(\s+pam_faillock.so authfail.*)({{{ parameter }}})=\S+\b(.*)
+        regexp: (^\s*auth\s+)([\w\[].*\b)(\s+pam_faillock.so authfail.*)({{{ parameter }}})=[0-9]+(.*)
         line: \1required\3\4={{ {{{ faillock_var_name }}} }}\5
         state: present
       loop:
@@ -1721,9 +1721,9 @@ Part of the grub2_bootloader_argument_absent template.
   ansible.builtin.replace:
     dest: "{{{ pam_file }}}"
     {{%- if control == '' %}}
-    regexp: (.*{{{ group }}}.*{{{ module }}}.*)\b{{{ option }}}\b(?:=\S+\b|\s+)(.*)
+    regexp: (.*{{{ group }}}.*{{{ module }}}.*)\b{{{ option }}}\b=?[0-9a-zA-Z]*(.*)
     {{%- else %}}
-    regexp: (.*{{{ group }}}.*{{ pam_module_control | regex_escape() }}.*{{{ module }}}.*)\b{{{ option }}}\b(?:=\S+\b|\s+)(.*)
+    regexp: (.*{{{ group }}}.*{{ pam_module_control | regex_escape() }}.*{{{ module }}}.*)\b{{{ option }}}\b=?[0-9a-zA-Z]*(.*)
     {{%- endif %}}
     replace: '\1\2'
   register: result_pam_option_removal

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1305,7 +1305,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
       ansible.builtin.lineinfile:
         path: "{{ item }}"
         backrefs: true
-        regexp: (^\s*auth\s+)([\w\[].*\b)(\s+pam_faillock.so preauth.*)
+        regexp: (^\s*auth\s+)(.+)(\s+pam_faillock.so preauth.*)
         {{%- if faillock_var_name == '' %}}
         line: \1required\3 {{{ parameter }}}
         {{%- else %}}
@@ -1323,7 +1323,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
       ansible.builtin.lineinfile:
         path: "{{ item }}"
         backrefs: true
-        regexp: (^\s*auth\s+)([\w\[].*\b)(\s+pam_faillock.so authfail.*)
+        regexp: (^\s*auth\s+)(.+)(\s+pam_faillock.so authfail.*)
         {{%- if faillock_var_name == '' %}}
         line: \1required\3 {{{ parameter }}}
         {{%- else %}}
@@ -1342,7 +1342,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
       ansible.builtin.lineinfile:
         path: "{{ item }}"
         backrefs: true
-        regexp: (^\s*auth\s+)([\w\[].*\b)(\s+pam_faillock.so preauth.*)({{{ parameter }}})=[0-9]+(.*)
+        regexp: (^\s*auth\s+)(.+)(\s+pam_faillock.so preauth.*)({{{ parameter }}})=\S+\b(.*)
         line: \1required\3\4={{ {{{ faillock_var_name }}} }}\5
         state: present
       loop:
@@ -1356,7 +1356,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
       ansible.builtin.lineinfile:
         path: "{{ item }}"
         backrefs: true
-        regexp: (^\s*auth\s+)([\w\[].*\b)(\s+pam_faillock.so authfail.*)({{{ parameter }}})=[0-9]+(.*)
+        regexp: (^\s*auth\s+)(.+)(\s+pam_faillock.so authfail.*)({{{ parameter }}})=\S+\b(.*)
         line: \1required\3\4={{ {{{ faillock_var_name }}} }}\5
         state: present
       loop:
@@ -1721,9 +1721,9 @@ Part of the grub2_bootloader_argument_absent template.
   ansible.builtin.replace:
     dest: "{{{ pam_file }}}"
     {{%- if control == '' %}}
-    regexp: (.*{{{ group }}}.*{{{ module }}}.*)\b{{{ option }}}\b=?[0-9a-zA-Z]*(.*)
+    regexp: (.*{{{ group }}}.*{{{ module }}}.*)\b{{{ option }}}\b(?:=\S+\b|\s+)(.*)
     {{%- else %}}
-    regexp: (.*{{{ group }}}.*{{ pam_module_control | regex_escape() }}.*{{{ module }}}.*)\b{{{ option }}}\b=?[0-9a-zA-Z]*(.*)
+    regexp: (.*{{{ group }}}.*{{ pam_module_control | regex_escape() }}.*{{{ module }}}.*)\b{{{ option }}}\b(?:=\S+\b|\s+)(.*)
     {{%- endif %}}
     replace: '\1\2'
   register: result_pam_option_removal

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1214,6 +1214,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
           Auth-Type: Primary
           Auth:
             [default=die]                   pam_faillock.so authfail
+            sufficient                      pam_faillock.so authsucc
         force: yes
       when: not faillock_file_stat.stat.exists
 

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1194,17 +1194,17 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
 - name: {{{ rule_title }}} - Remediation where pam-auth-update tool is present
   block:
     - name: {{{ rule_title }}} - Check the presence of cac_faillock file
-      stat:
+      ansible.builtin.stat:
         path: /usr/share/pam-configs/cac_faillock
       register: faillock_file_stat
 
     - name: {{{ rule_title }}} - Check the presence of cac_faillock_notify file
-      stat:
+      ansible.builtin.stat:
         path: /usr/share/pam-configs/cac_faillock_notify
       register: faillock_notify_file_stat
 
-    - name: Put the content into cac_faillock if it does not exist
-      copy:
+    - name: {{{ rule_title }}} - Put the content into cac_faillock if it does not exist
+      ansible.builtin.copy:
         dest: /usr/share/pam-configs/cac_faillock
         content: |+
           Name: Enable pam_faillock to deny access
@@ -1217,8 +1217,8 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
         force: yes
       when: not faillock_file_stat.stat.exists
 
-    - name: Put the content into cac_faillock_notify if it does not exist
-      copy:
+    - name: {{{ rule_title }}} - Put the content into cac_faillock_notify if it does not exist
+      ansible.builtin.copy:
         dest: /usr/share/pam-configs/cac_faillock_notify
         content: |+
           Name: Notify of failed login attempts and reset count upon success

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1130,7 +1130,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
 
 #}}
 {{%- macro ansible_pam_faillock_enable(rule_title=None) -%}}
-
+{{% if 'ubuntu' not in product %}}
 {{{ ansible_check_authselect_presence(rule_title=rule_title) }}}
 
 - name: {{{ rule_title }}} - Remediation where authselect tool is present
@@ -1187,6 +1187,60 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
         - result_pam_faillock_is_enabled.found == 0
   when:
     - not result_authselect_present.stat.exists
+
+{{% else %}}
+{{{ ansible_check_pam_auth_update_presence(rule_title=rule_title) }}}
+
+- name: {{{ rule_title }}} - Remediation where pam-auth-update tool is present
+  block:
+    - name: {{{ rule_title }}} - Check the presence of cac_faillock file
+      stat:
+        path: /usr/share/pam-configs/cac_faillock
+      register: faillock_file_stat
+
+    - name: {{{ rule_title }}} - Check the presence of cac_faillock_notify file
+      stat:
+        path: /usr/share/pam-configs/cac_faillock_notify
+      register: faillock_notify_file_stat
+
+    - name: Put the content into cac_faillock if it does not exist
+      copy:
+        dest: /usr/share/pam-configs/cac_faillock
+        content: |+
+          Name: Enable pam_faillock to deny access
+          Default: yes
+          Priority: 0
+          Conflicts: faillock
+          Auth-Type: Primary
+          Auth:
+            [default=die]                   pam_faillock.so authfail
+        force: yes
+      when: not faillock_file_stat.stat.exists
+
+    - name: Put the content into cac_faillock_notify if it does not exist
+      copy:
+        dest: /usr/share/pam-configs/cac_faillock_notify
+        content: |+
+          Name: Notify of failed login attempts and reset count upon success
+          Default: yes
+          Priority: 1025
+          Conflicts: faillock_notify
+          Auth-Type: Primary
+          Auth:
+            requisite                       pam_faillock.so preauth
+          Account-Type: Primary
+          Account:
+            required                        pam_faillock.so
+        force: yes
+      when: not faillock_notify_file_stat.stat.exists
+
+    {{{ ansible_apply_pam_auth_update_changes('cac_faillock') | indent(4) }}}
+    {{{ ansible_apply_pam_auth_update_changes('cac_faillock_notify') | indent(4) }}}
+
+  when:
+    - result_pam_auth_update_present.stat.exists
+
+{{% endif -%}}
 {{%- endmacro -%}}
 
 

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1180,9 +1180,9 @@ else
         fi
         {{%- else %}}
         else
-            sed -i --follow-symlinks 's/\(^auth.*required.*pam_faillock\.so.*preauth.*\)\('"{{{ option }}}"'=\)[0-9]\+\(.*\)/\1\2'"{{{ value }}}"'\3/' "$pam_file"
+            sed -i --follow-symlinks 's/\(^auth.*required.*pam_faillock\.so.*preauth.*\)\('"{{{ option }}}"'=\)\S\+\b\(.*\)/\1\2'"{{{ value }}}"'\3/' "$pam_file"
             {{%- if authfail %}}
-            sed -i --follow-symlinks 's/\(^auth.*required.*pam_faillock\.so.*authfail.*\)\('"{{{ option }}}"'=\)[0-9]\+\(.*\)/\1\2'"{{{ value }}}"'\3/' "$pam_file"
+            sed -i --follow-symlinks 's/\(^auth.*required.*pam_faillock\.so.*authfail.*\)\('"{{{ option }}}"'=\)\S\+\b\(.*\)/\1\2'"{{{ value }}}"'\3/' "$pam_file"
             {{%- endif %}}
         fi
         {{%- endif %}}

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1166,12 +1166,12 @@ else
     do
         if ! grep -qE '^\s*auth.*pam_faillock\.so (preauth|authfail).*{{{ option }}}' "$pam_file"; then
             {{%- if value == '' %}}
-            sed -i --follow-symlinks '/^auth.*required.*pam_faillock\.so.*preauth.*silent.*/ s/$/ {{{ option }}}/' "$pam_file"
+            sed -i --follow-symlinks '/^auth.*required.*pam_faillock\.so.*preauth.*/ s/$/ {{{ option }}}/' "$pam_file"
             {{%- if authfail %}}
             sed -i --follow-symlinks '/^auth.*required.*pam_faillock\.so.*authfail.*/ s/$/ {{{ option }}}/' "$pam_file"
             {{%- endif %}}
             {{%- else %}}
-            sed -i --follow-symlinks '/^auth.*required.*pam_faillock\.so.*preauth.*silent.*/ s/$/ {{{ option }}}='"{{{ value }}}"'/' "$pam_file"
+            sed -i --follow-symlinks '/^auth.*required.*pam_faillock\.so.*preauth.*/ s/$/ {{{ option }}}='"{{{ value }}}"'/' "$pam_file"
             {{%- if authfail %}}
             sed -i --follow-symlinks '/^auth.*required.*pam_faillock\.so.*authfail.*/ s/$/ {{{ option }}}='"{{{ value }}}"'/' "$pam_file"
             {{%- endif %}}
@@ -1180,7 +1180,7 @@ else
         fi
         {{%- else %}}
         else
-            sed -i --follow-symlinks 's/\(^auth.*required.*pam_faillock\.so.*preauth.*silent.*\)\('"{{{ option }}}"'=\)[0-9]\+\(.*\)/\1\2'"{{{ value }}}"'\3/' "$pam_file"
+            sed -i --follow-symlinks 's/\(^auth.*required.*pam_faillock\.so.*preauth.*\)\('"{{{ option }}}"'=\)[0-9]\+\(.*\)/\1\2'"{{{ value }}}"'\3/' "$pam_file"
             {{%- if authfail %}}
             sed -i --follow-symlinks 's/\(^auth.*required.*pam_faillock\.so.*authfail.*\)\('"{{{ option }}}"'=\)[0-9]\+\(.*\)/\1\2'"{{{ value }}}"'\3/' "$pam_file"
             {{%- endif %}}

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1164,7 +1164,7 @@ if [ -f $FAILLOCK_CONF ] || [ "$SKIP_FAILLOCK_CHECK" = "true" ]; then
 else
     for pam_file in "${AUTH_FILES[@]}"
     do
-        if ! grep -qE '^\s*auth.*pam_faillock\.so (preauth|authfail).*{{{ option }}}' "$pam_file"; then
+        if ! grep -qE '^\s*auth.*pam_faillock\.so\s+(preauth|authfail).*{{{ option }}}' "$pam_file"; then
             {{%- if value == '' %}}
             sed -i --follow-symlinks '/^auth.*required.*pam_faillock\.so.*preauth.*/ s/$/ {{{ option }}}/' "$pam_file"
             {{%- if authfail %}}

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -871,6 +871,7 @@ Priority: 0
 Auth-Type: Primary
 Auth:
     [default=die]                   pam_faillock.so authfail
+    sufficient                      pam_faillock.so authsucc
 EOF
 fi
 


### PR DESCRIPTION
#### Description:

- Enable ansible macro for faillock for Ubuntu
- Use macro ansible_pam_faillock_parameter_value and bash_pam_faillock_parameter_value for rule accounts_passwords_pam_faillock_silent
- Append authsucc to `pam_faillock.so authfail` in both ansible and bash macro
- In oval, allow requisite control type pass
- Fix faillock_silent tests for Ubuntu using pam-auth-update 

#### Rationale:

- Be more consistent with other faillock rules
- Append authsucc: 
> here (oval belongs to the faillock_silent rule)
https://github.com/ComplianceAsCode/content/blob/aeb495e48d92348813a5cc6adeafb5237fb53745/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/oval/ubuntu.xml#L60 and here (for reference) https://github.com/ComplianceAsCode/content/blob/aeb495e48d92348813a5cc6adeafb5237fb53745/shared/templates/pam_account_password_faillock/oval.template#L126 

all match the authsucc at the end of regex