### PR TITLE
[Stabilization]: update outdated links to documentation

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/rule.yml
@@ -12,8 +12,8 @@ description: |-
         {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/7/network/ol7-nettime.html") }}}
     {{% elif product == "ol8" %}}
         {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/8/network/network-ConfiguringNetworkTime.html#ol-nettime") }}}
-    {{% else %}}
-        {{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-configuring_ntp_using_the_chrony_suite") }}}
+    {{% elif "rhel" in product %}}
+        {{{ weblink(link="https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html-single/configuring_basic_system_settings/index#proc_migrating-to-chrony_configuring-time-synchronization") }}}
     {{% endif %}}
     for more detailed comparison of the features of both of the choices, and for
     further guidance how to choose between the two NTP daemons.

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/rule.yml
@@ -12,8 +12,8 @@ description: |-
          {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/7/network/ol7-nettime.html") }}}
      {{% elif product == "ol8" %}}
          {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/8/network/network-ConfiguringNetworkTime.html#ol-nettime") }}}
-    {{% else %}}
-        {{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-configuring_ntp_using_the_chrony_suite") }}}
+    {{% elif "rhel" in product %}}
+        {{{ weblink(link="https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html-single/configuring_basic_system_settings/index#proc_migrating-to-chrony_configuring-time-synchronization") }}}
     {{% endif %}}
     for more detailed comparison of the features of both of the choices, and for
     further guidance how to choose between the two NTP daemons.

--- a/linux_os/guide/services/ntp/group.yml
+++ b/linux_os/guide/services/ntp/group.yml
@@ -60,7 +60,7 @@ description: |-
     {{% elif product == "rhel9" %}}
         {{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_basic_system_settings/configuring-time-synchronization_configuring-basic-system-settings") }}}
     {{% elif product == "rhel10" %}}
-        {{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/10/html/configuring_basic_system_settings/configuring-time-synchronization_configuring-basic-system-settings") }}}
+        {{{ weblink(link="https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html/configuring_time_synchronization/index") }}}
     {{% elif "ubuntu" in product  %}}
         {{{ weblink(link="https://help.ubuntu.com/lts/serverguide/NTP.html") }}}
     {{% elif "debian" in product %}}

--- a/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/rule.yml
@@ -21,8 +21,8 @@ description: |-
         {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/8/network/network-ConfiguringNetworkTime.html#ol-nettime") }}}
     {{% elif product in ["sle12", "sle15"] %}}
         {{{ weblink(link="https://documentation.suse.com/sles/15-SP1/html/SLES-all/cha-ntp.html") }}}
-    {{% else %}}
-        {{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-configuring_ntp_using_the_chrony_suite") }}}
+    {{% elif "rhel" in product %}}
+        {{{ weblink(link="https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html-single/configuring_basic_system_settings/index#proc_migrating-to-chrony_configuring-time-synchronization") }}}
     {{% endif %}}
     for guidance which NTP daemon to choose depending on the environment used.
 

--- a/shared/macros/01-general.jinja
+++ b/shared/macros/01-general.jinja
@@ -1170,7 +1170,7 @@ The kernel arguments should be set in <tt>/usr/lib/bootc/kargs.d</tt> in a TOML 
 # /usr/lib/bootc/kargs.d/10-example.toml
 kargs = ["{{{ arg_name_value }}}"]
 </pre>
-For more details on configuring kernel arguments in bootable container images, please refer to {{{ weblink(link="https://containers.github.io/bootc/building/kernel-arguments.html", text="Bootc documentation") }}}.
+For more details on configuring kernel arguments in bootable container images, please refer to {{{ weblink(link="https://bootc-dev.github.io/bootc//building/kernel-arguments.html", text="Bootc documentation") }}}.
 {{%- endif -%}}
 {{%- endmacro -%}}
 
@@ -1188,7 +1188,7 @@ Run the following command to update command line for already installed kernels:
 {{% if bootable_containers_supported == "true" %}}
 If the system is distributed as a bootable container image, GRUB2 can't be configured using the method described above, but the kernel arguments should be configured using TOML files located in the <tt>/usr/lib/bootc/kargs.d</tt> directory.
 Remove all occurences of <tt>{{{ arg_name }}}</tt> from all files in <tt>/usr/lib/bootc/kargs.d</tt>.
-For more details on configuring kernel arguments in bootable container images, please refer to {{{ weblink(link="https://containers.github.io/bootc/building/kernel-arguments.html", text="Bootc documentation") }}}.
+For more details on configuring kernel arguments in bootable container images, please refer to {{{ weblink(link="https://bootc-dev.github.io/bootc//building/kernel-arguments.html", text="Bootc documentation") }}}.
 {{%- endif -%}}
 {{%- endmacro -%}}
 


### PR DESCRIPTION
#### Description:

- fix links leading to information about time sync in RHEL
- fix link leading to available kernel parameters when building Bootc image

#### Rationale:

- have working links o documentation 


