### PR TITLE
Add var_sudo_timestamp_timeout=always_prompt to RHEL 9 and RHEL 10 STIG

### DIFF
--- a/controls/srg_gpos/SRG-OS-000324-GPOS-00125.yml
+++ b/controls/srg_gpos/SRG-OS-000324-GPOS-00125.yml
@@ -16,4 +16,5 @@ controls:
             - sudo_remove_nopasswd
             - sudo_require_reauthentication
             - disallow_bypass_password_sudo
+            - var_sudo_timestamp_timeout=always_prompt
         status: automated

--- a/controls/stig_rhel9.yml
+++ b/controls/stig_rhel9.yml
@@ -2730,6 +2730,7 @@ controls:
         title: RHEL 9 must require reauthentication when using the "sudo" command.
         rules:
             - sudo_require_reauthentication
+            - var_sudo_timestamp_timeout=always_prompt
         status: automated
 
     -   id: RHEL-09-432020

--- a/tests/data/profile_stability/rhel10/stig.profile
+++ b/tests/data/profile_stability/rhel10/stig.profile
@@ -560,6 +560,7 @@ var_smartcard_drivers=cac
 var_sshd_disable_compression=no
 var_sshd_set_keepalive=1
 var_sssd_certificate_verification_digest_function=sha512
+var_sudo_timestamp_timeout=always_prompt
 var_system_crypto_policy=fips
 var_time_service_set_maxpoll=18_hours
 var_user_initialization_files_regex=all_dotfiles

--- a/tests/data/profile_stability/rhel10/stig_gui.profile
+++ b/tests/data/profile_stability/rhel10/stig_gui.profile
@@ -557,6 +557,7 @@ var_smartcard_drivers=cac
 var_sshd_disable_compression=no
 var_sshd_set_keepalive=1
 var_sssd_certificate_verification_digest_function=sha512
+var_sudo_timestamp_timeout=always_prompt
 var_system_crypto_policy=fips
 var_time_service_set_maxpoll=18_hours
 var_user_initialization_files_regex=all_dotfiles

--- a/tests/data/profile_stability/rhel9/stig.profile
+++ b/tests/data/profile_stability/rhel9/stig.profile
@@ -536,6 +536,7 @@ var_smartcard_drivers=cac
 var_sshd_disable_compression=no
 var_sshd_set_keepalive=1
 var_sssd_certificate_verification_digest_function=sha512
+var_sudo_timestamp_timeout=always_prompt
 var_system_crypto_policy=fips
 var_time_service_set_maxpoll=18_hours
 var_user_initialization_files_regex=all_dotfiles

--- a/tests/data/profile_stability/rhel9/stig_gui.profile
+++ b/tests/data/profile_stability/rhel9/stig_gui.profile
@@ -534,6 +534,7 @@ var_smartcard_drivers=cac
 var_sshd_disable_compression=no
 var_sshd_set_keepalive=1
 var_sssd_certificate_verification_digest_function=sha512
+var_sudo_timestamp_timeout=always_prompt
 var_system_crypto_policy=fips
 var_time_service_set_maxpoll=18_hours
 var_user_initialization_files_regex=all_dotfiles


### PR DESCRIPTION
#### Description:

Add  `var_sudo_timestamp_timeout=always_prompt` to RHEL 9 and RHEL 10 STIG
#### Rationale:

Fixes #13515 
