### PR TITLE
Improve AlmaLinux OS support

### DIFF
--- a/controls/srg_gpos/SRG-OS-000366-GPOS-00153.yml
+++ b/controls/srg_gpos/SRG-OS-000366-GPOS-00153.yml
@@ -21,5 +21,8 @@ controls:
             {{% if 'ol' in product %}}
             - ensure_oracle_gpgkey_installed
             {{% endif %}}
+            {{% if 'almalinux' in product %}}
+            - ensure_almalinux_gpgkey_installed
+            {{% endif %}}
 
         status: automated

--- a/linux_os/guide/system/software/gnome/group.yml
+++ b/linux_os/guide/system/software/gnome/group.yml
@@ -11,6 +11,8 @@ description: |-
     GNOME is developed by the GNOME Project and is considered the default
     {{% if 'ol' in product %}}
     Oracle Linux Graphical environment.
+    {{% elif 'almalinux' in product %}}
+    AlmaLinux Graphical environment.
     {{% else %}}
     Red Hat Graphical environment.
     {{% endif %}}

--- a/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_vendor_supported/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_vendor_supported/oval/shared.xml
@@ -4,6 +4,7 @@
         The operating system installed on the system is supported by a vendor that provides security patches.
       ") }}}
     <criteria comment="Installed operating system is supported by a vendor" operator="OR">
+      <extend_definition comment="Installed OS is ALMALINUX9" definition_ref="installed_OS_is_almalinux9" />
       <extend_definition comment="Installed OS is RHEL8" definition_ref="installed_OS_is_rhel8" />
       <extend_definition comment="Installed OS is RHEL9" definition_ref="installed_OS_is_rhel9" />
       <extend_definition comment="Installed OS is RHEL10" definition_ref="installed_OS_is_rhel10" />

--- a/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_vendor_supported/rule.yml
+++ b/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_vendor_supported/rule.yml
@@ -11,6 +11,9 @@ description: |-
 {{% elif product in ["sle12", "sle15", "slmicro5"] %}}
     SUSE Linux Enterprise is supported by SUSE. As the SUSE Linux Enterprise
     vendor, SUSE is responsible for providing security patches.
+{{% elif 'almalinux' in product %}}
+    AlmaLinux OS is supported by AlmaLinux OS Foundation. As the AlmaLinux OS
+    vendor, AlmaLinux OS Foundation is responsible for providing security patches.
 {{% else %}}
     Red Hat Enterprise Linux is supported by Red Hat, Inc. As the Red Hat Enterprise
     Linux vendor, Red Hat, Inc. is responsible for providing security patches.

--- a/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/rpm_verification/rpm_verify_hashes/ansible/shared.yml
@@ -7,7 +7,7 @@
 - name: "Set fact: Package manager reinstall command"
   set_fact:
     package_manager_reinstall_cmd: {{{ pkg_manager }}} reinstall -y
-  when: ansible_distribution in [ "Fedora", "RedHat", "CentOS", "OracleLinux" ]
+  when: ansible_distribution in [ "Fedora", "RedHat", "CentOS", "OracleLinux", "AlmaLinux" ]
 
 - name: "Set fact: Package manager reinstall command (zypper)"
   set_fact:

--- a/linux_os/guide/system/software/updating/security_patches_up_to_date/rule.yml
+++ b/linux_os/guide/system/software/updating/security_patches_up_to_date/rule.yml
@@ -16,6 +16,11 @@ description: |-
     <pre>$ sudo yum update</pre>
     If the system is not configured to use one of these sources, updates (in the form of RPM packages)
     can be manually downloaded from the ULN and installed using <tt>rpm</tt>.
+{{% elif 'almalinux' in product %}}
+    Run the following command to install updates:
+    <pre>$ sudo yum update</pre>
+    If the system is not configured to use repos, updates (in the form of RPM packages)
+    can be manually downloaded from the repos and installed using <tt>rpm</tt>.
 {{% elif product in ["sle12", "sle15", "slmicro5"] %}}
     If the system is configured for online updates, invoking the following command will list available
     security updates:

--- a/product_properties/10-grub.yml
+++ b/product_properties/10-grub.yml
@@ -6,7 +6,11 @@ default:
 
 overrides:
 {{% if "rhel-like" in families and major_version_ordinal <= 8 %}}
+{{% if "almalinux" in product %}}
+  grub2_uefi_boot_path: "/boot/efi/EFI/almalinux"
+{{% else %}}
   grub2_uefi_boot_path: "/boot/efi/EFI/redhat"
+{{% endif %}}
 {{% endif %}}
 {{% if "suse" in families %}}
   grub_helper_executable: "grub2-mkconfig"


### PR DESCRIPTION
#### Description:

- This PR improves AlmaLinux OS support in several places

#### Rationale:

- AlmaLinux OS support was introduced in version 0.1.76 but there is still room for improvement.

#### Review Hints:

- Changes here are mostly trivial and similar to Oracle Linux ones.
