### PR TITLE
Only allow server as directive for Ubuntu

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/bash/shared.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/bash/shared.sh
@@ -19,13 +19,17 @@ $pof ntpd || {
 # get list of ntp files
 
 for config_file in "${CONFIG_FILES[@]}" ; do
-    # Set maxpoll values to var_time_service_set_maxpoll
-    sed -i "s/^\(\(server\|pool\|peer\).*maxpoll\) [0-9,-][0-9]*\(.*\)$/\1 $var_time_service_set_maxpoll \3/" "$config_file"
-done
-
-for config_file in "${CONFIG_FILES[@]}" ; do
     # Add maxpoll to server, pool or peer entries without maxpoll
     grep "^\(server\|pool\|peer\)" "$config_file" | grep -v maxpoll | while read -r line ; do
         sed -i "s/$line/& maxpoll $var_time_service_set_maxpoll/" "$config_file"
     done
+done
+
+for config_file in "${CONFIG_FILES[@]}" ; do
+    # Set maxpoll values to var_time_service_set_maxpoll
+{{% if 'ubuntu' in product %}}
+    sed -i "s/^\(server\|pool\|peer\)\(.*maxpoll\) [0-9,-][0-9]*\(.*\)$/server\2 $var_time_service_set_maxpoll \3/" "$config_file"
+{{% else %}}
+    sed -i "s/^\(\(server\|pool\|peer\).*maxpoll\) [0-9,-][0-9]*\(.*\)$/\1 $var_time_service_set_maxpoll \3/" "$config_file"
+{{% endif %}}
 done

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/oval/shared.xml
@@ -31,6 +31,11 @@
   </ind:textfilecontent54_object>
 
 {{% set filepath_regex = "^(" + chrony_conf_path | replace(".", "\.") + "|" + chrony_d_path | replace(".", "\.") + ".+\.conf)$" %}}
+{{%- if "ubuntu" in product %}}
+{{%- set sources_regex = "^(?:server)" %}}
+{{%- else %}}
+{{%- set sources_regex = "^(?:server|pool|peer)" %}}
+{{%- endif %}}
 
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
   comment="check if maxpoll is set in {{{ chrony_conf_path }}} or {{{ chrony_d_path }}}"
@@ -40,7 +45,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_chrony_set_maxpoll" version="1">
     <ind:filepath operation="pattern match">{{{ filepath_regex }}}</ind:filepath>
-    <ind:pattern operation="pattern match">^(?:server|pool|peer)[\s]+[\S]+.*maxpoll[\s]+(\d+)</ind:pattern>
+    <ind:pattern operation="pattern match">{{{ sources_regex }}}[\s]+[\S]+.*maxpoll[\s]+(\d+)</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -71,7 +76,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_chrony_all_server_has_maxpoll" version="1">
     <ind:filepath operation="pattern match">{{{ filepath_regex }}}</ind:filepath>
-    <ind:pattern operation="pattern match">^(?:server|pool|peer)[\s]+[\S]+[\s]+(.*)</ind:pattern>
+    <ind:pattern operation="pattern match">{{{ sources_regex }}}[\s]+[\S]+[\s]+(.*)</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 


### PR DESCRIPTION
#### Description:

- Only allow server as directive for Ubuntu
- Move the maxpool value replacement down so that directive replacement can happen at the same time

#### Rationale:

- Ubuntu stig require server directive only.