### PR TITLE
Add OL9 to auditd_audispd_syslog_plugin_activated tests

### DIFF
--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_activated.pass.sh
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_activated.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 
 . $SHARED/auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_activated_not_there.fail.sh
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_activated_not_there.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_not_activated.fail.sh
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_not_activated.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 # remediation = bash
 
 . $SHARED/auditd_utils.sh


### PR DESCRIPTION
#### Description:

Add OL9 to the tests for auditd_audispd_syslog_plugin_activated

#### Rationale:

Missing product in the test
