### PR TITLE
Fix sshd_set_idle_timeout for RHEL 10

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/oval/shared.xml
@@ -34,7 +34,7 @@
           {{%- endif %}}
           <criterion comment="the configuration exists" test_ref="test_clientaliveinterval_present" />
         </criteria>
-        {{%- if product not in ["ol8", "ol9", "rhel8", "rhel9"] %}}
+        {{%- if product not in ["ol8", "ol9", "rhel8", "rhel9", "rhel10"] %}}
         <extend_definition comment="The SSH ClientAliveCountMax is set to zero" definition_ref="sshd_set_keepalive" />
         {{% endif %}}
       </criteria>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/oval/shared.xml
@@ -34,7 +34,7 @@
           {{%- endif %}}
           <criterion comment="the configuration exists" test_ref="test_clientaliveinterval_present" />
         </criteria>
-        {{%- if product not in ["ol8", "ol9", "rhel8", "rhel9", "rhel10"] %}}
+        {{%- if product not in ["ol8", "ol9"] and "rhel" not in product %}}
         <extend_definition comment="The SSH ClientAliveCountMax is set to zero" definition_ref="sshd_set_keepalive" />
         {{% endif %}}
       </criteria>


### PR DESCRIPTION
It was failing Automatus test scenarios on RHEL 10 because the templated test scenarios don't count with the extend_definition in static rule OVAL.

