### PR TITLE
Expand product specific control files CODEOWNERs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -21,8 +21,13 @@
 
 # Product Specific Control Files
 
+/controls/stig_ol9.yml  @ComplianceAsCode/oracle-maintainers
 /controls/cis_rhel8.yml @ComplianceAsCode/red-hatters
 /controls/cis_rhel9.yml @ComplianceAsCode/red-hatters
+/controls/cis_rhel10.yml @ComplianceAsCode/red-hatters
+/controls/stig_rhel8.yml @ComplianceAsCode/red-hatters
+/controls/stig_rhel9.yml @ComplianceAsCode/red-hatters
 /controls/cis_sle12.yml @ComplianceAsCode/suse-maintainers
 /controls/cis_sle15.yml @ComplianceAsCode/suse-maintainers
+/controls/stig_slemicro5.yml @ComplianceAsCode/suse-maintainers
 /controls/cis_ubuntu2404.yml @ComplianceAsCode/ubuntu-maintainers


### PR DESCRIPTION
#### Description:

Expand product specific control files CODEOWNERs

#### Rationale:
Ensure the rules are the same between products.
