### PR TITLE
Add Bash remediation for gnome_gdm_disable_guest_login on RHEL 10

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol,multi_platform_almalinux
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 10,multi_platform_fedora,multi_platform_ol,multi_platform_almalinux
 
 if rpm --quiet -q gdm
 then


### PR DESCRIPTION
The rule gnome_gdm_disable_guest_login has a bash remediation but wasn't enabled on RHEL10. This has been discovered by running the per-rule tests.


