### PR TITLE
Fix syntax error for sync cac oscal

### DIFF
--- a/.github/workflows/sync-cac-oscal.yml
+++ b/.github/workflows/sync-cac-oscal.yml
@@ -153,9 +153,9 @@ jobs:
                 # then convert them to impacted controls and profiles
                 rules=($line)
                 for rule in "${rules[@]}"; do
-                  python scripts/get_rule_impacted_files.py $RH_PRODUCTS "$GITHUB_WORKSPACE/cac-content" $value control >> rule_impacted_controls 2>&1
+                  python scripts/get_rule_impacted_files.py rh-products "$GITHUB_WORKSPACE/cac-content" $rule control >> rule_impacted_controls 2>&1
                   for product in "${RH_PRODUCTS[@]}"; do
-                    python scripts/get_rule_impacted_files.py $product "$GITHUB_WORKSPACE/cac-content" $value profile >> $product"_rule_impacted_profiles" 2>&1
+                    python scripts/get_rule_impacted_files.py $product "$GITHUB_WORKSPACE/cac-content" $rule profile >> $product"_rule_impacted_profiles" 2>&1
                   done
                 done
               fi
@@ -195,23 +195,20 @@ jobs:
             # Output all the updated controls in the PR
             echo "The updated controls: ${updated_controls[@]}"
           fi
-          # 1.2 Sync the updated controls to OSCAL catalog
-          for policy_id in "${updated_controls[@]}"; do
-            poetry run trestlebot sync-cac-content catalog  --repo-path ../oscal-content --committer-email "openscap-ci@gmail.com" --committer-name "openscap-ci" --branch "sync_cac_pr$pr_number" --cac-content-root "$GITHUB_WORKSPACE/cac-content" --cac-policy-id "$policy_id" --oscal-catalog "$policy_id"
-          done
-          # 1.3 Sync the updated controls to OSCAL profiles and component-definition
+          # 1.2 Sync the updated controls to OSCAL content
           for product in "${RH_PRODUCTS[@]}"; do
             for policy_id in "${updated_controls[@]}"; do
-              # 1.3.1 Sync the updated controls to OSCAL profile
               # This sync depends on the specific product available controls
               available_controls=($(cat $product"_controls")) # Get all the available controls of the product
-              IFS=' ' read -r -a controls_a <<< "$available_controls"
-              for pc in "${controls_a[@]}"; do
+              for pc in "${available_controls[@]}"; do
                 if [[ "$pc" == "$policy_id" ]]; then
+                  # 1.2.1 Sync the updated controls to OSCAL catalog
+                  poetry run trestlebot sync-cac-content catalog  --repo-path ../oscal-content --committer-email "openscap-ci@gmail.com" --committer-name "openscap-ci" --branch "sync_cac_pr$pr_number" --cac-content-root "$GITHUB_WORKSPACE/cac-content" --cac-policy-id "$policy_id" --oscal-catalog "$policy_id"
+                  # 1.2.2 Sync the updated controls to OSCAL profile
                   poetry run trestlebot sync-cac-content profile  --repo-path ../oscal-content --committer-email "openscap-ci@gmail.com" --committer-name "openscap-ci" --branch "sync_cac_pr$pr_number" --cac-content-root "$GITHUB_WORKSPACE/cac-content" --product "$product" --cac-policy-id "$policy_id" --oscal-catalog "$policy_id"
                 fi
               done
-              # 1.3.2 Sync the updated controls to OSCAL component-definition
+              # 1.2.3 Sync the updated controls to OSCAL component-definition
               # This sync depends on the control assoicated profile and levels
               sh ../cac-content/utils/trestlebot-cli-compd.sh true $policy_id $product $pr_number $GITHUB_WORKSPACE $product"_map.json"
             done

--- a/utils/trestlebot-cli-compd.sh
+++ b/utils/trestlebot-cli-compd.sh
@@ -28,11 +28,11 @@ if [ $# -lt 6 ]; then
     exit 1
 fi
 
+sed -i "s/'/\"/g" "$product_mapping_file"
 while IFS= read -r line; do
-  map=$(echo "$line" | sed "s/'/\"/g")
-  policy_id=$(echo "$map" | jq -r '.policy_id')
-  profile=$(echo "$map" | jq -r '.profile_name')
-  echo "$map" | jq -r '.levels[]' > levels
+  policy_id=$(echo "$line" | jq -r '.policy_id')
+  profile=$(echo "$line" | jq -r '.profile_name')
+  echo "$line" | jq -r '.levels[]' > levels
   if [ "$flag" = "true" ]; then
     param="$policy_id"
   else


### PR DESCRIPTION
#### Description:

- This PR aims to fix the [error](https://github.com/ComplianceAsCode/content/actions/runs/15604075871/job/43949425934) in sync_cac_to_oscal and update the scope of controls which are related to the rh-products for sync_cac_to_oscal.
- The test run against the forked repository is available [here](https://github.com/complytime/cac-content/actions/runs/15674033992/job/44150247601).

