### PR TITLE
[Ubuntu] Fix package_chrony_installed rule

### DIFF
--- a/controls/stig_ubuntu2404.yml
+++ b/controls/stig_ubuntu2404.yml
@@ -184,6 +184,7 @@ controls:
     levels:
       - low
     rules:
+      - var_timesync_service=chronyd
       - package_chrony_installed
     status: automated
 


### PR DESCRIPTION
#### Description:

- Add var_timesync_service for rule package_chrony_installed

#### Rationale:

- The template package_installed_guard_var needs to define chronyd as value to avoid other time sync pkg (systemd-timesyncd)