### PR TITLE
Remove excess dashes in Jinja 2 expression

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/non-uefi/group.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/group.yml
@@ -5,6 +5,6 @@ title: 'Non-UEFI GRUB2 bootloader configuration'
 description: |-
     Non-UEFI GRUB2 bootloader configuration
 
-{{%- if grub2_boot_path != grub2_uefi_boot_path -%}}
+{{% if grub2_boot_path != grub2_uefi_boot_path -%}}
 platform: non-uefi
-{{%- endif -%}}
+{{%- endif %}}

--- a/linux_os/guide/system/bootloader-grub2/uefi/group.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/group.yml
@@ -5,9 +5,9 @@ title: 'UEFI GRUB2 bootloader configuration'
 description: |-
     UEFI GRUB2 bootloader configuration
 
-{{%- if grub2_boot_path != grub2_uefi_boot_path -%}}
+{{% if grub2_boot_path != grub2_uefi_boot_path -%}}
 platform: uefi
-{{%- endif -%}}
+{{%- endif %}}
 
 warnings:
     - functionality: |-


### PR DESCRIPTION
These dashes consume all surrounding namespaces. As a result, the platform key isn't taken as a key but becomes part of the description value.


