### PR TITLE
[Ubuntu]: UBTU-24-300016

### DIFF
--- a/controls/stig_ubuntu2404.yml
+++ b/controls/stig_ubuntu2404.yml
@@ -564,11 +564,11 @@ controls:
       or new passwords are established, pwquality must be used.
     levels:
       - medium
-    related_rules:
+    rules:
       - var_password_pam_retry=3
       - accounts_password_pam_enforcing
       - accounts_password_pam_retry
-    status: planned
+    status: automated
 
   - id: UBTU-24-300017
     title: Ubuntu 24.04 LTS must enforce a delay of at least four seconds between

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/bash/ubuntu.sh
@@ -3,4 +3,15 @@
 {{{ bash_instantiate_variables("var_password_pam_retry") }}}
 
 {{{ bash_pam_pwquality_enable() }}}
+{{% if product == 'ubuntu2404' %}}
+sed -i -E '/^Password:/,/^[^[:space:]]/ {
+    /pam_pwquality\.so/ {
+        s/\s*\bretry=\d+\b//g
+        s/$/ retry='"$var_password_pam_retry"'/g
+    }
+}' /usr/share/pam-configs/cac_pwquality
+
+DEBIAN_FRONTEND=noninteractive pam-auth-update --enable cac_pwquality
+{{% else %}}
 {{{ bash_pam_pwquality_parameter_value('retry', "$var_password_pam_retry") }}}
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
@@ -9,7 +9,7 @@
   <definition class="compliance" id="{{{ rule_id }}}" version="2">
     {{{ oval_metadata("The password retry should meet minimum requirements") }}}
     <criteria operator="AND" comment="The password retry should meet minimum requirements">
-      {{% if 'debian' not in product %}}
+      {{% if 'debian' not in product and 'ubuntu' not in product %}}
       <extend_definition definition_ref="enable_authselect"/>
       {{% endif %}}
       <criteria operator="OR" comment="Conditions for retry are satisfied">

--- a/shared/applicability/package.yml
+++ b/shared/applicability/package.yml
@@ -47,7 +47,11 @@ args:
   iptables:
     pkgname: iptables
   libpwquality:
+    {{% if 'ubuntu' in product %}}
+    pkgname: libpwquality1
+    {{% else %}}
     pkgname: libpwquality
+    {{% endif %}}
   libreswan:
     pkgname: libreswan
   libuser:


### PR DESCRIPTION
#### Description:

- Implement stig rule UBTU-24-300016
-  Set package name of libpwquality for Ubuntu
- Exclude extend_definition enable_authselect for Ubuntu
- Use pam-auth-update to insert "retry" option into common-password instead of pwquality.conf 
 
