### PR TITLE
Fix a bug for syncing cac to oscal workflow

### DIFF
--- a/.github/workflows/sync-cac-oscal.yml
+++ b/.github/workflows/sync-cac-oscal.yml
@@ -13,7 +13,7 @@ jobs:
   check-pr-message:
     runs-on: ubuntu-latest
     outputs:
-      run_job_check_update: ${{ steps.check_pr.outputs.run_job_check_update }}
+      run_job_check_update: ${{ steps.check-pr.outputs.run_job_check_update }}
     steps:
     - name: Check if the PR comes from the sync of OSCAL content
       id: check-pr


### PR DESCRIPTION
#### Description:

There is a bug about the merge was skipped in the sync-cac-to-oscal [workflow](https://github.com/ComplianceAsCode/content/actions/runs/15460671066).
This PR is to fix it.
