### PR TITLE
audit_ospp_general_ppc64le: architecture cannot contain 32 bit rules

### DIFF
--- a/linux_os/guide/auditing/policy_rules/audit_ospp_general_ppc64le/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_ospp_general_ppc64le/rule.yml
@@ -41,76 +41,49 @@ title: 'Perform general configuration of Audit for OSPP (ppc64le)'
 ## Group add delete modify. This is covered by pam. However, someone could
 ## open a file and directly create or modify a user, so we'll watch group and
 ## gshadow for writes
--a always,exit -F arch=b32 -F path=/etc/passwd -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
 -a always,exit -F arch=b64 -F path=/etc/passwd -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
--a always,exit -F arch=b32 -F path=/etc/shadow -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
 -a always,exit -F arch=b64 -F path=/etc/shadow -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
--a always,exit -F arch=b32 -F path=/etc/group -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=group-modify
 -a always,exit -F arch=b64 -F path=/etc/group -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=group-modify
--a always,exit -F arch=b32 -F path=/etc/gshadow -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=group-modify
 -a always,exit -F arch=b64 -F path=/etc/gshadow -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=group-modify
 
 
 ## Use of special rights for config changes. This would be use of setuid
 ## programs that relate to user accts. This is not all setuid apps because
 ## requirements are only for ones that affect system configuration.
--a always,exit -F arch=b32 -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
 -a always,exit -F arch=b64 -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b32 -F path=/usr/sbin/usernetctl -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
 -a always,exit -F arch=b64 -F path=/usr/sbin/usernetctl -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b32 -F path=/usr/sbin/userhelper -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
 -a always,exit -F arch=b64 -F path=/usr/sbin/userhelper -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b32 -F path=/usr/sbin/seunshare -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
 -a always,exit -F arch=b64 -F path=/usr/sbin/seunshare -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b32 -F path=/usr/bin/mount -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
 -a always,exit -F arch=b64 -F path=/usr/bin/mount -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b32 -F path=/usr/bin/newgrp -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
 -a always,exit -F arch=b64 -F path=/usr/bin/newgrp -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b32 -F path=/usr/bin/newuidmap -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
 -a always,exit -F arch=b64 -F path=/usr/bin/newuidmap -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b32 -F path=/usr/bin/gpasswd -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
 -a always,exit -F arch=b64 -F path=/usr/bin/gpasswd -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b32 -F path=/usr/bin/newgidmap -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
 -a always,exit -F arch=b64 -F path=/usr/bin/newgidmap -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b32 -F path=/usr/bin/umount -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
 -a always,exit -F arch=b64 -F path=/usr/bin/umount -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b32 -F path=/usr/bin/passwd -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
 -a always,exit -F arch=b64 -F path=/usr/bin/passwd -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b32 -F path=/usr/bin/crontab -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
 -a always,exit -F arch=b64 -F path=/usr/bin/crontab -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b32 -F path=/usr/bin/at -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
 -a always,exit -F arch=b64 -F path=/usr/bin/at -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
--a always,exit -F arch=b32 -F path=/usr/sbin/grub2-set-bootflag -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
 -a always,exit -F arch=b64 -F path=/usr/sbin/grub2-set-bootflag -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
 
 ## Privilege escalation via su or sudo. This is entirely handled by pam.
 ## Special case for systemd-run. It is not audit aware, specifically watch it
--a always,exit -F arch=b32 -F path=/usr/bin/systemd-run -F perm=x -F auid!=unset -F key=maybe-escalation
 -a always,exit -F arch=b64 -F path=/usr/bin/systemd-run -F perm=x -F auid!=unset -F key=maybe-escalation
 ## Special case for pkexec. It is not audit aware, specifically watch it
--a always,exit -F arch=b32 -F path=/usr/bin/pkexec -F perm=x -F key=maybe-escalation
 -a always,exit -F arch=b64 -F path=/usr/bin/pkexec -F perm=x -F key=maybe-escalation
 
 
 ## Watch for configuration changes to privilege escalation.
--a always,exit -F arch=b32 -F path=/etc/sudoers -F perm=wa -F key=special-config-changes
 -a always,exit -F arch=b64 -F path=/etc/sudoers -F perm=wa -F key=special-config-changes
--a always,exit -F arch=b32 -F dir=/etc/sudoers.d/ -F perm=wa -F key=special-config-changes
 -a always,exit -F arch=b64 -F dir=/etc/sudoers.d/ -F perm=wa -F key=special-config-changes
 
 ## Audit log access
--a always,exit -F arch=b32 -F dir=/var/log/audit/ -F perm=r -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=access-audit-trail
 -a always,exit -F arch=b64 -F dir=/var/log/audit/ -F perm=r -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=access-audit-trail
 ## Attempts to Alter Process and Session Initiation Information
--a always,exit -F arch=b32 -F path=/var/run/utmp -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=session
 -a always,exit -F arch=b64 -F path=/var/run/utmp -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=session
--a always,exit -F arch=b32 -F path=/var/log/btmp -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=session
 -a always,exit -F arch=b64 -F path=/var/log/btmp -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=session
--a always,exit -F arch=b32 -F path=/var/log/wtmp -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=session
 -a always,exit -F arch=b64 -F path=/var/log/wtmp -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=session
 
 ## Attempts to modify MAC controls
--a always,exit -F arch=b32 -F dir=/etc/selinux/ -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=MAC-policy
 -a always,exit -F arch=b64 -F dir=/etc/selinux/ -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=MAC-policy
 
 ## Software updates. This is entirely handled by rpm.


### PR DESCRIPTION
#### Description:

- remove rules which contain b32

#### Rationale:

- these rules cannot be loaded and they prevent all other rules from loading (audit-rules.service)

#### Review Hints:

1. install RHEL 10 on ppc64le machine
2. remediate ospp profile from datastream built before this PR is applied
3. run augen-rules --load
4. Now try the same with this PR applied