### PR TITLE
Fix test_config support in build_tests.py

### DIFF
--- a/build-scripts/build_tests.py
+++ b/build-scripts/build_tests.py
@@ -18,6 +18,7 @@ import ssg.templates
 SSG_ROOT = str(pathlib.Path(__file__).resolve().parent.parent.absolute())
 JOB_COUNT = multiprocessing.cpu_count()
 T = TypeVar("T")
+TESTS_CONFIG_NAME = "test_config.yml"
 
 
 def _create_arg_parser() -> argparse.ArgumentParser:
@@ -120,8 +121,12 @@ def _process_local_tests(product: str, env_yaml: dict, rule_output_path: pathlib
             _write_path(content, rule_output_path / test.name)
 
 
-def _should_skip_templated_tests(deny_templated_scenarios, test):
-    return not test.name.endswith(".sh") or test.name in deny_templated_scenarios
+def _get_test_dir_config(test_dir: pathlib.Path) -> Dict:
+    test_config = dict()
+    test_config_filename = os.path.join(test_dir, TESTS_CONFIG_NAME)
+    if os.path.exists(test_config_filename):
+        test_config = ssg.yaml.open_raw(test_config_filename)
+    return test_config
 
 
 def _process_templated_tests(env_yaml: Dict, rendered_rule_obj: Dict, templates_root: pathlib.Path,
@@ -143,11 +148,13 @@ def _process_templated_tests(env_yaml: Dict, rendered_rule_obj: Dict, templates_
         logger.debug("Template %s doesn't have tests. Skipping for rule %s.",
                      template_name, rule_id)
         return
-    test_config_path = rule_tests_root / "test_config.yml"
-    deny_templated_scenarios = _get_deny_templated_scenarios(test_config_path)
-    for test in template_tests_root.iterdir():  # type: pathlib.Path
-        if _should_skip_templated_tests(deny_templated_scenarios, test):
-            logger.warning("Skipping %s for %s as it is a denied test scenario",
+    test_config = _get_test_dir_config(rule_tests_root)
+    all_templated_tests = set(x.name for x in template_tests_root.iterdir())
+    templated_tests = ssg.utils.select_templated_tests(test_config, all_templated_tests)
+    for test_name in templated_tests:  # type: str
+        test = template_tests_root / test_name
+        if not test.name.endswith(".sh"):
+            logger.warning("Skipping %s for %s as it isn't a test scenario",
                            test.name, rule_id)
             continue
         template = ssg.templates.Template.load_template(str(templates_root.absolute()),

--- a/build-scripts/build_tests.py
+++ b/build-scripts/build_tests.py
@@ -121,11 +121,13 @@ def _process_local_tests(product: str, env_yaml: dict, rule_output_path: pathlib
             _write_path(content, rule_output_path / test.name)
 
 
-def _get_test_dir_config(test_dir: pathlib.Path) -> Dict:
+def _get_test_dir_config(rule_path: pathlib.Path) -> Dict:
     test_config = dict()
-    test_config_filename = os.path.join(test_dir, TESTS_CONFIG_NAME)
-    if os.path.exists(test_config_filename):
-        test_config = ssg.yaml.open_raw(test_config_filename)
+    rule_root = rule_path.parent
+    tests_dir = rule_root / "tests"
+    test_config_path = tests_dir / TESTS_CONFIG_NAME
+    if test_config_path.exists():
+        test_config = ssg.yaml.open_raw(test_config_path)
     return test_config
 
 
@@ -141,14 +143,11 @@ def _process_templated_tests(env_yaml: Dict, rendered_rule_obj: Dict, templates_
     template_root = templates_root / template_name
     template_tests_root = template_root / "tests"
 
-    rule_root = rule_path.parent
-    rule_tests_root = rule_root / "tests"
-
     if not template_tests_root.exists():
         logger.debug("Template %s doesn't have tests. Skipping for rule %s.",
                      template_name, rule_id)
         return
-    test_config = _get_test_dir_config(rule_tests_root)
+    test_config = _get_test_dir_config(rule_path)
     all_templated_tests = set(x.name for x in template_tests_root.iterdir())
     templated_tests = ssg.utils.select_templated_tests(test_config, all_templated_tests)
     for test_name in templated_tests:  # type: str

--- a/ssg/utils.py
+++ b/ssg/utils.py
@@ -900,3 +900,28 @@ def ensure_file_paths_and_file_regexes_are_correctly_defined(data):
                 "rule '{0}'".format(data["_rule_id"]))
 
     check_conflict_regex_directory(data)
+
+
+def select_templated_tests(test_dir_config, available_scenarios_basenames):
+    deny_scenarios = set(test_dir_config.get("deny_templated_scenarios", []))
+    available_scenarios_basenames = {
+        test_name for test_name in available_scenarios_basenames
+        if test_name not in deny_scenarios
+    }
+
+    allow_scenarios = set(test_dir_config.get("allow_templated_scenarios", []))
+    if allow_scenarios:
+        available_scenarios_basenames = {
+            test_name for test_name in available_scenarios_basenames
+            if test_name in allow_scenarios
+        }
+
+    allowed_and_denied = deny_scenarios.intersection(allow_scenarios)
+    if allowed_and_denied:
+        msg = (
+            "Test directory configuration contain inconsistencies: {allowed_and_denied} "
+            "scenarios are both allowed and denied."
+            .format(allowed_and_denied=allowed_and_denied)
+        )
+        raise ValueError(msg)
+    return available_scenarios_basenames

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -20,7 +20,7 @@ from ssg.constants import OSCAP_RULE
 from ssg.jinja import process_file_with_macros
 from ssg.products import product_yaml_path, load_product_yaml
 from ssg.rules import get_rule_dir_yaml
-from ssg.utils import mkdir_p
+from ssg.utils import mkdir_p, select_templated_tests
 from tests.ssg_test_suite.log import LogHelper
 
 import ssg.templates
@@ -371,31 +371,6 @@ def get_test_dir_config(test_dir, product_yaml):
     if os.path.exists(test_config_filename):
         test_config = ssg.yaml.open_and_expand(test_config_filename, product_yaml)
     return test_config
-
-
-def select_templated_tests(test_dir_config, available_scenarios_basenames):
-    deny_scenarios = set(test_dir_config.get("deny_templated_scenarios", []))
-    available_scenarios_basenames = {
-        test_name for test_name in available_scenarios_basenames
-        if test_name not in deny_scenarios
-    }
-
-    allow_scenarios = set(test_dir_config.get("allow_templated_scenarios", []))
-    if allow_scenarios:
-        available_scenarios_basenames = {
-            test_name for test_name in available_scenarios_basenames
-            if test_name in allow_scenarios
-        }
-
-    allowed_and_denied = deny_scenarios.intersection(allow_scenarios)
-    if allowed_and_denied:
-        msg = (
-            "Test directory configuration contain inconsistencies: {allowed_and_denied} "
-            "scenarios are both allowed and denied."
-            .format(allowed_and_denied=allowed_and_denied)
-        )
-        raise ValueError(msg)
-    return available_scenarios_basenames
 
 
 def fetch_templated_tests_paths(


### PR DESCRIPTION
#### Description:

This change makes sure `build_tests.py` fully supports `test_config.yml` configuration files in rule directories.

For more details, please read commit messages of all commits.

#### Rationale:

Fixes: https://github.com/ComplianceAsCode/content/issues/13371


#### Review Hints:

```
./build_product --render-test-scenarios rhel10
```

Then, review built test scenarios in `build/rhel10/tests` for the rules affected by this problem, eg. `package_libselinux_installed`, `package_sudo_installed`.  See the `test_config.yml` of these rules at the same time.
