### PR TITLE
Remove service_rexec_disabled from RHEL 10 HIPAA

### DIFF
--- a/products/rhel10/profiles/default.profile
+++ b/products/rhel10/profiles/default.profile
@@ -29,3 +29,4 @@ selections:
   - package_iprutils_removed
   - service_rlogin_disabled
   - service_rsh_disabled
+  - service_rexec_disabled

--- a/products/rhel10/profiles/hipaa.profile
+++ b/products/rhel10/profiles/hipaa.profile
@@ -65,3 +65,4 @@ selections:
     - '!sshd_disable_gssapi_auth'
     - '!service_rlogin_disabled'
     - '!service_rsh_disabled'
+    - '!service_rexec_disabled'

--- a/tests/data/profile_stability/rhel10/hipaa.profile
+++ b/tests/data/profile_stability/rhel10/hipaa.profile
@@ -172,7 +172,6 @@ selections:
 - service_crond_enabled
 - service_debug-shell_disabled
 - service_kdump_disabled
-- service_rexec_disabled
 - service_rsyslog_enabled
 - service_telnet_disabled
 - sshd_disable_compression


### PR DESCRIPTION
This commit removes `service_rexec_disabled` from RHEL 10 HIPAA profile because this service isn't available on RHEL 10. This problem has been discovered by reviewing `/per-rule` test results.

