### PR TITLE
Implement OL09-00-000255 STIG id

### DIFF
--- a/controls/stig_ol9.yml
+++ b/controls/stig_ol9.yml
@@ -1889,7 +1889,10 @@ controls:
         title:
             OL 9 SSH server must be configured to use only Message Authentication Codes
             (MACs) employing FIPS 140-3 validated cryptographic hash algorithms.
-        status: pending
+        rules:
+            - harden_sshd_macs_opensshserver_conf_crypto_policy
+            - sshd_approved_macs=stig_ol9
+        status: automated
 
     -   id: OL09-00-002357
         levels:

--- a/linux_os/guide/services/ssh/sshd_approved_macs.var
+++ b/linux_os/guide/services/ssh/sshd_approved_macs.var
@@ -18,3 +18,4 @@ options:
     cis_sle15: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
     cis_ubuntu: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
     stig_ubuntu2204: hmac-sha2-512,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-256-etm@openssh.com
+    stig_ol9: hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/tests/rhel9_stig_incorrect_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/tests/rhel9_stig_incorrect_policy.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 9
+# platform = Oracle Linux 9,Red Hat Enterprise Linux 9
 # variables = sshd_approved_ciphers=aes256-gcm@openssh.com,aes256-ctr,aes128-gcm@openssh.com,aes128-ctr
 # remediation = none
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/oval/shared.xml
@@ -16,7 +16,11 @@
 
   <ind:textfilecontent54_object id="obj_{{{ rule_id }}}" version="1">
     <ind:filepath>{{{ PATH }}}</ind:filepath>
+    {{%- if product in ["ol8", "rhel8"] -%}}
     <ind:pattern operation="pattern match">^(?!#).*(-oMACs=\S+).+$</ind:pattern>
+    {{%- else -%}}
+    <ind:pattern operation="pattern match">^(?!\s*#)(MACs\s+\S+)$</ind:pattern>
+    {{%- endif -%}}
     <ind:instance operation="greater than or equal" datatype="int">-1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -26,7 +30,11 @@
 
   <local_variable id="sshd_macs_crypto_opensshserver" datatype="string" comment="The regex of the directive" version="1">
     <concat>
+      {{%- if product in ["ol8", "rhel8"] -%}}
       <literal_component>-oMACs=</literal_component>
+      {{%- else -%}}
+      <literal_component>MACs </literal_component>
+      {{%- endif -%}}
       <variable_component var_ref="sshd_approved_macs"/>
     </concat>
   </local_variable>

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/oval/shared.xml
@@ -17,27 +17,16 @@
   <ind:textfilecontent54_object id="obj_{{{ rule_id }}}" version="1">
     <ind:filepath>{{{ PATH }}}</ind:filepath>
     {{%- if product in ["ol8", "rhel8"] -%}}
-    <ind:pattern operation="pattern match">^(?!#).*(-oMACs=\S+).+$</ind:pattern>
+    <ind:pattern operation="pattern match">^(?!#).*-oMACs=([^\s']+).*$</ind:pattern>
     {{%- else -%}}
-    <ind:pattern operation="pattern match">^(?!\s*#)(MACs\s+\S+)$</ind:pattern>
+    <ind:pattern operation="pattern match">^(?!#).*MACs\s+([^\s']+).*$</ind:pattern>
     {{%- endif -%}}
     <ind:instance operation="greater than or equal" datatype="int">-1</ind:instance>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="ste_{{{ rule_id }}}" version="1">
-    <ind:subexpression var_ref="sshd_macs_crypto_opensshserver" operation="equals" />
+    <ind:subexpression var_ref="sshd_approved_macs" operation="equals" />
   </ind:textfilecontent54_state>
-
-  <local_variable id="sshd_macs_crypto_opensshserver" datatype="string" comment="The regex of the directive" version="1">
-    <concat>
-      {{%- if product in ["ol8", "rhel8"] -%}}
-      <literal_component>-oMACs=</literal_component>
-      {{%- else -%}}
-      <literal_component>MACs </literal_component>
-      {{%- endif -%}}
-      <variable_component var_ref="sshd_approved_macs"/>
-    </concat>
-  </local_variable>
 
   <external_variable comment="SSH Approved MACs by FIPS" datatype="string" id="sshd_approved_macs" version="1" />
 </def-group>

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/tests/rhel9_stig_correct.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/tests/rhel9_stig_correct.pass.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 # platform = Oracle Linux 9,Red Hat Enterprise Linux 9
-# variables = sshd_approved_ciphers=aes256-gcm@openssh.com,aes256-ctr,aes128-gcm@openssh.com,aes128-ctr
+# variables = sshd_approved_macs=hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
 
-sshd_approved_ciphers=aes256-gcm@openssh.com,aes256-ctr,aes128-gcm@openssh.com,aes128-ctr
+sshd_approved_macs=hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
 
 configfile=/etc/crypto-policies/back-ends/opensshserver.config
-correct_value="Ciphers ${sshd_approved_ciphers}"
+correct_value="MACs ${sshd_approved_macs}"
 
 # Ensure directory + file is there
 test -d /etc/crypto-policies/back-ends || mkdir -p /etc/crypto-policies/back-ends
 
 # Proceed when file exists
 if [[ -f $configfile ]]; then
-    sed -i -r "s/Ciphers\s+\S+/${correct_value}/" $configfile
+    sed -i -r "s/^(?!\s*#)MACs\s+\S+/${correct_value}/" $configfile
 else
     echo "${correct_value}" > "$configfile"
 fi

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/tests/rhel9_stig_correct.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/tests/rhel9_stig_correct.pass.sh
@@ -12,7 +12,7 @@ test -d /etc/crypto-policies/back-ends || mkdir -p /etc/crypto-policies/back-end
 
 # Proceed when file exists
 if [[ -f $configfile ]]; then
-    sed -i -r "s/^(?!\s*#)MACs\s+\S+/${correct_value}/" $configfile
+    sed -i -r "s/MACs\s+\S+/${correct_value}/" $configfile
 else
     echo "${correct_value}" > "$configfile"
 fi

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/tests/rhel9_stig_incorrect_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/tests/rhel9_stig_incorrect_policy.fail.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# platform = Oracle Linux 9,Red Hat Enterprise Linux 9
+# variables = sshd_approved_macs=hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
+# remediation = none
+
+configfile=/etc/crypto-policies/back-ends/opensshserver.config
+
+# Ensure directory + file is there
+test -d /etc/crypto-policies/back-ends || mkdir -p /etc/crypto-policies/back-ends
+
+if [[ -f $configfile ]]; then
+    sed -i -r "s/^(?!\s*#)MACs\s+\S+/MACs hmac-sha2-512,hmac-sha2-256,hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com/" $configfile
+else
+    echo "MACs hmac-sha2-512,hmac-sha2-256,hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com" > "$configfile"
+fi

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/tests/rhel9_stig_incorrect_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/tests/rhel9_stig_incorrect_policy.fail.sh
@@ -9,7 +9,7 @@ configfile=/etc/crypto-policies/back-ends/opensshserver.config
 test -d /etc/crypto-policies/back-ends || mkdir -p /etc/crypto-policies/back-ends
 
 if [[ -f $configfile ]]; then
-    sed -i -r "s/^(?!\s*#)MACs\s+\S+/MACs hmac-sha2-512,hmac-sha2-256,hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com/" $configfile
+    sed -i -r "s/MACs\s+\S+/MACs hmac-sha2-512,hmac-sha2-256,hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com/" $configfile
 else
     echo "MACs hmac-sha2-512,hmac-sha2-256,hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com" > "$configfile"
 fi


### PR DESCRIPTION
#### Description:

- Added harden_sshd_macs_opensshserver_conf_crypto_policy to cover OL09-00-000255
- Added a new value to sshd_approved_macs variable for OL9
- Update the rule harden_sshd_macs_opensshserver_conf_crypto_policy to work with OL9 and OL8
- Added OL9 test

#### Rationale:

Align OL9 STIG profile with DISA STIG OL9 V1R1
