### PR TITLE
Exclude remote mounted filesystems from local partition nodev tasks

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/ansible/shared.yml
@@ -8,6 +8,30 @@
   setup:
     gather_subset: mounts
 
+- name: "{{{ rule_title }}}: Define excluded (non-local) file systems"
+  ansible.builtin.set_fact:
+    excluded_fstypes:
+      - afs
+      - autofs
+      - ceph
+      - cifs
+      - smb3
+      - smbfs
+      - sshfs
+      - ncpfs
+      - ncp
+      - nfs
+      - nfs4
+      - gfs
+      - gfs2
+      - glusterfs
+      - gpfs
+      - pvfs2
+      - ocfs2
+      - lustre
+      - davfs
+      - fuse.sshfs
+
 - name: "{{{ rule_title }}}: Ensure non-root local partitions are mounted with nodev option"
   mount:
     path: "{{ item.mount }}"
@@ -18,6 +42,7 @@
   when:
     - "item.mount is match('/\\w')"
     - "item.options is not search('nodev')"
+    - "item.fstype not in excluded_fstypes"
   with_items:
     - "{{ ansible_facts.mounts }}"
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/bash/shared.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/bash/shared.sh
@@ -8,20 +8,55 @@ readarray -t partitions_records < <(findmnt --mtab --raw --evaluate | grep "^/\w
 readarray -t polyinstantiated_dirs < \
     <(grep -oP "^\s*[^#\s]+\s+\S+" /etc/security/namespace.conf | grep -oP "(?<=\s)\S+?(?=/?\$)")
 
+# Define excluded non-local file systems
+excluded_fstypes=(
+    afs
+    autofs
+    ceph
+    cifs
+    smb3
+    smbfs
+    sshfs
+    ncpfs
+    ncp
+    nfs
+    nfs4
+    gfs
+    gfs2
+    glusterfs
+    gpfs
+    pvfs2
+    ocfs2
+    lustre
+    davfs
+    fuse.sshfs
+)
 
 for partition_record in "${partitions_records[@]}"; do
     # Get all important information for fstab
-    mount_point="$(echo ${partition_record} | cut -d " " -f1)"
-    device="$(echo ${partition_record} | cut -d " " -f2)"
-    device_type="$(echo ${partition_record} | cut -d " " -f3)"
-    if ! printf '%s\0' "${polyinstantiated_dirs[@]}" | grep -qxzF "$mount_point"; then
-        # device and device_type will be used only in case when the device doesn't have fstab record
-        {{{ bash_ensure_mount_option_in_fstab("$mount_point",
-                                              "$MOUNT_OPTION",
-                                              "$device",
-                                              "$device_type") | indent(8) }}}
-        {{{ bash_ensure_partition_is_mounted("$mount_point") | indent(8)}}}
+    mount_point="$(echo "${partition_record}" | cut -d " " -f1)"
+    device="$(echo "${partition_record}" | cut -d " " -f2)"
+    device_type="$(echo "${partition_record}" | cut -d " " -f3)"
+
+    # Skip polyinstantiated directories
+    if printf '%s\0' "${polyinstantiated_dirs[@]}" | grep -qxzF "$mount_point"; then
+        continue
     fi
+
+    # Skip any non-local filesystem
+    for excluded_fstype in "${excluded_fstypes[@]}"; do
+        if [[ "$device_type" == "$excluded_fstype" ]]; then
+            # jump out of both loops and move to next partition_record
+            continue 2
+        fi
+    done
+
+    # If we reach here, it's a local, non-root partition that isn't excluded.
+    {{{ bash_ensure_mount_option_in_fstab("$mount_point",
+                                          "$MOUNT_OPTION",
+                                          "$device",
+                                          "$device_type") | indent(4) }}}
+    {{{ bash_ensure_partition_is_mounted("$mount_point")     | indent(4) }}}
 done
 
 # Remediate unmounted /etc/fstab entries

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/oval/shared.xml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/oval/shared.xml
@@ -33,9 +33,7 @@
   <linux:partition_state id="state_local_nodev" version="1">
     <!-- this check defines a local partition as one which has a device node in /dev -->
     <linux:device operation="pattern match">^/dev/.*$</linux:device>
-    <linux:fs_type operation="pattern match">
-        ^(?!afs$|autofs$|ceph$|cifs$|smb3$|smbfs$|sshfs$|ncpfs$|ncp$|nfs$|nfs4$|gfs$|gfs2$|glusterfs$|gpfs$|pvfs2$|ocfs2$|lustre$|davfs$|fuse\.sshfs$).+
-    </linux:fs_type>
+    <linux:fs_type operation="pattern match">^(?!afs$|autofs$|ceph$|cifs$|smb3$|smbfs$|sshfs$|ncpfs$|ncp$|nfs$|nfs4$|gfs$|gfs2$|glusterfs$|gpfs$|pvfs2$|ocfs2$|lustre$|davfs$|fuse\.sshfs$).+</linux:fs_type>
     <linux:mount_options datatype="string" entity_check="all"
     operation="not equal">nodev</linux:mount_options>
   </linux:partition_state>

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/oval/shared.xml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/oval/shared.xml
@@ -21,13 +21,33 @@
   </linux:partition_test>
   <linux:partition_object id="object_non_root_partitions" version="1">
     <!--
-      Look at all partitions except / (root), /boot and /efi. The / is
+      Look at all local partitions except / (root), /boot and /efi. The / is
       excluded because nodev is allowed on / by the rule text. The /boot and
       /efi are excluded because they are special paritions that are
       usually handled by a systemd mount which causes troubles if the rule is
       used in operating system installation.
       -->
     <linux:mount_point operation="pattern match">^/(?!boot|efi)\w.*$</linux:mount_point>
+    <linux:fstype operation="not equal">afs</linux:fstype>
+    <linux:fstype operation="not equal">autofs</linux:fstype>
+    <linux:fstype operation="not equal">ceph</linux:fstype>
+    <linux:fstype operation="not equal">cifs</linux:fstype>
+    <linux:fstype operation="not equal">smb3</linux:fstype>
+    <linux:fstype operation="not equal">smbfs</linux:fstype>
+    <linux:fstype operation="not equal">sshfs</linux:fstype>
+    <linux:fstype operation="not equal">ncpfs</linux:fstype>
+    <linux:fstype operation="not equal">ncp</linux:fstype>
+    <linux:fstype operation="not equal">nfs</linux:fstype>
+    <linux:fstype operation="not equal">nfs4</linux:fstype>
+    <linux:fstype operation="not equal">gfs</linux:fstype>
+    <linux:fstype operation="not equal">gfs2</linux:fstype>
+    <linux:fstype operation="not equal">glusterfs</linux:fstype>
+    <linux:fstype operation="not equal">gpfs</linux:fstype>
+    <linux:fstype operation="not equal">pvfs2</linux:fstype>
+    <linux:fstype operation="not equal">ocfs2</linux:fstype>
+    <linux:fstype operation="not equal">lustre</linux:fstype>
+    <linux:fstype operation="not equal">davfs</linux:fstype>
+    <linux:fstype operation="not equal">fuse.sshfs</linux:fstype>
     <filter action="include">state_local_nodev</filter>
   </linux:partition_object>
   <linux:partition_state id="state_local_nodev" version="1">

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/oval/shared.xml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/oval/shared.xml
@@ -21,38 +21,21 @@
   </linux:partition_test>
   <linux:partition_object id="object_non_root_partitions" version="1">
     <!--
-      Look at all local partitions except / (root), /boot and /efi. The / is
+      Look at all partitions except / (root), /boot and /efi. The / is
       excluded because nodev is allowed on / by the rule text. The /boot and
       /efi are excluded because they are special paritions that are
       usually handled by a systemd mount which causes troubles if the rule is
       used in operating system installation.
       -->
     <linux:mount_point operation="pattern match">^/(?!boot|efi)\w.*$</linux:mount_point>
-    <linux:fstype operation="not equal">afs</linux:fstype>
-    <linux:fstype operation="not equal">autofs</linux:fstype>
-    <linux:fstype operation="not equal">ceph</linux:fstype>
-    <linux:fstype operation="not equal">cifs</linux:fstype>
-    <linux:fstype operation="not equal">smb3</linux:fstype>
-    <linux:fstype operation="not equal">smbfs</linux:fstype>
-    <linux:fstype operation="not equal">sshfs</linux:fstype>
-    <linux:fstype operation="not equal">ncpfs</linux:fstype>
-    <linux:fstype operation="not equal">ncp</linux:fstype>
-    <linux:fstype operation="not equal">nfs</linux:fstype>
-    <linux:fstype operation="not equal">nfs4</linux:fstype>
-    <linux:fstype operation="not equal">gfs</linux:fstype>
-    <linux:fstype operation="not equal">gfs2</linux:fstype>
-    <linux:fstype operation="not equal">glusterfs</linux:fstype>
-    <linux:fstype operation="not equal">gpfs</linux:fstype>
-    <linux:fstype operation="not equal">pvfs2</linux:fstype>
-    <linux:fstype operation="not equal">ocfs2</linux:fstype>
-    <linux:fstype operation="not equal">lustre</linux:fstype>
-    <linux:fstype operation="not equal">davfs</linux:fstype>
-    <linux:fstype operation="not equal">fuse.sshfs</linux:fstype>
     <filter action="include">state_local_nodev</filter>
   </linux:partition_object>
   <linux:partition_state id="state_local_nodev" version="1">
     <!-- this check defines a local partition as one which has a device node in /dev -->
     <linux:device operation="pattern match">^/dev/.*$</linux:device>
+    <linux:fs_type operation="pattern match">
+        ^(?!afs$|autofs$|ceph$|cifs$|smb3$|smbfs$|sshfs$|ncpfs$|ncp$|nfs$|nfs4$|gfs$|gfs2$|glusterfs$|gpfs$|pvfs2$|ocfs2$|lustre$|davfs$|fuse\.sshfs$).+
+    </linux:fs_type>
     <linux:mount_options datatype="string" entity_check="all"
     operation="not equal">nodev</linux:mount_options>
   </linux:partition_state>


### PR DESCRIPTION
#### Description:

Added task to set excluded fstypes to keep remote partitions from beng remounted with nodev when only local partitions are meant to be targeted

#### Rationale:

Previous version of shared.yml would target remote mounted filesystems; explicitly excluding known remote filesystem types should help ensure only local partitions are targeted.

#### Review Hints:

Including a remote mount (my case used autofs) and testing with both the original and new shared.yml should show that the original will error out while the new one properly skips the partition.
