### PR TITLE
Move SCE build option to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,10 @@ find_program(XMLLINT_EXECUTABLE NAMES xmllint REQUIRED)
 find_program(XSLTPROC_EXECUTABLE NAMES xsltproc REQUIRED)
 find_program(YAMLLINT_EXECUTABLE NAMES yamllint)
 
+if(SSG_PRODUCT_RHEL9 OR SSG_PRODUCT_RHEL10 OR SSG_PRODUCT_UBUNTU2004 OR SSG_PRODUCT_UBUNTU2204 OR SSG_PRODUCT_UBUNTU2404)
+set(SSG_SCE_ENABLED ON)
+endif()
+
 message(STATUS "")
 message(STATUS "SCAP Security Guide ${SSG_VERSION}")
 message(STATUS "(see ${CMAKE_SOURCE_DIR}/docs/manual/developer_guide.adoc for build instructions)")

--- a/build_product
+++ b/build_product
@@ -342,14 +342,6 @@ set_no_derivatives_options() {
 	fi
 }
 
-set_sce_options() {
-	grep -q "SSG_SCE_ENABLED" <<< "$ADDITIONAL_CMAKE_OPTIONS" && return
-	# These products will build SCE by default
-	if grep -q -E 'rhel9|rhel10|ubuntu2004|ubuntu2204|ubuntu2404' <<< "${_arg_product[*]}"; then
-		CMAKE_OPTIONS+=("-DSSG_SCE_ENABLED:BOOL=ON")
-	fi
-}
-
 set_explict_build_targets() {
 	if test "$_arg_datastream_only" = on || test "$_arg_thin_datastream" = on || test "$_arg_rule_id" != off ; then
 		for chosen_product in "${_arg_product[@]}"; do
@@ -445,7 +437,6 @@ done
 
 CMAKE_OPTIONS=(${ADDITIONAL_CMAKE_OPTIONS} "${build_type_option}" "${oval_major_version_option}" "${oval_minor_version_option}" '-DSSG_PRODUCT_DEFAULT=OFF' "${cmake_enable_args[@]}" -G "$cmake_generator")
 set_no_derivatives_options
-set_sce_options
 if [ "$_arg_ansible_playbooks" = off ] ; then
 	CMAKE_OPTIONS+=("-DSSG_ANSIBLE_PLAYBOOKS_ENABLED:BOOL=OFF")
 fi


### PR DESCRIPTION
At this moment, the `build_product` script defines that data streams in some selected products should contain SCEs. But, downstream spec files don't call `build_product`, they call `cmake` directly. That means the spec files need to explicitely set `SSG_SCE_ENABLED` option. If they don't set it, a data stream without SCEs is built, which can be a surprise. To increase the upstream and downstream alignement, we will move the definition of the `SSG_SCE_ENABLED` from `build_product` to `CMakeLists.txt`.


