### PR TITLE
Change platform of grub2_password

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/rule.yml
@@ -92,6 +92,7 @@ warnings:
         Also, do NOT manually add the superuser account and password to the
         <tt>grub.cfg</tt> file as the grub2-mkconfig command overwrites this file.
 
+platform: not container
 
 fixtext: |-
     Configure {{{ full_name }}} to require a grub bootloader password for the grub superuser account.


### PR DESCRIPTION
We will mark this rule with `platform: not container` to make it not applicable during container image build but applicable on running RHEL Image Mode system. The reason is that the rule checks files in /boot/grub2/ which don't exist during the container image build because they are created at deployment time by `bootupd` On running RHEL Image Mode system it makes sense to configure the password for GRUB. The remediation for the rule isn't available, users need to remediate manually by `grub2-setpassword`.
