### PR TITLE
Fix smartcard package name on Ubuntu 24.04

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/rule.yml
@@ -79,6 +79,7 @@ template:
         pkgname@ubuntu1804: libpam-pkcs11
         pkgname@ubuntu2004: libpam-pkcs11
         pkgname@ubuntu2204: libpam-pkcs11
+        pkgname@ubuntu2404: libpam-pkcs11
 {{% endif %}}
 
 fixtext: |-


### PR DESCRIPTION
#### Description:

- Fix smartcard package name on Ubuntu 24.04 to `libpam-pkcs11`
