### PR TITLE
Adding autofs as excluded fstype for tests which select for non-remote-fstype directories

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/generate_privileged_commands_rule.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/generate_privileged_commands_rule.sh
@@ -3,6 +3,6 @@
 AUID=$1
 KEY=$2
 RULEPATH=$3
-for file in $(find / -not \( -fstype afs -o -fstype ceph -o -fstype cifs -o -fstype smb3 -o -fstype smbfs -o -fstype sshfs -o -fstype ncpfs -o -fstype ncp -o -fstype nfs -o -fstype nfs4 -o -fstype gfs -o -fstype gfs2 -o -fstype glusterfs -o -fstype gpfs -o -fstype pvfs2 -o -fstype ocfs2 -o -fstype lustre -o -fstype davfs -o -fstype fuse.sshfs \) -type f \( -perm -4000 -o -perm -2000 \) 2> /dev/null); do
+for file in $(find / -not \( -fstype afs -o -fstype autofs -o -fstype ceph -o -fstype cifs -o -fstype smb3 -o -fstype smbfs -o -fstype sshfs -o -fstype ncpfs -o -fstype ncp -o -fstype nfs -o -fstype nfs4 -o -fstype gfs -o -fstype gfs2 -o -fstype glusterfs -o -fstype gpfs -o -fstype pvfs2 -o -fstype ocfs2 -o -fstype lustre -o -fstype davfs -o -fstype fuse.sshfs \) -type f \( -perm -4000 -o -perm -2000 \) 2> /dev/null); do
      echo "-a always,exit -F path=$file -F perm=x -F auid>=$AUID -F auid!=unset -k $KEY" >> $RULEPATH
 done

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/bash/shared.sh
@@ -7,8 +7,8 @@
 # At least under containerized env /proc can have files w/o possilibity to
 # modify even as root. And touching /proc is not good idea anyways.
 find / -path /proc -prune -o \
-    -not -fstype afs -not -fstype ceph -not -fstype cifs -not -fstype smb3 -not -fstype smbfs \
-    -not -fstype sshfs -not -fstype ncpfs -not -fstype ncp -not -fstype nfs -not -fstype nfs4 \
-    -not -fstype gfs -not -fstype gfs2 -not -fstype glusterfs -not -fstype gpfs \
+    -not -fstype afs -not -fstype autofs -not -fstype ceph -not -fstype cifs -not -fstype smb3 \
+    -not -fstype smbfs -not -fstype sshfs -not -fstype ncpfs -not -fstype ncp -not -fstype nfs \
+    -not -fstype nfs4 -not -fstype gfs -not -fstype gfs2 -not -fstype glusterfs -not -fstype gpfs \
     -not -fstype pvfs2 -not -fstype ocfs2 -not -fstype lustre -not -fstype davfs \
     -not -fstype fuse.sshfs -type d -perm -0002 -uid +0 -exec chown root {} \;

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/tests/all_dirs_ok.pass.sh
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/tests/all_dirs_ok.pass.sh
@@ -2,4 +2,4 @@
 
 # At least under containerized env /proc can have files w/o possilibity to
 # modify even as root. And touching /proc is not good idea anyways.
-find / -path /proc -prune -o -not -fstype afs -not -fstype ceph -not -fstype cifs -not -fstype smb3 -not -fstype smbfs -not -fstype sshfs -not -fstype ncpfs -not -fstype ncp -not -fstype nfs -not -fstype nfs4 -not -fstype gfs -not -fstype gfs2 -not -fstype glusterfs -not -fstype gpfs -not -fstype pvfs2 -not -fstype ocfs2 -not -fstype lustre -not -fstype davfs -type d -perm -0002 -uid +0 -exec chown root {} \;
+find / -path /proc -prune -o -not -fstype afs -not -fstype autofs -not -fstype ceph -not -fstype cifs -not -fstype smb3 -not -fstype smbfs -not -fstype sshfs -not -fstype ncpfs -not -fstype ncp -not -fstype nfs -not -fstype nfs4 -not -fstype gfs -not -fstype gfs2 -not -fstype glusterfs -not -fstype gpfs -not -fstype pvfs2 -not -fstype ocfs2 -not -fstype lustre -not -fstype davfs -type d -perm -0002 -uid +0 -exec chown root {} \;

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1913,6 +1913,7 @@ Part of the grub2_bootloader_argument_absent template.
   ansible.builtin.set_fact:
     excluded_fstypes:
       - afs
+      - autofs
       - ceph
       - cifs
       - smb3


### PR DESCRIPTION
#### Description:

Added autofs to ansible and shell scripting lists of remote filesystem types to be excluded

#### Rationale:

Under most use-cases of autofs, the fstype would show as nfs or nfs4. However, when an autofs entry exists on the client side for a directory not yet shared server side, the placeholder directory will present as fstype autofs. Not excluding this causes tests to attempt find commands underneath not-truly-existent placeholder directories and subsequently fail. 

#### Note:

Not all autofs managed directories are remote directories (older use-cases such as USB/CD mounting). However, with all of those use-cases it should still be true that the directories will only ever show as fstype "autofs" when acting as placeholders and not when actually mounted. Therefore, using autofs as an excluded fstype shouldn't erroneously cause a local directory to be skipped. If edge cases of this behavior are identified, this should be revisited and addressed to accommodate those cases; however, at this time I know of no such case where an fstype of autofs should present on a directory which is truly mounted already and exists locally.