### PR TITLE
Update STIG IDs for SSH Client MAC and Ciphers rules on RHEL 8 

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/rule.yml
@@ -30,7 +30,7 @@ references:
     disa: CCI-001453
     nist: AC-17(2)
     srg: SRG-OS-000033-GPOS-00014,SRG-OS-000125-GPOS-00065,SRG-OS-000250-GPOS-00093,SRG-OS-000393-GPOS-00173,SRG-OS-000394-GPOS-00174,SRG-OS-000423-GPOS-00187
-    stigid@rhel8: RHEL-08-010020
+    stigid@rhel8: RHEL-08-010020,RHEL-08-010296
 
 ocil_clause: 'Crypto Policy for OpenSSH client is not configured correctly'
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/rule.yml
@@ -28,7 +28,7 @@ references:
     disa: CCI-000877,CCI-001453
     nist: AC-17(2)
     srg: SRG-OS-000125-GPOS-00065,SRG-OS-000250-GPOS-00093
-    stigid@rhel8: RHEL-08-010020
+    stigid@rhel8: RHEL-08-010020,RHEL-08-010296
 
 ocil_clause: 'Crypto Policy for OpenSSH client is not configured correctly'
 

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -220,6 +220,12 @@ selections:
     # RHEL-08-010295
     - configure_gnutls_tls_crypto_policy
 
+    # RHEL-08-010296
+    - harden_sshd_macs_openssh_conf_crypto_policy
+
+    # RHEL-08-010297
+    - harden_sshd_ciphers_openssh_conf_crypto_policy
+
     # RHEL-08-010300
     - file_permissions_binary_dirs
 

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -249,7 +249,9 @@ selections:
 - grub2_uefi_admin_username
 - grub2_uefi_password
 - grub2_vsyscall_argument
+- harden_sshd_ciphers_openssh_conf_crypto_policy
 - harden_sshd_ciphers_opensshserver_conf_crypto_policy
+- harden_sshd_macs_openssh_conf_crypto_policy
 - harden_sshd_macs_opensshserver_conf_crypto_policy
 - install_smartcard_packages
 - installed_OS_is_vendor_supported

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -260,7 +260,9 @@ selections:
 - grub2_uefi_admin_username
 - grub2_uefi_password
 - grub2_vsyscall_argument
+- harden_sshd_ciphers_openssh_conf_crypto_policy
 - harden_sshd_ciphers_opensshserver_conf_crypto_policy
+- harden_sshd_macs_openssh_conf_crypto_policy
 - harden_sshd_macs_opensshserver_conf_crypto_policy
 - install_smartcard_packages
 - installed_OS_is_vendor_supported


### PR DESCRIPTION
#### Description:
Add two rules to the RHEL 8 STIG.

#### Rationale:

Keep the STIG up-to-date.

#### Review Hints:

See https://stigaview.com/products/rhel8/v2r3/RHEL-08-010297/ and https://stigaview.com/products/rhel8/v2r3/RHEL-08-010296/
