### PR TITLE
Enable ansible remediation 

### DIFF
--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_exec.fail.sh
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_exec.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = audit
 #
-# remediation = bash
 
 . $SHARED/auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_halt.fail.sh
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_halt.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = audit
 #
-# remediation = bash
 
 . $SHARED/auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_ignore.fail.sh
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_ignore.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = audit
 #
-# remediation = bash
 
 . $SHARED/auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_not_there.fail.sh
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_not_there.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = audit
 #
-# remediation = bash
 
 . $SHARED/auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_single.fail.sh
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_single.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = audit
 #
-# remediation = bash
 
 . $SHARED/auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_suspend.fail.sh
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_suspend.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = audit
 #
-# remediation = bash
 
 . $SHARED/auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_syslog.fail.sh
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_syslog.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = audit
 #
-# remediation = bash
 
 . $SHARED/auditd_utils.sh
 prepare_auditd_test_enviroment


### PR DESCRIPTION
#### Description:

Enable ansible remediation for auditd_data_retention_space_left_action tests

#### Rationale:

The ansible remediation is present and works properly