### PR TITLE
Remove service_rlogin_disabled and service_rsh_disabled from RHEL 10 HIPAA

### DIFF
--- a/products/rhel10/profiles/default.profile
+++ b/products/rhel10/profiles/default.profile
@@ -27,3 +27,4 @@ selections:
   - configure_openssl_tls_crypto_policy
   - audit_rules_privileged_commands_pt_chown
   - package_iprutils_removed
+  - service_rlogin_disabled

--- a/products/rhel10/profiles/default.profile
+++ b/products/rhel10/profiles/default.profile
@@ -28,3 +28,4 @@ selections:
   - audit_rules_privileged_commands_pt_chown
   - package_iprutils_removed
   - service_rlogin_disabled
+  - service_rsh_disabled

--- a/products/rhel10/profiles/hipaa.profile
+++ b/products/rhel10/profiles/hipaa.profile
@@ -63,3 +63,4 @@ selections:
     - '!sshd_allow_only_protocol2'
     - '!sshd_disable_kerb_auth'
     - '!sshd_disable_gssapi_auth'
+    - '!service_rlogin_disabled'

--- a/products/rhel10/profiles/hipaa.profile
+++ b/products/rhel10/profiles/hipaa.profile
@@ -64,3 +64,4 @@ selections:
     - '!sshd_disable_kerb_auth'
     - '!sshd_disable_gssapi_auth'
     - '!service_rlogin_disabled'
+    - '!service_rsh_disabled'

--- a/tests/data/profile_stability/rhel10/hipaa.profile
+++ b/tests/data/profile_stability/rhel10/hipaa.profile
@@ -173,7 +173,6 @@ selections:
 - service_debug-shell_disabled
 - service_kdump_disabled
 - service_rexec_disabled
-- service_rlogin_disabled
 - service_rsh_disabled
 - service_rsyslog_enabled
 - service_telnet_disabled

--- a/tests/data/profile_stability/rhel10/hipaa.profile
+++ b/tests/data/profile_stability/rhel10/hipaa.profile
@@ -173,7 +173,6 @@ selections:
 - service_debug-shell_disabled
 - service_kdump_disabled
 - service_rexec_disabled
-- service_rsh_disabled
 - service_rsyslog_enabled
 - service_telnet_disabled
 - sshd_disable_compression


### PR DESCRIPTION
This rule checks for rsh and rsh-server packages which aren't present in RHEL 10.

