### PR TITLE
 [Ubuntu]: Implement stig rule UBTU-24-100120

### DIFF
--- a/controls/stig_ubuntu2404.yml
+++ b/controls/stig_ubuntu2404.yml
@@ -65,9 +65,10 @@ controls:
       30 days or less to check file integrity is the default one.
     levels:
       - medium
-    related_rules:
+    rules:
+      - aide_periodic_checking_systemd_timer
       - aide_periodic_cron_checking
-    status: planned
+    status: automated
 
   - id: UBTU-24-100130
     title: Ubuntu 24.04 LTS must notify designated personnel if baseline configurations

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/ansible/shared.yml
@@ -25,6 +25,7 @@
     name: "{{ cron_pkg_name }}"
     state: present
 
+{{% if product != 'ubuntu2404' %}}
 - name: "{{{ rule_title }}}"
   cron:
 {{% if product in ["sle12", "sle15"] %}}
@@ -38,3 +39,18 @@
     weekday: 0
     user: root
     job: "{{{ aide_bin_path }}} --check"
+{{% else %}}
+
+- name: "{{{ rule_title }}}"
+  lineinfile:
+    path: /etc/cron.daily/dailyaidecheck
+    line: 'SCRIPT="/usr/share/aide/bin/dailyaidecheck"''
+  check_mode: yes
+  register: line_check
+
+- name: Install AIDE cron script
+  copy:
+    src: /usr/share/aide/config/cron.daily/dailyaidecheck
+    dest: /etc/cron.daily/dailyaidecheck
+  when: not line_check.found
+{{% endif %}}

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/ansible/shared.yml
@@ -40,14 +40,14 @@
     user: root
     job: "{{{ aide_bin_path }}} --check"
 {{% else %}}
-- name: "{{{ rule_title }}}"
+- name: "{{{ rule_title }}} - Install AIDE Cron Job"
   ansible.builtin.lineinfile:
     path: /etc/cron.daily/dailyaidecheck
     line: 'SCRIPT="/usr/share/aide/bin/dailyaidecheck"'
   check_mode: yes
   register: line_check
 
-- name: Install AIDE cron script
+- name: "{{{ rule_title }}} - Install AIDE cron script"
   ansible.builtin.copy:
     src: /usr/share/aide/config/cron.daily/dailyaidecheck
     dest: /etc/cron.daily/dailyaidecheck

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/ansible/shared.yml
@@ -40,16 +40,15 @@
     user: root
     job: "{{{ aide_bin_path }}} --check"
 {{% else %}}
-
 - name: "{{{ rule_title }}}"
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: /etc/cron.daily/dailyaidecheck
-    line: 'SCRIPT="/usr/share/aide/bin/dailyaidecheck"''
+    line: 'SCRIPT="/usr/share/aide/bin/dailyaidecheck"'
   check_mode: yes
   register: line_check
 
 - name: Install AIDE cron script
-  copy:
+  ansible.builtin.copy:
     src: /usr/share/aide/config/cron.daily/dailyaidecheck
     dest: /etc/cron.daily/dailyaidecheck
   when: not line_check.found

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/bash/ubuntu.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/bash/ubuntu.sh
@@ -2,8 +2,13 @@
 
 {{{ bash_package_install("aide") }}}
 
+{{% if product == 'ubuntu2404' %}}
+if ! grep -q 'SCRIPT="/usr/share/aide/bin/dailyaidecheck"' /etc/cron.*/*; then
+    cp -f /usr/share/aide/config/cron.daily/dailyaidecheck /etc/cron.daily/
+{{% else %}}
 # AiDE usually adds its own cron jobs to /etc/cron.daily. If script is there, this rule is
 # compliant. Otherwise, we copy the script to the /etc/cron.weekly
 if ! grep -Eq '^(\/usr\/bin\/)?aide(\.wrapper)?\s+' /etc/cron.*/*; then
     cp -f /usr/share/aide/config/cron.daily/aide /etc/cron.weekly/
+{{% endif %}}
 fi

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/oval/ubuntu.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/oval/ubuntu.xml
@@ -6,6 +6,12 @@
       ") }}}
     <criteria operator="AND">
       <extend_definition comment="Aide is installed" definition_ref="package_aide_installed" />
+{{% if product == 'ubuntu2404' %}}
+      <criteria operator="OR">
+        <criterion test_ref="tst_daily_aide_check_in_etc_cron" comment="dailyaidecheck scheduled in /etc/cron.*" />
+        <criterion test_ref="tst_daily_aide_check_in_etc_crontab" comment="dailyaidecheck scheduled in /etc/crontab" />
+      </criteria>
+{{% else %}}
       <criteria operator="OR">
         <criterion test_ref="tst_aide_check_in_crontab_root" comment="aide check scheduled in crontab for root" />
         <criterion test_ref="tst_aide_check_in_etc_cron" comment="aide check scheduled in /etc/cron.*" />
@@ -16,6 +22,7 @@
           <criterion test_ref="tst_aidecheck-timer_active" comment="systemd aidecheck.timer active" />
         </criteria>
       </criteria>
+{{% endif %}}
     </criteria>
  </definition>
  <ind:textfilecontent54_object id="obj_root_crontab_aide" version="1">
@@ -32,6 +39,17 @@
   <ind:textfilecontent54_object id="obj_etc_crontab_aide" version="1">
     <ind:filepath datatype="string">/etc/crontab</ind:filepath>
     <ind:pattern operation="pattern match" datatype="string">[^\s]+\s+[^\s]+\s+\*(?:\/[1-7])*\s+\*\s+[^\s]+\s+(?:\/usr\/bin\/)?aide(\.wrapper)?\s+[^\s]+\s+(?=-C|--check).*</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_object id="obj_etc_crontab_daily_aide" version="1">
+    <ind:filepath datatype="string">/etc/crontab</ind:filepath>
+    <ind:pattern operation="pattern match" datatype="string">^SCRIPT="\/usr\/share\/aide\/bin\/dailyaidecheck"$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_object id="obj_etc_cron_daily_aide" version="1">
+    <ind:path operation="pattern match">/etc/cron\.(daily|hourly|weekly)</ind:path>
+    <ind:filename operation="pattern match">^.*$</ind:filename>
+    <ind:pattern operation="pattern match" datatype="string">^SCRIPT="\/usr\/share\/aide\/bin\/dailyaidecheck"$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <linux:systemdunitproperty_object id="obj_aidecheck-service_unitfilestate" version="1">
@@ -55,8 +73,14 @@
   <ind:textfilecontent54_test check="all" id="tst_aide_check_in_crontab_root" version="1" comment="aide check scheduled in crontab for root">
     <ind:object object_ref="obj_root_crontab_aide" />
   </ind:textfilecontent54_test>
+  <ind:textfilecontent54_test check="all" id="tst_daily_aide_check_in_etc_cron" version="1" comment="dailyaidecheck scheduled in /etc/cron.*">
+    <ind:object object_ref="obj_etc_cron_daily_aide" />
+  </ind:textfilecontent54_test>
   <ind:textfilecontent54_test check="all" id="tst_aide_check_in_etc_cron" version="1" comment="aide check scheduled in /etc/cron.*">
     <ind:object object_ref="obj_etc_cron_aide" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_test check="all" id="tst_daily_aide_check_in_etc_crontab" version="1" comment="dailyaidecheck scheduled in /etc/crontab">
+    <ind:object object_ref="obj_etc_crontab_daily_aide" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_test check="all" id="tst_aide_check_in_etc_crontab" version="1" comment="aide check scheduled in /etc/crontab">
     <ind:object object_ref="obj_etc_crontab_aide" />

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/aide_not_installed.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/aide_not_installed.fail.sh
@@ -1,29 +1,10 @@
 #!/bin/bash
-# packages = aide{{% if product != 'ubuntu2404' %}},crontabs{{% endif %}}
+# packages = aide,crontabs
 
 {{{ bash_package_remove("aide") }}}
 
 {{% if product == 'ubuntu2404' %}}
-cat << 'EOF' > /etc/crontab
-#!/bin/sh
-
-# Skip if systemd is running.
-if [ -d /run/systemd/system ]; then
-    exit 0
-fi
-
-SCRIPT="/usr/share/aide/bin/dailyaidecheck"
-if [ -x "${SCRIPT}" ]; then
-    if command -v capsh >/dev/null; then
-        capsh --caps="cap_dac_read_search,cap_audit_write+eip cap_setpcap,cap_setuid,cap_setgid+ep" --keep=1 --user=_aide --addamb=cap_dac_read_search,cap_audit_write -- -c "${SCRIPT} --crondaily"
-    else
-        # no capsh present, run with full capabilities
-        "${SCRIPT}" --crondaily
-    fi
-fi
-
-
-EOF
+echo 'SCRIPT="/usr/share/aide/bin/dailyaidecheck"' > /etc/crontab
 {{% else %}}
 echo '21    21    *    *    *    root    {{{ aide_bin_path }}} --check &>/dev/null' >> /etc/crontab
 {{% endif %}}

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/aide_not_installed.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/aide_not_installed.fail.sh
@@ -1,6 +1,29 @@
 #!/bin/bash
-# packages = aide,crontabs
+# packages = aide{{% if product != 'ubuntu2404' %}},crontabs{{% endif %}}
 
 {{{ bash_package_remove("aide") }}}
 
+{{% if product == 'ubuntu2404' %}}
+cat << 'EOF' > /etc/crontab
+#!/bin/sh
+
+# Skip if systemd is running.
+if [ -d /run/systemd/system ]; then
+    exit 0
+fi
+
+SCRIPT="/usr/share/aide/bin/dailyaidecheck"
+if [ -x "${SCRIPT}" ]; then
+    if command -v capsh >/dev/null; then
+        capsh --caps="cap_dac_read_search,cap_audit_write+eip cap_setpcap,cap_setuid,cap_setgid+ep" --keep=1 --user=_aide --addamb=cap_dac_read_search,cap_audit_write -- -c "${SCRIPT} --crondaily"
+    else
+        # no capsh present, run with full capabilities
+        "${SCRIPT}" --crondaily
+    fi
+fi
+
+
+EOF
+{{% else %}}
 echo '21    21    *    *    *    root    {{{ aide_bin_path }}} --check &>/dev/null' >> /etc/crontab
+{{% endif %}}

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/cron_daily.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/cron_daily.pass.sh
@@ -1,5 +1,28 @@
 #!/bin/bash
-# packages = aide,crontabs
+# packages = aide{{% if product != 'ubuntu2404' %}},crontabs{{% endif %}}
 
 mkdir -p /etc/cron.daily
+{{% if product == 'ubuntu2404' %}}
+cat << 'EOF' > /etc/cron.daily/dailyaidecheck
+#!/bin/sh
+
+# Skip if systemd is running.
+if [ -d /run/systemd/system ]; then
+    exit 0
+fi
+
+SCRIPT="/usr/share/aide/bin/dailyaidecheck"
+if [ -x "${SCRIPT}" ]; then
+    if command -v capsh >/dev/null; then
+        capsh --caps="cap_dac_read_search,cap_audit_write+eip cap_setpcap,cap_setuid,cap_setgid+ep" --keep=1 --user=_aide --addamb=cap_dac_read_search,cap_audit_write -- -c "${SCRIPT} --crondaily"
+    else
+        # no capsh present, run with full capabilities
+        "${SCRIPT}" --crondaily
+    fi
+fi
+
+
+EOF
+{{% else %}}
 echo "{{{ aide_bin_path }}} --check" > /etc/cron.daily/aide
+{{% endif %}}

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/cron_daily.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/cron_daily.pass.sh
@@ -1,28 +1,9 @@
 #!/bin/bash
-# packages = aide{{% if product != 'ubuntu2404' %}},crontabs{{% endif %}}
+# packages = aide,crontabs
 
 mkdir -p /etc/cron.daily
 {{% if product == 'ubuntu2404' %}}
-cat << 'EOF' > /etc/cron.daily/dailyaidecheck
-#!/bin/sh
-
-# Skip if systemd is running.
-if [ -d /run/systemd/system ]; then
-    exit 0
-fi
-
-SCRIPT="/usr/share/aide/bin/dailyaidecheck"
-if [ -x "${SCRIPT}" ]; then
-    if command -v capsh >/dev/null; then
-        capsh --caps="cap_dac_read_search,cap_audit_write+eip cap_setpcap,cap_setuid,cap_setgid+ep" --keep=1 --user=_aide --addamb=cap_dac_read_search,cap_audit_write -- -c "${SCRIPT} --crondaily"
-    else
-        # no capsh present, run with full capabilities
-        "${SCRIPT}" --crondaily
-    fi
-fi
-
-
-EOF
+echo 'SCRIPT="/usr/share/aide/bin/dailyaidecheck"' > /etc/cron.daily/dailyaidecheck
 {{% else %}}
 echo "{{{ aide_bin_path }}} --check" > /etc/cron.daily/aide
 {{% endif %}}

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/cron_daily_complex.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/cron_daily_complex.pass.sh
@@ -1,12 +1,35 @@
 #!/bin/bash
-# packages = aide,crontabs
+# packages = aide{{% if product != 'ubuntu2404' %}},crontabs{{% endif %}}
 
 # This TS is a regression test for https://bugzilla.redhat.com/show_bug.cgi?id=2175684
 
 mkdir -p /etc/cron.daily
+{{% if product == 'ubuntu2404' %}}
+cat << 'EOF' > /etc/cron.daily/dailyaidecheck
+#!/bin/sh
+
+# Skip if systemd is running.
+if [ -d /run/systemd/system ]; then
+    exit 0
+fi
+
+SCRIPT="/usr/share/aide/bin/dailyaidecheck"
+if [ -x "${SCRIPT}" ]; then
+    if command -v capsh >/dev/null; then
+        capsh --caps="cap_dac_read_search,cap_audit_write+eip cap_setpcap,cap_setuid,cap_setgid+ep" --keep=1 --user=_aide --addamb=cap_dac_read_search,cap_audit_write -- -c "${SCRIPT} --crondaily"
+    else
+        # no capsh present, run with full capabilities
+        "${SCRIPT}" --crondaily
+    fi
+fi
+
+
+EOF
+{{% else %}}
 cat > /etc/cron.daily/aide << EOF
 #!/bin/sh
 nice ionice {{{ aide_bin_path }}} --check
 nice ionice {{{ aide_bin_path }}} --init
 /bin/mv -f /var/lib/aide/aide.db.new.gz /var/lib/aide/aide.db.gz
 EOF
+{{% endif %}}

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/cron_daily_complex.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/cron_daily_complex.pass.sh
@@ -1,30 +1,11 @@
 #!/bin/bash
-# packages = aide{{% if product != 'ubuntu2404' %}},crontabs{{% endif %}}
+# packages = aide,crontabs
 
 # This TS is a regression test for https://bugzilla.redhat.com/show_bug.cgi?id=2175684
 
 mkdir -p /etc/cron.daily
 {{% if product == 'ubuntu2404' %}}
-cat << 'EOF' > /etc/cron.daily/dailyaidecheck
-#!/bin/sh
-
-# Skip if systemd is running.
-if [ -d /run/systemd/system ]; then
-    exit 0
-fi
-
-SCRIPT="/usr/share/aide/bin/dailyaidecheck"
-if [ -x "${SCRIPT}" ]; then
-    if command -v capsh >/dev/null; then
-        capsh --caps="cap_dac_read_search,cap_audit_write+eip cap_setpcap,cap_setuid,cap_setgid+ep" --keep=1 --user=_aide --addamb=cap_dac_read_search,cap_audit_write -- -c "${SCRIPT} --crondaily"
-    else
-        # no capsh present, run with full capabilities
-        "${SCRIPT}" --crondaily
-    fi
-fi
-
-
-EOF
+echo 'SCRIPT="/usr/share/aide/bin/dailyaidecheck"' > /etc/cron.daily/dailyaidecheck
 {{% else %}}
 cat > /etc/cron.daily/aide << EOF
 #!/bin/sh

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_daily.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_daily.pass.sh
@@ -1,27 +1,8 @@
 #!/bin/bash
-# packages = aide{{% if product != 'ubuntu2404' %}},crontabs{{% endif %}}
+# packages = aide,crontabs
 
 {{% if product == 'ubuntu2404' %}}
-cat << 'EOF' > /etc/crontab
-#!/bin/sh
-
-# Skip if systemd is running.
-if [ -d /run/systemd/system ]; then
-    exit 0
-fi
-
-SCRIPT="/usr/share/aide/bin/dailyaidecheck"
-if [ -x "${SCRIPT}" ]; then
-    if command -v capsh >/dev/null; then
-        capsh --caps="cap_dac_read_search,cap_audit_write+eip cap_setpcap,cap_setuid,cap_setgid+ep" --keep=1 --user=_aide --addamb=cap_dac_read_search,cap_audit_write -- -c "${SCRIPT} --crondaily"
-    else
-        # no capsh present, run with full capabilities
-        "${SCRIPT}" --crondaily
-    fi
-fi
-
-
-EOF
+echo 'SCRIPT="/usr/share/aide/bin/dailyaidecheck"' > /etc/crontab
 {{% else %}}
 echo '21    21    *    *    *    root    {{{ aide_bin_path }}} --check &>/dev/null' >> /etc/crontab
 {{% endif %}}

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_daily.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_daily.pass.sh
@@ -1,4 +1,27 @@
 #!/bin/bash
-# packages = aide,crontabs
+# packages = aide{{% if product != 'ubuntu2404' %}},crontabs{{% endif %}}
 
+{{% if product == 'ubuntu2404' %}}
+cat << 'EOF' > /etc/crontab
+#!/bin/sh
+
+# Skip if systemd is running.
+if [ -d /run/systemd/system ]; then
+    exit 0
+fi
+
+SCRIPT="/usr/share/aide/bin/dailyaidecheck"
+if [ -x "${SCRIPT}" ]; then
+    if command -v capsh >/dev/null; then
+        capsh --caps="cap_dac_read_search,cap_audit_write+eip cap_setpcap,cap_setuid,cap_setgid+ep" --keep=1 --user=_aide --addamb=cap_dac_read_search,cap_audit_write -- -c "${SCRIPT} --crondaily"
+    else
+        # no capsh present, run with full capabilities
+        "${SCRIPT}" --crondaily
+    fi
+fi
+
+
+EOF
+{{% else %}}
 echo '21    21    *    *    *    root    {{{ aide_bin_path }}} --check &>/dev/null' >> /etc/crontab
+{{% endif %}}

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_daily_shortcut.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_daily_shortcut.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = aide{{% if product != 'ubuntu2404' %}},crontabs{{% endif %}}
+# packages = aide,crontabs
 {{% if product == 'ubuntu2404' %}}
 # platform = Not Applicable
 {{% endif %}}

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_daily_shortcut.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_daily_shortcut.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = aide,crontabs
-{{% if product == 'ubuntu2404' %}}
+{{%- if product == 'ubuntu2404' %}}
 # platform = Not Applicable
-{{% endif %}}
+{{%- endif %}}
 
 echo '@daily    root    {{{ aide_bin_path }}} --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_daily_shortcut.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_daily_shortcut.pass.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
-# packages = aide,crontabs
+# packages = aide{{% if product != 'ubuntu2404' %}},crontabs{{% endif %}}
+{{% if product == 'ubuntu2404' %}}
+# platform = Not Applicable
+{{% endif %}}
 
 echo '@daily    root    {{{ aide_bin_path }}} --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_monthly.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_monthly.fail.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # packages = aide,crontabs
-{{% if product == 'ubuntu2404' %}}
+{{%- if product == 'ubuntu2404' %}}
 # platform = Not Applicable
-{{% endif %}}
+{{%- endif %}}
 
 # aide installs automatically a file that is periodically run on /etc/cron.daily/aide
 rm -f /etc/cron.daily/aide

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_monthly.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_monthly.fail.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 # packages = aide,crontabs
+{{% if product == 'ubuntu2404' %}}
+# platform = Not Applicable
+{{% endif %}}
 
 # aide installs automatically a file that is periodically run on /etc/cron.daily/aide
 rm -f /etc/cron.daily/aide

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_two_days_week.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_two_days_week.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = aide{{% if product != 'ubuntu2404' %}},crontabs{{% endif %}}
+# packages = aide,crontabs
 {{% if product == 'ubuntu2404' %}}
 # platform = Not Applicable
 {{% endif %}}

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_two_days_week.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_two_days_week.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = aide,crontabs
-{{% if product == 'ubuntu2404' %}}
+{{%- if product == 'ubuntu2404' %}}
 # platform = Not Applicable
-{{% endif %}}
+{{%- endif %}}
 
 echo '21    21    *    *    1-2    root    {{{ aide_bin_path }}} --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_two_days_week.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_two_days_week.pass.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
-# packages = aide,crontabs
+# packages = aide{{% if product != 'ubuntu2404' %}},crontabs{{% endif %}}
+{{% if product == 'ubuntu2404' %}}
+# platform = Not Applicable
+{{% endif %}}
 
 echo '21    21    *    *    1-2    root    {{{ aide_bin_path }}} --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_on_exact_day.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_on_exact_day.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = aide{{% if product != 'ubuntu2404' %}},crontabs{{% endif %}}
+# packages = aide,crontabs
 {{% if product == 'ubuntu2404' %}}
 # platform = Not Applicable
 {{% endif %}}

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_on_exact_day.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_on_exact_day.pass.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
-# packages = aide,crontabs
+# packages = aide{{% if product != 'ubuntu2404' %}},crontabs{{% endif %}}
+{{% if product == 'ubuntu2404' %}}
+# platform = Not Applicable
+{{% endif %}}
 
 echo '21    21    *    *    3    root    {{{ aide_bin_path }}} --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_on_exact_day.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_on_exact_day.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = aide,crontabs
-{{% if product == 'ubuntu2404' %}}
+{{%- if product == 'ubuntu2404' %}}
 # platform = Not Applicable
-{{% endif %}}
+{{%- endif %}}
 
 echo '21    21    *    *    3    root    {{{ aide_bin_path }}} --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_shortcut.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_shortcut.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = aide,crontabs
-{{% if product == 'ubuntu2404' %}}
+{{%- if product == 'ubuntu2404' %}}
 # platform = Not Applicable
-{{% endif %}}
+{{%- endif %}}
 
 echo '@weekly    root    {{{ aide_bin_path }}} --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_shortcut.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_shortcut.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = aide{{% if product != 'ubuntu2404' %}},crontabs{{% endif %}}
+# packages = aide,crontabs
 {{% if product == 'ubuntu2404' %}}
 # platform = Not Applicable
 {{% endif %}}

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_shortcut.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_shortcut.pass.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
-# packages = aide,crontabs
+# packages = aide{{% if product != 'ubuntu2404' %}},crontabs{{% endif %}}
+{{% if product == 'ubuntu2404' %}}
+# platform = Not Applicable
+{{% endif %}}
 
 echo '@weekly    root    {{{ aide_bin_path }}} --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_word.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_word.pass.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
-# packages = aide,crontabs
+# packages = aide{{% if product != 'ubuntu2404' %}},crontabs{{% endif %}}
+{{% if product == 'ubuntu2404' %}}
+# platform = Not Applicable
+{{% endif %}}
 
 echo '21    21    *    *    mon    root    {{{ aide_bin_path }}} --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_word.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_word.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = aide,crontabs
-{{% if product == 'ubuntu2404' %}}
+{{%- if product == 'ubuntu2404' %}}
 # platform = Not Applicable
-{{% endif %}}
+{{%- endif %}}
 
 echo '21    21    *    *    mon    root    {{{ aide_bin_path }}} --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_word.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_word.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = aide{{% if product != 'ubuntu2404' %}},crontabs{{% endif %}}
+# packages = aide,crontabs
 {{% if product == 'ubuntu2404' %}}
 # platform = Not Applicable
 {{% endif %}}

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_yearly.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_yearly.fail.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # packages = aide,crontabs
-{{% if product == 'ubuntu2404' %}}
+{{%- if product == 'ubuntu2404' %}}
 # platform = Not Applicable
-{{% endif %}}
+{{%- endif %}}
 
 # aide installs automatically a file that is periodically run on /etc/cron.daily/aide
 rm -f /etc/cron.daily/aide

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_yearly.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_yearly.fail.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 # packages = aide,crontabs
+{{% if product == 'ubuntu2404' %}}
+# platform = Not Applicable
+{{% endif %}}
 
 # aide installs automatically a file that is periodically run on /etc/cron.daily/aide
 rm -f /etc/cron.daily/aide

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/not_in_cron.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/not_in_cron.fail.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 # packages = aide,crontabs,cronie
+{{% if product == 'ubuntu2404' %}}
+# platform = Not Applicable
+{{% endif %}}
 
 # aide installs automatically a file that is periodically run on /etc/cron.daily/aide
 rm -f /etc/cron.daily/aide

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/not_in_cron.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/not_in_cron.fail.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # packages = aide,crontabs,cronie
-{{% if product == 'ubuntu2404' %}}
+{{%- if product == 'ubuntu2404' %}}
 # platform = Not Applicable
-{{% endif %}}
+{{%- endif %}}
 
 # aide installs automatically a file that is periodically run on /etc/cron.daily/aide
 rm -f /etc/cron.daily/aide

--- a/products/ubuntu2004/product.yml
+++ b/products/ubuntu2004/product.yml
@@ -38,6 +38,7 @@ cpes:
 platform_package_overrides:
   audit: auditd
   avahi: avahi-daemon
+  crontabs: cron
   dconf: dconf-editor
   gdm: gdm3
   grub2: grub2-common

--- a/products/ubuntu2204/product.yml
+++ b/products/ubuntu2204/product.yml
@@ -38,6 +38,7 @@ cpes:
 platform_package_overrides:
   audit: auditd
   avahi: avahi-daemon
+  crontabs: cron
   dconf: dconf-editor
   gdm: gdm3
   grub2: grub2-common

--- a/products/ubuntu2404/product.yml
+++ b/products/ubuntu2404/product.yml
@@ -39,6 +39,7 @@ cpes:
 platform_package_overrides:
   audit: auditd
   avahi: avahi-daemon
+  crontabs: cron
   dconf: dconf-editor
   gdm: gdm3
   grub2: grub2-common

--- a/tests/data/product_stability/ubuntu2004.yml
+++ b/tests/data/product_stability/ubuntu2004.yml
@@ -43,6 +43,7 @@ platform_package_overrides:
   aarch64_arch: null
   audit: auditd
   avahi: avahi-daemon
+  crontabs: cron
   dconf: dconf-editor
   gdm: gdm3
   grub2: grub2-common

--- a/tests/data/product_stability/ubuntu2204.yml
+++ b/tests/data/product_stability/ubuntu2204.yml
@@ -44,6 +44,7 @@ platform_package_overrides:
   aarch64_arch: null
   audit: auditd
   avahi: avahi-daemon
+  crontabs: cron
   dconf: dconf-editor
   gdm: gdm3
   grub2: grub2-common

--- a/tests/data/product_stability/ubuntu2404.yml
+++ b/tests/data/product_stability/ubuntu2404.yml
@@ -45,6 +45,7 @@ platform_package_overrides:
   aarch64_arch: null
   audit: auditd
   avahi: avahi-daemon
+  crontabs: cron
   dconf: dconf-editor
   gdm: gdm3
   grub2: grub2-common


### PR DESCRIPTION
#### Description:

- Implement stig rule UBTU-24-100120
- Ignore the aide.conf integrity check for now
- Update oval to check SCRIPT defined for Ubuntu2404 and enable rule aide_periodic_checking_systemd_timer 
- Update the aide path for Ubuntu2404
- Update ansible

#### Rationale:

- Enable rule aide_periodic_checking_systemd_timer for the service check instead combined in the existing oval
- The aide path of Ubuntu2404 is changed
- The point of the rule should be the timer
