### PR TITLE
package_sudo_installed: limit test scenarios

### DIFF
--- a/linux_os/guide/system/software/sudo/package_sudo_installed/tests/custom-package-removed.fail.sh
+++ b/linux_os/guide/system/software/sudo/package_sudo_installed/tests/custom-package-removed.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# platform = multi_platform_rhel,multi_platform_fedora
+
+# Package libselinux cannot be uninstalled normally
+# as it would cause removal of sudo package which is
+# protected and package manager returns error in such
+# case. If the package would be removed forcefully it
+# would make the system unusable. Therefore, we will
+# remove the package only from RPM database
+rpm -e --nodeps --justdb sudo

--- a/linux_os/guide/system/software/sudo/package_sudo_installed/tests/test_config.yml
+++ b/linux_os/guide/system/software/sudo/package_sudo_installed/tests/test_config.yml
@@ -1,0 +1,2 @@
+allow_templated_scenarios:
+  - package-installed.pass.sh


### PR DESCRIPTION
#### Description:

- add one custom scenario which fakes package removel
- allow only package_insallted.pass.sh templated scenario
- skip other test scenarios because they will render the test environment unusable

#### Rationale:

- do not execute test scenarios which render the test environment unusable


#### Review Hints:

- use Automatus.