### PR TITLE
Include marcusburghardt in new rules without group

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 # Global Owners
-/CODEOWNERS @vojtapolasek @jan-cerny @mab879 @ggbecker
-/ssg/ @vojtapolasek @jan-cerny @mab879 @ggbecker
+/CODEOWNERS @vojtapolasek @jan-cerny @mab879 @ggbecker @marcusburghardt
+/ssg/ @vojtapolasek @jan-cerny @mab879 @ggbecker @marcusburghardt
 /tests/ @matusmarhefka @mab879 @vojtapolasek @jan-cerny
 /linux_os/**/tests @matusmarhefka @mab879 @vojtapolasek @jan-cerny
 /shared/**/tests @matusmarhefka @mab879 @vojtapolasek @jan-cerny


### PR DESCRIPTION
I am activelly involved with SSG.

#### Description:

After the recent changes in CODEOWNERS, explicit handles are necessary in some new rules.
- https://github.com/ComplianceAsCode/content/pull/13333
- https://github.com/ComplianceAsCode/content/pull/13338
- https://github.com/ComplianceAsCode/content/pull/13342

This PR includes my name on rules related to files I am actively involved.

#### Rationale:

- I am actively involved with SSG
- Being able to merge PRs like this #13619

#### Review Hints:

It's a pretty simple PR.