### PR TITLE
file_owner template: add no_remediation option

### DIFF
--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -333,6 +333,9 @@ they must be of the same length.
         list of possible user names separated by |, e.g. "syslog|root".
         uids cannot be used with the '|' operator.
 
+    - **no_remediation** - this is a hint for templated test scenarios that the rule does not have remediation.
+        In this case, test scenarios are modified so that they do not expect the rule to be remediated.
+
 -   Languages: Ansible, Bash, OVAL
 
 Note that the interaction between **filepath** and **file_regex** is as such:

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_messages/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_owner_var_log_messages/rule.yml
@@ -54,4 +54,5 @@ template:
     vars:
         filepath: /var/log/messages
         uid_or_name: '0'
+        no_remediation: true
 {{%- endif %}}

--- a/shared/templates/file_owner/tests/incorrect_owner.fail.sh
+++ b/shared/templates/file_owner/tests/incorrect_owner.fail.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-
+{{%- if NO_REMEDIATION %}}
+# remediation = none
+{{%- endif %}}
 useradd testuser_123
 {{%- for own in OWNERS %}}
 id "{{{ own }}}" &>/dev/null || useradd {{{ own }}}


### PR DESCRIPTION
#### Description:

- If no_remediation is specified in the template instance, then test scenarios are modified appropriately and they do not expect remediation

#### Rationale:

- align expectations of test scenarios

#### Review Hints:

Use Automatus.