### PR TITLE
[Ubuntu]: Implement stig rule UBTU-24-700010

### DIFF
--- a/components/filesystem.yml
+++ b/components/filesystem.yml
@@ -115,6 +115,7 @@ rules:
 - file_permissions_unauthorized_world_writable
 - file_permissions_ungroupowned
 - file_permissions_var_log
+- file_permissions_var_log_stig
 - file_permissions_var_log_apt
 - file_permissions_var_log_auth
 - file_permissions_var_log_cloud-init

--- a/controls/stig_ubuntu2404.yml
+++ b/controls/stig_ubuntu2404.yml
@@ -1040,9 +1040,9 @@ controls:
       exploited by adversaries.
     levels:
       - medium
-    related_rules:
-      - permissions_local_var_log
-    status: planned
+    rules:
+      - file_permissions_var_log_stig
+    status: automated
 
   - id: UBTU-24-700020
     title: Ubuntu 24.04 LTS must generate system journal entries without revealing

--- a/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/rule.yml
@@ -25,6 +25,16 @@ rationale: |-
 
 severity: medium
 
+ocil_clause: 'not all log files have permission 640 or stricter'
+
+ocil: |-
+    Verify the operating system has all system log files except
+    [bw]tmp ad lastlog under the <pre>/var/log</pre> directory
+    with a permission set to 640, by using the following command:
+    <pre>
+    sudo find /var/log -perm /137 -type f ! -name '*[bw]tmp' ! -name '*lastlog' -exec stat -c "%n %a" {} \;
+    </pre>
+
 template:
     name: file_permissions
     vars:

--- a/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/rule.yml
@@ -1,0 +1,35 @@
+documentation_complete: true
+
+
+title: 'Verify permissions of log files'
+
+description: |-
+    Any operating system providing too much information in error messages
+    risks compromising the data and security of the structure, and content
+    of error messages needs to be carefully considered by the organization.
+
+    Organizations carefully consider the structure/content of error messages.
+    The extent to which information systems are able to identify and handle
+    error conditions is guided by organizational policy and operational
+    requirements. Information that could be exploited by adversaries includes,
+    for example, erroneous logon attempts with passwords entered by mistake
+    as the username, mission/business information that can be derived from
+    (if not stated explicitly by) information recorded, and personal
+    information, such as account numbers, social security numbers, and credit
+    card numbers.
+
+rationale: |-
+    The {{{ full_name }}} must generate error messages that provide information
+    necessary for corrective actions without revealing information that could
+    be exploited by adversaries.
+
+severity: medium
+
+template:
+    name: file_permissions
+    vars:
+        excluded_files@ubuntu2404: ['[bw]tmp', '[bw]tmp.*', '[bw]tmp-*', 'lastlog', 'lastlog.*']
+        file_regex: '.*'
+        filemode: '0640'
+        filepath: /var/log/
+        recursive@ubuntu2404: 'true'

--- a/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/tests/excluded_files.pass.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/tests/excluded_files.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_ubuntu
 
 find /var/log -exec chmod g-rwx,o-rwx {} \;
 

--- a/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/tests/excluded_files.pass.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/tests/excluded_files.pass.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+find /var/log -exec chmod g-rwx,o-rwx {} \;
+
+{{% if product in ['ubuntu2004', 'ubuntu2204'] %}}
+excluded_files=('history.log' 'eipp.log.xz' 'btmp' 'btmp.1' 'btmp-1' 'wtmp' 'wtmp.1' 'wtmp-1' 'lastlog' 'lastlog.1')
+{{% elif product in ['ubuntu2404'] %}}
+excluded_files=('btmp' 'btmp.1' 'btmp-1' 'wtmp' 'wtmp.1' 'wtmp-1' 'lastlog' 'lastlog.1')
+{{% endif %}}
+
+for f in ${excluded_files[@]}
+do
+    touch /var/log/$f
+    chmod 777 /var/log/$f
+done

--- a/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/tests/excluded_files_similar.fail.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/tests/excluded_files_similar.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_ubuntu
 
 find /var/log -exec chmod g-rwx,o-rwx {} \;
 

--- a/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/tests/excluded_files_similar.fail.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/tests/excluded_files_similar.fail.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+find /var/log -exec chmod g-rwx,o-rwx {} \;
+
+{{% if product in ['ubuntu2004', 'ubuntu2204'] %}}
+excluded_files=('2history.log' '2eipp.log.xz' 'btmp1' 'wtmp1' 'lastlog1')
+{{% elif product in ['ubuntu2404'] %}}
+excluded_files=('1btmp' '1wtmp' '1lastlog')
+{{% endif %}}
+
+for f in ${excluded_files[@]}
+do
+    touch /var/log/$f
+    chmod 777 /var/log/$f
+done

--- a/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/tests/group_writable_logfile.fail.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/tests/group_writable_logfile.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+mkdir -p /var/log/testme
+touch /var/log/testme/test_world_read.log
+chmod 660 /var/log/testme/test_world_read.log

--- a/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/tests/group_writable_logfile.fail.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/tests/group_writable_logfile.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_ubuntu
 
 mkdir -p /var/log/testme
 touch /var/log/testme/test_world_read.log

--- a/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/tests/var_logfile_correct_mode.pass.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/tests/var_logfile_correct_mode.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+chmod -R 640 /var/log
+mkdir -p /var/log/testme
+touch /var/log/testme/test.log
+chmod 640 /var/log/testme/test.log

--- a/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/tests/var_logfile_correct_mode.pass.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/tests/var_logfile_correct_mode.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_ubuntu
 
 chmod -R 640 /var/log
 mkdir -p /var/log/testme

--- a/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/tests/world_readable_logfile.fail.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/tests/world_readable_logfile.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+mkdir -p /var/log/testme
+touch /var/log/testme/test_world_read.log
+chmod a+r /var/log/testme/test_world_read.log

--- a/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/tests/world_readable_logfile.fail.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/tests/world_readable_logfile.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_ubuntu
 
 mkdir -p /var/log/testme
 touch /var/log/testme/test_world_read.log

--- a/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/tests/world_writable_dir.pass.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/tests/world_writable_dir.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+chmod -R 640 /var/log/
+mkdir -p /var/log/testme
+chmod 777 /var/log/testme

--- a/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/tests/world_writable_dir.pass.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/tests/world_writable_dir.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_ubuntu
 
 chmod -R 640 /var/log/
 mkdir -p /var/log/testme

--- a/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/tests/world_writable_logfile.fail.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/tests/world_writable_logfile.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+mkdir -p /var/log/testme
+touch /var/log/testme/test_world_read.log
+chmod o+w /var/log/testme/test_world_read.log

--- a/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/tests/world_writable_logfile.fail.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_var_log_stig/tests/world_writable_logfile.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_ubuntu
 
 mkdir -p /var/log/testme
 touch /var/log/testme/test_world_read.log


### PR DESCRIPTION
#### Description:

- Implement stig rule UBTU-24-700010

#### Rationale:

- Template in permissions_local_var_log already has `excluded_files@ubuntu2404` for cis Ubuntu2404 so it's necessary to create a new rule to distinguish different benchmarks