### PR TITLE
Disable wrong_runtime.fail.sh

### DIFF
--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_ip_local_port_range/tests/test_config.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_ip_local_port_range/tests/test_config.yml
@@ -1,0 +1,2 @@
+deny_templated_scenarios:
+- wrong_runtime.fail.sh

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_kexec_load_disabled/tests/test_config.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_kexec_load_disabled/tests/test_config.yml
@@ -1,0 +1,2 @@
+deny_templated_scenarios:
+- wrong_runtime.fail.sh

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_modules_disabled/tests/test_config.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_modules_disabled/tests/test_config.yml
@@ -1,0 +1,2 @@
+deny_templated_scenarios:
+- wrong_runtime.fail.sh

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_max_sample_rate/tests/test_config.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_max_sample_rate/tests/test_config.yml
@@ -1,0 +1,2 @@
+deny_templated_scenarios:
+- wrong_runtime.fail.sh

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_pid_max/tests/test_config.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_pid_max/tests/test_config.yml
@@ -1,0 +1,2 @@
+deny_templated_scenarios:
+- wrong_runtime.fail.sh


### PR DESCRIPTION
Disable templated test scenario wrong_runtime.fail.sh for selected rules using the sysctl template. The reason is that these rules configure sysctl value that can't be changed using the `sysctl -w` command which causes that the test scenario fails to configure the virtual machine in the expected way and consequently the oscap scan unexpectedly passes.

Addressing:
sysctl: setting key "kernel.kexec_load_disabled": Invalid argument


