### PR TITLE
Remove authselect selections from RHEL 10 OSPP

### DIFF
--- a/controls/ospp.yml
+++ b/controls/ospp.yml
@@ -299,8 +299,6 @@ controls:
             - var_accounts_passwords_pam_faillock_fail_interval=900
             - accounts_passwords_pam_faillock_unlock_time
             - var_accounts_passwords_pam_faillock_unlock_time=never
-            - enable_authselect
-            - var_authselect_profile=minimal
         status: automated
 
     -   id: FIA_UAU.1
@@ -313,8 +311,6 @@ controls:
             - require_singleuser_auth
             - service_debug-shell_disabled
             - no_empty_passwords
-            - enable_authselect
-            - var_authselect_profile=minimal
             - grub2_disable_recovery
             - grub2_systemd_debug-shell_argument_absent
             - grub2_password

--- a/products/rhel10/profiles/ospp.profile
+++ b/products/rhel10/profiles/ospp.profile
@@ -25,4 +25,3 @@ selections:
     - '!package_scap-security-guide_installed'
     # Currently not working RHEL 10, changes are being made to FIPS mode. Investigation is recommended.
     - '!enable_dracut_fips_module'
-    - '!enable_authselect'

--- a/tests/data/profile_stability/rhel10/ospp.profile
+++ b/tests/data/profile_stability/rhel10/ospp.profile
@@ -139,7 +139,6 @@ var_accounts_passwords_pam_faillock_deny=3
 var_accounts_passwords_pam_faillock_fail_interval=900
 var_accounts_passwords_pam_faillock_unlock_time=never
 var_auditd_flush=incremental_async
-var_authselect_profile=minimal
 var_logind_session_timeout=30_minutes
 var_password_pam_dcredit=1
 var_password_pam_lcredit=1


### PR DESCRIPTION
The rule has already been removed in commit
2c28d5f0b5bca280526b2b19f71a4272a3cb1d1a
but the variable `var_authselect_profile` remained in the profile.
Get rid of both by removing them from the control file.

Pinging also @ComplianceAsCode/oracle-maintainers as it will remove authselect from https://github.com/ComplianceAsCode/content/blob/master/products/ol10/profiles/ospp.profile too.