### PR TITLE
Fix(accounts_tmout): OVAL check incorrectly passes for TMOUT=0

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
@@ -4,7 +4,7 @@
   {{% set system_configuration_using_etc_bashrc_expected = true %}}
 {{%- endif -%}}
 <def-group>
-  <definition class="compliance" id="accounts_tmout" version="3">
+  <definition class="compliance" id="accounts_tmout" version="4">
     {{{ oval_metadata("Checks interactive shell timeout", rule_title=rule_title) }}}
     <criteria operator="AND">
       {{% if "ubuntu" in product %}}
@@ -16,6 +16,7 @@
       {{% if system_configuration_using_etc_bashrc_expected %}}
       <criterion comment="TMOUT value in /etc/bashrc &lt;= var_accounts_tmout" test_ref="test_etc_bashrc_tmout" />
       {{% endif %}}
+      <criterion comment="All configured TMOUT values must be >= 1" test_ref="test_accounts_tmout_lower_bound" />
     </criteria>
   </definition>
 
@@ -105,6 +106,15 @@
   <ind:textfilecontent54_state id="state_etc_profile_tmout" version="2">
     <ind:subexpression datatype="int" operation="less than or equal" var_check="all" var_ref="var_accounts_tmout" />
   </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_state id="state_etc_profile_tmout_lower_bound" version="1">
+    <ind:subexpression datatype="int" operation="greater than or equal">1</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_test check="all" check_existence="any_exist" comment="All TMOUT values must be greater than or equal to 1" id="test_accounts_tmout_lower_bound" version="1">
+    <ind:object object_ref="object_accounts_tmout_all_tmout_instances" />
+    <ind:state state_ref="state_etc_profile_tmout_lower_bound" />
+</ind:textfilecontent54_test>
 
   <external_variable comment="external variable for TMOUT" datatype="int" id="var_accounts_tmout" version="1" />
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
@@ -5,8 +5,9 @@ title: 'Set Interactive Session Timeout'
 
 description: |-
     Setting the <tt>TMOUT</tt> option in <tt>/etc/profile</tt> ensures that
-    all user sessions will terminate based on inactivity.
-    The value of TMOUT should be exported and read only.
+    all user sessions will terminate based on inactivity. A value of <tt>0</tt> (zero)
+    disables the automatic logout feature and is therefore not a compliant setting.
+    The value of TMOUT should be a positive integer, exported, and read only.
     The <tt>TMOUT</tt>
     {{% if product in ["sle12", "sle15", "slmicro5"] %}}
     setting in <tt>/etc/profile.d/autologout.sh</tt> should read as follows:
@@ -65,7 +66,7 @@ references:
     stigid@sle15: SLES-15-010130
     stigid@ubuntu2204: UBTU-22-412030
 
-ocil_clause: 'value of TMOUT is not less than or equal to expected setting'
+ocil_clause: 'the TMOUT value is not configured, is set to 0, or is not less than or equal to the expected setting'
 
 ocil: |-
     Run the following command to ensure the <tt>TMOUT</tt> value is configured for all users

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/tmout_is_zero_profile.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/tmout_is_zero_profile.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# variables = var_accounts_tmout=900
+
+sed -i "/.*TMOUT.*/d" /etc/profile.d/*.sh
+
+if grep -q "TMOUT=" /etc/profile; then
+    sed -i "s/.*TMOUT=.*/TMOUT=0/" /etc/profile
+else
+    echo "TMOUT=0" >> /etc/profile
+fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/tmout_is_zero_profile_d.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/tmout_is_zero_profile_d.fail.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# variables = var_accounts_tmout=900
+
+TEST_FILE=/etc/profile.d/tmout.sh
+
+sed -i "/.*TMOUT.*/d" /etc/profile
+
+test -f $TEST_FILE || touch $TEST_FILE
+
+if grep -q "TMOUT=" $TEST_FILE; then
+    sed -i "s/.*TMOUT=.*/TMOUT=0/" $TEST_FILE
+else
+    echo "TMOUT=0" >> $TEST_FILE
+fi


### PR DESCRIPTION
#### Description:

The current accounts_tmout OVAL definition is flawed, as it incorrectly passes on systems where TMOUT is set to 0.

This occurs because the existing check only validates an upper bound (e.g., less than or equal to 600), a condition that TMOUT=0 satisfies. However, a value of 0 disables the timeout feature in most shells, which contradicts the rule's intent.

This PR corrects the logic by adding a lower-bound check to ensure the TMOUT value is greater than or equal to 1. The top-level <definition> now combines both the existing upper-bound and new lower-bound checks with AND logic, ensuring TMOUT=0 is correctly reported as non-compliant.

The definition's version has been incremented from 3 to 4 to reflect this logical change.
