### PR TITLE
Add Missing Data for RHEL 10 SRG GPOS

### DIFF
--- a/controls/srg_gpos/SRG-OS-000042-GPOS-00020.yml
+++ b/controls/srg_gpos/SRG-OS-000042-GPOS-00020.yml
@@ -39,7 +39,6 @@ controls:
             - audit_rules_unsuccessful_file_modification_truncate
             - audit_rules_kernel_module_loading_delete
             - audit_rules_kernel_module_loading_finit
-            - audit_rules_kernel_module_loading_init
             - audit_rules_login_events_lastlog
             - audit_rules_privileged_commands_chage
             - audit_rules_privileged_commands_chsh
@@ -52,7 +51,6 @@ controls:
             - audit_rules_privileged_commands_passwd
             - audit_rules_privileged_commands_postdrop
             - audit_rules_privileged_commands_postqueue
-            - audit_rules_privileged_commands_pt_chown
             - audit_rules_privileged_commands_ssh_agent
             - audit_rules_privileged_commands_ssh_keysign
             - audit_rules_privileged_commands_su

--- a/controls/srg_gpos/SRG-OS-000392-GPOS-00172.yml
+++ b/controls/srg_gpos/SRG-OS-000392-GPOS-00172.yml
@@ -60,7 +60,6 @@ controls:
             - audit_rules_privileged_commands_passwd
             - audit_rules_privileged_commands_postdrop
             - audit_rules_privileged_commands_postqueue
-            - audit_rules_privileged_commands_pt_chown
             - audit_rules_privileged_commands_ssh_agent
             - audit_rules_privileged_commands_ssh_keysign
             - audit_rules_privileged_commands_su

--- a/controls/srg_gpos/SRG-OS-000471-GPOS-00215.yml
+++ b/controls/srg_gpos/SRG-OS-000471-GPOS-00215.yml
@@ -53,7 +53,6 @@ controls:
             - audit_rules_privileged_commands_passwd
             - audit_rules_privileged_commands_postdrop
             - audit_rules_privileged_commands_postqueue
-            - audit_rules_privileged_commands_pt_chown
             - audit_rules_privileged_commands_ssh_agent
             - audit_rules_privileged_commands_ssh_keysign
             - audit_rules_privileged_commands_su

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_percentage/policy/stig/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_percentage/policy/stig/shared.yml
@@ -1,0 +1,19 @@
+fixtext: |-
+    Configure {{{ full_name }}} to initiate an action when allocated audit record storage volume reaches 95 percent of the repository maximum audit record storage capacity by adding/modifying the following line in the /etc/audit/auditd.conf file.
+
+    admin_space_left = {{{ xccdf_value("var_auditd_admin_space_left_percentage") }}}%
+
+srg_requirement: |-
+    {{{ full_name }}} must take action when allocated audit record storage volume reaches 95 percent of the audit record storage capacity.
+
+checktext: |-
+    Verify {{{ full_name }}} takes action when allocated audit record storage volume reaches 95 percent of the repository maximum audit record storage capacity with the following command:
+
+    $ sudo grep -w admin_space_left /etc/audit/auditd.conf
+
+    admin_space_left = 5%
+
+    If the value of the "admin_space_left" keyword is not set to 5 percent of the storage volume allocated to audit logs, or if the line is commented out, ask the system administrator (SA) to indicate how the system is taking action if the allocated storage is about to reach capacity. If the "space_left" value is not configured to the correct value, this is a finding.
+
+vuldiscussion: |-
+    If action is not taken when storage volume reaches 95% utilization the auditing system may fail when the storage volume reaches capacity.

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_percentage/rule.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_percentage/rule.yml
@@ -1,6 +1,5 @@
 documentation_complete: true
 
-
 title: 'Configure auditd admin_space_left on Low Disk Space'
 
 description: |-

--- a/linux_os/guide/services/cron_and_at/package_cron_installed/policy/stig/rhel10.yml
+++ b/linux_os/guide/services/cron_and_at/package_cron_installed/policy/stig/rhel10.yml
@@ -1,0 +1,18 @@
+fixtext: |-
+    {{{ fixtext_package_installed(package="cronie") | indent(4) }}}
+
+srg_requirement: '{{{ srg_requirement_package_installed("cronie") }}}'
+
+checktext: |-
+    Verify that {{{ full_name }}} has the opensc package installed with the following command:
+
+    $ dnf list --installed cronie
+
+    Example output:
+
+    cronie.x86_64                            1.7.0-9.el10
+
+    If the "cronie" package is not installed, this is a finding.
+
+vuldiscussion: |-
+    The cronie package must be installed if it is to be available for multifactor authentication using smart cards.

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_pcsc-lite-ccid_installed/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_pcsc-lite-ccid_installed/policy/stig/shared.yml
@@ -1,0 +1,18 @@
+fixtext: |-
+    {{{ fixtext_package_installed(package="pcsc-lite-ccid") | indent(4) }}}
+
+srg_requirement: '{{{ srg_requirement_package_installed("pcsc-lite-ccid") }}}'
+
+checktext: |-
+    Verify that {{{ full_name }}} has the opensc package installed with the following command:
+
+    $ dnf list --installed pcsc-lite-ccid
+
+    Example output:
+
+    pcsc-lite-ccid.x86_64                            1.6.0-2.el10
+
+    If the "pcsc-lite-ccid" package is not installed, this is a finding.
+
+vuldiscussion: |-
+    The pcsc-lite-ccid package must be installed if it is to be available for multifactor authentication using smart cards.

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_messages/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_messages/policy/stig/shared.yml
@@ -15,7 +15,7 @@ checktext: |-
 
     If "/var/log/messages" does not have a mode of "0640" or less permissive, this is a finding.
 
-fixtext:
+fixtext: |-
     Configure the "/var/log/messages" file to have a mode of "0640" by running the following command:
 
     $ sudo chmod 0640 /var/log/messages

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_messages/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_messages/policy/stig/shared.yml
@@ -1,0 +1,21 @@
+srg_requirement: |-
+    {{{ full_name }}} /var/log/messages file must have mode 0640 or less permissive.
+
+vuldiscussion: |-
+    Only authorized personnel should be aware of errors and the details of the errors. Error messages are an indicator of an organization's operational state or can identify the {{{ full_name }}} system or platform. Additionally, personally identifiable information (PII) and operational information must not be revealed through error messages to unauthorized personnel or their designated representatives.
+
+    The structure and content of error messages must be carefully considered by the organization and development team. The extent to which the information system is able to identify and handle error conditions is guided by organizational policy and operational requirements.
+
+checktext: |-
+    Verify the "/var/log/messages" file has a mode of "0640" or less permissive with the following command:
+
+    $ stat -c '%a %n' /var/log/messages
+
+    600 /var/log/messages
+
+    If "/var/log/messages" does not have a mode of "0640" or less permissive, this is a finding.
+
+fixtext:
+    Configure the "/var/log/messages" file to have a mode of "0640" by running the following command:
+
+    $ sudo chmod 0640 /var/log/messages

--- a/linux_os/guide/system/permissions/files/rootfiles/rootfiles_configured/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/rootfiles/rootfiles_configured/policy/stig/shared.yml
@@ -1,0 +1,26 @@
+srg_requirements: |-
+    {{{ full_name }}} must have root's dotfiles configured correctly.
+
+checktext: |-
+    Check the all files from <tt>/usr/share/rootfiles/</tt> are overridden correctly in {{{ full_name }}}.
+    <pre>
+        $ grep /usr/share/rootfiles/.bash_logout *.conf
+        C /root/.bash_logout   600 root root - /usr/share/rootfiles/.bash_logout
+        C /root/.bash_profile  600 root root - /usr/share/rootfiles/.bash_profile
+        C /root/.bashrc        600 root root - /usr/share/rootfiles/.bashrc
+        C /root/.cshrc         600 root root - /usr/share/rootfiles/.cshrc
+        C /root/.tcshrc        600 root root - /usr/share/rootfiles/.tcshrc
+    </pre>
+
+fixtext: |-
+    Ensure the following lines are in <tt>.conf</tt> file under <tt>/etc/tmpfiles.d/</tt>.
+    <pre>
+        C /root/.bash_logout   600 root root - /usr/share/rootfiles/.bash_logout
+        C /root/.bash_profile  600 root root - /usr/share/rootfiles/.bash_profile
+        C /root/.bashrc        600 root root - /usr/share/rootfiles/.bashrc
+        C /root/.cshrc         600 root root - /usr/share/rootfiles/.cshrc
+        C /root/.tcshrc        600 root root - /usr/share/rootfiles/.tcshrc
+    </pre>
+
+vuldiscussion: |-
+     Excessive permissions on local interactive user home directories may allow unauthorized access to user files by other users.

--- a/linux_os/guide/system/selinux/package_policycoreutils_installed/policy/stig/rhel10.yml
+++ b/linux_os/guide/system/selinux/package_policycoreutils_installed/policy/stig/rhel10.yml
@@ -8,3 +8,17 @@ checktext: |-
     policycoreutils.x86_64           3.8-1.el10
 
     If the "policycoreutils" package is not installed, this is a finding.
+
+srg_requirement: |-
+    {{{ full_name }}} must have policycoreutils package installed.
+
+vuldiscussion: |-
+    Without verification of the security functions, security functions may not operate correctly and the failure may go unnoticed. Security function is defined as the hardware, software, and/or firmware of the information system responsible for enforcing the system security policy and supporting the isolation of code and data on which the protection is based. Security functionality includes, but is not limited to, establishing system accounts, configuring access authorizations (i.e., permissions, privileges), setting events to be audited, and setting intrusion detection parameters.
+
+    Policycoreutils contains the policy core utilities that are required for basic operation of an SELinux-enabled system. These utilities include load_policy to load SELinux policies, setfile to label filesystems, newrole to switch roles, and run_init to run /etc/init.d scripts in the proper context.
+
+
+fixtext: |-
+    The policycoreutils package can be installed with the following command:
+
+    $ sudo dnf install policycoreutils

--- a/products/rhel10/profiles/default.profile
+++ b/products/rhel10/profiles/default.profile
@@ -25,4 +25,5 @@ selections:
   - audit_rules_login_events
   - audit_rules_unsuccessful_file_modification
   - configure_openssl_tls_crypto_policy
+  - audit_rules_privileged_commands_pt_chown
   - package_iprutils_removed

--- a/tests/data/profile_stability/rhel10/stig.profile
+++ b/tests/data/profile_stability/rhel10/stig.profile
@@ -126,7 +126,6 @@ selections:
 - audit_rules_privileged_commands_pkexec
 - audit_rules_privileged_commands_postdrop
 - audit_rules_privileged_commands_postqueue
-- audit_rules_privileged_commands_pt_chown
 - audit_rules_privileged_commands_rmmod
 - audit_rules_privileged_commands_ssh_agent
 - audit_rules_privileged_commands_ssh_keysign

--- a/tests/data/profile_stability/rhel10/stig_gui.profile
+++ b/tests/data/profile_stability/rhel10/stig_gui.profile
@@ -126,7 +126,6 @@ selections:
 - audit_rules_privileged_commands_pkexec
 - audit_rules_privileged_commands_postdrop
 - audit_rules_privileged_commands_postqueue
-- audit_rules_privileged_commands_pt_chown
 - audit_rules_privileged_commands_rmmod
 - audit_rules_privileged_commands_ssh_agent
 - audit_rules_privileged_commands_ssh_keysign


### PR DESCRIPTION
#### Description:

Add Missing Data for RHEL 10 SRG GPOS.
See each commit for details.

#### Rationale:

Keep the content up to date.

