### PR TITLE
Update rule selection for OL09-00-000222

### DIFF
--- a/controls/stig_ol9.yml
+++ b/controls/stig_ol9.yml
@@ -1418,8 +1418,8 @@ controls:
             protocols, and/or services, as defined in the Ports, Protocols, and Services Management
             (PPSM) Category Assignments List (CAL) and vulnerability assessments.
         rules:
-            - firewalld_sshd_port_enabled
-        status: automated
+            - configure_firewalld_ports
+        status: supported
 
     -   id: OL09-00-006004
         levels:


### PR DESCRIPTION
#### Description:

- Change rule `firewalld_sshd_port_enabled` to `configure_firewalld_ports` that better covers `OL09-00-000222`

#### Rationale:

- Better align OL9 stig to DISA STIG
