### PR TITLE
Add no remediation tag to test in configure_openssl_tls_crypto_policy

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/correct_commented.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/correct_commented.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Oracle Linux 8,Red Hat Enterprise Linux 8
+# remediation = none
 
 configfile=/etc/crypto-policies/back-ends/opensslcnf.config
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/correct_followed_by_incorrect.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/correct_followed_by_incorrect.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Oracle Linux 8,Red Hat Enterprise Linux 8
+# remediation = none
 
 configfile=/etc/crypto-policies/back-ends/opensslcnf.config
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/empty_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/empty_policy.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Oracle Linux 8,Red Hat Enterprise Linux 8
+# remediation = none
 
 configfile=/etc/crypto-policies/back-ends/opensslcnf.config
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/incorrect_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/incorrect_policy.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Oracle Linux 8,Red Hat Enterprise Linux 8
+# remediation = none
 
 configfile=/etc/crypto-policies/back-ends/opensslcnf.config
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/missing_file.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/missing_file.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Oracle Linux 8,Red Hat Enterprise Linux 8
+# remediation = none
 
 configfile=/etc/crypto-policies/back-ends/opensslcnf.config
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/wrong_value_new.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/wrong_value_new.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # platform = Oracle Linux 8
+# remediation = none
 
 configfile=/etc/crypto-policies/back-ends/opensslcnf.config
 


### PR DESCRIPTION
The rule `configure_openssl_tls_crypto_policy` doesn't have a remediation. We need to mark the test scenarios of this rule with "remediation = none" tag. This issue has been discovered by review of `/per-rule` test results.


