### PR TITLE
[Ubuntu 24.04]: Add vlock_installed pkg override

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/vlock_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/vlock_installed/rule.yml
@@ -55,3 +55,4 @@ template:
     vars:
         pkgname: kbd
         pkgname@ubuntu2204: vlock
+        pkgname@ubuntu2404: vlock


### PR DESCRIPTION
#### Description:

- Add pkg override for rule vlock_installed

#### Rationale:
