### PR TITLE
Add check_root_user for OL9 in audit_rules_dac_modification_*

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fremovexattr/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fremovexattr/rule.yml
@@ -96,6 +96,7 @@ template:
     vars:
         attr: fremovexattr
         check_root_user@ol8: "true"
+        check_root_user@ol9: "true"
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
         check_root_user@ubuntu2004: "true"

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fsetxattr/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fsetxattr/rule.yml
@@ -91,6 +91,7 @@ template:
     vars:
         attr: fsetxattr
         check_root_user@ol8: "true"
+        check_root_user@ol9: "true"
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
         check_root_user@ubuntu2004: "true"

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lremovexattr/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lremovexattr/rule.yml
@@ -96,6 +96,7 @@ template:
     vars:
         attr: lremovexattr
         check_root_user@ol8: "true"
+        check_root_user@ol9: "true"
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
         check_root_user@ubuntu2004: "true"

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lsetxattr/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lsetxattr/rule.yml
@@ -91,6 +91,7 @@ template:
     vars:
         attr: lsetxattr
         check_root_user@ol8: "true"
+        check_root_user@ol9: "true"
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
         check_root_user@ubuntu2004: "true"

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_removexattr/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_removexattr/rule.yml
@@ -95,6 +95,7 @@ template:
     vars:
         attr: removexattr
         check_root_user@ol8: "true"
+        check_root_user@ol9: "true"
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
         check_root_user@ubuntu2004: "true"

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_setxattr/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_setxattr/rule.yml
@@ -91,6 +91,7 @@ template:
     vars:
         attr: setxattr
         check_root_user@ol8: "true"
+        check_root_user@ol9: "true"
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
         check_root_user@ubuntu2004: "true"


### PR DESCRIPTION
#### Description:

- Add `check_root_user` for OL9

#### Rationale:

Align OL9 STIG profile with DISA STIG OL9 V1R1