### PR TITLE
[Ubuntu] Switch rule 6.2.3.2 to audit_rules_suid_auid_privilege_function

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2595,7 +2595,7 @@ controls:
       - l2_server
       - l2_workstation
     rules:
-      - audit_rules_suid_privilege_function
+      - audit_rules_suid_auid_privilege_function
     status: automated
 
   - id: 6.2.3.3

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_auid_privilege_function/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_auid_privilege_function/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel,multi_platform_ubuntu
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_auid_privilege_function/bash/shared.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_auid_privilege_function/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel,multi_platform_ubuntu
 
 # First perform the remediation of the syscall rule
 # Retrieve hardware architecture of the underlying system


### PR DESCRIPTION
#### Description:

- Switch from rule audit_rules_suid_privilege_function to audit_rules_suid_auid_privilege_function
- Enable audit_rules_suid_auid_privilege_function on Ubuntu

#### Rationale:

- Rule 6.2.3.2 Ensure actions as another user are always logged detect "another user" where audit_rules_suid_auid_privilege_function fits better.
- The existing one audit_rules_suid_privilege_function has invalid filed **agid**