### PR TITLE
Remove leftovers of configure_gnutls_tls_crypto_policy from products

### DIFF
--- a/controls/cusp_fedora.yml
+++ b/controls/cusp_fedora.yml
@@ -107,7 +107,6 @@ controls:
       - configure_crypto_policy
       - var_system_crypto_policy=default_policy
       - configure_bind_crypto_policy
-      - configure_gnutls_tls_crypto_policy
       - configure_kerberos_crypto_policy
       - configure_libreswan_crypto_policy
       - configure_openssl_crypto_policy

--- a/controls/srg_gpos/SRG-OS-000250-GPOS-00093.yml
+++ b/controls/srg_gpos/SRG-OS-000250-GPOS-00093.yml
@@ -5,8 +5,6 @@ controls:
         title: {{{ full_name }}} must implement cryptography to protect the integrity
             of remote access sessions.
         rules:
-            # https://github.com/ComplianceAsCode/content/issues/9385
-            # - configure_gnutls_tls_crypto_policy
             - configure_ssh_crypto_policy
             - file_sshd_50_redhat_exists
             - sshd_include_crypto_policy

--- a/controls/srg_gpos/SRG-OS-000423-GPOS-00187.yml
+++ b/controls/srg_gpos/SRG-OS-000423-GPOS-00187.yml
@@ -8,7 +8,5 @@ controls:
             - package_openssh-server_installed
             - service_sshd_enabled
             - configure_bind_crypto_policy
-            # https://github.com/ComplianceAsCode/content/issues/9385
-            # - configure_gnutls_tls_crypto_policy
             - sysctl_crypto_fips_enabled
         status: automated

--- a/products/fedora/profiles/default.profile
+++ b/products/fedora/profiles/default.profile
@@ -543,3 +543,4 @@ selections:
     - enable_dracut_fips_module
     - accounts_password_pam_pwhistory_remember_system_auth
     - mount_option_var_log_nodev
+    - configure_gnutls_tls_crypto_policy


### PR DESCRIPTION
#### Description:
- Remove leftovers of configure_gnutls_tls_crypto_policy from products.
  - The only real occurrence was Fedora, which does not work with the format proposed in the aforementioned rule.

