### PR TITLE
Add no remediation tag to test in sshd_use_approved_kex_ordered_stig

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/comment.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/comment.fail.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 # platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicro,multi_platform_ubuntu,multi_platform_almalinux
+{{% if product in ['ol8', 'rhel8']  %}}
+# remediation = none
+{{% endif %}}
 
 source common.sh
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/comment.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/comment.fail.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicro,multi_platform_ubuntu,multi_platform_almalinux
-{{% if product in ['ol8', 'rhel8']  %}}
+{{% if product in ['ol8', 'rhel8'] -%}}
 # remediation = none
-{{% endif %}}
+{{%- endif %}}
 
 source common.sh
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/correct_scrambled.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/correct_scrambled.fail.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 # platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicro,multi_platform_ubuntu,multi_platform_almalinux
+{{% if product in ['ol8', 'rhel8']  %}}
+# remediation = none
+{{% endif %}}
 
 source common.sh
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/correct_scrambled.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/correct_scrambled.fail.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicro,multi_platform_ubuntu,multi_platform_almalinux
-{{% if product in ['ol8', 'rhel8']  %}}
+{{% if product in ['ol8', 'rhel8'] -%}}
 # remediation = none
-{{% endif %}}
+{{%- endif %}}
 
 source common.sh
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/line_not_there.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/line_not_there.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicro,multi_platform_ubuntu,multi_platform_almalinux
-{{% if product in ['ol8', 'rhel8']  %}}
+{{% if product in ['ol8', 'rhel8']  -%}}
 # remediation = none
-{{% endif %}}
+{{%- endif %}}
 
 source common.sh

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/line_not_there.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/line_not_there.fail.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 # platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicro,multi_platform_ubuntu,multi_platform_almalinux
+{{% if product in ['ol8', 'rhel8']  %}}
+# remediation = none
+{{% endif %}}
 
 source common.sh

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/no_parameters.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/no_parameters.fail.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 # platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicro,multi_platform_ubuntu,multi_platform_almalinux
+{{% if product in ['ol8', 'rhel8']  %}}
+# remediation = none
+{{% endif %}}
 
 source common.sh
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/no_parameters.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/no_parameters.fail.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicro,multi_platform_ubuntu,multi_platform_almalinux
-{{% if product in ['ol8', 'rhel8']  %}}
+{{% if product in ['ol8', 'rhel8'] -%}}
 # remediation = none
-{{% endif %}}
+{{%- endif %}}
 
 source common.sh
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/wrong_value.fail.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 # platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicro,multi_platform_ubuntu,multi_platform_almalinux
+{{% if product in ['ol8', 'rhel8']  %}}
+# remediation = none
+{{% endif %}}
 
 source common.sh
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/tests/wrong_value.fail.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicro,multi_platform_ubuntu,multi_platform_almalinux
-{{% if product in ['ol8', 'rhel8']  %}}
+{{% if product in ['ol8', 'rhel8'] -%}}
 # remediation = none
-{{% endif %}}
+{{%- endif %}}
 
 source common.sh
 


### PR DESCRIPTION
The rule `sshd_use_approved_kex_ordered_stig` doesn't have a remediation on RHEL 8 and OL 8. We need to mark the test scenarios of this rule with "remediation = none" tag. This issue has been discovered by review of `/per-rule` test results.


