### PR TITLE
Drop irrelevant rules for SLE platform

### DIFF
--- a/products/sle15/profiles/anssi_bp28_enhanced.profile
+++ b/products/sle15/profiles/anssi_bp28_enhanced.profile
@@ -64,4 +64,7 @@ selections:
     - '!dnf-automatic_apply_updates'
     - '!dnf-automatic_security_updates_only'
     - '!accounts_password_pam_unix_remember'
+    - '!accounts_password_pam_minclass'
+    - '!accounts_password_pam_retry'
+    - '!file_groupowner_etc_chrony_keys'
     - accounts_password_pam_pwhistory_remember

--- a/products/sle15/profiles/anssi_bp28_high.profile
+++ b/products/sle15/profiles/anssi_bp28_high.profile
@@ -91,4 +91,7 @@ selections:
     - '!dnf-automatic_apply_updates'
     - '!dnf-automatic_security_updates_only'
     - '!accounts_password_pam_unix_remember'
+    - '!accounts_password_pam_minclass'
+    - '!accounts_password_pam_retry'
+    - '!file_groupowner_etc_chrony_keys'
     - accounts_password_pam_pwhistory_remember

--- a/products/sle15/profiles/anssi_bp28_intermediary.profile
+++ b/products/sle15/profiles/anssi_bp28_intermediary.profile
@@ -61,4 +61,7 @@ selections:
   - '!dnf-automatic_apply_updates'
   - '!dnf-automatic_security_updates_only'
   - '!accounts_password_pam_unix_remember'
+  - '!accounts_password_pam_minclass'
+  - '!accounts_password_pam_retry'
+  - '!file_groupowner_etc_chrony_keys'
   - accounts_password_pam_pwhistory_remember

--- a/products/sle15/profiles/anssi_bp28_minimal.profile
+++ b/products/sle15/profiles/anssi_bp28_minimal.profile
@@ -49,4 +49,7 @@ selections:
   - '!dnf-automatic_apply_updates'
   - '!dnf-automatic_security_updates_only'
   - '!accounts_password_pam_unix_remember'
+  - '!accounts_password_pam_minclass'
+  - '!accounts_password_pam_retry'
+  - '!file_groupowner_etc_chrony_keys'
   - accounts_password_pam_pwhistory_remember

--- a/products/sle15/profiles/standard.profile
+++ b/products/sle15/profiles/standard.profile
@@ -82,7 +82,6 @@ selections:
     - var_accounts_passwords_pam_faillock_unlock_time=never
     - var_password_pam_retry=3
     - accounts_logon_fail_delay
-    - accounts_password_pam_retry
     - service_httpd_disabled
     - package_httpd_removed
     - package_firewalld_installed


### PR DESCRIPTION


#### Description:

- Drop irrelevant rules for SLE platform

#### Rationale:

- Remove rules from anssi profiles since they are irrelevant for the SLES platform. These were added directly in the control file but obviously were more or less platform specific

