### PR TITLE
Implement STIG id Ol09-00-000242

### DIFF
--- a/components/crypto-policies.yml
+++ b/components/crypto-policies.yml
@@ -22,3 +22,4 @@ rules:
 - openssl_use_strong_entropy
 - package_crypto-policies_installed
 - fips_crypto_subpolicy
+- fips_crypto_policy_symlinks

--- a/components/fips.yml
+++ b/components/fips.yml
@@ -13,3 +13,4 @@ rules:
 - sebool_fips_mode
 - sysctl_crypto_fips_enabled
 - system_booted_in_fips_mode
+- fips_crypto_policy_symlinks

--- a/controls/stig_ol9.yml
+++ b/controls/stig_ol9.yml
@@ -4128,7 +4128,9 @@ controls:
         levels:
             - medium
         title: OL 9 crypto policy must not be overridden.
-        status: pending
+        rules:
+            - fips_crypto_policy_symlinks
+        status: automated
 
     -   id: OL09-00-002424
         levels:

--- a/linux_os/guide/system/software/integrity/fips/fips_crypto_policy_symlinks/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/fips_crypto_policy_symlinks/oval/shared.xml
@@ -1,0 +1,48 @@
+{{% set expected_symlinks_src_dir = "/etc/crypto-policies/back-ends/" %}}
+{{% set expected_symlinks_dest_dir = "/usr/share/crypto-policies/FIPS/" %}}
+{{% set expected_symlinks_src_files = [ "bind",
+                                        "gnutls",
+                                        "java",
+                                        "javasystem",
+                                        "krb5",
+                                        "libreswan",
+                                        "libssh",
+                                        "openssh",
+                                        "opensshserver",
+                                        "opensslcnf",
+                                        "openssl",
+                                        "openssl_fips"
+                                        ] %}}
+
+{{% set symlinks_src_ext = ".config" %}}
+{{% set symlinks_dest_ext = ".txt" %}}
+
+<def-group>
+    <definition class="compliance" id="{{{ rule_id }}}" version="1">
+        {{{ oval_metadata("All system wide cryptopolicy symblinks should point to FIPS policy") }}}
+        <criteria operator="AND" comment="All crypto-policies symlinks should poin to FIPS">
+            {{% for symlink in expected_symlinks_src_files %}}
+            <criterion comment="Symlink from {{{ expected_symlinks_src_dir ~ symlink }}}"
+                test_ref="test_symlink_from_{{{ symlink | escape_id }}}" />
+            {{% endfor %}}
+        </criteria>
+    </definition>
+
+    {{% for symlink in expected_symlinks_src_files %}}
+    <unix:symlink_test check="all" check_existence="all_exist"
+            comment="{{{ expected_symlinks_src_dir ~ symlink }}} points to fips" version="1"
+            id="test_symlink_from_{{{ symlink | escape_id }}}">
+        <unix:object object_ref="object_symlink_from_{{{ symlink | escape_id }}}" />
+        <unix:state state_ref="state_symlink_from_{{{ symlink | escape_id }}}" />
+    </unix:symlink_test>
+    <unix:symlink_object comment="{{{ expected_symlinks_src_dir ~ symlink }}}" version="1"
+            id="object_symlink_from_{{{ symlink | escape_id }}}">
+        <unix:filepath>{{{ expected_symlinks_src_dir ~ symlink ~ symlinks_src_ext}}}</unix:filepath>
+    </unix:symlink_object>
+    <unix:symlink_state comment="{{{ expected_symlinks_src_dir ~ symlink }}} points to fips" version="1"
+            id="state_symlink_from_{{{ symlink | escape_id }}}">
+        <unix:canonical_path operation="equals">{{{ expected_symlinks_dest_dir
+            ~ symlink ~ symlinks_dest_ext }}}</unix:canonical_path>
+    </unix:symlink_state>
+    {{% endfor %}}
+</def-group>

--- a/linux_os/guide/system/software/integrity/fips/fips_crypto_policy_symlinks/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/fips_crypto_policy_symlinks/rule.yml
@@ -1,0 +1,56 @@
+documentation_complete: true
+
+title: 'System Wide Crypto Policy Files Must Point to FIPS Policy'
+
+description: |-
+    All files in /etc/crypto-policies/back-ends/ except for nss.config should be symlinks pointing
+    to /usr/share/crypto-policies/FIPS/
+    <pre>
+    $ stat -c%N /etc/crypto-policies/back-ends/*
+    '/etc/crypto-policies/back-ends/bind.config' -> '/usr/share/crypto-policies/FIPS/bind.txt'
+    '/etc/crypto-policies/back-ends/gnutls.config' -> '/usr/share/crypto-policies/FIPS/gnutls.txt'
+    '/etc/crypto-policies/back-ends/java.config' -> '/usr/share/crypto-policies/FIPS/java.txt'
+    '/etc/crypto-policies/back-ends/javasystem.config' -> '/usr/share/crypto-policies/FIPS/javasystem.txt'
+    '/etc/crypto-policies/back-ends/krb5.config' -> '/usr/share/crypto-policies/FIPS/krb5.txt'
+    '/etc/crypto-policies/back-ends/libreswan.config' -> '/usr/share/crypto-policies/FIPS/libreswan.txt'
+    '/etc/crypto-policies/back-ends/libssh.config' -> '/usr/share/crypto-policies/FIPS/libssh.txt'
+    '/etc/crypto-policies/back-ends/nss.config'
+    '/etc/crypto-policies/back-ends/openssh.config' -> '/usr/share/crypto-policies/FIPS/openssh.txt'
+    '/etc/crypto-policies/back-ends/opensshserver.config' -> '/usr/share/crypto-policies/FIPS/opensshserver.txt'
+    '/etc/crypto-policies/back-ends/opensslcnf.config' -> '/usr/share/crypto-policies/FIPS/opensslcnf.txt'
+    '/etc/crypto-policies/back-ends/openssl.config' -> '/usr/share/crypto-policies/FIPS/openssl.txt'
+    '/etc/crypto-policies/back-ends/openssl_fips.config' -> '/usr/share/crypto-policies/FIPS/openssl_fips.txt'
+    </pre>
+
+rationale: |-
+    Centralized cryptographic policies simplify applying secure ciphers across an operating
+    system and the applications that run on that operating system. Use of weak or untested
+    encryption algorithms undermines the purposes of using encryption to protect data.
+
+severity: medium
+
+references:
+    srg: SRG-OS-000396-GPOS-00176,SRG-OS-000393-GPOS-00173,SRG-OS-000394-GPOS-00174
+    nist: SC-13,MA-4(6)
+
+ocil_clause: Any file shows a different output
+
+ocil: |-
+    Validate all files are symlinks to ponting to /usr/share/crypto-policies/FIPS/ except for
+    nss.config:
+    <pre>
+    $ stat -c%N /etc/crypto-policies/back-ends/*
+    '/etc/crypto-policies/back-ends/bind.config' -> '/usr/share/crypto-policies/FIPS/bind.txt'
+    '/etc/crypto-policies/back-ends/gnutls.config' -> '/usr/share/crypto-policies/FIPS/gnutls.txt'
+    '/etc/crypto-policies/back-ends/java.config' -> '/usr/share/crypto-policies/FIPS/java.txt'
+    '/etc/crypto-policies/back-ends/javasystem.config' -> '/usr/share/crypto-policies/FIPS/javasystem.txt'
+    '/etc/crypto-policies/back-ends/krb5.config' -> '/usr/share/crypto-policies/FIPS/krb5.txt'
+    '/etc/crypto-policies/back-ends/libreswan.config' -> '/usr/share/crypto-policies/FIPS/libreswan.txt'
+    '/etc/crypto-policies/back-ends/libssh.config' -> '/usr/share/crypto-policies/FIPS/libssh.txt'
+    '/etc/crypto-policies/back-ends/nss.config'
+    '/etc/crypto-policies/back-ends/openssh.config' -> '/usr/share/crypto-policies/FIPS/openssh.txt'
+    '/etc/crypto-policies/back-ends/opensshserver.config' -> '/usr/share/crypto-policies/FIPS/opensshserver.txt'
+    '/etc/crypto-policies/back-ends/opensslcnf.config' -> '/usr/share/crypto-policies/FIPS/opensslcnf.txt'
+    '/etc/crypto-policies/back-ends/openssl.config' -> '/usr/share/crypto-policies/FIPS/openssl.txt'
+    '/etc/crypto-policies/back-ends/openssl_fips.config' -> '/usr/share/crypto-policies/FIPS/openssl_fips.txt'
+    </pre>

--- a/linux_os/guide/system/software/integrity/fips/fips_crypto_policy_symlinks/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/fips_crypto_policy_symlinks/rule.yml
@@ -30,8 +30,8 @@ rationale: |-
 severity: medium
 
 references:
-    srg: SRG-OS-000396-GPOS-00176,SRG-OS-000393-GPOS-00173,SRG-OS-000394-GPOS-00174
     nist: SC-13,MA-4(6)
+    srg: SRG-OS-000396-GPOS-00176,SRG-OS-000393-GPOS-00173,SRG-OS-000394-GPOS-00174
 
 ocil_clause: Any file shows a different output
 

--- a/linux_os/guide/system/software/integrity/fips/fips_crypto_policy_symlinks/tests/correct.pass.sh
+++ b/linux_os/guide/system/software/integrity/fips/fips_crypto_policy_symlinks/tests/correct.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = Oracle Linux 9
+
+update-crypto-policies --set FIPS

--- a/linux_os/guide/system/software/integrity/fips/fips_crypto_policy_symlinks/tests/wrong.fail.sh
+++ b/linux_os/guide/system/software/integrity/fips/fips_crypto_policy_symlinks/tests/wrong.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = Oracle Linux 9
+# remediation = none
+
+update-crypto-policies --set DEFAULT


### PR DESCRIPTION
#### Description:

-  Create rule `fips_crypto_policy_symlinks` with its OVAL
- Select the rule for OL9 STIG
- Create tests for it

#### Rationale:

- Better align OL9 with the DISA STIG standard

#### Review Hints:

- Automatus tests executed correctly on my environment to test OL9