### PR TITLE
rhel10 ospp: remove package_scap-security-guide_installed

### DIFF
--- a/products/rhel10/profiles/default.profile
+++ b/products/rhel10/profiles/default.profile
@@ -30,3 +30,4 @@ selections:
   - service_rlogin_disabled
   - service_rsh_disabled
   - service_rexec_disabled
+  - package_scap-security-guide_installed

--- a/products/rhel10/profiles/ospp.profile
+++ b/products/rhel10/profiles/ospp.profile
@@ -22,6 +22,7 @@ selections:
     - ospp:all
     - '!package_screen_installed'
     - '!package_dnf-plugin-subscription-manager_installed'
+    - '!package_scap-security-guide_installed'
     # Currently not working RHEL 10, changes are being made to FIPS mode. Investigation is recommended.
     - '!enable_dracut_fips_module'
     - '!enable_authselect'

--- a/tests/data/profile_stability/rhel10/ospp.profile
+++ b/tests/data/profile_stability/rhel10/ospp.profile
@@ -114,7 +114,6 @@ selections:
 - package_openscap-scanner_installed
 - package_openssh-clients_installed
 - package_openssh-server_installed
-- package_scap-security-guide_installed
 - package_subscription-manager_installed
 - package_sudo_installed
 - package_usbguard_installed


### PR DESCRIPTION
#### Description:

- remove the rule package_scap-security-guide_installed from RHEL 10 OSPP profile
- modify profile stability test data

#### Rationale:

- the rule is not needed because OSPP profile iss handled differently in RHEL 10


#### Review Hints:

Build the content for rhel10 product and inspect list of rules in the ospp profile.