### PR TITLE
Revert  #13049

### DIFF
--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -10,10 +10,7 @@ Then, assume that variables of that names are defined and contain the correct va
 #}}
 {{%- macro bash_instantiate_variables() -%}}
 {{%- for name in varargs -%}}
-{{{ name }}}=$(cat << EOF
-(bash-populate {{{ name }}})
-EOF
-)
+{{{ name }}}='(bash-populate {{{ name }}})'
 {{% endfor -%}}
 {{%- endmacro -%}}
 


### PR DESCRIPTION

#### Description:

Revert  #13049

#### Rationale:
This is preventing all pull requests to be blocked due to the automatus tests for banner_etc_issue failing.


#### Review Hints:
Check CI and run the Automatus tests for `banner_etc_issue`.