### PR TITLE
dir_group_ownership_library_dirs: exclude test scenario

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_group_ownership_library_dirs/tests/test_config.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_group_ownership_library_dirs/tests/test_config.yml
@@ -1,0 +1,2 @@
+deny_templated_scenarios:
+  - no_file.pass.sh


### PR DESCRIPTION
#### Description:

- exclude test scenario which deletes contents of library directories

#### Rationale:

- breaks the testing environment and the test cannot continue

#### Review Hints:

Use Automatus.