### PR TITLE
Add OL9 to disable_ctrlaltdel_reboot tests

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/tests/masked.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/tests/masked.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Oracle Linux 7,Oracle Linux 8,multi_platform_rhel,multi_platform_fedora,multi_platform_ubuntu
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_fedora,multi_platform_ubuntu
 
 systemctl disable --now ctrl-alt-del.target
 systemctl mask --now ctrl-alt-del.target

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/tests/not_masked.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/tests/not_masked.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = Oracle Linux 7,Oracle Linux 8,multi_platform_rhel,multi_platform_fedora,multi_platform_ubuntu
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_fedora,multi_platform_ubuntu
 
 systemctl unmask ctrl-alt-del.target


### PR DESCRIPTION
#### Description:

Add OL9 to disable_ctrlaltdel_reboot tests

#### Rationale:

Align OL9 STIG profile with DISA STIG OL9 V1R1