### PR TITLE
Add RHEL 10 to the list of supported systems

### DIFF
--- a/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_vendor_supported/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_vendor_supported/oval/shared.xml
@@ -6,6 +6,7 @@
     <criteria comment="Installed operating system is supported by a vendor" operator="OR">
       <extend_definition comment="Installed OS is RHEL8" definition_ref="installed_OS_is_rhel8" />
       <extend_definition comment="Installed OS is RHEL9" definition_ref="installed_OS_is_rhel9" />
+      <extend_definition comment="Installed OS is RHEL10" definition_ref="installed_OS_is_rhel10" />
       <extend_definition comment="Installed OS is OL7" definition_ref="installed_OS_is_ol7" />
       <extend_definition comment="Installed OS is OL8" definition_ref="installed_OS_is_ol8" />
       <extend_definition comment="Installed OS is OL9" definition_ref="installed_OS_is_ol9" />


### PR DESCRIPTION
#### Description:
Add RHEL 10 to the list of supported systems

#### Rationale:

Currently RHEL 10 fails in scanning the STIG profile on RHEL 10.

#### Review Hints:

