### PR TITLE
Update the suffix for rules used when generating components gh pages

### DIFF
--- a/utils/render_components.py
+++ b/utils/render_components.py
@@ -76,7 +76,7 @@ def load_rule_data(rule_path: str) -> RuleData:
 def find_rule_paths(component_rules: list, resolved_rules_dir: str) -> list:
     rule_paths = []
     for rule_id in component_rules:
-        rule_path = os.path.join(resolved_rules_dir, rule_id + ".yml")
+        rule_path = os.path.join(resolved_rules_dir, rule_id + ".json")
         if os.path.exists(rule_path):
             rule_paths.append(rule_path)
     return rule_paths


### PR DESCRIPTION
#### Description:

- Update the suffix for rules used when generating components gh pages

#### Rationale:

- Omission from https://github.com/ComplianceAsCode/content/pull/13445

- Fixes empty components page at: https://complianceascode.github.io/content-pages/components/index.html

#### Review Hints:

- Build a product
- Run `utils/generate_html_pages.sh __pages` and inspect `__pages/components/index.html` file
- If the product built uses components, then the page should contains components and their rules associated.

