### PR TITLE
Update OL10 profiles

### DIFF
--- a/products/ol10/profiles/anssi_bp28_enhanced.profile
+++ b/products/ol10/profiles/anssi_bp28_enhanced.profile
@@ -1,10 +1,9 @@
 documentation_complete: true
 
-title: 'DRAFT - ANSSI-BP-028 (enhanced)'
+title: 'ANSSI-BP-028 (enhanced)'
 
 description: |-
-    This is a draft profile for experimental purposes.
-    This draft profile contains configurations that align to ANSSI-BP-028 v2.0 at the enhanced hardening level.
+    This profile contains configurations that align to ANSSI-BP-028 v2.0 at the enhanced hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
@@ -17,6 +16,7 @@ description: |-
 
 selections:
     - anssi:all:enhanced
+    - var_password_hashing_algorithm_pam=yescrypt
     - '!package_ypserv_removed'
     - '!accounts_passwords_pam_tally2_deny_root'
     - '!install_PAE_kernel_on_x86-32'
@@ -32,6 +32,8 @@ selections:
     - '!sudo_add_umask'
     - '!cracklib_accounts_password_pam_minlen'
     - '!cracklib_accounts_password_pam_dcredit'
+    # authselect is enabled by default
+    - '!enable_authselect'
     # this rule is not automated anymore
     - '!security_patches_up_to_date'
     # There is only chrony package on OL 10, no ntpd

--- a/products/ol10/profiles/anssi_bp28_high.profile
+++ b/products/ol10/profiles/anssi_bp28_high.profile
@@ -1,10 +1,9 @@
 documentation_complete: true
 
-title: 'DRAFT - ANSSI-BP-028 (high)'
+title: 'ANSSI-BP-028 (high)'
 
 description: |-
-    This is a draft profile for experimental purposes.
-    This draft profile contains configurations that align to ANSSI-BP-028 v2.0 at the high hardening level.
+    This profile contains configurations that align to ANSSI-BP-028 v2.0 at the high hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
@@ -17,6 +16,7 @@ description: |-
 
 selections:
     - anssi:all:high
+    - var_password_hashing_algorithm_pam=yescrypt
     - '!package_ypserv_removed'
     - '!sebool_secure_mode_insmod'
     - '!accounts_passwords_pam_tally2_deny_root'
@@ -36,6 +36,8 @@ selections:
     - '!sudo_add_umask'
     - '!cracklib_accounts_password_pam_minlen'
     - '!cracklib_accounts_password_pam_dcredit'
+    # authselect is enabled by default
+    - '!enable_authselect'
     # this rule is not automated anymore
     - '!security_patches_up_to_date'
     # OL 10 unified the paths for grub2 files. These rules are selected in control file by R29.

--- a/products/ol10/profiles/anssi_bp28_intermediary.profile
+++ b/products/ol10/profiles/anssi_bp28_intermediary.profile
@@ -1,10 +1,9 @@
 documentation_complete: true
 
-title: 'DRAFT - ANSSI-BP-028 (intermediary)'
+title: 'ANSSI-BP-028 (intermediary)'
 
 description: |-
-    This is a draft profile for experimental purposes.
-    This draft profile contains configurations that align to ANSSI-BP-028 v2.0 at the intermediary hardening level.
+    This profile contains configurations that align to ANSSI-BP-028 v2.0 at the intermediary hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
@@ -17,6 +16,7 @@ description: |-
 
 selections:
     - anssi:all:intermediary
+    - var_password_hashing_algorithm_pam=yescrypt
     - '!package_ypbind_removed'
     - '!cracklib_accounts_password_pam_minlen'
     - '!package_ypserv_removed'
@@ -30,6 +30,8 @@ selections:
     - '!ensure_redhat_gpgkey_installed'
     - '!ensure_almalinux_gpgkey_installed'
     - '!sudo_add_umask'
+    # authselect is enabled by default
+    - '!enable_authselect'
     # this rule is not automated anymore
     - '!security_patches_up_to_date'
     # these packages do not exist in ol10 (R62)

--- a/products/ol10/profiles/anssi_bp28_minimal.profile
+++ b/products/ol10/profiles/anssi_bp28_minimal.profile
@@ -1,10 +1,9 @@
 documentation_complete: true
 
-title: 'DRAFT - ANSSI-BP-028 (minimal)'
+title: 'ANSSI-BP-028 (minimal)'
 
 description: |-
-    This is a draft profile for experimental purposes.
-    This draft profile contains configurations that align to ANSSI-BP-028 v2.0 at the minimal hardening level.
+    This profile contains configurations that align to ANSSI-BP-028 v2.0 at the minimal hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
@@ -17,6 +16,7 @@ description: |-
 
 selections:
     - anssi:all:minimal
+    - var_password_hashing_algorithm_pam=yescrypt
     - '!package_ypbind_removed'
     - '!cracklib_accounts_password_pam_minlen'
     - '!package_ypserv_removed'
@@ -30,6 +30,8 @@ selections:
     - '!ensure_redhat_gpgkey_installed'
     - '!ensure_almalinux_gpgkey_installed'
     - '!security_patches_up_to_date'
+    # authselect is enabled by default
+    - '!enable_authselect'
     # these packages do not exist in ol10 (R62)
     - '!package_dhcp_removed'
     - '!package_rsh_removed'

--- a/products/ol10/profiles/e8.profile
+++ b/products/ol10/profiles/e8.profile
@@ -2,12 +2,10 @@ documentation_complete: true
 
 reference: https://www.cyber.gov.au/acsc/view-all-content/publications/hardening-linux-workstations-and-servers
 
-title: 'DRAFT - Australian Cyber Security Centre (ACSC) Essential Eight'
+title: 'Australian Cyber Security Centre (ACSC) Essential Eight'
 
 description: |-
-    This is a draft profile for experimental purposes.
-
-    This draft profile contains configuration checks for Oracle Linux 10
+    This profile contains configuration checks for Oracle Linux 10
     that align to the Australian Cyber Security Centre (ACSC) Essential Eight.
 
     A copy of the Essential Eight in Linux Environments guide can be found at the
@@ -31,3 +29,5 @@ selections:
     - '!package_rsh_removed'
     - '!package_rsh-server_removed'
     - '!security_patches_up_to_date'
+    # authselect is enabled by default
+    - '!enable_authselect'

--- a/products/ol10/profiles/hipaa.profile
+++ b/products/ol10/profiles/hipaa.profile
@@ -2,11 +2,9 @@ documentation_complete: true
 
 reference: https://www.hhs.gov/hipaa/for-professionals/index.html
 
-title: 'DRAFT - Health Insurance Portability and Accountability Act (HIPAA)'
+title: 'Health Insurance Portability and Accountability Act (HIPAA)'
 
 description: |-
-    This is a draft profile for experimental purposes.
-
     The HIPAA Security Rule establishes U.S. national standards to protect individuals's
     electronic personal health information that is created, received, used, or
     maintained by a covered entity. The Security Rule requires appropriate
@@ -61,7 +59,10 @@ selections:
     - '!sshd_allow_only_protocol2'
     - '!sshd_disable_kerb_auth'
     - '!sshd_disable_gssapi_auth'
+    - '!service_rlogin_disabled'
 
+    # authselect is enabled by default
+    - '!enable_authselect'
     # OL 10 uses a different rule for auditing changes to selinux configuration
     - '!audit_rules_mac_modification'
     - audit_rules_mac_modification_etc_selinux

--- a/products/ol10/profiles/ism_o.profile
+++ b/products/ol10/profiles/ism_o.profile
@@ -2,12 +2,10 @@ documentation_complete: true
 
 reference: https://www.cyber.gov.au/ism
 
-title: 'DRAFT - Australian Cyber Security Centre (ACSC) ISM Official - Base'
+title: 'Australian Cyber Security Centre (ACSC) ISM Official - Base'
 
 description: |-
-    This is a draft profile for experimental purposes.
-
-    This draft profile contains configuration checks for Oracle Linux 10
+    This profile contains configuration checks for Oracle Linux 10
     that align to the Australian Cyber Security Centre (ACSC) Information Security Manual (ISM).
 
     The ISM uses a risk-based approach to cyber security. This profile provides a guide to aligning

--- a/products/ol10/profiles/ism_o_secret.profile
+++ b/products/ol10/profiles/ism_o_secret.profile
@@ -2,12 +2,10 @@ documentation_complete: true
 
 reference: https://www.cyber.gov.au/ism
 
-title: 'DRAFT - Australian Cyber Security Centre (ACSC) ISM Official - Secret'
+title: 'Australian Cyber Security Centre (ACSC) ISM Official - Secret'
 
 description: |-
-    This is a draft profile for experimental purposes.
-
-    This draft profile contains configuration checks for Oracle Linux 10
+    This profile contains configuration checks for Oracle Linux 10
     that align to the Australian Cyber Security Centre (ACSC) Information Security Manual (ISM).
 
     The ISM uses a risk-based approach to cyber security. This profile provides a guide to aligning

--- a/products/ol10/profiles/ism_o_top_secret.profile
+++ b/products/ol10/profiles/ism_o_top_secret.profile
@@ -2,12 +2,10 @@ documentation_complete: true
 
 reference: https://www.cyber.gov.au/ism
 
-title: 'DRAFT - Australian Cyber Security Centre (ACSC) ISM Official - Top Secret'
+title: 'Australian Cyber Security Centre (ACSC) ISM Official - Top Secret'
 
 description: |-
-    This is a draft profile for experimental purposes.
-
-    This draft profile contains configuration checks for Oracle Linux 10
+    This profile contains configuration checks for Oracle Linux 10
     that align to the Australian Cyber Security Centre (ACSC) Information Security Manual (ISM).
 
     The ISM uses a risk-based approach to cyber security. This profile provides a guide to aligning

--- a/products/ol10/profiles/ospp.profile
+++ b/products/ol10/profiles/ospp.profile
@@ -2,10 +2,10 @@ documentation_complete: true
 
 reference: https://www.niap-ccevs.org/Profile/Info.cfm?PPID=469&id=469
 
-title: 'DRAFT - Protection Profile for General Purpose Operating Systems'
+title: 'Protection Profile for General Purpose Operating Systems'
 
 description: |-
-    This is draft profile is based on the Oracle Linux 9 Common Criteria Guidance as
+    This is profile is based on the Oracle Linux 9 Common Criteria Guidance as
     guidance for Oracle Linux 10 was not available at the time of release.
 
 
@@ -14,6 +14,9 @@ description: |-
 
 selections:
     - ospp:all
+
+    # Trivial rule
+    - '!package_scap-security-guide_installed'
 
     - '!package_screen_installed'
     - '!package_dnf-plugin-subscription-manager_installed'

--- a/products/ol10/profiles/pci-dss.profile
+++ b/products/ol10/profiles/pci-dss.profile
@@ -2,11 +2,9 @@ documentation_complete: true
 
 reference: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0_1.pdf
 
-title: 'DRAFT - PCI-DSS v4.0.1 Control Baseline for Oracle Linux 10'
+title: 'PCI-DSS v4.0.1 Control Baseline for Oracle Linux 10'
 
 description: |-
-    This is a draft profile for experimental purposes.
-
     Payment Card Industry - Data Security Standard (PCI-DSS) is a set of
     security standards designed to ensure the secure handling of payment card
     data, with the goal of preventing data breaches and protecting sensitive
@@ -54,6 +52,8 @@ selections:
     - '!set_ip6tables_default_rule'
     - '!set_loopback_traffic'
     - '!set_password_hashing_algorithm_commonauth'
+    # authselect is enabled by default
+    - '!enable_authselect'
 
     # Following are incompatible with the ol10 product
     - '!service_chronyd_or_ntpd_enabled'

--- a/products/ol10/profiles/stig.profile
+++ b/products/ol10/profiles/stig.profile
@@ -2,7 +2,7 @@ documentation_complete: true
 
 reference: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
 
-title: 'DRAFT - DISA STIG for Oracle Linux 10'
+title: 'DRAFT - STIG for Oracle Linux 10'
 
 description: |-
     This is a draft profile for experimental purposes.

--- a/products/ol10/profiles/stig_gui.profile
+++ b/products/ol10/profiles/stig_gui.profile
@@ -1,13 +1,8 @@
 documentation_complete: true
 
-metadata:
-    SMEs:
-        - mab879
-
-
 reference: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
 
-title: 'DRAFT - DISA STIG for Oracle Linux 10'
+title: 'DRAFT - STIG with GUI for Oracle Linux 10'
 
 description: |-
     This is a draft profile for experimental purposes.


### PR DESCRIPTION
#### Description:

- Update OL10 profiles rule selection and titles
- Remove DISA from STIG profiles as for now they aren't based on DISA documents

#### Rationale:

- Better select rules associated with OL10
