### PR TITLE
improvement for sync-cac-oscal

### DIFF
--- a/.github/workflows/sync-cac-oscal.yml
+++ b/.github/workflows/sync-cac-oscal.yml
@@ -286,9 +286,14 @@ jobs:
           PR_EXISTS=$(gh pr list --repo $OWNER/$REPO \
             --head $BRANCH_NAME --state open --json id \
             | jq length)
-          # If the PR doesn't exist, create PR
+          # Get commits between main and branch
+          commits=$(git log main..$BRANCH_NAME --oneline)
+          # If the PR does not exist and there are commits in the branch,
+          # then create a PR for this branch.
           if [ "$PR_EXISTS" -gt 0 ]; then
             echo "PR $BRANCH_NAME already exists. Skipping PR creation."
+          elif [ -n "$commits" ]; then
+            echo "No commits between main and $BRANCH_NAME. Skipping PR creation."
           else
             echo "Creating PR for new branch: $BRANCH_NAME"
             gh pr create --repo $OWNER/$REPO \


### PR DESCRIPTION
#### Description:

If there are no commits between main and branch of ComplianceAsCode/oscal-content, it will skip creating PR for oscal-content.
This PR aims to fix the [failed case](https://github.com/ComplianceAsCode/content/actions/runs/15701375427/job/44236745630).
