### PR TITLE
Add OL9 to accounts_password_pam_enforce_root oval file

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_enforce_root/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_enforce_root/oval/shared.xml
@@ -1,4 +1,4 @@
-{{% if product == "ol8" or 'rhel' in product %}}
+{{% if product in ["ol8","ol9"] or 'rhel' in product %}}
 {{% set filepath_regex="^/etc/security/pwquality\.conf(\.d/[^/]+\.conf)?$" %}}
 {{% else %}}
 {{% set filepath_regex="^/etc/security/pwquality\.conf$" %}}


### PR DESCRIPTION
#### Description:

Add OL9 to accounts_password_pam_enforce_root oval file

#### Rationale:

Align OL9 STIG profile with DISA STIG OL9 V1R1