### PR TITLE
Change platform of GRUB 2 file rules

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/rule.yml
@@ -48,11 +48,7 @@ fixtext: '{{{ fixtext_file_group_owner(grub2_boot_path ~ "/grub.cfg", "root") }}
 
 srg_requirement: '{{{ srg_requirement_file_group_owner(grub2_boot_path ~ "/grub.cfg", "root") }}}'
 
-{{% if 'ubuntu' in product %}}
 platform: not container
-{{% else %}}
-platform: not bootc
-{{% endif %}}
 
 template:
     name: file_groupowner

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_user_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_user_cfg/rule.yml
@@ -43,7 +43,7 @@ fixtext: '{{{ fixtext_file_group_owner(grub2_boot_path ~ "/user.cfg", "root") }}
 
 srg_requirement: '{{{ srg_requirement_file_group_owner(grub2_boot_path ~ "/user.cfg", "root") }}}'
 
-platform: not bootc
+platform: not container
 
 template:
     name: file_groupowner

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/rule.yml
@@ -43,11 +43,7 @@ ocil_clause: '{{{ ocil_clause_file_owner(file=grub2_boot_path ~ "/grub.cfg", own
 ocil: |-
     {{{ ocil_file_owner(file=grub2_boot_path ~ "/grub.cfg", owner="root") }}}
 
-{{% if 'ubuntu' in product %}}
 platform: not container
-{{% else %}}
-platform: not bootc
-{{% endif %}}
 
 template:
     name: file_owner

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_user_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_user_cfg/rule.yml
@@ -38,7 +38,7 @@ ocil_clause: '{{{ ocil_clause_file_owner(file=grub2_boot_path ~ "/user.cfg", own
 ocil: |-
     {{{ ocil_file_owner(file=grub2_boot_path ~ "/user.cfg", owner="root") }}}
 
-platform: not bootc
+platform: not container
 
 template:
     name: file_owner

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_grub2_cfg/rule.yml
@@ -43,11 +43,7 @@ ocil: |-
     If properly configured, the output should indicate the following
     permissions: <tt>-rw-------</tt>
 
-{{% if 'ubuntu' in product %}}
 platform: not container
-{{% else %}}
-platform: not bootc
-{{% endif %}}
 
 template:
     name: file_permissions

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_user_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_user_cfg/rule.yml
@@ -34,7 +34,7 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file=grub2_boot_path ~ "/user.cfg
 ocil: |-
     {{{ ocil_file_permissions(file=grub2_boot_path ~ "/user.cfg", perms="-rw-------") }}}
 
-platform: not bootc
+platform: not container
 
 template:
     name: file_permissions


### PR DESCRIPTION
This commit will change platform in rules that check owner, group and mode of /boot/grub2/grub2.cfg and /boot/grub2/user.cfg. The platform will be set to "not container" in all these rules. The reason is that these 2 files don't exist during bootable container image build, but they exist on a running Image Mode RHEL system because they are created by bootupd during deployment. Also in application containers GRUB 2 don't make much sense.


