### PR TITLE
[workflow] Fix ansible for Ubuntu workflow

### DIFF
--- a/.github/workflows/automatus.yaml
+++ b/.github/workflows/automatus.yaml
@@ -67,7 +67,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Install Deps
-        run: sudo apt-get update && sudo apt-get install cmake ninja-build libopenscap8 libxml2-utils xsltproc python3-jinja2 python3-yaml ansible-lint podman
+        run: sudo apt-get update && sudo apt-get install cmake ninja-build libopenscap8 libxml2-utils xsltproc python3-jinja2 python3-pip python3-yaml podman
+      - name: Install deps python
+        run: pip install ansible setuptools
       - name: Checkout
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - name: Get cached CTF output

--- a/Dockerfiles/test_suite-fedora
+++ b/Dockerfiles/test_suite-fedora
@@ -11,7 +11,7 @@ ARG ADDITIONAL_PACKAGES
 # Don't clean all, as the test scenario may require package install.
 RUN true \
         && yum install -y openssh-clients openssh-server openscap-scanner \
-		python3 findutils python3-rpm gawk\
+		python3 findutils python3-rpm gawk python3-libdnf5\
 		$ADDITIONAL_PACKAGES \
         && true
 


### PR DESCRIPTION
#### Description:

-  Install missing libdnf5 binding for ansible
-  Install latest ansible from pip instead of obsolete one

#### Rationale:

- Without libdnf5 binding, ansible cannot perform pkg manage with dnf
- The old ansible 2.10.7 in Ubuntu use removed API according to https://github.com/ansible/ansible/pull/83020
- setuptools is a dependency of ansible