### PR TITLE
[Ubuntu] Fix audit_rules_suid_privilege_function for UBTU-24-200580

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/ansible/shared.yml
@@ -1,10 +1,10 @@
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicro,multi_platform_almalinux
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicro,multi_platform_ubuntu,multi_platform_almalinux
 # reboot = false
 # strategy = restrict
 # complexity = low
 # disruption = low
 
-{{% if product not in ["ol8", "ubuntu2404"] %}}
+{{% if product not in ["ol8"] %}}
 {{% set egid_arg = " -F egid=0" %}}
 {{% set euid_arg = " -F euid=0" %}}
 {{% endif %}}
@@ -13,7 +13,7 @@
 {{% set rx_b32 = "-F[\s]+arch=b32[\s]+" %}}
 {{% set rx_b64 = "-F[\s]+arch=b64[\s]+" %}}
 
-{{% if product in ["ol8", "ubuntu2404"] %}}
+{{% if product in ["ol8"] %}}
 {{% set rx_uid = "-S[\s]+execve[\s]+-C[\s]+uid!=euid[\s]+" %}}
 {{% set rx_gid = "-S[\s]+execve[\s]+-C[\s]+gid!=egid[\s]+" %}}
 {{% else %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/bash/shared.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/bash/shared.sh
@@ -7,16 +7,18 @@
 for ARCH in "${RULE_ARCHS[@]}"
 do
 	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
-    {{% if product in ["ubuntu2404"] %}}
-	OTHER_FILTERS="-C uid!=euid -F auid!=unset"
-    {{% elif product in ["ol8"] %}}
+    {{% if product in ["ol8"] %}}
 	OTHER_FILTERS="-C uid!=euid"
 	{{% else %}}
 	OTHER_FILTERS="-C uid!=euid -F euid=0"
 	{{% endif %}}
 	AUID_FILTERS=""
 	SYSCALL="execve"
+    {{% if product in ["ubuntu2404"] %}}
+	KEY="execpriv"
+	{{% else %}}
 	KEY="setuid"
+	{{% endif %}}
 	SYSCALL_GROUPING=""
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 	{{{ bash_fix_audit_syscall_rule("augenrules", "$ACTION_ARCH_FILTERS", "$OTHER_FILTERS", "$AUID_FILTERS", "$SYSCALL", "$SYSCALL_GROUPING", "$KEY") }}}
@@ -26,16 +28,18 @@ done
 for ARCH in "${RULE_ARCHS[@]}"
 do
 	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
-    {{% if product in ["ubuntu2404"] %}}
-	OTHER_FILTERS="-C gid!=egid -F agid!=unset"
-    {{% elif product in ["ol8"] %}}
+    {{% if product in ["ol8"] %}}
 	OTHER_FILTERS="-C gid!=egid"
 	{{% else %}}
 	OTHER_FILTERS="-C gid!=egid -F egid=0"
 	{{% endif %}}
 	AUID_FILTERS=""
 	SYSCALL="execve"
+    {{% if product in ["ubuntu2404"] %}}
+	KEY="execpriv"
+	{{% else %}}
 	KEY="setgid"
+	{{% endif %}}
 	SYSCALL_GROUPING=""
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 	{{{ bash_fix_audit_syscall_rule("augenrules", "$ACTION_ARCH_FILTERS", "$OTHER_FILTERS", "$AUID_FILTERS", "$SYSCALL", "$SYSCALL_GROUPING", "$KEY") }}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/oval/shared.xml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/oval/shared.xml
@@ -1,10 +1,7 @@
 {{% set rx_beg = "^[\s]*-a[\s]+always,exit[\s]+" %}}
 {{% set rx_b32 = "-F[\s]+arch=b32[\s]+" %}}
 {{% set rx_b64 = "-F[\s]+arch=b64[\s]+" %}}
-{{% if product in ["ubuntu2404"] %}}
-{{% set rx_uid = "-S[\s]+execve[\s]+-C[\s]+uid!=euid[\s]+-F[\s]+auid!=(-1|4294967295|unset)[\s]+" %}}
-{{% set rx_gid = "-S[\s]+execve[\s]+-C[\s]+gid!=egid[\s]+-F[\s]+agid!=(-1|4294967295|unset)[\s]+" %}}
-{{% elif product in ["ol8"] %}}
+{{% if product in ["ol8"] %}}
 {{% set rx_uid = "-S[\s]+execve[\s]+-C[\s]+uid!=euid[\s]+" %}}
 {{% set rx_gid = "-S[\s]+execve[\s]+-C[\s]+gid!=egid[\s]+" %}}
 {{% else %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/rule.yml
@@ -13,12 +13,7 @@ description: |-
 
     <pre>$ sudo grep -r execve /etc/audit/rules.d</pre>
 
-    {{% if product in ["ubuntu2404"] %}}
-    <pre>-a always,exit -F arch=b32 -S execve -C uid!=euid -F auid!=unset -k setuid</pre>
-    <pre>-a always,exit -F arch=b64 -S execve -C uid!=euid -F auid!=unset -k setuid</pre>
-    <pre>-a always,exit -F arch=b32 -S execve -C gid!=egid -F agid!=unset -k setgid</pre>
-    <pre>-a always,exit -F arch=b64 -S execve -C gid!=egid -F agid!=unset -k setgid</pre>
-    {{% elif product in ["ol8"] %}}
+    {{% if product in ["ol8"] %}}
     <pre>-a always,exit -F arch=b32 -S execve -C uid!=euid -k setuid</pre>
     <pre>-a always,exit -F arch=b64 -S execve -C uid!=euid -k setuid</pre>
     <pre>-a always,exit -F arch=b32 -S execve -C gid!=egid -k setgid</pre>
@@ -82,7 +77,7 @@ ocil: |-
 
     The output should be the following:
 
-    {{% if product in ["ol8", "ubuntu2404"] %}}
+    {{% if product in ["ol8"] %}}
     <pre>-a always,exit -F arch=b32 -S execve -C uid!=euid -k setuid</pre>
     <pre>-a always,exit -F arch=b64 -S execve -C uid!=euid -k setuid</pre>
     <pre>-a always,exit -F arch=b32 -S execve -C gid!=egid -k setgid</pre>
@@ -99,7 +94,7 @@ fixtext: |-
 
     Add or update the following rules to "/etc/audit/rules.d/audit.rules":
 
-    {{% if product in ["ol8", "ubuntu2404"] %}}
+    {{% if product in ["ol8"] %}}
     <pre>-a always,exit -F arch=b32 -S execve -C uid!=euid -k setuid</pre>
     <pre>-a always,exit -F arch=b64 -S execve -C uid!=euid -k setuid</pre>
     <pre>-a always,exit -F arch=b32 -S execve -C gid!=egid -k setgid</pre>

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/correct_value.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/correct_value.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = audit
 
-{{% if product in ["ol8", "ubuntu2404"] %}}
+{{% if product in ["ol8"] %}}
 OTHER_FILTERS_EUID=" -C uid!=euid"
 OTHER_FILTERS_EGID=" -C gid!=egid"
 {{% else %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/miss_arch.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/miss_arch.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = audit
 
-{{% if product in ["ol8", "ubuntu2404"] %}}
+{{% if product in ["ol8"] %}}
 OTHER_FILTERS_EUID=" -C uid!=euid"
 OTHER_FILTERS_EGID=" -C gid!=egid"
 {{% else %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/miss_c.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/miss_c.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = audit
 
-{{% if product not in ["ol8", "ubuntu2404"] %}}
+{{% if product not in ["ol8"] %}}
 OTHER_FILTERS_EUID=" -F euid=0"
 OTHER_FILTERS_EGID=" -F egid=0"
 {{% endif %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/other_key.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/other_key.pass.sh
@@ -3,7 +3,7 @@
 
 # This tests situation where key value is not std. And also situation where there is extra spaces in rules.
 
-{{% if product in ["ol8", "ubuntu2404"] %}}
+{{% if product in ["ol8"] %}}
 OTHER_FILTERS_EUID=" -C     uid!=euid"
 OTHER_FILTERS_EGID=" -C     gid!=egid"
 {{% else %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/use_f_key.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/use_f_key.pass.sh
@@ -2,7 +2,7 @@
 # packages = audit
 
 
-{{% if product in ["ol8", "ubuntu2404"] %}}
+{{% if product in ["ol8"] %}}
 OTHER_FILTERS_EUID=" -C uid!=euid"
 OTHER_FILTERS_EGID=" -C gid!=egid"
 {{% else %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_a.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_a.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = audit
 
-{{% if product in ["ol8", "ubuntu2404"] %}}
+{{% if product in ["ol8"] %}}
 OTHER_FILTERS_EUID=" -C uid!=euid"
 OTHER_FILTERS_EGID=" -C gid!=egid"
 {{% else %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_c_egid.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_c_egid.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = audit
 
-{{% if product in ["ol8", "ubuntu2404"] %}}
+{{% if product in ["ol8"] %}}
 OTHER_FILTERS_EUID=" -C uid!=egid"
 OTHER_FILTERS_EGID=" -C gid!=egid"
 {{% else %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_c_euid.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_c_euid.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = audit
 
-{{% if product in ["ol8", "ubuntu2404"] %}}
+{{% if product in ["ol8"] %}}
 OTHER_FILTERS_EUID=" -C uid!=euid"
 OTHER_FILTERS_EGID=" -C gid!=euid"
 {{% else %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_f_egid.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_f_egid.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
-{{% if product in ["ol8", "ubuntu2404"] %}}
+{{% if product in ["ol8"] %}}
 # platform = Not Applicable
 {{% endif %}}
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_f_euid.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_f_euid.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
-{{% if product in ["ol8", "ubuntu2404"] %}}
+{{% if product in ["ol8"] %}}
 # platform = Not Applicable
 {{% endif %}}
 


### PR DESCRIPTION
#### Description:

- Fix audit_rules_suid_privilege_function for stig rule UBTU-24-200580

#### Rationale:

- stig rule UBTU-24-200580 requires 
```
-a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -F key=execpriv
-a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -F key=execpriv
-a always,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -F key=execpriv
-a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -F key=execpriv
```