### PR TITLE
Update rule selection for OL09-00-000262

### DIFF
--- a/controls/stig_ol9.yml
+++ b/controls/stig_ol9.yml
@@ -1880,7 +1880,7 @@ controls:
             (MACs) employing FIPS 140-3 validated cryptographic hash algorithms.
         status: automated
         rules:
-            - sshd_use_strong_macs
+            - harden_sshd_macs_openssh_conf_crypto_policy
             - sshd_strong_macs=stig_ol9
 
     -   id: OL09-00-000255

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Red Hat Enterprise Linux 8,multi_platform_ol,multi_platform_fedora
 # reboot = true
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Red Hat Enterprise Linux 8,multi_platform_ol,multi_platform_fedora
 
 {{{ bash_instantiate_variables("sshd_approved_macs") }}}
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_correct.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_correct.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Red Hat Enterprise Linux 8,multi_platform_ol,multi_platform_fedora
 # variables = sshd_approved_macs=hmac-sha2-512,hmac-sha2-256,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com
 
 sshd_approved_macs=hmac-sha2-512,hmac-sha2-256,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_correct_commented.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_correct_commented.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Red Hat Enterprise Linux 8,multi_platform_ol,multi_platform_fedora
 # variables = sshd_approved_macs=hmac-sha2-512,hmac-sha2-256,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com
 
 sshd_approved_macs=hmac-sha2-512,hmac-sha2-256,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_correct_followed_by_incorrect_commented.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_correct_followed_by_incorrect_commented.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Red Hat Enterprise Linux 8,multi_platform_ol,multi_platform_fedora
 # variables = sshd_approved_macs=hmac-sha2-512,hmac-sha2-256,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com
 
 sshd_approved_macs=hmac-sha2-512,hmac-sha2-256,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_empty_file.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_empty_file.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Red Hat Enterprise Linux 8,multi_platform_ol,multi_platform_fedora
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 configfile=/etc/crypto-policies/back-ends/openssh.config

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_empty_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_empty_policy.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Red Hat Enterprise Linux 8,multi_platform_ol,multi_platform_fedora
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 configfile=/etc/crypto-policies/back-ends/openssh.config

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_incorrect_followed_by_correct_commented.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_incorrect_followed_by_correct_commented.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Red Hat Enterprise Linux 8,multi_platform_ol,multi_platform_fedora
 # variables = sshd_approved_macs=hmac-sha2-512,hmac-sha2-256,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com
 
 sshd_approved_macs=hmac-sha2-512,hmac-sha2-256,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_incorrect_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_incorrect_policy.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Red Hat Enterprise Linux 8,multi_platform_ol,multi_platform_fedora
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 configfile=/etc/crypto-policies/back-ends/openssh.config

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_missing_file.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_missing_file.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Red Hat Enterprise Linux 8,multi_platform_ol,multi_platform_fedora
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 configfile=/etc/crypto-policies/back-ends/openssh.config


### PR DESCRIPTION
#### Description:

- Replace rule `sshd_use_strong_macs` with `harden_sshd_macs_openssh_conf_crypto_policy`. So we check `/etc/crypto-policies/back-ends/openssh.config` instead of `/etc/ssh/sshd_config` 

#### Rationale:

- Better align OL9 stig with DISA STIG

