### PR TITLE
Update STIG IDs for SSHD Mac and Ciphers rules on RHEL 8

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/rule.yml
@@ -31,7 +31,7 @@ references:
     nist: AC-17(2)
     srg: SRG-OS-000125-GPOS-00065,SRG-OS-000250-GPOS-00093
     stigid@ol8: OL08-00-010291
-    stigid@rhel8: RHEL-08-010291
+    stigid@rhel8: RHEL-08-010297
 
 ocil_clause: 'Crypto Policy for OpenSSH Server is not configured correctly'
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/rule.yml
@@ -29,7 +29,7 @@ references:
     nist: AC-17(2)
     srg: SRG-OS-000125-GPOS-00065,SRG-OS-000250-GPOS-00093
     stigid@ol8: OL08-00-010290
-    stigid@rhel8: RHEL-08-010290
+    stigid@rhel8: RHEL-08-010296
 
 ocil_clause: 'Crypto Policy for OpenSSH Server is not configured correctly'
 

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -202,10 +202,10 @@ selections:
     # RHEL-08-010287
     - configure_ssh_crypto_policy
 
-    # RHEL-08-010290
+    # RHEL-08-010296
     - harden_sshd_macs_opensshserver_conf_crypto_policy
 
-    # RHEL-08-010291
+    # RHEL-08-010297
     - harden_sshd_ciphers_opensshserver_conf_crypto_policy
 
     # RHEL-08-010292


### PR DESCRIPTION
#### Description:
Update STIG IDs for SSHD Mac and Ciphers rules on RHEL 8
#### Rationale:

Keep the STIG up-to-date.

#### Review Hints:
See https://stigaview.com/products/rhel8/v2r3/RHEL-08-010297/ and https://stigaview.com/products/rhel8/v2r3/RHEL-08-010296/
