### PR TITLE
Implement OL09-00-900140 in OL9 stig

### DIFF
--- a/controls/stig_ol9.yml
+++ b/controls/stig_ol9.yml
@@ -4141,3 +4141,13 @@ controls:
         rules:
             - configure_bind_crypto_policy
         status: automated
+
+    -   id: OL09-00-900140
+        levels:
+            - medium
+        title:
+            OL 9 must only allow the use of DOD PKI-established certificate authorities for
+            authentication in the establishment of protected sessions to OL 9.
+        rules:
+            - only_allow_dod_certs
+        status: manual

--- a/controls/stig_ol9.yml
+++ b/controls/stig_ol9.yml
@@ -4150,4 +4150,4 @@ controls:
             authentication in the establishment of protected sessions to OL 9.
         rules:
             - only_allow_dod_certs
-        status: manual
+        status: supported


### PR DESCRIPTION
#### Description:

- Add manual rule `only_allow_dod_certs` to cover `OL09-00-900140` in OL9 STIG profile

#### Rationale:

- Filling gaps for OL9 STIG profile
