### PR TITLE
Update sysctl_net_ipv4_conf_all_rp_filter for OL

### DIFF
--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/rule.yml
@@ -47,8 +47,9 @@ ocil: |-
     <pre>$ sysctl net.ipv4.conf.all.rp_filter</pre>
     The output of the command should indicate either:
     <code>net.ipv4.conf.all.rp_filter = 1</code>
-    or:
+    {{% if product not in ['ol9','rhel9'] %}}or:
     <code>net.ipv4.conf.all.rp_filter = 2</code>
+    {{% endif %}}
     The output of the command should not indicate:
     <code>net.ipv4.conf.all.rp_filter = 0</code>
 
@@ -61,12 +62,14 @@ ocil: |-
     <pre>$ grep -r '^\s*net.ipv4.conf.all.rp_filter\s*=' /etc/sysctl.conf /etc/sysctl.d</pre>
     The command should not find any assignments other than:
     net.ipv4.conf.all.rp_filter = 1
-    or:
+    {{% if product not in ['ol9','rhel9'] %}}or:
     net.ipv4.conf.all.rp_filter = 2
+    {{% endif %}}
 
     Conflicting assignments are not allowed.
 
-ocil_clause: "the net.ipv4.conf.all.rp_filter is not set to 1 or 2 or is configured to be 0"
+ocil_clause: |-
+    the net.ipv4.conf.all.rp_filter is not set to {{% if product not in ['ol9','rhel9'] %}}1 or 2 or is configured to be 0{{% else %}}1 or is configured to be 0 or 2{{% endif %}}
 
 fixtext: |-
     Configure {{{ full_name }}} to use reverse path filtering on all IPv4 interfaces.
@@ -78,10 +81,11 @@ template:
     name: sysctl
     vars:
         sysctlvar: net.ipv4.conf.all.rp_filter
-        {{% if 'ol' in product or 'rhel' in product %}}
+        {{% if ('ol' in families or 'rhel' in product) and product not in ['ol9','rhel9'] %}}
         sysctlval:
         - '1'
         - '2'
-        wrong_sysctlval_for_testing: "0"
+        wrong_sysctlval_for_testing: 
+        - '0'
         {{% endif %}}
         datatype: int

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/tests/ol_value_2.fail.sh
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/tests/ol_value_2.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# platform = Oracle Linux 9,Red Hat Enterpise Linux 9
+
+# Clean sysctl config directories
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+
+sed -i "/net.ipv4.conf.all.rp_filter/d" /etc/sysctl.conf
+echo "net.ipv4.conf.all.rp_filter = 2" >> /etc/sysctl.conf
+
+# set correct runtime value to check if the filesystem configuration is evaluated properly
+sysctl -w net.ipv4.conf.all.rp_filter="2"

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/tests/value_2.pass.sh
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/tests/value_2.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_ol,multi_platform_rhel,multi_platform_almalinux
+# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_almalinux
 
 # Clean sysctl config directories
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*


### PR DESCRIPTION
#### Description:

- Add conditionals for OL9 to exclude the "2" value.
- Update existent value 2 test
- Add new test for OL and value 2

#### Rationale:

Align OL9 STIG profile with DISA STIG OL9 V1R1

Note:

Also update for RHEL9, I think this change can be useful for that product, if not please notify me
