### PR TITLE
Update TSs for no_nis_in_nsswitch

### DIFF
--- a/linux_os/guide/services/obsolete/nis/no_nis_in_nsswitch/tests/nis_is_one_of_several_dbs.fail.sh
+++ b/linux_os/guide/services/obsolete/nis/no_nis_in_nsswitch/tests/nis_is_one_of_several_dbs.fail.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# remediation = none
 
 echo "passwd files nis" > /etc/nsswitch.conf

--- a/linux_os/guide/services/obsolete/nis/no_nis_in_nsswitch/tests/nis_is_only_db.fail.sh
+++ b/linux_os/guide/services/obsolete/nis/no_nis_in_nsswitch/tests/nis_is_only_db.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# remediation = none
 
 # we use something because if passwd or groups is used, it breaks the system
 echo "something nis" > /etc/nsswitch.conf


### PR DESCRIPTION
Add `remediation` keyword to test scenario headers to visibly signalize that remediation shouldn't be executed as a part of the test.


