### PR TITLE
Add no remediation tag

### DIFF
--- a/linux_os/guide/system/software/integrity/fips/fips_crypto_subpolicy/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/fips_crypto_subpolicy/rule.yml
@@ -47,5 +47,5 @@ fixtext: |-
 
 warnings:
     - general: |-
-        This rule does not have a remedation.
+        This rule does not have a remediation.
 

--- a/linux_os/guide/system/software/integrity/fips/fips_crypto_subpolicy/tests/ad_support.fail.sh
+++ b/linux_os/guide/system/software/integrity/fips/fips_crypto_subpolicy/tests/ad_support.fail.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# remediation = none
 
 update-crypto-policies --set FIPS:AD-SUPPORT


### PR DESCRIPTION
This adds no remediation tag to TS `ad_support.fail.sh` because the rule has no remediation. This issue has been discovered by reviewing `/per-rule` test results.