### PR TITLE
Debian13 ANSSI BP28 (minimal)

### DIFF
--- a/linux_os/guide/auditing/package_audit_installed/rule.yml
+++ b/linux_os/guide/auditing/package_audit_installed/rule.yml
@@ -61,3 +61,4 @@ template:
         pkgname@ubuntu2404: auditd
         pkgname@debian11: auditd
         pkgname@debian12: auditd
+        pkgname@debian13: auditd

--- a/linux_os/guide/auditing/service_auditd_enabled/rule.yml
+++ b/linux_os/guide/auditing/service_auditd_enabled/rule.yml
@@ -83,6 +83,7 @@ template:
         packagename: audit
         packagename@debian11: auditd
         packagename@debian12: auditd
+        packagename@debian13: auditd
         packagename@ubuntu1604: auditd
         packagename@ubuntu1804: auditd
         packagename@ubuntu2004: auditd

--- a/linux_os/guide/services/ntp/package_ntp_installed/rule.yml
+++ b/linux_os/guide/services/ntp/package_ntp_installed/rule.yml
@@ -26,9 +26,15 @@ references:
 
 ocil_clause: 'the package is not installed'
 
-ocil: '{{{ ocil_package(package="ntp") }}}'
-
+ocil: |-
+  {{% if product == "debian13" %}}
+  {{{ ocil_package(package="ntpsec") }}}
+  {{% else %}}
+  {{{ ocil_package(package="ntp") }}}
+  {{% endif %}}
+  
 template:
     name: package_installed
     vars:
         pkgname: ntp
+        pkgname@debian13: ntpsec

--- a/linux_os/guide/services/ntp/service_ntp_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_ntp_enabled/rule.yml
@@ -39,12 +39,17 @@ references:
     pcidss: Req-10.4
 
 ocil: |-
+    {{% if product == "debian13" %}}
+    {{{ ocil_service_enabled(service="ntpsec") }}}
+    {{% else %}}
     {{{ ocil_service_enabled(service="ntp") }}}
-
+    {{% endif %}}
+    
 template:
     name: service_enabled
     vars:
         servicename: ntp
+        servicename@debian13: ntpsec
 
 {{% if product in ["sle15"] or 'rhel' in product %}}
 warnings:

--- a/linux_os/guide/system/accounts/accounts-pam/package_pam_pwquality_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/package_pam_pwquality_installed/rule.yml
@@ -48,5 +48,6 @@ template:
         pkgname@ubuntu2204: libpam-pwquality
         pkgname@ubuntu2404: libpam-pwquality
         pkgname@debian12: libpam-pwquality
+        pkgname@debian13: libpam-pwquality
 
 platform: package[pam]

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/bash/shared.sh
@@ -4,7 +4,7 @@
 
 {{% if product in ["sle12", "sle15"] %}}
 {{{ bash_ensure_pam_module_configuration('/etc/pam.d/common-password', 'password', 'sufficient', 'pam_unix.so', 'rounds', "$var_password_pam_unix_rounds", '') }}}
-{{% elif product in ["debian12"] %}}
+{{% elif product in ["debian12", "debian13"] %}}
 {{{ bash_ensure_pam_module_configuration('/etc/pam.d/common-password', 'password', '\[success=1 default=ignore\]', 'pam_unix.so', 'rounds', "$var_password_pam_unix_rounds", '') }}}
 {{% elif product in ["ubuntu2404"] %}}
 config_file="/usr/share/pam-configs/cac_unix"

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/oval/shared.xml
@@ -1,4 +1,4 @@
-{{% if product in ["sle12", "sle15", "debian12", 'ubuntu2404'] %}}
+{{% if product in ["sle12", "sle15", "debian12", "debian13", 'ubuntu2404'] %}}
 {{% set pam_passwd_file_path = "/etc/pam.d/common-password" %}}
 {{% else %}}
 {{% set pam_passwd_file_path = "/etc/pam.d/password-auth" %}}
@@ -19,7 +19,7 @@
 
   <ind:textfilecontent54_object id="object_password_auth_pam_unix_rounds" version="1">
     <ind:filepath operation="pattern match">^{{{ pam_passwd_file_path }}}$</ind:filepath>
-    {{% if product in ["debian12", 'ubuntu2404'] %}}
+    {{% if product in ["debian12", "debian13", 'ubuntu2404'] %}}
     <ind:pattern operation="pattern match">^\s*password\s+.*\s+pam_unix\.so[^#]*rounds=([0-9]*).*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^\s*password\s+(?:(?:sufficient)|(?:required))\s+pam_unix\.so[^#]*rounds=([0-9]*).*$</ind:pattern>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/rule.yml
@@ -3,7 +3,7 @@ documentation_complete: true
 
 title: 'Set number of Password Hashing Rounds - password-auth'
 
-{{% if product in ["sle12", "sle15", "debian12", 'ubuntu2404'] %}}
+{{% if product in ["sle12", "sle15", "debian12", "debian13", 'ubuntu2404'] %}}
 {{% set pam_passwd_file_path = "/etc/pam.d/common-password" %}}
 {{% else %}}
 {{% set pam_passwd_file_path = "/etc/pam.d/password-auth" %}}
@@ -15,7 +15,7 @@ description: |-
     <br /><br />
     In file <tt>{{{ pam_passwd_file_path }}}</tt> append <tt>rounds={{{ xccdf_value("var_password_pam_unix_rounds") }}}</tt>
     to the <tt>pam_unix.so</tt> entry, as shown below:
-    {{% if product in ["debian12", 'ubuntu2404'] %}}  
+    {{% if product in ["debian12", "debian13", 'ubuntu2404'] %}}
     <pre>password [success=1 default=ignore] pam_unix.so <i>...existing_options...</i> rounds={{{ xccdf_value("var_password_pam_unix_rounds") }}}</pre>
     {{% else %}}
     <pre>password sufficient pam_unix.so <i>...existing_options...</i> rounds={{{ xccdf_value("var_password_pam_unix_rounds") }}}</pre>
@@ -49,7 +49,7 @@ ocil: |-
     To verify the number of rounds for the password hashing algorithm is configured, run the following command:
     <pre>$ sudo grep rounds {{{ pam_passwd_file_path }}}</pre>
     The output should show the following match:
-    {{% if product in ["debian12", 'ubuntu2404'] %}} 
+    {{% if product in ["debian12", "debian13", 'ubuntu2404'] %}}
     <pre>password [sucess=1 default=ignore] pam_unix.so sha512 rounds={{{ xccdf_value("var_password_pam_unix_rounds") }}}</pre>
     {{% else %}}
     <pre>password sufficient pam_unix.so sha512 rounds={{{ xccdf_value("var_password_pam_unix_rounds") }}}</pre>
@@ -62,7 +62,7 @@ fixtext: |-
 
     Add or modify the following line in "{{{ pam_passwd_file_path }}}" and set "rounds" to {{{ xccdf_value("var_password_pam_unix_rounds") }}}.
     For example:
-    {{% if product in ["debian12", 'ubuntu2404'] %}} 
+    {{% if product in ["debian12", "debian13", 'ubuntu2404'] %}}
     password [sucess=1 default=ignore] pam_unix.so sha512 rounds=5000
     {{% else %}}
     password sufficient pam_unix.so sha512 rounds=5000

--- a/products/debian13/profiles/anssi_bp28_minimal.profile
+++ b/products/debian13/profiles/anssi_bp28_minimal.profile
@@ -1,0 +1,47 @@
+documentation_complete: true
+
+title: 'ANSSI-BP-028 (minimal)'
+
+description: |-
+    This profile contains configurations that align to ANSSI-BP-028 v2.0 at the minimal hardening level.
+
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
+    ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
+
+    A copy of the ANSSI-BP-028 can be found at the ANSSI website:
+    https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
+
+selections:
+  - anssi:all:minimal
+  # PASS_MIN_LEN is handled by PAM on debian systems.
+  - '!accounts_password_minlen_login_defs'
+  # ANSSI BP 28 suggest using libpam_pwquality, which isn't deployed by default
+  - 'package_pam_pwquality_installed'
+  # PAM honour login.defs file for algorithm
+  - 'set_password_hashing_algorithm_logindefs'
+
+  # Following rules once had a prodtype incompatible with the debian12 product
+  - '!accounts_passwords_pam_tally2_deny_root'
+  - '!ensure_redhat_gpgkey_installed'
+  - '!set_password_hashing_algorithm_systemauth'
+  - '!package_dnf-automatic_installed'
+  - '!accounts_passwords_pam_faillock_deny_root'
+  - '!dnf-automatic_security_updates_only'
+  - '!cracklib_accounts_password_pam_lcredit'
+  - '!dnf-automatic_apply_updates'
+  - '!cracklib_accounts_password_pam_ocredit'
+  - '!accounts_password_pam_unix_rounds_system_auth'
+  - '!timer_dnf-automatic_enabled'
+  - '!accounts_passwords_pam_tally2'
+  - '!cracklib_accounts_password_pam_ucredit'
+  - '!file_permissions_unauthorized_sgid'
+  - '!ensure_gpgcheck_local_packages'
+  - '!accounts_passwords_pam_tally2_unlock_time'
+  - '!enable_authselect'
+  - '!cracklib_accounts_password_pam_minlen'
+  - '!cracklib_accounts_password_pam_dcredit'
+  - '!ensure_gpgcheck_globally_activated'
+  - '!file_permissions_unauthorized_suid'
+  - '!ensure_gpgcheck_never_disabled'
+  - '!ensure_oracle_gpgkey_installed'
+  - '!ensure_almalinux_gpgkey_installed'

--- a/products/debian13/profiles/anssi_bp28_minimal.profile
+++ b/products/debian13/profiles/anssi_bp28_minimal.profile
@@ -20,7 +20,7 @@ selections:
   # PAM honour login.defs file for algorithm
   - 'set_password_hashing_algorithm_logindefs'
 
-  # Following rules once had a prodtype incompatible with the debian12 product
+  # Following rules once had a prodtype incompatible with the debian13 product
   - '!accounts_passwords_pam_tally2_deny_root'
   - '!ensure_redhat_gpgkey_installed'
   - '!set_password_hashing_algorithm_systemauth'

--- a/shared/applicability/package.yml
+++ b/shared/applicability/package.yml
@@ -47,7 +47,7 @@ args:
   iptables:
     pkgname: iptables
   libpwquality:
-    {{% if 'ubuntu' in product %}}
+    {{% if 'ubuntu' in product or 'debian' in product %}}
     pkgname: libpwquality1
     {{% else %}}
     pkgname: libpwquality

--- a/shared/applicability/package.yml
+++ b/shared/applicability/package.yml
@@ -75,7 +75,11 @@ args:
       pkgname: libpam-ldapd
     {{% endif %}}
   ntp:
+    {{% if product == "debian13" %}}
+    pkgname: ntpsec
+    {{% else %}}
     pkgname: ntp
+    {{% endif %}}
     title: NTP daemon and utilities
   openssh:
     pkgname: openssh

--- a/shared/templates/accounts_password/bash.template
+++ b/shared/templates/accounts_password/bash.template
@@ -21,7 +21,7 @@ fi
 }}}
 {{% endif %}}
 
-{{% if product == "ubuntu2404" %}}
+{{% if product == "ubuntu2404" or product == "debian13" %}}
 {{{ bash_pam_pwquality_enable() }}}
 {{% endif %}}
 


### PR DESCRIPTION
#### Description:

- add minimal ANSSI BP28 (minimal) and related debian 13 rules adjustments.


#### Review Hints:

- I had to modify shared/applicability/package.yml for some rules to pass.
- I first tried to set platform_package_overrides definitions in the product.yml file, but it seems those properties are ignored for package applicability checks.
- If there is a better way to achieve the same result, please tell me.
