### PR TITLE
Extend sshd_use_strong_kex to use distributed configs

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/ansible/shared.yml
@@ -6,4 +6,4 @@
 
 {{{ ansible_instantiate_variables("sshd_strong_kex") }}}
 
-{{{ ansible_sshd_set(parameter="KexAlgorithms", value="{{ sshd_strong_kex }}", rule_title=rule_title) }}}
+{{{ ansible_sshd_set(parameter="KexAlgorithms", value="{{ sshd_strong_kex }}", config_is_distributed=sshd_distributed_config, rule_title=rule_title) }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/bash/shared.sh
@@ -5,5 +5,5 @@
 # disruption = low
 {{{ bash_instantiate_variables("sshd_strong_kex") }}}
 
-{{{ bash_sshd_config_set(parameter="KexAlgorithms", value="$sshd_strong_kex", rule_id=rule_id) }}}
+{{{ bash_sshd_remediation(parameter="KexAlgorithms", value="$sshd_strong_kex", config_is_distributed=sshd_distributed_config, rule_id=rule_id) }}}
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/oval/shared.xml
@@ -26,11 +26,17 @@
         {{% endif %}}
         <criterion comment="Check KexAlgorithms in /etc/ssh/sshd_config"
             test_ref="test_sshd_use_strong_kex" />
+        {{%- if sshd_distributed_config == "true" %}}
+        <criterion comment="Check KexAlgorithms in /etc/ssh/sshd_config.d/"
+            test_ref="test_sshd_use_strong_kex_config_dir" />
+        {{%- endif %}}
+        <criterion comment="the configuration exists"
+            test_ref="test_sshd_kexalgorithms_exists" />
       </criteria>
     </criteria>
   </definition>
 
-  <ind:variable_test check="at least one"
+  <ind:variable_test check="all" check_existence="any_exist"
   comment="tests the value of KexAlgorithms setting in the /etc/ssh/sshd_config file"
   id="test_sshd_use_strong_kex" version="1">
     <ind:object object_ref="obj_sshd_use_strong_kex" />
@@ -48,7 +54,7 @@
   <ind:textfilecontent54_object id="obj_sshd_config_kex" version="1">
     <ind:filepath>/etc/ssh/sshd_config</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*(?i)KexAlgorithms(?-i)[\s]+([\w,-@]+)+[\s]*(?:#.*)?$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <local_variable id="var_sshd_config_kex" datatype="string" version="1" comment="KEXs values splitted on comma">
@@ -57,10 +63,57 @@
     </split>
   </local_variable>
 
+  {{%- if sshd_distributed_config == "true" %}}
+  <ind:variable_test check="all" check_existence="any_exist"
+  comment="tests the value of KexAlgorithms setting in the /etc/ssh/sshd_config.d dir"
+  id="test_sshd_use_strong_kex_config_dir" version="1">
+    <ind:object object_ref="obj_sshd_use_strong_kex_config_dir" />
+    <ind:state state_ref="ste_sshd_use_strong_kex_config_dir" />
+  </ind:variable_test>
+
+  <ind:variable_object id="obj_sshd_use_strong_kex_config_dir" version="1">
+    <ind:var_ref>var_sshd_config_kex_config_dir</ind:var_ref>
+  </ind:variable_object>
+
+  <ind:variable_state comment="approved strong kex" id="ste_sshd_use_strong_kex_config_dir" version="1">
+    <ind:value operation="equals" datatype="string" var_ref="var_sshd_strong_kex" var_check="at least one" />
+  </ind:variable_state>
+
+  <ind:textfilecontent54_object id="obj_sshd_config_kex_config_dir" version="1">
+    <ind:path>/etc/ssh/sshd_config.d</ind:path>
+    <ind:filename operation="pattern match">.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^[\s]*(?i)KexAlgorithms(?-i)[\s]+([\w,-@]+)+[\s]*(?:#.*)?$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <local_variable id="var_sshd_config_kex_config_dir" datatype="string" version="1" comment="KEXs values splitted on comma">
+    <split delimiter=",">
+      <object_component item_field="subexpression" object_ref="obj_sshd_config_kex_config_dir" />
+    </split>
+  </local_variable>
+  {{%- endif %}}
+
+  <ind:textfilecontent54_test id="test_sshd_kexalgorithms_exists" version="1" check="all" check_existence="at_least_one_exists"
+    comment="Verify that the value of KexAlgorithms is present">
+    <ind:object object_ref="obj_sshd_kex_all_configs" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object comment="All confs collection" id="obj_sshd_kex_all_configs" version="1">
+    <set>
+      <object_reference>obj_sshd_config_kex</object_reference>
+      {{% if sshd_distributed_config == "true" %}}
+      <object_reference>obj_sshd_config_kex_config_dir</object_reference>
+      {{% endif %}}
+    </set>
+  </ind:textfilecontent54_object>
+
+
   <local_variable id="var_sshd_strong_kex" datatype="string" version="1" comment="approved strong KEX values splitted on comma">
     <split delimiter=",">
       <variable_component var_ref="sshd_strong_kex" />
     </split>
   </local_variable>
   <external_variable comment="SSH Approved KEX by FIPS" datatype="string" id="sshd_strong_kex" version="1" />
+
+
 </def-group>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/commented.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/commented.fail.sh
@@ -2,6 +2,6 @@
 # platform = multi_platform_all
 # variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256
 
-sed -i '/^\s*KexAlgorithms\s/Id' /etc/ssh/sshd_config
+sed -i '/^\s*KexAlgorithms\s/Id' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
 echo "# KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256" >> /etc/ssh/sshd_config
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/commented.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/commented.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # platform = multi_platform_all
-# variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256
+# variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512
 
 sed -i '/^\s*KexAlgorithms\s/Id' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
-echo "# KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256" >> /etc/ssh/sshd_config
+echo "# KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512" >> /etc/ssh/sshd_config
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/commented.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/commented.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = multi_platform_all
+# variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256
+
+sed -i '/^\s*KexAlgorithms\s/Id' /etc/ssh/sshd_config
+echo "# KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256" >> /etc/ssh/sshd_config
+

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/conflicting.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/conflicting.fail.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
+{{% if sshd_distributed_config == "false" %}}
+# platform = Not Applicable (sshd_distributed_config=false)
+{{% else %}}
 # platform = multi_platform_all
+{{% endif %}}
 # variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256
+
 
 sed -i '/^\s*KexAlgorithms\s/Id' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
 echo "KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256" >> /etc/ssh/sshd_config
 
+echo "KexAlgorithms diffie-hellman-group-exchange-sha1" >> /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/conflicting.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/conflicting.fail.sh
@@ -4,10 +4,10 @@
 {{% else %}}
 # platform = multi_platform_all
 {{% endif %}}
-# variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256
+# variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512
 
 
 sed -i '/^\s*KexAlgorithms\s/Id' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
-echo "KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256" >> /etc/ssh/sshd_config
+echo "KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512" >> /etc/ssh/sshd_config
 
 echo "KexAlgorithms diffie-hellman-group-exchange-sha1" >> /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/conflicting_dir.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/conflicting_dir.fail.sh
@@ -4,10 +4,10 @@
 {{% else %}}
 # platform = multi_platform_all
 {{% endif %}}
-# variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256
+# variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512
 
 
 sed -i '/^\s*KexAlgorithms\s/Id' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
-echo "KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256" >> /etc/ssh/sshd_config
+echo "KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512" >> /etc/ssh/sshd_config
 
 echo "KexAlgorithms diffie-hellman-group-exchange-sha1" >> /etc/ssh/sshd_config.d/00-test.conf

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/conflicting_dir.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/conflicting_dir.fail.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
+{{% if sshd_distributed_config == "false" %}}
+# platform = Not Applicable (sshd_distributed_config=false)
+{{% else %}}
 # platform = multi_platform_all
+{{% endif %}}
 # variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256
+
 
 sed -i '/^\s*KexAlgorithms\s/Id' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
 echo "KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256" >> /etc/ssh/sshd_config
 
+echo "KexAlgorithms diffie-hellman-group-exchange-sha1" >> /etc/ssh/sshd_config.d/00-test.conf

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/correct_dir.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/correct_dir.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+{{% if sshd_distributed_config == "false" %}}
+# platform = Not Applicable (sshd_distributed_config=false)
+{{% else %}}
+# platform = multi_platform_all
+{{% endif %}}
+# variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256
+
+
+sed -i '/^\s*KexAlgorithms\s/Id' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
+echo "KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256" >> /etc/ssh/sshd_config.d/00-test.conf
+

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/correct_dir.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/correct_dir.pass.sh
@@ -4,9 +4,9 @@
 {{% else %}}
 # platform = multi_platform_all
 {{% endif %}}
-# variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256
+# variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512
 
 
 sed -i '/^\s*KexAlgorithms\s/Id' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
-echo "KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256" >> /etc/ssh/sshd_config.d/00-test.conf
+echo "KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512" >> /etc/ssh/sshd_config.d/00-test.conf
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/correct_mixed.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/correct_mixed.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = multi_platform_all
+# variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256
+
+sed -i '/^\s*KexAlgorithms\s/Id' /etc/ssh/sshd_config
+echo "KexAlgorithms diffie-hellman-group14-256,curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512" >> /etc/ssh/sshd_config
+

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/correct_mixed.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/correct_mixed.pass.sh
@@ -3,5 +3,5 @@
 # variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512
 
 sed -i '/^\s*KexAlgorithms\s/Id' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
-echo "KexAlgorithms diffie-hellman-group18-512,curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512" >> /etc/ssh/sshd_config
+echo "KexAlgorithms diffie-hellman-group18-sha512,curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512" >> /etc/ssh/sshd_config
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/correct_mixed.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/correct_mixed.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # platform = multi_platform_all
-# variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256
+# variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512
 
 sed -i '/^\s*KexAlgorithms\s/Id' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
-echo "KexAlgorithms diffie-hellman-group14-256,curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512" >> /etc/ssh/sshd_config
+echo "KexAlgorithms diffie-hellman-group18-512,curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512" >> /etc/ssh/sshd_config
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/correct_subset.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/correct_subset.pass.sh
@@ -2,4 +2,5 @@
 # platform = multi_platform_all
 # variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256
 
-sed -i 's/^\s*KexAlgorithms\s/# &/i' /etc/ssh/sshd_config
+sed -i '/^\s*KexAlgorithms\s/Id' /etc/ssh/sshd_config
+echo "KexAlgorithms diffie-hellman-group16-sha512,diffie-hellman-group18-sha512" >> /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/correct_subset.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/correct_subset.pass.sh
@@ -2,5 +2,5 @@
 # platform = multi_platform_all
 # variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256
 
-sed -i '/^\s*KexAlgorithms\s/Id' /etc/ssh/sshd_config
+sed -i '/^\s*KexAlgorithms\s/Id' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
 echo "KexAlgorithms diffie-hellman-group16-sha512,diffie-hellman-group18-sha512" >> /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/correct_subset.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/correct_subset.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # platform = multi_platform_all
-# variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256
+# variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512
 
 sed -i '/^\s*KexAlgorithms\s/Id' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
 echo "KexAlgorithms diffie-hellman-group16-sha512,diffie-hellman-group18-sha512" >> /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/correct_value.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = multi_platform_all
+# variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256
+
+sed -i '/^\s*KexAlgorithms\s/Id' /etc/ssh/sshd_config
+echo "KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256" >> /etc/ssh/sshd_config
+

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/correct_value.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # platform = multi_platform_all
-# variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256
+# variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512
 
 sed -i '/^\s*KexAlgorithms\s/Id' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
-echo "KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256" >> /etc/ssh/sshd_config
+echo "KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512" >> /etc/ssh/sshd_config
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/good_kex_sle.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/good_kex_sle.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # platform = multi_platform_sle,multi_platform_ubuntu
+# variables = sshd_strong_kex=diffie-hellman-group14-sha256
 
 sed -i 's/^\s*KexAlgorithms\s.*//i' /etc/ssh/sshd_config
 echo "KexAlgorithms diffie-hellman-group14-sha256" >> /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/no_kex.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/no_kex.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_all
-# variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256
+# variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512
 
 sed -i '/^\s*KexAlgorithms\s/Id' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* || true

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/no_kex.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/no_kex.fail.sh
@@ -2,4 +2,4 @@
 # platform = multi_platform_all
 # variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256
 
-sed -i 's/^\s*KexAlgorithms\s/# &/i' /etc/ssh/sshd_config
+sed -i '/^\s*KexAlgorithms\s/Id' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* || true

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/weak_kex.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/weak_kex.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # platform = multi_platform_all
-# variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256
+# variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512
 
 sed -i '/^\s*KexAlgorithms\s/Id' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
 echo "KexAlgorithms diffie-hellman-group-exchange-sha1" >> /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/weak_kex.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/weak_kex.fail.sh
@@ -2,6 +2,6 @@
 # platform = multi_platform_all
 # variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256
 
-sed -i '/^\s*KexAlgorithms\s/Id' /etc/ssh/sshd_config
+sed -i '/^\s*KexAlgorithms\s/Id' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
 echo "KexAlgorithms diffie-hellman-group-exchange-sha1" >> /etc/ssh/sshd_config
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/weak_kex.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/weak_kex.fail.sh
@@ -2,4 +2,6 @@
 # platform = multi_platform_all
 # variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256
 
-sed -i 's/^\s*KexAlgorithms\s/# &/i' /etc/ssh/sshd_config
+sed -i '/^\s*KexAlgorithms\s/Id' /etc/ssh/sshd_config
+echo "KexAlgorithms diffie-hellman-group-exchange-sha1" >> /etc/ssh/sshd_config
+

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/weak_kex_dir.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/weak_kex_dir.fail.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
+{{% if sshd_distributed_config == "false" %}}
+# platform = Not Applicable (sshd_distributed_config=false)
+{{% else %}}
 # platform = multi_platform_all
+{{% endif %}}
 # variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256
 
 sed -i '/^\s*KexAlgorithms\s/Id' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
-echo "KexAlgorithms diffie-hellman-group14-256,curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512" >> /etc/ssh/sshd_config
-
+echo "KexAlgorithms diffie-hellman-group-exchange-sha1" >> /etc/ssh/sshd_config.d/00-test.conf

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/weak_kex_dir.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/weak_kex_dir.fail.sh
@@ -4,7 +4,7 @@
 {{% else %}}
 # platform = multi_platform_all
 {{% endif %}}
-# variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-256
+# variables = sshd_strong_kex=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512
 
 sed -i '/^\s*KexAlgorithms\s/Id' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
 echo "KexAlgorithms diffie-hellman-group-exchange-sha1" >> /etc/ssh/sshd_config.d/00-test.conf


### PR DESCRIPTION
#### Description:

- Extend `sshd_use_strong_kex` to use distributed configs on products with `sshd_distributed_config==true`
- Add tests to `sshd_use_strong_kex`

#### Rationale:

- Partially fixes https://github.com/ComplianceAsCode/content/issues/13291