### PR TITLE
Slmicro5 disable ipv6 rules

### DIFF
--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/sysctl_net_ipv6_conf_all_disable_ipv6/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/sysctl_net_ipv6_conf_all_disable_ipv6/rule.yml
@@ -49,7 +49,11 @@ ocil: |-
     files in <tt>/etc/sysctl.d</tt>:
     <pre>$ grep -r ipv6 /etc/sysctl.d</pre>
 
+{{% if product in ["sle12", "sle15", "slmicro5"] %}}
+platform: ipv6[enabled]
+{{% else %}}
 platform: system_with_kernel
+{{% endif %}}
 
 template:
     name: sysctl

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/sysctl_net_ipv6_conf_default_disable_ipv6/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/sysctl_net_ipv6_conf_default_disable_ipv6/rule.yml
@@ -44,7 +44,11 @@ ocil: |-
     files in <tt>/etc/sysctl.d</tt>:
     <pre>$ grep -r ipv6 /etc/sysctl.d</pre>
 
+{{% if product in ["sle12", "sle15", "slmicro5"] %}}
+platform: ipv6[enabled]
+{{% else %}}
 platform: system_with_kernel
+{{% endif %}}
 
 template:
     name: sysctl

--- a/products/slmicro5/product.yml
+++ b/products/slmicro5/product.yml
@@ -2,6 +2,9 @@ product: slmicro5
 full_name: SUSE Linux Enterprise Micro 5
 type: platform
 
+families:
+  - suse
+
 major_version_ordinal: 5
 
 benchmark_id: SLMICRO5

--- a/shared/macros/01-general.jinja
+++ b/shared/macros/01-general.jinja
@@ -1258,7 +1258,11 @@ Part of the grub2_bootloader_argument(_absent) templates.
 {{%- if "update-grub" in grub_helper_executable -%}}
     {{%- set grub_helper_args = [] -%}}
 {{%- elif "grub2-mkconfig" in grub_helper_executable -%}}
+    {{%- if 'suse' in families -%}}
+    {{%- set grub_helper_args = ["-o " ~ grub2_boot_path ~ "/grub.cfg"] -%}}
+    {{%- else -%}}
     {{%- set grub_helper_args = ["-o " ~ grub2_boot_path ~ "/grub2.cfg"] -%}}
+    {{%- endif -%}}
 {{%- elif "grubby" in grub_helper_executable -%}}
     {{%- if action == "update" -%}}
         {{%- set grub_helper_args = ["--update-kernel=ALL"] -%}}

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1403,7 +1403,7 @@ Part of the grub2_bootloader_argument template.
 
 {{% endif -%}}
 
-{{% if product in ['sle12', 'sle15'] %}}
+{{% if product in ['sle12', 'sle15', 'slmicro5'] %}}
 - name: Update grub defaults and the bootloader menu
   command: /usr/sbin/grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg
 {{% elif 'debian' in product %}}

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1957,7 +1957,7 @@ Part of the grub2_bootloader_argument template.
 
 #}}
 {{% macro grub2_bootloader_argument_remediation(arg_name, arg_name_value) %}}
-{{% if 'ubuntu' in product or 'debian' in product or product in ['ol7', 'sle12', 'sle15'] %}}
+{{% if 'ubuntu' in product or 'debian' in product or product in ['ol7', 'sle12', 'sle15', 'slmicro5'] %}}
 {{{ update_etc_default_grub_manually(arg_name, arg_name_value) }}}
 {{% endif -%}}
 {{{ grub_command("add", arg_name_value) }}}


### PR DESCRIPTION
#### Description:

- Patches related to disable ipv6 rules for SL Mirco 5 platforms

#### Rationale:

- Make sure sysctl ipv6 is applicable on platform basis
- Make sure that slmicro5 is considered suse family so grub macros work
- Add slmicro5 support for grub configuration
- Make sure right file is used for grub config for sle platforms

