### PR TITLE
Stop processing templated remediations by Jinja

### DIFF
--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -128,8 +128,11 @@ class Remediation(object):
         self.local_env_yaml["rule_id"] = self.associated_rule.id_
         self.local_env_yaml["cce_identifiers"] = self.associated_rule.identifiers
 
-    def parse_from_file_with_jinja(self, env_yaml, cpe_platforms):
-        return parse_from_file_with_jinja(self.file_path, env_yaml)
+    def parse_from_file(self, env_yaml, cpe_platforms):
+        if "fixes_from_templates" in self.file_path:
+            return parse_from_file_without_jinja(self.file_path)
+        else:
+            return parse_from_file_with_jinja(self.file_path, env_yaml)
 
     def get_inherited_cpe_platform_names(self):
         inherited_cpe_platform_names = set()
@@ -188,7 +191,7 @@ def process(remediation, env_yaml, cpe_platforms):
     if not is_supported_filename(remediation.remediation_type, remediation.file_path):
         return
 
-    result = remediation.parse_from_file_with_jinja(env_yaml, cpe_platforms)
+    result = remediation.parse_from_file(env_yaml, cpe_platforms)
     platforms = result.config['platform']
 
     if not platforms:
@@ -215,9 +218,9 @@ class BashRemediation(Remediation):
     def __init__(self, file_path):
         super(BashRemediation, self).__init__(file_path, "bash")
 
-    def parse_from_file_with_jinja(self, env_yaml, cpe_platforms):
+    def parse_from_file(self, env_yaml, cpe_platforms):
         self.local_env_yaml.update(env_yaml)
-        result = super(BashRemediation, self).parse_from_file_with_jinja(
+        result = super(BashRemediation, self).parse_from_file(
             self.local_env_yaml, cpe_platforms)
 
         # Avoid platform wrapping empty fix text
@@ -266,9 +269,9 @@ class AnsibleRemediation(Remediation):
 
         self.body = None
 
-    def parse_from_file_with_jinja(self, env_yaml, cpe_platforms):
+    def parse_from_file(self, env_yaml, cpe_platforms):
         self.local_env_yaml.update(env_yaml)
-        result = super(AnsibleRemediation, self).parse_from_file_with_jinja(
+        result = super(AnsibleRemediation, self).parse_from_file(
             self.local_env_yaml, cpe_platforms)
 
         if not self.associated_rule:

--- a/tests/unit/ssg-module/test_build_remediations.py
+++ b/tests/unit/ssg-module/test_build_remediations.py
@@ -81,7 +81,7 @@ def test_ansible_class(env_yaml, cpe_platforms):
         os.path.join(DATADIR, "ansible.yml"), os.path.join(DATADIR, "file_owner_grub2_cfg.yml")
     )
 
-    remediation.parse_from_file_with_jinja(env_yaml, cpe_platforms)
+    remediation.parse_from_file(env_yaml, cpe_platforms)
 
     assert remediation.metadata["reboot"] == 'false'
     assert remediation.metadata["strategy"] == 'configure'
@@ -95,7 +95,7 @@ def test_ansible_conformance(env_yaml, cpe_platforms):
     )
     ref_remediation_dict = ordered_load(open(os.path.join(DATADIR, "ansible-resolved.yml")))
 
-    remediation.parse_from_file_with_jinja(env_yaml, cpe_platforms)
+    remediation.parse_from_file(env_yaml, cpe_platforms)
     # The comparison has to be done this way due to possible order variations,
     # which don't matter, but they make tests to fail.
     assert set(remediation.body[0]["tags"]) == set(ref_remediation_dict[0]["tags"])


### PR DESCRIPTION
Remediations that were generated from templates already have all Jinja code resolved. Therefore, it isn't necessary to process them with Jinja for the second time. In `collect_remediations.py`, we will process with Jinja only static remediations and we will not process with Jinja the generated remediations. This will speed the build up because there are many remediations generated from templates and Jinja processing takes a lot of time.

As a part of this change we will rename all `parse_from_file_with_jinja` methods in `Remediation` and subclasses.

