### PR TITLE
Corrected ansible task which adds "nodev" to local /etc/fstab entries other than root

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/ansible/shared.yml
@@ -24,5 +24,5 @@
 - name: "{{{ rule_title }}}: Ensure non-root local partitions are present with nodev option in /etc/fstab"
   ansible.builtin.replace:
     path: /etc/fstab
-    regexp: '^\s*(?!#)(/dev/\S+|UUID=\S+)\s+(/\w\S*)\s+(\S+)\s+(?!nodev)(\S+)(.*)$'
+    regexp: '^\s*(?!#)(/dev/\S+|UUID=\S+)\s+(/\w\S*)\s+(\S+)\s+(?!.*\bnodev\b)(\S+)(.*)$'
     replace: '\1 \2 \3 \4,nodev \5'


### PR DESCRIPTION
#### Description:

Corrected regex to properly match lines with nodev present. 

#### Rationale:

Previous version would fail to match lines with nodev present, resulting in non-idempotent runs which will add nodev to lines with nodev already present every time.

#### Review Hints:

Inside /etc/fstab, include a local mount entry other than root without nodev option set, then run the old playbook twice and note that nodev is added twice. Then, reverse the changes and run the new playbook twice, noting that nodev is only added the first time. 