### PR TITLE
Update path for OL9 in sysctl_kernel_exec_shield oval file

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/oval/shared.xml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/oval/shared.xml
@@ -47,7 +47,11 @@
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_nx_disabled_grub" version="1">
+    {{% if product in ['ol9'] %}}
+    <ind:filepath>/etc/default/grub</ind:filepath>
+    {{% else %}}
     <ind:filepath>{{{ grub2_boot_path }}}/grub.cfg</ind:filepath>
+    {{% endif %}}
     <ind:pattern operation="pattern match">[\s]*noexec[\s]*=[\s]*off</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>


### PR DESCRIPTION
#### Description:

Update path for OL9 in sysctl_kernel_exec_shield oval file

#### Rationale:

If we apply the remediation the file `/boot/grub2/grub.cfg` still with the argument but the system is compliant with the requirement.
