### PR TITLE
Move to using sha512 on RHEL 10 STIG

### DIFF
--- a/controls/srg_gpos/SRG-OS-000073-GPOS-00041.yml
+++ b/controls/srg_gpos/SRG-OS-000073-GPOS-00041.yml
@@ -9,8 +9,7 @@ controls:
             - set_password_hashing_algorithm_passwordauth
             - set_password_hashing_algorithm_systemauth
             - set_password_hashing_min_rounds_logindefs
-            - var_password_hashing_algorithm_pam=yescrypt
-            - set_password_hashing_yescrypt_cost_factor_logindefs
-            - var_password_pam_unix_rounds=5
-            - var_password_yescrypt_cost_factor_login_defs=5
+            - var_password_hashing_algorithm_pam=sha512
+            - set_password_hashing_min_rounds_logindefs
+            - var_password_pam_unix_rounds=100000
         status: automated

--- a/controls/srg_gpos/SRG-OS-000730-GPOS-00190.yml
+++ b/controls/srg_gpos/SRG-OS-000730-GPOS-00190.yml
@@ -10,6 +10,6 @@ controls:
             - var_password_pam_maxclassrepeat=4
             - var_password_pam_dictcheck=1
             - accounts_password_pam_dictcheck
-            - var_password_pam_unix_rounds=5
+            - var_password_pam_unix_rounds=100000
             - var_password_pam_remember=5
             - var_password_pam_remember_control_flag=requisite_or_required

--- a/products/rhel10/profiles/default.profile
+++ b/products/rhel10/profiles/default.profile
@@ -31,3 +31,4 @@ selections:
   - service_rsh_disabled
   - service_rexec_disabled
   - package_scap-security-guide_installed
+  - set_password_hashing_yescrypt_cost_factor_logindefs

--- a/tests/data/profile_stability/rhel10/stig.profile
+++ b/tests/data/profile_stability/rhel10/stig.profile
@@ -435,7 +435,6 @@ set_password_hashing_algorithm_logindefs
 set_password_hashing_algorithm_passwordauth
 set_password_hashing_algorithm_systemauth
 set_password_hashing_min_rounds_logindefs
-set_password_hashing_yescrypt_cost_factor_logindefs
 ssh_client_rekey_limit
 ssh_keys_passphrase_protected
 sshd_approved_ciphers=stig_rhel9
@@ -534,7 +533,7 @@ var_authselect_profile=sssd
 var_multiple_time_servers=stig
 var_networkmanager_dns_mode=explicit_default
 var_password_hashing_algorithm=SHA512
-var_password_hashing_algorithm_pam=yescrypt
+var_password_hashing_algorithm_pam=sha512
 var_password_pam_dcredit=1
 var_password_pam_dictcheck=1
 var_password_pam_difok=8
@@ -548,8 +547,7 @@ var_password_pam_remember=5
 var_password_pam_remember_control_flag=requisite_or_required
 var_password_pam_retry=3
 var_password_pam_ucredit=1
-var_password_pam_unix_rounds=5
-var_password_yescrypt_cost_factor_login_defs=5
+var_password_pam_unix_rounds=100000
 var_postfix_root_mail_alias=mil_sysadmin
 var_rekey_limit_size=1G
 var_rekey_limit_time=1hour

--- a/tests/data/profile_stability/rhel10/stig_gui.profile
+++ b/tests/data/profile_stability/rhel10/stig_gui.profile
@@ -432,7 +432,6 @@ set_password_hashing_algorithm_logindefs
 set_password_hashing_algorithm_passwordauth
 set_password_hashing_algorithm_systemauth
 set_password_hashing_min_rounds_logindefs
-set_password_hashing_yescrypt_cost_factor_logindefs
 ssh_client_rekey_limit
 ssh_keys_passphrase_protected
 sshd_approved_ciphers=stig_rhel9
@@ -531,7 +530,7 @@ var_authselect_profile=sssd
 var_multiple_time_servers=stig
 var_networkmanager_dns_mode=explicit_default
 var_password_hashing_algorithm=SHA512
-var_password_hashing_algorithm_pam=yescrypt
+var_password_hashing_algorithm_pam=sha512
 var_password_pam_dcredit=1
 var_password_pam_dictcheck=1
 var_password_pam_difok=8
@@ -545,8 +544,7 @@ var_password_pam_remember=5
 var_password_pam_remember_control_flag=requisite_or_required
 var_password_pam_retry=3
 var_password_pam_ucredit=1
-var_password_pam_unix_rounds=5
-var_password_yescrypt_cost_factor_login_defs=5
+var_password_pam_unix_rounds=100000
 var_postfix_root_mail_alias=mil_sysadmin
 var_rekey_limit_size=1G
 var_rekey_limit_time=1hour


### PR DESCRIPTION
#### Description:
Move to using sha512 on RHEL 10 STIG
#### Rationale:

Update and address #13545  easy way, by just removing it from the profile.


