### PR TITLE
Remove duplicate STIG id OL09-00-001105

### DIFF
--- a/controls/stig_ol9.yml
+++ b/controls/stig_ol9.yml
@@ -2905,14 +2905,6 @@ controls:
             - var_password_pam_minlen=15
         status: automated
 
-    -   id: OL09-00-001105
-        levels:
-            - medium
-        title: OL 9 passwords for new users must have a minimum of 15 characters.
-        rules:
-            - accounts_password_minlen_login_defs
-        status: automated
-
     -   id: OL09-00-001120
         levels:
             - medium


### PR DESCRIPTION
#### Description:

Remove OL9 duplicate STIG id

#### Rationale:

The STIG id must be unique
