### PR TITLE
Remove uefi/non-uefi platform from grub2 rules in case they do not need

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/non-uefi/group.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/group.yml
@@ -5,4 +5,6 @@ title: 'Non-UEFI GRUB2 bootloader configuration'
 description: |-
     Non-UEFI GRUB2 bootloader configuration
 
+{{%- if grub2_boot_path != grub2_uefi_boot_path -%}}
 platform: non-uefi
+{{%- endif -%}}

--- a/linux_os/guide/system/bootloader-grub2/uefi/group.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/group.yml
@@ -5,7 +5,9 @@ title: 'UEFI GRUB2 bootloader configuration'
 description: |-
     UEFI GRUB2 bootloader configuration
 
+{{%- if grub2_boot_path != grub2_uefi_boot_path -%}}
 platform: uefi
+{{%- endif -%}}
 
 warnings:
     - functionality: |-


### PR DESCRIPTION


#### Description:
- Remove uefi/non-uefi platform from grub2 rules in case they do not need.

#### Rationale:

- Products that have the same grub2 path for both UEFI/non-UEFI do not need to set the platform and the products have now consolidated the use of the grub2 rules to only select the ones that come from the non-UEFI set of rules.
