### PR TITLE
Add OL9 to platform in ssh ciphers rule's bash

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,multi_platform_fedora
 
 {{{ bash_instantiate_variables("sshd_approved_ciphers") }}}
 


### PR DESCRIPTION
#### Description:

- Add OL9 to platform in bash file for `harden_sshd_ciphers_openssh_conf_crypto_policy`

#### Rationale:

- Bash file also works for OL9
