### PR TITLE
Delete installed_OS_is_FIPS_certified or ssh(d) related rules

### DIFF
--- a/linux_os/guide/services/ssh/ssh_client/ssh_client_use_approved_ciphers_ordered_stig/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_client/ssh_client_use_approved_ciphers_ordered_stig/oval/shared.xml
@@ -4,15 +4,12 @@
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("Limit the ciphers to those which are FIPS-approved.", rule_title=rule_title) }}}
-    <criteria operator="AND">
-      <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
-      <criteria comment="the configuration is correct if it exists" operator="AND">
-        <criterion comment="Check the ciphers in /etc/ssh/ssh_config if any"
-          test_ref="test_{{{ rule_id }}}" />
-        <criterion comment="Check the ciphers in /etc/ssh/ssh_config.d if any"
-          test_ref="test_{{{ rule_id }}}_config_dir" />
-        <criterion comment="the configuraton exists" test_ref="test_ciphers_present_{{{ rule_id }}}" />
-      </criteria>
+    <criteria comment="the configuration is correct if it exists" operator="AND">
+      <criterion comment="Check the ciphers in /etc/ssh/ssh_config if any"
+        test_ref="test_{{{ rule_id }}}" />
+      <criterion comment="Check the ciphers in /etc/ssh/ssh_config.d if any"
+        test_ref="test_{{{ rule_id }}}_config_dir" />
+      <criterion comment="the configuraton exists" test_ref="test_ciphers_present_{{{ rule_id }}}" />
     </criteria>
   </definition>
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/oval/shared.xml
@@ -1,24 +1,21 @@
 <def-group>
   <definition class="compliance" id="sshd_use_approved_ciphers_ordered_stig" version="1">
     {{{ oval_metadata("Limit the ciphers to those which are FIPS-approved.", rule_title=rule_title) }}}
-    <criteria operator="AND">
-      <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
-      <criteria comment="SSH is configured correctly or is not installed"
-      operator="OR">
-        <criteria comment="sshd is not installed" operator="AND">
-          <extend_definition comment="sshd is not required or requirement is unset"
-          definition_ref="sshd_not_required_or_unset" />
-          <extend_definition comment="rpm package openssh-server removed"
-          definition_ref="package_openssh-server_removed" />
-        </criteria>
-        <criteria comment="sshd is installed and configured" operator="AND">
-          <extend_definition comment="sshd is required or requirement is unset"
-          definition_ref="sshd_required_or_unset" />
-          <extend_definition comment="rpm package openssh-server installed"
-          definition_ref="package_openssh-server_installed" />
-          <criterion comment="Check the Cipers list in /etc/ssh/sshd_config"
-          test_ref="test_sshd_use_approved_ciphers_ordered_stig" />
-        </criteria>
+    <criteria comment="SSH is configured correctly or is not installed"
+    operator="OR">
+      <criteria comment="sshd is not installed" operator="AND">
+        <extend_definition comment="sshd is not required or requirement is unset"
+        definition_ref="sshd_not_required_or_unset" />
+        <extend_definition comment="rpm package openssh-server removed"
+        definition_ref="package_openssh-server_removed" />
+      </criteria>
+      <criteria comment="sshd is installed and configured" operator="AND">
+        <extend_definition comment="sshd is required or requirement is unset"
+        definition_ref="sshd_required_or_unset" />
+        <extend_definition comment="rpm package openssh-server installed"
+        definition_ref="package_openssh-server_installed" />
+        <criterion comment="Check the Cipers list in /etc/ssh/sshd_config"
+        test_ref="test_sshd_use_approved_ciphers_ordered_stig" />
       </criteria>
     </criteria>
   </definition>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/oval/ubuntu.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/oval/ubuntu.xml
@@ -8,33 +8,30 @@
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("Limit the ciphers to those which are FIPS-approved.", rule_title=rule_title) }}}
-    <criteria operator="AND">
-      <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
-      <criteria comment="sshd is configured correctly or is not installed" operator="OR">
-        <criteria comment="sshd is not installed" operator="AND">
-          <extend_definition comment="sshd is not required or requirement is unset"
-            definition_ref="sshd_not_required_or_unset" />
-          <extend_definition comment="package openssh-server removed"
-            definition_ref="package_openssh-server_removed" />
-        </criteria>
-
-        <criteria comment="sshd is installed and configured" operator="AND">
-          <extend_definition comment="sshd is required or requirement is unset"
-            definition_ref="sshd_required_or_unset" />
-          <extend_definition comment="package openssh-server installed"
-            definition_ref="package_openssh-server_installed" />
-          <criteria comment="sshd is configured correctly" operator="AND">
-            <criteria comment="the configuration is correct if it exists" operator="AND">
-              <criterion comment="Check the ciphers in /etc/ssh/sshd_config if any"
-                test_ref="test_{{{ rule_id }}}" />
-              <criterion comment="Check the ciphers in /etc/ssh/sshd_config.d if any"
-                test_ref="test_{{{ rule_id }}}_config_dir" />
-            </criteria>
-            <criterion comment="the configuraton exists" test_ref="test_ciphers_present_{{{ rule_id }}}" />
-          </criteria>
-        </criteria>
-
+    <criteria comment="sshd is configured correctly or is not installed" operator="OR">
+      <criteria comment="sshd is not installed" operator="AND">
+        <extend_definition comment="sshd is not required or requirement is unset"
+          definition_ref="sshd_not_required_or_unset" />
+        <extend_definition comment="package openssh-server removed"
+          definition_ref="package_openssh-server_removed" />
       </criteria>
+
+      <criteria comment="sshd is installed and configured" operator="AND">
+        <extend_definition comment="sshd is required or requirement is unset"
+          definition_ref="sshd_required_or_unset" />
+        <extend_definition comment="package openssh-server installed"
+          definition_ref="package_openssh-server_installed" />
+        <criteria comment="sshd is configured correctly" operator="AND">
+          <criteria comment="the configuration is correct if it exists" operator="AND">
+            <criterion comment="Check the ciphers in /etc/ssh/sshd_config if any"
+              test_ref="test_{{{ rule_id }}}" />
+            <criterion comment="Check the ciphers in /etc/ssh/sshd_config.d if any"
+              test_ref="test_{{{ rule_id }}}_config_dir" />
+          </criteria>
+          <criterion comment="the configuraton exists" test_ref="test_ciphers_present_{{{ rule_id }}}" />
+        </criteria>
+      </criteria>
+
     </criteria>
   </definition>
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/oval/shared.xml
@@ -19,34 +19,31 @@
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("Limit the Key Exchange (Kex) algorithms to those which are FIPS-approved.", rule_title=rule_title) }}}
-    <criteria operator="AND">
-      <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
-      <criteria comment="SSH is configured correctly or is not installed"
-        operator="OR">
-        <criteria comment="sshd is not installed" operator="AND">
-          <extend_definition comment="sshd is not required or requirement is unset"
-            definition_ref="sshd_not_required_or_unset" />
-          {{% if product in ['sle12', 'sle15', 'slmicro5'] %}}
-          <extend_definition comment="package openssh removed"
-            definition_ref="package_openssh_removed" />
-          {{% else %}}
-          <extend_definition comment="package openssh-server removed"
-            definition_ref="package_openssh-server_removed" />
-          {{% endif %}}
-        </criteria>
-        <criteria comment="sshd is installed and configured" operator="AND">
-          <extend_definition comment="sshd is required or requirement is unset"
-            definition_ref="sshd_required_or_unset" />
-          {{% if product in ['sle12', 'sle15', 'slmicro5'] %}}
-          <extend_definition comment="package openssh installed"
-            definition_ref="package_openssh_installed" />
-          {{% else %}}
-          <extend_definition comment="package openssh-server installed"
-            definition_ref="package_openssh-server_installed" />
-          {{% endif %}}
-          <criterion comment="Check Kex in {{{ path }}}"
-            test_ref="test_{{{ rule_id }}}" />
-        </criteria>
+    <criteria comment="SSH is configured correctly or is not installed"
+      operator="OR">
+      <criteria comment="sshd is not installed" operator="AND">
+        <extend_definition comment="sshd is not required or requirement is unset"
+          definition_ref="sshd_not_required_or_unset" />
+        {{% if product in ['sle12', 'sle15', 'slmicro5'] %}}
+        <extend_definition comment="package openssh removed"
+          definition_ref="package_openssh_removed" />
+        {{% else %}}
+        <extend_definition comment="package openssh-server removed"
+          definition_ref="package_openssh-server_removed" />
+        {{% endif %}}
+      </criteria>
+      <criteria comment="sshd is installed and configured" operator="AND">
+        <extend_definition comment="sshd is required or requirement is unset"
+          definition_ref="sshd_required_or_unset" />
+        {{% if product in ['sle12', 'sle15', 'slmicro5'] %}}
+        <extend_definition comment="package openssh installed"
+          definition_ref="package_openssh_installed" />
+        {{% else %}}
+        <extend_definition comment="package openssh-server installed"
+          definition_ref="package_openssh-server_installed" />
+        {{% endif %}}
+        <criterion comment="Check Kex in {{{ path }}}"
+          test_ref="test_{{{ rule_id }}}" />
       </criteria>
     </criteria>
   </definition>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/oval/ubuntu.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/oval/ubuntu.xml
@@ -6,33 +6,30 @@
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("Limit the KexAlgorithms to those which are FIPS-approved.", rule_title=rule_title) }}}
-    <criteria operator="AND">
-      <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
-      <criteria comment="sshd is configured correctly or is not installed" operator="OR">
-        <criteria comment="sshd is not installed" operator="AND">
-          <extend_definition comment="sshd is not required or requirement is unset"
-            definition_ref="sshd_not_required_or_unset" />
-          <extend_definition comment="package openssh-server removed"
-            definition_ref="package_openssh-server_removed" />
-        </criteria>
-
-        <criteria comment="sshd is installed and configured" operator="AND">
-          <extend_definition comment="sshd is required or requirement is unset"
-            definition_ref="sshd_required_or_unset" />
-          <extend_definition comment="package openssh-server installed"
-            definition_ref="package_openssh-server_installed" />
-          <criteria comment="sshd is configured correctly" operator="AND">
-            <criteria comment="the configuration is correct if it exists" operator="AND">
-              <criterion comment="Check the KexAlgorithms in /etc/ssh/sshd_config if any"
-                test_ref="test_{{{ rule_id }}}" />
-              <criterion comment="Check the KexAlgorithms in /etc/ssh/sshd_config.d if any"
-                test_ref="test_{{{ rule_id }}}_config_dir" />
-            </criteria>
-            <criterion comment="the configuraton exists" test_ref="test_KexAlgorithms_present_{{{ rule_id }}}" />
-          </criteria>
-        </criteria>
-
+    <criteria comment="sshd is configured correctly or is not installed" operator="OR">
+      <criteria comment="sshd is not installed" operator="AND">
+        <extend_definition comment="sshd is not required or requirement is unset"
+          definition_ref="sshd_not_required_or_unset" />
+        <extend_definition comment="package openssh-server removed"
+          definition_ref="package_openssh-server_removed" />
       </criteria>
+
+      <criteria comment="sshd is installed and configured" operator="AND">
+        <extend_definition comment="sshd is required or requirement is unset"
+          definition_ref="sshd_required_or_unset" />
+        <extend_definition comment="package openssh-server installed"
+          definition_ref="package_openssh-server_installed" />
+        <criteria comment="sshd is configured correctly" operator="AND">
+          <criteria comment="the configuration is correct if it exists" operator="AND">
+            <criterion comment="Check the KexAlgorithms in /etc/ssh/sshd_config if any"
+              test_ref="test_{{{ rule_id }}}" />
+            <criterion comment="Check the KexAlgorithms in /etc/ssh/sshd_config.d if any"
+              test_ref="test_{{{ rule_id }}}_config_dir" />
+          </criteria>
+          <criterion comment="the configuraton exists" test_ref="test_KexAlgorithms_present_{{{ rule_id }}}" />
+        </criteria>
+      </criteria>
+
     </criteria>
   </definition>
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/oval/shared.xml
@@ -1,34 +1,31 @@
 <def-group>
   <definition class="compliance" id="sshd_use_approved_macs" version="1">
     {{{ oval_metadata("Limit the Message Authentication Codes (MACs) to those which are FIPS-approved.", rule_title=rule_title) }}}
-    <criteria operator="AND">
-      <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
-      <criteria comment="SSH is configured correctly or is not installed"
-      operator="OR">
-        <criteria comment="sshd is not installed" operator="AND">
-          <extend_definition comment="sshd is not required or requirement is unset"
-          definition_ref="sshd_not_required_or_unset" />
-          {{% if product in ['opensuse', 'sle12', 'sle15', 'slmicro5'] %}}
-          <extend_definition comment="rpm package openssh removed"
-          definition_ref="package_openssh_removed" />
-          {{% else %}}
-          <extend_definition comment="rpm package openssh-server removed"
-          definition_ref="package_openssh-server_removed" />
-          {{% endif %}}
-        </criteria>
-        <criteria comment="sshd is installed and configured" operator="AND">
-          <extend_definition comment="sshd is required or requirement is unset"
-          definition_ref="sshd_required_or_unset" />
-          {{% if product in ['opensuse', 'sle12', 'sle15', 'slmicro5'] %}}
-          <extend_definition comment="rpm package openssh installed"
-          definition_ref="package_openssh_installed" />
-          {{% else %}}
-          <extend_definition comment="rpm package openssh-server installed"
-          definition_ref="package_openssh-server_installed" />
-          {{% endif %}}
-          <criterion comment="Check MACs in /etc/ssh/sshd_config"
-          test_ref="test_sshd_use_approved_macs" />
-        </criteria>
+    <criteria comment="SSH is configured correctly or is not installed"
+    operator="OR">
+      <criteria comment="sshd is not installed" operator="AND">
+        <extend_definition comment="sshd is not required or requirement is unset"
+        definition_ref="sshd_not_required_or_unset" />
+        {{% if product in ['opensuse', 'sle12', 'sle15', 'slmicro5'] %}}
+        <extend_definition comment="rpm package openssh removed"
+        definition_ref="package_openssh_removed" />
+        {{% else %}}
+        <extend_definition comment="rpm package openssh-server removed"
+        definition_ref="package_openssh-server_removed" />
+        {{% endif %}}
+      </criteria>
+      <criteria comment="sshd is installed and configured" operator="AND">
+        <extend_definition comment="sshd is required or requirement is unset"
+        definition_ref="sshd_required_or_unset" />
+        {{% if product in ['opensuse', 'sle12', 'sle15', 'slmicro5'] %}}
+        <extend_definition comment="rpm package openssh installed"
+        definition_ref="package_openssh_installed" />
+        {{% else %}}
+        <extend_definition comment="rpm package openssh-server installed"
+        definition_ref="package_openssh-server_installed" />
+        {{% endif %}}
+        <criterion comment="Check MACs in /etc/ssh/sshd_config"
+        test_ref="test_sshd_use_approved_macs" />
       </criteria>
     </criteria>
   </definition>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/oval/shared.xml
@@ -1,24 +1,21 @@
 <def-group>
   <definition class="compliance" id="sshd_use_approved_macs_ordered_stig" version="1">
     {{{ oval_metadata("Limit the Message Authentication Codes (MACs) to those which are FIPS-approved.", rule_title=rule_title) }}}
-    <criteria operator="AND">
-      <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
-      <criteria comment="SSH is configured correctly or is not installed"
-      operator="OR">
-        <criteria comment="sshd is not installed" operator="AND">
-          <extend_definition comment="sshd is not required or requirement is unset"
-          definition_ref="sshd_not_required_or_unset" />
-          <extend_definition comment="rpm package openssh-server removed"
-          definition_ref="package_openssh-server_removed" />
-        </criteria>
-        <criteria comment="sshd is installed and configured" operator="AND">
-          <extend_definition comment="sshd is required or requirement is unset"
-          definition_ref="sshd_required_or_unset" />
-          <extend_definition comment="rpm package openssh-server installed"
-          definition_ref="package_openssh-server_installed" />
-          <criterion comment="Check MACs in /etc/ssh/sshd_config"
-          test_ref="test_sshd_use_approved_macs_ordered_stig" />
-        </criteria>
+    <criteria comment="SSH is configured correctly or is not installed"
+    operator="OR">
+      <criteria comment="sshd is not installed" operator="AND">
+        <extend_definition comment="sshd is not required or requirement is unset"
+        definition_ref="sshd_not_required_or_unset" />
+        <extend_definition comment="rpm package openssh-server removed"
+        definition_ref="package_openssh-server_removed" />
+      </criteria>
+      <criteria comment="sshd is installed and configured" operator="AND">
+        <extend_definition comment="sshd is required or requirement is unset"
+        definition_ref="sshd_required_or_unset" />
+        <extend_definition comment="rpm package openssh-server installed"
+        definition_ref="package_openssh-server_installed" />
+        <criterion comment="Check MACs in /etc/ssh/sshd_config"
+        test_ref="test_sshd_use_approved_macs_ordered_stig" />
       </criteria>
     </criteria>
   </definition>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/oval/ubuntu.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/oval/ubuntu.xml
@@ -8,8 +8,6 @@
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("Limit the Message Authentication Codes (MACs) to those which are FIPS-approved.", rule_title=rule_title) }}}
-    <criteria operator="AND">
-      <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
       <criteria comment="sshd is configured correctly or is not installed" operator="OR">
         <criteria comment="sshd is not installed" operator="AND">
           <extend_definition comment="sshd is not required or requirement is unset"
@@ -35,7 +33,6 @@
         </criteria>
 
       </criteria>
-    </criteria>
   </definition>
 
   <ind:textfilecontent54_test check="all" check_existence="any_exist"


### PR DESCRIPTION
#### Description:

- Delete installed_OS_is_FIPS_certified or ssh(d) related rules

#### Rationale:

- See comment https://github.com/ComplianceAsCode/content/pull/13581#discussion_r2149958960