### PR TITLE
Fix template sudo_defaults_option

### DIFF
--- a/shared/templates/sudo_defaults_option/bash.template
+++ b/shared/templates/sudo_defaults_option/bash.template
@@ -9,7 +9,7 @@
 {{% endif %}}
 if /usr/sbin/visudo -qcf /etc/sudoers; then
     cp /etc/sudoers /etc/sudoers.bak
-    if ! grep -P '^[\s]*Defaults[\s]*\b{{{ OPTION_REGEX }}}\b.*$' /etc/sudoers; then
+    if ! grep -P '^[\s]*Defaults\b[^!\n]*\b{{{ OPTION_REGEX }}}.*$' /etc/sudoers; then
         # sudoers file doesn't define Option {{{ OPTION }}}
         echo "Defaults {{{ OPTION_VALUE }}}" >> /etc/sudoers
     {{%- if not VARIABLE_NAME %}}

--- a/shared/templates/sudo_defaults_option/oval.template
+++ b/shared/templates/sudo_defaults_option/oval.template
@@ -1,6 +1,6 @@
 <def-group>
     <definition class="compliance" id="{{{ rule_id }}}" version="1">
-    {{{ oval_metadata("Checks sudoers Defaults {{ OPTION }} configuration") }}}
+    {{{ oval_metadata("Checks sudoers Defaults " + OPTION + " configuration") }}}
     <criteria >
         <criterion comment="{{{ OPTION }}} is configured in /etc/sudoers or /etc/sudoers.d/" test_ref="test_{{{ OPTION }}}_sudoers" />
     </criteria>
@@ -13,7 +13,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_{{{ OPTION }}}_sudoers" version="1">
     <ind:filepath operation="pattern match">^/etc/sudoers(|\.d/.*)$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*Defaults[\s]*[^!]\b{{{ OPTION_REGEX }}}.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*Defaults\b[^!\n]*\b{{{ OPTION_REGEX }}}.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal" >1</ind:instance>
   </ind:textfilecontent54_object>
 


### PR DESCRIPTION
The test scenario `0027_var_multiple_values.pass.sh` for rule `sudo_add_umask` failed because the template didn't allow multiple values in `Defaults` option. The commit updates the regexes to make the TS `0027_var_multiple_values.pass.sh` pass.

This issue has been discovered by revieweing `/per-rule` test results on RHEL 8.10.


