### PR TITLE
Format thin data streams

### DIFF
--- a/build-scripts/compose_ds.py
+++ b/build-scripts/compose_ds.py
@@ -3,7 +3,7 @@
 import argparse
 import os
 import sys
-import time
+import subprocess
 import glob
 import xml.etree.ElementTree as ET
 
@@ -300,6 +300,11 @@ def _compose_multiple_ds(args):
             os.makedirs(os.path.dirname(output))
 
         _store_ds(ds, output)
+        if not hasattr(ET, "indent"):
+            subprocess.run(
+                ["xmllint", "--nsclean", "--format", "--output", output, output],
+                check=True,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This prevents building data streams that contain very long lines because openscap has problems parsings them and segfaults or prints errors.
It will be executed only when the elementtree library doesn't contain the indent method which means when building with Python older that 3.9.

#### Review Hints:
On RHEL 8, run `./build_product -t rhel8`.  You need to build it on RHEL 8 machine because of the Python. Check in CMake stdout that Python 3.6 is used for building.

```
vim build/thin_ds/ssg-rhel8-ds_accounts_umask_etc_bashrc.xml
oscap xccdf eval --profile '(all)' build/thin_ds/ssg-rhel8-ds_accounts_umask_etc_bashrc.xml
```