### PR TITLE
Replace pam_unix_remember with pam_pwhistory_remember

### DIFF
--- a/products/sle15/profiles/anssi_bp28_enhanced.profile
+++ b/products/sle15/profiles/anssi_bp28_enhanced.profile
@@ -63,3 +63,5 @@ selections:
     - '!timer_dnf-automatic_enabled'
     - '!dnf-automatic_apply_updates'
     - '!dnf-automatic_security_updates_only'
+    - '!accounts_password_pam_unix_remember'
+    - accounts_password_pam_pwhistory_remember

--- a/products/sle15/profiles/anssi_bp28_high.profile
+++ b/products/sle15/profiles/anssi_bp28_high.profile
@@ -90,3 +90,5 @@ selections:
     - '!timer_dnf-automatic_enabled'
     - '!dnf-automatic_apply_updates'
     - '!dnf-automatic_security_updates_only'
+    - '!accounts_password_pam_unix_remember'
+    - accounts_password_pam_pwhistory_remember

--- a/products/sle15/profiles/anssi_bp28_intermediary.profile
+++ b/products/sle15/profiles/anssi_bp28_intermediary.profile
@@ -60,3 +60,5 @@ selections:
   - '!timer_dnf-automatic_enabled'
   - '!dnf-automatic_apply_updates'
   - '!dnf-automatic_security_updates_only'
+  - '!accounts_password_pam_unix_remember'
+  - accounts_password_pam_pwhistory_remember

--- a/products/sle15/profiles/anssi_bp28_minimal.profile
+++ b/products/sle15/profiles/anssi_bp28_minimal.profile
@@ -48,3 +48,5 @@ selections:
   - '!timer_dnf-automatic_enabled'
   - '!dnf-automatic_apply_updates'
   - '!dnf-automatic_security_updates_only'
+  - '!accounts_password_pam_unix_remember'
+  - accounts_password_pam_pwhistory_remember

--- a/products/sle15/profiles/pci-dss-4.profile
+++ b/products/sle15/profiles/pci-dss-4.profile
@@ -67,3 +67,4 @@ selections:
     - '!audit_rules_file_deletion_events_renameat2'
     - '!audit_rules_mac_modification_etc_selinux'
     - '!audit_rules_dac_modification_fchmodat2'
+    - '!accounts_password_pam_unix_remember'


### PR DESCRIPTION

#### Description:

- Replace accounts_password_pam_unix_remember with  accounts_password_pam_pwhistory_remember for sle15

#### Rationale:

- pam_pwhistory library is now the default choice for sle15 so better use that rule compared to pam_unix based rules