### PR TITLE
Make sure latest ansible setup works on sle15

### DIFF
--- a/Dockerfiles/test_suite-sle15
+++ b/Dockerfiles/test_suite-sle15
@@ -10,9 +10,10 @@ RUN zypper refresh
 
 RUN true \
         && zypper --non-interactive in openssh-clients openssh-server openscap-utils \
-        python3 python3-rpm tar gawk\
+        python311 python311-rpm python311-pip tar gawk\
         $ADDITIONAL_PACKAGES \
 && true
+RUN pip install ansible && ansible-galaxy collection install ansible.posix
 
 RUN true \
         && for key_type in rsa ecdsa; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \


### PR DESCRIPTION


#### Description:

- Upgrade python and put some newer ansible modules in sle15's tests docker image

#### Rationale:

- Latest ansible setup script relies on python > 3.7 so sle15 needs to upgrade its docker image
