### PR TITLE
Avoid deleting all the conf under /etc/rsyslog.d

### DIFF
--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0600.pass.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0600.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # packages = rsyslog
 
-sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/*
+sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/* || true
 echo '$FileCreateMode 0600' > /etc/rsyslog.d/99-rsyslog_filecreatemode.conf

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0601.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0601.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # packages = rsyslog
 
-sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/*
+sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/* || true
 echo '$FileCreateMode 0601' > /etc/rsyslog.d/99-rsyslog_filecreatemode.conf

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0640.pass.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0640.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # packages = rsyslog
 
-sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/*
+sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/* || true
 echo '$FileCreateMode 0640' > /etc/rsyslog.d/99-rsyslog_filecreatemode.conf

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0755.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0755.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # packages = rsyslog
 
-sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/*
+sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/* || true
 echo '$FileCreateMode 0755' > /etc/rsyslog.d/99-rsyslog_filecreatemode.conf

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_duplicate.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_duplicate.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = rsyslog
 
-sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/*
+sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/* || true
 echo '$FileCreateMode 0640' > /etc/rsyslog.d/99-rsyslog_filecreatemode.conf
 echo '$FileCreateMode 0640' >> /etc/rsyslog.conf

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_missing.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_missing.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 # packages = rsyslog
 
-rm -f /etc/rsyslog.d/*
-sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf
+sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/*

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_missing.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_missing.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # packages = rsyslog
 
-sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/*
+sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/* || true


### PR DESCRIPTION
#### Description:

- Avoid deleting all the conf under /etc/rsyslog.d
- Improve the test for #13438 

#### Rationale:

- On ubuntu, one will get error while restarting rsyslog.service if delete all conf in /etc/rsyslog.d. See https://www.rsyslog.com/rsyslog-error-2103/ 
- Found out during kvm testing for Ubuntu focal and jammy
