### PR TITLE
Fix platform tag in test scenarios

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/conflicting.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/conflicting.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 {{% if sshd_distributed_config == "false" %}}
-# platform = Not Applicable (sshd_distributed_config=false)
+# platform = Not Applicable
 {{% else %}}
 # platform = multi_platform_all
 {{% endif %}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/conflicting_dir.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/conflicting_dir.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 {{% if sshd_distributed_config == "false" %}}
-# platform = Not Applicable (sshd_distributed_config=false)
+# platform = Not Applicable
 {{% else %}}
 # platform = multi_platform_all
 {{% endif %}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/correct_dir.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/correct_dir.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 {{% if sshd_distributed_config == "false" %}}
-# platform = Not Applicable (sshd_distributed_config=false)
+# platform = Not Applicable
 {{% else %}}
 # platform = multi_platform_all
 {{% endif %}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/weak_kex_dir.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/tests/weak_kex_dir.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 {{% if sshd_distributed_config == "false" %}}
-# platform = Not Applicable (sshd_distributed_config=false)
+# platform = Not Applicable
 {{% else %}}
 # platform = multi_platform_all
 {{% endif %}}

--- a/shared/macros/20-test-scenarios.jinja
+++ b/shared/macros/20-test-scenarios.jinja
@@ -75,7 +75,7 @@ TEST_VALUE=4
 TEST_VALUE=6
 {{% elif state == "lenient_low" %}}
 # there is no lower limit so the test should be not-applicable
-# platform = Not Applicable (rule does not set a lower boundary for '{{{ PRM_NAME }}}')
+# platform = Not Applicable
 {{% endif %}}
 
 {{% elif variable_lower_bound == "use_ext_variable" and variable_upper_bound is number %}}
@@ -102,7 +102,7 @@ TEST_VALUE=5
 TEST_VALUE=6
 {{% elif state == "lenient_high" %}}
 # there is no upper limit so the test should be not-applicable
-# platform = Not Applicable (rule does not set an upper boundary for '{{{ PRM_NAME }}}')
+# platform = Not Applicable
 {{% elif state == "lenient_low" %}}
 # variables = {{{ ext_variable }}}=5
 TEST_VALUE=4


### PR DESCRIPTION
The `build_tests.py` doesn't understand the `platform` tag if there are additional information in parenthesis.

