### PR TITLE
Make the RHEL Automatus work with 10.1

### DIFF
--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -536,7 +536,7 @@ def install_packages(test_env, packages):
 
 def _match_rhel_version(cpe):
     rhel_cpe = {
-        "redhat:enterprise_linux": r":enterprise_linux:([^:]+):",
+        "redhat:enterprise_linux": r":enterprise_linux:([^:]+)",
         "centos:centos": r"centos:centos:([0-9]+)"}
     for cpe_item in rhel_cpe.keys():
         if cpe_item in cpe:


### PR DESCRIPTION
#### Description:

Make the RHEL Automatus work with 10.1

#### Rationale:
The CPE change, update to match.
#### Review Hints:

Run Automatus tests run RHEL 10.1 before after the change. Before the change observe the errors, after the Automatus tests should work.