### PR TITLE
RHEL 10 Ansible fixes

### DIFF
--- a/linux_os/guide/auditing/file_permissions_auditd/file_permissions_etc_audit_rulesd/tests/lenient_permissions.fail.sh
+++ b/linux_os/guide/auditing/file_permissions_auditd/file_permissions_etc_audit_rulesd/tests/lenient_permissions.fail.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
 
+rm -rf /etc/audit/rules.d/
+mkdir -p /etc/audit/rules.d/
 export TESTFILE=/etc/audit/rules.d/test_rule.rules
 mkdir -p $(dirname $TESTFILE)
 touch $TESTFILE

--- a/linux_os/guide/auditing/file_permissions_auditd/file_permissions_etc_audit_rulesd/tests/stricter_permissions.pass.sh
+++ b/linux_os/guide/auditing/file_permissions_auditd/file_permissions_etc_audit_rulesd/tests/stricter_permissions.pass.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
 
+rm -rf /etc/audit/rules.d/
+mkdir -p /etc/audit/rules.d/
 export TESTFILE=/etc/audit/rules.d/test_rule.rules
 mkdir -p $(dirname $TESTFILE)
 touch $TESTFILE

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_unprivileged_bpf_disabled_accept_default/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_unprivileged_bpf_disabled_accept_default/rule.yml
@@ -79,3 +79,4 @@ template:
         wrong_sysctlval_for_testing: "0"
         missing_parameter_pass: "true"
         datatype: int
+        no_remediation: "true"


### PR DESCRIPTION
This PR fixes failing /per-rule/ansible tests on RHEL 10.0.

Some of the fails on RHEL 10 were also present in RHEL 9 so they will be fixed in https://github.com/ComplianceAsCode/content/pull/13455, here are only thos that manifested specifically in RHEL 10.

For more details, please read commit messages of every commit.

