### PR TITLE
Add owner and repos for creating token of sync-cac-to-oscal

### DIFF
--- a/.github/workflows/sync-cac-oscal.yml
+++ b/.github/workflows/sync-cac-oscal.yml
@@ -54,6 +54,10 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            content
+            oscal-content
       # Step 5: Detect the updates of CAC content
       - name: Detect files changed by PR
         id: changed-files


### PR DESCRIPTION
#### Description:

- Add the owner and repos for creating a GitHub app token for the sync-cac-to-oscal workflow
