### PR TITLE
Remove package_rsh-server_removed from RHEL 8

### DIFF
--- a/products/rhel8/profiles/default.profile
+++ b/products/rhel8/profiles/default.profile
@@ -724,3 +724,4 @@ selections:
     - service_rexec_disabled
     - service_rlogin_disabled
     - service_zebra_disabled
+    - package_rsh-server_removed

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -972,9 +972,6 @@ selections:
     # RHEL-08-040004
     - grub2_pti_argument
 
-    # RHEL-08-040010
-    - package_rsh-server_removed
-
     # RHEL-08-040020
     - kernel_module_uvcvideo_disabled
 

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -322,7 +322,6 @@ selections:
 - package_postfix_installed
 - package_python3-abrt-addon_removed
 - package_rng-tools_installed
-- package_rsh-server_removed
 - package_rsyslog-gnutls_installed
 - package_rsyslog_installed
 - package_sendmail_removed

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -331,7 +331,6 @@ selections:
 - package_postfix_installed
 - package_python3-abrt-addon_removed
 - package_rng-tools_installed
-- package_rsh-server_removed
 - package_rsyslog-gnutls_installed
 - package_rsyslog_installed
 - package_sendmail_removed


### PR DESCRIPTION
The rsh-server package doesn't exist in RHEL 8.

