### PR TITLE
Mark test scenario with remediation header

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/wrong_value.fail.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 # platform = multi_platform_ol,multi_platform_rhel,multi_platform_almalinux
+{{% if product == 'rhel8' -%}}
+# remediation = none
+{{%- endif %}}
 
 {{{ bash_replace_or_append('/etc/ssh/sshd_config', '^MACs', "wrong_value_expected_to_fail.com", '%s %s') }}}


### PR DESCRIPTION
The rule sshd_use_approved_macs doesn't have any remediation on RHEL 8 therefore we need to mark the fail test scenario with the remediation header.


