### PR TITLE
Remove trailing colon char from Red Hat CPE automatus detection.

### DIFF
--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -536,7 +536,7 @@ def install_packages(test_env, packages):
 
 def _match_rhel_version(cpe):
     rhel_cpe = {
-        "redhat:enterprise_linux": r":enterprise_linux:([^:]+):",
+        "redhat:enterprise_linux": r":enterprise_linux:([^:]+)",
         "centos:centos": r"centos:centos:([0-9]+)"}
     for cpe_item in rhel_cpe.keys():
         if cpe_item in cpe:


### PR DESCRIPTION

#### Description:

Remove trailing colon char from Red Hat CPE automatus detection.

The file /etc/system-release-cpe now contains the following format:

cpe:/o:redhat:enterprise_linux:10.1

Whereas the old version had the trailing ::baseos part. cpe:/o:redhat:enterprise_linux:10::baseos

This change should still be able to match both formats.
#### Rationale:

- Fixes automatus fails such:
`ValueError: Unable to deduce a platform from these CPEs: ['cpe:/o:redhat:enterprise_linux:10.1']`

