### PR TITLE
Fix platform in test for grub2_password

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/tests/invalid_username.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/tests/invalid_username.fail.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # remediation = none
+# platform = Red Hat Enterprise Linux 9, Red Hat Enterprise Linux 10,multi_platform_ubuntu,multi_platform_sle
 
 . $SHARED/grub2.sh
 


### PR DESCRIPTION
In rule `grub2_password`, test scenario `invalid_username.fail.sh` shouldn't be applicable on OL7, OL8, OL9 and RHEL8 because the test scenario checks for `superusers` variable set but the OVAL on these products doesn't contain a check for `superusers`. As a result the rule unexpectedly passed on these products in this test scenario.

