### PR TITLE
Fix stabilization job

### DIFF
--- a/.github/workflows/stabilize.yaml
+++ b/.github/workflows/stabilize.yaml
@@ -17,7 +17,7 @@ jobs:
       image: fedora:latest
     steps:
       - name: Install Deps
-        run: dnf install -y cmake ninja-build openscap-utils python3-pyyaml python3-jinja2 python3-pytest ansible libxslt python3-ansible-lint linkchecker java-1.8.0-openjdk unar wget python-unversioned-command git-core python3-setuptools
+        run: dnf install -y cmake ninja-build openscap-utils python3-pyyaml python3-jinja2 python3-pytest ansible libxslt python3-ansible-lint linkchecker java-latest-openjdk unar wget python-unversioned-command git-core python3-setuptools
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - name: Configure


### PR DESCRIPTION
#### Description:
Update stabilization to use the latest JDK.

#### Rationale:
So the job doesn't fail on installing packages.
#### Review Hints:
The the [run](https://github.com/Mab879/content/actions/runs/14579271729/job/40892156739) on my fork.