### PR TITLE
Remove ubuntu2404 from conditionals in unused rules

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/rule.yml
@@ -90,7 +90,7 @@ fixtext: |-
 
 srg_requirement: 'The systemd Ctrl-Alt-Delete burst key sequence in {{{ full_name }}} must be disabled.'
 
-{{% if product not in ["ubuntu2004", "ubuntu2204", "ubuntu2404"] %}}
+{{% if product not in ["ubuntu2004", "ubuntu2204"] %}}
 warnings:
     - functionality: |-
         Disabling the <tt>Ctrl-Alt-Del</tt> key sequence

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/rule.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/rule.yml
@@ -5,7 +5,7 @@ title: 'Ensure Log Files Are Owned By Appropriate User'
 description: |-
     The owner of all log files written by
     <tt>rsyslog</tt> should be
-    {{% if product in ['ubuntu2404', 'ubuntu2204','ubuntu2004'] %}}
+    {{% if product in ['ubuntu2204','ubuntu2004'] %}}
     <tt>syslog</tt>.
     {{% elif 'debian' in product or 'ubuntu' in product %}}
     <tt>adm</tt>.
@@ -18,7 +18,7 @@ description: |-
     run the following command to inspect the file's owner:
     <pre>$ ls -l <i>LOGFILE</i></pre>
     If the owner is not
-    {{% if product in ['ubuntu2404', 'ubuntu2204','ubuntu2004'] %}}
+    {{% if product in ['ubuntu2204','ubuntu2004'] %}}
     <tt>syslog</tt>,
     {{% elif 'debian' in product or 'ubuntu' in product %}}
     <tt>adm</tt>,
@@ -27,7 +27,7 @@ description: |-
     {{% endif %}}
     run the following command to
     correct this:
-    {{% if product in ['ubuntu2404', 'ubuntu2204','ubuntu2004'] %}}
+    {{% if product in ['ubuntu2204','ubuntu2004'] %}}
     <pre>$ sudo chown syslog <i>LOGFILE</i></pre>
     {{% elif 'debian' in product or 'ubuntu' in product %}}
     <pre>$ sudo chown adm <i>LOGFILE</i></pre>
@@ -67,7 +67,7 @@ ocil_clause: 'the owner is not correct'
 
 ocil: |-
     The owner of all log files written by <tt>rsyslog</tt> should be
-    {{% if product in ['ubuntu2404', 'ubuntu2204','ubuntu2004'] %}}
+    {{% if product in ['ubuntu2204','ubuntu2004'] %}}
     <tt>syslog</tt>.
     {{% elif 'debian' in product or 'ubuntu' in product %}}
     <tt>adm</tt>.


### PR DESCRIPTION
#### Description:

- Remove ubuntu2404 from few conditionals

#### Rationale:

- Rules are not used in Ubuntu 24.04 profiles