### PR TITLE
Adjust some rules for latest tencentos4

### DIFF
--- a/controls/std_tencentos4.yml
+++ b/controls/std_tencentos4.yml
@@ -19,7 +19,7 @@ controls:
     rules:
       - kernel_module_cramfs_disabled
 
-  - id: 1.1.3
+  - id: 1.1.2
     title: Ensure mounting of squashfs filesystems is disabled
     levels:
       - l1_server
@@ -27,23 +27,7 @@ controls:
     rules:
       - kernel_module_squashfs_disabled
 
-  - id: 1.1.4
-    title: Ensure mounting of udf filesystems is disabled
-    levels:
-      - l1_server
-    status: automated
-    rules:
-      - kernel_module_udf_disabled
-
-  - id: 1.1.4
-    title: Disable Automounting
-    levels:
-      - l1_server
-    status: automated
-    rules:
-      - service_autofs_disabled
-
-  - id: 1.1.5
+  - id: 1.1.3
     title: Ensure USB Disabled
     levels:
       - l2_server
@@ -51,7 +35,7 @@ controls:
     rules:
       - kernel_module_usb-storage_disabled
 
-  - id: 1.1.6
+  - id: 1.1.4
     title: Ensure a separate partition exists for /tmp
     levels:
       - l2_server
@@ -59,105 +43,16 @@ controls:
     rules:
       - partition_for_tmp
 
-  - id: 1.1.7
+  - id: 1.1.5
     title: Ensure correct mounting options set on /tmp partition
     levels:
       - l2_server
     status: automated
     rules:
       - mount_option_tmp_nodev
-      - mount_option_tmp_noexec
       - mount_option_tmp_nosuid
 
-  - id: 1.1.8
-    title: Ensure a separate partition exists for /var
-    levels:
-      - l2_server
-    status: automated
-    rules:
-      - partition_for_var
-
-  - id: 1.1.9
-    title: Ensure correct mounting options set on /var partition
-    levels:
-      - l2_server
-    status: automated
-    rules:
-      - mount_option_var_nodev
-
-  - id: 1.1.10
-    title: Ensure a separate partition exists for /home
-    levels:
-      - l2_server
-    status: automated
-    rules:
-      - partition_for_home
-
-  - id: 1.1.11
-    title: Ensure correct mounting options set on /home partition
-    levels:
-      - l2_server
-    status: automated
-    rules:
-      - mount_option_home_nodev
-      - mount_option_home_nosuid
-      - mount_option_home_noexec
-
-  - id: 1.1.12
-    title: Ensure a separate partition exists for /var/log
-    levels:
-      - l2_server
-    status: automated
-    rules:
-      - partition_for_var_log
-
-  - id: 1.1.13
-    title: Ensure correct mounting options set on /var/log partition
-    levels:
-      - l2_server
-    status: automated
-    rules:
-      - mount_option_var_log_nodev
-      - mount_option_var_log_noexec
-      - mount_option_var_log_nosuid
-
-  - id: 1.1.14
-    title: Ensure a separate partition exists for /var/log/audit
-    levels:
-      - l2_server
-    status: automated
-    rules:
-      - partition_for_var_log_audit
-
-  - id: 1.1.15
-    title: Ensure correct mounting options set on /var/log/audit partition
-    levels:
-      - l2_server
-    status: automated
-    rules:
-      - mount_option_var_log_audit_nodev
-      - mount_option_var_log_audit_noexec
-      - mount_option_var_log_audit_nosuid
-
-  - id: 1.1.16
-    title: Ensure a separate partition exists for /var/tmp
-    levels:
-      - l2_server
-    status: automated
-    rules:
-      - partition_for_var_tmp
-
-  - id: 1.1.17
-    title: Ensure correct mounting options set on /var/tmp partition
-    levels:
-      - l2_server
-    status: automated
-    rules:
-      - mount_option_var_tmp_nodev
-      - mount_option_var_tmp_noexec
-      - mount_option_var_tmp_nosuid
-
-  - id: 1.1.18
+  - id: 1.1.6
     title: Ensure a separate partition exists for /dev/shm
     levels:
       - l2_server
@@ -165,7 +60,7 @@ controls:
     rules:
       - partition_for_dev_shm
 
-  - id: 1.1.19
+  - id: 1.1.7
     title: Ensure correct mounting options set on /dev/shm partition
     levels:
       - l2_server
@@ -183,7 +78,6 @@ controls:
     status: automated
     rules:
       - package_aide_installed
-      - aide_build_database
 
   - id: 1.2.2
     title: Ensure filesystem integrity is regularly checked
@@ -201,14 +95,6 @@ controls:
 
   # 1.3 Configure Software Updates
   - id: 1.3.1
-    title: Ensure updates, patches, and additional security software are installed
-    levels:
-      - l1_server
-    status: automated
-    rules:
-      - security_patches_up_to_date
-
-  - id: 1.3.2
     title: Ensure gpgcheck is globally activated
     levels:
       - l1_server
@@ -400,7 +286,6 @@ controls:
       - l1_server
     status: automated
     rules:
-      - service_avahi-daemon_disabled
       - package_avahi_removed
 
   - id: 2.3.2
@@ -453,7 +338,6 @@ controls:
       - l1_server
     status: automated
     rules:
-      - service_telnet_disabled
       - package_telnet_removed
       - package_telnet-server_removed
 
@@ -509,7 +393,6 @@ controls:
       - l2_server
     status: automated
     rules:
-      - service_squid_disabled
       - package_squid_removed
 
   - id: 2.3.14
@@ -518,7 +401,6 @@ controls:
       - l2_server
     status: automated
     rules:
-      - service_snmpd_disabled
       - package_net-snmp_removed
 
   - id: 2.3.15
@@ -531,15 +413,6 @@ controls:
       - package_rsh_removed
 
   - id: 2.3.16
-    title: Ensure mail transfer agent is configured for local-only mode
-    levels:
-      - l2_server
-    status: automated
-    rules:
-      - postfix_network_listening_disabled
-      - var_postfix_inet_interfaces=loopback-only
-
-  - id: 2.3.17
     title: Ensure IMAP and POP3 Server is disabled
     levels:
       - l2_server
@@ -548,7 +421,7 @@ controls:
       - service_dovecot_disabled
       - package_dovecot_removed
 
-  - id: 2.3.18
+  - id: 2.3.17
     title: Ensure RPC Service is disabled
     levels:
       - l2_server
@@ -556,7 +429,7 @@ controls:
     rules:
       - service_rpcbind_disabled
 
-  - id: 2.3.19
+  - id: 2.3.18
     title: Ensure DHCP Service is disabled
     levels:
       - l2_server
@@ -565,7 +438,7 @@ controls:
       - service_dhcpd_disabled
       - package_dhcp_removed
 
-  - id: 2.3.20
+  - id: 2.3.19
     title: Ensure NFS Service is disabled
     levels:
       - l2_server
@@ -1273,6 +1146,7 @@ controls:
       - l2_server
     status: automated
     rules:
+      - sshd_strong_macs=cis_tencentos4
       - sshd_use_strong_macs
 
   - id: 5.2.20
@@ -1315,15 +1189,6 @@ controls:
       - accounts_password_pam_enforce_root
 
   - id: 5.3.2
-    title: Ensure history passwords are limited to use
-    levels:
-      - l1_server
-    status: automated
-    rules:
-      - accounts_password_pam_pwhistory_remember
-      - var_password_pam_remember=5
-
-  - id: 5.3.3
     title: Ensure password hashing algorithm is SHA-512
     levels:
       - l1_server
@@ -1333,7 +1198,7 @@ controls:
       - set_password_hashing_algorithm_passwordauth
       - var_password_hashing_algorithm_pam=sha512
 
-  - id: 5.3.4
+  - id: 5.3.3
     title: Ensure password expiration is 180 days or less
     levels:
       - l1_server
@@ -1343,7 +1208,7 @@ controls:
       - var_accounts_maximum_age_login_defs=180
       - accounts_password_set_max_life_existing
 
-  - id: 5.3.5
+  - id: 5.3.4
     title: Ensure minimum days between password changes is configured
     levels:
       - l1_server
@@ -1353,7 +1218,7 @@ controls:
       - var_accounts_minimum_age_login_defs=1
       - accounts_password_set_min_life_existing
 
-  - id: 5.3.6
+  - id: 5.3.5
     title: Ensure password expiration warning days is 7 or more
     levels:
       - l1_server
@@ -1363,7 +1228,7 @@ controls:
       - var_accounts_password_warn_age_login_defs=7
       - accounts_password_set_warn_age_existing
 
-  - id: 5.3.7
+  - id: 5.3.6
     title: Ensure inactive password lock is 30 days or less
     levels:
       - l1_server
@@ -1373,7 +1238,7 @@ controls:
       - var_account_disable_post_pw_expiration=30
       - accounts_set_post_pw_existing
 
-  - id: 5.3.8
+  - id: 5.3.7
     title: Ensure all users last password change date is in the past
     levels:
       - l1_server
@@ -1381,7 +1246,7 @@ controls:
     rules:
       - accounts_password_last_change_is_in_past
 
-  - id: 5.3.9
+  - id: 5.3.8
     title: Ensure accounts locked after 5 failed logins is configured
     levels:
       - l1_server
@@ -1444,16 +1309,6 @@ controls:
       - display_login_attempts
 
   - id: 5.4.7
-    title: Ensure access to the su command is restricted
-    levels:
-      - l1_server
-    status: automated
-    rules:
-      - ensure_pam_wheel_group_empty
-      - use_pam_wheel_group_for_su
-      - var_pam_wheel_group_for_su=cis
-
-  - id: 5.4.8
     title: Ensure every UID is unique
     levels:
       - l1_server
@@ -1461,7 +1316,7 @@ controls:
     rules:
       - account_unique_id
 
-  - id: 5.4.9
+  - id: 5.4.8
     title: Ensure account name is unique
     levels:
       - l1_server
@@ -1469,7 +1324,7 @@ controls:
     rules:
       - account_unique_name
 
-  - id: 5.4.10
+  - id: 5.4.9
     title: Ensure every GID is unique
     levels:
       - l1_server
@@ -1477,7 +1332,7 @@ controls:
     rules:
       - group_unique_id
 
-  - id: 5.4.11
+  - id: 5.4.10
     title: Ensure every group name is unique
     levels:
       - l1_server
@@ -1485,7 +1340,7 @@ controls:
     rules:
       - group_unique_name
 
-  - id: 5.4.12
+  - id: 5.4.11
     title: Ensure accounts related files have correct permissions
     levels:
       - l1_server
@@ -1516,7 +1371,7 @@ controls:
       - file_owner_backup_etc_gshadow
       - file_groupowner_backup_etc_gshadow
 
-  - id: 5.4.13
+  - id: 5.4.12
     title: Ensure all users' home directories exist
     levels:
       - l1_server
@@ -1524,7 +1379,7 @@ controls:
     rules:
       - accounts_user_interactive_home_directory_exists
 
-  - id: 5.4.14
+  - id: 5.4.13
     title: Ensure all users' home directories permissions are 750 or more restrictive
     levels:
       - l1_server

--- a/linux_os/guide/services/ssh/sshd_strong_macs.var
+++ b/linux_os/guide/services/ssh/sshd_strong_macs.var
@@ -16,6 +16,7 @@ options:
     cis_rhel9: -hmac-md5,hmac-md5-96,hmac-ripemd160,hmac-sha1-96,umac-64@openssh.com,hmac-md5-etm@openssh.com,hmac-md5-96-etm@openssh.com,hmac-ripemd160-etm@openssh.com,hmac-sha1-96-etm@openssh.com,umac-64-etm@openssh.com
     cis_sle12: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160
     cis_sle15: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
+    cis_tencentos4: hmac-sha2-512,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-256-etm@openssh.com
     cis_ubuntu2204: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
     cis_ubuntu2404: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
     stig_rhel9: hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512


### PR DESCRIPTION
#### Description:

- Adjust some rules for latest TencentOS Server 4

#### Rationale:

- remove rules of separate partitions for /var, /home, /var/log, /var/log/audit, /var/tmp.
- remove security_patches_up_to_date because tencentos4 doesn't have CCE id for that.
- remove other rules which are not appliable for tencentos4.
- add cis_tencentos4 var in sshd_strong_macs.var because hmac-ripemd160 in default is not appliable for tencentos4.

#### Review Hints:

- Please review it and any feedback is my appreciate.
