### PR TITLE
Add tags to test scenarios in accounts_root_path_dirs_no_write

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/root_paths/accounts_root_path_dirs_no_write/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/accounts_root_path_dirs_no_write/tests/correct.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# remediation = ansible
 
 ( IFS=:
   for p in $PATH; do


### PR DESCRIPTION
The rule `accounts_root_path_dirs_no_write` has only Ansible remediation, it doesn't have Bash remediation. Adding `# remediation = ansible` tag will prevent attempts to run the nonexistent Bash remediation.

