### PR TITLE
Add OL09-00-000285 & OL09-00-000286 STIG ids

### DIFF
--- a/controls/stig_ol9.yml
+++ b/controls/stig_ol9.yml
@@ -516,6 +516,22 @@ controls:
             - install_smartcard_packages
         status: automated
 
+    -   id: OL09-00-000285
+        levels:
+            - medium
+        title: OL 9 must have the SSSD package installed.
+        rules:
+            - package_sssd_installed
+        status: automated
+
+    -   id: OL09-00-000286
+        levels:
+            - medium
+        title: OL 9 must use the SSSD package for multifactor authentication services.
+        rules:
+            - service_sssd_enabled
+        status: automated
+
     -   id: OL09-00-000430
         levels:
             - medium


### PR DESCRIPTION
#### Description:

- Add rule package_sssd_installed to cover OL09-00-000285 in OL9 STIG
- Add rule service_sssd_enabled to cover OL09-00-000286 in OL9 STIG

#### Rationale:

Align OL9 STIG profile with DISA STIG OL9 V1R1