### PR TITLE
Fix priority of configuation for rule rsyslog_filecreatemode

### DIFF
--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/ansible/shared.yml
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/ansible/shared.yml
@@ -35,7 +35,7 @@
 
 - name: "{{{ rule_title }}} - Add $FileCreateMode Parameter and Expected Value"
   ansible.builtin.lineinfile:
-    path: /etc/rsyslog.d/99-rsyslog_filecreatemode.conf
+    path: /etc/rsyslog.d/00-rsyslog_filecreatemode.conf
     line: '$FileCreateMode 0640'
     mode: 0640
     create: true

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/bash/shared.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/bash/shared.sh
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = low
 
- sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.d/*
+sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.d/*
 
 if ! grep -qE '^\s*\$FileCreateMode\s+0640' /etc/rsyslog.conf; then
     if grep -qE '^\s*\$FileCreateMode' /etc/rsyslog.conf; then

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0600.pass.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0600.pass.sh
@@ -2,4 +2,4 @@
 # packages = rsyslog
 
 sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/* || true
-echo '$FileCreateMode 0600' > /etc/rsyslog.d/99-rsyslog_filecreatemode.conf
+echo '$FileCreateMode 0600' > /etc/rsyslog.d/00-rsyslog_filecreatemode.conf

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0601.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0601.fail.sh
@@ -2,4 +2,4 @@
 # packages = rsyslog
 
 sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/* || true
-echo '$FileCreateMode 0601' > /etc/rsyslog.d/99-rsyslog_filecreatemode.conf
+echo '$FileCreateMode 0601' > /etc/rsyslog.d/00-rsyslog_filecreatemode.conf

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0640.pass.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0640.pass.sh
@@ -2,4 +2,4 @@
 # packages = rsyslog
 
 sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/* || true
-echo '$FileCreateMode 0640' > /etc/rsyslog.d/99-rsyslog_filecreatemode.conf
+echo '$FileCreateMode 0640' > /etc/rsyslog.d/00-rsyslog_filecreatemode.conf

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0755.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0755.fail.sh
@@ -2,4 +2,4 @@
 # packages = rsyslog
 
 sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/* || true
-echo '$FileCreateMode 0755' > /etc/rsyslog.d/99-rsyslog_filecreatemode.conf
+echo '$FileCreateMode 0755' > /etc/rsyslog.d/00-rsyslog_filecreatemode.conf

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_duplicate.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_duplicate.fail.sh
@@ -2,5 +2,5 @@
 # packages = rsyslog
 
 sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/* || true
-echo '$FileCreateMode 0640' > /etc/rsyslog.d/99-rsyslog_filecreatemode.conf
+echo '$FileCreateMode 0640' > /etc/rsyslog.d/00-rsyslog_filecreatemode.conf
 echo '$FileCreateMode 0640' >> /etc/rsyslog.conf


### PR DESCRIPTION
#### Description:

- Fix priority of configuation for rule rsyslog_filecreatemode
- Comment out the key if set incorrectly

#### Rationale:

- /etc/rsyslog.conf include configuration files in /etc/rsyslog.conf.d by glob so it's sorted which leads to priority issue. If filter take effect first and the log file not exist yet, then the 99 conf will not take effect for creating files with target permission
