### PR TITLE
[Ubuntu]: Implement stig rule UBTU-24-200090

### DIFF
--- a/controls/stig_ubuntu2404.yml
+++ b/controls/stig_ubuntu2404.yml
@@ -339,9 +339,9 @@ controls:
     title: Ubuntu 24.04 LTS must monitor remote access methods.
     levels:
       - medium
-    related_rules:
+    rules:
       - rsyslog_remote_access_monitoring
-    status: planned
+    status: automated
 
   - id: UBTU-24-200250
     title: Ubuntu 24.04 LTS must automatically remove or disable emergency accounts

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/bash/ubuntu.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/bash/ubuntu.sh
@@ -1,7 +1,7 @@
 # platform = multi_platform_ubuntu
 
 if [ ! -f /etc/rsyslog.d/50-default.conf ]; then
-    # Something is not right, create the file
+    mkdir -p /etc/rsyslog.d/
     touch /etc/rsyslog.d/50-default.conf
 fi
 

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/oval/shared.xml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/oval/shared.xml
@@ -24,16 +24,16 @@
   {{{ test_remote_method(method="authpriv", test_ref="remote_method_monitoring_authpriv") }}}
   {{{ test_remote_method(method="daemon", test_ref="remote_method_monitoring_daemon") }}}
 
-  {{% macro object_remote_method(regex, test_ref) %}}
+  {{% macro object_remote_method(method, test_ref) %}}
   <ind:textfilecontent54_object id="obj_{{{ test_ref }}}" version="1">
     <ind:filepath operation="pattern match">^/etc/rsyslog\.(conf|d/.+\.conf)$</ind:filepath>
-    <ind:pattern operation="pattern match">{{{ regex }}}</ind:pattern>
+    <ind:pattern operation="pattern match">^[^#\n]*{{{ method }}}(,\w+)*\.\*[^\n]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   {{% endmacro %}}
 
-  {{{ object_remote_method(regex="^[^#]*auth\.\*.*$", test_ref="remote_method_monitoring_auth") }}}
-  {{{ object_remote_method(regex="^[^#]*authpriv\.\*.*$", test_ref="remote_method_monitoring_authpriv") }}}
-  {{{ object_remote_method(regex="^[^#]*daemon\.\*.*$", test_ref="remote_method_monitoring_daemon") }}}
+  {{{ object_remote_method(method="auth", test_ref="remote_method_monitoring_auth") }}}
+  {{{ object_remote_method(method="authpriv", test_ref="remote_method_monitoring_authpriv") }}}
+  {{{ object_remote_method(method="daemon", test_ref="remote_method_monitoring_daemon") }}}
 
 </def-group>

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/rule.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/rule.yml
@@ -8,8 +8,8 @@ description: |-
     attacks and ensure ongoing compliance with remote access policies are being
     audited and upheld. An examples of a remote access method is the use of the
     Remote Desktop Protocol (RDP) from an external, non-organization controlled
-    network. The <tt>/etc/rsyslog.conf</tt> or
-    <tt>/etc/rsyslog.d/*.conf</tt> file should contain a match for the following
+    network. The {{% if 'ubuntu' in product %}}<tt>/etc/rsyslog.d/50-default.conf</tt>{{% else %}}<tt>/etc/rsyslog.conf</tt> or
+    <tt>/etc/rsyslog.d/*.conf</tt>{{% endif %}} file should contain a match for the following
     selectors: <tt>auth.*</tt>, <tt>authpriv.*</tt>, and <tt>daemon.*</tt>. If
     not, use the following as an example configuration:
     <code>
@@ -43,14 +43,27 @@ ocil_clause: 'remote access methods are not logging to rsyslog'
 ocil: |-
     To verify that <tt>remote access methods</tt> are logging to <tt>rsyslog</tt>,
     run the following command:
+    {{% if product == 'ubuntu2204' %}}
+    <pre>grep -rE '^(auth\.\*,authpriv\.\*|daemon\.\*)' /etc/rsyslog.*</pre>
+    {{% elif 'ubuntu' in product %}}
+    <pre>grep -rE '^(auth,authpriv\.\*|daemon\.\*)' /etc/rsyslog.*</pre>
+    {{% else %}}
     <pre>grep -rE '(auth.\*|authpriv.\*|daemon.\*)' /etc/rsyslog.*</pre>
+    {{% endif %}}
     The output should contain <tt>auth.*</tt>, <tt>authpriv.*</tt>, and <tt>daemon.*</tt>
     pointing to a log file.
 
 fixtext: |-
+{{% if 'ubuntu' in product %}}
+    add or update the following lines to the "/etc/rsyslog.d/50-default.conf" file:
+
+    auth.*,authpriv.* /var/log/secure
+    daemon.* /var/log/messages
+{{% else %}}
     add or update the following lines to the "/etc/rsyslog.conf" file:
 
     auth.*;authpriv.*;daemon.* /var/log/secure
+{{% endif %}}
 
     The "rsyslog" service must be restarted for the changes to take effect. To restart the "rsyslog" service, run the following command:
 

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/tests/priority_at_the_end.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/tests/priority_at_the_end.pass.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+declare -A REMOTE_METHODS=( ['auth.*']='^.*auth\.\*.*$' ['authpriv.*']='^.*authpriv\.\*.*$' ['daemon.*']='^.*daemon\.\*.*$' )
+RSYSLOG_CONF='/etc/rsyslog.conf'
+RSYSLOG_D_FOLDER='/etc/rsyslog.d'
+RSYSLOG_D_FILES='/etc/rsyslog.d/*'
+
+
+# clean up .d conf files (if applicable)
+if [[ -d ${RSYSLOG_D_FOLDER} ]]; then
+	for rsyslog_d_file in ${RSYSLOG_D_FILES} ${RSYSLOG_CONF}
+	do
+		for K in ${!REMOTE_METHODS[@]}
+		do
+			if grep -q "$K" ${rsyslog_d_file}; then
+				sed -i "/$K/d" ${rsyslog_d_file}
+			fi
+		done
+	done
+fi
+
+if [[ ! -f /etc/rsyslog.conf ]]; then
+	# Something is not right, create the file
+	touch /etc/rsyslog.conf
+fi
+
+echo "auth,authpriv.* /var/log/secure" >> $RSYSLOG_CONF
+echo "daemon.* /var/log/messages" >> $RSYSLOG_CONF


### PR DESCRIPTION
#### Description:

- Implement stig rule UBTU-24-200090
- Update desciption of rule rsyslog_remote_access_monitoring
- Create folder if not exist
- Create more precise regex for oval 

#### Rationale:

- The existing oval will match multiple lines as one match due to `[^#]*`
- Add `(,\w+)*` to match selectors following the targeting {{{ method }}}. e.g. `target_facility,facility2,facility3.*    action`
- Match `.*` explicitly in the end of selector part since rsyslog.conf indicates `You can specify multiple facilities with the same priority pattern in one statement using the comma (',') operator.`