### PR TITLE
Add var_password_hashing_min_rounds_login_defs to OL9 stig control

### DIFF
--- a/controls/stig_ol9.yml
+++ b/controls/stig_ol9.yml
@@ -3028,6 +3028,7 @@ controls:
             of hashing rounds.
         rules:
             - set_password_hashing_min_rounds_logindefs
+            - var_password_hashing_min_rounds_login_defs=100000
         status: automated
 
     -   id: OL09-00-001130


### PR DESCRIPTION
#### Description:

Add var_password_hashing_min_rounds_login_defs to OL9 stig control

#### Rationale:

Align OL9 STIG profile with DISA STIG OL9 V1R1
