### PR TITLE
Add OL9 to xwindows_runlevel_target tests

### DIFF
--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/tests/correct_target.pass.sh
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/tests/correct_target.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = Oracle Linux 8,multi_platform_fedora,multi_platform_rhv,multi_platform_rhel,multi_platform_sle
+# platform = multi_platform_ol,multi_platform_fedora,multi_platform_rhv,multi_platform_rhel,multi_platform_sle
 
 systemctl set-default multi-user.target

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/tests/correct_target_under_lib.pass.sh
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/tests/correct_target_under_lib.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = Oracle Linux 8,multi_platform_fedora,multi_platform_rhv,multi_platform_rhel,multi_platform_sle
+# platform = multi_platform_ol,multi_platform_fedora,multi_platform_rhv,multi_platform_rhel,multi_platform_sle
 
 ln -sf /lib/systemd/system/multi-user.target /etc/systemd/system/default.target

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/tests/wrong_target.fail.sh
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/tests/wrong_target.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = Oracle Linux 8,multi_platform_fedora,multi_platform_rhel,multi_platform_rhv,multi_platform_sle
+# platform = multi_platform_ol,multi_platform_fedora,multi_platform_rhel,multi_platform_rhv,multi_platform_sle
 
 systemctl set-default graphical.target

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/tests/wrong_target_under_lib.fail.sh
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/tests/wrong_target_under_lib.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = Oracle Linux 8,multi_platform_fedora,multi_platform_rhel,multi_platform_rhv,multi_platform_sle
+# platform = multi_platform_ol,multi_platform_fedora,multi_platform_rhel,multi_platform_rhv,multi_platform_sle
 
 ln -sf /lib/systemd/system/graphical.target /etc/systemd/system/default.target


### PR DESCRIPTION
#### Description:

Add OL9 to xwindows_runlevel_target tests

#### Rationale:

Align OL9 STIG profile with DISA STIG OL9 V1R1
