### PR TITLE
Fix failing tests for sysctl_net_ipv4_conf_all_rp_filter

### DIFF
--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/rule.yml
@@ -85,7 +85,6 @@ template:
         sysctlval:
         - '1'
         - '2'
-        wrong_sysctlval_for_testing: 
-        - '0'
+        wrong_sysctlval_for_testing: "0"
         {{% endif %}}
         datatype: int


### PR DESCRIPTION
The template parameter `wrong_sysctlval_for_testing` doesn't support lists, it needs to be a string.

