### PR TITLE
Fix macro tests_init_faillock_vars

### DIFF
--- a/shared/macros/20-test-scenarios.jinja
+++ b/shared/macros/20-test-scenarios.jinja
@@ -17,98 +17,106 @@ the external variable and parameter value to a desired state.
 
 :param state:         correct, stricter, lenient_high, lenient_low
 :type state: str
+:param prm_name: name of faillock parameter
+:type prm_name: str
+:param variable_lower_bound: lower boundary for allowed parameter value
+:type variable_lower_bound: str
+:param variable_upper_bound: upper boundary for allowed parameter value
+:type variable_upper_bound: str
+:param ext_variable: external XCCDF variable used to define interval boundaries and the value used in the remediation
+:param ext_variable: str
 #}}
 
-{{%- macro tests_init_faillock_vars(state) -%}}
+{{%- macro tests_init_faillock_vars(state, prm_name, ext_variable, variable_lower_bound, variable_upper_bound) -%}}
 
 {{% if state not in ["correct", "stricter", "lenient_high", "lenient_low"] %}}
 echo "Unsupported value for argument 'state': {{{ state }}}"
 exit 2
 
-{{% elif VARIABLE_UPPER_BOUND == "use_ext_variable" and VARIABLE_LOWER_BOUND == "use_ext_variable" %}}
+{{% elif variable_upper_bound == "use_ext_variable" and variable_lower_bound == "use_ext_variable" %}}
 {{% if state == "correct" %}}
-# variables = {{{ EXT_VARIABLE }}}=5
+# variables = {{{ ext_variable }}}=5
 TEST_VALUE=5
 {{% elif state == "stricter" %}}
-# variables = {{{ EXT_VARIABLE }}}=5
+# variables = {{{ ext_variable }}}=5
 TEST_VALUE=5
 {{% elif state == "lenient_high" %}}
-# variables = {{{ EXT_VARIABLE }}}=5
+# variables = {{{ ext_variable }}}=5
 TEST_VALUE=6
 {{% elif state == "lenient_low" %}}
-# variables = {{{ EXT_VARIABLE }}}=5
+# variables = {{{ ext_variable }}}=5
 TEST_VALUE=4
 {{% endif %}}
 
-{{% elif VARIABLE_UPPER_BOUND == "use_ext_variable" and VARIABLE_LOWER_BOUND is number %}}
+{{% elif variable_upper_bound == "use_ext_variable" and variable_lower_bound is number %}}
 {{% if state == "correct" %}}
-# variables = {{{ EXT_VARIABLE }}}={{{ VARIABLE_LOWER_BOUND }}}
-TEST_VALUE={{{ VARIABLE_LOWER_BOUND }}}
+# variables = {{{ ext_variable }}}={{{ variable_lower_bound }}}
+TEST_VALUE={{{ variable_lower_bound }}}
 {{% elif state == "stricter" %}}
-# variables = {{{ EXT_VARIABLE }}}={{{ VARIABLE_LOWER_BOUND + 2 }}}
-TEST_VALUE={{{ VARIABLE_LOWER_BOUND + 1 }}}
+# variables = {{{ ext_variable }}}={{{ variable_lower_bound + 2 }}}
+TEST_VALUE={{{ variable_lower_bound + 1 }}}
 {{% elif state == "lenient_high" %}}
-# variables = {{{ EXT_VARIABLE }}}={{{ VARIABLE_LOWER_BOUND }}}
-TEST_VALUE={{{ VARIABLE_LOWER_BOUND + 1 }}}
+# variables = {{{ ext_variable }}}={{{ variable_lower_bound }}}
+TEST_VALUE={{{ variable_lower_bound + 1 }}}
 {{% elif state == "lenient_low" %}}
-# variables = {{{ EXT_VARIABLE }}}={{{ VARIABLE_LOWER_BOUND }}}
-TEST_VALUE={{{ VARIABLE_LOWER_BOUND - 1 }}}
+# variables = {{{ ext_variable }}}={{{ variable_lower_bound }}}
+TEST_VALUE={{{ variable_lower_bound - 1 }}}
 {{% endif %}}
 
-{{% elif VARIABLE_UPPER_BOUND == "use_ext_variable" and VARIABLE_LOWER_BOUND is none %}}
+{{% elif variable_upper_bound == "use_ext_variable" and variable_lower_bound is none %}}
 {{% if state == "correct" %}}
-# variables = {{{ EXT_VARIABLE }}}=5
+# variables = {{{ ext_variable }}}=5
 TEST_VALUE=5
 {{% elif state == "stricter" %}}
-# variables = {{{ EXT_VARIABLE }}}=5
+# variables = {{{ ext_variable }}}=5
 TEST_VALUE=4
 {{% elif state == "lenient_high" %}}
-# variables = {{{ EXT_VARIABLE }}}=5
+# variables = {{{ ext_variable }}}=5
 TEST_VALUE=6
 {{% elif state == "lenient_low" %}}
 # there is no lower limit so the test should be not-applicable
 # platform = Not Applicable (rule does not set a lower boundary for '{{{ PRM_NAME }}}')
 {{% endif %}}
 
-{{% elif VARIABLE_LOWER_BOUND == "use_ext_variable" and VARIABLE_UPPER_BOUND is number %}}
+{{% elif variable_lower_bound == "use_ext_variable" and variable_upper_bound is number %}}
 {{% if state == "correct" %}}
-# variables = {{{ EXT_VARIABLE }}}={{{ VARIABLE_UPPER_BOUND | default(100) }}}
-TEST_VALUE={{{ VARIABLE_UPPER_BOUND | default(100) }}}
+# variables = {{{ ext_variable }}}={{{ variable_upper_bound | default(100) }}}
+TEST_VALUE={{{ variable_upper_bound | default(100) }}}
 {{% elif state == "stricter" %}}
-# variables = {{{ EXT_VARIABLE }}}={{{ VARIABLE_UPPER_BOUND | default(100) - 2 }}}
-TEST_VALUE={{{ VARIABLE_UPPER_BOUND | default(100) - 1 }}}
+# variables = {{{ ext_variable }}}={{{ variable_upper_bound | default(100) - 2 }}}
+TEST_VALUE={{{ variable_upper_bound | default(100) - 1 }}}
 {{% elif state == "lenient_high" %}}
-# variables = {{{ EXT_VARIABLE }}}={{{ VARIABLE_UPPER_BOUND }}}
-TEST_VALUE={{{ VARIABLE_UPPER_BOUND + 1 }}}
+# variables = {{{ ext_variable }}}={{{ variable_upper_bound }}}
+TEST_VALUE={{{ variable_upper_bound + 1 }}}
 {{% elif state == "lenient_low" %}}
-# variables = {{{ EXT_VARIABLE }}}={{{ VARIABLE_UPPER_BOUND }}}
-TEST_VALUE={{{ VARIABLE_UPPER_BOUND - 1 }}}
+# variables = {{{ ext_variable }}}={{{ variable_upper_bound }}}
+TEST_VALUE={{{ variable_upper_bound - 1 }}}
 {{% endif %}}
 
-{{% elif VARIABLE_LOWER_BOUND == "use_ext_variable" and VARIABLE_UPPER_BOUND is none %}}
+{{% elif variable_lower_bound == "use_ext_variable" and variable_upper_bound is none %}}
 {{% if state == "correct" %}}
-# variables = {{{ EXT_VARIABLE }}}=5
+# variables = {{{ ext_variable }}}=5
 TEST_VALUE=5
 {{% elif state == "stricter" %}}
-# variables = {{{ EXT_VARIABLE }}}=5
+# variables = {{{ ext_variable }}}=5
 TEST_VALUE=6
 {{% elif state == "lenient_high" %}}
 # there is no upper limit so the test should be not-applicable
 # platform = Not Applicable (rule does not set an upper boundary for '{{{ PRM_NAME }}}')
 {{% elif state == "lenient_low" %}}
-# variables = {{{ EXT_VARIABLE }}}=5
+# variables = {{{ ext_variable }}}=5
 TEST_VALUE=4
 {{% endif %}}
 
 {{% else %}}
 echo "The combination of template parameters is not supported by the test:"
-echo "  variable_upper_bound={{{ VARIABLE_UPPER_BOUND }}}"
-echo "  variable_lower_bound={{{ VARIABLE_LOWER_BOUND }}}"
-echo "  ext_variable={{{ EXT_VARIABLE }}}"
+echo "  variable_upper_bound={{{ variable_upper_bound }}}"
+echo "  variable_lower_bound={{{ variable_lower_bound }}}"
+echo "  ext_variable={{{ ext_variable }}}"
 exit 2
 {{% endif %}}
 
-PRM_NAME={{{ PRM_NAME }}}
+PRM_NAME={{{ prm_name }}}
 
 {{%- endmacro -%}}
 

--- a/shared/templates/pam_account_password_faillock/tests/conflicting_settings_authselect.fail.sh
+++ b/shared/templates/pam_account_password_faillock/tests/conflicting_settings_authselect.fail.sh
@@ -2,7 +2,7 @@
 # packages = authselect,pam
 # platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel
 
-{{{ tests_init_faillock_vars("correct") }}}
+{{{ tests_init_faillock_vars("correct", prm_name=PRM_NAME, ext_variable=EXT_VARIABLE, variable_lower_bound=VARIABLE_LOWER_BOUND, variable_upper_bound=VARIABLE_UPPER_BOUND) }}}
 
 pam_files=("password-auth" "system-auth")
 

--- a/shared/templates/pam_account_password_faillock/tests/pam_faillock_conflicting_settings.fail.sh
+++ b/shared/templates/pam_account_password_faillock/tests/pam_faillock_conflicting_settings.fail.sh
@@ -3,7 +3,7 @@
 # platform = multi_platform_fedora,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,Oracle Linux 8
 # remediation = none
 
-{{{ tests_init_faillock_vars("correct") }}}
+{{{ tests_init_faillock_vars("correct", prm_name=PRM_NAME, ext_variable=EXT_VARIABLE, variable_lower_bound=VARIABLE_LOWER_BOUND, variable_upper_bound=VARIABLE_UPPER_BOUND) }}}
 
 authselect select sssd --force
 authselect enable-feature with-faillock

--- a/shared/templates/pam_account_password_faillock/tests/pam_faillock_disabled.fail.sh
+++ b/shared/templates/pam_account_password_faillock/tests/pam_faillock_disabled.fail.sh
@@ -2,7 +2,7 @@
 # platform = multi_platform_fedora,multi_platform_rhel,multi_platform_ol,multi_platform_rhv,multi_platform_sle,multi_platform_almalinux
 # packages = authselect
 
-{{{ tests_init_faillock_vars("correct") }}}
+{{{ tests_init_faillock_vars("correct", prm_name=PRM_NAME, ext_variable=EXT_VARIABLE, variable_lower_bound=VARIABLE_LOWER_BOUND, variable_upper_bound=VARIABLE_UPPER_BOUND) }}}
 
 if [ -f /usr/sbin/authconfig ]; then
     authconfig --disablefaillock --update

--- a/shared/templates/pam_account_password_faillock/tests/pam_faillock_expected_faillock_conf.pass.sh
+++ b/shared/templates/pam_account_password_faillock/tests/pam_faillock_expected_faillock_conf.pass.sh
@@ -2,7 +2,7 @@
 # packages = authselect
 # platform = multi_platform_fedora,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,Oracle Linux 8
 
-{{{ tests_init_faillock_vars("correct") }}}
+{{{ tests_init_faillock_vars("correct", prm_name=PRM_NAME, ext_variable=EXT_VARIABLE, variable_lower_bound=VARIABLE_LOWER_BOUND, variable_upper_bound=VARIABLE_UPPER_BOUND) }}}
 
 authselect select sssd --force
 authselect enable-feature with-faillock

--- a/shared/templates/pam_account_password_faillock/tests/pam_faillock_expected_pam_files.pass.sh
+++ b/shared/templates/pam_account_password_faillock/tests/pam_faillock_expected_pam_files.pass.sh
@@ -2,6 +2,6 @@
 # packages = authconfig
 # platform = Oracle Linux 7,multi_platform_fedora
 
-{{{ tests_init_faillock_vars("correct") }}}
+{{{ tests_init_faillock_vars("correct", prm_name=PRM_NAME, ext_variable=EXT_VARIABLE, variable_lower_bound=VARIABLE_LOWER_BOUND, variable_upper_bound=VARIABLE_UPPER_BOUND) }}}
 
 authconfig --enablefaillock --faillockargs="$PRM_NAME=$TEST_VALUE" --update

--- a/shared/templates/pam_account_password_faillock/tests/pam_faillock_lenient_high_faillock_conf.fail.sh
+++ b/shared/templates/pam_account_password_faillock/tests/pam_faillock_lenient_high_faillock_conf.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-{{{ tests_init_faillock_vars("lenient_high") }}}
+{{{ tests_init_faillock_vars("lenient_high", prm_name=PRM_NAME, ext_variable=EXT_VARIABLE, variable_lower_bound=VARIABLE_LOWER_BOUND, variable_upper_bound=VARIABLE_UPPER_BOUND) }}}
 # packages = authselect
 # platform = multi_platform_fedora,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,Oracle Linux 8
 

--- a/shared/templates/pam_account_password_faillock/tests/pam_faillock_lenient_high_pam_files.fail.sh
+++ b/shared/templates/pam_account_password_faillock/tests/pam_faillock_lenient_high_pam_files.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-{{{ tests_init_faillock_vars("lenient_high") }}}
+{{{ tests_init_faillock_vars("lenient_high", prm_name=PRM_NAME, ext_variable=EXT_VARIABLE, variable_lower_bound=VARIABLE_LOWER_BOUND, variable_upper_bound=VARIABLE_UPPER_BOUND) }}}
 # packages = authconfig
 # platform = Oracle Linux 7,multi_platform_fedora
 

--- a/shared/templates/pam_account_password_faillock/tests/pam_faillock_lenient_low_faillock_conf.fail.sh
+++ b/shared/templates/pam_account_password_faillock/tests/pam_faillock_lenient_low_faillock_conf.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-{{{ tests_init_faillock_vars("lenient_low") }}}
+{{{ tests_init_faillock_vars("lenient_low", prm_name=PRM_NAME, ext_variable=EXT_VARIABLE, variable_lower_bound=VARIABLE_LOWER_BOUND, variable_upper_bound=VARIABLE_UPPER_BOUND) }}}
 # packages = authselect
 # platform = multi_platform_fedora,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,Oracle Linux 8
 

--- a/shared/templates/pam_account_password_faillock/tests/pam_faillock_lenient_low_pam_files.fail.sh
+++ b/shared/templates/pam_account_password_faillock/tests/pam_faillock_lenient_low_pam_files.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-{{{ tests_init_faillock_vars("lenient_low") }}}
+{{{ tests_init_faillock_vars("lenient_low", prm_name=PRM_NAME, ext_variable=EXT_VARIABLE, variable_lower_bound=VARIABLE_LOWER_BOUND, variable_upper_bound=VARIABLE_UPPER_BOUND) }}}
 # packages = authconfig
 # platform = Oracle Linux 7,multi_platform_fedora
 

--- a/shared/templates/pam_account_password_faillock/tests/pam_faillock_multiple_pam_unix_faillock_conf.fail.sh
+++ b/shared/templates/pam_account_password_faillock/tests/pam_faillock_multiple_pam_unix_faillock_conf.fail.sh
@@ -3,7 +3,7 @@
 # platform = multi_platform_fedora,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,Oracle Linux 8
 # remediation = none
 
-{{{ tests_init_faillock_vars("correct") }}}
+{{{ tests_init_faillock_vars("correct", prm_name=PRM_NAME, ext_variable=EXT_VARIABLE, variable_lower_bound=VARIABLE_LOWER_BOUND, variable_upper_bound=VARIABLE_UPPER_BOUND) }}}
 
 authselect select sssd --force
 authselect enable-feature with-faillock

--- a/shared/templates/pam_account_password_faillock/tests/pam_faillock_multiple_pam_unix_pam_files.fail.sh
+++ b/shared/templates/pam_account_password_faillock/tests/pam_faillock_multiple_pam_unix_pam_files.fail.sh
@@ -3,7 +3,7 @@
 # platform = Oracle Linux 7,multi_platform_fedora
 # remediation = none
 
-{{{ tests_init_faillock_vars("correct") }}}
+{{{ tests_init_faillock_vars("correct", prm_name=PRM_NAME, ext_variable=EXT_VARIABLE, variable_lower_bound=VARIABLE_LOWER_BOUND, variable_upper_bound=VARIABLE_UPPER_BOUND) }}}
 
 authconfig --enablefaillock --faillockargs="$PRM_NAME=$TEST_VALUE" --update
 

--- a/shared/templates/pam_account_password_faillock/tests/pam_faillock_not_required_pam_files.fail.sh
+++ b/shared/templates/pam_account_password_faillock/tests/pam_faillock_not_required_pam_files.fail.sh
@@ -3,7 +3,7 @@
 # packages = authselect
 # remediation = none
 
-{{{ tests_init_faillock_vars("correct") }}}
+{{{ tests_init_faillock_vars("correct", prm_name=PRM_NAME, ext_variable=EXT_VARIABLE, variable_lower_bound=VARIABLE_LOWER_BOUND, variable_upper_bound=VARIABLE_UPPER_BOUND) }}}
 
 # This test scenario manually modify the pam_faillock.so entries in auth section from
 # "required" to "sufficient". This makes pam_faillock.so behave differently than initially

--- a/shared/templates/pam_account_password_faillock/tests/pam_faillock_stricter_faillock_conf.pass.sh
+++ b/shared/templates/pam_account_password_faillock/tests/pam_faillock_stricter_faillock_conf.pass.sh
@@ -2,7 +2,7 @@
 # packages = authselect
 # platform = multi_platform_fedora,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,Oracle Linux 8
 
-{{{ tests_init_faillock_vars("stricter") }}}
+{{{ tests_init_faillock_vars("stricter", prm_name=PRM_NAME, ext_variable=EXT_VARIABLE, variable_lower_bound=VARIABLE_LOWER_BOUND, variable_upper_bound=VARIABLE_UPPER_BOUND) }}}
 
 authselect select sssd --force
 authselect enable-feature with-faillock

--- a/shared/templates/pam_account_password_faillock/tests/pam_faillock_stricter_pam_files.pass.sh
+++ b/shared/templates/pam_account_password_faillock/tests/pam_faillock_stricter_pam_files.pass.sh
@@ -2,6 +2,6 @@
 # packages = authconfig
 # platform = Oracle Linux 7,multi_platform_fedora
 
-{{{ tests_init_faillock_vars("stricter") }}}
+{{{ tests_init_faillock_vars("stricter", prm_name=PRM_NAME, ext_variable=EXT_VARIABLE, variable_lower_bound=VARIABLE_LOWER_BOUND, variable_upper_bound=VARIABLE_UPPER_BOUND) }}}
 
 authconfig --enablefaillock --faillockargs="$PRM_NAME=$TEST_VALUE" --update

--- a/shared/templates/pam_account_password_faillock/tests/ubuntu_commented_values.fail.sh
+++ b/shared/templates/pam_account_password_faillock/tests/ubuntu_commented_values.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 
-{{{ tests_init_faillock_vars("correct") }}}
+{{{ tests_init_faillock_vars("correct", prm_name=PRM_NAME, ext_variable=EXT_VARIABLE, variable_lower_bound=VARIABLE_LOWER_BOUND, variable_upper_bound=VARIABLE_UPPER_BOUND) }}}
 
 {{{ bash_enable_pam_faillock_directly_in_pam_files() }}}
 

--- a/shared/templates/pam_account_password_faillock/tests/ubuntu_correct.pass.sh
+++ b/shared/templates/pam_account_password_faillock/tests/ubuntu_correct.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 
-{{{ tests_init_faillock_vars("correct") }}}
+{{{ tests_init_faillock_vars("correct", prm_name=PRM_NAME, ext_variable=EXT_VARIABLE, variable_lower_bound=VARIABLE_LOWER_BOUND, variable_upper_bound=VARIABLE_UPPER_BOUND) }}}
 
 {{{ bash_enable_pam_faillock_directly_in_pam_files() }}}
 

--- a/shared/templates/pam_account_password_faillock/tests/ubuntu_correct_pamd.pass.sh
+++ b/shared/templates/pam_account_password_faillock/tests/ubuntu_correct_pamd.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 
-{{{ tests_init_faillock_vars("correct") }}}
+{{{ tests_init_faillock_vars("correct", prm_name=PRM_NAME, ext_variable=EXT_VARIABLE, variable_lower_bound=VARIABLE_LOWER_BOUND, variable_upper_bound=VARIABLE_UPPER_BOUND) }}}
 
 {{{ bash_enable_pam_faillock_directly_in_pam_files() }}}
 

--- a/shared/templates/pam_account_password_faillock/tests/ubuntu_correct_stricter.pass.sh
+++ b/shared/templates/pam_account_password_faillock/tests/ubuntu_correct_stricter.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 
-{{{ tests_init_faillock_vars("stricter") }}}
+{{{ tests_init_faillock_vars("stricter", prm_name=PRM_NAME, ext_variable=EXT_VARIABLE, variable_lower_bound=VARIABLE_LOWER_BOUND, variable_upper_bound=VARIABLE_UPPER_BOUND) }}}
 
 {{{ bash_enable_pam_faillock_directly_in_pam_files() }}}
 

--- a/shared/templates/pam_account_password_faillock/tests/ubuntu_empty_faillock_conf.fail.sh
+++ b/shared/templates/pam_account_password_faillock/tests/ubuntu_empty_faillock_conf.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 
-{{{ tests_init_faillock_vars("correct") }}}
+{{{ tests_init_faillock_vars("correct", prm_name=PRM_NAME, ext_variable=EXT_VARIABLE, variable_lower_bound=VARIABLE_LOWER_BOUND, variable_upper_bound=VARIABLE_UPPER_BOUND) }}}
 
 {{{ bash_enable_pam_faillock_directly_in_pam_files() }}}
 

--- a/shared/templates/pam_account_password_faillock/tests/ubuntu_lenient_high.fail.sh
+++ b/shared/templates/pam_account_password_faillock/tests/ubuntu_lenient_high.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-{{{ tests_init_faillock_vars("lenient_high") }}}
+{{{ tests_init_faillock_vars("lenient_high", prm_name=PRM_NAME, ext_variable=EXT_VARIABLE, variable_lower_bound=VARIABLE_LOWER_BOUND, variable_upper_bound=VARIABLE_UPPER_BOUND) }}}
 # platform = multi_platform_ubuntu
 
 

--- a/shared/templates/pam_account_password_faillock/tests/ubuntu_lenient_low.fail.sh
+++ b/shared/templates/pam_account_password_faillock/tests/ubuntu_lenient_low.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-{{{ tests_init_faillock_vars("lenient_low") }}}
+{{{ tests_init_faillock_vars("lenient_low", prm_name=PRM_NAME, ext_variable=EXT_VARIABLE, variable_lower_bound=VARIABLE_LOWER_BOUND, variable_upper_bound=VARIABLE_UPPER_BOUND) }}}
 # platform = multi_platform_ubuntu
 
 

--- a/shared/templates/pam_account_password_faillock/tests/ubuntu_missing_pamd.fail.sh
+++ b/shared/templates/pam_account_password_faillock/tests/ubuntu_missing_pamd.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 
-{{{ tests_init_faillock_vars("correct") }}}
+{{{ tests_init_faillock_vars("correct", prm_name=PRM_NAME, ext_variable=EXT_VARIABLE, variable_lower_bound=VARIABLE_LOWER_BOUND, variable_upper_bound=VARIABLE_UPPER_BOUND) }}}
 
 echo "$PRM_NAME=$TEST_VALUE" > /etc/security/faillock.conf

--- a/shared/templates/pam_account_password_faillock/tests/ubuntu_multiple_pam_unix.fail.sh
+++ b/shared/templates/pam_account_password_faillock/tests/ubuntu_multiple_pam_unix.fail.sh
@@ -2,7 +2,7 @@
 # platform = multi_platform_ubuntu
 # remediation = none
 
-{{{ tests_init_faillock_vars("correct") }}}
+{{{ tests_init_faillock_vars("correct", prm_name=PRM_NAME, ext_variable=EXT_VARIABLE, variable_lower_bound=VARIABLE_LOWER_BOUND, variable_upper_bound=VARIABLE_UPPER_BOUND) }}}
 
 {{{ bash_enable_pam_faillock_directly_in_pam_files() }}}
 


### PR DESCRIPTION
After changes done in https://github.com/ComplianceAsCode/content/pull/13502 we don't support macros that use global variables that aren't constants. Macro `tests_init_faillock_vars` uses multiple global variables.  This macro has been missed because it's used only in templated scenarios, but for templated test scenarios Jinja macros preloading is applied as well. We will fix this macro by changing the globals to macro parameters.


#### Review Hints:

Run automatus tests for rules accounts_passwords_pam_faillock_deny, accounts_passwords_pam_faillock_interval, accounts_passwords_pam_faillock_unlock_time.
