### PR TITLE
Debian13:  add BP28 intermediary profile 

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/bash/debian13.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/bash/debian13.sh
@@ -7,14 +7,14 @@
 unit=tmp.mount
 mount_option=noexec
 
-# check wether unit is in use
+# check whether unit is in use
 unit_check=$(systemctl -q list-units $unit | grep active)
 
 if [ "x$unit_check" == "x" ]; then
     exit 0
 fi
 
-# check wether mount option is present
+# check whether mount option is present
 current_options=$(systemctl show $unit -P Options)
 option_check=$(echo $current_options | grep $mount_option | wc -l)
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/bash/debian13.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/bash/debian13.sh
@@ -1,0 +1,38 @@
+# platform = multi_platform_debian
+# reboot = false
+# strategy = enable
+# complexity = low
+# disruption = low
+
+unit=tmp.mount
+mount_option=noexec
+
+# check wether unit is in use
+unit_check=$(systemctl -q list-units $unit | grep active)
+
+if [ "x$unit_check" == "x" ]; then
+    exit 0
+fi
+
+# check wether mount option is present
+current_options=$(systemctl show $unit -P Options)
+option_check=$(echo $current_options | grep $mount_option | wc -l)
+
+# add systemd drop in to add missing option
+if [ $option_check == "0" ]; then
+    mkdir -p /etc/systemd/system/$unit.d
+    cat > /etc/systemd/system/$unit.d/mount_options.conf <<EOF
+[Mount]
+Options=$current_options,$mount_option
+EOF
+
+    # unit changed on disk. reload.
+    systemctl daemon-reload
+    
+    # note: mount point is probably in use, so we cannot restart
+    # the unit without getting an error, but we may be able to
+    # remount the filesystem with the new option
+    mount_point=$(systemctl show $unit -P Where)
+    mount $mount_point -o remount,$mount_option
+fi
+

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/bash/debian.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/bash/debian.sh
@@ -6,11 +6,19 @@ AIDE_CONFIG=/etc/aide/aide.conf
 DEFAULT_DB_PATH=/var/lib/aide/aide.db
 
 # Fix db path in the config file, if necessary
+{{% if product == 'debian13' %}}
+if ! grep -q '^database_in=file:' ${AIDE_CONFIG}; then
+    # replace_or_append gets confused by 'database=file' as a key, so should not be used.
+    #replace_or_append "${AIDE_CONFIG}" '^database=file' "${DEFAULT_DB_PATH}" '@CCENUM@' '%s:%s'
+    echo "database_in=file:${DEFAULT_DB_PATH}" >> ${AIDE_CONFIG}
+fi
+{{% else %}}
 if ! grep -q '^database=file:' ${AIDE_CONFIG}; then
     # replace_or_append gets confused by 'database=file' as a key, so should not be used.
     #replace_or_append "${AIDE_CONFIG}" '^database=file' "${DEFAULT_DB_PATH}" '@CCENUM@' '%s:%s'
     echo "database=file:${DEFAULT_DB_PATH}" >> ${AIDE_CONFIG}
 fi
+{{% endif %}}
 
 # Fix db out path in the config file, if necessary
 if ! grep -q '^database_out=file:' ${AIDE_CONFIG}; then

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/bash/debian.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/bash/debian.sh
@@ -8,8 +8,6 @@ DEFAULT_DB_PATH=/var/lib/aide/aide.db
 # Fix db path in the config file, if necessary
 {{% if product == 'debian13' %}}
 if ! grep -q '^database_in=file:' ${AIDE_CONFIG}; then
-    # replace_or_append gets confused by 'database=file' as a key, so should not be used.
-    #replace_or_append "${AIDE_CONFIG}" '^database=file' "${DEFAULT_DB_PATH}" '@CCENUM@' '%s:%s'
     echo "database_in=file:${DEFAULT_DB_PATH}" >> ${AIDE_CONFIG}
 fi
 {{% else %}}

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/oval/debian.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/oval/debian.xml
@@ -39,7 +39,11 @@
   <!-- OVAL object to collect filename for Aide build database -->
   <ind:textfilecontent54_object id="object_aide_operational_database_filepath" version="1">
     <ind:filepath>/etc/aide/aide.conf</ind:filepath>
+    {{% if product == "debian13" %}}
+    <ind:pattern operation="pattern match">^database_in=file:(?:@@{DBDIR}/)?([a-z./]+)$</ind:pattern>
+    {{% else %}}
     <ind:pattern operation="pattern match">^database=file:(?:@@{DBDIR}/)?([a-z./]+)$</ind:pattern>
+    {{% endif %}}
     <!-- From aide.conf(5) - "If there are multiple database lines, then the first one is used" =>
                   therefore we will retrieve only the first instance -->
     <ind:instance operation="equals" datatype="int">1</ind:instance>

--- a/products/debian13/profiles/anssi_bp28_intermediary.profile
+++ b/products/debian13/profiles/anssi_bp28_intermediary.profile
@@ -1,0 +1,58 @@
+documentation_complete: true
+
+title: 'ANSSI-BP-028 (intermediary)'
+
+description: |-
+    This profile contains configurations that align to ANSSI-BP-028 v2.0 at the intermediary hardening level.
+
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
+    ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
+
+    A copy of the ANSSI-BP-028 can be found at the ANSSI website:
+    https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
+
+# selinux_state: not applicable
+# postfix_client_configure_mail_alias: not applicable. should be exim
+# grub2_l1tf_argument debian kernels are not vulnerable, but switching from
+# conditional cache flush to force mode prevent protection disabling.
+
+selections:
+  - anssi:all:intermediary
+  # PASS_MIN_LEN is handled by PAM on debian systems.
+  - '!accounts_password_minlen_login_defs'
+  # ANSSI BP 28 suggest using libpam_pwquality, which isn't deployed by default
+  - 'package_pam_pwquality_installed'
+  # PAM honour login.defs file for algorithm
+  - 'set_password_hashing_algorithm_logindefs'
+  # Debian uses apparmor
+  - '!selinux_state'
+  # The following are MLS related rules (not part of ANSSI-BP-028)
+  - '!accounts_polyinstantiated_tmp'
+  - '!accounts_polyinstantiated_var_tmp'
+  - '!enable_pam_namespace'
+
+  # Following rules once had a prodtype incompatible with the debian13 product
+  - '!accounts_passwords_pam_tally2_deny_root'
+  - '!ensure_redhat_gpgkey_installed'
+  - '!set_password_hashing_algorithm_systemauth'
+  - '!package_dnf-automatic_installed'
+  - '!accounts_passwords_pam_faillock_deny_root'
+  - '!dnf-automatic_security_updates_only'
+  - '!cracklib_accounts_password_pam_lcredit'
+  - '!dnf-automatic_apply_updates'
+  - '!cracklib_accounts_password_pam_ocredit'
+  - '!accounts_password_pam_unix_rounds_system_auth'
+  - '!timer_dnf-automatic_enabled'
+  - '!accounts_passwords_pam_tally2'
+  - '!cracklib_accounts_password_pam_ucredit'
+  - '!file_permissions_unauthorized_sgid'
+  - '!ensure_gpgcheck_local_packages'
+  - '!accounts_passwords_pam_tally2_unlock_time'
+  - '!enable_authselect'
+  - '!cracklib_accounts_password_pam_minlen'
+  - '!cracklib_accounts_password_pam_dcredit'
+  - '!ensure_gpgcheck_globally_activated'
+  - '!file_permissions_unauthorized_suid'
+  - '!ensure_gpgcheck_never_disabled'
+  - '!ensure_oracle_gpgkey_installed'
+  - '!ensure_almalinux_gpgkey_installed'

--- a/shared/checks/oval/audit_rules_augenrules.xml
+++ b/shared/checks/oval/audit_rules_augenrules.xml
@@ -22,8 +22,13 @@
     <ind:filepath>/usr/lib/systemd/system/audit-rules.service</ind:filepath>
     <ind:pattern operation="pattern match">^ExecStart=(\/usr|)?\/sbin\/augenrules.*$</ind:pattern>
   {{% else %}}
-    <ind:filepath>/usr/lib/systemd/system/auditd.service</ind:filepath>
-    <ind:pattern operation="pattern match">^(ExecStartPost=\-\/sbin\/augenrules.*$|Requires=augenrules.service)</ind:pattern>
+    {{% if product in ['debian13'] %}}
+      <ind:filepath>/usr/lib/systemd/system/audit-rules.service</ind:filepath>
+      <ind:pattern operation="pattern match">^ExecStart=\/usr\/sbin\/augenrules.*$</ind:pattern>
+    {{% else %}}
+      <ind:filepath>/usr/lib/systemd/system/auditd.service</ind:filepath>
+      <ind:pattern operation="pattern match">^(ExecStartPost=\-\/sbin\/augenrules.*$|Requires=augenrules.service)</ind:pattern>
+    {{% endif %}}
 {{% endif %}}
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/shared/templates/audit_rules_privileged_commands/ansible.template
+++ b/shared/templates/audit_rules_privileged_commands/ansible.template
@@ -1,4 +1,4 @@
-{{%- if product in ["almalinux9", "debian12", "fedora", "ol7", "ol8", "ol9", "ol10", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2204", "ubuntu2404"] %}}
+{{%- if product in ["almalinux9", "debian12", "debian13", "fedora", "ol7", "ol8", "ol9", "ol10", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2204", "ubuntu2404"] %}}
   {{%- set perm_x=" -F perm=x" %}}
 {{%- endif %}}
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle,multi_platform_slmicro,multi_platform_ubuntu,multi_platform_almalinux

--- a/shared/templates/audit_rules_privileged_commands/bash.template
+++ b/shared/templates/audit_rules_privileged_commands/bash.template
@@ -1,4 +1,4 @@
-{{%- if product in ["almalinux9", "debian12", "fedora", "ol7", "ol8", "ol9", "ol10", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2204", "ubuntu2404"] %}}
+{{%- if product in ["almalinux9", "debian12", "debian13", "fedora", "ol7", "ol8", "ol9", "ol10", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2204", "ubuntu2404"] %}}
   {{%- set perm_x=" -F perm=x" %}}
 {{%- endif %}}
 # platform = multi_platform_all

--- a/shared/templates/audit_rules_privileged_commands/kubernetes.template
+++ b/shared/templates/audit_rules_privileged_commands/kubernetes.template
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = medium
 
-{{%- if product in ["almalinux9", "debian12", "fedora", "ol7", "ol8", "ol9", "ol10", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2204", "ubuntu2404"] %}}
+{{%- if product in ["almalinux9", "debian12", "debian13", "fedora", "ol7", "ol8", "ol9", "ol10", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2204", "ubuntu2404"] %}}
   {{%- set perm_x="%20-F%20perm%3Dx" %}}
 {{%- endif %}}
 

--- a/shared/templates/audit_rules_privileged_commands/oval.template
+++ b/shared/templates/audit_rules_privileged_commands/oval.template
@@ -1,4 +1,4 @@
-{{%- if product in ["almalinux9", "debian12", "fedora", "ol7", "ol8", "ol9", "ol10", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2204", "ubuntu2404"] %}}
+{{%- if product in ["almalinux9", "debian12", "debian13", "fedora", "ol7", "ol8", "ol9", "ol10", "rhel8", "rhel9", "rhel10", "sle12", "sle15", "slmicro5", "ubuntu2204", "ubuntu2404"] %}}
   {{%- set perm_x="(?:[\s]+-F[\s]+perm=x)" %}}
 {{%- endif %}}
 <def-group>


### PR DESCRIPTION
#### Description:

- add a Debian 13 ANSSI BP28 intermediary profile
- update related rules and templates

#### Review hints

- A remediation based on systemd unit has been added for /tmp noexec mount options.
- This remediation has reuse potential and should maybe be turned into a macro.  
