### PR TITLE
Improve bash/ansible_ensure_pam_module_option macros

### DIFF
--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1633,7 +1633,7 @@ Part of the grub2_bootloader_argument_absent template.
   ansible.builtin.lineinfile:
     path: "{{{ pam_file }}}"
     backrefs: true
-    regexp: ^(\s*{{{ group }}}\s+{{ pam_module_control | regex_escape() }}\s+{{{ module }}}\s+.*)({{{ option }}})=[0-9a-zA-Z]+\s*(.*)
+    regexp: ^(\s*{{{ group }}}\s+{{ pam_module_control | regex_escape() }}\s+{{{ module }}}\s+.*)({{{ option }}})=[0-9a-zA-Z]*\s*(.*)
     line: \1\2={{{ value }}} \3
   register: result_pam_{{{ rule_id }}}_edit
   when:

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -2388,7 +2388,7 @@ if ! grep -qP "^\s*{{{ group }}}\s+{{{ control_regex }}}\s+{{{ module }}}\s*.*\s
 fi
 {{%- else %}}
 else
-    sed -i -E --follow-symlinks "s/(\s*{{{ group }}}\s+{{{ control_regex }}}\s+{{{ module }}}\s+.*)({{{ option }}}=)[[:alnum:]]+\s*(.*)/\1\2{{{ value }}} \3/" "{{{ pam_file }}}"
+    sed -i -E --follow-symlinks "s/(\s*{{{ group }}}\s+{{{ control_regex }}}\s+{{{ module }}}\s+.*)({{{ option }}}=)[[:alnum:]]*\s*(.*)/\1\2{{{ value }}} \3/" "{{{ pam_file }}}"
 fi
 {{%- endif %}}
 {{%- endmacro -%}}


### PR DESCRIPTION




#### Description:

- Make sure that bash/ansible_ensure_pam_module_option can handle situation in which option with value is not set correctly

#### Rationale:

- Current implementation was failing in case the pam option(i.e. deny) is set but to an empty value ,i.e. instead of `deny=5`, if we have the `deny= ` or even `deny=-3` the regex will fail to match the option
