### PR TITLE
package_bind_removed: unify test scenarios

### DIFF
--- a/linux_os/guide/services/dns/disabling_dns_server/package_bind_removed/tests/one_of_packages_installed.fail.sh
+++ b/linux_os/guide/services/dns/disabling_dns_server/package_bind_removed/tests/one_of_packages_installed.fail.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-# platform = Red Hat Enterprise Linux 9
-
-dnf install -y bind9.18 || dnf install -y bind

--- a/linux_os/guide/services/dns/disabling_dns_server/package_bind_removed/tests/package-installed-removed.pass.sh
+++ b/linux_os/guide/services/dns/disabling_dns_server/package_bind_removed/tests/package-installed-removed.pass.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 10, multi_platform_fedora, multi_platform_debian, multi_platform_ol, multi_platform_sle
 
+{{% if product == "rhel9" -%}}
+dnf install -y bind9.18 || dnf install -y bind
+dnf remove -y bind9.18
+dnf -y remove bind
+{{% else -%}}
 {{{ bash_package_install("bind") }}}
 {{{ bash_package_remove("bind") }}}
+{{% endif -%}}

--- a/linux_os/guide/services/dns/disabling_dns_server/package_bind_removed/tests/package-installed.fail.sh
+++ b/linux_os/guide/services/dns/disabling_dns_server/package_bind_removed/tests/package-installed.fail.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 10, multi_platform_fedora, multi_platform_debian, multi_platform_ol, multi_platform_sle
 
+{{% if product == "rhel9" -%}}
+dnf install -y bind9.18 || dnf install -y bind
+{{% else -%}}
 {{{ bash_package_install("bind") }}}
+{{% endif -%}}


### PR DESCRIPTION
#### Description:

- use Jinja conditionals to define a different behavior for rhel9 product rather than fishy overriding of templated test scenarios

#### Rationale:

- the script generating compiled test scenarios generated undesired package_installed.fail.sh script. I wanted to fill an issue against the script, but then I realised that the implementation before this PR was a bit shaky, so I modified it.



#### Review Hints:

Test with Automatus on rhel9 product and some other product which has the rule.