### PR TITLE
Change platform of GNOME rules

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/rule.yml
@@ -53,4 +53,3 @@ ocil: |-
     <pre>$ grep disable-restart-buttons /etc/dconf/db/{{{ dconf_gdm_dir }}}/locks/*</pre>
     If properly configured, the output should be <tt>/org/gnome/login-screen/disable-restart-buttons</tt>
 
-platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/rule.yml
@@ -55,4 +55,3 @@ ocil: |-
     <pre>$ grep disable-user-list /etc/dconf/db/{{{ dconf_gdm_dir }}}/locks/*</pre>
     If properly configured, the output should be <tt>/org/gnome/login-screen/disable-user-list</tt>
 
-platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/rule.yml
@@ -45,7 +45,6 @@ ocil: |-
     <pre>$ grep enable-smartcard-authentication /etc/dconf/db/{{{ dconf_gdm_dir }}}/locks/*</pre>
     If properly configured, the output should be <tt>/org/gnome/login-screen/enable-smartcard-authentication</tt>
 
-platform: machine
 
 fixtext: |-
     The dconf settings can be edited in the /etc/dconf/db/* location.

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_lock_screen_on_smartcard_removal/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_lock_screen_on_smartcard_removal/rule.yml
@@ -50,7 +50,6 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} must be able to initiate directly a session lock for all connection types using smartcard when the smartcard is removed.'
 
-platform: machine
 
 template:
     name: dconf_ini_file

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/rule.yml
@@ -46,4 +46,3 @@ ocil: |-
     <pre>$ grep allowed-failures /etc/dconf/db/{{{ dconf_gdm_dir }}}/locks/*</pre>
     If properly configured, the output should be <tt>/org/gnome/login-screen/allowed-failures</tt>
 
-platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/rule.yml
@@ -55,6 +55,5 @@ fixtext: |-
     [daemon]
     AutomaticLoginEnable=false
 
-platform: machine
 
 srg_requirement: 'Unattended or automatic logon via the {{{ full_name }}} graphical user interface must not be allowed.'

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/rule.yml
@@ -44,4 +44,3 @@ ocil: |-
     <pre>[daemon]
     TimedLoginEnable=false</pre>
 
-platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_unattended_automatic_login/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_unattended_automatic_login/rule.yml
@@ -40,4 +40,3 @@ ocil: |-
     <pre>DISPLAYMANAGER_AUTOLOGIN=""
          DISPLAYMANAGER_PASSWORD_LESS_LOGIN="no"</pre>
 
-platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_xdmcp/rule.yml
@@ -41,4 +41,3 @@ ocil: |-
     </pre>
 
 # There is a gdm platform implied by the parent group.
-# platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount/rule.yml
@@ -54,4 +54,3 @@ ocil: |-
     <pre>$ grep 'automount' /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output for <tt>automount</tt> should be <tt>/org/gnome/desktop/media-handling/automount</tt>
 
-platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount_open/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount_open/rule.yml
@@ -55,7 +55,6 @@ ocil: |-
     <pre>$ grep 'automount-open' /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output for <tt>automount-open</tt> should be <tt>/org/gnome/desktop/media-handling/automount-open</tt>
 
-platform: machine
 
 fixtext: |-
     Configure GNOME 3 to disable automated mount of removable media.

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_autorun/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_autorun/rule.yml
@@ -55,7 +55,6 @@ ocil: |-
     <pre>$ grep 'autorun-never' /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output for <tt>autorun-never</tt> should be <tt>/org/gnome/desktop/media-handling/autorun-never</tt>
 
-platform: machine
 
 fixtext: |-
     Configure GNOME 3 to disable automated mount of removable media.

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_thumbnailers/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_thumbnailers/rule.yml
@@ -51,4 +51,3 @@ ocil: |-
     <pre>$ grep disable-all /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output should be <tt>/org/gnome/desktop/thumbnailers/disable-all</tt>
 
-platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_create/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_create/rule.yml
@@ -40,4 +40,3 @@ ocil: |-
     If properly configured, the output should be
     <tt>/org/gnome/nm-applet/disable-wifi-create</tt>
 
-platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_notification/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_notification/rule.yml
@@ -42,4 +42,3 @@ ocil: |-
     If properly configured, the output should be
     <tt>/org/gnome/nm-applet/suppress-wireless-networks-available</tt>
 
-platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_credential_prompt/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_credential_prompt/rule.yml
@@ -44,4 +44,3 @@ ocil: |-
     If properly configured, the output should be
     <tt>/org/gnome/Vino/authentication-methods</tt>
 
-platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_encryption/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_encryption/rule.yml
@@ -53,4 +53,3 @@ ocil: |-
     If properly configured, the output should be
     <tt>/org/gnome/Vino/require-encryption</tt>
 
-platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/rule.yml
@@ -62,4 +62,3 @@ ocil: |-
     <pre>$ grep idle-activation-enabled /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output should be <tt>/org/gnome/desktop/screensaver/idle-activation-enabled</tt>
 
-platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/rule.yml
@@ -66,4 +66,3 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} must automatically lock graphical user sessions after 15 minutes of inactivity.'
 
-platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/rule.yml
@@ -53,4 +53,3 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} must initiate a session lock for graphical user interfaces when the screensaver is activated.'
 
-platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/rule.yml
@@ -85,4 +85,3 @@ fixtext: |-
 srg_requirement: |-
     {{{ full_name }}} must enable a user session lock until that user re-establishes access using established identification and authentication procedures for graphical user sessions.
 
-platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/rule.yml
@@ -83,4 +83,3 @@ fixtext: |-
     {{{ fixtext_dconf_ini_file("org/gnome/desktop/screensaver", "picture-uri", "string ''") }}}
 
 
-platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_info/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_info/rule.yml
@@ -40,4 +40,3 @@ ocil: |-
     <pre>$ grep show-full-name-in-top-bar /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output should be <tt>/org/gnome/desktop/screensaver/show-full-name-in-top-bar</tt>
 
-platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/rule.yml
@@ -53,4 +53,3 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} must prevent a user from overriding the session lock-delay setting for the graphical user interface.'
 
-platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/rule.yml
@@ -58,4 +58,3 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} must prevent a user from overriding the session idle-delay setting for the graphical user interface.'
 
-platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/rule.yml
@@ -63,4 +63,3 @@ fixtext: '{{{ fixtext_dconf_ini_file("/org/gnome/settings-daemon/plugins/media-k
 
 srg_requirement: 'The x86 Ctrl-Alt-Delete key sequence in {{{ full_name }}} must be disabled if a graphical user interface is installed.'
 
-platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_geolocation/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_geolocation/rule.yml
@@ -45,4 +45,3 @@ ocil: |-
     If properly configured, the output should be
     <tt>/org/gnome/system/location/enabled</tt> and <tt>/org/gnome/clocks/geolocation</tt>.
 
-platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_power_settings/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_power_settings/rule.yml
@@ -39,4 +39,3 @@ ocil: |-
     If properly configured, the output should be
     <tt>/org/gnome/settings-daemon/plugins/power/active</tt>
 
-platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_user_admin/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_user_admin/rule.yml
@@ -47,7 +47,6 @@ ocil: |-
     If properly configured, the output should be
     <tt>/org/gnome/desktop/lockdown/user-administration-disabled</tt>
 
-platform: machine
 
 template:
     name: dconf_ini_file


### PR DESCRIPTION
Rules that are related to GNOME and dconf were marked with the `machine` platform. But, there isn't anything special about them that would require to mark them with the `machine` platform. Also, the group is marked with `package[gdm]` platform which already prevents their evaluation on the system that don't contain GNOME.

We will remove the `machine` platform. This will make the rules applicable and passing during a build of a bootable container image. The `Containerfile` needs to run `dnf install -y gdm` before running `oscap-im` to see the effect of this commit.

Related to: https://issues.redhat.com/browse/OPENSCAP-5328


#### Review Hints:

Build a hardened RHEL 10 container bootable image with the stig_gui profile using data stream built from this PR. The Containerfile needs to install "gdm". Deploy a VM using podman-bootc from the built image. Scan the VM and generate HTML report. Review the report and focus on rules changed by this PR.
