### PR TITLE
Update invalid source URL for std_openeuler2203 benchmark

### DIFF
--- a/controls/std_openeuler2203.yml
+++ b/controls/std_openeuler2203.yml
@@ -3,7 +3,7 @@ policy: 'Standard Benchmark for openEuler'
 title: 'Standard Benchmark for openEuler'
 id: std_openeuler2203
 version: '1.0'
-source: https://gitee.com/openeuler/security-committee/blob/master/secure-configuration-benchmark/release/
+source: https://gitee.com/openeuler/security-committee/blob/master/sub-projects/secure-configuration-benchmark/release/
 levels:
   - id: l1_server
   - id: l2_server


### PR DESCRIPTION
#### Description:

Fix broken source URL for std_openeuler2203 benchmark in `controls/std_openeuler2203.yml`.

#### Rationale:

The previous source URL, https://gitee.com/openeuler/security-committee/blob/master/secure-configuration-benchmark/release/, was found to be invalid and inaccessible (e.g., resulting in a 404 error). This change corrects the URL to https://gitee.com/openeuler/security-committee/blob/master/sub-projects/secure-configuration-benchmark/release/, ensuring that the benchmark definition points to the correct and current documentation.
#### Review Hints:

Verify that the new source URL (https://gitee.com/openeuler/security-committee/blob/master/sub-projects/secure-configuration-benchmark/release/) in `controls/std_openeuler2203.yml` is correct and accessible.

