### PR TITLE
Enable audit configure rules for slmicro5

### DIFF
--- a/controls/general_slmicro5.yml
+++ b/controls/general_slmicro5.yml
@@ -739,6 +739,14 @@ controls:
           - audit_rules_login_events_tallylog
       status: automated
 
+    - id: SLEM-5-AUD-01080000
+      levels:
+          - medium
+      title: Record Attempts to Alter Process and Session Initiation Information
+      rules:
+          - audit_rules_session_events
+      status: automated
+
     - id: SLEM-5-AUD-01090000
       levels:
           - medium
@@ -811,6 +819,14 @@ controls:
           - audit_rules_privileged_commands_modprobe
           - audit_rules_privileged_commands_rmmod
           - audit_rules_kernel_module_loading_delete
+      status: automated
+
+    - id: SLEM-5-AUD-01017000
+      title: Make the auditd Configuration Immutable
+      levels:
+          - medium
+      rules:
+          - audit_rules_immutable
       status: automated
 
     - id: SLEM-5-AUD-02010500

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_immutable/bash/shared.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_immutable/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu,multi_platform_debian,multi_platform_almalinux
+# platform = Red Hat Virtualization 4,multi_platform_almalinux,multi_platform_debian,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicro,multi_platform_ubuntu
 
 # Traverse all of:
 #

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_session_events/bash/shared.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_session_events/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_debian,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicor,multi_platform_ubuntu,multi_platform_almalinux
+# platform = Red Hat Virtualization 4,multi_platform_almalinux,multi_platform_debian,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicro,multi_platform_ubuntu
 
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 {{{ bash_fix_audit_watch_rule("auditctl", "/var/run/utmp", "wa", "session") }}}


### PR DESCRIPTION
#### Description:

- Enable audit configure rules for slmicro5

#### Rationale:

- Enable  slmicro5 platform for audit_rules_immutable and audit_rules_session_events rules
