### PR TITLE
Improve reproducibility and stability

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -3356,7 +3356,8 @@ class LinearLoader(object):
         Returns:
             A list of rules that are selected in all profiles of the given benchmark.
         """
-        return [self.rules[rule_id] for rule_id in sorted(benchmark.get_rules_selected_in_all_profiles())]
+        ids = sorted(benchmark.get_rules_selected_in_all_profiles())
+        return [self.rules[rule_id] for rule_id in ids]
 
     def export_ocil_to_xml(self, benchmark=None):
         """


### PR DESCRIPTION
This change will ensure that if a data stream is built multiple times but from the same sources the output is always the same. This will be achieved by sorting child elements of `<ocil:questionnaires>` and `<cpe-lang:platform-specification>` elements.


#### Rationale

This will help people when diffing 2 data streams for example if they want to see that changes that they made to the code don't affect the built data stream.

#### Review Hints:

Do this first with master and then with the contents of this PR:
```
SOURCE_DATE_EPOCH=1 ./build_product -d rhel9
cp build/ssg-rhel9-ds.xml /tmp
SOURCE_DATE_EPOCH=1 ./build_product -d rhel9
diff /tmp/ssg-rhel9-ds.xml build/ssg-rhel9-ds.xml
```