### PR TITLE
Fix Debian 13 in CI

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -78,7 +78,7 @@ jobs:
         env:
           ADDITIONAL_CMAKE_OPTIONS: "-DSSG_ANSIBLE_PLAYBOOKS_PER_RULE_ENABLED=ON -DSSG_OVAL_SCHEMATRON_VALIDATION_ENABLED=OFF"
         run: |-
-          ./build_product debian11 debian12
+          ./build_product debian11 debian12 debian13
       - name: Test
         working-directory: ./build
         run: ctest -j2 --output-on-failure -E unique-stigids

--- a/build-scripts/verify_references.py
+++ b/build-scripts/verify_references.py
@@ -138,7 +138,8 @@ def is_remote_feed(href):
             href.startswith("oval-com.ubuntu") or \
             href.startswith("pub-projects-security-oval-suse") or \
             href.startswith('security-oval-oval-definitions-bookworm') or \
-            href.startswith("oval-org.almalinux")
+            href.startswith("oval-org.almalinux") or \
+            href.startswith('security-oval-oval-definitions-trixie')
 
 
 def main():


### PR DESCRIPTION
#### Description:
* Fix Debian 13 in CI
* Add Debian 13 to CI

#### Rationale:

Fix nightly build and catch errors early.
#### Review Hints:
Build Debian 13 and run ctest, you will see the error on master.
