### PR TITLE
Add OVAL for encrypt_partitions rule

### DIFF
--- a/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/oval/shared.xml
+++ b/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/oval/shared.xml
@@ -1,11 +1,11 @@
 <def-group>
     <definition class="compliance" id="{{{ rule_id }}}" version="1">
         {{{ oval_metadata("Verify all partitions are encrypted except /boot /boot/efi",
-                            affected_platforms=["multi_platform_ol"]) }}}
+                            affected_platforms=["multi_platform_ol"], rule_title=rule_title) }}}
         <criteria>
             <criterion test_ref="test_encrypted_partitions" comment="Check all partitions are encrypted" />
             <!-- Needed to collect the obj_crypttab_partitions object -->
-            <criterion test_ref="test_crypttab_partitions" comment="Check there are encrypted partitions" />
+            <criterion test_ref="test_crypttab_partitions" comment="Check there are encrypted partitions in /etc/crypttab" />
         </criteria>
     </definition>
 

--- a/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/oval/shared.xml
+++ b/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/oval/shared.xml
@@ -1,0 +1,50 @@
+<def-group>
+    <definition class="compliance" id="{{{ rule_id }}}" version="1">
+        {{{ oval_metadata("Verify all partitions are encrypted except /boot /boot/efi",
+                            affected_platforms=["multi_platform_ol"]) }}}
+        <criteria>
+            <criterion test_ref="test_encrypted_partitions" comment="Check all partitions are encrypted" />
+            <!-- Needed to collect the obj_crypttab_partitions object -->
+            <criterion test_ref="test_crypttab_partitions" comment="Check there are encrypted partitions" />
+        </criteria>
+    </definition>
+
+    <linux:partition_test id="test_encrypted_partitions" version="1" check="all"
+            check_existence="none_exist" comment="Check there are no partitions not encrypted">
+        <linux:object object_ref="obj_encrypted_partitions" />
+    </linux:partition_test>
+    <ind:textfilecontent54_test id="test_crypttab_partitions" check_existence="at_least_one_exists" version="1"
+            comment="There are encrypted partitions" check="all" >
+        <ind:object object_ref="obj_crypttab_partitions" />
+    </ind:textfilecontent54_test>
+
+    <linux:partition_object id="obj_encrypted_partitions" version="1">
+        <!-- Collect all partition but /boot and /boot/efi -->
+        <linux:mount_point operation="pattern match">^(?!\/boot(?:\/efi)?$).*</linux:mount_point>
+        <filter action="exclude">state_encrypted_partitions</filter>
+        <filter action="include">state_non_pseudo_file_systems</filter>
+    </linux:partition_object>
+
+    <linux:partition_state id="state_encrypted_partitions" version="1">
+        <linux:device operation="equals" var_check="at least one" var_ref="var_crypttab_partitions" />
+    </linux:partition_state>
+
+    <linux:partition_state id="state_non_pseudo_file_systems" version="1">
+        <linux:uuid operation="pattern match">.+</linux:uuid>
+        <linux:fs_type operation="not equal">iso9660</linux:fs_type>
+    </linux:partition_state>
+
+    <ind:textfilecontent54_object id="obj_crypttab_partitions" version="1">
+        <ind:filepath operation="equals">/etc/crypttab</ind:filepath>
+        <ind:pattern operation="pattern match">^\s*(\S+)</ind:pattern>
+        <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    </ind:textfilecontent54_object>
+
+    <local_variable id="var_crypttab_partitions" datatype="string" version="1"
+            comment="devices of partitions in /etc/crypttab">
+        <concat>
+            <literal_component>/dev/mapper/</literal_component>
+            <object_component item_field="subexpression" object_ref="obj_crypttab_partitions" />
+        </concat>
+    </local_variable>
+</def-group>

--- a/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/rule.yml
@@ -177,3 +177,10 @@ checktext: |-
 
     Every persistent disk partition present must be of type "crypto_LUKS". If any partitions other than the boot partition or pseudo file systems (such as /proc or /sys) or temporary file systems (that are tmpfs) are not type "crypto_LUKS", ask the administrator to indicate how the partitions are encrypted.  If there is no evidence that these partitions are encrypted, this is a finding.
     {{% endif -%}}
+
+{{% if 'ol' in families %}}
+warnings:
+    - general: |-
+        Due to different needs, possibilities, and passphrase requirement automated remediation is
+        not available for this configuration check.
+{{% endif %}}


### PR DESCRIPTION
#### Description:

- Add OVAL for encrypt_partitions rule only applicable to OL products. 
- This might be applicable to other products but don't have the chance to test

#### Rationale:

- Add automation content

#### Review Hints:

- In a system with any encrypted partitions the collected objects should be a good hint that everything is correctly in place. The encrypted partitions shouldn't be collected, and any other should be a valid partition
