### PR TITLE
Format rhel8 related yaml files

### DIFF
--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -4,3018 +4,3019 @@ title: 'CIS Benchmark for Red Hat Enterprise Linux 8'
 id: cis_rhel8
 version: '3.0.0'
 source: https://www.cisecurity.org/cis-benchmarks/#red_hat_linux
+
 levels:
-  - id: l1_server
-  - id: l2_server
-    inherits_from:
-      - l1_server
-  - id: l1_workstation
-  - id: l2_workstation
-    inherits_from:
-      - l1_workstation
+    - id: l1_server
+    - id: l2_server
+      inherits_from:
+          - l1_server
+    - id: l1_workstation
+    - id: l2_workstation
+      inherits_from:
+          - l1_workstation
+
 reference_type: cis
 product: rhel8
 
 controls:
-  - id: reload_dconf_db
-    title: Reload Dconf database
-    levels:
-      - l1_server
-      - l1_workstation
-    notes: <-
-      This is a helper rule to reload Dconf database correctly.
-    status: automated
-    rules:
-      - dconf_db_up_to_date
-
-  - id: enable_authselect
-    title: Enable Authselect
-    levels:
-      - l1_server
-      - l1_workstation
-    notes: <-
-      We need this in all CIS versions, but the policy doesn't have any section where this would fit better.
-    status: automated
-    rules:
-      - var_authselect_profile=sssd
-      - enable_authselect
-
-  - id: 1.1.1.1
-    title: Ensure cramfs kernel module is not available (Automated)
-    levels:
-      - l1_workstation
-      - l1_server
-    status: automated
-    rules:
-      - kernel_module_cramfs_disabled
-
-  - id: 1.1.1.2
-    title: Ensure freevxfs kernel module is not available (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - kernel_module_freevxfs_disabled
-
-  - id: 1.1.1.3
-    title: Ensure hfs kernel module is not available (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - kernel_module_hfs_disabled
-
-  - id: 1.1.1.4
-    title: Ensure hfsplus kernel module is not available (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - kernel_module_hfsplus_disabled
-
-  - id: 1.1.1.5
-    title: Ensure jffs2 kernel module is not available (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - kernel_module_jffs2_disabled
-
-  - id: 1.1.1.6
-    title: Ensure squashfs kernel module is not available (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - kernel_module_squashfs_disabled
-
-  - id: 1.1.1.7
-    title: Ensure udf kernel module is not available (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - kernel_module_udf_disabled
-
-  - id: 1.1.1.8
-    title: Ensure usb-storage kernel module is not available (Automated)
-    levels:
-      - l1_server
-      - l2_workstation
-    status: automated
-    rules:
-      - kernel_module_usb-storage_disabled
-
-  - id: 1.1.2.1.1
-    title: Ensure /tmp is a separate partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - partition_for_tmp
-
-  - id: 1.1.2.1.2
-    title: Ensure nodev option set on /tmp partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_tmp_nodev
-
-  - id: 1.1.2.1.3
-    title: Ensure nosuid option set on /tmp partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_tmp_nosuid
-
-  - id: 1.1.2.1.4
-    title: Ensure noexec option set on /tmp partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_tmp_noexec
-
-  - id: 1.1.2.2.1
-    title: Ensure /dev/shm is a separate partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - partition_for_dev_shm
-
-  - id: 1.1.2.2.2
-    title: Ensure nodev option set on /dev/shm partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_dev_shm_nodev
-
-  - id: 1.1.2.2.3
-    title: Ensure nosuid option set on /dev/shm partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_dev_shm_nosuid
-
-  - id: 1.1.2.2.4
-    title: Ensure noexec option set on /dev/shm partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_dev_shm_noexec
-
-  - id: 1.1.2.3.1
-    title: Ensure separate partition exists for /home (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - partition_for_home
-
-  - id: 1.1.2.3.2
-    title: Ensure nodev option set on /home partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_home_nodev
-
-  - id: 1.1.2.3.3
-    title: Ensure nosuid option set on /home partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_home_nosuid
-
-  - id: 1.1.2.4.1
-    title: Ensure separate partition exists for /var (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - partition_for_var
-
-  - id: 1.1.2.4.2
-    title: Ensure nodev option set on /var partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_nodev
-
-  - id: 1.1.2.4.3
-    title: Ensure nosuid option set on /var partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_nosuid
-
-  - id: 1.1.2.5.1
-    title: Ensure separate partition exists for /var/tmp (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - partition_for_var_tmp
-
-  - id: 1.1.2.5.2
-    title: Ensure nodev option set on /var/tmp partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_tmp_nodev
-
-  - id: 1.1.2.5.3
-    title: Ensure nosuid option set on /var/tmp partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_tmp_nosuid
-
-  - id: 1.1.2.5.4
-    title: Ensure noexec option set on /var/tmp partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_tmp_noexec
-
-  - id: 1.1.2.6.1
-    title: Ensure separate partition exists for /var/log (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - partition_for_var_log
-
-  - id: 1.1.2.6.2
-    title: Ensure nodev option set on /var/log partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_log_nodev
-
-  - id: 1.1.2.6.3
-    title: Ensure nosuid option set on /var/log partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_log_nosuid
-
-  - id: 1.1.2.6.4
-    title: Ensure noexec option set on /var/log partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_log_noexec
-
-  - id: 1.1.2.7.1
-    title: Ensure separate partition exists for /var/log/audit (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - partition_for_var_log_audit
-
-  - id: 1.1.2.7.2
-    title: Ensure nodev option set on /var/log/audit partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_log_audit_nodev
-
-  - id: 1.1.2.7.3
-    title: Ensure nosuid option set on /var/log/audit partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_log_audit_nosuid
-
-  - id: 1.1.2.7.4
-    title: Ensure noexec option set on /var/log/audit partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_log_audit_noexec
-
-  - id: 1.2.1
-    title: Ensure GPG keys are configured (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-    related_rules:
-      - ensure_redhat_gpgkey_installed
-
-  - id: 1.2.2
-    title: Ensure gpgcheck is globally activated (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - ensure_gpgcheck_globally_activated
-      - ensure_gpgcheck_never_disabled
-
-  - id: 1.2.3
-    title: Ensure repo_gpgcheck is globally activated (Manual)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: manual
-
-  - id: 1.2.4
-    title: Ensure package manager repositories are configured (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 1.2.5
-    title: Ensure updates, patches, and additional security software are installed (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-    related_rules:
-      - security_patches_up_to_date
-
-  - id: 1.3.1
-    title: Ensure bootloader password is set (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - grub2_password
-      - grub2_uefi_password
-
-  - id: 1.3.2
-    title: Ensure permissions on bootloader config are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_efi_grub2_cfg
-      - file_groupowner_grub2_cfg
-      - file_owner_efi_grub2_cfg
-      - file_owner_grub2_cfg
-      - file_permissions_efi_grub2_cfg
-      - file_permissions_grub2_cfg
-      - file_groupowner_efi_user_cfg
-      - file_groupowner_user_cfg
-      - file_owner_efi_user_cfg
-      - file_owner_user_cfg
-      - file_permissions_efi_user_cfg
-      - file_permissions_user_cfg
-
-  - id: 1.4.1
-    title: Ensure address space layout randomization (ASLR) is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_kernel_randomize_va_space
-
-  - id: 1.4.2
-    title: Ensure ptrace_scope is restricted (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_kernel_yama_ptrace_scope
-
-  - id: 1.4.3
-    title: Ensure core dump backtraces are disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - coredump_disable_backtraces
-
-  - id: 1.4.4
-    title: Ensure core dump storage is disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - coredump_disable_storage
-
-  - id: 1.5.1.1
-    title: Ensure SELinux is installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_libselinux_installed
-
-  - id: 1.5.1.2
-    title: Ensure SELinux is not disabled in bootloader configuration (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - grub2_enable_selinux
-
-  - id: 1.5.1.3
-    title: Ensure SELinux policy is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - var_selinux_policy_name=targeted
-      - selinux_policytype
-
-  - id: 1.5.1.4
-    title: Ensure the SELinux mode is not disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - selinux_not_disabled
-
-  - id: 1.5.1.5
-    title: Ensure the SELinux mode is enforcing (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - var_selinux_state=enforcing
-      - selinux_state
-
-  - id: 1.5.1.6
-    title: Ensure no unconfined services exist (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - selinux_confinement_of_daemons
-
-  - id: 1.5.1.7
-    title: Ensure the MCS Translation Service (mcstrans) is not installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_mcstrans_removed
-
-  - id: 1.5.1.8
-    title: Ensure SETroubleshoot is not installed (Automated)
-    levels:
-      - l1_server
-    status: automated
-    rules:
-      - package_setroubleshoot_removed
-
-  - id: 1.6.1
-    title: Ensure system wide crypto policy is not set to legacy (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - configure_crypto_policy
-      - var_system_crypto_policy=default_nosha1
-
-  - id: 1.6.2
-    title: Ensure system wide crypto policy disables sha1 hash and signature support (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      This requirement is already satisfied by 1.6.1.
-    related_rules:
-      - configure_crypto_policy
-
-  - id: 1.6.3
-    title: Ensure system wide crypto policy disables cbc for ssh (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      It is necessary a new rule to ensure a module disabling CBC in
-      /etc/crypto-policies/policies/modules/ so it can be used by update-crypto-policies command.
-    related_rules:
-      - configure_crypto_policy
-
-  - id: 1.6.4
-    title: Ensure system wide crypto policy disables macs less than 128 bits (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      It is necessary a new rule to ensure a module disabling weak MACs in
-      /etc/crypto-policies/policies/modules/ so it can be used by update-crypto-policies command.
-    related_rules:
-      - configure_crypto_policy
-
-  - id: 1.7.1
-    title: Ensure message of the day is configured properly (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - banner_etc_motd_cis
-      - cis_banner_text=cis
-
-  - id: 1.7.2
-    title: Ensure local login warning banner is configured properly (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - banner_etc_issue_cis
-      - cis_banner_text=cis
-
-  - id: 1.7.3
-    title: Ensure remote login warning banner is configured properly (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - banner_etc_issue_net_cis
-      - cis_banner_text=cis
-
-  - id: 1.7.4
-    title: Ensure access to /etc/motd is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_etc_motd
-      - file_owner_etc_motd
-      - file_permissions_etc_motd
-
-  - id: 1.7.5
-    title: Ensure access to /etc/issue is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_etc_issue
-      - file_owner_etc_issue
-      - file_permissions_etc_issue
-
-  - id: 1.7.6
-    title: Ensure access to /etc/issue.net is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_etc_issue_net
-      - file_owner_etc_issue_net
-      - file_permissions_etc_issue_net
-
-  - id: 1.8.1
-    title: Ensure GNOME Display Manager is removed (Automated)
-    levels:
-      - l2_server
-    status: automated
-    rules:
-      - package_gdm_removed
-
-  - id: 1.8.2
-    title: Ensure GDM login banner is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - dconf_gnome_banner_enabled
-      - dconf_gnome_login_banner_text
-      - login_banner_text=cis_banners
-
-  - id: 1.8.3
-    title: Ensure GDM disable-user-list option is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - dconf_gnome_disable_user_list
-
-  - id: 1.8.4
-    title: Ensure GDM screen locks when the user is idle (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - dconf_gnome_screensaver_idle_delay
-      - dconf_gnome_screensaver_lock_delay
-      - inactivity_timeout_value=15_minutes
-      - var_screensaver_lock_delay=5_seconds
-
-  - id: 1.8.5
-    title: Ensure GDM screen locks cannot be overridden (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - dconf_gnome_session_idle_user_locks
-      - dconf_gnome_screensaver_user_locks
-
-  - id: 1.8.6
-    title: Ensure GDM automatic mounting of removable media is disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - dconf_gnome_disable_automount
-      - dconf_gnome_disable_automount_open
-
-  - id: 1.8.7
-    title: Ensure GDM disabling automatic mounting of removable media is not overridden (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      The same rules used in 1.8.6 are applicable here since they configure and also lock the
-      settings.
-    related_rules:
-      - dconf_gnome_disable_automount
-      - dconf_gnome_disable_automount_open
-
-  - id: 1.8.8
-    title: Ensure GDM autorun-never is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - dconf_gnome_disable_autorun
-
-  - id: 1.8.9
-    title: Ensure GDM autorun-never is not overridden (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      The same rules used in 1.8.8 are applicable here since they configure and also lock the
-      settings.
-    related_rules:
-      - dconf_gnome_disable_autorun
-
-  - id: 1.8.10
-    title: Ensure XDMCP is not enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - gnome_gdm_disable_xdmcp
-
-  - id: 2.1.1
-    title: Ensure time synchronization is in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_chrony_installed
-
-  - id: 2.1.2
-    title: Ensure chrony is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - chronyd_specify_remote_server
-      - var_multiple_time_servers=rhel
-
-  - id: 2.1.3
-    title: Ensure chrony is not run as the root user (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - chronyd_run_as_chrony_user
-
-  - id: 2.2.1
-    title: Ensure autofs services are not in use (Automated)
-    levels:
-      - l1_server
-      - l2_workstation
-    status: automated
-    rules:
-      - service_autofs_disabled
-
-  - id: 2.2.2
-    title: Ensure avahi daemon services are not in use (Automated)
-    levels:
-      - l1_server
-      - l2_workstation
-    status: automated
-    rules:
-      - service_avahi-daemon_disabled
-    related_rules:
-      - package_avahi_removed
-
-  - id: 2.2.3
-    title: Ensure dhcp server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_dhcp_removed
-    related_rules:
-      - service_dhcpd_disabled
-
-  - id: 2.2.4
-    title: Ensure dns server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_bind_removed
-    related_rules:
-      - service_named_disabled
-
-  - id: 2.2.5
-    title: Ensure dnsmasq services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_dnsmasq_removed
-
-  - id: 2.2.6
-    title: Ensure samba file server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_samba_removed
-    related_rules:
-      - service_smb_disabled
-
-  - id: 2.2.7
-    title: Ensure ftp server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_vsftpd_removed
-    related_rules:
-      - service_vsftpd_disabled
-
-  - id: 2.2.8
-    title: Ensure message access server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_dovecot_removed
-      - package_cyrus-imapd_removed
-    related_rules:
-      - service_dovecot_disabled
+    - id: reload_dconf_db
+      title: Reload Dconf database
+      levels:
+          - l1_server
+          - l1_workstation
+      notes: <- This is a helper rule to reload Dconf database correctly.
+      status: automated
+      rules:
+          - dconf_db_up_to_date
+
+    - id: enable_authselect
+      title: Enable Authselect
+      levels:
+          - l1_server
+          - l1_workstation
+      notes: <- We need this in all CIS versions, but the policy doesn't have any section where this
+          would fit better.
+      status: automated
+      rules:
+          - var_authselect_profile=sssd
+          - enable_authselect
+
+    - id: 1.1.1.1
+      title: Ensure cramfs kernel module is not available (Automated)
+      levels:
+          - l1_workstation
+          - l1_server
+      status: automated
+      rules:
+          - kernel_module_cramfs_disabled
+
+    - id: 1.1.1.2
+      title: Ensure freevxfs kernel module is not available (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - kernel_module_freevxfs_disabled
+
+    - id: 1.1.1.3
+      title: Ensure hfs kernel module is not available (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - kernel_module_hfs_disabled
+
+    - id: 1.1.1.4
+      title: Ensure hfsplus kernel module is not available (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - kernel_module_hfsplus_disabled
+
+    - id: 1.1.1.5
+      title: Ensure jffs2 kernel module is not available (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - kernel_module_jffs2_disabled
+
+    - id: 1.1.1.6
+      title: Ensure squashfs kernel module is not available (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - kernel_module_squashfs_disabled
+
+    - id: 1.1.1.7
+      title: Ensure udf kernel module is not available (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - kernel_module_udf_disabled
+
+    - id: 1.1.1.8
+      title: Ensure usb-storage kernel module is not available (Automated)
+      levels:
+          - l1_server
+          - l2_workstation
+      status: automated
+      rules:
+          - kernel_module_usb-storage_disabled
+
+    - id: 1.1.2.1.1
+      title: Ensure /tmp is a separate partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - partition_for_tmp
+
+    - id: 1.1.2.1.2
+      title: Ensure nodev option set on /tmp partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_tmp_nodev
+
+    - id: 1.1.2.1.3
+      title: Ensure nosuid option set on /tmp partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_tmp_nosuid
+
+    - id: 1.1.2.1.4
+      title: Ensure noexec option set on /tmp partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_tmp_noexec
+
+    - id: 1.1.2.2.1
+      title: Ensure /dev/shm is a separate partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - partition_for_dev_shm
+
+    - id: 1.1.2.2.2
+      title: Ensure nodev option set on /dev/shm partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_dev_shm_nodev
+
+    - id: 1.1.2.2.3
+      title: Ensure nosuid option set on /dev/shm partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_dev_shm_nosuid
+
+    - id: 1.1.2.2.4
+      title: Ensure noexec option set on /dev/shm partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_dev_shm_noexec
+
+    - id: 1.1.2.3.1
+      title: Ensure separate partition exists for /home (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - partition_for_home
+
+    - id: 1.1.2.3.2
+      title: Ensure nodev option set on /home partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_home_nodev
+
+    - id: 1.1.2.3.3
+      title: Ensure nosuid option set on /home partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_home_nosuid
+
+    - id: 1.1.2.4.1
+      title: Ensure separate partition exists for /var (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - partition_for_var
+
+    - id: 1.1.2.4.2
+      title: Ensure nodev option set on /var partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_nodev
+
+    - id: 1.1.2.4.3
+      title: Ensure nosuid option set on /var partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_nosuid
+
+    - id: 1.1.2.5.1
+      title: Ensure separate partition exists for /var/tmp (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - partition_for_var_tmp
+
+    - id: 1.1.2.5.2
+      title: Ensure nodev option set on /var/tmp partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_tmp_nodev
+
+    - id: 1.1.2.5.3
+      title: Ensure nosuid option set on /var/tmp partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_tmp_nosuid
+
+    - id: 1.1.2.5.4
+      title: Ensure noexec option set on /var/tmp partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_tmp_noexec
+
+    - id: 1.1.2.6.1
+      title: Ensure separate partition exists for /var/log (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - partition_for_var_log
+
+    - id: 1.1.2.6.2
+      title: Ensure nodev option set on /var/log partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_log_nodev
+
+    - id: 1.1.2.6.3
+      title: Ensure nosuid option set on /var/log partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_log_nosuid
+
+    - id: 1.1.2.6.4
+      title: Ensure noexec option set on /var/log partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_log_noexec
+
+    - id: 1.1.2.7.1
+      title: Ensure separate partition exists for /var/log/audit (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - partition_for_var_log_audit
+
+    - id: 1.1.2.7.2
+      title: Ensure nodev option set on /var/log/audit partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_log_audit_nodev
+
+    - id: 1.1.2.7.3
+      title: Ensure nosuid option set on /var/log/audit partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_log_audit_nosuid
+
+    - id: 1.1.2.7.4
+      title: Ensure noexec option set on /var/log/audit partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_log_audit_noexec
+
+    - id: 1.2.1
+      title: Ensure GPG keys are configured (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+      related_rules:
+          - ensure_redhat_gpgkey_installed
+
+    - id: 1.2.2
+      title: Ensure gpgcheck is globally activated (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - ensure_gpgcheck_globally_activated
+          - ensure_gpgcheck_never_disabled
+
+    - id: 1.2.3
+      title: Ensure repo_gpgcheck is globally activated (Manual)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: manual
+
+    - id: 1.2.4
+      title: Ensure package manager repositories are configured (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 1.2.5
+      title: Ensure updates, patches, and additional security software are installed (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+      related_rules:
+          - security_patches_up_to_date
+
+    - id: 1.3.1
+      title: Ensure bootloader password is set (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - grub2_password
+          - grub2_uefi_password
+
+    - id: 1.3.2
+      title: Ensure permissions on bootloader config are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_efi_grub2_cfg
+          - file_groupowner_grub2_cfg
+          - file_owner_efi_grub2_cfg
+          - file_owner_grub2_cfg
+          - file_permissions_efi_grub2_cfg
+          - file_permissions_grub2_cfg
+          - file_groupowner_efi_user_cfg
+          - file_groupowner_user_cfg
+          - file_owner_efi_user_cfg
+          - file_owner_user_cfg
+          - file_permissions_efi_user_cfg
+          - file_permissions_user_cfg
+
+    - id: 1.4.1
+      title: Ensure address space layout randomization (ASLR) is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_kernel_randomize_va_space
+
+    - id: 1.4.2
+      title: Ensure ptrace_scope is restricted (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_kernel_yama_ptrace_scope
+
+    - id: 1.4.3
+      title: Ensure core dump backtraces are disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - coredump_disable_backtraces
+
+    - id: 1.4.4
+      title: Ensure core dump storage is disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - coredump_disable_storage
+
+    - id: 1.5.1.1
+      title: Ensure SELinux is installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_libselinux_installed
+
+    - id: 1.5.1.2
+      title: Ensure SELinux is not disabled in bootloader configuration (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - grub2_enable_selinux
+
+    - id: 1.5.1.3
+      title: Ensure SELinux policy is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - var_selinux_policy_name=targeted
+          - selinux_policytype
+
+    - id: 1.5.1.4
+      title: Ensure the SELinux mode is not disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - selinux_not_disabled
+
+    - id: 1.5.1.5
+      title: Ensure the SELinux mode is enforcing (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - var_selinux_state=enforcing
+          - selinux_state
+
+    - id: 1.5.1.6
+      title: Ensure no unconfined services exist (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - selinux_confinement_of_daemons
+
+    - id: 1.5.1.7
+      title: Ensure the MCS Translation Service (mcstrans) is not installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_mcstrans_removed
+
+    - id: 1.5.1.8
+      title: Ensure SETroubleshoot is not installed (Automated)
+      levels:
+          - l1_server
+      status: automated
+      rules:
+          - package_setroubleshoot_removed
+
+    - id: 1.6.1
+      title: Ensure system wide crypto policy is not set to legacy (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - configure_crypto_policy
+          - var_system_crypto_policy=default_nosha1
+
+    - id: 1.6.2
+      title: Ensure system wide crypto policy disables sha1 hash and signature support (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          This requirement is already satisfied by 1.6.1.
+      related_rules:
+          - configure_crypto_policy
+
+    - id: 1.6.3
+      title: Ensure system wide crypto policy disables cbc for ssh (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          It is necessary a new rule to ensure a module disabling CBC in
+          /etc/crypto-policies/policies/modules/ so it can be used by update-crypto-policies command.
+      related_rules:
+          - configure_crypto_policy
+
+    - id: 1.6.4
+      title: Ensure system wide crypto policy disables macs less than 128 bits (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          It is necessary a new rule to ensure a module disabling weak MACs in
+          /etc/crypto-policies/policies/modules/ so it can be used by update-crypto-policies command.
+      related_rules:
+          - configure_crypto_policy
+
+    - id: 1.7.1
+      title: Ensure message of the day is configured properly (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - banner_etc_motd_cis
+          - cis_banner_text=cis
+
+    - id: 1.7.2
+      title: Ensure local login warning banner is configured properly (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - banner_etc_issue_cis
+          - cis_banner_text=cis
+
+    - id: 1.7.3
+      title: Ensure remote login warning banner is configured properly (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - banner_etc_issue_net_cis
+          - cis_banner_text=cis
+
+    - id: 1.7.4
+      title: Ensure access to /etc/motd is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_etc_motd
+          - file_owner_etc_motd
+          - file_permissions_etc_motd
+
+    - id: 1.7.5
+      title: Ensure access to /etc/issue is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_etc_issue
+          - file_owner_etc_issue
+          - file_permissions_etc_issue
+
+    - id: 1.7.6
+      title: Ensure access to /etc/issue.net is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_etc_issue_net
+          - file_owner_etc_issue_net
+          - file_permissions_etc_issue_net
+
+    - id: 1.8.1
+      title: Ensure GNOME Display Manager is removed (Automated)
+      levels:
+          - l2_server
+      status: automated
+      rules:
+          - package_gdm_removed
+
+    - id: 1.8.2
+      title: Ensure GDM login banner is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - dconf_gnome_banner_enabled
+          - dconf_gnome_login_banner_text
+          - login_banner_text=cis_banners
+
+    - id: 1.8.3
+      title: Ensure GDM disable-user-list option is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - dconf_gnome_disable_user_list
+
+    - id: 1.8.4
+      title: Ensure GDM screen locks when the user is idle (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - dconf_gnome_screensaver_idle_delay
+          - dconf_gnome_screensaver_lock_delay
+          - inactivity_timeout_value=15_minutes
+          - var_screensaver_lock_delay=5_seconds
+
+    - id: 1.8.5
+      title: Ensure GDM screen locks cannot be overridden (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - dconf_gnome_session_idle_user_locks
+          - dconf_gnome_screensaver_user_locks
+
+    - id: 1.8.6
+      title: Ensure GDM automatic mounting of removable media is disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - dconf_gnome_disable_automount
+          - dconf_gnome_disable_automount_open
+
+    - id: 1.8.7
+      title: Ensure GDM disabling automatic mounting of removable media is not overridden (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          The same rules used in 1.8.6 are applicable here since they configure and also lock the
+          settings.
+      related_rules:
+          - dconf_gnome_disable_automount
+          - dconf_gnome_disable_automount_open
+
+    - id: 1.8.8
+      title: Ensure GDM autorun-never is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - dconf_gnome_disable_autorun
+
+    - id: 1.8.9
+      title: Ensure GDM autorun-never is not overridden (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          The same rules used in 1.8.8 are applicable here since they configure and also lock the
+          settings.
+      related_rules:
+          - dconf_gnome_disable_autorun
+
+    - id: 1.8.10
+      title: Ensure XDMCP is not enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - gnome_gdm_disable_xdmcp
+
+    - id: 2.1.1
+      title: Ensure time synchronization is in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_chrony_installed
+
+    - id: 2.1.2
+      title: Ensure chrony is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - chronyd_specify_remote_server
+          - var_multiple_time_servers=rhel
+
+    - id: 2.1.3
+      title: Ensure chrony is not run as the root user (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - chronyd_run_as_chrony_user
+
+    - id: 2.2.1
+      title: Ensure autofs services are not in use (Automated)
+      levels:
+          - l1_server
+          - l2_workstation
+      status: automated
+      rules:
+          - service_autofs_disabled
+
+    - id: 2.2.2
+      title: Ensure avahi daemon services are not in use (Automated)
+      levels:
+          - l1_server
+          - l2_workstation
+      status: automated
+      rules:
+          - service_avahi-daemon_disabled
+      related_rules:
+          - package_avahi_removed
+
+    - id: 2.2.3
+      title: Ensure dhcp server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_dhcp_removed
+      related_rules:
+          - service_dhcpd_disabled
+
+    - id: 2.2.4
+      title: Ensure dns server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_bind_removed
+      related_rules:
+          - service_named_disabled
+
+    - id: 2.2.5
+      title: Ensure dnsmasq services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_dnsmasq_removed
+
+    - id: 2.2.6
+      title: Ensure samba file server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_samba_removed
+      related_rules:
+          - service_smb_disabled
+
+    - id: 2.2.7
+      title: Ensure ftp server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_vsftpd_removed
+      related_rules:
+          - service_vsftpd_disabled
+
+    - id: 2.2.8
+      title: Ensure message access server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_dovecot_removed
+          - package_cyrus-imapd_removed
+      related_rules:
+          - service_dovecot_disabled
     # new rule would be nice to disable cyrus-imapd service
 
-  - id: 2.2.9
-    title: Ensure network file system services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - service_nfs_disabled
-    related_rules:
-      - package_nfs-utils_removed
-    notes: |-
-      Many of the libvirt packages used by Enterprise Linux virtualization are
-      dependent on the nfs-utils package.
+    - id: 2.2.9
+      title: Ensure network file system services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - service_nfs_disabled
+      related_rules:
+          - package_nfs-utils_removed
+      notes: |-
+          Many of the libvirt packages used by Enterprise Linux virtualization are
+          dependent on the nfs-utils package.
 
-  - id: 2.2.10
-    title: Ensure nis server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_ypserv_removed
-    related_rules:
-      - service_ypserv_disabled
+    - id: 2.2.10
+      title: Ensure nis server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_ypserv_removed
+      related_rules:
+          - service_ypserv_disabled
 
-  - id: 2.2.11
-    title: Ensure print server services are not in use (Automated)
-    levels:
-      - l1_server
-    status: automated
-    rules:
-      - service_cups_disabled
-    related_rules:
-      - package_cups_removed
+    - id: 2.2.11
+      title: Ensure print server services are not in use (Automated)
+      levels:
+          - l1_server
+      status: automated
+      rules:
+          - service_cups_disabled
+      related_rules:
+          - package_cups_removed
 
-  - id: 2.2.12
-    title: Ensure rpcbind services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - service_rpcbind_disabled
-    related_rules:
-      - package_rpcbind_removed
-    notes: |-
-      Many of the libvirt packages used by Enterprise Linux virtualization, and
-      the nfs-utils
-      package used for The Network File System (NFS), are dependent on the rpcbind
-      package.
+    - id: 2.2.12
+      title: Ensure rpcbind services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - service_rpcbind_disabled
+      related_rules:
+          - package_rpcbind_removed
+      notes: |-
+          Many of the libvirt packages used by Enterprise Linux virtualization, and
+          the nfs-utils
+          package used for The Network File System (NFS), are dependent on the rpcbind
+          package.
 
-  - id: 2.2.13
-    title: Ensure rsync services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_rsync_removed
-    related_rules:
-      - service_rsyncd_disabled
+    - id: 2.2.13
+      title: Ensure rsync services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_rsync_removed
+      related_rules:
+          - service_rsyncd_disabled
 
-  - id: 2.2.14
-    title: Ensure snmp services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_net-snmp_removed
-    related_rules:
-      - service_snmpd_disabled
+    - id: 2.2.14
+      title: Ensure snmp services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_net-snmp_removed
+      related_rules:
+          - service_snmpd_disabled
 
-  - id: 2.2.15
-    title: Ensure telnet server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_telnet-server_removed
-    related_rules:
-      - service_telnet_disabled
+    - id: 2.2.15
+      title: Ensure telnet server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_telnet-server_removed
+      related_rules:
+          - service_telnet_disabled
 
-  - id: 2.2.16
-    title: Ensure tftp server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_tftp-server_removed
-    related_rules:
-      - service_tftp_disabled
+    - id: 2.2.16
+      title: Ensure tftp server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_tftp-server_removed
+      related_rules:
+          - service_tftp_disabled
 
-  - id: 2.2.17
-    title: Ensure web proxy server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_squid_removed
-    related_rules:
-      - service_squid_disabled
+    - id: 2.2.17
+      title: Ensure web proxy server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_squid_removed
+      related_rules:
+          - service_squid_disabled
 
-  - id: 2.2.18
-    title: Ensure web server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_httpd_removed
-      - package_nginx_removed
-    related_rules:
-      - service_httpd_disabled
+    - id: 2.2.18
+      title: Ensure web server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_httpd_removed
+          - package_nginx_removed
+      related_rules:
+          - service_httpd_disabled
     # rule would be nice to disable nginx service
 
-  - id: 2.2.19
-    title: Ensure xinetd services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_xinetd_removed
-    related_rules:
-      - service_xinetd_disabled
-
-  - id: 2.2.20
-    title: Ensure X window server services are not in use (Automated)
-    levels:
-      - l2_server
-    status: automated
-    notes: >-
-      The rule also configures correct run level to prevent unbootable system.
-    rules:
-      - package_xorg-x11-server-common_removed
-      - xwindows_runlevel_target
-
-  - id: 2.2.21
-    title: Ensure mail transfer agents are configured for local-only mode (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: partial
-    notes:  |-
-      The rule has_nonlocal_mta currently checks for services listening only on
-      port 25, but the policy checks also for ports 465 and 587
-    rules:
-      - postfix_network_listening_disabled
-      - var_postfix_inet_interfaces=loopback-only
-      - has_nonlocal_mta
-
-  - id: 2.2.22
-    title: Ensure only approved services are listening on a network interface (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 2.3.1
-    title: Ensure ftp client is not installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_ftp_removed
-
-  - id: 2.3.2
-    title: Ensure LDAP client is not installed (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - package_openldap-clients_removed
-
-  - id: 2.3.3
-    title: Ensure NIS Client is not installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_ypbind_removed
-
-  - id: 2.3.4
-    title: Ensure telnet client is not installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_telnet_removed
-
-  - id: 2.3.5
-    title: Ensure tftp client is not installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_tftp_removed
-
-  - id: 3.1.1
-    title: Ensure IPv6 status is identified (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 3.1.2
-    title: Ensure wireless interfaces are disabled (Automated)
-    levels:
-      - l1_server
-    status: automated
-    rules:
-      - wireless_disable_interfaces
-
-  - id: 3.1.3
-    title: Ensure bluetooth services are not in use (Automated)
-    levels:
-      - l1_server
-      - l2_workstation
-    status: automated
-    rules:
-      - service_bluetooth_disabled
-
-  - id: 3.2.1
-    title: Ensure dccp kernel module is not available (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - kernel_module_dccp_disabled
-
-  - id: 3.2.2
-    title: Ensure tipc kernel module is not available (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - kernel_module_tipc_disabled
-
-  - id: 3.2.3
-    title: Ensure rds kernel module is not available (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - kernel_module_rds_disabled
-
-  - id: 3.2.4
-    title: Ensure sctp kernel module is not available (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - kernel_module_sctp_disabled
-
-  - id: 3.3.1
-    title: Ensure ip forwarding is disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_ip_forward
-      - sysctl_net_ipv6_conf_all_forwarding
-      - sysctl_net_ipv6_conf_all_forwarding_value=disabled
-
-  - id: 3.3.2
-    title: Ensure packet redirect sending is disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_conf_all_send_redirects
-      - sysctl_net_ipv4_conf_default_send_redirects
-
-  - id: 3.3.3
-    title: Ensure bogus icmp responses are ignored (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
-      - sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value=enabled
-
-  - id: 3.3.4
-    title: Ensure broadcast icmp requests are ignored(Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
-      - sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value=enabled
-
-  - id: 3.3.5
-    title: Ensure icmp redirects are not accepted (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_conf_all_accept_redirects
-      - sysctl_net_ipv4_conf_all_accept_redirects_value=disabled
-      - sysctl_net_ipv4_conf_default_accept_redirects
-      - sysctl_net_ipv4_conf_default_accept_redirects_value=disabled
-      - sysctl_net_ipv6_conf_all_accept_redirects
-      - sysctl_net_ipv6_conf_all_accept_redirects_value=disabled
-      - sysctl_net_ipv6_conf_default_accept_redirects
-      - sysctl_net_ipv6_conf_default_accept_redirects_value=disabled
-
-  - id: 3.3.6
-    title: Ensure secure icmp redirects are not accepted (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_conf_all_secure_redirects
-      - sysctl_net_ipv4_conf_all_secure_redirects_value=disabled
-      - sysctl_net_ipv4_conf_default_secure_redirects
-      - sysctl_net_ipv4_conf_default_secure_redirects_value=disabled
-
-  - id: 3.3.7
-    title: Ensure reverse path filtering is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_conf_all_rp_filter
-      - sysctl_net_ipv4_conf_all_rp_filter_value=enabled
-      - sysctl_net_ipv4_conf_default_rp_filter
-      - sysctl_net_ipv4_conf_default_rp_filter_value=enabled
-
-  - id: 3.3.8
-    title: Ensure source routed packets are not accepted (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_conf_all_accept_source_route
-      - sysctl_net_ipv4_conf_all_accept_source_route_value=disabled
-      - sysctl_net_ipv4_conf_default_accept_source_route
-      - sysctl_net_ipv4_conf_default_accept_source_route_value=disabled
-      - sysctl_net_ipv6_conf_all_accept_source_route
-      - sysctl_net_ipv6_conf_all_accept_source_route_value=disabled
-      - sysctl_net_ipv6_conf_default_accept_source_route
-      - sysctl_net_ipv6_conf_default_accept_source_route_value=disabled
-
-  - id: 3.3.9
-    title: Ensure suspicious packets are logged (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_conf_all_log_martians
-      - sysctl_net_ipv4_conf_all_log_martians_value=enabled
-      - sysctl_net_ipv4_conf_default_log_martians
-      - sysctl_net_ipv4_conf_default_log_martians_value=enabled
-
-  - id: 3.3.10
-    title: Ensure tcp sync cookies is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_tcp_syncookies
-      - sysctl_net_ipv4_tcp_syncookies_value=enabled
-
-  - id: 3.3.11
-    title: Ensure IPv6 router advertisements are not accepted (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv6_conf_all_accept_ra
-      - sysctl_net_ipv6_conf_all_accept_ra_value=disabled
-      - sysctl_net_ipv6_conf_default_accept_ra
-      - sysctl_net_ipv6_conf_default_accept_ra_value=disabled
-
-  - id: 3.4.1.1
-    title: Ensure nftables is installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_nftables_installed
-
-  - id: 3.4.1.2
-    title: Ensure a single firewall configuration utility is in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - service_firewalld_enabled
-      - package_firewalld_installed
-      - service_nftables_disabled
-
-  - id: 3.4.2.1
-    title: Ensure nftables base chains exist (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: supported
-    notes: |-
-      RHEL systems use firewalld for firewall management. Although nftables is the default
-      back-end for firewalld, it is not recommended to use nftables directly when firewalld
-      is in use. When using firewalld the base chains are installed by default.
-    related_rules:
-      - set_nftables_base_chain
-      - var_nftables_table=firewalld
-      - var_nftables_family=inet
-      - var_nftables_base_chain_names=chain_names
-      - var_nftables_base_chain_types=chain_types
-      - var_nftables_base_chain_hooks=chain_hooks
-      - var_nftables_base_chain_priorities=chain_priorities
-      - var_nftables_base_chain_policies=chain_policies
-
-  - id: 3.4.2.2
-    title: Ensure host based firewall loopback traffic is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - firewalld_loopback_traffic_trusted
-      - firewalld_loopback_traffic_restricted
-
-  - id: 3.4.2.3
-    title: Ensure firewalld drops unnecessary services and ports (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 3.4.2.4
-    title: Ensure nftables established connections are configured (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: supported
-    notes: |-
-      RHEL systems use firewalld for firewall management. Although nftables is the default
-      back-end for firewalld, it is not recommended to use nftables directly when firewalld
-      is in use. When using firewalld the base chains are installed by default.
-    related_rules:
-    - set_nftables_new_connections
-
-  - id: 3.4.2.5
-    title: Ensure nftables default deny firewall policy (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: supported
-    notes: |-
-      RHEL systems use firewalld for firewall management. Although nftables is the default
-      back-end for firewalld, it is not recommended to use nftables directly when firewalld
-      is in use.
-    related_rules:
-      - nftables_ensure_default_deny_policy
-
-  - id: 4.1.1.1
-    title: Ensure cron daemon is enabled and active (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - service_crond_enabled
-
-  - id: 4.1.1.2
-    title: Ensure permissions on /etc/crontab are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_crontab
-      - file_owner_crontab
-      - file_permissions_crontab
-
-  - id: 4.1.1.3
-    title: Ensure permissions on /etc/cron.hourly are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_cron_hourly
-      - file_owner_cron_hourly
-      - file_permissions_cron_hourly
-
-  - id: 4.1.1.4
-    title: Ensure permissions on /etc/cron.daily are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_cron_daily
-      - file_owner_cron_daily
-      - file_permissions_cron_daily
-
-  - id: 4.1.1.5
-    title: Ensure permissions on /etc/cron.weekly are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_cron_weekly
-      - file_owner_cron_weekly
-      - file_permissions_cron_weekly
-
-  - id: 4.1.1.6
-    title: Ensure permissions on /etc/cron.monthly are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_cron_monthly
-      - file_owner_cron_monthly
-      - file_permissions_cron_monthly
-
-  - id: 4.1.1.7
-    title: Ensure permissions on /etc/cron.d are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_cron_d
-      - file_owner_cron_d
-      - file_permissions_cron_d
-
-  - id: 4.1.1.8
-    title: Ensure cron is restricted to authorized users (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_cron_deny_not_exist
-      - file_cron_allow_exists
-      - file_groupowner_cron_allow
-      - file_owner_cron_allow
-      - file_permissions_cron_allow
-
-  - id: 4.1.2.1
-    title: Ensure at is restricted to authorized users (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: partial
-    notes: |-
-      It is necessary to create a rule to ensure the existence of at.allow.
-      file_cron_allow_exists can be used as reference for a new templated rule.
-    rules:
-      - file_at_deny_not_exist
-      - file_groupowner_at_allow
-      - file_owner_at_allow
-      - file_permissions_at_allow
-
-  - id: 4.2.1
-    title: Ensure permissions on /etc/ssh/sshd_config are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: partial
-    notes: |-
-      These rules only check the /etc/ssh/sshd_config file but the policy also mentions files in
-      /etc/ssh/sshd_config.d directory. New templated rules should be created for sshd_config.d.
-    rules:
-      - file_groupowner_sshd_config
-      - file_owner_sshd_config
-      - file_permissions_sshd_config
-
-  - id: 4.2.2
-    title: Ensure permissions on SSH private host key files are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_permissions_sshd_private_key
-      - file_ownership_sshd_private_key
-      - file_groupownership_sshd_private_key
-
-  - id: 4.2.3
-    title: Ensure permissions on SSH public host key files are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_permissions_sshd_pub_key
-      - file_ownership_sshd_pub_key
-      - file_groupownership_sshd_pub_key
-
-  - id: 4.2.4
-    title: Ensure sshd access is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_limit_user_access
-
-  - id: 4.2.5
-    title: Ensure sshd Banner is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_enable_warning_banner_net
-    related_rules:
-      - sshd_enable_warning_banner
-
-  - id: 4.2.6
-    title: Ensure sshd Ciphers are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      Introduced in CIS RHEL8 v3.0.0
-    rules:
-      - sshd_use_approved_ciphers
-      - sshd_approved_ciphers=cis_rhel8
-
-  - id: 4.2.7
-    title: Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      The requirement gives an example of 45 seconds, but is flexible about the values. It is only
-      necessary to ensure there is a timeout is configured in alignment to the site policy.
-    rules:
-      - sshd_idle_timeout_value=5_minutes
-      - sshd_set_idle_timeout
-      - sshd_set_keepalive
-      - var_sshd_set_keepalive=1
-
-  - id: 4.2.8
-    title: Ensure sshd DisableForwarding is enabled (Automated)
-    levels:
-      - l2_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      New templated rule is necessary for "disableforwarding" option.
-    related_rules:
-      - sshd_disable_tcp_forwarding
-      - sshd_disable_x11_forwarding
-
-  - id: 4.2.9
-    title: Ensure sshd HostbasedAuthentication is disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - disable_host_auth
-
-  - id: 4.2.10
-    title: Ensure sshd IgnoreRhosts is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_disable_rhosts
-
-  - id: 4.2.11
-    title: Ensure sshd KexAlgorithms is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_use_strong_kex
-      - sshd_strong_kex=cis_rhel8
-
-  - id: 4.2.12
-    title: Ensure sshd LoginGraceTime is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_set_login_grace_time
-      - var_sshd_set_login_grace_time=60
-
-  - id: 4.2.13
-    title: Ensure sshd LogLevel is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      The CIS benchmark is not opinionated about which loglevel is selected here. Here, this
-      profile uses VERBOSE by default, as it allows for the capture of login and logout activity
-      as well as key fingerprints.
-    rules:
-      - sshd_set_loglevel_verbose
-    related_rules:
-      - sshd_set_loglevel_info
-
-  - id: 4.2.14
-    title: Ensure sshd MACs are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_use_strong_macs
-      - sshd_strong_macs=cis_rhel8
-
-  - id: 4.2.15
-    title: Ensure sshd MaxAuthTries is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_max_auth_tries_value=4
-      - sshd_set_max_auth_tries
-
-  - id: 4.2.16
-    title: Ensure sshd MaxSessions is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_set_max_sessions
-      - var_sshd_max_sessions=10
-
-  - id: 4.2.17
-    title: Ensure sshd MaxStartups is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_set_maxstartups
-      - var_sshd_set_maxstartups=10:30:60
-
-  - id: 4.2.18
-    title: Ensure sshd PermitEmptyPasswords is disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_disable_empty_passwords
-
-  - id: 4.2.19
-    title: Ensure sshd PermitRootLogin is disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_disable_root_login
-
-  - id: 4.2.20
-    title: Ensure sshd PermitUserEnvironment is disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_do_not_permit_user_env
-
-  - id: 4.2.21
-    title: Ensure sshd UsePAM is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_enable_pam
-
-  - id: 4.2.22
-    title: Ensure sshd crypto_policy is not set (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - configure_ssh_crypto_policy
-
-  - id: 4.3.1
-    title: Ensure sudo is installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_sudo_installed
-
-  - id: 4.3.2
-    title: Ensure sudo commands use pty (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sudo_add_use_pty
-
-  - id: 4.3.3
-    title: Ensure sudo log file exists (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sudo_custom_logfile
-
-  - id: 4.3.4
-    title: Ensure users must provide password for escalation (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    notes: |-
-      The rule sudo_require_authentication can probably be split to better attend requirements
-      4.3.4 and 4.3.5.
-    rules:
-      - sudo_require_authentication
-
-  - id: 4.3.5
-    title: Ensure re-authentication for privilege escalation is not disabled globally (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      The rule sudo_require_authentication can probably be split to better attend requirements
-      4.3.4 and 4.3.5.
-    rules:
-      - sudo_require_authentication
-
-  - id: 4.3.6
-    title: Ensure sudo authentication timeout is configured correctly (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sudo_require_reauthentication
-
-  - id: 4.3.7
-    title: Ensure access to the su command is restricted (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      Members of "wheel" or GID 0 groups are checked by default if the group option is not set for
-      pam_wheel.so module. The recommendation states the group should be empty to reinforce the
-      use of "sudo" for privileged access. Therefore, members of these groups should be manually
-      checked or a different group should be informed.
-    rules:
-      - var_pam_wheel_group_for_su=cis
-      - use_pam_wheel_group_for_su
-      - ensure_pam_wheel_group_empty
-
-  - id: 4.4.1.1
-    title: Ensure latest version of pam is installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      It is necessary a new rule to ensure PAM package is updated.
-
-  - id: 4.4.1.2
-    title: Ensure latest version of authselect is installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      It is necessary a new rule to ensure PAM package is updated.
-
-  - id: 4.4.2.1
-    title: Ensure active authselect profile includes pam modules (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: partial
-    notes: |-
-      This requirement is hard to be automated without any specific requirement. The policy even
-      states that provided commands are examples, other custom settings might be in place and the
-      settings might be different depending on site policies. The other rules will already make
-      sure there is a correct autheselect profile regardless of the existing settings. It is
-      necessary to better discuss with CIS Community.
-    related_rules:
-      - no_empty_passwords
-
-  - id: 4.4.2.2
-    title: Ensure pam_faillock module is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      This requirement is also indirectly satisfied by the requirement 4.4.3.1.
-    rules:
-      - account_password_pam_faillock_password_auth
-      - account_password_pam_faillock_system_auth
-
-  - id: 4.4.2.3
-    title: Ensure pam_pwquality module is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      CIS requirement asks to enable an authselect feature called "with-pwquality" but this
-      feature is not present in RHEL 8. This needs to be discussed in CIS Community. For now the
-      requirement is attended by ensuring the libpwquality is present. Its configuration is
-      covered by other requirements.
-    rules:
-      - package_pam_pwquality_installed
-
-  - id: 4.4.2.4
-    title: Ensure pam_pwhistory module is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      The module is properly enabled by the rules mentioned in related_rules.
-      Requirements in 4.4.3.3 use these rules.
-    related_rules:
-      - accounts_password_pam_pwhistory_remember_password_auth
-      - accounts_password_pam_pwhistory_remember_system_auth
-
-  - id: 4.4.2.5
-    title: Ensure pam_unix module is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: partial
-    notes: |-
-      This module is always present by default. It is necessary to investigate if a new rule to
-      check its existence needs to be created. But so far the rule no_empty_passwords, used in
-      4.4.3.4.1 can ensure this requirement is attended.
-    related_rules:
-      - no_empty_passwords
-
-  - id: 4.4.3.1.1
-    title: Ensure password failed attempts lockout is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_passwords_pam_faillock_deny
-      - var_accounts_passwords_pam_faillock_deny=5
-
-  - id: 4.4.3.1.2
-    title: Ensure password unlock time is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      The policy also accepts value 0, which means the locked accounts should be manually unlocked
-      by an administrator. However, it also mentions that using value 0 can facilitate a DoS
-      attack to legitimate users.
-    rules:
-      - accounts_passwords_pam_faillock_unlock_time
-      - var_accounts_passwords_pam_faillock_unlock_time=900
-
-  - id: 4.4.3.1.3
-    title: Ensure password failed attempts lockout includes root account (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - accounts_passwords_pam_faillock_deny_root
-
-  - id: 4.4.3.2.1
-    title: Ensure password number of changed characters is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_password_pam_difok
-      - var_password_pam_difok=2
-
-  - id: 4.4.3.2.2
-    title: Ensure password length is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_password_pam_minlen
-      - var_password_pam_minlen=14
-
-  - id: 4.4.3.2.3
-    title: Ensure password complexity is configured (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      This requirement is expected to be manual. However, in previous versions of the policy
-      it was already automated the configuration of "minclass" option. This posture was kept for
-      RHEL 8 in this new version. Rules related to other options are informed in related_rules.
-      In short, minclass=4 alone can achieve the same result achieved by the combination of the
-      other 4 options mentioned in the policy.
-    rules:
-      - accounts_password_pam_minclass
-      - var_password_pam_minclass=4
-    related_rules:
-      - accounts_password_pam_dcredit
-      - accounts_password_pam_lcredit
-      - accounts_password_pam_ocredit
-      - accounts_password_pam_ucredit
-
-  - id: 4.4.3.2.4
-    title: Ensure password same consecutive characters is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_password_pam_maxrepeat
-      - var_password_pam_maxrepeat=3
-
-  - id: 4.4.3.2.5
-    title: Ensure password maximum sequential characters is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: planned
-    notes: |-
-      A new templated rule and variable are necessary for the maxsequence option.
-
-  - id: 4.4.3.2.6
-    title: Ensure password dictionary check is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_password_pam_dictcheck
-      - var_password_pam_dictcheck=1
-
-  - id: 4.4.3.2.7
-    title: Ensure password quality is enforced for the root user (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_password_pam_enforce_root
-
-  - id: 4.4.3.3.1
-    title: Ensure password history remember is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      Although mentioned in the section 4.4.3.3, there is no explicit requirement to configure
-      retry option of pam_pwhistory. If come in the future, the rule accounts_password_pam_retry
-      can be used.
-    rules:
-      - accounts_password_pam_pwhistory_remember_password_auth
-      - accounts_password_pam_pwhistory_remember_system_auth
-      - var_password_pam_remember_control_flag=requisite_or_required
-      - var_password_pam_remember=24
-    related_rules:
-      - accounts_password_pam_retry
-
-  - id: 4.4.3.3.2
-    title: Ensure password history is enforced for the root user (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: planned
-    notes: |-
-      A new rule needs to be created to check and remediate the enforce_for_root option in
-      /etc/security/pwhistory.conf. accounts_password_pam_enforce_root can be used as reference.
-
-  - id: 4.4.3.3.3
-    title: Ensure pam_pwhistory includes use_authtok (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: partial
-    notes: |-
-      In RHEL 8 pam_pwhistory is enabled via authselect feature, as required in 4.4.3.3.1. The
-      feature automatically set "use_authok" option. In any case, we don't have a rule to check
-      this option specifically.
-    related_rules:
-      - accounts_password_pam_pwhistory_remember_password_auth
-      - accounts_password_pam_pwhistory_remember_system_auth
-
-  - id: 4.4.3.4.1
-    title: Ensure pam_unix does not include nullok (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      The rule more specifically used in this requirement also satify the requirements 4.4.2.1
-      and 4.4.2.5.
-    rules:
-      - no_empty_passwords
-
-  - id: 4.4.3.4.2
-    title: Ensure pam_unix does not include remember (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      Usage of pam_unix.so module together with "remember" option is deprecated and is not
-      recommened by this policy. Instead, it should be used remember option of pam_pwhistory
-      module, as required in 4.4.3.3.1. See here for more details about pam_unix.so:
-      https://bugzilla.redhat.com/show_bug.cgi?id=1778929
-      A new rule needs to be created to remove the remember option from pam_unix module.
-
-  - id: 4.4.3.4.3
-    title: Ensure pam_unix includes a strong password hashing algorithm (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      Changes in logindefs mentioned in this requirement are more specifically covered by 4.5.1.1.
-    rules:
-      - set_password_hashing_algorithm_systemauth
-      - set_password_hashing_algorithm_passwordauth
-      - var_password_hashing_algorithm_pam=sha512
-
-  - id: 4.4.3.4.4
-    title: Ensure pam_unix includes use_authtok (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: partial
-    notes: |-
-      In RHEL 8 pam_unix is enabled by default in all authselect profiles already with the
-      use_authtok option set. In any case, we don't have a rule to check this option specifically,
-      like in 4.4.3.3.3.
-
-  - id: 4.5.1.1
-    title: Ensure strong password hashing algorithm is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - set_password_hashing_algorithm_libuserconf
-      - set_password_hashing_algorithm_logindefs
-      - var_password_hashing_algorithm=SHA512
-      - var_password_hashing_algorithm_pam=sha512
-
-  - id: 4.5.1.2
-    title: Ensure password expiration is 365 days or less (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_maximum_age_login_defs
-      - accounts_password_set_max_life_existing
-      - var_accounts_maximum_age_login_defs=365
-
-  - id: 4.5.1.3
-    title: Ensure password expiration warning days is 7 or more (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_password_set_warn_age_existing
-      - accounts_password_warn_age_login_defs
-      - var_accounts_password_warn_age_login_defs=7
-
-  - id: 4.5.1.4
-    title: Ensure inactive password lock is 30 days or less (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - account_disable_post_pw_expiration
-      - accounts_set_post_pw_existing
-      - var_account_disable_post_pw_expiration=30
-
-  - id: 4.5.1.5
-    title: Ensure all users last password change date is in the past (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_password_last_change_is_in_past
-
-  - id: 4.5.2.1
-    title: Ensure default group for the root account is GID 0 (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_root_gid_zero
-
-  - id: 4.5.2.2
-    title: Ensure root user umask is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      There is no rule to ensure umask in /root/.bash_profile and /root/.bashrc. A new rule have
-      to be created. It can be based on accounts_umask_interactive_users.
-
-  - id: 4.5.2.3
-    title: Ensure system accounts are secured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - no_password_auth_for_systemaccounts
-      - no_shelllogin_for_systemaccounts
-
-  - id: 4.5.2.4
-    title: Ensure root password is set (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - ensure_root_password_configured
-
-  - id: 4.5.3.1
-    title: Ensure nologin is not listed in /etc/shells (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: pending
-    notes: |-
-      It is necessary to create a new rule to check and remove nologin from /etc/shells.
-      The no_tmux_in_shells rule can be used as referece.
-
-  - id: 4.5.3.2
-    title: Ensure default user shell timeout is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_tmout
-      - var_accounts_tmout=15_min
-
-  - id: 4.5.3.3
-    title: Ensure default user umask is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      It is missing a rule to check /etc/pam.d/postlogin. Files /etc/bash.bashrc and
-      /etc/default/login are not used in RHEL 8, but are mentioned in the policy. It has to be
-      clarified in CIS Community. The policy allows the user to override the default system umask
-      on its discretion. This is the reason the accounts_umask_interactive_users rule is in
-      related_rules. If this changes in the future, the rule can be used to ensure that users do
-      not override the system default.
-    rules:
-      - accounts_umask_etc_bashrc
-      - accounts_umask_etc_login_defs
-      - accounts_umask_etc_profile
-      - var_accounts_user_umask=027
-    related_rules:
-      - accounts_umask_interactive_users
-
-  - id: 5.1.1.1
-    title: Ensure rsyslog is installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_rsyslog_installed
-
-  - id: 5.1.1.2
-    title: Ensure rsyslog service is enabled (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      This requirement is expected to be manual in the policy because there are valid cases where
-      other solutions are used for logging. rsyslog is the default in RHEL 8 and so far other
-      solutions are not expected to be incompatible with rsyslog. If so, for these particular
-      cases, this rule should be removed for those systems by a tailored file.
-    rules:
-      - service_rsyslog_enabled
-
-  - id: 5.1.1.3
-    title: Ensure journald is configured to send logs to rsyslog (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - journald_forward_to_syslog
-
-  - id: 5.1.1.4
-    title: Ensure rsyslog default file permissions are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - rsyslog_filecreatemode
-
-  - id: 5.1.1.5
-    title: Ensure logging is configured (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 5.1.1.6
-    title: Ensure rsyslog is configured to send logs to a remote log host (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-    related_rules:
-      - rsyslog_remote_loghost
-
-  - id: 5.1.1.7
-    title: Ensure rsyslog is not configured to recieve logs from a remote client (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - rsyslog_nolisten
-
-  - id: 5.1.2.1.1
-    title: Ensure systemd-journal-remote is installed (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-    related_rules:
-      - package_systemd-journal-remote_installed
-
-  - id: 5.1.2.1.2
-    title: Ensure systemd-journal-remote is configured (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 5.1.2.1.3
-    title: Ensure systemd-journal-remote is enabled (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 5.1.2.1.4
-    title: Ensure journald is not configured to recieve logs from a remote client (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - socket_systemd-journal-remote_disabled
-
-  - id: 5.1.2.2
-    title: Ensure journald service is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - service_systemd-journald_enabled
-
-  - id: 5.1.2.3
-    title: Ensure journald is configured to compress large log files (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - journald_compress
-
-  - id: 5.1.2.4
-    title: Ensure journald is configured to write logfiles to persistent disk (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - journald_storage
-
-  - id: 5.1.2.5
-    title: Ensure journald is not configured to send logs to rsyslog (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 5.1.2.6
-    title: Ensure journald log rotation is configured per site policy (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 5.1.3
-    title: Ensure logrotate is configured (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-    related_rules:
-      - ensure_logrotate_activated
-      - package_logrotate_installed
-      - timer_logrotate_enabled
-
-  - id: 5.1.4
-    title: Ensure all logfiles have appropriate access configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - rsyslog_files_groupownership
-      - rsyslog_files_ownership
-      - rsyslog_files_permissions
-
-  - id: 5.2.1.1
-    title: Ensure audit is installed (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - package_audit_installed
-
-  - id: 5.2.1.2
-    title: Ensure auditing for processes that start prior to auditd is enabled (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - grub2_audit_argument
-
-  - id: 5.2.1.3
-    title: Ensure audit_backlog_limit is sufficient (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - grub2_audit_backlog_limit_argument
-
-  - id: 5.2.1.4
-    title: Ensure auditd service is enabled (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - service_auditd_enabled
-
-  - id: 5.2.2.1
-    title: Ensure audit log storage size is configured (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - auditd_data_retention_max_log_file
-      - var_auditd_max_log_file=6
-
-  - id: 5.2.2.2
-    title: Ensure audit logs are not automatically deleted (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - auditd_data_retention_max_log_file_action
-      - var_auditd_max_log_file_action=keep_logs
-
-  - id: 5.2.2.3
-    title: Ensure system is disabled when audit logs are full (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - auditd_data_disk_error_action
-      - auditd_data_disk_full_action
-      - var_auditd_disk_error_action=cis_rhel8
-      - var_auditd_disk_full_action=cis_rhel8
-
-  - id: 5.2.2.4
-    title: Ensure system warns when audit logs are low on space (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - auditd_data_retention_action_mail_acct
-      - auditd_data_retention_admin_space_left_action
-      - auditd_data_retention_space_left_action
-      - var_auditd_action_mail_acct=root
-      - var_auditd_admin_space_left_action=cis_rhel8
-      - var_auditd_space_left_action=cis_rhel8
-
-  - id: 5.2.3.1
-    title: Ensure changes to system administration scope (sudoers) is collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_sysadmin_actions
-
-  - id: 5.2.3.2
-    title: Ensure actions as another user are always logged (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_suid_auid_privilege_function
-
-  - id: 5.2.3.3
-    title: Ensure events that modify the sudo log file are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_sudo_log_events
-
-  - id: 5.2.3.4
-    title: Ensure events that modify date and time information are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_time_adjtimex
-      - audit_rules_time_settimeofday
-      - audit_rules_time_clock_settime
-      - audit_rules_time_stime
-      - audit_rules_time_watch_localtime
-
-  - id: 5.2.3.5
-    title: Ensure events that modify the system's network environment are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-    - audit_rules_networkconfig_modification
-    - audit_rules_networkconfig_modification_network_scripts
-
-  - id: 5.2.3.6
-    title: Ensure use of privileged commands are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_privileged_commands
-
-  - id: 5.2.3.7
-    title: Ensure unsuccessful file access attempts are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_unsuccessful_file_modification_creat
-      - audit_rules_unsuccessful_file_modification_ftruncate
-      - audit_rules_unsuccessful_file_modification_open
-      - audit_rules_unsuccessful_file_modification_openat
-      - audit_rules_unsuccessful_file_modification_truncate
-
-  - id: 5.2.3.8
-    title: Ensure events that modify user/group information are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_usergroup_modification_group
-      - audit_rules_usergroup_modification_gshadow
-      - audit_rules_usergroup_modification_opasswd
-      - audit_rules_usergroup_modification_passwd
-      - audit_rules_usergroup_modification_shadow
-
-  - id: 5.2.3.9
-    title: Ensure discretionary access control permission modification events are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_dac_modification_chmod
-      - audit_rules_dac_modification_chown
-      - audit_rules_dac_modification_fchmod
-      - audit_rules_dac_modification_fchmodat
-      - audit_rules_dac_modification_fchown
-      - audit_rules_dac_modification_fchownat
-      - audit_rules_dac_modification_fremovexattr
-      - audit_rules_dac_modification_fsetxattr
-      - audit_rules_dac_modification_lchown
-      - audit_rules_dac_modification_lremovexattr
-      - audit_rules_dac_modification_lsetxattr
-      - audit_rules_dac_modification_removexattr
-      - audit_rules_dac_modification_setxattr
-
-  - id: 5.2.3.10
-    title: Ensure successful file system mounts are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_media_export
-
-  - id: 5.2.3.11
-    title: Ensure session initiation information is collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_session_events_utmp
-      - audit_rules_session_events_btmp
-      - audit_rules_session_events_wtmp
-
-  - id: 5.2.3.12
-    title: Ensure login and logout events are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_login_events_faillock
-      - audit_rules_login_events_lastlog
-      - var_accounts_passwords_pam_faillock_dir=run
-
-  - id: 5.2.3.13
-    title: Ensure file deletion events by users are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_file_deletion_events_rename
-      - audit_rules_file_deletion_events_renameat
-      - audit_rules_file_deletion_events_unlink
-      - audit_rules_file_deletion_events_unlinkat
-
-  - id: 5.2.3.14
-    title: Ensure events that modify the system's Mandatory Access Controls are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_mac_modification
-      - audit_rules_mac_modification_usr_share
-
-  - id: 5.2.3.15
-    title: Ensure successful and unsuccessful attempts to use the chcon command are recorded (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_execution_chcon
-
-  - id: 5.2.3.16
-    title: Ensure successful and unsuccessful attempts to use the setfacl command are recorded (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_execution_setfacl
-
-  - id: 5.2.3.17
-    title: Ensure successful and unsuccessful attempts to use the chacl command are recorded (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_execution_chacl
-
-  - id: 5.2.3.18
-    title: Ensure successful and unsuccessful attempts to use the usermod command are recorded (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_privileged_commands_usermod
-
-  - id: 5.2.3.19
-    title: Ensure kernel module loading, unloading and modification is collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_kernel_module_loading_create
-      - audit_rules_kernel_module_loading_delete
-      - audit_rules_kernel_module_loading_finit
-      - audit_rules_kernel_module_loading_init
-      - audit_rules_kernel_module_loading_query
-      - audit_rules_privileged_commands_kmod
-
-  - id: 5.2.3.20
-    title: Ensure the audit configuration is immutable (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_immutable
-
-  - id: 5.2.3.21
-    title: Ensure the running and on disk configuration is the same (Manual)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: manual
-
-  - id: 5.2.4.1
-    title: Ensure the audit log directory is 0750 or more restrictive (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - directory_permissions_var_log_audit
-
-  - id: 5.2.4.2
-    title: Ensure audit log files are mode 0640 or less permissive (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - file_permissions_var_log_audit
-
-  - id: 5.2.4.3
-    title: Ensure only authorized users own audit log files (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - file_ownership_var_log_audit_stig
-
-  - id: 5.2.4.4
-    title: Ensure only authorized groups are assigned ownership of audit log files (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - file_group_ownership_var_log_audit
-
-  - id: 5.2.4.5
-    title: Ensure audit configuration files are 640 or more restrictive (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - file_permissions_audit_configuration
-
-  - id: 5.2.4.6
-    title: Ensure audit configuration files are owned by root (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - file_ownership_audit_configuration
-
-  - id: 5.2.4.7
-    title: Ensure audit configuration files belong to group root (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - file_groupownership_audit_configuration
-
-  - id: 5.2.4.8
-    title: Ensure audit tools are 755 or more restrictive (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - file_permissions_audit_binaries
-
-  - id: 5.2.4.9
-    title: Ensure audit tools are owned by root (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - file_ownership_audit_binaries
-
-  - id: 5.2.4.10
-    title: Ensure audit tools belong to group root (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - file_groupownership_audit_binaries
-
-  - id: 5.3.1
-    title: Ensure AIDE is installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_aide_installed
-      - aide_build_database
-
-  - id: 5.3.2
-    title: Ensure filesystem integrity is regularly checked (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - aide_periodic_cron_checking
-    related_rules:
-      - aide_periodic_checking_systemd_timer
-
-  - id: 5.3.3
-    title: Ensure cryptographic mechanisms are used to protect the integrity of audit tools (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - aide_check_audit_tools
-    related_rules:
-      - aide_use_fips_hashes
-
-  - id: 6.1.1
-    title: Ensure permissions on /etc/passwd are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_etc_passwd
-      - file_owner_etc_passwd
-      - file_permissions_etc_passwd
-
-  - id: 6.1.2
-    title: Ensure permissions on /etc/passwd- are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_backup_etc_passwd
-      - file_owner_backup_etc_passwd
-      - file_permissions_backup_etc_passwd
-
-  - id: 6.1.3
-    title: Ensure permissions on /etc/security/opasswd are configured (Automated)
-    levels:
-    - l1_server
-    - l1_workstation
-    status: partial
-    rules:
+    - id: 2.2.19
+      title: Ensure xinetd services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_xinetd_removed
+      related_rules:
+          - service_xinetd_disabled
+
+    - id: 2.2.20
+      title: Ensure X window server services are not in use (Automated)
+      levels:
+          - l2_server
+      status: automated
+      notes: >-
+          The rule also configures correct run level to prevent unbootable system.
+      rules:
+          - package_xorg-x11-server-common_removed
+          - xwindows_runlevel_target
+
+    - id: 2.2.21
+      title: Ensure mail transfer agents are configured for local-only mode (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: partial
+      notes: |-
+          The rule has_nonlocal_mta currently checks for services listening only on
+          port 25, but the policy checks also for ports 465 and 587
+      rules:
+          - postfix_network_listening_disabled
+          - var_postfix_inet_interfaces=loopback-only
+          - has_nonlocal_mta
+
+    - id: 2.2.22
+      title: Ensure only approved services are listening on a network interface (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 2.3.1
+      title: Ensure ftp client is not installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_ftp_removed
+
+    - id: 2.3.2
+      title: Ensure LDAP client is not installed (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - package_openldap-clients_removed
+
+    - id: 2.3.3
+      title: Ensure NIS Client is not installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_ypbind_removed
+
+    - id: 2.3.4
+      title: Ensure telnet client is not installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_telnet_removed
+
+    - id: 2.3.5
+      title: Ensure tftp client is not installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_tftp_removed
+
+    - id: 3.1.1
+      title: Ensure IPv6 status is identified (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 3.1.2
+      title: Ensure wireless interfaces are disabled (Automated)
+      levels:
+          - l1_server
+      status: automated
+      rules:
+          - wireless_disable_interfaces
+
+    - id: 3.1.3
+      title: Ensure bluetooth services are not in use (Automated)
+      levels:
+          - l1_server
+          - l2_workstation
+      status: automated
+      rules:
+          - service_bluetooth_disabled
+
+    - id: 3.2.1
+      title: Ensure dccp kernel module is not available (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - kernel_module_dccp_disabled
+
+    - id: 3.2.2
+      title: Ensure tipc kernel module is not available (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - kernel_module_tipc_disabled
+
+    - id: 3.2.3
+      title: Ensure rds kernel module is not available (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - kernel_module_rds_disabled
+
+    - id: 3.2.4
+      title: Ensure sctp kernel module is not available (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - kernel_module_sctp_disabled
+
+    - id: 3.3.1
+      title: Ensure ip forwarding is disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_ip_forward
+          - sysctl_net_ipv6_conf_all_forwarding
+          - sysctl_net_ipv6_conf_all_forwarding_value=disabled
+
+    - id: 3.3.2
+      title: Ensure packet redirect sending is disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_conf_all_send_redirects
+          - sysctl_net_ipv4_conf_default_send_redirects
+
+    - id: 3.3.3
+      title: Ensure bogus icmp responses are ignored (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
+          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value=enabled
+
+    - id: 3.3.4
+      title: Ensure broadcast icmp requests are ignored(Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+          - sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value=enabled
+
+    - id: 3.3.5
+      title: Ensure icmp redirects are not accepted (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_conf_all_accept_redirects
+          - sysctl_net_ipv4_conf_all_accept_redirects_value=disabled
+          - sysctl_net_ipv4_conf_default_accept_redirects
+          - sysctl_net_ipv4_conf_default_accept_redirects_value=disabled
+          - sysctl_net_ipv6_conf_all_accept_redirects
+          - sysctl_net_ipv6_conf_all_accept_redirects_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_redirects
+          - sysctl_net_ipv6_conf_default_accept_redirects_value=disabled
+
+    - id: 3.3.6
+      title: Ensure secure icmp redirects are not accepted (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_conf_all_secure_redirects
+          - sysctl_net_ipv4_conf_all_secure_redirects_value=disabled
+          - sysctl_net_ipv4_conf_default_secure_redirects
+          - sysctl_net_ipv4_conf_default_secure_redirects_value=disabled
+
+    - id: 3.3.7
+      title: Ensure reverse path filtering is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_conf_all_rp_filter
+          - sysctl_net_ipv4_conf_all_rp_filter_value=enabled
+          - sysctl_net_ipv4_conf_default_rp_filter
+          - sysctl_net_ipv4_conf_default_rp_filter_value=enabled
+
+    - id: 3.3.8
+      title: Ensure source routed packets are not accepted (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_conf_all_accept_source_route
+          - sysctl_net_ipv4_conf_all_accept_source_route_value=disabled
+          - sysctl_net_ipv4_conf_default_accept_source_route
+          - sysctl_net_ipv4_conf_default_accept_source_route_value=disabled
+          - sysctl_net_ipv6_conf_all_accept_source_route
+          - sysctl_net_ipv6_conf_all_accept_source_route_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_source_route
+          - sysctl_net_ipv6_conf_default_accept_source_route_value=disabled
+
+    - id: 3.3.9
+      title: Ensure suspicious packets are logged (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_conf_all_log_martians
+          - sysctl_net_ipv4_conf_all_log_martians_value=enabled
+          - sysctl_net_ipv4_conf_default_log_martians
+          - sysctl_net_ipv4_conf_default_log_martians_value=enabled
+
+    - id: 3.3.10
+      title: Ensure tcp sync cookies is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_tcp_syncookies
+          - sysctl_net_ipv4_tcp_syncookies_value=enabled
+
+    - id: 3.3.11
+      title: Ensure IPv6 router advertisements are not accepted (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv6_conf_all_accept_ra
+          - sysctl_net_ipv6_conf_all_accept_ra_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_ra
+          - sysctl_net_ipv6_conf_default_accept_ra_value=disabled
+
+    - id: 3.4.1.1
+      title: Ensure nftables is installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_nftables_installed
+
+    - id: 3.4.1.2
+      title: Ensure a single firewall configuration utility is in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - service_firewalld_enabled
+          - package_firewalld_installed
+          - service_nftables_disabled
+
+    - id: 3.4.2.1
+      title: Ensure nftables base chains exist (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: supported
+      notes: |-
+          RHEL systems use firewalld for firewall management. Although nftables is the default
+          back-end for firewalld, it is not recommended to use nftables directly when firewalld
+          is in use. When using firewalld the base chains are installed by default.
+      related_rules:
+          - set_nftables_base_chain
+          - var_nftables_table=firewalld
+          - var_nftables_family=inet
+          - var_nftables_base_chain_names=chain_names
+          - var_nftables_base_chain_types=chain_types
+          - var_nftables_base_chain_hooks=chain_hooks
+          - var_nftables_base_chain_priorities=chain_priorities
+          - var_nftables_base_chain_policies=chain_policies
+
+    - id: 3.4.2.2
+      title: Ensure host based firewall loopback traffic is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - firewalld_loopback_traffic_trusted
+          - firewalld_loopback_traffic_restricted
+
+    - id: 3.4.2.3
+      title: Ensure firewalld drops unnecessary services and ports (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 3.4.2.4
+      title: Ensure nftables established connections are configured (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: supported
+      notes: |-
+          RHEL systems use firewalld for firewall management. Although nftables is the default
+          back-end for firewalld, it is not recommended to use nftables directly when firewalld
+          is in use. When using firewalld the base chains are installed by default.
+      related_rules:
+          - set_nftables_new_connections
+
+    - id: 3.4.2.5
+      title: Ensure nftables default deny firewall policy (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: supported
+      notes: |-
+          RHEL systems use firewalld for firewall management. Although nftables is the default
+          back-end for firewalld, it is not recommended to use nftables directly when firewalld
+          is in use.
+      related_rules:
+          - nftables_ensure_default_deny_policy
+
+    - id: 4.1.1.1
+      title: Ensure cron daemon is enabled and active (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - service_crond_enabled
+
+    - id: 4.1.1.2
+      title: Ensure permissions on /etc/crontab are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_crontab
+          - file_owner_crontab
+          - file_permissions_crontab
+
+    - id: 4.1.1.3
+      title: Ensure permissions on /etc/cron.hourly are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_cron_hourly
+          - file_owner_cron_hourly
+          - file_permissions_cron_hourly
+
+    - id: 4.1.1.4
+      title: Ensure permissions on /etc/cron.daily are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_cron_daily
+          - file_owner_cron_daily
+          - file_permissions_cron_daily
+
+    - id: 4.1.1.5
+      title: Ensure permissions on /etc/cron.weekly are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_cron_weekly
+          - file_owner_cron_weekly
+          - file_permissions_cron_weekly
+
+    - id: 4.1.1.6
+      title: Ensure permissions on /etc/cron.monthly are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_cron_monthly
+          - file_owner_cron_monthly
+          - file_permissions_cron_monthly
+
+    - id: 4.1.1.7
+      title: Ensure permissions on /etc/cron.d are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_cron_d
+          - file_owner_cron_d
+          - file_permissions_cron_d
+
+    - id: 4.1.1.8
+      title: Ensure cron is restricted to authorized users (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_cron_deny_not_exist
+          - file_cron_allow_exists
+          - file_groupowner_cron_allow
+          - file_owner_cron_allow
+          - file_permissions_cron_allow
+
+    - id: 4.1.2.1
+      title: Ensure at is restricted to authorized users (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: partial
+      notes: |-
+          It is necessary to create a rule to ensure the existence of at.allow.
+          file_cron_allow_exists can be used as reference for a new templated rule.
+      rules:
+          - file_at_deny_not_exist
+          - file_groupowner_at_allow
+          - file_owner_at_allow
+          - file_permissions_at_allow
+
+    - id: 4.2.1
+      title: Ensure permissions on /etc/ssh/sshd_config are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: partial
+      notes: |-
+          These rules only check the /etc/ssh/sshd_config file but the policy also mentions files in
+          /etc/ssh/sshd_config.d directory. New templated rules should be created for sshd_config.d.
+      rules:
+          - file_groupowner_sshd_config
+          - file_owner_sshd_config
+          - file_permissions_sshd_config
+
+    - id: 4.2.2
+      title: Ensure permissions on SSH private host key files are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_permissions_sshd_private_key
+          - file_ownership_sshd_private_key
+          - file_groupownership_sshd_private_key
+
+    - id: 4.2.3
+      title: Ensure permissions on SSH public host key files are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_permissions_sshd_pub_key
+          - file_ownership_sshd_pub_key
+          - file_groupownership_sshd_pub_key
+
+    - id: 4.2.4
+      title: Ensure sshd access is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_limit_user_access
+
+    - id: 4.2.5
+      title: Ensure sshd Banner is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_enable_warning_banner_net
+      related_rules:
+          - sshd_enable_warning_banner
+
+    - id: 4.2.6
+      title: Ensure sshd Ciphers are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          Introduced in CIS RHEL8 v3.0.0
+      rules:
+          - sshd_use_approved_ciphers
+          - sshd_approved_ciphers=cis_rhel8
+
+    - id: 4.2.7
+      title: Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          The requirement gives an example of 45 seconds, but is flexible about the values. It is only
+          necessary to ensure there is a timeout is configured in alignment to the site policy.
+      rules:
+          - sshd_idle_timeout_value=5_minutes
+          - sshd_set_idle_timeout
+          - sshd_set_keepalive
+          - var_sshd_set_keepalive=1
+
+    - id: 4.2.8
+      title: Ensure sshd DisableForwarding is enabled (Automated)
+      levels:
+          - l2_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          New templated rule is necessary for "disableforwarding" option.
+      related_rules:
+          - sshd_disable_tcp_forwarding
+          - sshd_disable_x11_forwarding
+
+    - id: 4.2.9
+      title: Ensure sshd HostbasedAuthentication is disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - disable_host_auth
+
+    - id: 4.2.10
+      title: Ensure sshd IgnoreRhosts is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_disable_rhosts
+
+    - id: 4.2.11
+      title: Ensure sshd KexAlgorithms is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_use_strong_kex
+          - sshd_strong_kex=cis_rhel8
+
+    - id: 4.2.12
+      title: Ensure sshd LoginGraceTime is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_set_login_grace_time
+          - var_sshd_set_login_grace_time=60
+
+    - id: 4.2.13
+      title: Ensure sshd LogLevel is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          The CIS benchmark is not opinionated about which loglevel is selected here. Here, this
+          profile uses VERBOSE by default, as it allows for the capture of login and logout activity
+          as well as key fingerprints.
+      rules:
+          - sshd_set_loglevel_verbose
+      related_rules:
+          - sshd_set_loglevel_info
+
+    - id: 4.2.14
+      title: Ensure sshd MACs are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_use_strong_macs
+          - sshd_strong_macs=cis_rhel8
+
+    - id: 4.2.15
+      title: Ensure sshd MaxAuthTries is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_max_auth_tries_value=4
+          - sshd_set_max_auth_tries
+
+    - id: 4.2.16
+      title: Ensure sshd MaxSessions is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_set_max_sessions
+          - var_sshd_max_sessions=10
+
+    - id: 4.2.17
+      title: Ensure sshd MaxStartups is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_set_maxstartups
+          - var_sshd_set_maxstartups=10:30:60
+
+    - id: 4.2.18
+      title: Ensure sshd PermitEmptyPasswords is disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_disable_empty_passwords
+
+    - id: 4.2.19
+      title: Ensure sshd PermitRootLogin is disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_disable_root_login
+
+    - id: 4.2.20
+      title: Ensure sshd PermitUserEnvironment is disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_do_not_permit_user_env
+
+    - id: 4.2.21
+      title: Ensure sshd UsePAM is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_enable_pam
+
+    - id: 4.2.22
+      title: Ensure sshd crypto_policy is not set (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - configure_ssh_crypto_policy
+
+    - id: 4.3.1
+      title: Ensure sudo is installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_sudo_installed
+
+    - id: 4.3.2
+      title: Ensure sudo commands use pty (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sudo_add_use_pty
+
+    - id: 4.3.3
+      title: Ensure sudo log file exists (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sudo_custom_logfile
+
+    - id: 4.3.4
+      title: Ensure users must provide password for escalation (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      notes: |-
+          The rule sudo_require_authentication can probably be split to better attend requirements
+          4.3.4 and 4.3.5.
+      rules:
+          - sudo_require_authentication
+
+    - id: 4.3.5
+      title: Ensure re-authentication for privilege escalation is not disabled globally (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          The rule sudo_require_authentication can probably be split to better attend requirements
+          4.3.4 and 4.3.5.
+      rules:
+          - sudo_require_authentication
+
+    - id: 4.3.6
+      title: Ensure sudo authentication timeout is configured correctly (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sudo_require_reauthentication
+
+    - id: 4.3.7
+      title: Ensure access to the su command is restricted (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          Members of "wheel" or GID 0 groups are checked by default if the group option is not set for
+          pam_wheel.so module. The recommendation states the group should be empty to reinforce the
+          use of "sudo" for privileged access. Therefore, members of these groups should be manually
+          checked or a different group should be informed.
+      rules:
+          - var_pam_wheel_group_for_su=cis
+          - use_pam_wheel_group_for_su
+          - ensure_pam_wheel_group_empty
+
+    - id: 4.4.1.1
+      title: Ensure latest version of pam is installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          It is necessary a new rule to ensure PAM package is updated.
+
+    - id: 4.4.1.2
+      title: Ensure latest version of authselect is installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          It is necessary a new rule to ensure PAM package is updated.
+
+    - id: 4.4.2.1
+      title: Ensure active authselect profile includes pam modules (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: partial
+      notes: |-
+          This requirement is hard to be automated without any specific requirement. The policy even
+          states that provided commands are examples, other custom settings might be in place and the
+          settings might be different depending on site policies. The other rules will already make
+          sure there is a correct autheselect profile regardless of the existing settings. It is
+          necessary to better discuss with CIS Community.
+      related_rules:
+          - no_empty_passwords
+
+    - id: 4.4.2.2
+      title: Ensure pam_faillock module is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          This requirement is also indirectly satisfied by the requirement 4.4.3.1.
+      rules:
+          - account_password_pam_faillock_password_auth
+          - account_password_pam_faillock_system_auth
+
+    - id: 4.4.2.3
+      title: Ensure pam_pwquality module is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          CIS requirement asks to enable an authselect feature called "with-pwquality" but this
+          feature is not present in RHEL 8. This needs to be discussed in CIS Community. For now the
+          requirement is attended by ensuring the libpwquality is present. Its configuration is
+          covered by other requirements.
+      rules:
+          - package_pam_pwquality_installed
+
+    - id: 4.4.2.4
+      title: Ensure pam_pwhistory module is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          The module is properly enabled by the rules mentioned in related_rules.
+          Requirements in 4.4.3.3 use these rules.
+      related_rules:
+          - accounts_password_pam_pwhistory_remember_password_auth
+          - accounts_password_pam_pwhistory_remember_system_auth
+
+    - id: 4.4.2.5
+      title: Ensure pam_unix module is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: partial
+      notes: |-
+          This module is always present by default. It is necessary to investigate if a new rule to
+          check its existence needs to be created. But so far the rule no_empty_passwords, used in
+          4.4.3.4.1 can ensure this requirement is attended.
+      related_rules:
+          - no_empty_passwords
+
+    - id: 4.4.3.1.1
+      title: Ensure password failed attempts lockout is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_passwords_pam_faillock_deny
+          - var_accounts_passwords_pam_faillock_deny=5
+
+    - id: 4.4.3.1.2
+      title: Ensure password unlock time is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          The policy also accepts value 0, which means the locked accounts should be manually unlocked
+          by an administrator. However, it also mentions that using value 0 can facilitate a DoS
+          attack to legitimate users.
+      rules:
+          - accounts_passwords_pam_faillock_unlock_time
+          - var_accounts_passwords_pam_faillock_unlock_time=900
+
+    - id: 4.4.3.1.3
+      title: Ensure password failed attempts lockout includes root account (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - accounts_passwords_pam_faillock_deny_root
+
+    - id: 4.4.3.2.1
+      title: Ensure password number of changed characters is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_password_pam_difok
+          - var_password_pam_difok=2
+
+    - id: 4.4.3.2.2
+      title: Ensure password length is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_password_pam_minlen
+          - var_password_pam_minlen=14
+
+    - id: 4.4.3.2.3
+      title: Ensure password complexity is configured (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          This requirement is expected to be manual. However, in previous versions of the policy
+          it was already automated the configuration of "minclass" option. This posture was kept for
+          RHEL 8 in this new version. Rules related to other options are informed in related_rules.
+          In short, minclass=4 alone can achieve the same result achieved by the combination of the
+          other 4 options mentioned in the policy.
+      rules:
+          - accounts_password_pam_minclass
+          - var_password_pam_minclass=4
+      related_rules:
+          - accounts_password_pam_dcredit
+          - accounts_password_pam_lcredit
+          - accounts_password_pam_ocredit
+          - accounts_password_pam_ucredit
+
+    - id: 4.4.3.2.4
+      title: Ensure password same consecutive characters is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_password_pam_maxrepeat
+          - var_password_pam_maxrepeat=3
+
+    - id: 4.4.3.2.5
+      title: Ensure password maximum sequential characters is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: planned
+      notes: |-
+          A new templated rule and variable are necessary for the maxsequence option.
+
+    - id: 4.4.3.2.6
+      title: Ensure password dictionary check is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_password_pam_dictcheck
+          - var_password_pam_dictcheck=1
+
+    - id: 4.4.3.2.7
+      title: Ensure password quality is enforced for the root user (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_password_pam_enforce_root
+
+    - id: 4.4.3.3.1
+      title: Ensure password history remember is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          Although mentioned in the section 4.4.3.3, there is no explicit requirement to configure
+          retry option of pam_pwhistory. If come in the future, the rule accounts_password_pam_retry
+          can be used.
+      rules:
+          - accounts_password_pam_pwhistory_remember_password_auth
+          - accounts_password_pam_pwhistory_remember_system_auth
+          - var_password_pam_remember_control_flag=requisite_or_required
+          - var_password_pam_remember=24
+      related_rules:
+          - accounts_password_pam_retry
+
+    - id: 4.4.3.3.2
+      title: Ensure password history is enforced for the root user (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: planned
+      notes: |-
+          A new rule needs to be created to check and remediate the enforce_for_root option in
+          /etc/security/pwhistory.conf. accounts_password_pam_enforce_root can be used as reference.
+
+    - id: 4.4.3.3.3
+      title: Ensure pam_pwhistory includes use_authtok (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: partial
+      notes: |-
+          In RHEL 8 pam_pwhistory is enabled via authselect feature, as required in 4.4.3.3.1. The
+          feature automatically set "use_authok" option. In any case, we don't have a rule to check
+          this option specifically.
+      related_rules:
+          - accounts_password_pam_pwhistory_remember_password_auth
+          - accounts_password_pam_pwhistory_remember_system_auth
+
+    - id: 4.4.3.4.1
+      title: Ensure pam_unix does not include nullok (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          The rule more specifically used in this requirement also satify the requirements 4.4.2.1
+          and 4.4.2.5.
+      rules:
+          - no_empty_passwords
+
+    - id: 4.4.3.4.2
+      title: Ensure pam_unix does not include remember (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          Usage of pam_unix.so module together with "remember" option is deprecated and is not
+          recommened by this policy. Instead, it should be used remember option of pam_pwhistory
+          module, as required in 4.4.3.3.1. See here for more details about pam_unix.so:
+          https://bugzilla.redhat.com/show_bug.cgi?id=1778929
+          A new rule needs to be created to remove the remember option from pam_unix module.
+
+    - id: 4.4.3.4.3
+      title: Ensure pam_unix includes a strong password hashing algorithm (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          Changes in logindefs mentioned in this requirement are more specifically covered by 4.5.1.1.
+      rules:
+          - set_password_hashing_algorithm_systemauth
+          - set_password_hashing_algorithm_passwordauth
+          - var_password_hashing_algorithm_pam=sha512
+
+    - id: 4.4.3.4.4
+      title: Ensure pam_unix includes use_authtok (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: partial
+      notes: |-
+          In RHEL 8 pam_unix is enabled by default in all authselect profiles already with the
+          use_authtok option set. In any case, we don't have a rule to check this option specifically,
+          like in 4.4.3.3.3.
+
+    - id: 4.5.1.1
+      title: Ensure strong password hashing algorithm is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - set_password_hashing_algorithm_libuserconf
+          - set_password_hashing_algorithm_logindefs
+          - var_password_hashing_algorithm=SHA512
+          - var_password_hashing_algorithm_pam=sha512
+
+    - id: 4.5.1.2
+      title: Ensure password expiration is 365 days or less (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_maximum_age_login_defs
+          - accounts_password_set_max_life_existing
+          - var_accounts_maximum_age_login_defs=365
+
+    - id: 4.5.1.3
+      title: Ensure password expiration warning days is 7 or more (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_password_set_warn_age_existing
+          - accounts_password_warn_age_login_defs
+          - var_accounts_password_warn_age_login_defs=7
+
+    - id: 4.5.1.4
+      title: Ensure inactive password lock is 30 days or less (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - account_disable_post_pw_expiration
+          - accounts_set_post_pw_existing
+          - var_account_disable_post_pw_expiration=30
+
+    - id: 4.5.1.5
+      title: Ensure all users last password change date is in the past (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_password_last_change_is_in_past
+
+    - id: 4.5.2.1
+      title: Ensure default group for the root account is GID 0 (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_root_gid_zero
+
+    - id: 4.5.2.2
+      title: Ensure root user umask is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          There is no rule to ensure umask in /root/.bash_profile and /root/.bashrc. A new rule have
+          to be created. It can be based on accounts_umask_interactive_users.
+
+    - id: 4.5.2.3
+      title: Ensure system accounts are secured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - no_password_auth_for_systemaccounts
+          - no_shelllogin_for_systemaccounts
+
+    - id: 4.5.2.4
+      title: Ensure root password is set (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - ensure_root_password_configured
+
+    - id: 4.5.3.1
+      title: Ensure nologin is not listed in /etc/shells (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: pending
+      notes: |-
+          It is necessary to create a new rule to check and remove nologin from /etc/shells.
+          The no_tmux_in_shells rule can be used as referece.
+
+    - id: 4.5.3.2
+      title: Ensure default user shell timeout is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_tmout
+          - var_accounts_tmout=15_min
+
+    - id: 4.5.3.3
+      title: Ensure default user umask is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          It is missing a rule to check /etc/pam.d/postlogin. Files /etc/bash.bashrc and
+          /etc/default/login are not used in RHEL 8, but are mentioned in the policy. It has to be
+          clarified in CIS Community. The policy allows the user to override the default system umask
+          on its discretion. This is the reason the accounts_umask_interactive_users rule is in
+          related_rules. If this changes in the future, the rule can be used to ensure that users do
+          not override the system default.
+      rules:
+          - accounts_umask_etc_bashrc
+          - accounts_umask_etc_login_defs
+          - accounts_umask_etc_profile
+          - var_accounts_user_umask=027
+      related_rules:
+          - accounts_umask_interactive_users
+
+    - id: 5.1.1.1
+      title: Ensure rsyslog is installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_rsyslog_installed
+
+    - id: 5.1.1.2
+      title: Ensure rsyslog service is enabled (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          This requirement is expected to be manual in the policy because there are valid cases where
+          other solutions are used for logging. rsyslog is the default in RHEL 8 and so far other
+          solutions are not expected to be incompatible with rsyslog. If so, for these particular
+          cases, this rule should be removed for those systems by a tailored file.
+      rules:
+          - service_rsyslog_enabled
+
+    - id: 5.1.1.3
+      title: Ensure journald is configured to send logs to rsyslog (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - journald_forward_to_syslog
+
+    - id: 5.1.1.4
+      title: Ensure rsyslog default file permissions are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - rsyslog_filecreatemode
+
+    - id: 5.1.1.5
+      title: Ensure logging is configured (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 5.1.1.6
+      title: Ensure rsyslog is configured to send logs to a remote log host (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+      related_rules:
+          - rsyslog_remote_loghost
+
+    - id: 5.1.1.7
+      title: Ensure rsyslog is not configured to recieve logs from a remote client (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - rsyslog_nolisten
+
+    - id: 5.1.2.1.1
+      title: Ensure systemd-journal-remote is installed (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+      related_rules:
+          - package_systemd-journal-remote_installed
+
+    - id: 5.1.2.1.2
+      title: Ensure systemd-journal-remote is configured (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 5.1.2.1.3
+      title: Ensure systemd-journal-remote is enabled (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 5.1.2.1.4
+      title: Ensure journald is not configured to recieve logs from a remote client (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - socket_systemd-journal-remote_disabled
+
+    - id: 5.1.2.2
+      title: Ensure journald service is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - service_systemd-journald_enabled
+
+    - id: 5.1.2.3
+      title: Ensure journald is configured to compress large log files (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - journald_compress
+
+    - id: 5.1.2.4
+      title: Ensure journald is configured to write logfiles to persistent disk (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - journald_storage
+
+    - id: 5.1.2.5
+      title: Ensure journald is not configured to send logs to rsyslog (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 5.1.2.6
+      title: Ensure journald log rotation is configured per site policy (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 5.1.3
+      title: Ensure logrotate is configured (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+      related_rules:
+          - ensure_logrotate_activated
+          - package_logrotate_installed
+          - timer_logrotate_enabled
+
+    - id: 5.1.4
+      title: Ensure all logfiles have appropriate access configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - rsyslog_files_groupownership
+          - rsyslog_files_ownership
+          - rsyslog_files_permissions
+
+    - id: 5.2.1.1
+      title: Ensure audit is installed (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - package_audit_installed
+
+    - id: 5.2.1.2
+      title: Ensure auditing for processes that start prior to auditd is enabled (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - grub2_audit_argument
+
+    - id: 5.2.1.3
+      title: Ensure audit_backlog_limit is sufficient (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - grub2_audit_backlog_limit_argument
+
+    - id: 5.2.1.4
+      title: Ensure auditd service is enabled (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - service_auditd_enabled
+
+    - id: 5.2.2.1
+      title: Ensure audit log storage size is configured (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - auditd_data_retention_max_log_file
+          - var_auditd_max_log_file=6
+
+    - id: 5.2.2.2
+      title: Ensure audit logs are not automatically deleted (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - auditd_data_retention_max_log_file_action
+          - var_auditd_max_log_file_action=keep_logs
+
+    - id: 5.2.2.3
+      title: Ensure system is disabled when audit logs are full (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - auditd_data_disk_error_action
+          - auditd_data_disk_full_action
+          - var_auditd_disk_error_action=cis_rhel8
+          - var_auditd_disk_full_action=cis_rhel8
+
+    - id: 5.2.2.4
+      title: Ensure system warns when audit logs are low on space (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - auditd_data_retention_action_mail_acct
+          - auditd_data_retention_admin_space_left_action
+          - auditd_data_retention_space_left_action
+          - var_auditd_action_mail_acct=root
+          - var_auditd_admin_space_left_action=cis_rhel8
+          - var_auditd_space_left_action=cis_rhel8
+
+    - id: 5.2.3.1
+      title: Ensure changes to system administration scope (sudoers) is collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_sysadmin_actions
+
+    - id: 5.2.3.2
+      title: Ensure actions as another user are always logged (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_suid_auid_privilege_function
+
+    - id: 5.2.3.3
+      title: Ensure events that modify the sudo log file are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_sudo_log_events
+
+    - id: 5.2.3.4
+      title: Ensure events that modify date and time information are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_time_adjtimex
+          - audit_rules_time_settimeofday
+          - audit_rules_time_clock_settime
+          - audit_rules_time_stime
+          - audit_rules_time_watch_localtime
+
+    - id: 5.2.3.5
+      title: Ensure events that modify the system's network environment are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_networkconfig_modification
+          - audit_rules_networkconfig_modification_network_scripts
+
+    - id: 5.2.3.6
+      title: Ensure use of privileged commands are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_privileged_commands
+
+    - id: 5.2.3.7
+      title: Ensure unsuccessful file access attempts are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_unsuccessful_file_modification_creat
+          - audit_rules_unsuccessful_file_modification_ftruncate
+          - audit_rules_unsuccessful_file_modification_open
+          - audit_rules_unsuccessful_file_modification_openat
+          - audit_rules_unsuccessful_file_modification_truncate
+
+    - id: 5.2.3.8
+      title: Ensure events that modify user/group information are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_usergroup_modification_group
+          - audit_rules_usergroup_modification_gshadow
+          - audit_rules_usergroup_modification_opasswd
+          - audit_rules_usergroup_modification_passwd
+          - audit_rules_usergroup_modification_shadow
+
+    - id: 5.2.3.9
+      title: Ensure discretionary access control permission modification events are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_dac_modification_chmod
+          - audit_rules_dac_modification_chown
+          - audit_rules_dac_modification_fchmod
+          - audit_rules_dac_modification_fchmodat
+          - audit_rules_dac_modification_fchown
+          - audit_rules_dac_modification_fchownat
+          - audit_rules_dac_modification_fremovexattr
+          - audit_rules_dac_modification_fsetxattr
+          - audit_rules_dac_modification_lchown
+          - audit_rules_dac_modification_lremovexattr
+          - audit_rules_dac_modification_lsetxattr
+          - audit_rules_dac_modification_removexattr
+          - audit_rules_dac_modification_setxattr
+
+    - id: 5.2.3.10
+      title: Ensure successful file system mounts are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_media_export
+
+    - id: 5.2.3.11
+      title: Ensure session initiation information is collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_session_events_utmp
+          - audit_rules_session_events_btmp
+          - audit_rules_session_events_wtmp
+
+    - id: 5.2.3.12
+      title: Ensure login and logout events are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_login_events_faillock
+          - audit_rules_login_events_lastlog
+          - var_accounts_passwords_pam_faillock_dir=run
+
+    - id: 5.2.3.13
+      title: Ensure file deletion events by users are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_file_deletion_events_rename
+          - audit_rules_file_deletion_events_renameat
+          - audit_rules_file_deletion_events_unlink
+          - audit_rules_file_deletion_events_unlinkat
+
+    - id: 5.2.3.14
+      title: Ensure events that modify the system's Mandatory Access Controls are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_mac_modification
+          - audit_rules_mac_modification_usr_share
+
+    - id: 5.2.3.15
+      title: Ensure successful and unsuccessful attempts to use the chcon command are recorded (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_execution_chcon
+
+    - id: 5.2.3.16
+      title: Ensure successful and unsuccessful attempts to use the setfacl command are recorded (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_execution_setfacl
+
+    - id: 5.2.3.17
+      title: Ensure successful and unsuccessful attempts to use the chacl command are recorded (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_execution_chacl
+
+    - id: 5.2.3.18
+      title: Ensure successful and unsuccessful attempts to use the usermod command are recorded (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_privileged_commands_usermod
+
+    - id: 5.2.3.19
+      title: Ensure kernel module loading, unloading and modification is collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_kernel_module_loading_create
+          - audit_rules_kernel_module_loading_delete
+          - audit_rules_kernel_module_loading_finit
+          - audit_rules_kernel_module_loading_init
+          - audit_rules_kernel_module_loading_query
+          - audit_rules_privileged_commands_kmod
+
+    - id: 5.2.3.20
+      title: Ensure the audit configuration is immutable (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_immutable
+
+    - id: 5.2.3.21
+      title: Ensure the running and on disk configuration is the same (Manual)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: manual
+
+    - id: 5.2.4.1
+      title: Ensure the audit log directory is 0750 or more restrictive (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - directory_permissions_var_log_audit
+
+    - id: 5.2.4.2
+      title: Ensure audit log files are mode 0640 or less permissive (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - file_permissions_var_log_audit
+
+    - id: 5.2.4.3
+      title: Ensure only authorized users own audit log files (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - file_ownership_var_log_audit_stig
+
+    - id: 5.2.4.4
+      title: Ensure only authorized groups are assigned ownership of audit log files (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - file_group_ownership_var_log_audit
+
+    - id: 5.2.4.5
+      title: Ensure audit configuration files are 640 or more restrictive (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - file_permissions_audit_configuration
+
+    - id: 5.2.4.6
+      title: Ensure audit configuration files are owned by root (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - file_ownership_audit_configuration
+
+    - id: 5.2.4.7
+      title: Ensure audit configuration files belong to group root (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - file_groupownership_audit_configuration
+
+    - id: 5.2.4.8
+      title: Ensure audit tools are 755 or more restrictive (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - file_permissions_audit_binaries
+
+    - id: 5.2.4.9
+      title: Ensure audit tools are owned by root (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - file_ownership_audit_binaries
+
+    - id: 5.2.4.10
+      title: Ensure audit tools belong to group root (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - file_groupownership_audit_binaries
+
+    - id: 5.3.1
+      title: Ensure AIDE is installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_aide_installed
+          - aide_build_database
+
+    - id: 5.3.2
+      title: Ensure filesystem integrity is regularly checked (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - aide_periodic_cron_checking
+      related_rules:
+          - aide_periodic_checking_systemd_timer
+
+    - id: 5.3.3
+      title: Ensure cryptographic mechanisms are used to protect the integrity of audit tools (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - aide_check_audit_tools
+      related_rules:
+          - aide_use_fips_hashes
+
+    - id: 6.1.1
+      title: Ensure permissions on /etc/passwd are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_etc_passwd
+          - file_owner_etc_passwd
+          - file_permissions_etc_passwd
+
+    - id: 6.1.2
+      title: Ensure permissions on /etc/passwd- are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_backup_etc_passwd
+          - file_owner_backup_etc_passwd
+          - file_permissions_backup_etc_passwd
+
+    - id: 6.1.3
+      title: Ensure permissions on /etc/security/opasswd are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: partial
+      rules:
     # TODO: We need another rule that checks /etc/security/opasswd.old
-    - file_etc_security_opasswd
+          - file_etc_security_opasswd
 
-  - id: 6.1.4
-    title: Ensure permissions on /etc/group are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_etc_group
-      - file_owner_etc_group
-      - file_permissions_etc_group
+    - id: 6.1.4
+      title: Ensure permissions on /etc/group are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_etc_group
+          - file_owner_etc_group
+          - file_permissions_etc_group
 
-  - id: 6.1.5
-    title: Ensure permissions on /etc/group- are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_backup_etc_group
-      - file_owner_backup_etc_group
-      - file_permissions_backup_etc_group
+    - id: 6.1.5
+      title: Ensure permissions on /etc/group- are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_backup_etc_group
+          - file_owner_backup_etc_group
+          - file_permissions_backup_etc_group
 
-  - id: 6.1.6
-    title: Ensure permissions on /etc/shadow are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_owner_etc_shadow
-      - file_groupowner_etc_shadow
-      - file_permissions_etc_shadow
+    - id: 6.1.6
+      title: Ensure permissions on /etc/shadow are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_owner_etc_shadow
+          - file_groupowner_etc_shadow
+          - file_permissions_etc_shadow
 
-  - id: 6.1.7
-    title: Ensure permissions on /etc/shadow- are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_backup_etc_shadow
-      - file_owner_backup_etc_shadow
-      - file_permissions_backup_etc_shadow
+    - id: 6.1.7
+      title: Ensure permissions on /etc/shadow- are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_backup_etc_shadow
+          - file_owner_backup_etc_shadow
+          - file_permissions_backup_etc_shadow
 
-  - id: 6.1.8
-    title: Ensure permissions on /etc/gshadow are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_etc_gshadow
-      - file_owner_etc_gshadow
-      - file_permissions_etc_gshadow
+    - id: 6.1.8
+      title: Ensure permissions on /etc/gshadow are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_etc_gshadow
+          - file_owner_etc_gshadow
+          - file_permissions_etc_gshadow
 
-  - id: 6.1.9
-    title: Ensure permissions on /etc/gshadow- are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_backup_etc_gshadow
-      - file_owner_backup_etc_gshadow
-      - file_permissions_backup_etc_gshadow
+    - id: 6.1.9
+      title: Ensure permissions on /etc/gshadow- are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_backup_etc_gshadow
+          - file_owner_backup_etc_gshadow
+          - file_permissions_backup_etc_gshadow
 
-  - id: 6.1.10
-    title: Ensure permissions on /etc/shells are configured (Automated)
-    levels:
-    - l1_server
-    - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_etc_shells
-      - file_owner_etc_shells
-      - file_permissions_etc_shells
+    - id: 6.1.10
+      title: Ensure permissions on /etc/shells are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_etc_shells
+          - file_owner_etc_shells
+          - file_permissions_etc_shells
 
-  - id: 6.1.11
-    title: Ensure world writable files and directories are secured (Automated)
-    levels:
-    - l1_server
-    - l1_workstation
-    status: automated
-    rules:
-    - file_permissions_unauthorized_world_writable
-    - dir_perms_world_writable_sticky_bits
+    - id: 6.1.11
+      title: Ensure world writable files and directories are secured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_permissions_unauthorized_world_writable
+          - dir_perms_world_writable_sticky_bits
 
-  - id: 6.1.12
-    title: Ensure no unowned or ungrouped files or directories exist (Automated)
-    levels:
-    - l1_server
-    - l1_workstation
-    status: partial
-    rules:
+    - id: 6.1.12
+      title: Ensure no unowned or ungrouped files or directories exist (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: partial
+      rules:
     # TODO: add rules for unowned/ungrouped directories
-    - no_files_unowned_by_user
-    - file_permissions_ungroupowned
+          - no_files_unowned_by_user
+          - file_permissions_ungroupowned
 
-  - id: 6.1.13
-    title: Ensure SUID and SGID files are reviewed (Manual)
-    levels:
-    - l1_server
-    - l1_workstation
-    status: manual
-    related_rules:
-      - file_permissions_unauthorized_suid
-      - file_permissions_unauthorized_sgid
+    - id: 6.1.13
+      title: Ensure SUID and SGID files are reviewed (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+      related_rules:
+          - file_permissions_unauthorized_suid
+          - file_permissions_unauthorized_sgid
 
-  - id: 6.1.14
-    title: Audit system file permissions (Manual)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: manual
-    related_rules:
-      - rpm_verify_permissions
-      - rpm_verify_ownership
+    - id: 6.1.14
+      title: Audit system file permissions (Manual)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: manual
+      related_rules:
+          - rpm_verify_permissions
+          - rpm_verify_ownership
 
-  - id: 6.2.1
-    title: Ensure accounts in /etc/passwd use shadowed passwords (Automated)
-    levels:
-    - l1_server
-    - l1_workstation
-    status: automated
-    rules:
-    - accounts_password_all_shadowed
+    - id: 6.2.1
+      title: Ensure accounts in /etc/passwd use shadowed passwords (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_password_all_shadowed
 
-  - id: 6.2.2
-    title: Ensure /etc/shadow password fields are not empty (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - no_empty_passwords_etc_shadow
+    - id: 6.2.2
+      title: Ensure /etc/shadow password fields are not empty (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - no_empty_passwords_etc_shadow
 
-  - id: 6.2.3
-    title: Ensure all groups in /etc/passwd exist in /etc/group (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - gid_passwd_group_same
+    - id: 6.2.3
+      title: Ensure all groups in /etc/passwd exist in /etc/group (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - gid_passwd_group_same
 
-  - id: 6.2.4
-    title: Ensure no duplicate UIDs exist (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - account_unique_id
+    - id: 6.2.4
+      title: Ensure no duplicate UIDs exist (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - account_unique_id
 
-  - id: 6.2.5
-    title: Ensure no duplicate GIDs exist (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - group_unique_id
+    - id: 6.2.5
+      title: Ensure no duplicate GIDs exist (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - group_unique_id
 
-  - id: 6.2.6
-    title: Ensure no duplicate user names exist (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - account_unique_name
+    - id: 6.2.6
+      title: Ensure no duplicate user names exist (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - account_unique_name
 
-  - id: 6.2.7
-    title: Ensure no duplicate group names exist (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - group_unique_name
+    - id: 6.2.7
+      title: Ensure no duplicate group names exist (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - group_unique_name
 
-  - id: 6.2.8
-    title: Ensure root path integrity (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_root_path_dirs_no_write
-      - root_path_no_dot
+    - id: 6.2.8
+      title: Ensure root path integrity (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_root_path_dirs_no_write
+          - root_path_no_dot
 
-  - id: 6.2.9
-    title: Ensure root is the only UID 0 account (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_no_uid_except_zero
+    - id: 6.2.9
+      title: Ensure root is the only UID 0 account (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_no_uid_except_zero
 
-  - id: 6.2.10
-    title: Ensure local interactive user home directories are configured (Automated)
-    levels:
-    - l1_server
-    - l1_workstation
-    status: automated
-    rules:
-    - accounts_user_interactive_home_directory_exists
-    - file_ownership_home_directories
-    - file_permissions_home_directories
+    - id: 6.2.10
+      title: Ensure local interactive user home directories are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_user_interactive_home_directory_exists
+          - file_ownership_home_directories
+          - file_permissions_home_directories
 
-  - id: 6.2.11
-    title: Ensure local interactive user dot files access is configured (Automated)
-    levels:
-    - l1_server
-    - l1_workstation
-    notes: |-
-      According to the RHEL 8 CIS Benchmark guidance, the incompliant .forward
-      and .rhost files should be investigated and remediated manually.
-      However, in other profiles we remediate the rule using the automated
-      remediation.
-    status: partial
+    - id: 6.2.11
+      title: Ensure local interactive user dot files access is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      notes: |-
+          According to the RHEL 8 CIS Benchmark guidance, the incompliant .forward
+          and .rhost files should be investigated and remediated manually.
+          However, in other profiles we remediate the rule using the automated
+          remediation.
+      status: partial
     # TODO: add rule checking that .bash_history is mode 0600 or more restrictive
-    rules:
-    - accounts_user_dot_group_ownership
-    - accounts_user_dot_user_ownership
-    - file_permission_user_init_files
-    - var_user_initialization_files_regex=all_dotfiles
-    - no_forward_files
-    - no_rsh_trust_files
-    - accounts_users_netrc_file_permissions
+      rules:
+          - accounts_user_dot_group_ownership
+          - accounts_user_dot_user_ownership
+          - file_permission_user_init_files
+          - var_user_initialization_files_regex=all_dotfiles
+          - no_forward_files
+          - no_rsh_trust_files
+          - accounts_users_netrc_file_permissions

--- a/controls/ism_o.yml
+++ b/controls/ism_o.yml
@@ -1,753 +1,775 @@
+---
 id: 'ism_o'
 title: 'Australian Signals Directorate Information Security Manual'
 policy: 'Australian Signals Directorate Information Security Manual'
 version: '2024.03'
 source: 'https://www.cyber.gov.au/resources-business-and-government/essential-cyber-security/ism'
+
 levels:
-    -   id: base
-    -   id: secret
-        inherits_from:
-            - base
-    -   id: top_secret
-        inherits_from:
-            - secret
+    - id: base
+    - id: secret
+      inherits_from:
+          - base
+    - id: top_secret
+      inherits_from:
+          - secret
 
 controls:
-    -   id: '0418'
-        title: 'Credentials are kept separate from systems they are used to authenticate to, except for when performing authentication activities.'
-        levels:
-            - base
-        rules:
-            - accounts_maximum_age_login_defs
-            - accounts_minimum_age_login_defs
-            - accounts_password_warn_age_login_defs
-            - configure_kerberos_crypto_policy
-            - enable_ldap_client
-            - kerberos_disable_no_keytab
-            - network_nmcli_permissions
-            - sebool_kerberos_enabled
-            - set_password_hashing_algorithm_libuserconf
-            - set_password_hashing_algorithm_logindefs
-            - set_password_hashing_algorithm_passwordauth
-            - set_password_hashing_algorithm_systemauth
-            - sshd_disable_gssapi_auth
-            - var_password_hashing_algorithm_pam=yescrypt
-        status: automated
+    - id: '0418'
+      title: 'Credentials are kept separate from systems they are used to authenticate to, except for
+          when performing authentication activities.'
+      levels:
+          - base
+      rules:
+          - accounts_maximum_age_login_defs
+          - accounts_minimum_age_login_defs
+          - accounts_password_warn_age_login_defs
+          - configure_kerberos_crypto_policy
+          - enable_ldap_client
+          - kerberos_disable_no_keytab
+          - network_nmcli_permissions
+          - sebool_kerberos_enabled
+          - set_password_hashing_algorithm_libuserconf
+          - set_password_hashing_algorithm_logindefs
+          - set_password_hashing_algorithm_passwordauth
+          - set_password_hashing_algorithm_systemauth
+          - sshd_disable_gssapi_auth
+          - var_password_hashing_algorithm_pam=yescrypt
+      status: automated
 
-    -   id: '0421'
-        title: 'Passphrases used for single-factor authentication are at least 4 random words with a total minimum length of 14 characters, unless more stringent requirements apply.'
-        levels:
-            - base
-        rules:
-            - accounts_password_minlen_login_defs
-            - accounts_password_pam_dcredit
-            - accounts_password_pam_lcredit
-            - accounts_password_pam_minclass
-            - accounts_password_pam_minlen
-            - accounts_password_pam_ocredit
-            - accounts_password_pam_ucredit
-            - accounts_passwords_pam_faillock_deny
-            - accounts_passwords_pam_faillock_deny_root
-            - accounts_passwords_pam_faillock_interval
-            - accounts_passwords_pam_faillock_unlock_time
-            - accounts_passwords_pam_tally2_deny_root
-            - accounts_passwords_pam_tally2_unlock_time
-            - disable_host_auth
-            - require_emergency_target_auth
-            - require_singleuser_auth
-            - sebool_authlogin_nsswitch_use_ldap
-            - sebool_authlogin_radius
-            - sshd_disable_kerb_auth
-            - sshd_set_max_auth_tries
-            - sshd_max_auth_tries_value=5
-            - sssd_enable_smartcards
-            - var_password_pam_minlen=14
-            - var_accounts_password_minlen_login_defs=14
-            - var_accounts_password_warn_age_login_defs=7
-            - var_accounts_minimum_age_login_defs=1
-            - var_accounts_maximum_age_login_defs=60
-            - var_authselect_profile=sssd
-        status: automated
+    - id: '0421'
+      title: 'Passphrases used for single-factor authentication are at least 4 random words with a total
+          minimum length of 14 characters, unless more stringent requirements apply.'
+      levels:
+          - base
+      rules:
+          - accounts_password_minlen_login_defs
+          - accounts_password_pam_dcredit
+          - accounts_password_pam_lcredit
+          - accounts_password_pam_minclass
+          - accounts_password_pam_minlen
+          - accounts_password_pam_ocredit
+          - accounts_password_pam_ucredit
+          - accounts_passwords_pam_faillock_deny
+          - accounts_passwords_pam_faillock_deny_root
+          - accounts_passwords_pam_faillock_interval
+          - accounts_passwords_pam_faillock_unlock_time
+          - accounts_passwords_pam_tally2_deny_root
+          - accounts_passwords_pam_tally2_unlock_time
+          - disable_host_auth
+          - require_emergency_target_auth
+          - require_singleuser_auth
+          - sebool_authlogin_nsswitch_use_ldap
+          - sebool_authlogin_radius
+          - sshd_disable_kerb_auth
+          - sshd_set_max_auth_tries
+          - sshd_max_auth_tries_value=5
+          - sssd_enable_smartcards
+          - var_password_pam_minlen=14
+          - var_accounts_password_minlen_login_defs=14
+          - var_accounts_password_warn_age_login_defs=7
+          - var_accounts_minimum_age_login_defs=1
+          - var_accounts_maximum_age_login_defs=60
+          - var_authselect_profile=sssd
+      status: automated
 
-    -   id: '0422'
-        title: 'Passphrases used for single-factor authentication on TOP SECRET systems are at least 6 random words with a total minimum length of 20 characters.'
-        levels:
-            - top_secret
-        rules:
-            - accounts_password_minlen_login_defs
-            - accounts_password_pam_dcredit
-            - accounts_password_pam_lcredit
-            - accounts_password_pam_minclass
-            - accounts_password_pam_minlen
-            - accounts_password_pam_ocredit
-            - accounts_password_pam_ucredit
-            - accounts_passwords_pam_faillock_deny
-            - accounts_passwords_pam_faillock_deny_root
-            - accounts_passwords_pam_faillock_interval
-            - accounts_passwords_pam_faillock_unlock_time
-            - accounts_passwords_pam_tally2_deny_root
-            - accounts_passwords_pam_tally2_unlock_time
-            - disable_host_auth
-            - require_emergency_target_auth
-            - require_singleuser_auth
-            - sebool_authlogin_nsswitch_use_ldap
-            - sebool_authlogin_radius
-            - sshd_disable_kerb_auth
-            - sshd_set_max_auth_tries
-            - sssd_enable_smartcards
-            - var_password_pam_minlen=20
-            - var_accounts_password_minlen_login_defs=20
-        status: automated
-    -   id: '0484'
-        title: 'SSH daemon configuration'
-        levels:
-            - base
-        rules:
-            - disable_host_auth
-            - sshd_enable_warning_banner
-            - sshd_disable_x11_forwarding
-        status: partial
-    -   id: '0487'
-        title: 'Passwordless SSH Connections Configuration'
-        levels:
-            - base
-        status: pending
+    - id: '0422'
+      title: 'Passphrases used for single-factor authentication on TOP SECRET systems are at least 6
+          random words with a total minimum length of 20 characters.'
+      levels:
+          - top_secret
+      rules:
+          - accounts_password_minlen_login_defs
+          - accounts_password_pam_dcredit
+          - accounts_password_pam_lcredit
+          - accounts_password_pam_minclass
+          - accounts_password_pam_minlen
+          - accounts_password_pam_ocredit
+          - accounts_password_pam_ucredit
+          - accounts_passwords_pam_faillock_deny
+          - accounts_passwords_pam_faillock_deny_root
+          - accounts_passwords_pam_faillock_interval
+          - accounts_passwords_pam_faillock_unlock_time
+          - accounts_passwords_pam_tally2_deny_root
+          - accounts_passwords_pam_tally2_unlock_time
+          - disable_host_auth
+          - require_emergency_target_auth
+          - require_singleuser_auth
+          - sebool_authlogin_nsswitch_use_ldap
+          - sebool_authlogin_radius
+          - sshd_disable_kerb_auth
+          - sshd_set_max_auth_tries
+          - sssd_enable_smartcards
+          - var_password_pam_minlen=20
+          - var_accounts_password_minlen_login_defs=20
+      status: automated
+    - id: '0484'
+      title: 'SSH daemon configuration'
+      levels:
+          - base
+      rules:
+          - disable_host_auth
+          - sshd_enable_warning_banner
+          - sshd_disable_x11_forwarding
+      status: partial
+    - id: '0487'
+      title: 'Passwordless SSH Connections Configuration'
+      levels:
+          - base
+      status: pending
 
-    -   id: '0582'
-        title: 'Central Logging for OS Events'
-        levels:
-            - base
-        rules:
-            - audit_access_failed
-            - audit_access_failed_aarch64
-            - audit_access_failed_ppc64le
-            - audit_access_success
-            - audit_access_success_aarch64
-            - audit_access_success_ppc64le
-            - audit_rules_privileged_commands
-            - audit_rules_session_events_utmp
-            - audit_rules_session_events_btmp
-            - audit_rules_session_events_wtmp
-            - audit_rules_unsuccessful_file_modification_creat
-            - audit_rules_unsuccessful_file_modification_open
-            - audit_rules_unsuccessful_file_modification_openat
-            - audit_rules_unsuccessful_file_modification_open_by_handle_at
-            - audit_rules_unsuccessful_file_modification_truncate
-            - audit_rules_unsuccessful_file_modification_ftruncate
-            - package_audit_installed
-            - sshd_print_last_log
-            - sebool_auditadm_exec_content
-        status: automated
+    - id: '0582'
+      title: 'Central Logging for OS Events'
+      levels:
+          - base
+      rules:
+          - audit_access_failed
+          - audit_access_failed_aarch64
+          - audit_access_failed_ppc64le
+          - audit_access_success
+          - audit_access_success_aarch64
+          - audit_access_success_ppc64le
+          - audit_rules_privileged_commands
+          - audit_rules_session_events_utmp
+          - audit_rules_session_events_btmp
+          - audit_rules_session_events_wtmp
+          - audit_rules_unsuccessful_file_modification_creat
+          - audit_rules_unsuccessful_file_modification_open
+          - audit_rules_unsuccessful_file_modification_openat
+          - audit_rules_unsuccessful_file_modification_open_by_handle_at
+          - audit_rules_unsuccessful_file_modification_truncate
+          - audit_rules_unsuccessful_file_modification_ftruncate
+          - package_audit_installed
+          - sshd_print_last_log
+          - sebool_auditadm_exec_content
+      status: automated
 
-    -   id: '0846'
-        title: 'All users (with the exception of local administrator accounts and break glass accounts) cannot disable, bypass or be exempted from application control.'
-        levels:
-            - base
-        rules:
-            - audit_access_failed
-            - audit_access_failed_aarch64
-            - audit_access_failed_ppc64le
-            - audit_access_success
-            - audit_access_success_aarch64
-            - audit_access_success_ppc64le
-            - audit_rules_privileged_commands
-            - audit_rules_session_events_utmp
-            - audit_rules_session_events_btmp
-            - audit_rules_session_events_wtmp
-            - audit_rules_unsuccessful_file_modification_creat
-            - audit_rules_unsuccessful_file_modification_open
-            - audit_rules_unsuccessful_file_modification_openat
-            - audit_rules_unsuccessful_file_modification_open_by_handle_at
-            - audit_rules_unsuccessful_file_modification_truncate
-            - audit_rules_unsuccessful_file_modification_ftruncate
-            - package_audit_installed
-            - sshd_print_last_log
-            - sebool_auditadm_exec_content
-        status: automated
+    - id: '0846'
+      title: 'All users (with the exception of local administrator accounts and break glass accounts)
+          cannot disable, bypass or be exempted from application control.'
+      levels:
+          - base
+      rules:
+          - audit_access_failed
+          - audit_access_failed_aarch64
+          - audit_access_failed_ppc64le
+          - audit_access_success
+          - audit_access_success_aarch64
+          - audit_access_success_ppc64le
+          - audit_rules_privileged_commands
+          - audit_rules_session_events_utmp
+          - audit_rules_session_events_btmp
+          - audit_rules_session_events_wtmp
+          - audit_rules_unsuccessful_file_modification_creat
+          - audit_rules_unsuccessful_file_modification_open
+          - audit_rules_unsuccessful_file_modification_openat
+          - audit_rules_unsuccessful_file_modification_open_by_handle_at
+          - audit_rules_unsuccessful_file_modification_truncate
+          - audit_rules_unsuccessful_file_modification_ftruncate
+          - package_audit_installed
+          - sshd_print_last_log
+          - sebool_auditadm_exec_content
+      status: automated
 
-    -   id: '0974'
-        title: 'Multi-factor authentication is used to authenticate unprivileged users of systems.'
-        levels:
-            - base
-        rules:
-            - accounts_password_minlen_login_defs
-            - accounts_password_pam_dcredit
-            - accounts_password_pam_lcredit
-            - accounts_password_pam_minclass
-            - accounts_password_pam_minlen
-            - accounts_password_pam_ocredit
-            - accounts_password_pam_ucredit
-            - accounts_passwords_pam_faillock_deny
-            - accounts_passwords_pam_faillock_deny_root
-            - accounts_passwords_pam_faillock_interval
-            - accounts_passwords_pam_faillock_unlock_time
-            - accounts_passwords_pam_tally2_deny_root
-            - accounts_passwords_pam_tally2_unlock_time
-            - disable_host_auth
-            - require_emergency_target_auth
-            - require_singleuser_auth
-            - sebool_authlogin_nsswitch_use_ldap
-            - sebool_authlogin_radius
-            - sshd_disable_kerb_auth
-            - sshd_set_max_auth_tries
-            - sssd_enable_smartcards
-        status: partial
-        notes: |-
-            This needs reevaluation.
+    - id: '0974'
+      title: 'Multi-factor authentication is used to authenticate unprivileged users of systems.'
+      levels:
+          - base
+      rules:
+          - accounts_password_minlen_login_defs
+          - accounts_password_pam_dcredit
+          - accounts_password_pam_lcredit
+          - accounts_password_pam_minclass
+          - accounts_password_pam_minlen
+          - accounts_password_pam_ocredit
+          - accounts_password_pam_ucredit
+          - accounts_passwords_pam_faillock_deny
+          - accounts_passwords_pam_faillock_deny_root
+          - accounts_passwords_pam_faillock_interval
+          - accounts_passwords_pam_faillock_unlock_time
+          - accounts_passwords_pam_tally2_deny_root
+          - accounts_passwords_pam_tally2_unlock_time
+          - disable_host_auth
+          - require_emergency_target_auth
+          - require_singleuser_auth
+          - sebool_authlogin_nsswitch_use_ldap
+          - sebool_authlogin_radius
+          - sshd_disable_kerb_auth
+          - sshd_set_max_auth_tries
+          - sssd_enable_smartcards
+      status: partial
+      notes: |-
+          This needs reevaluation.
 
-    -   id: '0988'
-        title: 'An accurate time source is established and used consistently across systems to assist with identifying connections between events.'
-        levels:
-            - base
-        rules:
-            - chronyd_configure_pool_and_server
-            - chronyd_or_ntpd_specify_multiple_servers
-            - chronyd_specify_remote_server
-            - package_chrony_installed
-            - rsyslog_cron_logging
-            - rsyslog_files_groupownership
-            - rsyslog_files_ownership
-            - rsyslog_files_permissions
-            - rsyslog_nolisten
-            - rsyslog_remote_loghost
-            - rsyslog_remote_tls
-            - rsyslog_remote_tls_cacert
-            - service_chronyd_enabled
-            - service_chronyd_or_ntpd_enabled
-        status: automated
+    - id: '0988'
+      title: 'An accurate time source is established and used consistently across systems to assist with
+          identifying connections between events.'
+      levels:
+          - base
+      rules:
+          - chronyd_configure_pool_and_server
+          - chronyd_or_ntpd_specify_multiple_servers
+          - chronyd_specify_remote_server
+          - package_chrony_installed
+          - rsyslog_cron_logging
+          - rsyslog_files_groupownership
+          - rsyslog_files_ownership
+          - rsyslog_files_permissions
+          - rsyslog_nolisten
+          - rsyslog_remote_loghost
+          - rsyslog_remote_tls
+          - rsyslog_remote_tls_cacert
+          - service_chronyd_enabled
+          - service_chronyd_or_ntpd_enabled
+      status: automated
 
-    -   id: '1034'
-        title: 'A HIPS is implemented on critical servers and high-value servers.'
-        levels:
-            - base
-        rules:
-            - package_aide_installed
-        status: automated
+    - id: '1034'
+      title: 'A HIPS is implemented on critical servers and high-value servers.'
+      levels:
+          - base
+      rules:
+          - package_aide_installed
+      status: automated
 
-    -   id: '1055'
-        title: 'LAN Manager and NT LAN Manager authentication methods are disabled.'
-        levels:
-            - base
-        rules:
-            - accounts_maximum_age_login_defs
-            - accounts_minimum_age_login_defs
-            - accounts_password_warn_age_login_defs
-            - configure_kerberos_crypto_policy
-            - enable_ldap_client
-            - kerberos_disable_no_keytab
-            - network_nmcli_permissions
-            - sebool_kerberos_enabled
-            - set_password_hashing_algorithm_libuserconf
-            - set_password_hashing_algorithm_logindefs
-            - set_password_hashing_algorithm_passwordauth
-            - set_password_hashing_algorithm_systemauth
-            - sshd_disable_gssapi_auth
-        status: partial
-        notes: |-
-            Needs reevaluation
+    - id: '1055'
+      title: 'LAN Manager and NT LAN Manager authentication methods are disabled.'
+      levels:
+          - base
+      rules:
+          - accounts_maximum_age_login_defs
+          - accounts_minimum_age_login_defs
+          - accounts_password_warn_age_login_defs
+          - configure_kerberos_crypto_policy
+          - enable_ldap_client
+          - kerberos_disable_no_keytab
+          - network_nmcli_permissions
+          - sebool_kerberos_enabled
+          - set_password_hashing_algorithm_libuserconf
+          - set_password_hashing_algorithm_logindefs
+          - set_password_hashing_algorithm_passwordauth
+          - set_password_hashing_algorithm_systemauth
+          - sshd_disable_gssapi_auth
+      status: partial
+      notes: |-
+          Needs reevaluation
 
-    -   id: '1173'
-        title: 'Multi-factor authentication is used to authenticate privileged users of systems.'
-        levels:
-            - base
-        rules:
-            - accounts_password_minlen_login_defs
-            - accounts_password_pam_dcredit
-            - accounts_password_pam_lcredit
-            - accounts_password_pam_minclass
-            - accounts_password_pam_minlen
-            - accounts_password_pam_ocredit
-            - accounts_password_pam_ucredit
-            - accounts_passwords_pam_faillock_deny
-            - accounts_passwords_pam_faillock_deny_root
-            - accounts_passwords_pam_faillock_interval
-            - accounts_passwords_pam_faillock_unlock_time
-            - accounts_passwords_pam_tally2_deny_root
-            - accounts_passwords_pam_tally2_unlock_time
-            - disable_host_auth
-            - require_emergency_target_auth
-            - require_singleuser_auth
-            - sebool_authlogin_nsswitch_use_ldap
-            - sebool_authlogin_radius
-            - sshd_disable_kerb_auth
-            - sshd_set_max_auth_tries
-            - sssd_enable_smartcards
-        status: automated
+    - id: '1173'
+      title: 'Multi-factor authentication is used to authenticate privileged users of systems.'
+      levels:
+          - base
+      rules:
+          - accounts_password_minlen_login_defs
+          - accounts_password_pam_dcredit
+          - accounts_password_pam_lcredit
+          - accounts_password_pam_minclass
+          - accounts_password_pam_minlen
+          - accounts_password_pam_ocredit
+          - accounts_password_pam_ucredit
+          - accounts_passwords_pam_faillock_deny
+          - accounts_passwords_pam_faillock_deny_root
+          - accounts_passwords_pam_faillock_interval
+          - accounts_passwords_pam_faillock_unlock_time
+          - accounts_passwords_pam_tally2_deny_root
+          - accounts_passwords_pam_tally2_unlock_time
+          - disable_host_auth
+          - require_emergency_target_auth
+          - require_singleuser_auth
+          - sebool_authlogin_nsswitch_use_ldap
+          - sebool_authlogin_radius
+          - sshd_disable_kerb_auth
+          - sshd_set_max_auth_tries
+          - sssd_enable_smartcards
+      status: automated
 
-    -   id: '1277'
-        title: 'Data communicated between database servers and web servers is encrypted.'
-        levels:
-            - base
-        rules:
-            - openssl_use_strong_entropy
-        status: partial
+    - id: '1277'
+      title: 'Data communicated between database servers and web servers is encrypted.'
+      levels:
+          - base
+      rules:
+          - openssl_use_strong_entropy
+      status: partial
 
-    -   id: '1288'
-        title: 'Files imported or exported via gateways or CDSs undergo antivirus scanning using multiple different scanning engines.'
-        levels:
-            - base
-        rules:
-            - package_aide_installed
-        status: partial
+    - id: '1288'
+      title: 'Files imported or exported via gateways or CDSs undergo antivirus scanning using multiple
+          different scanning engines.'
+      levels:
+          - base
+      rules:
+          - package_aide_installed
+      status: partial
 
-    -   id: '1311'
-        title: 'SNMP version 1 and SNMP version 2 are not used on networks.'
-        levels:
-            - base
-        rules:
-            - service_snmpd_disabled
-            - snmpd_use_newer_protocol
-        status: partial
+    - id: '1311'
+      title: 'SNMP version 1 and SNMP version 2 are not used on networks.'
+      levels:
+          - base
+      rules:
+          - service_snmpd_disabled
+          - snmpd_use_newer_protocol
+      status: partial
 
-    -   id: '1315'
-        title: 'The administrative interface on wireless access points is disabled for wireless network connections.'
-        levels:
-            - base
-        rules:
-            - network_ipv6_static_address
-            - wireless_disable_interfaces
-        status: automated
+    - id: '1315'
+      title: 'The administrative interface on wireless access points is disabled for wireless network
+          connections.'
+      levels:
+          - base
+      rules:
+          - network_ipv6_static_address
+          - wireless_disable_interfaces
+      status: automated
 
-    -   id: '1319'
-        title: 'Static addressing is not used for assigning IP addresses on wireless networks.'
-        levels:
-            - base
-        rules:
-            - network_ipv6_static_address
-            - wireless_disable_interfaces
-        status: partial
+    - id: '1319'
+      title: 'Static addressing is not used for assigning IP addresses on wireless networks.'
+      levels:
+          - base
+      rules:
+          - network_ipv6_static_address
+          - wireless_disable_interfaces
+      status: partial
 
-    -   id: '1341'
-        title: 'A HIPS is implemented on workstations.'
-        levels:
-            - base
-        rules:
-            - package_aide_installed
-        status: automated
+    - id: '1341'
+      title: 'A HIPS is implemented on workstations.'
+      levels:
+          - base
+      rules:
+          - package_aide_installed
+      status: automated
 
-    -   id: '1386'
-        title: 'Network management traffic can only originate from administrative infrastructure.'
-        levels:
-            - base
-        rules:
-            - configure_opensc_card_drivers
-            - force_opensc_card_drivers
-            - package_opensc_installed
-            - package_pcsc-lite_installed
-            - package_pcsc-lite-ccid_installed
-            - package_sudo_installed
-            - service_pcscd_enabled
-        status: partial
-        notes: |-
-            This needs reevaluation.
+    - id: '1386'
+      title: 'Network management traffic can only originate from administrative infrastructure.'
+      levels:
+          - base
+      rules:
+          - configure_opensc_card_drivers
+          - force_opensc_card_drivers
+          - package_opensc_installed
+          - package_pcsc-lite_installed
+          - package_pcsc-lite-ccid_installed
+          - package_sudo_installed
+          - service_pcscd_enabled
+      status: partial
+      notes: |-
+          This needs reevaluation.
 
-    -   id: '1401'
-        title: 'Multi-factor authentication uses either: something users have and something users know, or something users have that is
-                unlocked by something users know or are.'
-        levels:
-            - base
-        rules:
-            - accounts_password_minlen_login_defs
-            - accounts_password_pam_dcredit
-            - accounts_password_pam_lcredit
-            - accounts_password_pam_minclass
-            - accounts_password_pam_minlen
-            - accounts_password_pam_ocredit
-            - accounts_password_pam_ucredit
-            - accounts_passwords_pam_faillock_deny
-            - accounts_passwords_pam_faillock_deny_root
-            - accounts_passwords_pam_faillock_interval
-            - accounts_passwords_pam_faillock_unlock_time
-            - accounts_passwords_pam_tally2_deny_root
-            - accounts_passwords_pam_tally2_unlock_time
-            - disable_host_auth
-            - require_emergency_target_auth
-            - require_singleuser_auth
-            - sebool_authlogin_nsswitch_use_ldap
-            - sebool_authlogin_radius
-            - sshd_disable_kerb_auth
-            - sshd_set_max_auth_tries
-            - sssd_enable_smartcards
-        status: partial
+    - id: '1401'
+      title: 'Multi-factor authentication uses either: something users have and something users know,
+          or something users have that is unlocked by something users know or are.'
+      levels:
+          - base
+      rules:
+          - accounts_password_minlen_login_defs
+          - accounts_password_pam_dcredit
+          - accounts_password_pam_lcredit
+          - accounts_password_pam_minclass
+          - accounts_password_pam_minlen
+          - accounts_password_pam_ocredit
+          - accounts_password_pam_ucredit
+          - accounts_passwords_pam_faillock_deny
+          - accounts_passwords_pam_faillock_deny_root
+          - accounts_passwords_pam_faillock_interval
+          - accounts_passwords_pam_faillock_unlock_time
+          - accounts_passwords_pam_tally2_deny_root
+          - accounts_passwords_pam_tally2_unlock_time
+          - disable_host_auth
+          - require_emergency_target_auth
+          - require_singleuser_auth
+          - sebool_authlogin_nsswitch_use_ldap
+          - sebool_authlogin_radius
+          - sshd_disable_kerb_auth
+          - sshd_set_max_auth_tries
+          - sssd_enable_smartcards
+      status: partial
 
-    -   id: '1402'
-        title: 'Credentials stored on systems are protected by a password manager; a hardware security module; or by salting, hashing
-and stretching them before storage within a database'
-        levels:
-            - base
-        rules:
-            - accounts_maximum_age_login_defs
-            - accounts_minimum_age_login_defs
-            - accounts_password_warn_age_login_defs
-            - configure_kerberos_crypto_policy
-            - enable_ldap_client
-            - kerberos_disable_no_keytab
-            - network_nmcli_permissions
-            - sebool_kerberos_enabled
-            - set_password_hashing_algorithm_libuserconf
-            - set_password_hashing_algorithm_logindefs
-            - set_password_hashing_algorithm_passwordauth
-            - set_password_hashing_algorithm_systemauth
-            - sshd_disable_gssapi_auth
-        status: automated
+    - id: '1402'
+      title: 'Credentials stored on systems are protected by a password manager; a hardware security
+          module; or by salting, hashing and stretching them before storage within a database'
+      levels:
+          - base
+      rules:
+          - accounts_maximum_age_login_defs
+          - accounts_minimum_age_login_defs
+          - accounts_password_warn_age_login_defs
+          - configure_kerberos_crypto_policy
+          - enable_ldap_client
+          - kerberos_disable_no_keytab
+          - network_nmcli_permissions
+          - sebool_kerberos_enabled
+          - set_password_hashing_algorithm_libuserconf
+          - set_password_hashing_algorithm_logindefs
+          - set_password_hashing_algorithm_passwordauth
+          - set_password_hashing_algorithm_systemauth
+          - sshd_disable_gssapi_auth
+      status: automated
 
-    -   id: '1405'
-        title: 'A centralised event logging facility is implemented and event logs are sent to the facility as soon as possible after they occur.'
-        levels:
-            - base
-        rules:
-            - chronyd_configure_pool_and_server
-            - chronyd_or_ntpd_specify_multiple_servers
-            - chronyd_specify_remote_server
-            - package_chrony_installed
-            - rsyslog_cron_logging
-            - rsyslog_files_groupownership
-            - rsyslog_files_ownership
-            - rsyslog_files_permissions
-            - rsyslog_nolisten
-            - rsyslog_remote_loghost
-            - rsyslog_remote_tls
-            - rsyslog_remote_tls_cacert
-            - service_chronyd_enabled
-            - service_chronyd_or_ntpd_enabled
-        status: automated
+    - id: '1405'
+      title: 'A centralised event logging facility is implemented and event logs are sent to the facility
+          as soon as possible after they occur.'
+      levels:
+          - base
+      rules:
+          - chronyd_configure_pool_and_server
+          - chronyd_or_ntpd_specify_multiple_servers
+          - chronyd_specify_remote_server
+          - package_chrony_installed
+          - rsyslog_cron_logging
+          - rsyslog_files_groupownership
+          - rsyslog_files_ownership
+          - rsyslog_files_permissions
+          - rsyslog_nolisten
+          - rsyslog_remote_loghost
+          - rsyslog_remote_tls
+          - rsyslog_remote_tls_cacert
+          - service_chronyd_enabled
+          - service_chronyd_or_ntpd_enabled
+      status: automated
 
-    -   id: '1416'
-        title: 'A software firewall is implemented on workstations and servers to restrict inbound and outbound network connections to an organisation-approved set of applications and services.'
-        levels:
-            - base
-        rules:
-            - configure_firewalld_ports
-            - firewalld_sshd_port_enabled
-            - set_firewalld_default_zone
-        status: automated
+    - id: '1416'
+      title: 'A software firewall is implemented on workstations and servers to restrict inbound and
+          outbound network connections to an organisation-approved set of applications and services.'
+      levels:
+          - base
+      rules:
+          - configure_firewalld_ports
+          - firewalld_sshd_port_enabled
+          - set_firewalld_default_zone
+      status: automated
 
-    -   id: '1417'
-        title: 'Antivirus software is implemented on workstations and server.'
-        levels:
-            - base
-        rules:
-            - package_aide_installed
-        status: partial
+    - id: '1417'
+      title: 'Antivirus software is implemented on workstations and server.'
+      levels:
+          - base
+      rules:
+          - package_aide_installed
+      status: partial
 
-    -   id: '1418'
-        title: 'If there is no business requirement for reading from removable media and devices, such functionality is disabled via the
-use of device access control software or by disabling external communication interfaces'
-        levels:
-            - base
-        rules:
-            - package_usbguard_installed
-            - service_usbguard_enabled
-        status: automated
+    - id: '1418'
+      title: 'If there is no business requirement for reading from removable media and devices, such
+          functionality is disabled via the use of device access control software or by disabling external
+          communication interfaces'
+      levels:
+          - base
+      rules:
+          - package_usbguard_installed
+          - service_usbguard_enabled
+      status: automated
 
-    -   id: '1446'
-        title: 'When using elliptic curve cryptography, a suitable curve from NIST SP 800-186 is used.'
-        levels:
-            - base
-        rules:
-            - configure_crypto_policy
-            - enable_dracut_fips_module
-            - system_booted_in_fips_mode
-            - var_system_crypto_policy=fips
-            - enable_fips_mode
-        status: automated
+    - id: '1446'
+      title: 'When using elliptic curve cryptography, a suitable curve from NIST SP 800-186 is used.'
+      levels:
+          - base
+      rules:
+          - configure_crypto_policy
+          - enable_dracut_fips_module
+          - system_booted_in_fips_mode
+          - var_system_crypto_policy=fips
+          - enable_fips_mode
+      status: automated
 
-    -   id: '1449'
-        title: 'SSH private keys are protected with a passphrase or a key encryption key'
-        levels:
-            - base
-        rules:
-            - file_permissions_sshd_private_key
-        status: partial
-        notes: |-
-            This needs more
+    - id: '1449'
+      title: 'SSH private keys are protected with a passphrase or a key encryption key'
+      levels:
+          - base
+      rules:
+          - file_permissions_sshd_private_key
+      status: partial
+      notes: |-
+          This needs more
 
-    -   id: '1467'
-        title: 'The latest release of office productivity suites, web browsers and their extensions, email clients, PDF software, and security products are used.'
-        levels:
-            - base
-        rules:
-            - dnf-automatic_apply_updates
-            - package_libdnf-plugin-subscription-manager_installed
-            - package_subscription-manager_installed
-        status: automated
+    - id: '1467'
+      title: 'The latest release of office productivity suites, web browsers and their extensions, email
+          clients, PDF software, and security products are used.'
+      levels:
+          - base
+      rules:
+          - dnf-automatic_apply_updates
+          - package_libdnf-plugin-subscription-manager_installed
+          - package_subscription-manager_installed
+      status: automated
 
-    -   id: '1483'
-        title: 'The latest release of internet-facing server applications are used.'
-        levels:
-            - base
-        rules:
-            - dnf-automatic_apply_updates
-            - package_libdnf-plugin-subscription-manager_installed
-            - package_subscription-manager_installed
-        status: automated
+    - id: '1483'
+      title: 'The latest release of internet-facing server applications are used.'
+      levels:
+          - base
+      rules:
+          - dnf-automatic_apply_updates
+          - package_libdnf-plugin-subscription-manager_installed
+          - package_subscription-manager_installed
+      status: automated
 
-    -   id: '1491'
-        title: 'Unprivileged users are prevented from running script execution engines.'
-        levels:
-            - base
-        rules:
-            - no_shelllogin_for_systemaccounts
-        status: automated
+    - id: '1491'
+      title: 'Unprivileged users are prevented from running script execution engines.'
+      levels:
+          - base
+      rules:
+          - no_shelllogin_for_systemaccounts
+      status: automated
 
-    -   id: '1493'
-        title: 'Software registers for workstations, servers, network devices and other ICT equipment are developed, implemented, maintained and verified on a regular basis.'
-        levels:
-            - base
-        rules:
-            - dnf-automatic_apply_updates
-            - package_libdnf-plugin-subscription-manager_installed
-            - package_subscription-manager_installed
-        status: automated
+    - id: '1493'
+      title: 'Software registers for workstations, servers, network devices and other ICT equipment are
+          developed, implemented, maintained and verified on a regular basis.'
+      levels:
+          - base
+      rules:
+          - dnf-automatic_apply_updates
+          - package_libdnf-plugin-subscription-manager_installed
+          - package_subscription-manager_installed
+      status: automated
 
-    -   id: '1504'
-        title: 'Multi-factor authentication is used to authenticate users to their organisation’s online services that process, store or communicate their organisation’s sensitive data.'
-        levels:
-            - base
-        rules:
-            - accounts_password_minlen_login_defs
-            - accounts_password_pam_dcredit
-            - accounts_password_pam_lcredit
-            - accounts_password_pam_minclass
-            - accounts_password_pam_minlen
-            - accounts_password_pam_ocredit
-            - accounts_password_pam_ucredit
-            - accounts_passwords_pam_faillock_deny
-            - accounts_passwords_pam_faillock_deny_root
-            - accounts_passwords_pam_faillock_interval
-            - accounts_passwords_pam_faillock_unlock_time
-            - accounts_passwords_pam_tally2_deny_root
-            - accounts_passwords_pam_tally2_unlock_time
-            - disable_host_auth
-            - require_emergency_target_auth
-            - require_singleuser_auth
-            - sebool_authlogin_nsswitch_use_ldap
-            - sebool_authlogin_radius
-            - sshd_disable_kerb_auth
-            - sshd_set_max_auth_tries
-            - sssd_enable_smartcards
-        status: partial
+    - id: '1504'
+      title: 'Multi-factor authentication is used to authenticate users to their organisation’s online
+          services that process, store or communicate their organisation’s sensitive data.'
+      levels:
+          - base
+      rules:
+          - accounts_password_minlen_login_defs
+          - accounts_password_pam_dcredit
+          - accounts_password_pam_lcredit
+          - accounts_password_pam_minclass
+          - accounts_password_pam_minlen
+          - accounts_password_pam_ocredit
+          - accounts_password_pam_ucredit
+          - accounts_passwords_pam_faillock_deny
+          - accounts_passwords_pam_faillock_deny_root
+          - accounts_passwords_pam_faillock_interval
+          - accounts_passwords_pam_faillock_unlock_time
+          - accounts_passwords_pam_tally2_deny_root
+          - accounts_passwords_pam_tally2_unlock_time
+          - disable_host_auth
+          - require_emergency_target_auth
+          - require_singleuser_auth
+          - sebool_authlogin_nsswitch_use_ldap
+          - sebool_authlogin_radius
+          - sshd_disable_kerb_auth
+          - sshd_set_max_auth_tries
+          - sssd_enable_smartcards
+      status: partial
 
-    -   id: '1505'
-        title: 'Multi-factor authentication is used to authenticate users of data repositories.'
-        levels:
-            - base
-        rules:
-            - accounts_password_minlen_login_defs
-            - accounts_password_pam_dcredit
-            - accounts_password_pam_lcredit
-            - accounts_password_pam_minclass
-            - accounts_password_pam_minlen
-            - accounts_password_pam_ocredit
-            - accounts_password_pam_ucredit
-            - accounts_passwords_pam_faillock_deny
-            - accounts_passwords_pam_faillock_deny_root
-            - accounts_passwords_pam_faillock_interval
-            - accounts_passwords_pam_faillock_unlock_time
-            - accounts_passwords_pam_tally2_deny_root
-            - accounts_passwords_pam_tally2_unlock_time
-            - disable_host_auth
-            - require_emergency_target_auth
-            - require_singleuser_auth
-            - sebool_authlogin_nsswitch_use_ldap
-            - sebool_authlogin_radius
-            - sshd_disable_kerb_auth
-            - sshd_set_max_auth_tries
-            - sssd_enable_smartcards
-        status: partial
+    - id: '1505'
+      title: 'Multi-factor authentication is used to authenticate users of data repositories.'
+      levels:
+          - base
+      rules:
+          - accounts_password_minlen_login_defs
+          - accounts_password_pam_dcredit
+          - accounts_password_pam_lcredit
+          - accounts_password_pam_minclass
+          - accounts_password_pam_minlen
+          - accounts_password_pam_ocredit
+          - accounts_password_pam_ucredit
+          - accounts_passwords_pam_faillock_deny
+          - accounts_passwords_pam_faillock_deny_root
+          - accounts_passwords_pam_faillock_interval
+          - accounts_passwords_pam_faillock_unlock_time
+          - accounts_passwords_pam_tally2_deny_root
+          - accounts_passwords_pam_tally2_unlock_time
+          - disable_host_auth
+          - require_emergency_target_auth
+          - require_singleuser_auth
+          - sebool_authlogin_nsswitch_use_ldap
+          - sebool_authlogin_radius
+          - sshd_disable_kerb_auth
+          - sshd_set_max_auth_tries
+          - sssd_enable_smartcards
+      status: partial
 
-    -   id: '1506'
-        title: 'The use of SSH version 1 is disabled for SSH connections.'
-        levels:
-            - base
-        related_rules:
-            - sshd_allow_only_protocol2
-        status: inherently met
-        notes: |-
-            As of OpenSSH 7.6, OpenSSH only supports SSH 2.
+    - id: '1506'
+      title: 'The use of SSH version 1 is disabled for SSH connections.'
+      levels:
+          - base
+      related_rules:
+          - sshd_allow_only_protocol2
+      status: inherently met
+      notes: |-
+          As of OpenSSH 7.6, OpenSSH only supports SSH 2.
 
-    -   id: '1546'
-        title: 'Users are authenticated before they are granted access to a system and its resources'
-        levels:
-            - base
-        rules:
-            - accounts_password_minlen_login_defs
-            - accounts_password_pam_dcredit
-            - accounts_password_pam_lcredit
-            - accounts_password_pam_minclass
-            - accounts_password_pam_minlen
-            - accounts_password_pam_ocredit
-            - accounts_password_pam_ucredit
-            - accounts_passwords_pam_faillock_deny
-            - accounts_passwords_pam_faillock_deny_root
-            - accounts_passwords_pam_faillock_interval
-            - accounts_passwords_pam_faillock_unlock_time
-            - accounts_passwords_pam_tally2_deny_root
-            - accounts_passwords_pam_tally2_unlock_time
-            - disable_host_auth
-            - require_emergency_target_auth
-            - require_singleuser_auth
-            - sebool_authlogin_nsswitch_use_ldap
-            - sebool_authlogin_radius
-            - sshd_disable_kerb_auth
-            - sshd_set_max_auth_tries
-            - sssd_enable_smartcards
-        status: automated
+    - id: '1546'
+      title: 'Users are authenticated before they are granted access to a system and its resources'
+      levels:
+          - base
+      rules:
+          - accounts_password_minlen_login_defs
+          - accounts_password_pam_dcredit
+          - accounts_password_pam_lcredit
+          - accounts_password_pam_minclass
+          - accounts_password_pam_minlen
+          - accounts_password_pam_ocredit
+          - accounts_password_pam_ucredit
+          - accounts_passwords_pam_faillock_deny
+          - accounts_passwords_pam_faillock_deny_root
+          - accounts_passwords_pam_faillock_interval
+          - accounts_passwords_pam_faillock_unlock_time
+          - accounts_passwords_pam_tally2_deny_root
+          - accounts_passwords_pam_tally2_unlock_time
+          - disable_host_auth
+          - require_emergency_target_auth
+          - require_singleuser_auth
+          - sebool_authlogin_nsswitch_use_ldap
+          - sebool_authlogin_radius
+          - sshd_disable_kerb_auth
+          - sshd_set_max_auth_tries
+          - sssd_enable_smartcards
+      status: automated
 
-    -   id: '1552'
-        title: 'All web application content is offered exclusively using HTTPS.'
-        levels:
-            - base
-        rules:
-            - openssl_use_strong_entropy
-        status: partial
+    - id: '1552'
+      title: 'All web application content is offered exclusively using HTTPS.'
+      levels:
+          - base
+      rules:
+          - openssl_use_strong_entropy
+      status: partial
 
-    -   id: '1557'
-        title: 'Passphrases used for single-factor authentication on SECRET systems are at least 5 random words with a total minimum length of 17 characters.'
-        levels:
-            - secret
-        rules:
-            - accounts_password_minlen_login_defs
-            - accounts_password_pam_dcredit
-            - accounts_password_pam_lcredit
-            - accounts_password_pam_minclass
-            - accounts_password_pam_minlen
-            - accounts_password_pam_ocredit
-            - accounts_password_pam_ucredit
-            - accounts_passwords_pam_faillock_deny
-            - accounts_passwords_pam_faillock_deny_root
-            - accounts_passwords_pam_faillock_interval
-            - accounts_passwords_pam_faillock_unlock_time
-            - accounts_passwords_pam_tally2_deny_root
-            - accounts_passwords_pam_tally2_unlock_time
-            - disable_host_auth
-            - require_emergency_target_auth
-            - require_singleuser_auth
-            - sebool_authlogin_nsswitch_use_ldap
-            - sebool_authlogin_radius
-            - sshd_disable_kerb_auth
-            - sshd_set_max_auth_tries
-            - sssd_enable_smartcards
-            - var_password_pam_minlen=17
-            - var_accounts_password_minlen_login_defs=17
-        status: partial
+    - id: '1557'
+      title: 'Passphrases used for single-factor authentication on SECRET systems are at least 5 random
+          words with a total minimum length of 17 characters.'
+      levels:
+          - secret
+      rules:
+          - accounts_password_minlen_login_defs
+          - accounts_password_pam_dcredit
+          - accounts_password_pam_lcredit
+          - accounts_password_pam_minclass
+          - accounts_password_pam_minlen
+          - accounts_password_pam_ocredit
+          - accounts_password_pam_ucredit
+          - accounts_passwords_pam_faillock_deny
+          - accounts_passwords_pam_faillock_deny_root
+          - accounts_passwords_pam_faillock_interval
+          - accounts_passwords_pam_faillock_unlock_time
+          - accounts_passwords_pam_tally2_deny_root
+          - accounts_passwords_pam_tally2_unlock_time
+          - disable_host_auth
+          - require_emergency_target_auth
+          - require_singleuser_auth
+          - sebool_authlogin_nsswitch_use_ldap
+          - sebool_authlogin_radius
+          - sshd_disable_kerb_auth
+          - sshd_set_max_auth_tries
+          - sssd_enable_smartcards
+          - var_password_pam_minlen=17
+          - var_accounts_password_minlen_login_defs=17
+      status: partial
 
-    -   id: '1558'
-        title: 'Passphrases used for single-factor authentication are not a list of categorised words; do not form a real sentence in a natural language; and are not constructed from song lyrics, movies, literature or any other publicly available material.'
-        levels:
-            - base
-        rules:
-            - accounts_password_minlen_login_defs
-            - accounts_password_pam_dcredit
-            - accounts_password_pam_lcredit
-            - accounts_password_pam_minclass
-            - accounts_password_pam_minlen
-            - accounts_password_pam_ocredit
-            - accounts_password_pam_ucredit
-            - accounts_passwords_pam_faillock_deny
-            - accounts_passwords_pam_faillock_deny_root
-            - accounts_passwords_pam_faillock_interval
-            - accounts_passwords_pam_faillock_unlock_time
-            - accounts_passwords_pam_tally2_deny_root
-            - accounts_passwords_pam_tally2_unlock_time
-            - disable_host_auth
-            - require_emergency_target_auth
-            - require_singleuser_auth
-            - sebool_authlogin_nsswitch_use_ldap
-            - sebool_authlogin_radius
-            - sshd_disable_kerb_auth
-            - sshd_set_max_auth_tries
-            - sssd_enable_smartcards
-        status: automated
+    - id: '1558'
+      title: 'Passphrases used for single-factor authentication are not a list of categorised words;
+          do not form a real sentence in a natural language; and are not constructed from song lyrics,
+          movies, literature or any other publicly available material.'
+      levels:
+          - base
+      rules:
+          - accounts_password_minlen_login_defs
+          - accounts_password_pam_dcredit
+          - accounts_password_pam_lcredit
+          - accounts_password_pam_minclass
+          - accounts_password_pam_minlen
+          - accounts_password_pam_ocredit
+          - accounts_password_pam_ucredit
+          - accounts_passwords_pam_faillock_deny
+          - accounts_passwords_pam_faillock_deny_root
+          - accounts_passwords_pam_faillock_interval
+          - accounts_passwords_pam_faillock_unlock_time
+          - accounts_passwords_pam_tally2_deny_root
+          - accounts_passwords_pam_tally2_unlock_time
+          - disable_host_auth
+          - require_emergency_target_auth
+          - require_singleuser_auth
+          - sebool_authlogin_nsswitch_use_ldap
+          - sebool_authlogin_radius
+          - sshd_disable_kerb_auth
+          - sshd_set_max_auth_tries
+          - sssd_enable_smartcards
+      status: automated
 
-    -   id: '1559'
-        title: 'Memorised secrets used for multi-factor authentication are a minimum of 6 characters, unless more stringent requirements apply.'
-        levels:
-            - base
-        rules:
-            - accounts_password_minlen_login_defs
-            - accounts_password_pam_dcredit
-            - accounts_password_pam_lcredit
-            - accounts_password_pam_minclass
-            - accounts_password_pam_minlen
-            - accounts_password_pam_ocredit
-            - accounts_password_pam_ucredit
-            - accounts_passwords_pam_faillock_deny
-            - accounts_passwords_pam_faillock_deny_root
-            - accounts_passwords_pam_faillock_interval
-            - accounts_passwords_pam_faillock_unlock_time
-            - accounts_passwords_pam_tally2_deny_root
-            - accounts_passwords_pam_tally2_unlock_time
-            - disable_host_auth
-            - require_emergency_target_auth
-            - require_singleuser_auth
-            - sebool_authlogin_nsswitch_use_ldap
-            - sebool_authlogin_radius
-            - sshd_disable_kerb_auth
-            - sshd_set_max_auth_tries
-            - sssd_enable_smartcards
-        status: automated
+    - id: '1559'
+      title: 'Memorised secrets used for multi-factor authentication are a minimum of 6 characters, unless
+          more stringent requirements apply.'
+      levels:
+          - base
+      rules:
+          - accounts_password_minlen_login_defs
+          - accounts_password_pam_dcredit
+          - accounts_password_pam_lcredit
+          - accounts_password_pam_minclass
+          - accounts_password_pam_minlen
+          - accounts_password_pam_ocredit
+          - accounts_password_pam_ucredit
+          - accounts_passwords_pam_faillock_deny
+          - accounts_passwords_pam_faillock_deny_root
+          - accounts_passwords_pam_faillock_interval
+          - accounts_passwords_pam_faillock_unlock_time
+          - accounts_passwords_pam_tally2_deny_root
+          - accounts_passwords_pam_tally2_unlock_time
+          - disable_host_auth
+          - require_emergency_target_auth
+          - require_singleuser_auth
+          - sebool_authlogin_nsswitch_use_ldap
+          - sebool_authlogin_radius
+          - sshd_disable_kerb_auth
+          - sshd_set_max_auth_tries
+          - sssd_enable_smartcards
+      status: automated
 
-    -   id: '1560'
-        title: 'Memorised secrets used for multi-factor authentication on SECRET systems are a minimum of 8 characters'
-        levels:
-            - secret
-        rules:
-            - accounts_password_minlen_login_defs
-            - accounts_password_pam_dcredit
-            - accounts_password_pam_lcredit
-            - accounts_password_pam_minclass
-            - accounts_password_pam_minlen
-            - accounts_password_pam_ocredit
-            - accounts_password_pam_ucredit
-            - accounts_passwords_pam_faillock_deny
-            - accounts_passwords_pam_faillock_deny_root
-            - accounts_passwords_pam_faillock_interval
-            - accounts_passwords_pam_faillock_unlock_time
-            - accounts_passwords_pam_tally2_deny_root
-            - accounts_passwords_pam_tally2_unlock_time
-            - disable_host_auth
-            - require_emergency_target_auth
-            - require_singleuser_auth
-            - sebool_authlogin_nsswitch_use_ldap
-            - sebool_authlogin_radius
-            - sshd_disable_kerb_auth
-            - sshd_set_max_auth_tries
-            - sssd_enable_smartcards
-        status: automated
+    - id: '1560'
+      title: 'Memorised secrets used for multi-factor authentication on SECRET systems are a minimum
+          of 8 characters'
+      levels:
+          - secret
+      rules:
+          - accounts_password_minlen_login_defs
+          - accounts_password_pam_dcredit
+          - accounts_password_pam_lcredit
+          - accounts_password_pam_minclass
+          - accounts_password_pam_minlen
+          - accounts_password_pam_ocredit
+          - accounts_password_pam_ucredit
+          - accounts_passwords_pam_faillock_deny
+          - accounts_passwords_pam_faillock_deny_root
+          - accounts_passwords_pam_faillock_interval
+          - accounts_passwords_pam_faillock_unlock_time
+          - accounts_passwords_pam_tally2_deny_root
+          - accounts_passwords_pam_tally2_unlock_time
+          - disable_host_auth
+          - require_emergency_target_auth
+          - require_singleuser_auth
+          - sebool_authlogin_nsswitch_use_ldap
+          - sebool_authlogin_radius
+          - sshd_disable_kerb_auth
+          - sshd_set_max_auth_tries
+          - sssd_enable_smartcards
+      status: automated
 
-    -   id: '1561'
-        title: 'Memorised secrets used for multi-factor authentication on TOP SECRET systems are a minimum of 10 characters.'
-        levels:
-            - top_secret
-        rules:
-            - accounts_password_minlen_login_defs
-            - accounts_password_pam_dcredit
-            - accounts_password_pam_lcredit
-            - accounts_password_pam_minclass
-            - accounts_password_pam_minlen
-            - accounts_password_pam_ocredit
-            - accounts_password_pam_ucredit
-            - accounts_passwords_pam_faillock_deny
-            - accounts_passwords_pam_faillock_deny_root
-            - accounts_passwords_pam_faillock_interval
-            - accounts_passwords_pam_faillock_unlock_time
-            - accounts_passwords_pam_tally2_deny_root
-            - accounts_passwords_pam_tally2_unlock_time
-            - disable_host_auth
-            - require_emergency_target_auth
-            - require_singleuser_auth
-            - sebool_authlogin_nsswitch_use_ldap
-            - sebool_authlogin_radius
-            - sshd_disable_kerb_auth
-            - sshd_set_max_auth_tries
-            - sssd_enable_smartcards
-        status: automated
+    - id: '1561'
+      title: 'Memorised secrets used for multi-factor authentication on TOP SECRET systems are a minimum
+          of 10 characters.'
+      levels:
+          - top_secret
+      rules:
+          - accounts_password_minlen_login_defs
+          - accounts_password_pam_dcredit
+          - accounts_password_pam_lcredit
+          - accounts_password_pam_minclass
+          - accounts_password_pam_minlen
+          - accounts_password_pam_ocredit
+          - accounts_password_pam_ucredit
+          - accounts_passwords_pam_faillock_deny
+          - accounts_passwords_pam_faillock_deny_root
+          - accounts_passwords_pam_faillock_interval
+          - accounts_passwords_pam_faillock_unlock_time
+          - accounts_passwords_pam_tally2_deny_root
+          - accounts_passwords_pam_tally2_unlock_time
+          - disable_host_auth
+          - require_emergency_target_auth
+          - require_singleuser_auth
+          - sebool_authlogin_nsswitch_use_ldap
+          - sebool_authlogin_radius
+          - sshd_disable_kerb_auth
+          - sshd_set_max_auth_tries
+          - sssd_enable_smartcards
+      status: automated
 
-    -   id: '1745'
-        title: 'Early Launch Antimalware, Secure Boot, Trusted Boot and Measured Boot functionality is enabled.'
-        levels:
-            - base
-        rules:
-            - secure_boot_enabled
-        status: manual
+    - id: '1745'
+      title: 'Early Launch Antimalware, Secure Boot, Trusted Boot and Measured Boot functionality is
+          enabled.'
+      levels:
+          - base
+      rules:
+          - secure_boot_enabled
+      status: manual

--- a/controls/pcidss_4.yml
+++ b/controls/pcidss_4.yml
@@ -1,4080 +1,4064 @@
+---
 policy: PCI-DSS
 title: Payment Card Industry - Data Security Standard (PCI-DSS)
 id: pcidss_4
 version: '4.0.1'
 source: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0_1.pdf
+
 levels:
-- id: base
+    - id: base
+
 reference_type: pcidss4
 
 controls:
-  - id: '1.1'
-    title: 'Processes and mechanisms for installing and maintaining network security
-      controls are defined and understood.'
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 1.1.1
-      title: 'All security policies and operational procedures that are identified in
-        Requirement 1 are Documented, Kept up to date, In use and Known to all affected parties.'
+    - id: '1.1'
+      title: 'Processes and mechanisms for installing and maintaining network security controls are defined
+          and understood.'
       levels:
-        - base
+          - base
       status: manual
-      notes: |-
-        Examine documentation and interview personnel to verify that security policies and
-        operational procedures identified in Requirement 1 are managed in accordance with all
-        elements specified in this requirement.
+      controls:
+          - id: 1.1.1
+            title: 'All security policies and operational procedures that are identified in Requirement
+                1 are Documented, Kept up to date, In use and Known to all affected parties.'
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Examine documentation and interview personnel to verify that security policies and
+                operational procedures identified in Requirement 1 are managed in accordance with all
+                elements specified in this requirement.
 
-    - id: 1.1.2
-      title: 'Roles and responsibilities for performing activities in Requirement 1 are
-        documented, assigned, and understood.'
-      levels:
-        - base
-      status: manual
-      notes: |-
-        Examine documentation and interview personnel to verify that day-to-day responsibilities
-        for performing all the activities in Requirement 1 are documented, assigned and understood
-        by the assigned personnel.
+          - id: 1.1.2
+            title: 'Roles and responsibilities for performing activities in Requirement 1 are documented,
+                assigned, and understood.'
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Examine documentation and interview personnel to verify that day-to-day responsibilities
+                for performing all the activities in Requirement 1 are documented, assigned and understood
+                by the assigned personnel.
 
-  - id: '1.2'
-    title: 'Network Security Controls (NSCs) are configured and maintained.'
-    levels:
-      - base
-    status: automated
-    controls:
-    - id: 1.2.1
-      title: 'Configuration standards for NSC rulesets are Defined, Implemented and Maintained.'
+    - id: '1.2'
+      title: 'Network Security Controls (NSCs) are configured and maintained.'
       levels:
-        - base
+          - base
       status: automated
-      notes: |-
-        Examples of NSCs covered by these configuration standards include, but are not limited to,
-        firewalls, routers configured with access control lists, and cloud virtual networks. The
-        objective of this requirement is to ensure the way that NSCs are configured and operate
-        are defined and consistently applied. While the tooling and standards can be automated,
-        the review of allowed accesses should be manual as different sites may have different
-        policies.
-      rules:
-        - package_nftables_installed
-        - package_firewalld_installed
-        - service_firewalld_enabled
-        - service_nftables_disabled
+      controls:
+          - id: 1.2.1
+            title: 'Configuration standards for NSC rulesets are Defined, Implemented and Maintained.'
+            levels:
+                - base
+            status: automated
+            notes: |-
+                Examples of NSCs covered by these configuration standards include, but are not limited to,
+                firewalls, routers configured with access control lists, and cloud virtual networks. The
+                objective of this requirement is to ensure the way that NSCs are configured and operate
+                are defined and consistently applied. While the tooling and standards can be automated,
+                the review of allowed accesses should be manual as different sites may have different
+                policies.
+            rules:
+                - package_nftables_installed
+                - package_firewalld_installed
+                - service_firewalld_enabled
+                - service_nftables_disabled
 
-    - id: 1.2.2
-      title: 'All changes to network connections and to configurations of NSCs are approved and
-        managed in accordance with the change control process defined at Requirement 6.5.1.'
-      levels:
-        - base
-      status: manual
-      notes: |-
-        Changes to network connections and NSCs cannot result in misconfiguration, implementation
-        of insecure services, or unauthorized network connections. Changes to network connections
-        include the addition, removal, or modification of a connection. Changes to NSC
-        configurations include those related to the component itself as well as those affecting
-        how it performs its security function. A formal change control process should be in place.
+          - id: 1.2.2
+            title: 'All changes to network connections and to configurations of NSCs are approved and
+                managed in accordance with the change control process defined at Requirement 6.5.1.'
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Changes to network connections and NSCs cannot result in misconfiguration, implementation
+                of insecure services, or unauthorized network connections. Changes to network connections
+                include the addition, removal, or modification of a connection. Changes to NSC
+                configurations include those related to the component itself as well as those affecting
+                how it performs its security function. A formal change control process should be in place.
 
-    - id: 1.2.3
-      title: 'An accurate network diagram(s) is maintained that shows all connections between the
-        CDE and other networks, including any wireless networks.'
-      levels:
-        - base
-      status: manual
-      notes: |-
-        A representation of the boundaries between the CDE, all trusted networks, and all
-        untrusted networks, is maintained and available. A current network diagram(s) or other
-        technical or topological solution that identifies network connections and devices can be
-        used to meet this requirement.
+          - id: 1.2.3
+            title: 'An accurate network diagram(s) is maintained that shows all connections between the
+                CDE and other networks, including any wireless networks.'
+            levels:
+                - base
+            status: manual
+            notes: |-
+                A representation of the boundaries between the CDE, all trusted networks, and all
+                untrusted networks, is maintained and available. A current network diagram(s) or other
+                technical or topological solution that identifies network connections and devices can be
+                used to meet this requirement.
 
-    - id: 1.2.4
-      title: 'An accurate data-flow diagram(s) is maintained'
-      description: |-
-        An accurate data-flow diagram(s) is maintained that meets the following:
-          - Shows all account data flows across systems and networks
-          - Updated as needed upon changes to the environment
-      levels:
-        - base
-      status: manual
+          - id: 1.2.4
+            title: 'An accurate data-flow diagram(s) is maintained'
+            description: |-
+                An accurate data-flow diagram(s) is maintained that meets the following:
+                  - Shows all account data flows across systems and networks
+                  - Updated as needed upon changes to the environment
+            levels:
+                - base
+            status: manual
 
-    - id: 1.2.5
-      title: 'All services, protocols, and ports allowed are identified, approved, and have a
-        defined business need.'
-      levels:
-        - base
-      status: manual
-      related_rules:
-        - configure_firewalld_ports
+          - id: 1.2.5
+            title: 'All services, protocols, and ports allowed are identified, approved, and have a defined
+                business need.'
+            levels:
+                - base
+            status: manual
+            related_rules:
+                - configure_firewalld_ports
 
-    - id: 1.2.6
-      title: Security features are defined and implemented for all services, protocols, and ports
-        that are in use and considered to be insecure, such that the risk is mitigated.
-      levels:
-        - base
-      status: automated
-      notes: |-
-        The specific risks associated with the use of insecure services, protocols, and ports are
-        understood, assessed, and appropriately mitigated. The selected rules here basically
-        remove services without encryption and restricted some common services.
-      rules:
-        - grub2_enable_selinux
-        - package_libselinux_installed
-        - selinux_policytype
-        - var_selinux_policy_name=targeted
-        - selinux_state
-        - var_selinux_state=enforcing
-        - selinux_confinement_of_daemons
+          - id: 1.2.6
+            title: Security features are defined and implemented for all services, protocols, and ports
+                that are in use and considered to be insecure, such that the risk is mitigated.
+            levels:
+                - base
+            status: automated
+            notes: |-
+                The specific risks associated with the use of insecure services, protocols, and ports are
+                understood, assessed, and appropriately mitigated. The selected rules here basically
+                remove services without encryption and restricted some common services.
+            rules:
+                - grub2_enable_selinux
+                - package_libselinux_installed
+                - selinux_policytype
+                - var_selinux_policy_name=targeted
+                - selinux_state
+                - var_selinux_state=enforcing
+                - selinux_confinement_of_daemons
 
-    - id: 1.2.7
-      title: Configurations of NSCs are reviewed at least once every six months to confirm they
-        are relevant and effective.
-      description: |-
-        NSC configurations that allow or restrict access to trusted networks are verified
-        periodically to ensure that only authorized connections with a current business
-        justification are permitted.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        Some configuration automation solution, such as Ansible could be helpful here.
+          - id: 1.2.7
+            title: Configurations of NSCs are reviewed at least once every six months to confirm they
+                are relevant and effective.
+            description: |-
+                NSC configurations that allow or restrict access to trusted networks are verified
+                periodically to ensure that only authorized connections with a current business
+                justification are permitted.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Some configuration automation solution, such as Ansible could be helpful here.
 
-    - id: 1.2.8
-      title: Configuration files for NSCs are secured from unauthorized access and kept consistent
-        with active network configurations.
-      levels:
-        - base
-      status: automated
-      rules:
-        - file_groupowner_etc_issue_net
-        - file_owner_etc_issue_net
-        - file_permissions_etc_issue_net
-        - network_nmcli_permissions
+          - id: 1.2.8
+            title: Configuration files for NSCs are secured from unauthorized access and kept consistent
+                with active network configurations.
+            levels:
+                - base
+            status: automated
+            rules:
+                - file_groupowner_etc_issue_net
+                - file_owner_etc_issue_net
+                - file_permissions_etc_issue_net
+                - network_nmcli_permissions
 
-  - id: '1.3'
-    title: Network access to and from the cardholder data environment is restricted.
-    levels:
-      - base
-    status: partial
-    controls:
-    - id: 1.3.1
-      title: Inbound traffic to the CDE is restricted to only traffic that is necessary
-      description: |-
-        Inbound traffic to the CDE is restricted as follows:
-        - To only traffic that is necessary.
-        - All other traffic is specifically denied.
+    - id: '1.3'
+      title: Network access to and from the cardholder data environment is restricted.
       levels:
-        - base
-      status: automated
-      rules:
-        - configure_firewalld_ports
-        - ensure_firewall_rules_for_open_ports
-        - set_firewalld_default_zone
-        - nftables_ensure_default_deny_policy
-
-    - id: 1.3.2
-      title: Outbound traffic from the CDE is restricted to only traffic that is necessary
-      description: |-
-        Outbound traffic from the CDE is restricted as follows:
-        - To only traffic that is necessary.
-        - All other traffic is specifically denied.
-      levels:
-        - base
-      status: pending
-      notes: |-
-        It appears there is no rule in the project to restrict outbound traffic on the firewall.
-        Perhaps a rule to automates this would do more harm than good. Probably a manual
-        assessment is more reasonable here.
-
-    - id: 1.3.3
-      title: NSCs are installed between all wireless networks and the CDE, regardless of whether
-        the wireless network is a CDE.
-      description: |-
-        NSCs are installed between all wireless networks and the CDE, regardless of whether the
-        wireless network is a CDE, such that:
-        - All wireless traffic from wireless networks into the CDE is denied by default.
-        - Only wireless traffic with an authorized business purpose is allowed into the CDE.
-      levels:
-        - base
-      status: automated
-      notes: |-
-        Wireless interfaces are not expected in servers so they are disabled by default in this
-        policy.
-      rules:
-        - wireless_disable_interfaces
-
-  - id: '1.4'
-    title: Network connections between trusted and untrusted networks are controlled.
-    levels:
-      - base
-    status: partial
-    controls:
-    - id: 1.4.1
-      title: NSCs are implemented between trusted and untrusted networks.
-      description: |-
-        Unauthorized traffic cannot traverse network boundaries between trusted and untrusted
-        networks.
-      levels:
-        - base
-      status: automated
-      notes: |-
-        Trusted and untrusted networks are expected to be different for each environment.
-        But loopback traffic is assumed to be trusted and even necessary for some services.
-        This requirement is complements 1.2.1 and 1.3.1 requirements.
-      rules:
-        - firewalld_loopback_traffic_restricted
-        - firewalld_loopback_traffic_trusted
-        - set_ipv6_loopback_traffic
-        - set_ip6tables_default_rule
-        - set_loopback_traffic
-
-    - id: 1.4.2
-      title: Inbound traffic from untrusted networks to trusted networks is restricted.
-      description: |-
-        Inbound traffic from untrusted networks to trusted networks is restricted to:
-        - Communications with system components that are authorized to provide publicly accessible
-        services, protocols, and ports.
-        - Stateful responses to communications initiated by system components in a trusted network.
-        - All other traffic is denied.
-      levels:
-        - base
-      status: partial
-      notes: |-
-        Probably missing some relevant IPv6 related rules. Needs to be investigated.
-      rules:
-        - postfix_network_listening_disabled
-        - var_postfix_inet_interfaces=loopback-only
-        - kernel_module_sctp_disabled
-        - kernel_module_dccp_disabled
-        - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
-        - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
-        - sysctl_net_ipv6_conf_default_accept_source_route
-
-    - id: 1.4.3
-      title: Anti-spoofing measures are implemented to detect and block forged source IP
-        addresses from entering the trusted network.
-      levels:
-        - base
-      status: partial
-      notes: |-
-        Probably missing some relevant IPv6 related rules. Needs to be investigated.
-      rules:
-        - sysctl_net_ipv4_conf_all_rp_filter
-        - sysctl_net_ipv4_conf_all_secure_redirects
-        - sysctl_net_ipv4_conf_default_accept_redirects
-        - sysctl_net_ipv4_ip_forward
-        - sysctl_net_ipv4_tcp_syncookies
-
-    - id: 1.4.4
-      title: System components that store cardholder data are not directly accessible from
-        untrusted networks.
-      levels:
-        - base
-      status: pending
-      notes: |-
-        This requirement is not intended to apply to storage of account data in volatile memory
-        but does apply where memory is being treated as persistent storage (for example, RAM
-        disk). Account data can only be stored in volatile memory during the time necessary to
-        support the associated business process (for example, until completion of the related
-        payment card transaction).
-      related_rules:
-        - configure_firewalld_ports
-
-    - id: 1.4.5
-      title: The disclosure of internal IP addresses and routing information is limited to only
-        authorized parties.
-      description: |-
-        Internal network information is protected from unauthorized disclosure.
-      levels:
-        - base
-      status: automated
-      rules:
-        - sysctl_net_ipv4_conf_all_send_redirects
-        - sysctl_net_ipv4_conf_default_send_redirects
-        - network_sniffer_disabled
-
-  - id: '1.5'
-    title: Risks to the CDE from computing devices that are able to connect to both untrusted
-      networks and the CDE are mitigated.
-    levels:
-      - base
-    status: partial
-    controls:
-    - id: 1.5.1
-      title: Security controls are implemented on any computing devices, including company- and
-        employee-owned devices, that connect to both untrusted networks (including the Internet)
-        and the CDE
-      description: |-
-        Security controls are implemented on any computing devices, including company- and
-        employee-owned devices, that connect to both untrusted networks (including the Internet)
-        and the CDE as follows:
-        - Specific configuration settings are defined to prevent threats being introduced into the
-        entity's network.
-        - Security controls are actively running.
-        - Security controls are not alterable by users of the computing devices unless
-        specifically documented and authorized by management on a case-by-case basis for a limited
-        period.
-      levels:
-        - base
-      status: partial
-      notes: |-
-        To ensure this requirement, a manual analysis of site policy and topology is inevitable.
-        From the technical perspective, previous requirements should already cover this
-        requirement at some level.
-      related_rules:
-        # These rules are already covered by 1.3.1.
-        - ensure_firewall_rules_for_open_ports
-        - set_firewalld_default_zone
-        # This rule is already covered by 1.2.6
-        - selinux_state
-
-  - id: '2.1'
-    title: Processes and mechanisms for applying secure configurations to all system components
-      are defined and understood.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 2.1.1
-      title: All security policies and operational procedures that are identified in Requirement 2
-        are Documented, Kept up to date, In use and Known to all affected parties.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        Examine documentation and interview personnel to verify that security policies and
-        operational procedures identified in Requirement 2 are managed in accordance with all
-        elements specified in this requirement.
-
-    - id: 2.1.2
-      title: Roles and responsibilities for performing activities in Requirement 2 are
-        documented, assigned, and understood.
-      description: |-
-        Day-to-day responsibilities for performing all the activities in Requirement 2 are
-        allocated. Personnel are accountable for successful, continuous operation of these
-        requirements.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        Examine documentation and interview personnel to verify that day-to-day responsibilities
-        for performing all the activities in Requirement 2 are documented, assigned and understood
-        by the assigned personnel.
-
-  - id: '2.2'
-    title: 'System components are configured and managed securely.'
-    levels:
-      - base
-    status: partial
-    controls:
-    - id: 2.2.1
-      title: Configuration standards are developed, implemented, and maintained
-      description: |-
-        Configuration standards are developed, implemented, and maintained to:
-        - Cover all system components.
-        - Address all known security vulnerabilities.
-        - Be consistent with industry-accepted system hardening standards or vendor hardening
-        recommendations.
-        - Be updated as new vulnerability issues are identified, as defined in Requirement 6.3.1.
-        - Be applied when new systems are configured and verified as in place before or
-        immediately after a system component is connected to a production environment.
-      levels:
-        - base
-      status: partial
-      notes: |-
-        Interestingly this requirement recommends other standards, such as Center for Internet
-        Security (CIS), International Organization for Standardization (ISO), National Institute
-        of Standards and Technology (NIST), Cloud Security Alliance, and product vendors. So, the
-        rules included here are very generic in terms of hardening.
-      rules:
-        - bios_enable_execution_restrictions
-        - install_PAE_kernel_on_x86-32
-
-    - id: 2.2.2
-      title: Vendor default accounts are managed.
-      description: |-
-        Vendor default accounts are managed as follows:
-        - If the vendor default account(s) will be used, the default password is changed per
-        Requirement 8.3.6.
-        - If the vendor default account(s) will not be used, the account is removed or disabled.
-      levels:
-        - base
-      status: automated
-      notes: |-
-        Also related to requirement 8.2.6 and 8.3.5.
-      rules:
-        - ensure_root_password_configured
-        - no_empty_passwords_etc_shadow
-
-    - id: 2.2.3
-      title: 'Primary functions requiring different security levels are managed'
-      levels:
-        - base
-      status: manual
-
-    - id: 2.2.4
-      title: Only necessary services, protocols, daemons, and functions are enabled, and all
-        unnecessary functionality is removed or disabled
-      description: |-
-        System components cannot be compromised by exploiting unnecessary functionality present in
-        the system component.
-      levels:
-        - base
-      status: automated
-      rules:
-        - mask_nonessential_services
-        - package_dhcp_removed
-        - package_ftp_removed
-        - package_net-snmp_removed
-        - package_rsh_removed
-        - package_rsh-server_removed
-        - package_talk_removed
-        - package_talk-server_removed
-        - package_telnet_removed
-        - package_telnet-server_removed
-        - package_tftp_removed
-        - package_tftp-server_removed
-        - package_xinetd_removed
-        - package_ypbind_removed
-        - package_ypserv_removed
-        - service_avahi-daemon_disabled
-        - service_rpcbind_disabled
-        - service_rsyncd_disabled
-      related_rules:
-        - package_bind_removed
-        - package_dnsmasq_removed
-        - package_httpd_removed
-        - package_nfs-utils_removed
-        - package_openldap-clients_removed
-        - package_openldap-servers_removed
-        - package_rsync_removed
-        - package_samba_removed
-        - package_squid_removed
-        - package_vsftpd_removed
-        - service_cups_disabled
-        - service_nfs_disabled
-
-    - id: 2.2.5
-      title: If any insecure services, protocols, or daemons are present, business justification
-        is documented and the risk is reduced.
-      description: |-
-        If any insecure services, protocols, or daemons are present:
-        - Business justification is documented.
-        - Additional security features are documented and implemented that reduce the risk of
-        using insecure services, protocols, or daemons.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        Known insecure services are removed or disabled by 2.2.4
-        General security measures are covered by 1.2.6
-        This requirement is more about checking exceptions and their respective documentation.
-
-    - id: 2.2.6
-      title: System security parameters are configured to prevent misuse.
-      description: |-
-        System components cannot be compromised because of incorrect security parameter
-        configuration.
-      levels:
-        - base
-      status: automated
-      notes: |-
-        This requirement is not specific but also points to 2.2.1, where other policies are
-        referenced. Therefore, the most common rules related to system configuration in order to
-        prevent misuse and selected in main profiles are also selected here.
-      rules:
-        # bootloader files protection
-        - file_groupowner_grub2_cfg
-        - file_owner_grub2_cfg
-        - file_permissions_grub2_cfg
-        - file_groupowner_user_cfg
-        - file_owner_user_cfg
-        - file_permissions_user_cfg
-        # at files protection
-        - file_at_deny_not_exist
-        - file_groupowner_at_allow
-        - file_owner_at_allow
-        - file_permissions_at_allow
-        # cron files protection
-        - file_cron_deny_not_exist
-        - file_groupowner_cron_allow
-        - file_owner_cron_allow
-        - file_permissions_cron_allow
-        - file_groupowner_crontab
-        - file_owner_crontab
-        - package_cron_installed
-        - file_permissions_crontab
-        - file_groupowner_cron_d
-        - file_owner_cron_d
-        - file_permissions_cron_d
-        - file_groupowner_cron_hourly
-        - file_owner_cron_hourly
-        - file_permissions_cron_hourly
-        - file_groupowner_cron_daily
-        - file_owner_cron_daily
-        - file_permissions_cron_daily
-        - file_groupowner_cron_weekly
-        - file_owner_cron_weekly
-        - file_permissions_cron_weekly
-        - file_groupowner_cron_monthly
-        - file_owner_cron_monthly
-        - file_permissions_cron_monthly
-        # ssh files protection
-        - file_permissions_sshd_config
-        - file_permissions_sshd_private_key
-        - file_permissions_sshd_pub_key
-        # users files protection
-        - file_groupowner_etc_group
-        - file_groupowner_backup_etc_group
-        - file_owner_etc_group
-        - file_owner_backup_etc_group
-        - file_permissions_etc_group
-        - file_permissions_backup_etc_group
-        - file_groupowner_etc_passwd
-        - file_groupowner_backup_etc_passwd
-        - file_owner_etc_passwd
-        - file_owner_backup_etc_passwd
-        - file_permissions_etc_passwd
-        - file_permissions_backup_etc_passwd
-        - file_groupowner_etc_shadow
-        - file_groupowner_backup_etc_shadow
-        - file_owner_etc_shadow
-        - file_owner_backup_etc_shadow
-        - file_permissions_etc_shadow
-        - file_permissions_backup_etc_shadow
-        # general files protection
-        - file_permissions_unauthorized_world_writable
-        - file_permissions_ungroupowned
-        - no_files_unowned_by_user
-        - dir_perms_world_writable_sticky_bits
-        # ssh settings
-        - sshd_disable_empty_passwords
-        - sshd_disable_rhosts
-        - sshd_disable_root_login
-        - sshd_disable_tcp_forwarding
-        - sshd_disable_x11_forwarding
-        - sshd_do_not_permit_user_env
-        - sshd_enable_pam
-        - sshd_limit_user_access
-        - sshd_set_loglevel_verbose
-        - sshd_set_max_auth_tries
-        - sshd_set_max_sessions
-        - sshd_set_maxstartups
-        - sshd_set_login_grace_time
-        - var_sshd_set_login_grace_time=60
-        # sudo settings
-        - package_sudo_installed
-        - sudo_add_use_pty
-        - sudo_custom_logfile
-        - sudo_require_authentication
-        - sudo_require_reauthentication
-        # su command limitation
-        - use_pam_wheel_group_for_su
-        - ensure_pam_wheel_group_empty
-
-    - id: 2.2.7
-      title: All non-console administrative access is encrypted using strong cryptography.
-      description: |-
-        Cleartext administrative authorization factors cannot be read or intercepted from any
-        network transmissions. This includes administrative access via browser-based interfaces
-        and application programming interfaces (APIs).
-      levels:
-        - base
-      status: automated
-      notes: |-
-        Related to requirement 12.3.3.
-      rules:
-        - configure_crypto_policy
-        - var_system_crypto_policy=default_policy
-        - configure_ssh_crypto_policy
-        - sshd_use_approved_ciphers
-        - sshd_use_approved_macs
-        - sshd_use_strong_kex
-      related_rules:
-        - configure_libreswan_crypto_policy
-        - configure_openssl_crypto_policy
-
-  - id: '2.3'
-    title: Wireless environments are configured and managed securely.
-    levels:
-      - base
-    status: supported
-    controls:
-    - id: 2.3.1
-      title: For wireless environments connected to the CDE or transmitting account data, all
-        wireless vendor defaults are changed at installation or are confirmed to be secure.
-      description: |-
-        For wireless environments connected to the CDE or transmitting account data, all wireless
-        vendor defaults are changed at installation or are confirmed to be secure, including but
-        not limited to:
-        - Default wireless encryption keys.
-        - Passwords on wireless access points.
-        - SNMP defaults.
-        - Any other security-related wireless vendor defaults.
-      levels:
-        - base
-      status: supported
-      notes: |-
-        Wireless interfaces are disabled by 1.3.3.
-      related_rules:
-        - wireless_disable_interfaces
-
-    - id: 2.3.2
-      title: For wireless environments connected to the CDE or transmitting account data, wireless
-        encryption keys are changed
-      description: |-
-        For wireless environments connected to the CDE or transmitting account
-        data, wireless encryption keys are changed
-      levels:
-        - base
-      status: supported
-      notes: |-
-        Wireless interfaces are disabled by 1.3.3.
-      related_rules:
-        - wireless_disable_interfaces
-
-  - id: '3.1'
-    title: Processes and mechanisms for protecting stored account data are defined and understood.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 3.1.1
-      title: All security policies and operational procedures that are identified in Requirement 3
-        are Documented, Kept up to date, In use and Known to all affected parties.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        Examine documentation and interview personnel to verify that security policies and
-        operational procedures identified in Requirement 3 are managed in accordance with all
-        elements specified in this requirement.
-
-    - id: 3.1.2
-      title: Roles and responsibilities for performing activities in Requirement 3 are
-        documented, assigned, and understood.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        Examine documentation and interview personnel to verify that day-to-day responsibilities
-        for performing all the activities in Requirement 3 are documented, assigned and understood
-        by the assigned personnel.
-
-  - id: '3.2'
-    title: Storage of account data is kept to a minimum.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 3.2.1
-      title: Account data storage is kept to a minimum through implementation of data retention
-        and disposal policies, procedures, and processes.
-      description: |-
-        Account data storage is kept to a minimum through implementation of data retention and
-        disposal policies, procedures, and processes that include at least the following:
-        - Coverage for all locations of stored account data.
-        - Coverage for any sensitive authentication data (SAD) stored prior to completion of
-        authorization.
-        - Limiting data storage amount and retention time to that which is required for legal or
-        regulatory, and/or business requirements.
-        - Specific retention requirements for stored account data that defines length of retention
-        period and includes a documented business justification.
-        - Processes for secure deletion or rendering account data unrecoverable when no longer
-        needed per the retention policy.
-        - A process for verifying, at least once every three months, that stored account data
-        exceeding the defined retention period has been securely deleted or rendered unrecoverable.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        This requirement is very dependent on each site policies and business model.
-        Local policies should be consulted and audited. Manual checking is reasonable.
-
-  - id: '3.3'
-    title: Sensitive authentication data (SAD) is not stored after authorization.
-    levels:
-      - base
-    status: partial
-    controls:
-    - id: 3.3.1
-      title: SAD is not stored after authorization, even if encrypted. All sensitive
-        authentication data received is rendered unrecoverable upon completion of the
-        authorization process.
-      description: |-
-        This requirement is not eligible for the customized approach. This requirement does not
-        apply to issuers and companies that support issuing services (where SAD is needed for a
-        legitimate issuing business need) and have a business justification to store the sensitive
-        authentication data. Refer to Requirement 3.3.3 for additional requirements specifically
-        for issuers. Sensitive authentication data includes the data cited in Requirements 3.3.1.1
-        through 3.3.1.3.
-      levels:
-        - base
+          - base
       status: partial
       controls:
-      - id: 3.3.1.1
-        title: The full contents of any track are not stored upon completion of the
-          authorization process.
-        description: |-
-          This requirement is not eligible for the customized approach. In the normal course of
-          business, the following data elements from the track may need to be retained:
-          - Cardholder name.
-          - Primary account number (PAN).
-          - Expiration date.
-          - Service code.
-          To minimize risk, store securely only these data elements as needed for business.
-        levels:
+          - id: 1.3.1
+            title: Inbound traffic to the CDE is restricted to only traffic that is necessary
+            description: |-
+                Inbound traffic to the CDE is restricted as follows:
+                - To only traffic that is necessary.
+                - All other traffic is specifically denied.
+            levels:
+                - base
+            status: automated
+            rules:
+                - configure_firewalld_ports
+                - ensure_firewall_rules_for_open_ports
+                - set_firewalld_default_zone
+                - nftables_ensure_default_deny_policy
+
+          - id: 1.3.2
+            title: Outbound traffic from the CDE is restricted to only traffic that is necessary
+            description: |-
+                Outbound traffic from the CDE is restricted as follows:
+                - To only traffic that is necessary.
+                - All other traffic is specifically denied.
+            levels:
+                - base
+            status: pending
+            notes: |-
+                It appears there is no rule in the project to restrict outbound traffic on the firewall.
+                Perhaps a rule to automates this would do more harm than good. Probably a manual
+                assessment is more reasonable here.
+
+          - id: 1.3.3
+            title: NSCs are installed between all wireless networks and the CDE, regardless of whether
+                the wireless network is a CDE.
+            description: |-
+                NSCs are installed between all wireless networks and the CDE, regardless of whether the
+                wireless network is a CDE, such that:
+                - All wireless traffic from wireless networks into the CDE is denied by default.
+                - Only wireless traffic with an authorized business purpose is allowed into the CDE.
+            levels:
+                - base
+            status: automated
+            notes: |-
+                Wireless interfaces are not expected in servers so they are disabled by default in this
+                policy.
+            rules:
+                - wireless_disable_interfaces
+
+    - id: '1.4'
+      title: Network connections between trusted and untrusted networks are controlled.
+      levels:
           - base
-        status: partial
-        notes: |-
-          This requirement consists in auditing files, databases and memory to make sure the full
-          content of any track is not unnecessarily stored. It involves manual auditing but some
-          automated rules fit this requirement in order to reduce the chances if this data be
-          unintentionally stored in memory.
-        rules:
-          - coredump_disable_backtraces
-          - coredump_disable_storage
-          - disable_users_coredumps
-          - sysctl_fs_suid_dumpable
-          - sysctl_kernel_core_pattern
-          - sysctl_kernel_randomize_va_space
-        related_rules:
+      status: partial
+      controls:
+          - id: 1.4.1
+            title: NSCs are implemented between trusted and untrusted networks.
+            description: |-
+                Unauthorized traffic cannot traverse network boundaries between trusted and untrusted
+                networks.
+            levels:
+                - base
+            status: automated
+            notes: |-
+                Trusted and untrusted networks are expected to be different for each environment.
+                But loopback traffic is assumed to be trusted and even necessary for some services.
+                This requirement is complements 1.2.1 and 1.3.1 requirements.
+            rules:
+                - firewalld_loopback_traffic_restricted
+                - firewalld_loopback_traffic_trusted
+                - set_ipv6_loopback_traffic
+                - set_ip6tables_default_rule
+                - set_loopback_traffic
+
+          - id: 1.4.2
+            title: Inbound traffic from untrusted networks to trusted networks is restricted.
+            description: |-
+                Inbound traffic from untrusted networks to trusted networks is restricted to:
+                - Communications with system components that are authorized to provide publicly accessible
+                services, protocols, and ports.
+                - Stateful responses to communications initiated by system components in a trusted network.
+                - All other traffic is denied.
+            levels:
+                - base
+            status: partial
+            notes: |-
+                Probably missing some relevant IPv6 related rules. Needs to be investigated.
+            rules:
+                - postfix_network_listening_disabled
+                - var_postfix_inet_interfaces=loopback-only
+                - kernel_module_sctp_disabled
+                - kernel_module_dccp_disabled
+                - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+                - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
+                - sysctl_net_ipv6_conf_default_accept_source_route
+
+          - id: 1.4.3
+            title: Anti-spoofing measures are implemented to detect and block forged source IP addresses
+                from entering the trusted network.
+            levels:
+                - base
+            status: partial
+            notes: |-
+                Probably missing some relevant IPv6 related rules. Needs to be investigated.
+            rules:
+                - sysctl_net_ipv4_conf_all_rp_filter
+                - sysctl_net_ipv4_conf_all_secure_redirects
+                - sysctl_net_ipv4_conf_default_accept_redirects
+                - sysctl_net_ipv4_ip_forward
+                - sysctl_net_ipv4_tcp_syncookies
+
+          - id: 1.4.4
+            title: System components that store cardholder data are not directly accessible from untrusted
+                networks.
+            levels:
+                - base
+            status: pending
+            notes: |-
+                This requirement is not intended to apply to storage of account data in volatile memory
+                but does apply where memory is being treated as persistent storage (for example, RAM
+                disk). Account data can only be stored in volatile memory during the time necessary to
+                support the associated business process (for example, until completion of the related
+                payment card transaction).
+            related_rules:
+                - configure_firewalld_ports
+
+          - id: 1.4.5
+            title: The disclosure of internal IP addresses and routing information is limited to only
+                authorized parties.
+            description: |-
+                Internal network information is protected from unauthorized disclosure.
+            levels:
+                - base
+            status: automated
+            rules:
+                - sysctl_net_ipv4_conf_all_send_redirects
+                - sysctl_net_ipv4_conf_default_send_redirects
+                - network_sniffer_disabled
+
+    - id: '1.5'
+      title: Risks to the CDE from computing devices that are able to connect to both untrusted networks
+          and the CDE are mitigated.
+      levels:
+          - base
+      status: partial
+      controls:
+          - id: 1.5.1
+            title: Security controls are implemented on any computing devices, including company- and
+                employee-owned devices, that connect to both untrusted networks (including the Internet)
+                and the CDE
+            description: |-
+                Security controls are implemented on any computing devices, including company- and
+                employee-owned devices, that connect to both untrusted networks (including the Internet)
+                and the CDE as follows:
+                - Specific configuration settings are defined to prevent threats being introduced into the
+                entity's network.
+                - Security controls are actively running.
+                - Security controls are not alterable by users of the computing devices unless
+                specifically documented and authorized by management on a case-by-case basis for a limited
+                period.
+            levels:
+                - base
+            status: partial
+            notes: |-
+                To ensure this requirement, a manual analysis of site policy and topology is inevitable.
+                From the technical perspective, previous requirements should already cover this
+                requirement at some level.
+            related_rules:
+        # These rules are already covered by 1.3.1.
+                - ensure_firewall_rules_for_open_ports
+                - set_firewalld_default_zone
+        # This rule is already covered by 1.2.6
+                - selinux_state
+
+    - id: '2.1'
+      title: Processes and mechanisms for applying secure configurations to all system components are
+          defined and understood.
+      levels:
+          - base
+      status: manual
+      controls:
+          - id: 2.1.1
+            title: All security policies and operational procedures that are identified in Requirement
+                2 are Documented, Kept up to date, In use and Known to all affected parties.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Examine documentation and interview personnel to verify that security policies and
+                operational procedures identified in Requirement 2 are managed in accordance with all
+                elements specified in this requirement.
+
+          - id: 2.1.2
+            title: Roles and responsibilities for performing activities in Requirement 2 are documented,
+                assigned, and understood.
+            description: |-
+                Day-to-day responsibilities for performing all the activities in Requirement 2 are
+                allocated. Personnel are accountable for successful, continuous operation of these
+                requirements.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Examine documentation and interview personnel to verify that day-to-day responsibilities
+                for performing all the activities in Requirement 2 are documented, assigned and understood
+                by the assigned personnel.
+
+    - id: '2.2'
+      title: 'System components are configured and managed securely.'
+      levels:
+          - base
+      status: partial
+      controls:
+          - id: 2.2.1
+            title: Configuration standards are developed, implemented, and maintained
+            description: |-
+                Configuration standards are developed, implemented, and maintained to:
+                - Cover all system components.
+                - Address all known security vulnerabilities.
+                - Be consistent with industry-accepted system hardening standards or vendor hardening
+                recommendations.
+                - Be updated as new vulnerability issues are identified, as defined in Requirement 6.3.1.
+                - Be applied when new systems are configured and verified as in place before or
+                immediately after a system component is connected to a production environment.
+            levels:
+                - base
+            status: partial
+            notes: |-
+                Interestingly this requirement recommends other standards, such as Center for Internet
+                Security (CIS), International Organization for Standardization (ISO), National Institute
+                of Standards and Technology (NIST), Cloud Security Alliance, and product vendors. So, the
+                rules included here are very generic in terms of hardening.
+            rules:
+                - bios_enable_execution_restrictions
+                - install_PAE_kernel_on_x86-32
+
+          - id: 2.2.2
+            title: Vendor default accounts are managed.
+            description: |-
+                Vendor default accounts are managed as follows:
+                - If the vendor default account(s) will be used, the default password is changed per
+                Requirement 8.3.6.
+                - If the vendor default account(s) will not be used, the account is removed or disabled.
+            levels:
+                - base
+            status: automated
+            notes: |-
+                Also related to requirement 8.2.6 and 8.3.5.
+            rules:
+                - ensure_root_password_configured
+                - no_empty_passwords_etc_shadow
+
+          - id: 2.2.3
+            title: 'Primary functions requiring different security levels are managed'
+            levels:
+                - base
+            status: manual
+
+          - id: 2.2.4
+            title: Only necessary services, protocols, daemons, and functions are enabled, and all unnecessary
+                functionality is removed or disabled
+            description: |-
+                System components cannot be compromised by exploiting unnecessary functionality present in
+                the system component.
+            levels:
+                - base
+            status: automated
+            rules:
+                - mask_nonessential_services
+                - package_dhcp_removed
+                - package_ftp_removed
+                - package_net-snmp_removed
+                - package_rsh_removed
+                - package_rsh-server_removed
+                - package_talk_removed
+                - package_talk-server_removed
+                - package_telnet_removed
+                - package_telnet-server_removed
+                - package_tftp_removed
+                - package_tftp-server_removed
+                - package_xinetd_removed
+                - package_ypbind_removed
+                - package_ypserv_removed
+                - service_avahi-daemon_disabled
+                - service_rpcbind_disabled
+                - service_rsyncd_disabled
+            related_rules:
+                - package_bind_removed
+                - package_dnsmasq_removed
+                - package_httpd_removed
+                - package_nfs-utils_removed
+                - package_openldap-clients_removed
+                - package_openldap-servers_removed
+                - package_rsync_removed
+                - package_samba_removed
+                - package_squid_removed
+                - package_vsftpd_removed
+                - service_cups_disabled
+                - service_nfs_disabled
+
+          - id: 2.2.5
+            title: If any insecure services, protocols, or daemons are present, business justification
+                is documented and the risk is reduced.
+            description: |-
+                If any insecure services, protocols, or daemons are present:
+                - Business justification is documented.
+                - Additional security features are documented and implemented that reduce the risk of
+                using insecure services, protocols, or daemons.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Known insecure services are removed or disabled by 2.2.4
+                General security measures are covered by 1.2.6
+                This requirement is more about checking exceptions and their respective documentation.
+
+          - id: 2.2.6
+            title: System security parameters are configured to prevent misuse.
+            description: |-
+                System components cannot be compromised because of incorrect security parameter
+                configuration.
+            levels:
+                - base
+            status: automated
+            notes: |-
+                This requirement is not specific but also points to 2.2.1, where other policies are
+                referenced. Therefore, the most common rules related to system configuration in order to
+                prevent misuse and selected in main profiles are also selected here.
+            rules:
+        # bootloader files protection
+                - file_groupowner_grub2_cfg
+                - file_owner_grub2_cfg
+                - file_permissions_grub2_cfg
+                - file_groupowner_user_cfg
+                - file_owner_user_cfg
+                - file_permissions_user_cfg
+        # at files protection
+                - file_at_deny_not_exist
+                - file_groupowner_at_allow
+                - file_owner_at_allow
+                - file_permissions_at_allow
+        # cron files protection
+                - file_cron_deny_not_exist
+                - file_groupowner_cron_allow
+                - file_owner_cron_allow
+                - file_permissions_cron_allow
+                - file_groupowner_crontab
+                - file_owner_crontab
+                - package_cron_installed
+                - file_permissions_crontab
+                - file_groupowner_cron_d
+                - file_owner_cron_d
+                - file_permissions_cron_d
+                - file_groupowner_cron_hourly
+                - file_owner_cron_hourly
+                - file_permissions_cron_hourly
+                - file_groupowner_cron_daily
+                - file_owner_cron_daily
+                - file_permissions_cron_daily
+                - file_groupowner_cron_weekly
+                - file_owner_cron_weekly
+                - file_permissions_cron_weekly
+                - file_groupowner_cron_monthly
+                - file_owner_cron_monthly
+                - file_permissions_cron_monthly
+        # ssh files protection
+                - file_permissions_sshd_config
+                - file_permissions_sshd_private_key
+                - file_permissions_sshd_pub_key
+        # users files protection
+                - file_groupowner_etc_group
+                - file_groupowner_backup_etc_group
+                - file_owner_etc_group
+                - file_owner_backup_etc_group
+                - file_permissions_etc_group
+                - file_permissions_backup_etc_group
+                - file_groupowner_etc_passwd
+                - file_groupowner_backup_etc_passwd
+                - file_owner_etc_passwd
+                - file_owner_backup_etc_passwd
+                - file_permissions_etc_passwd
+                - file_permissions_backup_etc_passwd
+                - file_groupowner_etc_shadow
+                - file_groupowner_backup_etc_shadow
+                - file_owner_etc_shadow
+                - file_owner_backup_etc_shadow
+                - file_permissions_etc_shadow
+                - file_permissions_backup_etc_shadow
+        # general files protection
+                - file_permissions_unauthorized_world_writable
+                - file_permissions_ungroupowned
+                - no_files_unowned_by_user
+                - dir_perms_world_writable_sticky_bits
+        # ssh settings
+                - sshd_disable_empty_passwords
+                - sshd_disable_rhosts
+                - sshd_disable_root_login
+                - sshd_disable_tcp_forwarding
+                - sshd_disable_x11_forwarding
+                - sshd_do_not_permit_user_env
+                - sshd_enable_pam
+                - sshd_limit_user_access
+                - sshd_set_loglevel_verbose
+                - sshd_set_max_auth_tries
+                - sshd_set_max_sessions
+                - sshd_set_maxstartups
+                - sshd_set_login_grace_time
+                - var_sshd_set_login_grace_time=60
+        # sudo settings
+                - package_sudo_installed
+                - sudo_add_use_pty
+                - sudo_custom_logfile
+                - sudo_require_authentication
+                - sudo_require_reauthentication
+        # su command limitation
+                - use_pam_wheel_group_for_su
+                - ensure_pam_wheel_group_empty
+
+          - id: 2.2.7
+            title: All non-console administrative access is encrypted using strong cryptography.
+            description: |-
+                Cleartext administrative authorization factors cannot be read or intercepted from any
+                network transmissions. This includes administrative access via browser-based interfaces
+                and application programming interfaces (APIs).
+            levels:
+                - base
+            status: automated
+            notes: |-
+                Related to requirement 12.3.3.
+            rules:
+                - configure_crypto_policy
+                - var_system_crypto_policy=default_policy
+                - configure_ssh_crypto_policy
+                - sshd_use_approved_ciphers
+                - sshd_use_approved_macs
+                - sshd_use_strong_kex
+            related_rules:
+                - configure_libreswan_crypto_policy
+                - configure_openssl_crypto_policy
+
+    - id: '2.3'
+      title: Wireless environments are configured and managed securely.
+      levels:
+          - base
+      status: supported
+      controls:
+          - id: 2.3.1
+            title: For wireless environments connected to the CDE or transmitting account data, all wireless
+                vendor defaults are changed at installation or are confirmed to be secure.
+            description: |-
+                For wireless environments connected to the CDE or transmitting account data, all wireless
+                vendor defaults are changed at installation or are confirmed to be secure, including but
+                not limited to:
+                - Default wireless encryption keys.
+                - Passwords on wireless access points.
+                - SNMP defaults.
+                - Any other security-related wireless vendor defaults.
+            levels:
+                - base
+            status: supported
+            notes: |-
+                Wireless interfaces are disabled by 1.3.3.
+            related_rules:
+                - wireless_disable_interfaces
+
+          - id: 2.3.2
+            title: For wireless environments connected to the CDE or transmitting account data, wireless
+                encryption keys are changed
+            description: |-
+                For wireless environments connected to the CDE or transmitting account
+                data, wireless encryption keys are changed
+            levels:
+                - base
+            status: supported
+            notes: |-
+                Wireless interfaces are disabled by 1.3.3.
+            related_rules:
+                - wireless_disable_interfaces
+
+    - id: '3.1'
+      title: Processes and mechanisms for protecting stored account data are defined and understood.
+      levels:
+          - base
+      status: manual
+      controls:
+          - id: 3.1.1
+            title: All security policies and operational procedures that are identified in Requirement
+                3 are Documented, Kept up to date, In use and Known to all affected parties.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Examine documentation and interview personnel to verify that security policies and
+                operational procedures identified in Requirement 3 are managed in accordance with all
+                elements specified in this requirement.
+
+          - id: 3.1.2
+            title: Roles and responsibilities for performing activities in Requirement 3 are documented,
+                assigned, and understood.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Examine documentation and interview personnel to verify that day-to-day responsibilities
+                for performing all the activities in Requirement 3 are documented, assigned and understood
+                by the assigned personnel.
+
+    - id: '3.2'
+      title: Storage of account data is kept to a minimum.
+      levels:
+          - base
+      status: manual
+      controls:
+          - id: 3.2.1
+            title: Account data storage is kept to a minimum through implementation of data retention
+                and disposal policies, procedures, and processes.
+            description: |-
+                Account data storage is kept to a minimum through implementation of data retention and
+                disposal policies, procedures, and processes that include at least the following:
+                - Coverage for all locations of stored account data.
+                - Coverage for any sensitive authentication data (SAD) stored prior to completion of
+                authorization.
+                - Limiting data storage amount and retention time to that which is required for legal or
+                regulatory, and/or business requirements.
+                - Specific retention requirements for stored account data that defines length of retention
+                period and includes a documented business justification.
+                - Processes for secure deletion or rendering account data unrecoverable when no longer
+                needed per the retention policy.
+                - A process for verifying, at least once every three months, that stored account data
+                exceeding the defined retention period has been securely deleted or rendered unrecoverable.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                This requirement is very dependent on each site policies and business model.
+                Local policies should be consulted and audited. Manual checking is reasonable.
+
+    - id: '3.3'
+      title: Sensitive authentication data (SAD) is not stored after authorization.
+      levels:
+          - base
+      status: partial
+      controls:
+          - id: 3.3.1
+            title: SAD is not stored after authorization, even if encrypted. All sensitive authentication
+                data received is rendered unrecoverable upon completion of the authorization process.
+            description: |-
+                This requirement is not eligible for the customized approach. This requirement does not
+                apply to issuers and companies that support issuing services (where SAD is needed for a
+                legitimate issuing business need) and have a business justification to store the sensitive
+                authentication data. Refer to Requirement 3.3.3 for additional requirements specifically
+                for issuers. Sensitive authentication data includes the data cited in Requirements 3.3.1.1
+                through 3.3.1.3.
+            levels:
+                - base
+            status: partial
+            controls:
+                - id: 3.3.1.1
+                  title: The full contents of any track are not stored upon completion of the authorization
+                      process.
+                  description: |-
+                      This requirement is not eligible for the customized approach. In the normal course of
+                      business, the following data elements from the track may need to be retained:
+                      - Cardholder name.
+                      - Primary account number (PAN).
+                      - Expiration date.
+                      - Service code.
+                      To minimize risk, store securely only these data elements as needed for business.
+                  levels:
+                      - base
+                  status: partial
+                  notes: |-
+                      This requirement consists in auditing files, databases and memory to make sure the full
+                      content of any track is not unnecessarily stored. It involves manual auditing but some
+                      automated rules fit this requirement in order to reduce the chances if this data be
+                      unintentionally stored in memory.
+                  rules:
+                      - coredump_disable_backtraces
+                      - coredump_disable_storage
+                      - disable_users_coredumps
+                      - sysctl_fs_suid_dumpable
+                      - sysctl_kernel_core_pattern
+                      - sysctl_kernel_randomize_va_space
+                  related_rules:
           # These next three rules are interesting but can hit performance so it is better to
           # investigate the performance impact before enabling them.
-          - kernel_config_page_poisoning
-          - kernel_config_page_poisoning_no_sanity
-          - kernel_config_page_poisoning_zero
-          - sysctl_kernel_core_uses_pid
+                      - kernel_config_page_poisoning
+                      - kernel_config_page_poisoning_no_sanity
+                      - kernel_config_page_poisoning_zero
+                      - sysctl_kernel_core_uses_pid
 
-      - id: 3.3.1.2
-        title: The card verification code is not stored upon completion of the authorization
-          process.
-        description: |-
-          This requirement is not eligible for the customized approach. The card verification code
-          is the three- or four-digit number printed on the front or back of a payment card used
-          to verify card-not-present transactions.
-        levels:
+                - id: 3.3.1.2
+                  title: The card verification code is not stored upon completion of the authorization
+                      process.
+                  description: |-
+                      This requirement is not eligible for the customized approach. The card verification code
+                      is the three- or four-digit number printed on the front or back of a payment card used
+                      to verify card-not-present transactions.
+                  levels:
+                      - base
+                  status: partial
+                  notes: |-
+                      Same rules already selected in 3.3.1.1 are valid here, but they are not repeated.
+                  related_rules:
+                      - coredump_disable_backtraces
+                      - coredump_disable_storage
+                      - disable_users_coredumps
+                      - sysctl_fs_suid_dumpable
+
+                - id: 3.3.1.3
+                  title: The personal identification number (PIN) and the PIN block are not stored upon
+                      completion of the authorization process.
+                  description: |-
+                      This requirement is not eligible for the customized approach. PIN blocks are encrypted
+                      during the natural course of transaction processes, but even if an entity encrypts the
+                      PIN block again, it is still not allowed to be stored after the completion of the
+                      authorization process.
+                  levels:
+                      - base
+                  status: partial
+                  notes: |-
+                      Same rules already selected in 3.3.1.1 are valid here, but they are not repeated.
+                  related_rules:
+                      - coredump_disable_backtraces
+                      - coredump_disable_storage
+                      - disable_users_coredumps
+                      - sysctl_fs_suid_dumpable
+
+          - id: 3.3.2
+            title: SAD that is stored electronically prior to completion of authorization is encrypted
+                using strong cryptography.
+            description: |-
+                This requirement is not eligible for the customized approach. Whether SAD is permitted to
+                be stored prior to authorization is determined by the organizations that manage compliance
+                programs (for example, payment brands and acquirers). Contact the organizations of
+                interest for any additional criteria. This requirement applies to all storage of SAD, even
+                if no PAN is present in the environment. Refer to Requirement 3.2.1 for an additional
+                requirement that applies if SAD is stored prior to completion of authorization. Issuers
+                and companies that support issuing services, where there is a legitimate and documented
+                business need to store SAD, are not required to meet this requirement. A legitimate
+                business need is one that is necessary for the performance of the function being provided
+                by or for the issuer. Refer to Requirement 3.3.3 for requirements specifically for issuers.
+                This requirement does not replace how PIN blocks are required to be managed, nor does it
+                mean that a properly encrypted PIN block needs to be encrypted again.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                This requirement is a best practice until 31 March 2025, after which it will be required
+                and must be fully considered during a PCI DSS assessment.
+                This requirement consists of auditing information stored during a relatively short period
+                of time. Where and how the information is possibly stored depends in each Business and
+                local policies so the check is not actually automatable.
+
+          - id: 3.3.3
+            title: Additional requirement for issuers and companies that support issuing services and
+                store sensitive authentication data.
+            description: |-
+                Additional requirement for issuers and companies that support issuing services and store
+                sensitive authentication data: Any storage of sensitive authentication data is:
+                - Limited to that which is needed for a legitimate issuing business need and is secured.
+                - Encrypted using strong cryptography. This bullet is a best practice until until
+                31 March 2025, after which it will be required as part of Requirement 3.3.3 and must be
+                fully considered during a PCI DSS assessment.
+            levels:
+                - base
+            status: manual
+
+    - id: '3.4'
+      title: Access to displays of full PAN and ability to copy PAN is restricted.
+      levels:
           - base
-        status: partial
-        notes: |-
-          Same rules already selected in 3.3.1.1 are valid here, but they are not repeated.
-        related_rules:
-          - coredump_disable_backtraces
-          - coredump_disable_storage
-          - disable_users_coredumps
-          - sysctl_fs_suid_dumpable
-
-      - id: 3.3.1.3
-        title: The personal identification number (PIN) and the PIN block are not stored upon
-          completion of the authorization process.
-        description: |-
-          This requirement is not eligible for the customized approach. PIN blocks are encrypted
-          during the natural course of transaction processes, but even if an entity encrypts the
-          PIN block again, it is still not allowed to be stored after the completion of the
-          authorization process.
-        levels:
-          - base
-        status: partial
-        notes: |-
-          Same rules already selected in 3.3.1.1 are valid here, but they are not repeated.
-        related_rules:
-          - coredump_disable_backtraces
-          - coredump_disable_storage
-          - disable_users_coredumps
-          - sysctl_fs_suid_dumpable
-
-    - id: 3.3.2
-      title: SAD that is stored electronically prior to completion of authorization is encrypted
-        using strong cryptography.
-      description: |-
-        This requirement is not eligible for the customized approach. Whether SAD is permitted to
-        be stored prior to authorization is determined by the organizations that manage compliance
-        programs (for example, payment brands and acquirers). Contact the organizations of
-        interest for any additional criteria. This requirement applies to all storage of SAD, even
-        if no PAN is present in the environment. Refer to Requirement 3.2.1 for an additional
-        requirement that applies if SAD is stored prior to completion of authorization. Issuers
-        and companies that support issuing services, where there is a legitimate and documented
-        business need to store SAD, are not required to meet this requirement. A legitimate
-        business need is one that is necessary for the performance of the function being provided
-        by or for the issuer. Refer to Requirement 3.3.3 for requirements specifically for issuers.
-        This requirement does not replace how PIN blocks are required to be managed, nor does it
-        mean that a properly encrypted PIN block needs to be encrypted again.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        This requirement is a best practice until 31 March 2025, after which it will be required
-        and must be fully considered during a PCI DSS assessment.
-        This requirement consists of auditing information stored during a relatively short period
-        of time. Where and how the information is possibly stored depends in each Business and
-        local policies so the check is not actually automatable.
-
-    - id: 3.3.3
-      title: Additional requirement for issuers and companies that support issuing services and
-        store sensitive authentication data.
-      description: |-
-        Additional requirement for issuers and companies that support issuing services and store
-        sensitive authentication data: Any storage of sensitive authentication data is:
-        - Limited to that which is needed for a legitimate issuing business need and is secured.
-        - Encrypted using strong cryptography. This bullet is a best practice until until
-        31 March 2025, after which it will be required as part of Requirement 3.3.3 and must be
-        fully considered during a PCI DSS assessment.
-      levels:
-        - base
-      status: manual
-
-  - id: '3.4'
-    title: Access to displays of full PAN and ability to copy PAN is restricted.
-    levels:
-      - base
-    status: automated
-    controls:
-    - id: 3.4.1
-      title: PAN is masked when displayed (the BIN and last four digits are the maximum number of
-        digits to be displayed), such that only personnel with a legitimate business need can see
-        more than the BIN and last four digits of the PAN.
-      description: |-
-        PAN displays are restricted to the minimum number of digits necessary to meet a defined
-        business need. This requirement does not supersede stricter requirements in place for
-        displays of cardholder data — for example, legal or payment brand requirements for
-        point-of-sale (POS) receipts. This requirement relates to protection of PAN where it is
-        displayed on screens, paper receipts, printouts, etc., and is not to be confused with
-        Requirement 3.5.1 for protection of PAN when stored, processed, or transmitted.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        Consists on examining documented policies and procedures, checking system configurations
-        and observing relevant applications.
-
-    - id: 3.4.2
-      title: When using remote-access technologies, technical controls prevent copy and/or
-        relocation of PAN for all personnel, except for those with documented, explicit
-        authorization and a legitimate, defined business need.
-      description: |-
-        PAN cannot be copied or relocated by unauthorized personnel using remote-access
-        technologies. Storing or relocating PAN onto local hard drives, removable electronic
-        media, and other storage devices brings these devices into scope for PCI DSS.
-        This requirement is a best practice until 31 March 2025, after which it will be required
-        and must be fully considered during a PCI DSS assessment.
-      levels:
-        - base
       status: automated
-      notes: |-
-        There are technical rules to disable removable storage devices. However, this requirement
-        still demand some manual auditing in documentation and eventual exceptions.
-      rules:
-        - kernel_module_usb-storage_disabled
-        - dconf_gnome_disable_automount
-        - dconf_gnome_disable_automount_open
+      controls:
+          - id: 3.4.1
+            title: PAN is masked when displayed (the BIN and last four digits are the maximum number
+                of digits to be displayed), such that only personnel with a legitimate business need
+                can see more than the BIN and last four digits of the PAN.
+            description: |-
+                PAN displays are restricted to the minimum number of digits necessary to meet a defined
+                business need. This requirement does not supersede stricter requirements in place for
+                displays of cardholder data — for example, legal or payment brand requirements for
+                point-of-sale (POS) receipts. This requirement relates to protection of PAN where it is
+                displayed on screens, paper receipts, printouts, etc., and is not to be confused with
+                Requirement 3.5.1 for protection of PAN when stored, processed, or transmitted.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Consists on examining documented policies and procedures, checking system configurations
+                and observing relevant applications.
 
-  - id: '3.5'
-    title: Primary account number (PAN) is secured wherever it is stored.
-    levels:
-      - base
-    status: partial
-    controls:
-    - id: 3.5.1
-      title: PAN is rendered unreadable anywhere it is stored
-      description: |-
-        PAN is rendered unreadable anywhere it is stored by using any of the following approaches:
-        - One-way hashes based on strong cryptography of the entire PAN.
-        - Truncation (hashing cannot be used to replace the truncated segment of PAN).
-          - If hashed and truncated versions of the same PAN, or different truncation formats of
-          the same PAN, are present in an environment, additional controls are in place such that
-          the different versions cannot be correlated to reconstruct the original PAN.
-        - Indexes tokens.
-        - Strong cryptography with associated key-management processes and procedures.
+          - id: 3.4.2
+            title: When using remote-access technologies, technical controls prevent copy and/or relocation
+                of PAN for all personnel, except for those with documented, explicit authorization and
+                a legitimate, defined business need.
+            description: |-
+                PAN cannot be copied or relocated by unauthorized personnel using remote-access
+                technologies. Storing or relocating PAN onto local hard drives, removable electronic
+                media, and other storage devices brings these devices into scope for PCI DSS.
+                This requirement is a best practice until 31 March 2025, after which it will be required
+                and must be fully considered during a PCI DSS assessment.
+            levels:
+                - base
+            status: automated
+            notes: |-
+                There are technical rules to disable removable storage devices. However, this requirement
+                still demand some manual auditing in documentation and eventual exceptions.
+            rules:
+                - kernel_module_usb-storage_disabled
+                - dconf_gnome_disable_automount
+                - dconf_gnome_disable_automount_open
+
+    - id: '3.5'
+      title: Primary account number (PAN) is secured wherever it is stored.
       levels:
-        - base
+          - base
       status: partial
       controls:
-      - id: 3.5.1.1
-        title: Hashes used to render PAN unreadable (per the first bullet of Requirement 3.5.1)
-          are keyed cryptographic hashes of the entire PAN, with associated key-management
-          processes and procedures in accordance with Requirements 3.6 and 3.7.
-        description: |-
-          All Applicability Notes for Requirement 3.5.1 also apply to this requirement.
-          Key-management processes and procedures (Requirements 3.6 and 3.7) do not apply to
-          system components used to generate individual keyed hashes of a PAN for comparison to
-          another system if:
-          - The system components only have access to one hash value at a time (hash values are
-          not stored on the system)
-          AND
-          - There is no other account data stored on the same system as the hashes.
-          This requirement is considered a best practice until 31 March 2025, after which it will
-          be required and must be fully considered during a PCI DSS assessment. This requirement
-          will replace the bullet in Requirement 3.5.1 for one-way hashes once its effective date
-          is reached.
-        levels:
-          - base
-        status: planned
-        notes: |-
-          This requirement likely demand assessment in application level for some environments and
-          this would be too specific to be automated. However, on system level we can ensure some
-          strong cryptographic algorithms. This is also generally covered by 2.2.7 but here would
-          be possible to include more specific rules, for openssl and libreswan for example.
-          However it would be first necessary to include a platform conditional in these rules
-          before selecting them so they are applicable only if the respective packages are
-          installed.
-        related_rules:
-          - configure_libreswan_crypto_policy
-          - configure_openssl_crypto_policy
+          - id: 3.5.1
+            title: PAN is rendered unreadable anywhere it is stored
+            description: |-
+                PAN is rendered unreadable anywhere it is stored by using any of the following approaches:
+                - One-way hashes based on strong cryptography of the entire PAN.
+                - Truncation (hashing cannot be used to replace the truncated segment of PAN).
+                  - If hashed and truncated versions of the same PAN, or different truncation formats of
+                  the same PAN, are present in an environment, additional controls are in place such that
+                  the different versions cannot be correlated to reconstruct the original PAN.
+                - Indexes tokens.
+                - Strong cryptography with associated key-management processes and procedures.
+            levels:
+                - base
+            status: partial
+            controls:
+                - id: 3.5.1.1
+                  title: Hashes used to render PAN unreadable (per the first bullet of Requirement 3.5.1)
+                      are keyed cryptographic hashes of the entire PAN, with associated key-management
+                      processes and procedures in accordance with Requirements 3.6 and 3.7.
+                  description: |-
+                      All Applicability Notes for Requirement 3.5.1 also apply to this requirement.
+                      Key-management processes and procedures (Requirements 3.6 and 3.7) do not apply to
+                      system components used to generate individual keyed hashes of a PAN for comparison to
+                      another system if:
+                      - The system components only have access to one hash value at a time (hash values are
+                      not stored on the system)
+                      AND
+                      - There is no other account data stored on the same system as the hashes.
+                      This requirement is considered a best practice until 31 March 2025, after which it will
+                      be required and must be fully considered during a PCI DSS assessment. This requirement
+                      will replace the bullet in Requirement 3.5.1 for one-way hashes once its effective date
+                      is reached.
+                  levels:
+                      - base
+                  status: planned
+                  notes: |-
+                      This requirement likely demand assessment in application level for some environments and
+                      this would be too specific to be automated. However, on system level we can ensure some
+                      strong cryptographic algorithms. This is also generally covered by 2.2.7 but here would
+                      be possible to include more specific rules, for openssl and libreswan for example.
+                      However it would be first necessary to include a platform conditional in these rules
+                      before selecting them so they are applicable only if the respective packages are
+                      installed.
+                  related_rules:
+                      - configure_libreswan_crypto_policy
+                      - configure_openssl_crypto_policy
 
-      - id: 3.5.1.2
-        title: If disk-level or partition-level encryption (rather than file-, column-, or
-          field-level database encryption) is used to render PAN unreadable, it is implemented
-          only on removable electronic media or complemented by another mechanism that meets
-          Requirement 3.5.1
-        levels:
-          - base
-        status: automated
-        rules:
-          - package_cryptsetup-luks_installed
+                - id: 3.5.1.2
+                  title: If disk-level or partition-level encryption (rather than file-, column-, or
+                      field-level database encryption) is used to render PAN unreadable, it is implemented
+                      only on removable electronic media or complemented by another mechanism that meets
+                      Requirement 3.5.1
+                  levels:
+                      - base
+                  status: automated
+                  rules:
+                      - package_cryptsetup-luks_installed
 
-      - id: 3.5.1.3
-        title: If disk-level or partition-level encryption is used (rather than file-, column-, or
-          field--level database encryption) to render PAN unreadable, it is managed.
-        description: |-
-          If disk-level or partition-level encryption is used (rather than file-, column-, or
-          field--level database encryption) to render PAN unreadable, it is managed as follows:
-          - Logical access is managed separately and independently of native operating system
-          authentication and access control mechanisms.
-          - Decryption keys are not associated with user accounts.
-          - Authentication factors (passwords, passphrases, or cryptographic keys) that allow
-          access to unencrypted data are stored securely.
-        levels:
-          - base
-        status: manual
-        notes: |-
-          To properly check this requirement, site policies and documentation should be consulted.
+                - id: 3.5.1.3
+                  title: If disk-level or partition-level encryption is used (rather than file-, column-,
+                      or field--level database encryption) to render PAN unreadable, it is managed.
+                  description: |-
+                      If disk-level or partition-level encryption is used (rather than file-, column-, or
+                      field--level database encryption) to render PAN unreadable, it is managed as follows:
+                      - Logical access is managed separately and independently of native operating system
+                      authentication and access control mechanisms.
+                      - Decryption keys are not associated with user accounts.
+                      - Authentication factors (passwords, passphrases, or cryptographic keys) that allow
+                      access to unencrypted data are stored securely.
+                  levels:
+                      - base
+                  status: manual
+                  notes: |-
+                      To properly check this requirement, site policies and documentation should be consulted.
 
-  - id: '3.6'
-    title: Cryptographic keys used to protect stored account data are secured.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 3.6.1
-      title: Procedures are defined and implemented to protect cryptographic keys used to protect
-        stored account data against disclosure and misuse.
-      description: |-
-        Procedures are defined and implemented to protect cryptographic keys used to protect
-        stored account data against disclosure and misuse that include:
-        - Access to keys is restricted to the fewest number of custodians necessary.
-        - Key-encrypting keys are at least as strong as the data-encrypting keys they protect.
-        - Key-encrypting keys are stored separately from data-encrypting keys.
-        - Keys are stored securely in the fewest possible locations and forms.
+    - id: '3.6'
+      title: Cryptographic keys used to protect stored account data are secured.
       levels:
-        - base
+          - base
       status: manual
       controls:
-      - id: 3.6.1.1
-        title: 'Additional requirement for service providers only: A documented description of the
-          cryptographic architecture is maintained'
-        description: |-
-          Additional requirement for service providers only: A documented description of the
-          cryptographic architecture is maintained that includes:
-          - Details of all algorithms, protocols, and keys used for the protection of stored
-          account data, including key strength and expiry date.
-          - Preventing the use of the same cryptographic keys in production and test environments.
-          This bullet is a best practice until 31 March 2025, after which it will be required as
-          part of Requirement 3.6.1.1 and must be fully considered during a PCI DSS assessment.
-          - Description of the key usage for each key.
-          - Inventory of any hardware security modules (HSMs), key management systems (KMS), and
-          other secure cryptographic devices (SCDs) used for key management, including type and
-          location of devices, as outlined in Requirement 12.3.4.
-        levels:
+          - id: 3.6.1
+            title: Procedures are defined and implemented to protect cryptographic keys used to protect
+                stored account data against disclosure and misuse.
+            description: |-
+                Procedures are defined and implemented to protect cryptographic keys used to protect
+                stored account data against disclosure and misuse that include:
+                - Access to keys is restricted to the fewest number of custodians necessary.
+                - Key-encrypting keys are at least as strong as the data-encrypting keys they protect.
+                - Key-encrypting keys are stored separately from data-encrypting keys.
+                - Keys are stored securely in the fewest possible locations and forms.
+            levels:
+                - base
+            status: manual
+            controls:
+                - id: 3.6.1.1
+                  title: 'Additional requirement for service providers only: A documented description
+                      of the cryptographic architecture is maintained'
+                  description: |-
+                      Additional requirement for service providers only: A documented description of the
+                      cryptographic architecture is maintained that includes:
+                      - Details of all algorithms, protocols, and keys used for the protection of stored
+                      account data, including key strength and expiry date.
+                      - Preventing the use of the same cryptographic keys in production and test environments.
+                      This bullet is a best practice until 31 March 2025, after which it will be required as
+                      part of Requirement 3.6.1.1 and must be fully considered during a PCI DSS assessment.
+                      - Description of the key usage for each key.
+                      - Inventory of any hardware security modules (HSMs), key management systems (KMS), and
+                      other secure cryptographic devices (SCDs) used for key management, including type and
+                      location of devices, as outlined in Requirement 12.3.4.
+                  levels:
+                      - base
+                  status: manual
+
+                - id: 3.6.1.2
+                  title: Secret and private keys used to encrypt/decrypt stored account data are stored
+                      in secure forms.
+                  description: |-
+                      Secret and private keys used to encrypt/decrypt stored account data are stored in one
+                      (or more) of the following forms at all times:
+                      - Encrypted with a key-encrypting key that is at least as strong as the data-encrypting
+                      key, and that is stored separately from the data-encrypting key.
+                      - Within a secure cryptographic device (SCD), such as a hardware security module (HSM)
+                      or PTS-approved point-of-interaction device.
+                      - As at least two full-length key components or key shares, in accordance with an
+                      industry-accepted method.
+                      Secret and private keys are stored in a secure form that prevents unauthorized retrieval
+                      or access. It is not required that public keys be stored in one of these forms.
+                      Cryptographic keys stored as part of a key management system (KMS) that employs SCDs are
+                      acceptable. A cryptographic key that is split into two parts does not meet this
+                      requirement. Secret or private keys stored as key components or key shares must be
+                      generated via one of the following
+                  levels:
+                      - base
+                  status: manual
+
+                - id: 3.6.1.3
+                  title: Access to cleartext cryptographic key components is restricted to the fewest
+                      number of custodians necessary.
+                  description: |-
+                      Access to cleartext cryptographic key components is restricted to necessary personnel.
+                  levels:
+                      - base
+                  status: manual
+
+                - id: 3.6.1.4
+                  title: Cryptographic keys are stored in the fewest possible locations.
+                  description: |-
+                      Cryptographic keys are retained only where necessary.
+                  levels:
+                      - base
+                  status: manual
+
+    - id: '3.7'
+      title: Where cryptography is used to protect stored account data, key management processes and
+          procedures covering all aspects of the key lifecycle are defined and implemented.
+      levels:
           - base
-        status: manual
-
-      - id: 3.6.1.2
-        title: Secret and private keys used to encrypt/decrypt stored account data are stored in
-          secure forms.
-        description: |-
-          Secret and private keys used to encrypt/decrypt stored account data are stored in one
-          (or more) of the following forms at all times:
-          - Encrypted with a key-encrypting key that is at least as strong as the data-encrypting
-          key, and that is stored separately from the data-encrypting key.
-          - Within a secure cryptographic device (SCD), such as a hardware security module (HSM)
-          or PTS-approved point-of-interaction device.
-          - As at least two full-length key components or key shares, in accordance with an
-          industry-accepted method.
-          Secret and private keys are stored in a secure form that prevents unauthorized retrieval
-          or access. It is not required that public keys be stored in one of these forms.
-          Cryptographic keys stored as part of a key management system (KMS) that employs SCDs are
-          acceptable. A cryptographic key that is split into two parts does not meet this
-          requirement. Secret or private keys stored as key components or key shares must be
-          generated via one of the following
-        levels:
-          - base
-        status: manual
-
-      - id: 3.6.1.3
-        title: Access to cleartext cryptographic key components is restricted to the fewest number
-          of custodians necessary.
-        description: |-
-          Access to cleartext cryptographic key components is restricted to necessary personnel.
-        levels:
-          - base
-        status: manual
-
-      - id: 3.6.1.4
-        title: Cryptographic keys are stored in the fewest possible locations.
-        description: |-
-          Cryptographic keys are retained only where necessary.
-        levels:
-          - base
-        status: manual
-
-  - id: '3.7'
-    title: Where cryptography is used to protect stored account data, key management processes and
-      procedures covering all aspects of the key lifecycle are defined and implemented.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 3.7.1
-      title: Key-management policies and procedures are implemented to include generation of
-        strong cryptographic keys used to protect stored account data.
-      description: |-
-        Strong cryptographic keys are generated.
-      levels:
-        - base
-      status: manual
-
-    - id: 3.7.2
-      title: Key-management policies and procedures are implemented to include secure distribution
-        of cryptographic keys used to protect stored account data.
-      description: |-
-        Cryptographic keys are secured during distribution.
-      levels:
-        - base
-      status: manual
-
-    - id: 3.7.3
-      title: Key-management policies and procedures are implemented to include secure storage of
-        cryptographic keys used to protect stored account data.
-      description: |-
-        Cryptographic keys are secured when stored.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        The scope of this requirement seems much wider going even to application level, which
-        might be different for each site. Regarding local system there are some technical measures
-        ensured by 2.2.6.
-
-    - id: 3.7.4
-      title: Key management policies and procedures are implemented for cryptographic key changes
-        for keys that have reached the end of their cryptoperiod, as defined by the associated
-        application vendor or key owner, and based on industry best practices and guidelines.
-      description: |-
-        Key management policies and procedures are implemented for cryptographic key changes for
-        keys that have reached the end of their cryptoperiod, as defined by the associated
-        application vendor or key owner, and based on industry best practices and guidelines,
-        including the following:
-        - A defined cryptoperiod for each key type in use.
-        - A process for key changes at the end of the defined cryptoperiod.
-      levels:
-        - base
-      status: manual
-
-    - id: 3.7.5
-      title: Key management policies procedures are implemented to include the retirement,
-        replacement, or destruction of keys used to protect stored account data, as deemed
-        necessary.
-      description: |-
-        Key management policies procedures are implemented to include the retirement, replacement,
-        or destruction of keys used to protect stored account data, as deemed necessary when:
-        - The key has reached the end of its defined cryptoperiod.
-        - The integrity of the key has been weakened, including when personnel with knowledge of a
-        cleartext key component leaves the company, or the role for which the key component was
-        known.
-        - The key is suspected of or known to be compromised.
-        - Retired or replaced keys are not used for encryption operations.
-      levels:
-        - base
-      status: manual
-
-    - id: 3.7.6
-      title: Where manual cleartext cryptographic key-management operations are performed by
-        personnel, key-management policies and procedures are implemented include managing these
-        operations using split knowledge and dual control.
-      description: |-
-        Cleartext secret or private keys cannot be known by anyone. Operations involving cleartext
-        keys cannot be carried out by a single person. This control is applicable for manual
-        key-management operations or where key management is not controlled by the encryption
-        product. A cryptographic key that is simply split into two parts does not meet this
-        requirement. Secret or private keys stored as key components or key shares must be
-        generated via one of the following
-      levels:
-        - base
-      status: manual
-
-    - id: 3.7.7
-      title: Key management policies and procedures are implemented to include the prevention of
-        unauthorized substitution of cryptographic keys.
-      description: |-
-        Cryptographic keys cannot be substituted by unauthorized personnel.
-      levels:
-        - base
-      status: manual
-
-    - id: 3.7.8
-      title: Key management policies and procedures are implemented to include that cryptographic
-        key custodians formally acknowledge (in writing or electronically) that they understand
-        and accept their key-custodian responsibilities.
-      description: |-
-        Key custodians are knowledgeable about their responsibilities in relation to cryptographic
-        operations and can access assistance and guidance when required.
-      levels:
-        - base
-      status: manual
-
-    - id: 3.7.9
-      title: 'Additional requirement for service providers only: Where a service provider shares
-        cryptographic keys with its customers for transmission or storage of account data,
-        guidance on secure transmission, storage and updating of such keys is documented and
-        distributed to the service provider’s customers.'
-      description: |-
-        Customers are provided with appropriate key management guidance whenever they receive
-        shared cryptographic keys. This requirement applies only when the entity being assessed is
-        a service provider.
-      levels:
-        - base
-      status: manual
-
-  - id: '4.1'
-    title: Processes and mechanisms for protecting cardholder data with strong cryptography during
-      transmission over open, public networks are defined and documented.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 4.1.1
-      title: All security policies and operational procedures that are identified in Requirement 4
-        are Documented, Kept up to date, In use and Known to all affected parties.
-      levels:
-        - base
-      status: manual
-
-    - id: 4.1.2
-      title: Roles and responsibilities for performing activities in Requirement 4 are documented,
-        assigned, and understood.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        Examine documentation and interview personnel to verify that day-to-day responsibilities
-        for performing all the activities in Requirement 4 are documented, assigned and understood
-        by the assigned personnel.
-
-  - id: '4.2'
-    title: PAN is protected with strong cryptography during transmission.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 4.2.1
-      title: Strong cryptography and security protocols are implemented as follows to safeguard
-        PAN during transmission over open, public networks.
-      description: |-
-        Strong cryptography and security protocols are implemented as follows to safeguard PAN
-        during transmission over open, public networks:
-        - Only trusted keys and certificates are accepted.
-        - Certificates used to safeguard PAN during transmission over open, public networks are
-        confirmed as valid and are not expired or revoked. This bullet is a best practice until
-        31 March 2025, after which it will be required as part of Requirement 4.2.1 and must be
-        fully considered during a PCI DSS assessment.
-        - The protocol in use supports only secure versions or configurations and does not support
-        fallback to, or use of insecure versions, algorithms, key sizes, or implementations.
-        - The encryption strength is appropriate for the encryption methodology in use.
-      levels:
-        - base
-      status: supported
-      related_rules:
-        - package_strongswan_installed
-        - package_libreswan_installed
-      controls:
-      - id: 4.2.1.1
-        title: An inventory of the entity's trusted keys and certificates used to protect PAN
-          during transmission is maintained.
-        description: |-
-          All keys and certificates used to protect PAN during transmission are identified and
-          confirmed as trusted. This requirement is a best practice until 31 March 2025, after
-          which it will be required and must be fully considered during a PCI DSS assessment.
-        levels:
-          - base
-        status: manual
-
-      - id: 4.2.1.2
-        title: Wireless networks transmitting PAN or connected to the CDE use industry best
-          practices to implement strong cryptography for authentication and transmission.
-        description: |-
-          Cleartext PAN cannot be read or intercepted from wireless network transmissions.
-        levels:
-          - base
-        status: manual
-        notes: |-
-          Wireless interfaces are disabled by 1.3.3.
-        related_rules:
-          - wireless_disable_interfaces
-
-    - id: 4.2.2
-      title: PAN is secured with strong cryptography whenever it is sent via end-user messaging
-        technologies.
-      description: |-
-        Cleartext PAN cannot be read or intercepted from transmissions using end-user messaging
-        technologies. This requirement also applies if a customer, or other third-party, requests
-        that PAN is sent to them via end-user messaging technologies. There could be occurrences
-        where an entity receives unsolicited cardholder data via an insecure communication channel
-        that was not intended for transmissions of sensitive data. In this situation, the entity
-        can choose to either include the channel in the scope of their CDE and secure it according
-        to PCI DSS or delete the cardholder data and implement measures to prevent the channel
-        from being used for cardholder data.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        Some known insecure services and protocols are disabled by 2.2.4.
-        If any specific end-user messaging technology is used, it should be manually checked in
-        alignment to site policies.
-
-  - id: '5.1'
-    title: Processes and mechanisms for protecting all systems and networks from malicious
-      software are defined and understood.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 5.1.1
-      title: All security policies and operational procedures that are identified in Requirement 5
-        are Documented, Kept up to date, In use and Known to all affected parties.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        Examine documentation and interview personnel to verify that security policies and
-        operational procedures identified in Requirement 5 are managed in accordance with all
-        elements specified in this requirement.
-
-    - id: 5.1.2
-      title: Roles and responsibilities for performing activities in Requirement 5 are documented,
-        assigned, and understood.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        Examine documentation and interview personnel to verify that day-to-day responsibilities
-        for performing all the activities in Requirement 5 are documented, assigned and understood
-        by the assigned personnel.
-
-  - id: '5.2'
-    title: Malicious software (malware) is prevented, or detected and addressed.
-    levels:
-      - base
-    status: automated
-    notes: |-
-      Related measures are covered by 1.2.6, 1.4.5 and 3.4.2.
-    controls:
-    - id: 5.2.1
-      title: An anti-malware solution(s) is deployed on all system components, except for those
-        system components identified in periodic evaluations per Requirement 5.2.3 that concludes
-        the system components are not at risk from malware.
-      description: |-
-        Automated mechanisms are implemented to prevent systems from becoming an attack vector for
-        malware.
-      levels:
-        - base
-      status: supported
-      notes: |-
-        There are many options of anti-malware and the criteria for any adopted solution or
-        approach relies on each site policy. Technologies are supported but manual assessment is
-        required.
-
-    - id: 5.2.2
-      title: The deployed anti-malware solution(s) detects all known types of malware and removes,
-        blocks, or contains all known types of malware.
-      levels:
-        - base
-      status: manual
-
-    - id: 5.2.3
-      title: Any system components that are not at risk for malware are evaluated periodically.
-      description: |-
-        Any system components that are not at risk for malware are evaluated periodically to
-        include the following:
-        - A documented list of all system components not at risk for malware.
-        - Identification and evaluation of evolving malware threats for those system components.
-        - Confirmation whether such system components continue to not require anti-malware
-        protection.
-      levels:
-        - base
       status: manual
       controls:
-      - id: 5.2.3.1
-        title: The frequency of periodic evaluations of system components identified as not at
-          risk for malware is defined in the entity's targeted risk analysis, which is performed
-          according to all elements specified in Requirement 12.3.1.
-        description: |-
-          Systems not known to be at risk from malware are re-evaluated at a frequency that
-          addresses the entity's risk. This requirement is a best practice until 31 March 2025,
-          after which it will be required and must be fully considered during a PCI DSS
-          assessment.
-        levels:
+          - id: 3.7.1
+            title: Key-management policies and procedures are implemented to include generation of strong
+                cryptographic keys used to protect stored account data.
+            description: |-
+                Strong cryptographic keys are generated.
+            levels:
+                - base
+            status: manual
+
+          - id: 3.7.2
+            title: Key-management policies and procedures are implemented to include secure distribution
+                of cryptographic keys used to protect stored account data.
+            description: |-
+                Cryptographic keys are secured during distribution.
+            levels:
+                - base
+            status: manual
+
+          - id: 3.7.3
+            title: Key-management policies and procedures are implemented to include secure storage of
+                cryptographic keys used to protect stored account data.
+            description: |-
+                Cryptographic keys are secured when stored.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                The scope of this requirement seems much wider going even to application level, which
+                might be different for each site. Regarding local system there are some technical measures
+                ensured by 2.2.6.
+
+          - id: 3.7.4
+            title: Key management policies and procedures are implemented for cryptographic key changes
+                for keys that have reached the end of their cryptoperiod, as defined by the associated
+                application vendor or key owner, and based on industry best practices and guidelines.
+            description: |-
+                Key management policies and procedures are implemented for cryptographic key changes for
+                keys that have reached the end of their cryptoperiod, as defined by the associated
+                application vendor or key owner, and based on industry best practices and guidelines,
+                including the following:
+                - A defined cryptoperiod for each key type in use.
+                - A process for key changes at the end of the defined cryptoperiod.
+            levels:
+                - base
+            status: manual
+
+          - id: 3.7.5
+            title: Key management policies procedures are implemented to include the retirement, replacement,
+                or destruction of keys used to protect stored account data, as deemed necessary.
+            description: |-
+                Key management policies procedures are implemented to include the retirement, replacement,
+                or destruction of keys used to protect stored account data, as deemed necessary when:
+                - The key has reached the end of its defined cryptoperiod.
+                - The integrity of the key has been weakened, including when personnel with knowledge of a
+                cleartext key component leaves the company, or the role for which the key component was
+                known.
+                - The key is suspected of or known to be compromised.
+                - Retired or replaced keys are not used for encryption operations.
+            levels:
+                - base
+            status: manual
+
+          - id: 3.7.6
+            title: Where manual cleartext cryptographic key-management operations are performed by personnel,
+                key-management policies and procedures are implemented include managing these operations
+                using split knowledge and dual control.
+            description: |-
+                Cleartext secret or private keys cannot be known by anyone. Operations involving cleartext
+                keys cannot be carried out by a single person. This control is applicable for manual
+                key-management operations or where key management is not controlled by the encryption
+                product. A cryptographic key that is simply split into two parts does not meet this
+                requirement. Secret or private keys stored as key components or key shares must be
+                generated via one of the following
+            levels:
+                - base
+            status: manual
+
+          - id: 3.7.7
+            title: Key management policies and procedures are implemented to include the prevention of
+                unauthorized substitution of cryptographic keys.
+            description: |-
+                Cryptographic keys cannot be substituted by unauthorized personnel.
+            levels:
+                - base
+            status: manual
+
+          - id: 3.7.8
+            title: Key management policies and procedures are implemented to include that cryptographic
+                key custodians formally acknowledge (in writing or electronically) that they understand
+                and accept their key-custodian responsibilities.
+            description: |-
+                Key custodians are knowledgeable about their responsibilities in relation to cryptographic
+                operations and can access assistance and guidance when required.
+            levels:
+                - base
+            status: manual
+
+          - id: 3.7.9
+            title: 'Additional requirement for service providers only: Where a service provider shares
+                cryptographic keys with its customers for transmission or storage of account data, guidance
+                on secure transmission, storage and updating of such keys is documented and distributed
+                to the service provider’s customers.'
+            description: |-
+                Customers are provided with appropriate key management guidance whenever they receive
+                shared cryptographic keys. This requirement applies only when the entity being assessed is
+                a service provider.
+            levels:
+                - base
+            status: manual
+
+    - id: '4.1'
+      title: Processes and mechanisms for protecting cardholder data with strong cryptography during
+          transmission over open, public networks are defined and documented.
+      levels:
           - base
-        status: manual
-
-  - id: '5.3'
-    title: Anti-malware mechanisms and processes are active, maintained, and monitored.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 5.3.1
-      title: The anti-malware solution(s) is kept current via automatic updates.
-      description: |-
-        Anti-malware mechanisms can detect and address the latest malware threats.
-      levels:
-        - base
-      status: manual
-
-    - id: 5.3.2
-      title: The anti-malware solution(s) performs periodic scans and active or real-time scans or
-        performs continuous behavioral analysis of systems or processes.
-      levels:
-        - base
       status: manual
       controls:
-      - id: 5.3.2.1
-        title: If periodic malware scans are performed to meet Requirement 5.3.2, the frequency of
-          scans is defined in the entity's targeted risk analysis, which is performed according to
-          all elements specified in Requirement 12.3.1.
-        description: |-
-          Scans by the malware solution are performed at a frequency that addresses the entity's
-          risk. This requirement applies to entities conducting periodic malware scans to meet
-          Requirement 5.3.2. This requirement is a best practice until 31 March 2025, after which
-          it will be required and must be fully considered during a PCI DSS assessment.
-        levels:
+          - id: 4.1.1
+            title: All security policies and operational procedures that are identified in Requirement
+                4 are Documented, Kept up to date, In use and Known to all affected parties.
+            levels:
+                - base
+            status: manual
+
+          - id: 4.1.2
+            title: Roles and responsibilities for performing activities in Requirement 4 are documented,
+                assigned, and understood.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Examine documentation and interview personnel to verify that day-to-day responsibilities
+                for performing all the activities in Requirement 4 are documented, assigned and understood
+                by the assigned personnel.
+
+    - id: '4.2'
+      title: PAN is protected with strong cryptography during transmission.
+      levels:
           - base
-        status: manual
-
-    - id: 5.3.3
-      title: For removable electronic media, the anti-malware solution(s) performs automatic scans
-        of when the media is inserted, connected, or logically mounted, or Performs continuous
-        behavioral analysis of systems or processes when the media is inserted, connected, or
-        logically mounted.
-      levels:
-        - base
       status: manual
+      controls:
+          - id: 4.2.1
+            title: Strong cryptography and security protocols are implemented as follows to safeguard
+                PAN during transmission over open, public networks.
+            description: |-
+                Strong cryptography and security protocols are implemented as follows to safeguard PAN
+                during transmission over open, public networks:
+                - Only trusted keys and certificates are accepted.
+                - Certificates used to safeguard PAN during transmission over open, public networks are
+                confirmed as valid and are not expired or revoked. This bullet is a best practice until
+                31 March 2025, after which it will be required as part of Requirement 4.2.1 and must be
+                fully considered during a PCI DSS assessment.
+                - The protocol in use supports only secure versions or configurations and does not support
+                fallback to, or use of insecure versions, algorithms, key sizes, or implementations.
+                - The encryption strength is appropriate for the encryption methodology in use.
+            levels:
+                - base
+            status: supported
+            related_rules:
+                - package_strongswan_installed
+                - package_libreswan_installed
+            controls:
+                - id: 4.2.1.1
+                  title: An inventory of the entity's trusted keys and certificates used to protect PAN
+                      during transmission is maintained.
+                  description: |-
+                      All keys and certificates used to protect PAN during transmission are identified and
+                      confirmed as trusted. This requirement is a best practice until 31 March 2025, after
+                      which it will be required and must be fully considered during a PCI DSS assessment.
+                  levels:
+                      - base
+                  status: manual
+
+                - id: 4.2.1.2
+                  title: Wireless networks transmitting PAN or connected to the CDE use industry best
+                      practices to implement strong cryptography for authentication and transmission.
+                  description: |-
+                      Cleartext PAN cannot be read or intercepted from wireless network transmissions.
+                  levels:
+                      - base
+                  status: manual
+                  notes: |-
+                      Wireless interfaces are disabled by 1.3.3.
+                  related_rules:
+                      - wireless_disable_interfaces
+
+          - id: 4.2.2
+            title: PAN is secured with strong cryptography whenever it is sent via end-user messaging
+                technologies.
+            description: |-
+                Cleartext PAN cannot be read or intercepted from transmissions using end-user messaging
+                technologies. This requirement also applies if a customer, or other third-party, requests
+                that PAN is sent to them via end-user messaging technologies. There could be occurrences
+                where an entity receives unsolicited cardholder data via an insecure communication channel
+                that was not intended for transmissions of sensitive data. In this situation, the entity
+                can choose to either include the channel in the scope of their CDE and secure it according
+                to PCI DSS or delete the cardholder data and implement measures to prevent the channel
+                from being used for cardholder data.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Some known insecure services and protocols are disabled by 2.2.4.
+                If any specific end-user messaging technology is used, it should be manually checked in
+                alignment to site policies.
+
+    - id: '5.1'
+      title: Processes and mechanisms for protecting all systems and networks from malicious software
+          are defined and understood.
+      levels:
+          - base
+      status: manual
+      controls:
+          - id: 5.1.1
+            title: All security policies and operational procedures that are identified in Requirement
+                5 are Documented, Kept up to date, In use and Known to all affected parties.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Examine documentation and interview personnel to verify that security policies and
+                operational procedures identified in Requirement 5 are managed in accordance with all
+                elements specified in this requirement.
+
+          - id: 5.1.2
+            title: Roles and responsibilities for performing activities in Requirement 5 are documented,
+                assigned, and understood.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Examine documentation and interview personnel to verify that day-to-day responsibilities
+                for performing all the activities in Requirement 5 are documented, assigned and understood
+                by the assigned personnel.
+
+    - id: '5.2'
+      title: Malicious software (malware) is prevented, or detected and addressed.
+      levels:
+          - base
+      status: automated
       notes: |-
-        Related measures are covered by 3.4.2.
+          Related measures are covered by 1.2.6, 1.4.5 and 3.4.2.
+      controls:
+          - id: 5.2.1
+            title: An anti-malware solution(s) is deployed on all system components, except for those
+                system components identified in periodic evaluations per Requirement 5.2.3 that concludes
+                the system components are not at risk from malware.
+            description: |-
+                Automated mechanisms are implemented to prevent systems from becoming an attack vector for
+                malware.
+            levels:
+                - base
+            status: supported
+            notes: |-
+                There are many options of anti-malware and the criteria for any adopted solution or
+                approach relies on each site policy. Technologies are supported but manual assessment is
+                required.
 
-    - id: 5.3.4
-      title: Audit logs for the anti-malware solution(s) are enabled and retained in accordance
-        with Requirement 10.5.1.
-      description: |-
-        Historical records of anti-malware actions are immediately available and retained for at
-        least 12 months.
+          - id: 5.2.2
+            title: The deployed anti-malware solution(s) detects all known types of malware and removes,
+                blocks, or contains all known types of malware.
+            levels:
+                - base
+            status: manual
+
+          - id: 5.2.3
+            title: Any system components that are not at risk for malware are evaluated periodically.
+            description: |-
+                Any system components that are not at risk for malware are evaluated periodically to
+                include the following:
+                - A documented list of all system components not at risk for malware.
+                - Identification and evaluation of evolving malware threats for those system components.
+                - Confirmation whether such system components continue to not require anti-malware
+                protection.
+            levels:
+                - base
+            status: manual
+            controls:
+                - id: 5.2.3.1
+                  title: The frequency of periodic evaluations of system components identified as not
+                      at risk for malware is defined in the entity's targeted risk analysis, which is
+                      performed according to all elements specified in Requirement 12.3.1.
+                  description: |-
+                      Systems not known to be at risk from malware are re-evaluated at a frequency that
+                      addresses the entity's risk. This requirement is a best practice until 31 March 2025,
+                      after which it will be required and must be fully considered during a PCI DSS
+                      assessment.
+                  levels:
+                      - base
+                  status: manual
+
+    - id: '5.3'
+      title: Anti-malware mechanisms and processes are active, maintained, and monitored.
       levels:
-        - base
+          - base
       status: manual
+      controls:
+          - id: 5.3.1
+            title: The anti-malware solution(s) is kept current via automatic updates.
+            description: |-
+                Anti-malware mechanisms can detect and address the latest malware threats.
+            levels:
+                - base
+            status: manual
 
-    - id: 5.3.5
-      title: Anti-malware mechanisms cannot be disabled or altered by users, unless specifically
-        documented, and authorized by management on a case-by-case basis for a limited time
-        period.
-      description: |-
-        Anti-malware mechanisms cannot be modified by unauthorized personnel.Anti-malware
-        solutions may be temporarily disabled only if there is a legitimate technical need, as
-        authorized by management on a case-by-case basis. If anti-malware protection needs to be
-        disabled for a specific purpose, it must be formally authorized. Additional security
-        measures may also need to be implemented for the period during which anti-malware
-        protection is not active.
+          - id: 5.3.2
+            title: The anti-malware solution(s) performs periodic scans and active or real-time scans
+                or performs continuous behavioral analysis of systems or processes.
+            levels:
+                - base
+            status: manual
+            controls:
+                - id: 5.3.2.1
+                  title: If periodic malware scans are performed to meet Requirement 5.3.2, the frequency
+                      of scans is defined in the entity's targeted risk analysis, which is performed
+                      according to all elements specified in Requirement 12.3.1.
+                  description: |-
+                      Scans by the malware solution are performed at a frequency that addresses the entity's
+                      risk. This requirement applies to entities conducting periodic malware scans to meet
+                      Requirement 5.3.2. This requirement is a best practice until 31 March 2025, after which
+                      it will be required and must be fully considered during a PCI DSS assessment.
+                  levels:
+                      - base
+                  status: manual
+
+          - id: 5.3.3
+            title: For removable electronic media, the anti-malware solution(s) performs automatic scans
+                of when the media is inserted, connected, or logically mounted, or Performs continuous
+                behavioral analysis of systems or processes when the media is inserted, connected, or
+                logically mounted.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Related measures are covered by 3.4.2.
+
+          - id: 5.3.4
+            title: Audit logs for the anti-malware solution(s) are enabled and retained in accordance
+                with Requirement 10.5.1.
+            description: |-
+                Historical records of anti-malware actions are immediately available and retained for at
+                least 12 months.
+            levels:
+                - base
+            status: manual
+
+          - id: 5.3.5
+            title: Anti-malware mechanisms cannot be disabled or altered by users, unless specifically
+                documented, and authorized by management on a case-by-case basis for a limited time period.
+            description: |-
+                Anti-malware mechanisms cannot be modified by unauthorized personnel.Anti-malware
+                solutions may be temporarily disabled only if there is a legitimate technical need, as
+                authorized by management on a case-by-case basis. If anti-malware protection needs to be
+                disabled for a specific purpose, it must be formally authorized. Additional security
+                measures may also need to be implemented for the period during which anti-malware
+                protection is not active.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Related measures are covered by 2.2.6 requirement and 8.2 section.
+
+    - id: '5.4'
+      title: Anti-phishing mechanisms protect users against phishing attacks.
       levels:
-        - base
+          - base
       status: manual
-      notes: |-
-        Related measures are covered by 2.2.6 requirement and 8.2 section.
+      controls:
+          - id: 5.4.1
+            title: Processes and automated mechanisms are in place to detect and protect personnel against
+                phishing attacks.
+            description: |-
+                Mechanisms are in place to protect against and mitigate risk posed by phishing attacks.
+                The focus of this requirement is on protecting personnel with access to system components
+                in-scope for PCI DSS. Meeting this requirement for technical and automated controls to
+                detect and protect personnel against phishing is not the same as Requirement 12.6.3.1 for
+                security awareness training. Meeting this requirement does not also meet the requirement
+                for providing personnel with security awareness training, and vice versa. This requirement
+                is a best practice until 31 March 2025, after which it will be required and must be fully
+                considered during a PCI DSS assessment.
+            levels:
+                - base
+            status: manual
 
-  - id: '5.4'
-    title: Anti-phishing mechanisms protect users against phishing attacks.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 5.4.1
-      title: Processes and automated mechanisms are in place to detect and protect personnel
-        against phishing attacks.
-      description: |-
-        Mechanisms are in place to protect against and mitigate risk posed by phishing attacks.
-        The focus of this requirement is on protecting personnel with access to system components
-        in-scope for PCI DSS. Meeting this requirement for technical and automated controls to
-        detect and protect personnel against phishing is not the same as Requirement 12.6.3.1 for
-        security awareness training. Meeting this requirement does not also meet the requirement
-        for providing personnel with security awareness training, and vice versa. This requirement
-        is a best practice until 31 March 2025, after which it will be required and must be fully
-        considered during a PCI DSS assessment.
+    - id: '6.1'
+      title: Processes and mechanisms for developing and maintaining secure systems and software are
+          defined and understood.
       levels:
-        - base
+          - base
       status: manual
+      controls:
+          - id: 6.1.1
+            title: All security policies and operational procedures that are identified in Requirement
+                6 are Documented, Kept up to date, In use and Known to all affected parties.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Examine documentation and interview personnel to verify that security policies and
+                operational procedures identified in Requirement 6 are managed in accordance with all
+                elements specified in this requirement.
 
-  - id: '6.1'
-    title: Processes and mechanisms for developing and maintaining secure systems and software are
-      defined and understood.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 6.1.1
-      title: All security policies and operational procedures that are identified in Requirement 6
-        are Documented, Kept up to date, In use and Known to all affected parties.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        Examine documentation and interview personnel to verify that security policies and
-        operational procedures identified in Requirement 6 are managed in accordance with all
-        elements specified in this requirement.
+          - id: 6.1.2
+            title: Roles and responsibilities for performing activities in Requirement 6 are documented,
+                assigned, and understood.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Examine documentation and interview personnel to verify that day-to-day responsibilities
+                for performing all the activities in Requirement 6 are documented, assigned and understood
+                by the assigned personnel.
 
-    - id: 6.1.2
-      title: Roles and responsibilities for performing activities in Requirement 6 are
-        documented, assigned, and understood.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        Examine documentation and interview personnel to verify that day-to-day responsibilities
-        for performing all the activities in Requirement 6 are documented, assigned and understood
-        by the assigned personnel.
-
-  - id: '6.2'
-    title: Bespoke and custom software are developed securely.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 6.2.1
+    - id: '6.2'
       title: Bespoke and custom software are developed securely.
-      description: |-
-        Bespoke and custom software are developed securely, as follows:
-        - Based on industry standards and/or best practices for secure development.
-        - In accordance with PCI DSS (for example, secure authentication and logging).
-        - Incorporating consideration of information security issues during each stage of the
-        software development lifecycle.
       levels:
-        - base
-      status: manual
-
-    - id: 6.2.2
-      title: Software development personnel working on bespoke and custom software are trained at
-        least once every 12 months
-      description: |-
-        Software development personnel working on bespoke and custom software are trained at least
-        once every 12 months as follows:
-        - On software security relevant to their job function and development languages.
-        - Including secure software design and secure coding techniques.
-        - Including, if security testing tools are used, how to use the tools for detecting
-        vulnerabilities in software.
-      levels:
-        - base
-      status: manual
-
-    - id: 6.2.3
-      title: Bespoke and custom software is reviewed prior to being released into production or to
-        customers, to identify and correct potential coding vulnerabilities.
-      description: |-
-        Bespoke and custom software is reviewed prior to being released into production or to
-        customers, to identify and correct potential coding vulnerabilities, as follows:
-        - Code reviews ensure code is developed according to secure coding guidelines.
-        - Code reviews look for both existing and emerging software vulnerabilities.
-        - Appropriate corrections are implemented prior to release.
-      levels:
-        - base
+          - base
       status: manual
       controls:
-      - id: 6.2.3.1
-        title: If manual code reviews are performed for bespoke and custom software prior to
-          release to production code changes co-reviewed and approved.
-        description: |-
-          If manual code reviews are performed for bespoke and custom software prior to release
-          to production code changes are:
-          - Reviewed by individuals other than the originating code author, and who are
-          knowledgeable about code-review techniques and secure coding practices.
-          - Reviewed and approved by management prior to release.
-        levels:
+          - id: 6.2.1
+            title: Bespoke and custom software are developed securely.
+            description: |-
+                Bespoke and custom software are developed securely, as follows:
+                - Based on industry standards and/or best practices for secure development.
+                - In accordance with PCI DSS (for example, secure authentication and logging).
+                - Incorporating consideration of information security issues during each stage of the
+                software development lifecycle.
+            levels:
+                - base
+            status: manual
+
+          - id: 6.2.2
+            title: Software development personnel working on bespoke and custom software are trained
+                at least once every 12 months
+            description: |-
+                Software development personnel working on bespoke and custom software are trained at least
+                once every 12 months as follows:
+                - On software security relevant to their job function and development languages.
+                - Including secure software design and secure coding techniques.
+                - Including, if security testing tools are used, how to use the tools for detecting
+                vulnerabilities in software.
+            levels:
+                - base
+            status: manual
+
+          - id: 6.2.3
+            title: Bespoke and custom software is reviewed prior to being released into production or
+                to customers, to identify and correct potential coding vulnerabilities.
+            description: |-
+                Bespoke and custom software is reviewed prior to being released into production or to
+                customers, to identify and correct potential coding vulnerabilities, as follows:
+                - Code reviews ensure code is developed according to secure coding guidelines.
+                - Code reviews look for both existing and emerging software vulnerabilities.
+                - Appropriate corrections are implemented prior to release.
+            levels:
+                - base
+            status: manual
+            controls:
+                - id: 6.2.3.1
+                  title: If manual code reviews are performed for bespoke and custom software prior to
+                      release to production code changes co-reviewed and approved.
+                  description: |-
+                      If manual code reviews are performed for bespoke and custom software prior to release
+                      to production code changes are:
+                      - Reviewed by individuals other than the originating code author, and who are
+                      knowledgeable about code-review techniques and secure coding practices.
+                      - Reviewed and approved by management prior to release.
+                  levels:
+                      - base
+                  status: manual
+
+          - id: 6.2.4
+            title: Software engineering techniques or other methods are defined and in use by software
+                development personnel to prevent or mitigate common software attacks and related vulnerabilities
+                in bespoke and custom software.
+            levels:
+                - base
+            status: manual
+
+    - id: '6.3'
+      title: Security vulnerabilities are identified and addressed.
+      levels:
           - base
-        status: manual
-
-    - id: 6.2.4
-      title: Software engineering techniques or other methods are defined and in use by software
-        development personnel to prevent or mitigate common software attacks and related
-        vulnerabilities in bespoke and custom software.
-      levels:
-        - base
-      status: manual
-
-  - id: '6.3'
-    title: Security vulnerabilities are identified and addressed.
-    levels:
-      - base
-    status: automated
-    controls:
-    - id: 6.3.1
-      title: Security vulnerabilities are identified and managed
-      levels:
-        - base
-      status: manual
-
-    - id: 6.3.2
-      title: An inventory of bespoke and custom software, and third-party software components
-        incorporated into bespoke and custom software is maintained to facilitate vulnerability
-        and patch management.
-      description: |-
-        Known vulnerabilities in third-party software components cannot be exploited in bespoke
-        and custom software.This requirement is a best practice until 31 March 2025, after which
-        it will be required and must be fully considered during a PCI DSS assessment.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        This requirement is a best practice until 31 March 2025, after which it will be required
-        and must be fully considered during a PCI DSS assessment.
-
-    - id: 6.3.3
-      title: All system components are protected from known vulnerabilities by installing
-        applicable security patches/updates.
-      description: |-
-        All system components are protected from known vulnerabilities by installing
-        applicable security patches/updates as follows:
-        - Patches/updates for critical vulnerabilities (identified according to the risk ranking
-        process at Requirement 6.3.1) are installed within one month of release.
-        - All other applicable security patches/updates are installed within an appropriate time
-        frame as determined by the entity's assessment of the criticality of the risk to the
-        environment as identified according to the risk ranking process at Requirement 6.3.1.
-      levels:
-        - base
       status: automated
-      rules:
-        - ensure_redhat_gpgkey_installed
-        - ensure_suse_gpgkey_installed
-        - ensure_almalinux_gpgkey_installed
-        - ensure_gpgcheck_globally_activated
-        - ensure_gpgcheck_never_disabled
-        - security_patches_up_to_date
-
-  - id: '6.4'
-    title: Public-facing web applications are protected against attacks.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 6.4.1
-      title: For public-facing web applications, new threats and vulnerabilities are addressed on
-        an ongoing basis and these applications are protected against known attacks.
-      description: |-
-        For public-facing web applications, new threats and vulnerabilities are addressed on an
-        ongoing basis and these applications are protected against known attacks as follows:
-        - Reviewing public-facing web applications via manual or automated application
-        vulnerability security assessment tools or methods as follows:
-          - At least once every 12 months and after significant changes.
-          - By an entity that specializes in application security.
-          - Including, at a minimum, all common software attacks in Requirement 6.2.4.
-          - All vulnerabilities are ranked in accordance with requirement 6.3.1.
-          - All vulnerabilities are corrected.
-          - The application is re-evaluated after the corrections
-        OR
-        - Installing an automated technical solution(s) that continually detects and prevents
-        web-based attacks as follows:
-          - Installed in front of public-facing web applications to detect and prevent web-based
-          attacks.
-          - Actively running and up to date as applicable.
-          - Generating audit logs.
-          - Configured to either block web-based attacks or generate an alert that is immediately
-          investigated.
-      levels:
-        - base
-      status: manual
-
-    - id: 6.4.2
-      title: For public-facing web applications, an automated technical solution is deployed that
-        continually detects and prevents web-based attacks.
-      levels:
-        - base
-      status: manual
-
-    - id: 6.4.3
-      title: All payment page scripts that are loaded and executed in the consumer's browser are
-        managed
-      description: |-
-        All payment page scripts that are loaded and executed in the consumer's browser are
-        managed as follows:
-        - A method is implemented to confirm that each script is authorized.
-        - A method is implemented to assure the integrity of each script.
-        - An inventory of all scripts is maintained with written business or technical
-        justification as to why each is necessary.
-      levels:
-        - base
-      status: manual
-
-  - id: '6.5'
-    title: Changes to all system components are managed securely.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 6.5.1
-      title: Changes to all system components in the production environment are made according to
-        established procedures.
-      levels:
-        - base
-      status: manual
-
-    - id: 6.5.2
-      title: Upon completion of a significant change, all applicable PCI DSS requirements are
-        confirmed to be in place on all new or changed systems and networks, and documentation is
-        updated as applicable.
-      description: |-
-        All system components are verified after a significant change to be compliant with the
-        applicable PCI DSS requirements.These significant changes should also be captured and
-        reflected in the entity's annual PCI DSS scope confirmation activity per Requirement
-        12.5.2.
-      levels:
-        - base
-      status: manual
-
-    - id: 6.5.3
-      title: Pre-production environments are separated from production environments and the
-        separation is enforced with access controls.
-      description: |-
-        Pre-production environments cannot introduce risks and vulnerabilities into production
-        environments.
-      levels:
-        - base
-      status: manual
-
-    - id: 6.5.4
-      title: Roles and functions are separated between production and pre-production environments
-        to provide accountability such that only reviewed and approved changes are deployed.
-      description: |-
-        Job roles and accountability that differentiate between pre-production and production
-        activities are defined and managed to minimize the risk of unauthorized, unintentional,
-        or inappropriate actions. In environments with limited personnel where individuals perform
-        multiple roles or functions, this same goal can be achieved with additional procedural
-        controls that provide accountability. For example, a developer may also be an administrator
-        that uses an administrator-level account with elevated privileges in the development
-        environment and, for their developer role, they use a separate account with user-level
-        access to the production environment.
-      levels:
-        - base
-      status: manual
-
-    - id: 6.5.5
-      title: Live PANs are not used in pre-production environments, except where those
-        environments are included in the CDE and protected in accordance with all applicable
-        PCI DSS requirements.
-      description: |-
-        Live PANs cannot be present in pre-production environments outside the CDE.s
-      levels:
-        - base
-      status: manual
-
-    - id: 6.5.6
-      title: Test data and test accounts are removed from system components before the system goes
-        into production.
-      description: |-
-        Test data and test accounts cannot exist in production environments.
-      levels:
-        - base
-      status: manual
-
-  - id: '7.1'
-    title: Processes and mechanisms for restricting access to system components and cardholder
-      data by business need to know are defined and understood.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 7.1.1
-      title: All security policies and operational procedures that are identified in Requirement 7
-        are Documented, Kept up to date, In use and Known to all affected parties.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        Examine documentation and interview personnel to verify that security policies and
-        operational procedures identified in Requirement 7 are managed in accordance with all
-        elements specified in this requirement.
-
-    - id: 7.1.2
-      title: Roles and responsibilities for performing activities in Requirement 7 are documented,
-        assigned, and understood.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        Examine documentation and interview personnel to verify that day-to-day responsibilities
-        for performing all the activities in Requirement 7 are documented, assigned and understood
-        by the assigned personnel.
-
-  - id: '7.2'
-    title: Access to system components and data is appropriately defined and assigned.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 7.2.1
-      title: An access control model is defined and includes granting access
-      description: |-
-        An access control model is defined and includes granting access as follows:
-        - Appropriate access depending on the entity's business and access needs.
-        - Access to system components and data resources that is based on users' job
-        classification and functions.
-        - The least privileges required (for example, user, administrator) to perform a job
-        function.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        General access are restricted by 2.2.6 and 8.2 section. This requirement is more about
-        checking granting access process.
-
-    - id: 7.2.2
-      title: Access is assigned to users, including privileged users, based on job classification
-        and function, and least privileges necessary to perform job responsibilities.
-      levels:
-        - base
-      status: manual
-
-    - id: 7.2.3
-      title: Required privileges are approved by authorized personnel.
-      description: |-
-        Access privileges cannot be granted to users without appropriate, documented
-        authorization.
-      levels:
-        - base
-      status: manual
-
-    - id: 7.2.4
-      title: All user accounts and related access privileges, including third-party/vendor
-        accounts, are reviewed
-      description: |-
-        All user accounts and related access privileges, including third-party/vendor accounts,
-        are reviewed as follows:
-        - At least once every six months.
-        - To ensure user accounts and access remain appropriate based on job function.
-        - Any inappropriate access is addressed.
-        - Management acknowledges that access remains appropriate.
-      levels:
-        - base
-      status: manual
-
-    - id: 7.2.5
-      title: All application and system accounts and related access privileges are assigned and
-        managed.
-      description: |-
-        All application and system accounts and related access privileges are assigned and managed
-        as follows:
-        - Based on the least privileges necessary for the operability of the system or application.
-        - Access is limited to the systems, applications, or processes that specifically require
-        their use.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        General access are restricted by 2.2.6 and 8.2 section.
       controls:
-      - id: 7.2.5.1
-        title: All access by application and system accounts and related access privileges are
-          reviewed.
-        levels:
+          - id: 6.3.1
+            title: Security vulnerabilities are identified and managed
+            levels:
+                - base
+            status: manual
+
+          - id: 6.3.2
+            title: An inventory of bespoke and custom software, and third-party software components incorporated
+                into bespoke and custom software is maintained to facilitate vulnerability and patch
+                management.
+            description: |-
+                Known vulnerabilities in third-party software components cannot be exploited in bespoke
+                and custom software.This requirement is a best practice until 31 March 2025, after which
+                it will be required and must be fully considered during a PCI DSS assessment.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                This requirement is a best practice until 31 March 2025, after which it will be required
+                and must be fully considered during a PCI DSS assessment.
+
+          - id: 6.3.3
+            title: All system components are protected from known vulnerabilities by installing applicable
+                security patches/updates.
+            description: |-
+                All system components are protected from known vulnerabilities by installing
+                applicable security patches/updates as follows:
+                - Patches/updates for critical vulnerabilities (identified according to the risk ranking
+                process at Requirement 6.3.1) are installed within one month of release.
+                - All other applicable security patches/updates are installed within an appropriate time
+                frame as determined by the entity's assessment of the criticality of the risk to the
+                environment as identified according to the risk ranking process at Requirement 6.3.1.
+            levels:
+                - base
+            status: automated
+            rules:
+                - ensure_redhat_gpgkey_installed
+                - ensure_suse_gpgkey_installed
+                - ensure_almalinux_gpgkey_installed
+                - ensure_gpgcheck_globally_activated
+                - ensure_gpgcheck_never_disabled
+                - security_patches_up_to_date
+
+    - id: '6.4'
+      title: Public-facing web applications are protected against attacks.
+      levels:
           - base
-        status: manual
-
-    - id: 7.2.6
-      title: All user access to query repositories of stored cardholder data is restricted
-      levels:
-        - base
       status: manual
-      notes: |-
-        This requirement is specific about cardholder data, which can be available in different
-        formats, such as clear and binary files, and databases depending on site policies.
-        General system restrictions are covered in 2.2.6.
+      controls:
+          - id: 6.4.1
+            title: For public-facing web applications, new threats and vulnerabilities are addressed
+                on an ongoing basis and these applications are protected against known attacks.
+            description: |-
+                For public-facing web applications, new threats and vulnerabilities are addressed on an
+                ongoing basis and these applications are protected against known attacks as follows:
+                - Reviewing public-facing web applications via manual or automated application
+                vulnerability security assessment tools or methods as follows:
+                  - At least once every 12 months and after significant changes.
+                  - By an entity that specializes in application security.
+                  - Including, at a minimum, all common software attacks in Requirement 6.2.4.
+                  - All vulnerabilities are ranked in accordance with requirement 6.3.1.
+                  - All vulnerabilities are corrected.
+                  - The application is re-evaluated after the corrections
+                OR
+                - Installing an automated technical solution(s) that continually detects and prevents
+                web-based attacks as follows:
+                  - Installed in front of public-facing web applications to detect and prevent web-based
+                  attacks.
+                  - Actively running and up to date as applicable.
+                  - Generating audit logs.
+                  - Configured to either block web-based attacks or generate an alert that is immediately
+                  investigated.
+            levels:
+                - base
+            status: manual
 
-  - id: '7.3'
-    title: 'Access to system components and data is managed via an access control
-      system(s).'
-    levels:
-      - base
-    status: planned
-    controls:
-    - id: 7.3.1
-      title: An access control system(s) is in place that restricts access based on a user's need
-        to know and covers all system components.
-      description: |-
-        Access rights and privileges are managed via mechanisms intended for that purpose.
+          - id: 6.4.2
+            title: For public-facing web applications, an automated technical solution is deployed that
+                continually detects and prevents web-based attacks.
+            levels:
+                - base
+            status: manual
+
+          - id: 6.4.3
+            title: All payment page scripts that are loaded and executed in the consumer's browser are
+                managed
+            description: |-
+                All payment page scripts that are loaded and executed in the consumer's browser are
+                managed as follows:
+                - A method is implemented to confirm that each script is authorized.
+                - A method is implemented to assure the integrity of each script.
+                - An inventory of all scripts is maintained with written business or technical
+                justification as to why each is necessary.
+            levels:
+                - base
+            status: manual
+
+    - id: '6.5'
+      title: Changes to all system components are managed securely.
       levels:
-        - base
+          - base
       status: manual
+      controls:
+          - id: 6.5.1
+            title: Changes to all system components in the production environment are made according
+                to established procedures.
+            levels:
+                - base
+            status: manual
 
-    - id: 7.3.2
-      title: The access control system(s) is configured to enforce permissions assigned to
-        individuals, applications, and systems based on job classification and function.
-      description: |-
-        Individual account access rights and privileges to systems, applications, and data are
-        only inherited from group membership.
+          - id: 6.5.2
+            title: Upon completion of a significant change, all applicable PCI DSS requirements are confirmed
+                to be in place on all new or changed systems and networks, and documentation is updated
+                as applicable.
+            description: |-
+                All system components are verified after a significant change to be compliant with the
+                applicable PCI DSS requirements.These significant changes should also be captured and
+                reflected in the entity's annual PCI DSS scope confirmation activity per Requirement
+                12.5.2.
+            levels:
+                - base
+            status: manual
+
+          - id: 6.5.3
+            title: Pre-production environments are separated from production environments and the separation
+                is enforced with access controls.
+            description: |-
+                Pre-production environments cannot introduce risks and vulnerabilities into production
+                environments.
+            levels:
+                - base
+            status: manual
+
+          - id: 6.5.4
+            title: Roles and functions are separated between production and pre-production environments
+                to provide accountability such that only reviewed and approved changes are deployed.
+            description: |-
+                Job roles and accountability that differentiate between pre-production and production
+                activities are defined and managed to minimize the risk of unauthorized, unintentional,
+                or inappropriate actions. In environments with limited personnel where individuals perform
+                multiple roles or functions, this same goal can be achieved with additional procedural
+                controls that provide accountability. For example, a developer may also be an administrator
+                that uses an administrator-level account with elevated privileges in the development
+                environment and, for their developer role, they use a separate account with user-level
+                access to the production environment.
+            levels:
+                - base
+            status: manual
+
+          - id: 6.5.5
+            title: Live PANs are not used in pre-production environments, except where those environments
+                are included in the CDE and protected in accordance with all applicable PCI DSS requirements.
+            description: |-
+                Live PANs cannot be present in pre-production environments outside the CDE.s
+            levels:
+                - base
+            status: manual
+
+          - id: 6.5.6
+            title: Test data and test accounts are removed from system components before the system goes
+                into production.
+            description: |-
+                Test data and test accounts cannot exist in production environments.
+            levels:
+                - base
+            status: manual
+
+    - id: '7.1'
+      title: Processes and mechanisms for restricting access to system components and cardholder data
+          by business need to know are defined and understood.
       levels:
-        - base
+          - base
       status: manual
+      controls:
+          - id: 7.1.1
+            title: All security policies and operational procedures that are identified in Requirement
+                7 are Documented, Kept up to date, In use and Known to all affected parties.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Examine documentation and interview personnel to verify that security policies and
+                operational procedures identified in Requirement 7 are managed in accordance with all
+                elements specified in this requirement.
 
-    - id: 7.3.3
-      title: The access control system(s) is set to "deny all" by default.
-      description: |-
-        Access rights and privileges are prohibited unless expressly permitted.
+          - id: 7.1.2
+            title: Roles and responsibilities for performing activities in Requirement 7 are documented,
+                assigned, and understood.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Examine documentation and interview personnel to verify that day-to-day responsibilities
+                for performing all the activities in Requirement 7 are documented, assigned and understood
+                by the assigned personnel.
+
+    - id: '7.2'
+      title: Access to system components and data is appropriately defined and assigned.
       levels:
-        - base
+          - base
+      status: manual
+      controls:
+          - id: 7.2.1
+            title: An access control model is defined and includes granting access
+            description: |-
+                An access control model is defined and includes granting access as follows:
+                - Appropriate access depending on the entity's business and access needs.
+                - Access to system components and data resources that is based on users' job
+                classification and functions.
+                - The least privileges required (for example, user, administrator) to perform a job
+                function.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                General access are restricted by 2.2.6 and 8.2 section. This requirement is more about
+                checking granting access process.
+
+          - id: 7.2.2
+            title: Access is assigned to users, including privileged users, based on job classification
+                and function, and least privileges necessary to perform job responsibilities.
+            levels:
+                - base
+            status: manual
+
+          - id: 7.2.3
+            title: Required privileges are approved by authorized personnel.
+            description: |-
+                Access privileges cannot be granted to users without appropriate, documented
+                authorization.
+            levels:
+                - base
+            status: manual
+
+          - id: 7.2.4
+            title: All user accounts and related access privileges, including third-party/vendor accounts,
+                are reviewed
+            description: |-
+                All user accounts and related access privileges, including third-party/vendor accounts,
+                are reviewed as follows:
+                - At least once every six months.
+                - To ensure user accounts and access remain appropriate based on job function.
+                - Any inappropriate access is addressed.
+                - Management acknowledges that access remains appropriate.
+            levels:
+                - base
+            status: manual
+
+          - id: 7.2.5
+            title: All application and system accounts and related access privileges are assigned and
+                managed.
+            description: |-
+                All application and system accounts and related access privileges are assigned and managed
+                as follows:
+                - Based on the least privileges necessary for the operability of the system or application.
+                - Access is limited to the systems, applications, or processes that specifically require
+                their use.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                General access are restricted by 2.2.6 and 8.2 section.
+            controls:
+                - id: 7.2.5.1
+                  title: All access by application and system accounts and related access privileges
+                      are reviewed.
+                  levels:
+                      - base
+                  status: manual
+
+          - id: 7.2.6
+            title: All user access to query repositories of stored cardholder data is restricted
+            levels:
+                - base
+            status: manual
+            notes: |-
+                This requirement is specific about cardholder data, which can be available in different
+                formats, such as clear and binary files, and databases depending on site policies.
+                General system restrictions are covered in 2.2.6.
+
+    - id: '7.3'
+      title: 'Access to system components and data is managed via an access control system(s).'
+      levels:
+          - base
       status: planned
-      notes: |-
-        It is possible we can select some rules for this requirement but more investigation is
-        needed to confirm.
+      controls:
+          - id: 7.3.1
+            title: An access control system(s) is in place that restricts access based on a user's need
+                to know and covers all system components.
+            description: |-
+                Access rights and privileges are managed via mechanisms intended for that purpose.
+            levels:
+                - base
+            status: manual
 
-  - id: '8.1'
-    title: Processes and mechanisms for identifying users and authenticating access to system
-      components are defined and understood.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 8.1.1
-      title: All security policies and operational procedures that are identified in Requirement 8
-        are Documented, Kept up to date, In use and Known to all affected parties.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        Examine documentation and interview personnel to verify that security policies and
-        operational procedures identified in Requirement 8 are managed in accordance with all
-        elements specified in this requirement.
+          - id: 7.3.2
+            title: The access control system(s) is configured to enforce permissions assigned to individuals,
+                applications, and systems based on job classification and function.
+            description: |-
+                Individual account access rights and privileges to systems, applications, and data are
+                only inherited from group membership.
+            levels:
+                - base
+            status: manual
 
-    - id: 8.1.2
-      title: Roles and responsibilities for performing activities in Requirement 8 are documented,
-        assigned, and understood.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        Examine documentation and interview personnel to verify that day-to-day responsibilities
-        for performing all the activities in Requirement 8 are documented, assigned and understood
-        by the assigned personnel.
+          - id: 7.3.3
+            title: The access control system(s) is set to "deny all" by default.
+            description: |-
+                Access rights and privileges are prohibited unless expressly permitted.
+            levels:
+                - base
+            status: planned
+            notes: |-
+                It is possible we can select some rules for this requirement but more investigation is
+                needed to confirm.
 
-  - id: '8.2'
-    title: User identification and related accounts for users and administrators are strictly
-      managed throughout an account's lifecycle.
-    levels:
-      - base
-    status: partial
-    controls:
-    - id: 8.2.1
-      title: All users are assigned a unique ID before access to system components or cardholder
-        data is allowed.
-      description: |-
-        All actions by all users are attributable to an individual. This requirement is not
-        intended to apply to user accounts within point-of-sale terminals that have access to only
-        one card number at a time to facilitate a single transaction (such as IDs used by cashiers
-        on point-of-sale terminals).
+    - id: '8.1'
+      title: Processes and mechanisms for identifying users and authenticating access to system components
+          are defined and understood.
       levels:
-        - base
-      status: planned
-      notes: |-
-        The rules selected in this requirement are incomplete. Missing remediation and test
-        scenarios. They should include test scenarios and likely remediation or a warning
-        informing why a remediation is not present.
-      rules:
-        - account_unique_id
-        - account_unique_name
-        - accounts_no_uid_except_zero
-        - accounts_root_gid_zero
-        - group_unique_id
-        - group_unique_name
-
-    - id: 8.2.2
-      title: Group, shared, or generic IDs, or other shared authentication credentials are only
-        used when necessary on an exception basis, and are managed.
-      description: |-
-        - ID use is prevented unless needed for an exceptional circumstance.
-        - Use is limited to the time needed for the exceptional circumstance.
-        - Business justification for use is documented.
-        - Use is explicitly approved by management.
-        - Individual user identity is confirmed before access to an account is granted.
-        - Every action taken is attributable to an individual user.
-      levels:
-        - base
-      status: automated
-      notes: |-
-        This requirement is complemented by 8.2.1 and related to 8.3.5.
-      rules:
-        - gid_passwd_group_same
-        - no_password_auth_for_systemaccounts
-        - no_shelllogin_for_systemaccounts
-
-    - id: 8.2.3
-      title: 'Additional requirement for service providers only: Service providers with remote
-        access to customer premises use unique authentication factors for each customer premises.'
-      levels:
-        - base
-      status: manual
-
-    - id: 8.2.4
-      title: Addition, deletion, and modification of user IDs, authentication factors, and other
-        identifier objects are managed
-      levels:
-        - base
-      status: manual
-
-    - id: 8.2.5
-      title: Access for terminated users is immediately revoked.
-      description: |-
-        The accounts of terminated users cannot be used.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        This requirement depends on site policies for user termination.
-
-    - id: 8.2.6
-      title: Inactive user accounts are removed or disabled within 90 days of inactivity.
-      description: |-
-        Inactive user accounts cannot be used.
-      levels:
-        - base
-      status: automated
-      notes: |-
-        Also related to requirements 2.2.2 and 8.3.5.
-      rules:
-        - var_account_disable_post_pw_expiration=90
-        - account_disable_post_pw_expiration
-        - accounts_set_post_pw_existing
-
-    - id: 8.2.7
-      title: Accounts used by third parties to access, support, or maintain system components via
-        remote access are managed.
-      levels:
-        - base
-      status: manual
-
-    - id: 8.2.8
-      title: If a user session has been idle for more than 15 minutes, the user is required to
-        re-authenticate to re-activate the terminal or session.
-      description: |-
-        A user session cannot be used except by the authorized user. This requirement is not
-        intended to apply to user accounts on point-of-sale terminals that have access to only one
-        card number at a time to facilitate a single transaction (such as IDs used by cashiers on
-        point-of-sale terminals). This requirement is not meant to prevent legitimate activities
-        from being performed while the console/PC is unattended.
-      levels:
-        - base
-      status: automated
-      rules:
-        - enable_dconf_user_profile
-        - dconf_db_up_to_date
-        - dconf_gnome_session_idle_user_locks
-        - dconf_gnome_screensaver_idle_activation_enabled
-        - dconf_gnome_screensaver_idle_delay
-        - inactivity_timeout_value=15_minutes
-        - dconf_gnome_screensaver_lock_delay
-        - var_screensaver_lock_delay=10_seconds
-        - dconf_gnome_screensaver_lock_enabled
-        - dconf_gnome_screensaver_mode_blank
-        - sshd_set_idle_timeout
-        - sshd_idle_timeout_value=15_minutes
-        - sshd_set_keepalive
-        - var_sshd_set_keepalive=1
-      related_rules:
-        - sshd_set_keepalive_0
-
-  - id: '8.3'
-    title: Strong authentication for users and administrators is established and managed.
-    levels:
-      - base
-    status: partial
-    controls:
-    - id: 8.3.1
-      title: All user access to system components for users and administrators is authenticated.
-      levels:
-        - base
-      status: automated
-      rules:
-        - disable_host_auth
-        - gnome_gdm_disable_automatic_login
-        - gnome_gdm_disable_guest_login
-        - gnome_gdm_disable_unattended_automatic_login
-        - no_empty_passwords
-
-    - id: 8.3.2
-      title: Strong cryptography is used to render all authentication factors unreadable during
-        transmission and storage on all system components.
-      description: |-
-        Cleartext authentication factors cannot be obtained, derived, or reused from the
-        interception of communications or from stored data.
-      levels:
-        - base
-      status: automated
-      notes: |-
-        There are similar rules that might be redundant for some distros.
-      rules:
-        - accounts_password_all_shadowed
-        - ensure_shadow_group_empty
-        - set_password_hashing_algorithm_commonauth
-        - set_password_hashing_algorithm_libuserconf
-        - set_password_hashing_algorithm_logindefs
-        - set_password_hashing_algorithm_systemauth
-        - var_password_hashing_algorithm=SHA512
-        - var_password_hashing_algorithm_pam=sha512
-
-    - id: 8.3.3
-      title: User identity is verified before modifying any authentication factor.
-      description: |-
-        Unauthorized individuals cannot gain system access by impersonating the identity of an
-        authorized user.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        This requirement is about processes, such as password resets, provisioning new hardware or
-        software tokens, and generating new keys. It is common that these activities involve help
-        desk teams and administrators and the involved people should ensure identities are properly
-        verified.
-
-    - id: 8.3.4
-      title: Invalid authentication attempts are limited.
-      description: |-
-        - Locking out the user ID after not more than 10 attempts.
-        - Setting the lockout duration to a minimum of 30 minutes or until the user's identity is
-        confirmed.
-      levels:
-        - base
-      status: automated
-      rules:
-        - enable_authselect
-        - var_authselect_profile=sssd
-        - accounts_passwords_pam_faillock_deny
-        - var_accounts_passwords_pam_faillock_deny=10
-        - accounts_passwords_pam_faillock_unlock_time
-        - var_accounts_passwords_pam_faillock_unlock_time=1800
-        - accounts_passwords_pam_tally2
-        - var_password_pam_tally2=10
-        - accounts_passwords_pam_tally2_unlock_time
-        - var_accounts_passwords_pam_tally2_unlock_time=1800
-        - cracklib_accounts_password_pam_retry
-
-    - id: 8.3.5
-      title: If passwords/passphrases are used as authentication factors to meet Requirement
-        8.3.1, they are set and reset for each user.
-      description: |-
-        - Set to a unique value for first-time use and upon reset.
-        - Forced to be changed immediately after the first use.
-      levels:
-        - base
-      status: automated
-      notes: |-
-        Also related to requirement 2.2.2, 8.2.2 and 8.2.6.
-      rules:
-        - accounts_password_last_change_is_in_past
-
-    - id: 8.3.6
-      title: If passwords/passphrases are used as authentication factors to meet Requirement
-        8.3.1, they meet the minimum level of complexity.
-      description: |-
-        - A minimum length of 12 characters (or IF the system does not support 12 characters, a
-        minimum length of eight characters).
-        - Contain both numeric and alphabetic characters.
-        A guessed password/passphrase cannot be verified by either an online or offline brute
-        force attack.
-      levels:
-        - base
-      status: automated
-      notes: |-
-        This requirement is not intended to apply to:
-        - User accounts on point-of-sale terminals that have access to only one card number at a
-        time to facilitate a single transaction (such as IDs used by cashiers on point-of-sale
-        terminals).
-        - Application or system accounts, which are governed by requirements in section 8.6.
-      rules:
-        - var_password_pam_dcredit=1
-        - var_password_pam_lcredit=1
-        - var_password_pam_minlen=12
-        - accounts_password_pam_dcredit
-        - accounts_password_pam_lcredit
-        - accounts_password_pam_minlen
-        - cracklib_accounts_password_pam_dcredit
-        - cracklib_accounts_password_pam_lcredit
-        - cracklib_accounts_password_pam_minlen
-      related_rules:
-        - var_password_pam_ocredit=1
-        - var_password_pam_ucredit=1
-        - accounts_password_pam_ucredit
-        - cracklib_accounts_password_pam_ocredit
-        - cracklib_accounts_password_pam_ucredit
-
-    - id: 8.3.7
-      title: Individuals are not allowed to submit a new password/passphrase that is the same as
-        any of the last four passwords/passphrases used.
-      description: |-
-        A previously used password cannot be used to gain access to an account for at least 12
-        months.
-      levels:
-        - base
-      status: automated
-      notes: |-
-        This requirement is not intended to apply to user accounts on point-of-sale terminals that
-        have access to only one card number at a time to facilitate a single transaction (such as
-        IDs used by cashiers on point-of-sale terminals).
-        For RHEL 8 and RHEL 9 systems, the accounts_password_pam_pwhistory_... rules should be
-        prefered in detriment of accounts_password_pam_unix_remember. Using both should not create
-        conflict but is unnecessary and the last should be filtered out from the profile.
-      rules:
-        - var_password_pam_unix_remember=4
-        - accounts_password_pam_unix_remember
-        - var_password_pam_remember=4
-        - var_password_pam_remember_control_flag=requisite_or_required
-        - accounts_password_pam_pwhistory_remember_password_auth
-        - accounts_password_pam_pwhistory_remember_system_auth
-      related_rules:
-        - var_accounts_minimum_age_login_defs=1
-        - accounts_minimum_age_login_defs
-
-    - id: 8.3.8
-      title: Authentication policies and procedures are documented and communicated to all users.
-      levels:
-        - base
-      status: manual
-
-    - id: 8.3.9
-      title: If passwords/passphrases are used as the only authentication factor for user access
-        (i.e., in any single-factor authentication implementation) they should have a limited
-        lifetime.
-      description: |-
-        If passwords/passphrases are used as the only authentication factor for user access (i.e.,
-        in any single-factor authentication implementation) then either:
-        - Passwords/passphrases are changed at least once every 90 days,
-        OR
-        - The security posture of accounts is dynamically analyzed, and real-time access to
-        resources is automatically determined accordingly.
-      levels:
-        - base
-      status: automated
-      notes: |-
-        The requirement does not explicitily define the number of days before the password
-        expiration to warn the users, but the relevant rules were selected here as they do not
-        cause any problems in combination with password lifetime rules.
-      rules:
-        - var_accounts_maximum_age_login_defs=90
-        - accounts_maximum_age_login_defs
-        - accounts_password_set_max_life_existing
-        - var_accounts_password_warn_age_login_defs=7
-        - accounts_password_warn_age_login_defs
-        - accounts_password_set_warn_age_existing
-
-    - id: 8.3.10
-      title: 'Additional requirement for service providers only: If passwords/passphrases are used
-        as the only authentication factor for customer user access to cardholder data (i.e., in
-        any single-factor authentication implementation) then guidance is provided to customer
-        users.'
-      levels:
-        - base
+          - base
       status: manual
       controls:
-      - id: 8.3.10.1
-        title: 'Additional requirement for service providers only: If passwords/passphrases are
-          used as the only authentication factor for customer user access (i.e., in any
-          single-factor authentication implementation) they should have a limited lifetime.'
-        levels:
+          - id: 8.1.1
+            title: All security policies and operational procedures that are identified in Requirement
+                8 are Documented, Kept up to date, In use and Known to all affected parties.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Examine documentation and interview personnel to verify that security policies and
+                operational procedures identified in Requirement 8 are managed in accordance with all
+                elements specified in this requirement.
+
+          - id: 8.1.2
+            title: Roles and responsibilities for performing activities in Requirement 8 are documented,
+                assigned, and understood.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Examine documentation and interview personnel to verify that day-to-day responsibilities
+                for performing all the activities in Requirement 8 are documented, assigned and understood
+                by the assigned personnel.
+
+    - id: '8.2'
+      title: User identification and related accounts for users and administrators are strictly managed
+          throughout an account's lifecycle.
+      levels:
           - base
-        status: automated
-        notes: |-
-          This requirement is already covered by 8.3.9.
-        related_rules:
-          - accounts_maximum_age_login_defs
-          - var_accounts_maximum_age_login_defs=90
+      status: partial
+      controls:
+          - id: 8.2.1
+            title: All users are assigned a unique ID before access to system components or cardholder
+                data is allowed.
+            description: |-
+                All actions by all users are attributable to an individual. This requirement is not
+                intended to apply to user accounts within point-of-sale terminals that have access to only
+                one card number at a time to facilitate a single transaction (such as IDs used by cashiers
+                on point-of-sale terminals).
+            levels:
+                - base
+            status: planned
+            notes: |-
+                The rules selected in this requirement are incomplete. Missing remediation and test
+                scenarios. They should include test scenarios and likely remediation or a warning
+                informing why a remediation is not present.
+            rules:
+                - account_unique_id
+                - account_unique_name
+                - accounts_no_uid_except_zero
+                - accounts_root_gid_zero
+                - group_unique_id
+                - group_unique_name
 
-    - id: 8.3.11
-      title: Where authentication factors such as physical or logical security tokens, smart
-        cards, or certificates are used, factors are not shared among multiple users and the usage
-        is controlled.'
-      levels:
-        - base
-      status: manual
+          - id: 8.2.2
+            title: Group, shared, or generic IDs, or other shared authentication credentials are only
+                used when necessary on an exception basis, and are managed.
+            description: |-
+                - ID use is prevented unless needed for an exceptional circumstance.
+                - Use is limited to the time needed for the exceptional circumstance.
+                - Business justification for use is documented.
+                - Use is explicitly approved by management.
+                - Individual user identity is confirmed before access to an account is granted.
+                - Every action taken is attributable to an individual user.
+            levels:
+                - base
+            status: automated
+            notes: |-
+                This requirement is complemented by 8.2.1 and related to 8.3.5.
+            rules:
+                - gid_passwd_group_same
+                - no_password_auth_for_systemaccounts
+                - no_shelllogin_for_systemaccounts
 
-  - id: '8.4'
-    title: Multi-factor authentication (MFA) is implemented to secure access into the CDE.
-    levels:
-      - base
-    status: supported
-    notes: |-
-      This parent requirement does not set one specific combination of Multi-factor authentication
-      (MFA), so we can't enforce the use of smartcards or any specific solution. The systems
-      usually support MFA but the chosen solution depends on site policies.
-    controls:
-    - id: 8.4.1
-      title: MFA is implemented for all non-console access into the CDE for personnel with
-        administrative access.
+          - id: 8.2.3
+            title: 'Additional requirement for service providers only: Service providers with remote
+                access to customer premises use unique authentication factors for each customer premises.'
+            levels:
+                - base
+            status: manual
+
+          - id: 8.2.4
+            title: Addition, deletion, and modification of user IDs, authentication factors, and other
+                identifier objects are managed
+            levels:
+                - base
+            status: manual
+
+          - id: 8.2.5
+            title: Access for terminated users is immediately revoked.
+            description: |-
+                The accounts of terminated users cannot be used.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                This requirement depends on site policies for user termination.
+
+          - id: 8.2.6
+            title: Inactive user accounts are removed or disabled within 90 days of inactivity.
+            description: |-
+                Inactive user accounts cannot be used.
+            levels:
+                - base
+            status: automated
+            notes: |-
+                Also related to requirements 2.2.2 and 8.3.5.
+            rules:
+                - var_account_disable_post_pw_expiration=90
+                - account_disable_post_pw_expiration
+                - accounts_set_post_pw_existing
+
+          - id: 8.2.7
+            title: Accounts used by third parties to access, support, or maintain system components via
+                remote access are managed.
+            levels:
+                - base
+            status: manual
+
+          - id: 8.2.8
+            title: If a user session has been idle for more than 15 minutes, the user is required to
+                re-authenticate to re-activate the terminal or session.
+            description: |-
+                A user session cannot be used except by the authorized user. This requirement is not
+                intended to apply to user accounts on point-of-sale terminals that have access to only one
+                card number at a time to facilitate a single transaction (such as IDs used by cashiers on
+                point-of-sale terminals). This requirement is not meant to prevent legitimate activities
+                from being performed while the console/PC is unattended.
+            levels:
+                - base
+            status: automated
+            rules:
+                - enable_dconf_user_profile
+                - dconf_db_up_to_date
+                - dconf_gnome_session_idle_user_locks
+                - dconf_gnome_screensaver_idle_activation_enabled
+                - dconf_gnome_screensaver_idle_delay
+                - inactivity_timeout_value=15_minutes
+                - dconf_gnome_screensaver_lock_delay
+                - var_screensaver_lock_delay=10_seconds
+                - dconf_gnome_screensaver_lock_enabled
+                - dconf_gnome_screensaver_mode_blank
+                - sshd_set_idle_timeout
+                - sshd_idle_timeout_value=15_minutes
+                - sshd_set_keepalive
+                - var_sshd_set_keepalive=1
+            related_rules:
+                - sshd_set_keepalive_0
+
+    - id: '8.3'
+      title: Strong authentication for users and administrators is established and managed.
       levels:
-        - base
+          - base
+      status: partial
+      controls:
+          - id: 8.3.1
+            title: All user access to system components for users and administrators is authenticated.
+            levels:
+                - base
+            status: automated
+            rules:
+                - disable_host_auth
+                - gnome_gdm_disable_automatic_login
+                - gnome_gdm_disable_guest_login
+                - gnome_gdm_disable_unattended_automatic_login
+                - no_empty_passwords
+
+          - id: 8.3.2
+            title: Strong cryptography is used to render all authentication factors unreadable during
+                transmission and storage on all system components.
+            description: |-
+                Cleartext authentication factors cannot be obtained, derived, or reused from the
+                interception of communications or from stored data.
+            levels:
+                - base
+            status: automated
+            notes: |-
+                There are similar rules that might be redundant for some distros.
+            rules:
+                - accounts_password_all_shadowed
+                - ensure_shadow_group_empty
+                - set_password_hashing_algorithm_commonauth
+                - set_password_hashing_algorithm_libuserconf
+                - set_password_hashing_algorithm_logindefs
+                - set_password_hashing_algorithm_systemauth
+                - var_password_hashing_algorithm=SHA512
+                - var_password_hashing_algorithm_pam=sha512
+
+          - id: 8.3.3
+            title: User identity is verified before modifying any authentication factor.
+            description: |-
+                Unauthorized individuals cannot gain system access by impersonating the identity of an
+                authorized user.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                This requirement is about processes, such as password resets, provisioning new hardware or
+                software tokens, and generating new keys. It is common that these activities involve help
+                desk teams and administrators and the involved people should ensure identities are properly
+                verified.
+
+          - id: 8.3.4
+            title: Invalid authentication attempts are limited.
+            description: |-
+                - Locking out the user ID after not more than 10 attempts.
+                - Setting the lockout duration to a minimum of 30 minutes or until the user's identity is
+                confirmed.
+            levels:
+                - base
+            status: automated
+            rules:
+                - enable_authselect
+                - var_authselect_profile=sssd
+                - accounts_passwords_pam_faillock_deny
+                - var_accounts_passwords_pam_faillock_deny=10
+                - accounts_passwords_pam_faillock_unlock_time
+                - var_accounts_passwords_pam_faillock_unlock_time=1800
+                - accounts_passwords_pam_tally2
+                - var_password_pam_tally2=10
+                - accounts_passwords_pam_tally2_unlock_time
+                - var_accounts_passwords_pam_tally2_unlock_time=1800
+                - cracklib_accounts_password_pam_retry
+
+          - id: 8.3.5
+            title: If passwords/passphrases are used as authentication factors to meet Requirement 8.3.1,
+                they are set and reset for each user.
+            description: |-
+                - Set to a unique value for first-time use and upon reset.
+                - Forced to be changed immediately after the first use.
+            levels:
+                - base
+            status: automated
+            notes: |-
+                Also related to requirement 2.2.2, 8.2.2 and 8.2.6.
+            rules:
+                - accounts_password_last_change_is_in_past
+
+          - id: 8.3.6
+            title: If passwords/passphrases are used as authentication factors to meet Requirement 8.3.1,
+                they meet the minimum level of complexity.
+            description: |-
+                - A minimum length of 12 characters (or IF the system does not support 12 characters, a
+                minimum length of eight characters).
+                - Contain both numeric and alphabetic characters.
+                A guessed password/passphrase cannot be verified by either an online or offline brute
+                force attack.
+            levels:
+                - base
+            status: automated
+            notes: |-
+                This requirement is not intended to apply to:
+                - User accounts on point-of-sale terminals that have access to only one card number at a
+                time to facilitate a single transaction (such as IDs used by cashiers on point-of-sale
+                terminals).
+                - Application or system accounts, which are governed by requirements in section 8.6.
+            rules:
+                - var_password_pam_dcredit=1
+                - var_password_pam_lcredit=1
+                - var_password_pam_minlen=12
+                - accounts_password_pam_dcredit
+                - accounts_password_pam_lcredit
+                - accounts_password_pam_minlen
+                - cracklib_accounts_password_pam_dcredit
+                - cracklib_accounts_password_pam_lcredit
+                - cracklib_accounts_password_pam_minlen
+            related_rules:
+                - var_password_pam_ocredit=1
+                - var_password_pam_ucredit=1
+                - accounts_password_pam_ucredit
+                - cracklib_accounts_password_pam_ocredit
+                - cracklib_accounts_password_pam_ucredit
+
+          - id: 8.3.7
+            title: Individuals are not allowed to submit a new password/passphrase that is the same as
+                any of the last four passwords/passphrases used.
+            description: |-
+                A previously used password cannot be used to gain access to an account for at least 12
+                months.
+            levels:
+                - base
+            status: automated
+            notes: |-
+                This requirement is not intended to apply to user accounts on point-of-sale terminals that
+                have access to only one card number at a time to facilitate a single transaction (such as
+                IDs used by cashiers on point-of-sale terminals).
+                For RHEL 8 and RHEL 9 systems, the accounts_password_pam_pwhistory_... rules should be
+                prefered in detriment of accounts_password_pam_unix_remember. Using both should not create
+                conflict but is unnecessary and the last should be filtered out from the profile.
+            rules:
+                - var_password_pam_unix_remember=4
+                - accounts_password_pam_unix_remember
+                - var_password_pam_remember=4
+                - var_password_pam_remember_control_flag=requisite_or_required
+                - accounts_password_pam_pwhistory_remember_password_auth
+                - accounts_password_pam_pwhistory_remember_system_auth
+            related_rules:
+                - var_accounts_minimum_age_login_defs=1
+                - accounts_minimum_age_login_defs
+
+          - id: 8.3.8
+            title: Authentication policies and procedures are documented and communicated to all users.
+            levels:
+                - base
+            status: manual
+
+          - id: 8.3.9
+            title: If passwords/passphrases are used as the only authentication factor for user access
+                (i.e., in any single-factor authentication implementation) they should have a limited
+                lifetime.
+            description: |-
+                If passwords/passphrases are used as the only authentication factor for user access (i.e.,
+                in any single-factor authentication implementation) then either:
+                - Passwords/passphrases are changed at least once every 90 days,
+                OR
+                - The security posture of accounts is dynamically analyzed, and real-time access to
+                resources is automatically determined accordingly.
+            levels:
+                - base
+            status: automated
+            notes: |-
+                The requirement does not explicitily define the number of days before the password
+                expiration to warn the users, but the relevant rules were selected here as they do not
+                cause any problems in combination with password lifetime rules.
+            rules:
+                - var_accounts_maximum_age_login_defs=90
+                - accounts_maximum_age_login_defs
+                - accounts_password_set_max_life_existing
+                - var_accounts_password_warn_age_login_defs=7
+                - accounts_password_warn_age_login_defs
+                - accounts_password_set_warn_age_existing
+
+          - id: 8.3.10
+            title: 'Additional requirement for service providers only: If passwords/passphrases are used
+                as the only authentication factor for customer user access to cardholder data (i.e.,
+                in any single-factor authentication implementation) then guidance is provided to customer
+                users.'
+            levels:
+                - base
+            status: manual
+            controls:
+                - id: 8.3.10.1
+                  title: 'Additional requirement for service providers only: If passwords/passphrases
+                      are used as the only authentication factor for customer user access (i.e., in any
+                      single-factor authentication implementation) they should have a limited lifetime.'
+                  levels:
+                      - base
+                  status: automated
+                  notes: |-
+                      This requirement is already covered by 8.3.9.
+                  related_rules:
+                      - accounts_maximum_age_login_defs
+                      - var_accounts_maximum_age_login_defs=90
+
+          - id: 8.3.11
+            title: Where authentication factors such as physical or logical security tokens, smart cards,
+                or certificates are used, factors are not shared among multiple users and the usage is
+                controlled.'
+            levels:
+                - base
+            status: manual
+
+    - id: '8.4'
+      title: Multi-factor authentication (MFA) is implemented to secure access into the CDE.
+      levels:
+          - base
       status: supported
-      related_rules:
-        - var_smartcard_drivers=cac
-        - configure_opensc_card_drivers
-        - force_opensc_card_drivers
-        - install_smartcard_packages
-        - service_pcscd_enabled
-        - sssd_enable_smartcards
-
-    - id: 8.4.2
-      title: MFA is implemented for all non-console access into the CDE.
-      description: |-
-        Access into the CDE cannot be obtained by the use of a single authentication factor.
-      levels:
-        - base
-      status: manual
-
-    - id: 8.4.3
-      title: MFA is implemented for all remote access originating from outside the entity's
-        network that could access or impact the CDE.
-      levels:
-        - base
-      status: manual
-
-  - id: '8.5'
-    title: Multi-factor authentication (MFA) systems are configured to prevent misuse.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 8.5.1
-      title: MFA systems are properly implemented.
-      description: |-
-        - The MFA system is not susceptible to replay attacks.
-        - MFA systems cannot be bypassed by any users, including administrative users unless
-        specifically documented, and authorized by management on an exception basis, for a limited
-        time period.
-        - At least two different types of authentication factors are used.
-        - Success of all authentication factors is required before access is granted.
-      levels:
-        - base
-      status: manual
       notes: |-
-        Each site might have a different MFA solution and each solution has its own capabilities.
-        This requirement demands manual assessment based on site policies.
+          This parent requirement does not set one specific combination of Multi-factor authentication
+          (MFA), so we can't enforce the use of smartcards or any specific solution. The systems
+          usually support MFA but the chosen solution depends on site policies.
+      controls:
+          - id: 8.4.1
+            title: MFA is implemented for all non-console access into the CDE for personnel with administrative
+                access.
+            levels:
+                - base
+            status: supported
+            related_rules:
+                - var_smartcard_drivers=cac
+                - configure_opensc_card_drivers
+                - force_opensc_card_drivers
+                - install_smartcard_packages
+                - service_pcscd_enabled
+                - sssd_enable_smartcards
 
-  - id: '8.6'
-    title: Use of application and system accounts and associated authentication factors is
-      strictly managed.
-    levels:
-      - base
-    status: automated
-    controls:
-    - id: 8.6.1
-      title: If accounts used by systems or applications can be used for interactive login, they
-        are managed.
-      description: |-
-        - Interactive use is prevented unless needed for an exceptional circumstance.
-        - Interactive use is limited to the time needed for the exceptional circumstance.
-        - Business justification for interactive use is documented.
-        - Interactive use is explicitly approved by management.
-        - Individual user identity is confirmed before access to account is granted.
-        - Every action taken is attributable to an individual user.
+          - id: 8.4.2
+            title: MFA is implemented for all non-console access into the CDE.
+            description: |-
+                Access into the CDE cannot be obtained by the use of a single authentication factor.
+            levels:
+                - base
+            status: manual
+
+          - id: 8.4.3
+            title: MFA is implemented for all remote access originating from outside the entity's network
+                that could access or impact the CDE.
+            levels:
+                - base
+            status: manual
+
+    - id: '8.5'
+      title: Multi-factor authentication (MFA) systems are configured to prevent misuse.
       levels:
-        - base
+          - base
+      status: manual
+      controls:
+          - id: 8.5.1
+            title: MFA systems are properly implemented.
+            description: |-
+                - The MFA system is not susceptible to replay attacks.
+                - MFA systems cannot be bypassed by any users, including administrative users unless
+                specifically documented, and authorized by management on an exception basis, for a limited
+                time period.
+                - At least two different types of authentication factors are used.
+                - Success of all authentication factors is required before access is granted.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Each site might have a different MFA solution and each solution has its own capabilities.
+                This requirement demands manual assessment based on site policies.
+
+    - id: '8.6'
+      title: Use of application and system accounts and associated authentication factors is strictly
+          managed.
+      levels:
+          - base
       status: automated
-      notes: |-
-        This requirement is related to 2.2.2, 2.2.6, 8.2.1 and 8.2.2. Specifically on 8.2.2 system
-        accounts usage is restricted. Exceptions to system accounts should be manually checked to
-        ensure the requirements in description. This requirement although implements some extra
-        controls regarding root account.
-      rules:
-        - accounts_tmout
-        - no_direct_root_logins
-        - securetty_root_login_console_only
+      controls:
+          - id: 8.6.1
+            title: If accounts used by systems or applications can be used for interactive login, they
+                are managed.
+            description: |-
+                - Interactive use is prevented unless needed for an exceptional circumstance.
+                - Interactive use is limited to the time needed for the exceptional circumstance.
+                - Business justification for interactive use is documented.
+                - Interactive use is explicitly approved by management.
+                - Individual user identity is confirmed before access to account is granted.
+                - Every action taken is attributable to an individual user.
+            levels:
+                - base
+            status: automated
+            notes: |-
+                This requirement is related to 2.2.2, 2.2.6, 8.2.1 and 8.2.2. Specifically on 8.2.2 system
+                accounts usage is restricted. Exceptions to system accounts should be manually checked to
+                ensure the requirements in description. This requirement although implements some extra
+                controls regarding root account.
+            rules:
+                - accounts_tmout
+                - no_direct_root_logins
+                - securetty_root_login_console_only
 
-    - id: 8.6.2
-      title: Passwords/passphrases for any application and system accounts that can be used for
-        interactive login are not hard coded in scripts, configuration/property files, or bespoke
-        and custom source code.
-      description: |-
-        Passwords/passphrases used by application and system accounts cannot be used by
-        unauthorized personnel.
-      levels:
-        - base
-      status: manual
+          - id: 8.6.2
+            title: Passwords/passphrases for any application and system accounts that can be used for
+                interactive login are not hard coded in scripts, configuration/property files, or bespoke
+                and custom source code.
+            description: |-
+                Passwords/passphrases used by application and system accounts cannot be used by
+                unauthorized personnel.
+            levels:
+                - base
+            status: manual
 
-    - id: 8.6.3
-      title: Passwords/passphrases for any application and system accounts are protected against
-        misuse.
-      description: |-
-        - Passwords/passphrases are changed periodically (at the frequency defined in the entity's
-        targeted risk analysis, which is performed according to all elements specified in
-        Requirement 12.3.1) and upon suspicion or confirmation of compromise.
-        - Passwords/passphrases are constructed with sufficient complexity appropriate for how
-        frequently the entity changes the passwords/passphrases.
-      levels:
-        - base
-      status: automated
-      notes: |-
-        Related to requirements 8.3.6 and 8.3.9.
+          - id: 8.6.3
+            title: Passwords/passphrases for any application and system accounts are protected against
+                misuse.
+            description: |-
+                - Passwords/passphrases are changed periodically (at the frequency defined in the entity's
+                targeted risk analysis, which is performed according to all elements specified in
+                Requirement 12.3.1) and upon suspicion or confirmation of compromise.
+                - Passwords/passphrases are constructed with sufficient complexity appropriate for how
+                frequently the entity changes the passwords/passphrases.
+            levels:
+                - base
+            status: automated
+            notes: |-
+                Related to requirements 8.3.6 and 8.3.9.
 
-  - id: '9.1'
-    title: Processes and mechanisms for restricting physical access to cardholder data are defined
-      and understood.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 9.1.1
-      title: All security policies and operational procedures that are identified in Requirement 9
-        are Documented, Kept up to date, In use and Known to all affected parties.
+    - id: '9.1'
+      title: Processes and mechanisms for restricting physical access to cardholder data are defined
+          and understood.
       levels:
-        - base
-      status: manual
-      notes: |-
-        Examine documentation and interview personnel to verify that security policies and
-        operational procedures identified in Requirement 9 are managed in accordance with all
-        elements specified in this requirement.
-
-    - id: 9.1.2
-      title: Roles and responsibilities for performing activities in Requirement 9 are documented,
-        assigned, and understood.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        Examine documentation and interview personnel to verify that day-to-day responsibilities
-        for performing all the activities in Requirement 9 are documented, assigned and understood
-        by the assigned personnel.
-
-  - id: '9.2'
-    title: Physical access controls manage entry into facilities and systems containing cardholder
-      data.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 9.2.1
-      title: Appropriate facility entry controls are in place to restrict physical access to
-        systems in the CDE.
-      description: |-
-        System components in the CDE cannot be physically accessed by unauthorized personnel.
-      levels:
-        - base
+          - base
       status: manual
       controls:
-      - id: 9.2.1.1
-        title: Individual physical access to sensitive areas within the CDE is monitored with
-          either video cameras or physical access control mechanisms (or both).
-        levels:
+          - id: 9.1.1
+            title: All security policies and operational procedures that are identified in Requirement
+                9 are Documented, Kept up to date, In use and Known to all affected parties.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Examine documentation and interview personnel to verify that security policies and
+                operational procedures identified in Requirement 9 are managed in accordance with all
+                elements specified in this requirement.
+
+          - id: 9.1.2
+            title: Roles and responsibilities for performing activities in Requirement 9 are documented,
+                assigned, and understood.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Examine documentation and interview personnel to verify that day-to-day responsibilities
+                for performing all the activities in Requirement 9 are documented, assigned and understood
+                by the assigned personnel.
+
+    - id: '9.2'
+      title: Physical access controls manage entry into facilities and systems containing cardholder
+          data.
+      levels:
           - base
-        status: manual
-
-    - id: 9.2.2
-      title: Physical and/or logical controls are implemented to restrict use of publicly
-        accessible network jacks within the facility.
-      description: |-
-        Unauthorized devices cannot connect to the entity's network from public areas within the
-        facility.
-      levels:
-        - base
-      status: not applicable
-
-    - id: 9.2.3
-      title: Physical access to wireless access points, gateways, networking/communications
-        hardware, and telecommunication lines within the facility is restricted
-      description: |-
-        Physical networking equipment cannot be accessed by unauthorized personnel.
-      levels:
-        - base
-      status: not applicable
-
-    - id: 9.2.4
-      title: Access to consoles in sensitive areas is restricted via locking when not in use.
-      description: |-
-        Physical consoles within sensitive areas cannot be used by unauthorized personnel.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        Related to requirement 8.2.8.
-        This requirement asks to observe a system administrator's attempt to log into consoles in
-        sensitive areas and verify that they are "locked" to prevent unauthorized use. Therefore
-        it is a manual requirement applicable only very specific circumstances.
-
-  - id: '9.3'
-    title: Physical access for personnel and visitors is authorized and managed.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 9.3.1
-      title: Procedures are implemented for authorizing and managing physical access of personnel
-        to the CDE.
-      levels:
-        - base
       status: manual
       controls:
-      - id: 9.3.1.1
-        title: Physical access to sensitive areas within the CDE for personnel is controlled
-        levels:
+          - id: 9.2.1
+            title: Appropriate facility entry controls are in place to restrict physical access to systems
+                in the CDE.
+            description: |-
+                System components in the CDE cannot be physically accessed by unauthorized personnel.
+            levels:
+                - base
+            status: manual
+            controls:
+                - id: 9.2.1.1
+                  title: Individual physical access to sensitive areas within the CDE is monitored with
+                      either video cameras or physical access control mechanisms (or both).
+                  levels:
+                      - base
+                  status: manual
+
+          - id: 9.2.2
+            title: Physical and/or logical controls are implemented to restrict use of publicly accessible
+                network jacks within the facility.
+            description: |-
+                Unauthorized devices cannot connect to the entity's network from public areas within the
+                facility.
+            levels:
+                - base
+            status: not applicable
+
+          - id: 9.2.3
+            title: Physical access to wireless access points, gateways, networking/communications hardware,
+                and telecommunication lines within the facility is restricted
+            description: |-
+                Physical networking equipment cannot be accessed by unauthorized personnel.
+            levels:
+                - base
+            status: not applicable
+
+          - id: 9.2.4
+            title: Access to consoles in sensitive areas is restricted via locking when not in use.
+            description: |-
+                Physical consoles within sensitive areas cannot be used by unauthorized personnel.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Related to requirement 8.2.8.
+                This requirement asks to observe a system administrator's attempt to log into consoles in
+                sensitive areas and verify that they are "locked" to prevent unauthorized use. Therefore
+                it is a manual requirement applicable only very specific circumstances.
+
+    - id: '9.3'
+      title: Physical access for personnel and visitors is authorized and managed.
+      levels:
           - base
-        status: manual
-
-    - id: 9.3.2
-      title: Procedures are implemented for authorizing and managing visitor access to the CDE.
-      levels:
-        - base
-      status: manual
-
-    - id: 9.3.3
-      title: Visitor badges or identification are surrendered or deactivated before visitors leave
-        the facility or at the date of expiration.
-      description: |-
-        Visitor identification or badges cannot be reused after expiration.
-      levels:
-        - base
-      status: manual
-
-    - id: 9.3.4
-      title: Visitor logs are used to maintain a physical record of visitor activity both within
-        the facility and within sensitive areas.
-      levels:
-        - base
-      status: manual
-
-  - id: '9.4'
-    title: Media with cardholder data is securely stored, accessed, distributed, and destroyed.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 9.4.1
-      title: All media with cardholder data is physically secured.
-      description: |-
-        Media with cardholder data cannot be accessed by unauthorized personnel.
-      levels:
-        - base
       status: manual
       controls:
-      - id: 9.4.1.1
-        title: Offline media backups with cardholder data are stored in a secure location.
-        description: |-
-          Offline backups cannot be accessed by unauthorized personnel.
-        levels:
+          - id: 9.3.1
+            title: Procedures are implemented for authorizing and managing physical access of personnel
+                to the CDE.
+            levels:
+                - base
+            status: manual
+            controls:
+                - id: 9.3.1.1
+                  title: Physical access to sensitive areas within the CDE for personnel is controlled
+                  levels:
+                      - base
+                  status: manual
+
+          - id: 9.3.2
+            title: Procedures are implemented for authorizing and managing visitor access to the CDE.
+            levels:
+                - base
+            status: manual
+
+          - id: 9.3.3
+            title: Visitor badges or identification are surrendered or deactivated before visitors leave
+                the facility or at the date of expiration.
+            description: |-
+                Visitor identification or badges cannot be reused after expiration.
+            levels:
+                - base
+            status: manual
+
+          - id: 9.3.4
+            title: Visitor logs are used to maintain a physical record of visitor activity both within
+                the facility and within sensitive areas.
+            levels:
+                - base
+            status: manual
+
+    - id: '9.4'
+      title: Media with cardholder data is securely stored, accessed, distributed, and destroyed.
+      levels:
           - base
-        status: manual
-
-      - id: 9.4.1.2
-        title: The security of the offline media backup location(s) with cardholder data is
-          reviewed at least once every 12 months.
-        description: |-
-          The security controls protecting offline backups are verified periodically by
-          inspection.
-        levels:
-          - base
-        status: manual
-
-    - id: 9.4.2
-      title: All media with cardholder data is classified in accordance with the sensitivity of
-        the data.
-      description: |-
-        Media are classified and protected appropriately.
-      levels:
-        - base
-      status: manual
-
-    - id: 9.4.3
-      title: Media with cardholder data sent outside the facility is secured.
-      description: |-
-        Media is secured and tracked when transported outside the facility.
-        - Media sent outside the facility is logged.
-        - Media is sent by secured courier or other delivery method that can be accurately
-        tracked.
-        - Offsite tracking logs include details about media location.
-      levels:
-        - base
-      status: manual
-
-    - id: 9.4.4
-      title: Management approves all media with cardholder data that is moved outside the facility
-        (including when media is distributed to individuals).
-      description: |-
-        Media cannot leave a facility without the approval of accountable personnel. Individuals
-        approving media movements should have the appropriate level of management authority to
-        grant this approval. However, it is not specifically required that such individuals have
-        "manager" as part of their title.
-      levels:
-        - base
-      status: manual
-
-    - id: 9.4.5
-      title: Inventory logs of all electronic media with cardholder data are maintained.
-      description: |-
-        Accurate inventories of stored electronic media are maintained.
-      levels:
-        - base
       status: manual
       controls:
-      - id: 9.4.5.1
-        title: Inventories of electronic media with cardholder data are conducted at least once
-          every 12 months.
-        description: |-
-          Media inventories are verified periodically.
-        levels:
+          - id: 9.4.1
+            title: All media with cardholder data is physically secured.
+            description: |-
+                Media with cardholder data cannot be accessed by unauthorized personnel.
+            levels:
+                - base
+            status: manual
+            controls:
+                - id: 9.4.1.1
+                  title: Offline media backups with cardholder data are stored in a secure location.
+                  description: |-
+                      Offline backups cannot be accessed by unauthorized personnel.
+                  levels:
+                      - base
+                  status: manual
+
+                - id: 9.4.1.2
+                  title: The security of the offline media backup location(s) with cardholder data is
+                      reviewed at least once every 12 months.
+                  description: |-
+                      The security controls protecting offline backups are verified periodically by
+                      inspection.
+                  levels:
+                      - base
+                  status: manual
+
+          - id: 9.4.2
+            title: All media with cardholder data is classified in accordance with the sensitivity of
+                the data.
+            description: |-
+                Media are classified and protected appropriately.
+            levels:
+                - base
+            status: manual
+
+          - id: 9.4.3
+            title: Media with cardholder data sent outside the facility is secured.
+            description: |-
+                Media is secured and tracked when transported outside the facility.
+                - Media sent outside the facility is logged.
+                - Media is sent by secured courier or other delivery method that can be accurately
+                tracked.
+                - Offsite tracking logs include details about media location.
+            levels:
+                - base
+            status: manual
+
+          - id: 9.4.4
+            title: Management approves all media with cardholder data that is moved outside the facility
+                (including when media is distributed to individuals).
+            description: |-
+                Media cannot leave a facility without the approval of accountable personnel. Individuals
+                approving media movements should have the appropriate level of management authority to
+                grant this approval. However, it is not specifically required that such individuals have
+                "manager" as part of their title.
+            levels:
+                - base
+            status: manual
+
+          - id: 9.4.5
+            title: Inventory logs of all electronic media with cardholder data are maintained.
+            description: |-
+                Accurate inventories of stored electronic media are maintained.
+            levels:
+                - base
+            status: manual
+            controls:
+                - id: 9.4.5.1
+                  title: Inventories of electronic media with cardholder data are conducted at least
+                      once every 12 months.
+                  description: |-
+                      Media inventories are verified periodically.
+                  levels:
+                      - base
+                  status: manual
+
+          - id: 9.4.6
+            title: Hard-copy materials with cardholder data are destroyed when no longer needed for business
+                or legal reasons.
+            levels:
+                - base
+            status: manual
+
+          - id: 9.4.7
+            title: Electronic media with cardholder data is destroyed when no longer needed for business
+                or legal reasons.
+            description: |-
+                - The electronic media is destroyed.
+                - The cardholder data is rendered unrecoverable so that it cannot be reconstructed.
+            levels:
+                - base
+            status: manual
+
+    - id: '9.5'
+      title: Point-of-interaction (POI) devices are protected from tampering and unauthorized substitution.
+      levels:
           - base
-        status: manual
-
-    - id: 9.4.6
-      title: Hard-copy materials with cardholder data are destroyed when no longer needed for
-        business or legal reasons.
-      levels:
-        - base
-      status: manual
-
-    - id: 9.4.7
-      title: Electronic media with cardholder data is destroyed when no longer needed for business
-        or legal reasons.
-      description: |-
-        - The electronic media is destroyed.
-        - The cardholder data is rendered unrecoverable so that it cannot be reconstructed.
-      levels:
-        - base
-      status: manual
-
-  - id: '9.5'
-    title: Point-of-interaction (POI) devices are protected from tampering and unauthorized
-      substitution.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 9.5.1
-      title: POI devices that capture payment card data via direct physical interaction with the
-        payment card form factor are protected from tampering and unauthorized substitution.
-      levels:
-        - base
       status: manual
       controls:
-      - id: 9.5.1.1
-        title: An up-to-date list of POI devices is maintained.
-        levels:
-          - base
-        status: manual
+          - id: 9.5.1
+            title: POI devices that capture payment card data via direct physical interaction with the
+                payment card form factor are protected from tampering and unauthorized substitution.
+            levels:
+                - base
+            status: manual
+            controls:
+                - id: 9.5.1.1
+                  title: An up-to-date list of POI devices is maintained.
+                  levels:
+                      - base
+                  status: manual
 
-      - id: 9.5.1.2
-        title: POI device surfaces are periodically inspected to detect tampering and unauthorized
-          substitution.
-        description: |-
-          Point of Interaction Devices cannot be tampered with, substituted without authorization,
-          or have skimming attachments installed without timely detection.
-        levels:
-          - base
-        status: manual
-        controls:
-        - id: 9.5.1.2.1
-          title: The frequency of periodic POI device inspections and the type of inspections
-            performed is defined in the entity's targeted risk analysis, which is performed
-            according to all elements specified in Requirement 12.3.1.
-          description: |-
-            POI devices are inspected at a frequency that addresses the entity's risk.
-            This requirement is a best practice until 31 March 2025, after which it will be
-            required and must be fully considered during a PCI DSS assessment.
-          levels:
-            - base
-          status: manual
+                - id: 9.5.1.2
+                  title: POI device surfaces are periodically inspected to detect tampering and unauthorized
+                      substitution.
+                  description: |-
+                      Point of Interaction Devices cannot be tampered with, substituted without authorization,
+                      or have skimming attachments installed without timely detection.
+                  levels:
+                      - base
+                  status: manual
+                  controls:
+                      - id: 9.5.1.2.1
+                        title: The frequency of periodic POI device inspections and the type of inspections
+                            performed is defined in the entity's targeted risk analysis, which is performed
+                            according to all elements specified in Requirement 12.3.1.
+                        description: |-
+                            POI devices are inspected at a frequency that addresses the entity's risk.
+                            This requirement is a best practice until 31 March 2025, after which it will be
+                            required and must be fully considered during a PCI DSS assessment.
+                        levels:
+                            - base
+                        status: manual
 
-      - id: 9.5.1.3
-        title: Training is provided for personnel in POI environments to be aware of attempted
-          tampering or replacement of POI devices.
-        levels:
-          - base
-        status: manual
+                - id: 9.5.1.3
+                  title: Training is provided for personnel in POI environments to be aware of attempted
+                      tampering or replacement of POI devices.
+                  levels:
+                      - base
+                  status: manual
 
-  - id: '10.1'
-    title: Processes and mechanisms for logging and monitoring all access to system components and
-      cardholder data are defined and documented.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 10.1.1
-      title: All security policies and operational procedures that are identified in Requirement
-        10 are Documented, Kept up to date, In use and Known to all affected parties.
+    - id: '10.1'
+      title: Processes and mechanisms for logging and monitoring all access to system components and
+          cardholder data are defined and documented.
       levels:
-        - base
+          - base
       status: manual
-      notes: |-
-        Examine documentation and interview personnel to verify that security policies and
-        operational procedures identified in Requirement 10 are managed in accordance with all
-        elements specified in this requirement.
+      controls:
+          - id: 10.1.1
+            title: All security policies and operational procedures that are identified in Requirement
+                10 are Documented, Kept up to date, In use and Known to all affected parties.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Examine documentation and interview personnel to verify that security policies and
+                operational procedures identified in Requirement 10 are managed in accordance with all
+                elements specified in this requirement.
 
-    - id: 10.1.2
-      title: Roles and responsibilities for performing activities in Requirement 10 are
-        documented, assigned, and understood.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        Examine documentation and interview personnel to verify that day-to-day responsibilities
-        for performing all the activities in Requirement 10 are documented, assigned and
-        understood by the assigned personnel.
+          - id: 10.1.2
+            title: Roles and responsibilities for performing activities in Requirement 10 are documented,
+                assigned, and understood.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Examine documentation and interview personnel to verify that day-to-day responsibilities
+                for performing all the activities in Requirement 10 are documented, assigned and
+                understood by the assigned personnel.
 
-  - id: '10.2'
-    title: Audit logs are implemented to support the detection of anomalies and suspicious
-      activity, and the forensic analysis of events.
-    levels:
-      - base
-    status: partial
-    controls:
-    - id: 10.2.1
-      title: Audit logs are enabled and active for all system components and cardholder data.
-      description: |-
-        Records of all activities affecting system components and cardholder data are captured.
+    - id: '10.2'
+      title: Audit logs are implemented to support the detection of anomalies and suspicious activity,
+          and the forensic analysis of events.
       levels:
-        - base
-      status: automated
-      rules:
-        - package_audit_installed
-        - service_auditd_enabled
-      related_rules:
+          - base
+      status: partial
+      controls:
+          - id: 10.2.1
+            title: Audit logs are enabled and active for all system components and cardholder data.
+            description: |-
+                Records of all activities affecting system components and cardholder data are captured.
+            levels:
+                - base
+            status: automated
+            rules:
+                - package_audit_installed
+                - service_auditd_enabled
+            related_rules:
         # The policy is not specific about products or solutions but the level of information
         # necessary, as defined in 10.2.2. These rsyslog rules might be good candidates to be
         # selected in the future.
-        - rsyslog_cron_logging
-        - rsyslog_logging_configured
-        - service_systemd-journald_enabled
-        - service_rsyslog_enabled
-      controls:
-      - id: 10.2.1.1
-        title: Audit logs capture all individual user access to cardholder data.
-        description: |-
-          Records of all individual user access to cardholder data are captured.
-        levels:
-          - base
-        status: planned
-        notes: |-
-          Differently than 10.2.1.4, this requirement is about logginh successful access to
-          cardholder data. This kind of events can easily hit performance issues and are usually
-          not necessary if a good access policy is in place. More clarification is needed about
-          this requirement.
-        related_rules:
+                - rsyslog_cron_logging
+                - rsyslog_logging_configured
+                - service_systemd-journald_enabled
+                - service_rsyslog_enabled
+            controls:
+                - id: 10.2.1.1
+                  title: Audit logs capture all individual user access to cardholder data.
+                  description: |-
+                      Records of all individual user access to cardholder data are captured.
+                  levels:
+                      - base
+                  status: planned
+                  notes: |-
+                      Differently than 10.2.1.4, this requirement is about logginh successful access to
+                      cardholder data. This kind of events can easily hit performance issues and are usually
+                      not necessary if a good access policy is in place. More clarification is needed about
+                      this requirement.
+                  related_rules:
           # There are already many rules related to successful access, if we need to include them.
           # e.g.:
-          - audit_rules_successful_file_modification_open
+                      - audit_rules_successful_file_modification_open
 
-      - id: 10.2.1.2
-        title: Audit logs capture all actions taken by any individual with administrative access,
-          including any interactive use of application or system accounts.
-        description: |-
-          Records of all actions performed by individuals with elevated privileges are captured.
-        levels:
-          - base
-        status: partial
-        notes: |-
-          Not all privileged commands have suid or sgid enabled. We probably want to include more
-          rules for this requirement.
-        rules:
-          - audit_rules_suid_privilege_function
-        related_rules:
-          - audit_rules_privileged_commands
-          - audit_rules_privileged_commands_usermod
+                - id: 10.2.1.2
+                  title: Audit logs capture all actions taken by any individual with administrative access,
+                      including any interactive use of application or system accounts.
+                  description: |-
+                      Records of all actions performed by individuals with elevated privileges are captured.
+                  levels:
+                      - base
+                  status: partial
+                  notes: |-
+                      Not all privileged commands have suid or sgid enabled. We probably want to include more
+                      rules for this requirement.
+                  rules:
+                      - audit_rules_suid_privilege_function
+                  related_rules:
+                      - audit_rules_privileged_commands
+                      - audit_rules_privileged_commands_usermod
 
-      - id: 10.2.1.3
-        title: Audit logs capture all access to audit logs.
-        description: |-
-          Records of all access to audit logs are captured.
-        levels:
-          - base
-        status: automated
-        rules:
-          - audit_rules_login_events_faillock
-          - audit_rules_login_events_lastlog
-          - audit_rules_login_events_tallylog
-          - audit_rules_session_events_utmp
-          - audit_rules_session_events_btmp
-          - audit_rules_session_events_wtmp
-          - audit_sudo_log_events
-        related_rules:
+                - id: 10.2.1.3
+                  title: Audit logs capture all access to audit logs.
+                  description: |-
+                      Records of all access to audit logs are captured.
+                  levels:
+                      - base
+                  status: automated
+                  rules:
+                      - audit_rules_login_events_faillock
+                      - audit_rules_login_events_lastlog
+                      - audit_rules_login_events_tallylog
+                      - audit_rules_session_events_utmp
+                      - audit_rules_session_events_btmp
+                      - audit_rules_session_events_wtmp
+                      - audit_sudo_log_events
+                  related_rules:
           # This rule incorportes faillock, lastlog and tallylog. It is redundant to keep it.
           # The others are more granular and share the same template, so they were prefered here.
-          - audit_rules_login_events
+                      - audit_rules_login_events
 
-      - id: 10.2.1.4
-        title: Audit logs capture all invalid logical access attempts.
-        description: |-
-          Records of all invalid access attempts are captured.
-        levels:
-          - base
-        status: automated
-        rules:
-          - display_login_attempts
-        related_rules:
+                - id: 10.2.1.4
+                  title: Audit logs capture all invalid logical access attempts.
+                  description: |-
+                      Records of all invalid access attempts are captured.
+                  levels:
+                      - base
+                  status: automated
+                  rules:
+                      - display_login_attempts
+                  related_rules:
           # The following rules are related to unauthorized attempts to modify files but for
           # already logged users and could be useful but the requirement is more about logins.
-          - audit_rules_unsuccessful_file_modification_creat
-          - audit_rules_unsuccessful_file_modification_ftruncate
-          - audit_rules_unsuccessful_file_modification_open
-          - audit_rules_unsuccessful_file_modification_open_by_handle_at
-          - audit_rules_unsuccessful_file_modification_openat
-          - audit_rules_unsuccessful_file_modification_rename
-          - audit_rules_unsuccessful_file_modification_renameat
-          - audit_rules_unsuccessful_file_modification_truncate
-          - audit_rules_unsuccessful_file_modification_unlink
-          - audit_rules_unsuccessful_file_modification_unlinkat
+                      - audit_rules_unsuccessful_file_modification_creat
+                      - audit_rules_unsuccessful_file_modification_ftruncate
+                      - audit_rules_unsuccessful_file_modification_open
+                      - audit_rules_unsuccessful_file_modification_open_by_handle_at
+                      - audit_rules_unsuccessful_file_modification_openat
+                      - audit_rules_unsuccessful_file_modification_rename
+                      - audit_rules_unsuccessful_file_modification_renameat
+                      - audit_rules_unsuccessful_file_modification_truncate
+                      - audit_rules_unsuccessful_file_modification_unlink
+                      - audit_rules_unsuccessful_file_modification_unlinkat
           # This rule incorportes creat, ftruncate and open. It is redundant to keep it here.
           # The others are more granular and share the same template, so they were prefered here.
-          - audit_rules_unsuccessful_file_modification
+                      - audit_rules_unsuccessful_file_modification
 
-      - id: 10.2.1.5
-        title: Audit logs capture all changes to identification and authentication credentials.
-        levels:
-          - base
-        status: automated
-        rules:
-          - audit_rules_usergroup_modification_group
-          - audit_rules_usergroup_modification_gshadow
-          - audit_rules_usergroup_modification_opasswd
-          - audit_rules_usergroup_modification_passwd
-          - audit_rules_usergroup_modification_shadow
-          - audit_rules_sysadmin_actions
-        related_rules:
+                - id: 10.2.1.5
+                  title: Audit logs capture all changes to identification and authentication credentials.
+                  levels:
+                      - base
+                  status: automated
+                  rules:
+                      - audit_rules_usergroup_modification_group
+                      - audit_rules_usergroup_modification_gshadow
+                      - audit_rules_usergroup_modification_opasswd
+                      - audit_rules_usergroup_modification_passwd
+                      - audit_rules_usergroup_modification_shadow
+                      - audit_rules_sysadmin_actions
+                  related_rules:
           # This rule incorportes group, gshadow and passwd. It is redundant to keep it here.
           # The others are more granular and share the same template, so they were prefered here.
-          - audit_rules_usergroup_modification
+                      - audit_rules_usergroup_modification
 
-      - id: 10.2.1.6
-        title: Audit logs capture the initialization of new audit logs, and starting, stopping, or
-          pausing of the existing audit logs.
-        levels:
-          - base
-        status: planned
-        notes: |-
-          Ideally should exist rules specifically logging when audit configuration files are
-          modified and audit service state is changed.
+                - id: 10.2.1.6
+                  title: Audit logs capture the initialization of new audit logs, and starting, stopping,
+                      or pausing of the existing audit logs.
+                  levels:
+                      - base
+                  status: planned
+                  notes: |-
+                      Ideally should exist rules specifically logging when audit configuration files are
+                      modified and audit service state is changed.
 
-      - id: 10.2.1.7
-        title: Audit logs capture all creation and deletion of system-level objects.
-        description: |-
-          Records of alterations that indicate a system has been modified from its intended
-          functionality are captured.
-        levels:
-          - base
-        status: partial
-        notes: |-
-          There are enough rules to capture deletion events but not for creation events.
-          This requirement needs to be better investigated to confirm which additional rules would
-          satistfy the requirement.
-        rules:
-          - audit_rules_file_deletion_events_rename
-          - audit_rules_file_deletion_events_renameat
-          - audit_rules_file_deletion_events_renameat2
-          - audit_rules_file_deletion_events_rmdir
-          - audit_rules_file_deletion_events_unlink
-          - audit_rules_file_deletion_events_unlinkat
-          - audit_rules_media_export
-        related_rules:
+                - id: 10.2.1.7
+                  title: Audit logs capture all creation and deletion of system-level objects.
+                  description: |-
+                      Records of alterations that indicate a system has been modified from its intended
+                      functionality are captured.
+                  levels:
+                      - base
+                  status: partial
+                  notes: |-
+                      There are enough rules to capture deletion events but not for creation events.
+                      This requirement needs to be better investigated to confirm which additional rules would
+                      satistfy the requirement.
+                  rules:
+                      - audit_rules_file_deletion_events_rename
+                      - audit_rules_file_deletion_events_renameat
+                      - audit_rules_file_deletion_events_renameat2
+                      - audit_rules_file_deletion_events_rmdir
+                      - audit_rules_file_deletion_events_unlink
+                      - audit_rules_file_deletion_events_unlinkat
+                      - audit_rules_media_export
+                  related_rules:
           # This rule incorportes rmdir, unlink and unlinkat. It is redundant to keep it here.
           # The others are more granular and share the same template, so they were prefered here.
-          - audit_rules_file_deletion_events
+                      - audit_rules_file_deletion_events
 
-    - id: 10.2.2
-      title: Audit logs record sufficient details for each auditable event.
-      description: |-
-        - User identification.
-        - Type of event.
-        - Date and time.
-        - Success and failure indication.
-        - Origination of event.
-        - Identity or name of affected data, system component, resource, or service (for example,
-          name and protocol).
-      levels:
-        - base
-      status: automated
-      notes: |-
-        Standard settings for audit should be enough.
-      rules:
-        - var_auditd_name_format=fqd
-        - auditd_name_format
+          - id: 10.2.2
+            title: Audit logs record sufficient details for each auditable event.
+            description: |-
+                - User identification.
+                - Type of event.
+                - Date and time.
+                - Success and failure indication.
+                - Origination of event.
+                - Identity or name of affected data, system component, resource, or service (for example,
+                  name and protocol).
+            levels:
+                - base
+            status: automated
+            notes: |-
+                Standard settings for audit should be enough.
+            rules:
+                - var_auditd_name_format=fqd
+                - auditd_name_format
 
-  - id: '10.3'
-    title: Audit logs are protected from destruction and unauthorized modifications.
-    levels:
-      - base
-    status: partial
-    controls:
-    - id: 10.3.1
-      title: Read access to audit logs files is limited to those with a job-related need.
-      description: |-
-        Stored activity records cannot be accessed by unauthorized personnel.
+    - id: '10.3'
+      title: Audit logs are protected from destruction and unauthorized modifications.
       levels:
-        - base
-      status: automated
-      rules:
-        - directory_access_var_log_audit
-        - file_permissions_var_log_audit
-        - permissions_local_var_log
-        - rsyslog_files_permissions
-
-    - id: 10.3.2
-      title: Audit log files are protected to prevent modifications by individuals.
-      description: |-
-        Stored activity records cannot be modified by personnel.
-      levels:
-        - base
-      status: automated
-      rules:
-        - file_group_ownership_var_log_audit
-        - file_ownership_var_log_audit
-        - rsyslog_files_ownership
-        - rsyslog_files_groupownership
-        - audit_rules_immutable
-
-    - id: 10.3.3
-      title: Audit log files, including those for external-facing technologies, are promptly
-        backed up to a secure, central, internal log server(s) or other media that is difficult to
-        modify.
-      description: |-
-        Stored activity records are secured and preserved in a central location to prevent
-        unauthorized modification.
-      levels:
-        - base
+          - base
       status: partial
-      notes: |-
-        Although the technologies in general allow to send logs to a centralized server, some
-        parameters for this configuration are specific to each site policy and therefore the
-        requirement demands manual assessment.
-      rules:
-        - auditd_audispd_syslog_plugin_activated
-        - package_audispd-plugins_installed
-        - package_audit-audispd-plugins_installed
-      related_rules:
-        - rsyslog_remote_loghost
-        - rsyslog_nolisten
+      controls:
+          - id: 10.3.1
+            title: Read access to audit logs files is limited to those with a job-related need.
+            description: |-
+                Stored activity records cannot be accessed by unauthorized personnel.
+            levels:
+                - base
+            status: automated
+            rules:
+                - directory_access_var_log_audit
+                - file_permissions_var_log_audit
+                - permissions_local_var_log
+                - rsyslog_files_permissions
 
-    - id: 10.3.4
-      title: File integrity monitoring or change-detection mechanisms is used on audit logs to
-        ensure that existing log data cannot be changed without generating alerts.
-      description: |-
-        Stored activity records cannot be modified without an alert being generated.
-      levels:
-        - base
-      status: automated
-      rules:
-        - audit_rules_mac_modification
-        - audit_rules_dac_modification_chmod
-        - audit_rules_dac_modification_chown
-        - audit_rules_dac_modification_fchmod
-        - audit_rules_dac_modification_fchmodat
-        - audit_rules_dac_modification_fchmodat2
-        - audit_rules_dac_modification_fchown
-        - audit_rules_dac_modification_fchownat
-        - audit_rules_dac_modification_fremovexattr
-        - audit_rules_dac_modification_fsetxattr
-        - audit_rules_dac_modification_lremovexattr
-        - audit_rules_dac_modification_lchown
-        - audit_rules_dac_modification_lsetxattr
-        - audit_rules_dac_modification_removexattr
-        - audit_rules_dac_modification_setxattr
-        - audit_rules_networkconfig_modification
-        - audit_rules_mac_modification_etc_selinux
+          - id: 10.3.2
+            title: Audit log files are protected to prevent modifications by individuals.
+            description: |-
+                Stored activity records cannot be modified by personnel.
+            levels:
+                - base
+            status: automated
+            rules:
+                - file_group_ownership_var_log_audit
+                - file_ownership_var_log_audit
+                - rsyslog_files_ownership
+                - rsyslog_files_groupownership
+                - audit_rules_immutable
 
-  - id: '10.4'
-    title: Audit logs are reviewed to identify anomalies or suspicious activity.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 10.4.1
-      title: The audit logs are reviewed at least once daily.
-      description: |-
-        - All security events.
-        - Logs of all system components that store, process, or transmit CHD and/or SAD.
-        - Logs of all critical system components.
-        - Logs of all servers and system components that perform security functions (for example,
-          network security controls, intrusion-detection systems/intrusion-prevention systems
-          (IDS/IPS), authentication servers).
+          - id: 10.3.3
+            title: Audit log files, including those for external-facing technologies, are promptly backed
+                up to a secure, central, internal log server(s) or other media that is difficult to modify.
+            description: |-
+                Stored activity records are secured and preserved in a central location to prevent
+                unauthorized modification.
+            levels:
+                - base
+            status: partial
+            notes: |-
+                Although the technologies in general allow to send logs to a centralized server, some
+                parameters for this configuration are specific to each site policy and therefore the
+                requirement demands manual assessment.
+            rules:
+                - auditd_audispd_syslog_plugin_activated
+                - package_audispd-plugins_installed
+                - package_audit-audispd-plugins_installed
+            related_rules:
+                - rsyslog_remote_loghost
+                - rsyslog_nolisten
+
+          - id: 10.3.4
+            title: File integrity monitoring or change-detection mechanisms is used on audit logs to
+                ensure that existing log data cannot be changed without generating alerts.
+            description: |-
+                Stored activity records cannot be modified without an alert being generated.
+            levels:
+                - base
+            status: automated
+            rules:
+                - audit_rules_mac_modification
+                - audit_rules_dac_modification_chmod
+                - audit_rules_dac_modification_chown
+                - audit_rules_dac_modification_fchmod
+                - audit_rules_dac_modification_fchmodat
+                - audit_rules_dac_modification_fchmodat2
+                - audit_rules_dac_modification_fchown
+                - audit_rules_dac_modification_fchownat
+                - audit_rules_dac_modification_fremovexattr
+                - audit_rules_dac_modification_fsetxattr
+                - audit_rules_dac_modification_lremovexattr
+                - audit_rules_dac_modification_lchown
+                - audit_rules_dac_modification_lsetxattr
+                - audit_rules_dac_modification_removexattr
+                - audit_rules_dac_modification_setxattr
+                - audit_rules_networkconfig_modification
+                - audit_rules_mac_modification_etc_selinux
+
+    - id: '10.4'
+      title: Audit logs are reviewed to identify anomalies or suspicious activity.
       levels:
-        - base
+          - base
       status: manual
       controls:
-      - id: 10.4.1.1
-        title: Automated mechanisms are used to perform audit log reviews.
-        description: |-
-          Potentially suspicious or anomalous activities are identified via a repeatable and
-          consistent mechanism. This requirement is a best practice until 31 March 2025, after
-          which it will be required and must be fully considered during a PCI DSS assessment.
-        levels:
-          - base
-        status: manual
-        notes: |-
-          Automation mechanisms, solutions and approaches vary for each organizarion.
+          - id: 10.4.1
+            title: The audit logs are reviewed at least once daily.
+            description: |-
+                - All security events.
+                - Logs of all system components that store, process, or transmit CHD and/or SAD.
+                - Logs of all critical system components.
+                - Logs of all servers and system components that perform security functions (for example,
+                  network security controls, intrusion-detection systems/intrusion-prevention systems
+                  (IDS/IPS), authentication servers).
+            levels:
+                - base
+            status: manual
+            controls:
+                - id: 10.4.1.1
+                  title: Automated mechanisms are used to perform audit log reviews.
+                  description: |-
+                      Potentially suspicious or anomalous activities are identified via a repeatable and
+                      consistent mechanism. This requirement is a best practice until 31 March 2025, after
+                      which it will be required and must be fully considered during a PCI DSS assessment.
+                  levels:
+                      - base
+                  status: manual
+                  notes: |-
+                      Automation mechanisms, solutions and approaches vary for each organizarion.
 
-    - id: 10.4.2
-      title: Logs of all other system components (those not specified in Requirement 10.4.1) are
-        reviewed periodically.
-      description: |-
-        Potentially suspicious or anomalous activities for other system components (not included
-        in 10.4.1) are reviewed in accordance with the entity's identified risk. This requirement
-        is applicable to all other in-scope system components not included in Requirement 10.4.1.
+          - id: 10.4.2
+            title: Logs of all other system components (those not specified in Requirement 10.4.1) are
+                reviewed periodically.
+            description: |-
+                Potentially suspicious or anomalous activities for other system components (not included
+                in 10.4.1) are reviewed in accordance with the entity's identified risk. This requirement
+                is applicable to all other in-scope system components not included in Requirement 10.4.1.
+            levels:
+                - base
+            status: manual
+            controls:
+                - id: 10.4.2.1
+                  title: The frequency of periodic log reviews for all other system components (not defined
+                      in Requirement 10.4.1) is defined in the entity's targeted risk analysis, which
+                      is performed according to all elements specified in Requirement 12.3.1
+                  description: |-
+                      Log reviews for lower-risk system components are performed at a frequency that addresses
+                      the entity's risk. This requirement is a best practice until 31 March 2025, after which
+                      it will be required and must be fully considered during a PCI DSS assessment.
+                  levels:
+                      - base
+                  status: manual
+
+          - id: 10.4.3
+            title: Exceptions and anomalies identified during the review process are addressed.
+            description: |-
+                Suspicious or anomalous activities are addressed.
+            levels:
+                - base
+            status: manual
+
+    - id: '10.5'
+      title: Audit log history is retained and available for analysis.
       levels:
-        - base
-      status: manual
+          - base
+      status: automated
       controls:
-      - id: 10.4.2.1
-        title: The frequency of periodic log reviews for all other system components (not defined
-          in Requirement 10.4.1) is defined in the entity's targeted risk analysis, which is
-          performed according to all elements specified in Requirement 12.3.1
-        description: |-
-          Log reviews for lower-risk system components are performed at a frequency that addresses
-          the entity's risk. This requirement is a best practice until 31 March 2025, after which
-          it will be required and must be fully considered during a PCI DSS assessment.
-        levels:
+          - id: 10.5.1
+            title: Retain audit log history for at least 12 months, with at least the most recent three
+                months immediately available for analysis.
+            description: |-
+                Historical records of activity are available immediately to support incident response and
+                are retained for at least 12 months.
+            levels:
+                - base
+            status: automated
+            notes: |-
+                It is not simple to ensure 12 months history is present in each system but the rules in
+                this requirement ensures the logs are not lost without administrators awareness.
+            rules:
+                - var_auditd_admin_space_left_action=single
+                - var_auditd_space_left=100MB
+                - var_auditd_space_left_action=email
+                - auditd_data_retention_admin_space_left_action
+                - auditd_data_retention_space_left
+                - auditd_data_retention_space_left_action
+                - package_logrotate_installed
+                - timer_logrotate_enabled
+            related_rules:
+                - var_auditd_action_mail_acct=root
+                - auditd_data_retention_action_mail_acct
+                - auditd_data_retention_num_logs
+                - auditd_data_retention_max_log_file
+                - auditd_data_retention_max_log_file_action
+                - auditd_data_retention_max_log_file_action_stig
+                - ensure_logrotate_activated
+
+    - id: '10.6'
+      title: Time-synchronization mechanisms support consistent time settings across all systems.
+      levels:
           - base
-        status: manual
-
-    - id: 10.4.3
-      title: Exceptions and anomalies identified during the review process are addressed.
-      description: |-
-        Suspicious or anomalous activities are addressed.
-      levels:
-        - base
-      status: manual
-
-  - id: '10.5'
-    title: Audit log history is retained and available for analysis.
-    levels:
-      - base
-    status: automated
-    controls:
-    - id: 10.5.1
-      title: Retain audit log history for at least 12 months, with at least the most recent three
-        months immediately available for analysis.
-      description: |-
-        Historical records of activity are available immediately to support incident response and
-        are retained for at least 12 months.
-      levels:
-        - base
       status: automated
-      notes: |-
-        It is not simple to ensure 12 months history is present in each system but the rules in
-        this requirement ensures the logs are not lost without administrators awareness.
-      rules:
-        - var_auditd_admin_space_left_action=single
-        - var_auditd_space_left=100MB
-        - var_auditd_space_left_action=email
-        - auditd_data_retention_admin_space_left_action
-        - auditd_data_retention_space_left
-        - auditd_data_retention_space_left_action
-        - package_logrotate_installed
-        - timer_logrotate_enabled
-      related_rules:
-        - var_auditd_action_mail_acct=root
-        - auditd_data_retention_action_mail_acct
-        - auditd_data_retention_num_logs
-        - auditd_data_retention_max_log_file
-        - auditd_data_retention_max_log_file_action
-        - auditd_data_retention_max_log_file_action_stig
-        - ensure_logrotate_activated
+      controls:
+          - id: 10.6.1
+            title: System clocks and time are synchronized using time-synchronization technology.
+            description: |-
+                Common time is established across all systems. Keeping time-synchronization technology
+                current includes managing vulnerabilities and patching the technology according to PCI DSS
+                Requirements 6.3.1 and 6.3.3.
+            levels:
+                - base
+            status: automated
+            notes: |-
+                Maybe it is possible to optmize some similar rules related to ntp.
+            rules:
+                - package_chrony_installed
+                - service_chronyd_or_ntpd_enabled
+                - service_ntp_enabled
+                - service_ntpd_enabled
+                - service_timesyncd_enabled
 
-  - id: '10.6'
-    title: Time-synchronization mechanisms support consistent time settings across all systems.
-    levels:
-      - base
-    status: automated
-    controls:
-    - id: 10.6.1
-      title: System clocks and time are synchronized using time-synchronization technology.
-      description: |-
-        Common time is established across all systems. Keeping time-synchronization technology
-        current includes managing vulnerabilities and patching the technology according to PCI DSS
-        Requirements 6.3.1 and 6.3.3.
-      levels:
-        - base
-      status: automated
-      notes: |-
-        Maybe it is possible to optmize some similar rules related to ntp.
-      rules:
-        - package_chrony_installed
-        - service_chronyd_or_ntpd_enabled
-        - service_ntp_enabled
-        - service_ntpd_enabled
-        - service_timesyncd_enabled
-
-    - id: 10.6.2
-      title: Systems are configured to the correct and consistent time.
-      description: |-
-        - One or more designated time servers are in use.
-        - Only the designated central time server(s) receives time from external sources.
-        - Time received from external sources is based on International Atomic Time or Coordinated
-          Universal Time (UTC).
-        - The designated time server(s) accept time updates only from specific industry-accepted
-          external sources.
-        - Where there is more than one designated time server, the time servers peer with one
-          another to keep accurate time.
-        - Internal systems receive time information only from designated central time server(s).
-      levels:
-        - base
-      status: automated
-      notes: |-
-        The selected rules might need updates in order to restrict their platform applicability
-        to avoid conflicts.
-      rules:
+          - id: 10.6.2
+            title: Systems are configured to the correct and consistent time.
+            description: |-
+                - One or more designated time servers are in use.
+                - Only the designated central time server(s) receives time from external sources.
+                - Time received from external sources is based on International Atomic Time or Coordinated
+                  Universal Time (UTC).
+                - The designated time server(s) accept time updates only from specific industry-accepted
+                  external sources.
+                - Where there is more than one designated time server, the time servers peer with one
+                  another to keep accurate time.
+                - Internal systems receive time information only from designated central time server(s).
+            levels:
+                - base
+            status: automated
+            notes: |-
+                The selected rules might need updates in order to restrict their platform applicability
+                to avoid conflicts.
+            rules:
         # specific products should update the variable value when defining the profile based on
         # this control file.
-        - var_multiple_time_servers=generic
-        - chronyd_specify_remote_server
-        - ntpd_specify_remote_server
-        - ntpd_specify_multiple_servers
-      related_rules:
-        - chronyd_configure_pool_and_server
-        - chronyd_or_ntpd_specify_multiple_servers
+                - var_multiple_time_servers=generic
+                - chronyd_specify_remote_server
+                - ntpd_specify_remote_server
+                - ntpd_specify_multiple_servers
+            related_rules:
+                - chronyd_configure_pool_and_server
+                - chronyd_or_ntpd_specify_multiple_servers
 
-    - id: 10.6.3
-      title: Time synchronization settings and data are protected.
-      description: |-
-        - Access to time data is restricted to only personnel with a business need.
-        - Any changes to time settings on critical systems are logged, monitored, and reviewed.
+          - id: 10.6.3
+            title: Time synchronization settings and data are protected.
+            description: |-
+                - Access to time data is restricted to only personnel with a business need.
+                - Any changes to time settings on critical systems are logged, monitored, and reviewed.
+            levels:
+                - base
+            status: automated
+            rules:
+                - audit_rules_time_watch_localtime
+                - audit_rules_time_settimeofday
+                - audit_rules_time_clock_settime
+                - audit_rules_time_stime
+                - audit_rules_time_adjtimex
+                - chronyd_run_as_chrony_user
+            related_rules:
+                - chronyd_client_only
+
+    - id: '10.7'
+      title: Failures of critical security control systems are detected, reported, and responded to promptly.
       levels:
-        - base
+          - base
+      status: partial
+      controls:
+          - id: 10.7.1
+            title: 'Additional requirement for service providers only: Failures of critical security
+                control systems are detected, alerted, and addressed promptly.'
+            description: |-
+                It includes but is not limited to failure of the following critical security control
+                systems:
+                - Network security controls.
+                - IDS/IPS.
+                - FIM.
+                - Anti-malware solutions.
+                - Physical access controls.
+                - Logical access controls.
+                - Audit logging mechanisms.
+                - Segmentation controls (if used).
+            levels:
+                - base
+            status: manual
+
+          - id: 10.7.2
+            title: Failures of critical security control systems are detected, alerted, and addressed
+                promptly.
+            description: |-
+                It includes but is not limited to failure of the following critical security control
+                systems:
+                - Network security controls.
+                - IDS/IPS.
+                - Change-detection mechanisms.
+                - Anti-malware solutions.
+                - Physical access controls.
+                - Logical access controls.
+                - Audit logging mechanisms.
+                - Segmentation controls (if used).
+                - Audit log review mechanisms.
+                - Automated security testing tools (if used).
+            levels:
+                - base
+            status: partial
+            rules:
+                - grub2_audit_argument
+                - grub2_audit_backlog_limit_argument
+
+          - id: 10.7.3
+            title: Failures of any critical security controls systems are responded to restore security
+                functions, ensure documentation, address security issues and prevent other failures.
+            description: |-
+                It includes but is not limited to:
+                - Restoring security functions.
+                - Identifying and documenting the duration (date and time from start to end) of the
+                  security failure.
+                - Identifying and documenting the cause(s) of failure and documenting required
+                  remediation.
+                - Identifying and addressing any security issues that arose during the failure.
+                - Determining whether further actions are required as a result of the security failure.
+                - Implementing controls to prevent the cause of failure from reoccurring.
+                - Resuming monitoring of security controls.
+            levels:
+                - base
+            status: manual
+
+    - id: '11.1'
+      title: Processes and mechanisms for regularly testing security of systems and networks are defined
+          and understood.
+      levels:
+          - base
+      status: manual
+      controls:
+          - id: 11.1.1
+            title: All security policies and operational procedures that are identified in Requirement
+                11 are Documented, Kept up to date, In use and Known to all affected parties.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Examine documentation and interview personnel to verify that security policies and
+                operational procedures identified in Requirement 11 are managed in accordance with all
+                elements specified in this requirement.
+
+          - id: 11.1.2
+            title: Roles and responsibilities for performing activities in Requirement 11 are documented,
+                assigned, and understood.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Examine documentation and interview personnel to verify that day-to-day responsibilities
+                for performing all the activities in Requirement 11 are documented, assigned and
+                understood by the assigned personnel.
+
+    - id: '11.2'
+      title: Wireless access points are identified and monitored, and unauthorized wireless access points
+          are addressed.
+      levels:
+          - base
+      status: manual
+      controls:
+          - id: 11.2.1
+            title: Authorized and unauthorized wireless access points are managed.
+            levels:
+                - base
+            status: manual
+
+          - id: 11.2.2
+            title: An inventory of authorized wireless access points is maintained, including a documented
+                business justification.
+            description: |-
+                Unauthorized wireless access points are not mistaken for authorized wireless access
+                points.
+            levels:
+                - base
+            status: manual
+
+    - id: '11.3'
+      title: External and internal vulnerabilities are regularly identified, prioritized, and addressed.
+      levels:
+          - base
+      status: manual
+      controls:
+          - id: 11.3.1
+            title: Internal vulnerability scans are performed.
+            levels:
+                - base
+            status: manual
+            controls:
+                - id: 11.3.1.1
+                  title: All other applicable vulnerabilities (those not ranked as high-risk vulnerabilities
+                      or critical vulnerabilities according to the entity's vulnerability risk rankings
+                      defined at Requirement 6.3.1) are managed.
+                  levels:
+                      - base
+                  status: manual
+
+                - id: 11.3.1.2
+                  title: Internal vulnerability scans are performed via authenticated scanning.
+                  levels:
+                      - base
+                  status: manual
+
+                - id: 11.3.1.3
+                  title: Internal vulnerability scans are performed after any significant change.
+                  levels:
+                      - base
+                  status: manual
+
+          - id: 11.3.2
+            title: External vulnerability scans are performed.
+            levels:
+                - base
+            status: manual
+            controls:
+                - id: 11.3.2.1
+                  title: External vulnerability scans are performed after any significant change.
+                  levels:
+                      - base
+                  status: manual
+
+    - id: '11.4'
+      title: External and internal penetration testing is regularly performed, and exploitable vulnerabilities
+          and security weaknesses are corrected.
+      levels:
+          - base
+      status: manual
+      controls:
+          - id: 11.4.1
+            title: A penetration testing methodology is defined, documented, and implemented by the entity.
+            levels:
+                - base
+            status: manual
+
+          - id: 11.4.2
+            title: Internal penetration testing is performed.
+            levels:
+                - base
+            status: manual
+
+          - id: 11.4.3
+            title: External penetration testing is performed.
+            levels:
+                - base
+            status: manual
+
+          - id: 11.4.4
+            title: Exploitable vulnerabilities and security weaknesses found during penetration testing
+                are corrected
+            levels:
+                - base
+            status: manual
+
+          - id: 11.4.5
+            title: If segmentation is used to isolate the CDE from other networks, penetration tests
+                are performed on segmentation controls.
+            levels:
+                - base
+            status: manual
+
+          - id: 11.4.6
+            title: 'Additional requirement for service providers only: If segmentation is used to isolate
+                the CDE from other networks, penetration tests are performed on segmentation controls.'
+            levels:
+                - base
+            status: manual
+
+          - id: 11.4.7
+            title: 'Additional requirement for multi-tenant service providers only: Multi-tenant service
+                providers support their customers for external penetration testing per Requirement 11.4.3
+                and 11.4.4.'
+            description: |-
+                Multi-tenant service providers support their customers' need for technical testing either
+                by providing access or evidence that comparable technical testing has been undertaken.
+            levels:
+                - base
+            status: manual
+
+    - id: '11.5'
+      title: Network intrusions and unexpected file changes are detected and responded to.
+      levels:
+          - base
+      status: automated
+      controls:
+          - id: 11.5.1
+            title: Intrusion-detection and/or intrusion-prevention techniques are used to detect and/or
+                prevent intrusions into the network.
+            levels:
+                - base
+            status: manual
+            controls:
+                - id: 11.5.1.1
+                  title: 'Additional requirement for service providers only: Intrusion-detection and/or
+                      intrusion-prevention techniques detect, alert on/prevent, and address covert malware
+                      communication channels.'
+                  description: |-
+                      Mechanisms are in place to detect and alert/prevent covert communications with
+                      command-and-control systems. Alerts generated by these mechanisms are responded to by
+                      personnel, or by automated means that ensure that such communications are blocked. This
+                      requirement applies only when the entity being assessed is a service provider. This
+                      requirement is a best practice until 31 March 2025, after which it will be required and
+                      must be fully considered during a PCI DSS assessment.
+                  levels:
+                      - base
+                  status: manual
+                  notes: |-
+                      The policy is not explicit about any specific solution. The solution might vary
+                      depending on site policies.
+                  related_rules:
+                      - install_hids
+                      - package_MFEhiplsm_installed
+
+    - id: 11.5.2
+      title: A change-detection mechanism (for example, file integrity monitoring tools) is deployed.
+      levels:
+          - base
       status: automated
       rules:
-        - audit_rules_time_watch_localtime
-        - audit_rules_time_settimeofday
-        - audit_rules_time_clock_settime
-        - audit_rules_time_stime
-        - audit_rules_time_adjtimex
-        - chronyd_run_as_chrony_user
+          - aide_build_database
+          - aide_periodic_cron_checking
+          - aide_periodic_checking_systemd_timer
+          - package_aide_installed
+          - rpm_verify_hashes
+          - rpm_verify_ownership
+          - rpm_verify_permissions
       related_rules:
-        - chronyd_client_only
+          - disable_prelink
 
-  - id: '10.7'
-    title: Failures of critical security control systems are detected, reported, and responded to
-      promptly.
-    levels:
-      - base
-    status: partial
-    controls:
-    - id: 10.7.1
-      title: 'Additional requirement for service providers only: Failures of critical security
-        control systems are detected, alerted, and addressed promptly.'
-      description: |-
-        It includes but is not limited to failure of the following critical security control
-        systems:
-        - Network security controls.
-        - IDS/IPS.
-        - FIM.
-        - Anti-malware solutions.
-        - Physical access controls.
-        - Logical access controls.
-        - Audit logging mechanisms.
-        - Segmentation controls (if used).
+    - id: '11.6'
+      title: Unauthorized changes on payment pages are detected and responded to.
       levels:
-        - base
+          - base
       status: manual
+      controls:
+          - id: 11.6.1
+            title: A change- and tamper-detection mechanism is deployed.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                It depends on controls in application level, which varies based on site policies.
 
-    - id: 10.7.2
-      title: Failures of critical security control systems are detected, alerted, and addressed
-        promptly.
-      description: |-
-        It includes but is not limited to failure of the following critical security control
-        systems:
-        - Network security controls.
-        - IDS/IPS.
-        - Change-detection mechanisms.
-        - Anti-malware solutions.
-        - Physical access controls.
-        - Logical access controls.
-        - Audit logging mechanisms.
-        - Segmentation controls (if used).
-        - Audit log review mechanisms.
-        - Automated security testing tools (if used).
+    - id: '12.1'
+      title: A comprehensive information security policy that governs and provides direction for protection
+          of the entity's information assets is known and current.
       levels:
-        - base
+          - base
       status: partial
-      rules:
-        - grub2_audit_argument
-        - grub2_audit_backlog_limit_argument
+      controls:
+          - id: 12.1.1
+            title: An overall information security policy is established, published, maintained and disseminated
+                to all relevant personnel, as well as to relevant vendors and business partners.
+            levels:
+                - base
+            status: manual
 
-    - id: 10.7.3
-      title: Failures of any critical security controls systems are responded to restore security
-        functions, ensure documentation, address security issues and prevent other failures.
-      description: |-
-        It includes but is not limited to:
-        - Restoring security functions.
-        - Identifying and documenting the duration (date and time from start to end) of the
-          security failure.
-        - Identifying and documenting the cause(s) of failure and documenting required
-          remediation.
-        - Identifying and addressing any security issues that arose during the failure.
-        - Determining whether further actions are required as a result of the security failure.
-        - Implementing controls to prevent the cause of failure from reoccurring.
-        - Resuming monitoring of security controls.
-      levels:
-        - base
-      status: manual
+          - id: 12.1.2
+            title: The information security policy is updated and reviewed at least once every 12 months.
+            levels:
+                - base
+            status: manual
 
-  - id: '11.1'
-    title: Processes and mechanisms for regularly testing security of systems and networks are
-      defined and understood.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 11.1.1
-      title: All security policies and operational procedures that are identified in Requirement
-        11 are Documented, Kept up to date, In use and Known to all affected parties.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        Examine documentation and interview personnel to verify that security policies and
-        operational procedures identified in Requirement 11 are managed in accordance with all
-        elements specified in this requirement.
+          - id: 12.1.3
+            title: The security policy clearly defines information security roles and responsibilities
+                for all personnel, and all personnel are aware of and acknowledge their information security
+                responsibilities.
+            description: |-
+                Personnel understand their role in protecting the entity's cardholder data.
+            levels:
+                - base
+            status: manual
 
-    - id: 11.1.2
-      title: Roles and responsibilities for performing activities in Requirement 11 are
-        documented, assigned, and understood.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        Examine documentation and interview personnel to verify that day-to-day responsibilities
-        for performing all the activities in Requirement 11 are documented, assigned and
-        understood by the assigned personnel.
+          - id: 12.1.4
+            title: Responsibility for information security is formally assigned to a Chief Information
+                Security Officer or other information security knowledgeable member of executive management.
+            description: |-
+                A designated member of executive management is responsible for information security.
+            levels:
+                - base
+            status: manual
 
-  - id: '11.2'
-    title: Wireless access points are identified and monitored, and unauthorized wireless access
-      points are addressed.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 11.2.1
-      title: Authorized and unauthorized wireless access points are managed.
+    - id: '12.2'
+      title: Acceptable use policies for end-user technologies are defined and implemented.
       levels:
-        - base
-      status: manual
-
-    - id: 11.2.2
-      title: An inventory of authorized wireless access points is maintained, including a
-        documented business justification.
-      description: |-
-        Unauthorized wireless access points are not mistaken for authorized wireless access
-        points.
-      levels:
-        - base
-      status: manual
-
-  - id: '11.3'
-    title: External and internal vulnerabilities are regularly identified, prioritized, and
-      addressed.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 11.3.1
-      title: Internal vulnerability scans are performed.
-      levels:
-        - base
+          - base
       status: manual
       controls:
-      - id: 11.3.1.1
-        title: All other applicable vulnerabilities (those not ranked as high-risk vulnerabilities
-          or critical vulnerabilities according to the entity's vulnerability risk rankings
-          defined at Requirement 6.3.1) are managed.
-        levels:
-          - base
-        status: manual
+          - id: 12.2.1
+            title: Acceptable use policies for end-user technologies are documented and implemented.
+            levels:
+                - base
+            status: manual
 
-      - id: 11.3.1.2
-        title: Internal vulnerability scans are performed via authenticated scanning.
-        levels:
-          - base
-        status: manual
-
-      - id: 11.3.1.3
-        title: Internal vulnerability scans are performed after any significant change.
-        levels:
-          - base
-        status: manual
-
-    - id: 11.3.2
-      title: External vulnerability scans are performed.
+    - id: '12.3'
+      title: Risks to the cardholder data environment are formally identified, evaluated, and managed.
       levels:
-        - base
+          - base
       status: manual
       controls:
-      - id: 11.3.2.1
-        title: External vulnerability scans are performed after any significant change.
-        levels:
+          - id: 12.3.1
+            title: For each PCI DSS requirement that specifies completion of a targeted risk analysis,
+                the analysis is documented.
+            levels:
+                - base
+            status: manual
+
+          - id: 12.3.2
+            title: A targeted risk analysis is performed for each PCI DSS requirement that the entity
+                meets with the customized approach
+            levels:
+                - base
+            status: manual
+
+          - id: 12.3.3
+            title: Cryptographic cipher suites and protocols in use are documented and reviewed at least
+                once every 12 months.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Related to requirement 2.2.7.
+
+          - id: 12.3.4
+            title: Hardware and software technologies in use are reviewed at least once every 12 months.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                The technical requirement related to this is 6.3.3.
+
+    - id: '12.4'
+      title: PCI DSS compliance is managed.
+      levels:
           - base
-        status: manual
-
-  - id: '11.4'
-    title: External and internal penetration testing is regularly performed, and exploitable
-      vulnerabilities and security weaknesses are corrected.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 11.4.1
-      title: A penetration testing methodology is defined, documented, and implemented by the
-        entity.
-      levels:
-        - base
-      status: manual
-
-    - id: 11.4.2
-      title: Internal penetration testing is performed.
-      levels:
-        - base
-      status: manual
-
-    - id: 11.4.3
-      title: External penetration testing is performed.
-      levels:
-        - base
-      status: manual
-
-    - id: 11.4.4
-      title: Exploitable vulnerabilities and security weaknesses found during penetration testing
-        are corrected
-      levels:
-        - base
-      status: manual
-
-    - id: 11.4.5
-      title: If segmentation is used to isolate the CDE from other networks, penetration tests are
-        performed on segmentation controls.
-      levels:
-        - base
-      status: manual
-
-    - id: 11.4.6
-      title: 'Additional requirement for service providers only: If segmentation is used to
-        isolate the CDE from other networks, penetration tests are performed on segmentation
-        controls.'
-      levels:
-        - base
-      status: manual
-
-    - id: 11.4.7
-      title: 'Additional requirement for multi-tenant service providers only: Multi-tenant service
-        providers support their customers for external penetration testing per Requirement 11.4.3
-        and 11.4.4.'
-      description: |-
-        Multi-tenant service providers support their customers' need for technical testing either
-        by providing access or evidence that comparable technical testing has been undertaken.
-      levels:
-        - base
-      status: manual
-
-  - id: '11.5'
-    title: Network intrusions and unexpected file changes are detected and responded to.
-    levels:
-      - base
-    status: automated
-    controls:
-    - id: 11.5.1
-      title: Intrusion-detection and/or intrusion-prevention techniques are used to detect and/or
-        prevent intrusions into the network.
-      levels:
-        - base
       status: manual
       controls:
-      - id: 11.5.1.1
-        title: 'Additional requirement for service providers only: Intrusion-detection and/or
-          intrusion-prevention techniques detect, alert on/prevent, and address covert malware
-          communication channels.'
-        description: |-
-          Mechanisms are in place to detect and alert/prevent covert communications with
-          command-and-control systems. Alerts generated by these mechanisms are responded to by
-          personnel, or by automated means that ensure that such communications are blocked. This
-          requirement applies only when the entity being assessed is a service provider. This
-          requirement is a best practice until 31 March 2025, after which it will be required and
-          must be fully considered during a PCI DSS assessment.
-        levels:
+          - id: 12.4.1
+            title: 'Additional requirement for service providers only: Responsibility is established
+                by executive management for the protection of cardholder data and a PCI DSS compliance
+                program.'
+            levels:
+                - base
+            status: manual
+
+          - id: 12.4.2
+            title: 'Additional requirement for service providers only: Reviews are performed at least
+                once every three months to confirm that personnel are performing their tasks in accordance
+                with all security policies and operational procedures.'
+            description: |-
+                Reviews are performed by personnel other than those responsible for performing the given
+                task.
+            levels:
+                - base
+            status: manual
+            controls:
+                - id: 12.4.2.1
+                  title: 'Additional requirement for service providers only: Reviews conducted in accordance
+                      with Requirement 12.4.2 are documented.'
+                  levels:
+                      - base
+                  status: manual
+
+    - id: '12.5'
+      title: PCI DSS scope is documented and validated.
+      levels:
           - base
-        status: manual
-        notes: |-
-          The policy is not explicit about any specific solution. The solution might vary
-          depending on site policies.
-        related_rules:
-          - install_hids
-          - package_MFEhiplsm_installed
-
-  - id: 11.5.2
-    title: A change-detection mechanism (for example, file integrity monitoring tools) is deployed.
-    levels:
-      - base
-    status: automated
-    rules:
-      - aide_build_database
-      - aide_periodic_cron_checking
-      - aide_periodic_checking_systemd_timer
-      - package_aide_installed
-      - rpm_verify_hashes
-      - rpm_verify_ownership
-      - rpm_verify_permissions
-    related_rules:
-      - disable_prelink
-
-  - id: '11.6'
-    title: Unauthorized changes on payment pages are detected and responded to.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 11.6.1
-      title: A change- and tamper-detection mechanism is deployed.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        It depends on controls in application level, which varies based on site policies.
-
-  - id: '12.1'
-    title: A comprehensive information security policy that governs and provides direction for
-      protection of the entity's information assets is known and current.
-    levels:
-      - base
-    status: partial
-    controls:
-    - id: 12.1.1
-      title: An overall information security policy is established, published, maintained and
-        disseminated to all relevant personnel, as well as to relevant vendors and business
-        partners.
-      levels:
-        - base
-      status: manual
-
-    - id: 12.1.2
-      title: The information security policy is updated and reviewed at least once every 12
-        months.
-      levels:
-        - base
-      status: manual
-
-    - id: 12.1.3
-      title: The security policy clearly defines information security roles and responsibilities
-        for all personnel, and all personnel are aware of and acknowledge their information
-        security responsibilities.
-      description: |-
-        Personnel understand their role in protecting the entity's cardholder data.
-      levels:
-        - base
-      status: manual
-
-    - id: 12.1.4
-      title: Responsibility for information security is formally assigned to a Chief Information
-        Security Officer or other information security knowledgeable member of executive
-        management.
-      description: |-
-        A designated member of executive management is responsible for information security.
-      levels:
-        - base
-      status: manual
-
-  - id: '12.2'
-    title: Acceptable use policies for end-user technologies are defined and implemented.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 12.2.1
-      title: Acceptable use policies for end-user technologies are documented and implemented.
-      levels:
-        - base
-      status: manual
-
-  - id: '12.3'
-    title: Risks to the cardholder data environment are formally identified, evaluated, and
-      managed.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 12.3.1
-      title: For each PCI DSS requirement that specifies completion of a targeted risk analysis,
-        the analysis is documented.
-      levels:
-        - base
-      status: manual
-
-    - id: 12.3.2
-      title: A targeted risk analysis is performed for each PCI DSS requirement that the entity
-        meets with the customized approach
-      levels:
-        - base
-      status: manual
-
-    - id: 12.3.3
-      title: Cryptographic cipher suites and protocols in use are documented and reviewed at least
-        once every 12 months.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        Related to requirement 2.2.7.
-
-    - id: 12.3.4
-      title: Hardware and software technologies in use are reviewed at least once every 12 months.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        The technical requirement related to this is 6.3.3.
-
-  - id: '12.4'
-    title: PCI DSS compliance is managed.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 12.4.1
-      title: 'Additional requirement for service providers only: Responsibility is established by
-        executive management for the protection of cardholder data and a PCI DSS compliance
-        program.'
-      levels:
-        - base
-      status: manual
-
-    - id: 12.4.2
-      title: 'Additional requirement for service providers only: Reviews are performed at least
-        once every three months to confirm that personnel are performing their tasks in accordance
-        with all security policies and operational procedures.'
-      description: |-
-        Reviews are performed by personnel other than those responsible for performing the given
-        task.
-      levels:
-        - base
       status: manual
       controls:
-      - id: 12.4.2.1
-        title: 'Additional requirement for service providers only: Reviews conducted in accordance
-          with Requirement 12.4.2 are documented.'
-        levels:
+          - id: 12.5.1
+            title: An inventory of system components that are in scope for PCI DSS, including a description
+                of function/use, is maintained and kept current.
+            description: |-
+                All system components in scope for PCI DSS are identified and known.
+            levels:
+                - base
+            status: manual
+
+          - id: 12.5.2
+            title: PCI DSS scope is documented and confirmed by the entity at least once every 12 months
+                and upon significant change to the in-scope environment.
+            levels:
+                - base
+            status: manual
+            controls:
+                - id: 12.5.2.1
+                  title: 'Additional requirement for service providers only: PCI DSS scope is documented
+                      and confirmed by the entity at least once every six months and upon significant
+                      change to the in-scope environment. At a minimum, the scoping validation includes
+                      all the elements specified in Requirement 12.5.2.'
+                  description: |-
+                      The accuracy of PCI DSS scope is verified to be continuously accurate by comprehensive
+                      analysis and appropriate technical measures. This requirement applies only when the
+                      entity being assessed is a service provider. This requirement is a best practice until
+                      31 March 2025, after which it will be required and must be fully considered during a
+                      PCI DSS assessment.
+                  levels:
+                      - base
+                  status: manual
+
+          - id: 12.5.3
+            title: 'Additional requirement for service providers only: Significant changes to organizational
+                structure result in a documented (internal) review of the impact to PCI DSS scope and
+                applicability of controls, with results communicated to executive management.'
+            description: |-
+                PCI DSS scope is confirmed after significant organizational change. This requirement
+                applies only when the entity being assessed is a service provider. This requirement is a
+                best practice until 31 March 2025, after which it will be required and must be fully
+                considered during a PCI DSS assessment.
+            levels:
+                - base
+            status: manual
+
+    - id: '12.6'
+      title: Security awareness education is an ongoing activity.
+      levels:
           - base
-        status: manual
-
-  - id: '12.5'
-    title: PCI DSS scope is documented and validated.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 12.5.1
-      title: An inventory of system components that are in scope for PCI DSS, including a
-        description of function/use, is maintained and kept current.
-      description: |-
-        All system components in scope for PCI DSS are identified and known.
-      levels:
-        - base
-      status: manual
-
-    - id: 12.5.2
-      title: PCI DSS scope is documented and confirmed by the entity at least once every 12 months
-        and upon significant change to the in-scope environment.
-      levels:
-        - base
       status: manual
       controls:
-      - id: 12.5.2.1
-        title: 'Additional requirement for service providers only: PCI DSS scope is documented and
-          confirmed by the entity at least once every six months and upon significant change to
-          the in-scope environment. At a minimum, the scoping validation includes all the elements
-          specified in Requirement 12.5.2.'
-        description: |-
-          The accuracy of PCI DSS scope is verified to be continuously accurate by comprehensive
-          analysis and appropriate technical measures. This requirement applies only when the
-          entity being assessed is a service provider. This requirement is a best practice until
-          31 March 2025, after which it will be required and must be fully considered during a
-          PCI DSS assessment.
-        levels:
+          - id: 12.6.1
+            title: A formal security awareness program is implemented to make all personnel aware of
+                the entity's information security policy and procedures, and their role in protecting
+                the cardholder data.
+            description: |-
+                Personnel are knowledgeable about the threat landscape, their responsibility for the
+                operation of relevant security controls, and are able to access assistance and guidance
+                when required.
+            levels:
+                - base
+            status: manual
+
+          - id: 12.6.2
+            title: The security awareness program is updated and reviewed at least once every 12 months.
+            levels:
+                - base
+            status: manual
+
+          - id: 12.6.3
+            title: Personnel receive security awareness training upon hire and at least once every 12
+                months via multiple methods of communication.
+            levels:
+                - base
+            status: manual
+            controls:
+                - id: 12.6.3.1
+                  title: Security awareness training includes awareness of threats and vulnerabilities
+                      that could impact the security of the CDE.
+                  levels:
+                      - base
+                  status: manual
+
+                - id: 12.6.3.2
+                  title: Security awareness training includes awareness about the acceptable use of end-user
+                      technologies in accordance with Requirement 12.2.1.
+                  description: |-
+                      Personnel are knowledgeable about their responsibility for the security and operation of
+                      end-user technologies and are able to access assistance and guidance when required. This
+                      requirement is a best practice until 31 March 2025, after which it will be required and
+                      must be fully considered during a PCI DSS assessment.
+                  levels:
+                      - base
+                  status: manual
+
+    - id: '12.7'
+      title: Personnel are screened to reduce risks from insider threats.
+      levels:
           - base
-        status: manual
-
-    - id: 12.5.3
-      title: 'Additional requirement for service providers only: Significant changes to
-        organizational structure result in a documented (internal) review of the impact to PCI DSS
-        scope and applicability of controls, with results communicated to executive management.'
-      description: |-
-        PCI DSS scope is confirmed after significant organizational change. This requirement
-        applies only when the entity being assessed is a service provider. This requirement is a
-        best practice until 31 March 2025, after which it will be required and must be fully
-        considered during a PCI DSS assessment.
-      levels:
-        - base
-      status: manual
-
-  - id: '12.6'
-    title: Security awareness education is an ongoing activity.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 12.6.1
-      title: A formal security awareness program is implemented to make all personnel aware of the
-        entity's information security policy and procedures, and their role in protecting the
-        cardholder data.
-      description: |-
-        Personnel are knowledgeable about the threat landscape, their responsibility for the
-        operation of relevant security controls, and are able to access assistance and guidance
-        when required.
-      levels:
-        - base
-      status: manual
-
-    - id: 12.6.2
-      title: The security awareness program is updated and reviewed at least once every 12 months.
-      levels:
-        - base
-      status: manual
-
-    - id: 12.6.3
-      title: Personnel receive security awareness training upon hire and at least once every 12
-        months via multiple methods of communication.
-      levels:
-        - base
       status: manual
       controls:
-      - id: 12.6.3.1
-        title: Security awareness training includes awareness of threats and vulnerabilities that
-          could impact the security of the CDE.
-        levels:
+          - id: 12.7.1
+            title: Potential personnel who will have access to the CDE are screened, within the constraints
+                of local laws, prior to hire to minimize the risk of attacks from internal sources.
+            description: |-
+                The risk related to allowing new members of staff access to the CDE is understood and
+                managed. For those potential personnel to be hired for positions such as store cashiers,
+                who only have access to one card number at a time when facilitating a transaction, this
+                requirement is a recommendation only.
+            levels:
+                - base
+            status: manual
+
+    - id: '12.8'
+      title: Risk to information assets associated with third-party service provider (TPSP) relationships
+          is managed.
+      levels:
           - base
-        status: manual
-
-      - id: 12.6.3.2
-        title: Security awareness training includes awareness about the acceptable use of end-user
-          technologies in accordance with Requirement 12.2.1.
-        description: |-
-          Personnel are knowledgeable about their responsibility for the security and operation of
-          end-user technologies and are able to access assistance and guidance when required. This
-          requirement is a best practice until 31 March 2025, after which it will be required and
-          must be fully considered during a PCI DSS assessment.
-        levels:
-          - base
-        status: manual
-
-  - id: '12.7'
-    title: Personnel are screened to reduce risks from insider threats.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 12.7.1
-      title: Potential personnel who will have access to the CDE are screened, within the
-        constraints of local laws, prior to hire to minimize the risk of attacks from internal
-        sources.
-      description: |-
-        The risk related to allowing new members of staff access to the CDE is understood and
-        managed. For those potential personnel to be hired for positions such as store cashiers,
-        who only have access to one card number at a time when facilitating a transaction, this
-        requirement is a recommendation only.
-      levels:
-        - base
-      status: manual
-
-  - id: '12.8'
-    title: Risk to information assets associated with third-party service provider (TPSP)
-      relationships is managed.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 12.8.1
-      title: A list of all third-party service providers (TPSPs) with which account data is shared
-        or that could affect the security of account data is maintained, including a description
-        for each of the services provided.
-      description: |-
-        Records are maintained of TPSPs and the services provided. The use of a PCI DSS compliant
-        TPSP does not make an entity PCI DSS compliant, nor does it remove the entit's
-        responsibility for its own PCI DSS compliance.
-      levels:
-        - base
-      status: manual
-
-    - id: 12.8.2
-      title: Written agreements with TPSPs are maintained
-      levels:
-        - base
-      status: manual
-
-    - id: 12.8.3
-      title: An established process is implemented for engaging TPSPs, including proper due
-        diligence prior to engagement.
-      description: |-
-        The capability, intent, and resources of a prospective TPSP to adequately protect account
-        data are assessed before the TPSP is engaged.
-      levels:
-        - base
-      status: manual
-
-    - id: 12.8.4
-      title: A program is implemented to monitor TPSPs' PCI DSS compliance status at least once
-        every 12 months.
-      description: |-
-        The PCI DSS compliance status of TPSPs is verified periodically. Where an entity has an
-        agreement with a TPSP for meeting PCI DSS requirements on behalf of the entity (for
-        example, via a firewall service), the entity must work with the TPSP to make sure the
-        applicable PCI DSS requirements are met. If the TPSP does not meet those applicable
-        PCI DSS requirements, then those requirements are also "not in place" for the entity.
-      levels:
-        - base
-      status: manual
-
-    - id: 12.8.5
-      title: Information is maintained about which PCI DSS requirements are managed by each TPSP,
-        which are managed by the entity, and any that are shared between the TPSP and the entity.
-      description: |-
-        Records detailing the PCI DSS requirements and related system components for which each
-        TPSP is solely or jointly responsible, are maintained and reviewed periodically.
-      levels:
-        - base
-      status: manual
-
-  - id: '12.9'
-    title: Third-party service providers (TPSPs) support their customers' PCI DSS compliance.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 12.9.1
-      title: |-
-        Additional requirement for service providers only: TPSPs provide written agreements to
-        customers that include acknowledgments that TPSPs are responsible for the security of
-        account data the TPSP possesses or otherwise stores, processes, or transmits on behalf of
-        the customer, or to the extent that the TPSP could impact the security of the customer's
-        cardholder data and/or sensitive authentication data.
-      description: |-
-        TPSPs formally acknowledge their security responsibilities to their customers. This
-        requirement applies only when the entity being assessed is a service provider. The exact
-        wording of an agreement will depend on the details of the service being provided, and the
-        responsibilities assigned to each party. The agreement does not have to include the exact
-        wording provided in this requirement.
-      levels:
-        - base
-      status: manual
-
-    - id: 12.9.2
-      title: |-
-        Additional requirement for service providers only: TPSPs support their customers' requests
-        for information to meet Requirements 12.8.4 and 12.8.5.
-      levels:
-        - base
-      status: manual
-
-  - id: '12.10'
-    title: Suspected and confirmed security incidents that could impact the CDE are responded to
-      immediately.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: 12.10.1
-      title: An incident response plan exists and is ready to be activated in the event of a
-        suspected or confirmed security incident.
-      levels:
-        - base
-      status: manual
-
-    - id: 12.10.2
-      title: At least once every 12 months, the security incident response plan is reviewed,
-        updated, and tested.
-      levels:
-        - base
-      status: manual
-
-    - id: 12.10.3
-      title: Specific personnel are designated to be available on a 24/7 basis to respond to
-        suspected or confirmed security incidents.
-      description: |-
-        Incidents are responded to immediately where appropriate.
-      levels:
-        - base
-      status: manual
-
-    - id: 12.10.4
-      title: Personnel responsible for responding to suspected and confirmed security incidents
-        are appropriately and periodically trained on their incident response responsibilities.
-      description: |-
-        Personnel are knowledgeable about their role and responsibilities in incident response and
-        are able to access assistance and guidance when required.
-      levels:
-        - base
       status: manual
       controls:
-      - id: 12.10.4.1
-        title: The frequency of periodic training for incident response personnel is defined in
-          the entity's targeted risk analysis, which is performed according to all elements
-          specified in Requirement 12.3.1.
-        description: |-
-          Incident response personnel are trained at a frequency that addresses the entity's risk.
-          This requirement is a best practice until 31 March 2025, after which it will be required
-          and must be fully considered during a PCI DSS assessment.
-        levels:
+          - id: 12.8.1
+            title: A list of all third-party service providers (TPSPs) with which account data is shared
+                or that could affect the security of account data is maintained, including a description
+                for each of the services provided.
+            description: |-
+                Records are maintained of TPSPs and the services provided. The use of a PCI DSS compliant
+                TPSP does not make an entity PCI DSS compliant, nor does it remove the entit's
+                responsibility for its own PCI DSS compliance.
+            levels:
+                - base
+            status: manual
+
+          - id: 12.8.2
+            title: Written agreements with TPSPs are maintained
+            levels:
+                - base
+            status: manual
+
+          - id: 12.8.3
+            title: An established process is implemented for engaging TPSPs, including proper due diligence
+                prior to engagement.
+            description: |-
+                The capability, intent, and resources of a prospective TPSP to adequately protect account
+                data are assessed before the TPSP is engaged.
+            levels:
+                - base
+            status: manual
+
+          - id: 12.8.4
+            title: A program is implemented to monitor TPSPs' PCI DSS compliance status at least once
+                every 12 months.
+            description: |-
+                The PCI DSS compliance status of TPSPs is verified periodically. Where an entity has an
+                agreement with a TPSP for meeting PCI DSS requirements on behalf of the entity (for
+                example, via a firewall service), the entity must work with the TPSP to make sure the
+                applicable PCI DSS requirements are met. If the TPSP does not meet those applicable
+                PCI DSS requirements, then those requirements are also "not in place" for the entity.
+            levels:
+                - base
+            status: manual
+
+          - id: 12.8.5
+            title: Information is maintained about which PCI DSS requirements are managed by each TPSP,
+                which are managed by the entity, and any that are shared between the TPSP and the entity.
+            description: |-
+                Records detailing the PCI DSS requirements and related system components for which each
+                TPSP is solely or jointly responsible, are maintained and reviewed periodically.
+            levels:
+                - base
+            status: manual
+
+    - id: '12.9'
+      title: Third-party service providers (TPSPs) support their customers' PCI DSS compliance.
+      levels:
           - base
-        status: manual
-
-    - id: 12.10.5
-      title: The security incident response plan includes monitoring and responding to alerts from
-        security monitoring systems.
-      levels:
-        - base
       status: manual
-
-    - id: 12.10.6
-      title: The security incident response plan is modified and evolved according to lessons
-        learned and to incorporate industry developments.
-      description: |-
-        The effectiveness and accuracy of the incident response plan is reviewed and updated after
-        each invocation.
-      levels:
-        - base
-      status: manual
-
-    - id: 12.10.7
-      title: Incident response procedures are in place, to be initiated upon the detection of
-        stored PAN anywhere it is not expected.
-      levels:
-        - base
-      status: manual
-
-  - id: A1.1
-    title: Multi-tenant service providers protect and separate all customer environments and data.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: A1.1.1
-      title: Logical separation is implemented.
-      description: |-
-        - The provider cannot access its customers' environments without authorization.
-        - Customers cannot access the provider's environment without authorization.
-      levels:
-        - base
-      status: manual
-
-    - id: A1.1.2
-      title: Controls are implemented such that each customer only has permission to access its
-        own cardholder data and CDE.
-      description: |-
-        Customers cannot access other customers' environments.
-      levels:
-        - base
-      status: manual
-
-    - id: A1.1.3
-      title: Controls are implemented such that each customer can only access resources allocated
-        to them.
-      description: |-
-        Customers cannot impact resources allocated to other customers.
-      levels:
-        - base
-      status: manual
-
-    - id: A1.1.4
-      title: The effectiveness of logical separation controls used to separate customer
-        environments is confirmed at least once every six months via penetration testing.
-      description: |-
-        Segmentation of customer environments from other environments is periodically validated to
-        be effective. The testing of adequate separation between customers in a multi-tenant
-        service provider environment is in addition to the penetration tests specified in
-        Requirement 11.4.6. This requirement is a best practice until 31 March 2025, after which
-        it will be required and must be fully considered during a PCI DSS assessment.
-      levels:
-        - base
-      status: manual
-
-  - id: A1.2
-    title: Multi-tenant service providers facilitate logging and incident response for all
-      customers.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: A1.2.1
-      title: Audit log capability is enabled for each customer's environment that is consistent
-        with PCI DSS Requirement 10.
-      levels:
-        - base
-      status: manual
-
-    - id: A1.2.2
-      title: Processes or mechanisms are implemented to support and/or facilitate prompt forensic
-        investigations in the event of a suspected or confirmed security incident for any
-        customer.
-      description: |-
-        Forensic investigation is readily available to all customers in the event of a suspected
-        or confirmed security incident.
-      levels:
-        - base
-      status: manual
-
-    - id: A1.2.3
-      title: Processes or mechanisms are implemented for reporting and addressing suspected or
-        confirmed security incidents and vulnerabilities.
-      levels:
-        - base
-      status: manual
-
-  - id: A2.1
-    title: POI terminals using SSL and/or early TLS are confirmed as not susceptible to known
-      SSL/TLS exploits.
-    description: |-
-      Appendix A2: Additional PCI DSS Requirements for Entities Using SSL/Early TLS for
-      Card-Present POS POI Terminal Connections.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: A2.1.1
-      title: Where POS POI terminals at the merchant or payment acceptance location use SSL and/or
-        early TLS, the entity confirms the devices are not susceptible to any known exploits for
-        those protocols.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        Related to requirements 2.2.7 and 3.5.1.1.
-        Service level settings for web servers such as Apache and NGINX should also be checked.
-      related_rules:
-        - configure_openssl_crypto_policy
-        - configure_openssl_tls_crypto_policy
-        - harden_openssl_crypto_policy
-
-    - id: A2.1.2
-      title: 'Additional requirement for service providers only: All service providers with
-        existing connection points to POS POI terminals that use SSL and/or early TLS as defined
-        in A2.1 have a formal Risk Mitigation and Migration Plan in place.'
-      levels:
-        - base
-      status: manual
-
-    - id: A2.1.3
-      title: 'Additional requirement for service providers only: All service providers provide a
-        secure service offering.'
-      description: |-
-        This requirement is not eligible for the customized approach. This requirement applies
-        only when the entity being assessed is a service provider.
-      levels:
-        - base
-      status: manual
-
-  - id: A3.1
-    title: A PCI DSS compliance program is implemented.
-    description: |-
-      Appendix A3: Designated Entities Supplemental Validation (DESV)
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: A3.1.1
-      title: Responsibility is established by executive management for the protection of account
-        data and a PCI DSS compliance program.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        PCI DSS Reference: Requirement 12
-
-    - id: A3.1.2
-      title: A formal PCI DSS compliance program is in place.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        PCI DSS Reference: Requirements 1-12
-
-    - id: A3.1.3
-      title: PCI DSS compliance roles and responsibilities are specifically defined and formally
-        assigned to one or more personnel.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        PCI DSS Reference: Requirement 12
-
-    - id: A3.1.4
-      title: Up-to-date PCI DSS and/or information security training is provided at least once
-        every 12 months to personnel with PCI DSS compliance responsibilities (as identified in
-        A3.1.3).
-      levels:
-        - base
-      status: manual
-      notes: |-
-        PCI DSS Reference: Requirement 12
-
-  - id: A3.2
-    title: PCI DSS scope is documented and validated.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: A3.2.1
-      title: PCI DSS scope is documented and confirmed for accuracy at least once every three
-        months and upon significant changes to the in-scope environment.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        PCI DSS Reference: Scope of PCI DSS Requirements, Requirement 12.
-
-    - id: A3.2.2
-      title: PCI DSS scope impact for all changes to systems or networks is determined, including
-        additions of new systems and new network connections.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        PCI DSS Reference: Scope of PCI DSS Requirements; Requirements 1-12
       controls:
-      - id: A3.2.2.1
-        title: Upon completion of a change, all relevant PCI DSS requirements are confirmed to be
-          implemented on all new or changed systems and networks, and documentation is updated as
-          applicable.
-        levels:
+          - id: 12.9.1
+            title: |-
+                Additional requirement for service providers only: TPSPs provide written agreements to
+                customers that include acknowledgments that TPSPs are responsible for the security of
+                account data the TPSP possesses or otherwise stores, processes, or transmits on behalf of
+                the customer, or to the extent that the TPSP could impact the security of the customer's
+                cardholder data and/or sensitive authentication data.
+            description: |-
+                TPSPs formally acknowledge their security responsibilities to their customers. This
+                requirement applies only when the entity being assessed is a service provider. The exact
+                wording of an agreement will depend on the details of the service being provided, and the
+                responsibilities assigned to each party. The agreement does not have to include the exact
+                wording provided in this requirement.
+            levels:
+                - base
+            status: manual
+
+          - id: 12.9.2
+            title: |-
+                Additional requirement for service providers only: TPSPs support their customers' requests
+                for information to meet Requirements 12.8.4 and 12.8.5.
+            levels:
+                - base
+            status: manual
+
+    - id: '12.10'
+      title: Suspected and confirmed security incidents that could impact the CDE are responded to immediately.
+      levels:
           - base
-        status: manual
-        notes: |-
-          PCI DSS Reference: Scope of PCI DSS Requirements; Requirements 1-12
-
-    - id: A3.2.3
-      title: Changes to organizational structure result in a formal (internal) review of the
-        impact to PCI DSS scope and applicability of controls.
-      levels:
-        - base
       status: manual
-      notes: |-
-        PCI DSS Reference: Requirement 12
-
-    - id: A3.2.4
-      title: If segmentation is used, PCI DSS scope is confirmed.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        PCI DSS Reference: Requirement 11
-
-    - id: A3.2.5
-      title: A data-discovery methodology is implemented.
-      levels:
-        - base
-      status: manual
-      notes: |-
-        PCI DSS Reference: Scope of PCI DSS Requirements.
       controls:
-      - id: A3.2.5.1
-        title: Data discovery methods are confirmed.
-        levels:
-          - base
-        status: manual
-        notes: |-
-          PCI DSS Reference: Scope of PCI DSS Requirements.
+          - id: 12.10.1
+            title: An incident response plan exists and is ready to be activated in the event of a suspected
+                or confirmed security incident.
+            levels:
+                - base
+            status: manual
 
-      - id: A3.2.5.2
-        title: Response procedures are implemented to be initiated upon the detection of cleartext
-          PAN outside the CDE.
-        levels:
-          - base
-        status: manual
+          - id: 12.10.2
+            title: At least once every 12 months, the security incident response plan is reviewed, updated,
+                and tested.
+            levels:
+                - base
+            status: manual
 
-    - id: A3.2.6
-      title: Mechanisms are implemented for detecting and preventing cleartext PAN from leaving
-        the CDE via an unauthorized channel, method, or process.
+          - id: 12.10.3
+            title: Specific personnel are designated to be available on a 24/7 basis to respond to suspected
+                or confirmed security incidents.
+            description: |-
+                Incidents are responded to immediately where appropriate.
+            levels:
+                - base
+            status: manual
+
+          - id: 12.10.4
+            title: Personnel responsible for responding to suspected and confirmed security incidents
+                are appropriately and periodically trained on their incident response responsibilities.
+            description: |-
+                Personnel are knowledgeable about their role and responsibilities in incident response and
+                are able to access assistance and guidance when required.
+            levels:
+                - base
+            status: manual
+            controls:
+                - id: 12.10.4.1
+                  title: The frequency of periodic training for incident response personnel is defined
+                      in the entity's targeted risk analysis, which is performed according to all elements
+                      specified in Requirement 12.3.1.
+                  description: |-
+                      Incident response personnel are trained at a frequency that addresses the entity's risk.
+                      This requirement is a best practice until 31 March 2025, after which it will be required
+                      and must be fully considered during a PCI DSS assessment.
+                  levels:
+                      - base
+                  status: manual
+
+          - id: 12.10.5
+            title: The security incident response plan includes monitoring and responding to alerts from
+                security monitoring systems.
+            levels:
+                - base
+            status: manual
+
+          - id: 12.10.6
+            title: The security incident response plan is modified and evolved according to lessons learned
+                and to incorporate industry developments.
+            description: |-
+                The effectiveness and accuracy of the incident response plan is reviewed and updated after
+                each invocation.
+            levels:
+                - base
+            status: manual
+
+          - id: 12.10.7
+            title: Incident response procedures are in place, to be initiated upon the detection of stored
+                PAN anywhere it is not expected.
+            levels:
+                - base
+            status: manual
+
+    - id: A1.1
+      title: Multi-tenant service providers protect and separate all customer environments and data.
       levels:
-        - base
+          - base
       status: manual
-      notes: |-
-        PCI DSS Reference: Scope of PCI DSS Requirements, Requirement 12
       controls:
-      - id: A3.2.6.1
-        title: Response procedures are implemented to be initiated upon the detection of attempts
-          to remove cleartext PAN from the CDE via an unauthorized channel, method, or process.
-        levels:
-          - base
-        status: manual
-        notes: |-
-          PCI DSS Reference: Requirement 12
+          - id: A1.1.1
+            title: Logical separation is implemented.
+            description: |-
+                - The provider cannot access its customers' environments without authorization.
+                - Customers cannot access the provider's environment without authorization.
+            levels:
+                - base
+            status: manual
 
-  - id: A3.3
-    title: PCI DSS is incorporated into business-as-usual (BAU) activities.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: A3.3.1
-      title: Failures of critical security control systems are detected, alerted, and addressed
-        promptly.
+          - id: A1.1.2
+            title: Controls are implemented such that each customer only has permission to access its
+                own cardholder data and CDE.
+            description: |-
+                Customers cannot access other customers' environments.
+            levels:
+                - base
+            status: manual
+
+          - id: A1.1.3
+            title: Controls are implemented such that each customer can only access resources allocated
+                to them.
+            description: |-
+                Customers cannot impact resources allocated to other customers.
+            levels:
+                - base
+            status: manual
+
+          - id: A1.1.4
+            title: The effectiveness of logical separation controls used to separate customer environments
+                is confirmed at least once every six months via penetration testing.
+            description: |-
+                Segmentation of customer environments from other environments is periodically validated to
+                be effective. The testing of adequate separation between customers in a multi-tenant
+                service provider environment is in addition to the penetration tests specified in
+                Requirement 11.4.6. This requirement is a best practice until 31 March 2025, after which
+                it will be required and must be fully considered during a PCI DSS assessment.
+            levels:
+                - base
+            status: manual
+
+    - id: A1.2
+      title: Multi-tenant service providers facilitate logging and incident response for all customers.
       levels:
-        - base
+          - base
       status: manual
-      notes: |-
-          PCI DSS Reference: Requirement 12
       controls:
-      - id: A3.3.1.2
-        title: Failures of any critical security control systems are responded to promptly.
-        levels:
-          - base
-        status: manual
-        notes: |-
-          PCI DSS Reference: Requirements 1-12
-          If you noticed, this requirement should be A3.3.1.1 instead of A3.3.1.2 but it was kept
-          this way to be aligned to the policy.
+          - id: A1.2.1
+            title: Audit log capability is enabled for each customer's environment that is consistent
+                with PCI DSS Requirement 10.
+            levels:
+                - base
+            status: manual
 
-    - id: A3.3.2
-      title: Hardware and software technologies are reviewed at least once every 12 months to
-        confirm whether they continue to meet the organization's PCI DSS requirements.
-      levels:
-        - base
-      status: manual
-      notes: |-
-          PCI DSS Reference: Requirements 2, 6, 12.
+          - id: A1.2.2
+            title: Processes or mechanisms are implemented to support and/or facilitate prompt forensic
+                investigations in the event of a suspected or confirmed security incident for any customer.
+            description: |-
+                Forensic investigation is readily available to all customers in the event of a suspected
+                or confirmed security incident.
+            levels:
+                - base
+            status: manual
 
-    - id: A3.3.3
-      title: Reviews are performed at least once every three months to verify BAU activities are
-        being followed.
+          - id: A1.2.3
+            title: Processes or mechanisms are implemented for reporting and addressing suspected or
+                confirmed security incidents and vulnerabilities.
+            levels:
+                - base
+            status: manual
+
+    - id: A2.1
+      title: POI terminals using SSL and/or early TLS are confirmed as not susceptible to known SSL/TLS
+          exploits.
       description: |-
-        Reviews are performed by personnel assigned to the PCI DSS compliance program (as
-        identified in A3.1.3).
+          Appendix A2: Additional PCI DSS Requirements for Entities Using SSL/Early TLS for
+          Card-Present POS POI Terminal Connections.
       levels:
-        - base
+          - base
       status: manual
-      notes: |-
-          PCI DSS Reference: Requirements 1-12.
+      controls:
+          - id: A2.1.1
+            title: Where POS POI terminals at the merchant or payment acceptance location use SSL and/or
+                early TLS, the entity confirms the devices are not susceptible to any known exploits
+                for those protocols.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                Related to requirements 2.2.7 and 3.5.1.1.
+                Service level settings for web servers such as Apache and NGINX should also be checked.
+            related_rules:
+                - configure_openssl_crypto_policy
+                - configure_openssl_tls_crypto_policy
+                - harden_openssl_crypto_policy
 
-  - id: A3.4
-    title: Logical access to the cardholder data environment is controlled and managed.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: A3.4.1
-      title: User accounts and access privileges to in-scope system components are reviewed at
-        least once every six months to ensure user accounts and access privileges remain
-        appropriate based on job function, and that all access is authorized.
-      levels:
-        - base
-      status: manual
-      notes: |-
-          PCI DSS Reference: Requirement 7.
+          - id: A2.1.2
+            title: 'Additional requirement for service providers only: All service providers with existing
+                connection points to POS POI terminals that use SSL and/or early TLS as defined in A2.1
+                have a formal Risk Mitigation and Migration Plan in place.'
+            levels:
+                - base
+            status: manual
 
-  - id: A3.5
-    title: Suspicious events are identified and responded to.
-    levels:
-      - base
-    status: manual
-    controls:
-    - id: A3.5.1
-      title: A methodology is implemented for the prompt identification of attack patterns and
-        undesirable behavior across systems.
+          - id: A2.1.3
+            title: 'Additional requirement for service providers only: All service providers provide
+                a secure service offering.'
+            description: |-
+                This requirement is not eligible for the customized approach. This requirement applies
+                only when the entity being assessed is a service provider.
+            levels:
+                - base
+            status: manual
+
+    - id: A3.1
+      title: A PCI DSS compliance program is implemented.
+      description: |-
+          Appendix A3: Designated Entities Supplemental Validation (DESV)
       levels:
-        - base
+          - base
       status: manual
-      notes: |-
-        PCI DSS Reference: Requirement 10, 12.
+      controls:
+          - id: A3.1.1
+            title: Responsibility is established by executive management for the protection of account
+                data and a PCI DSS compliance program.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                PCI DSS Reference: Requirement 12
+
+          - id: A3.1.2
+            title: A formal PCI DSS compliance program is in place.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                PCI DSS Reference: Requirements 1-12
+
+          - id: A3.1.3
+            title: PCI DSS compliance roles and responsibilities are specifically defined and formally
+                assigned to one or more personnel.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                PCI DSS Reference: Requirement 12
+
+          - id: A3.1.4
+            title: Up-to-date PCI DSS and/or information security training is provided at least once
+                every 12 months to personnel with PCI DSS compliance responsibilities (as identified
+                in A3.1.3).
+            levels:
+                - base
+            status: manual
+            notes: |-
+                PCI DSS Reference: Requirement 12
+
+    - id: A3.2
+      title: PCI DSS scope is documented and validated.
+      levels:
+          - base
+      status: manual
+      controls:
+          - id: A3.2.1
+            title: PCI DSS scope is documented and confirmed for accuracy at least once every three months
+                and upon significant changes to the in-scope environment.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                PCI DSS Reference: Scope of PCI DSS Requirements, Requirement 12.
+
+          - id: A3.2.2
+            title: PCI DSS scope impact for all changes to systems or networks is determined, including
+                additions of new systems and new network connections.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                PCI DSS Reference: Scope of PCI DSS Requirements; Requirements 1-12
+            controls:
+                - id: A3.2.2.1
+                  title: Upon completion of a change, all relevant PCI DSS requirements are confirmed
+                      to be implemented on all new or changed systems and networks, and documentation
+                      is updated as applicable.
+                  levels:
+                      - base
+                  status: manual
+                  notes: |-
+                      PCI DSS Reference: Scope of PCI DSS Requirements; Requirements 1-12
+
+          - id: A3.2.3
+            title: Changes to organizational structure result in a formal (internal) review of the impact
+                to PCI DSS scope and applicability of controls.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                PCI DSS Reference: Requirement 12
+
+          - id: A3.2.4
+            title: If segmentation is used, PCI DSS scope is confirmed.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                PCI DSS Reference: Requirement 11
+
+          - id: A3.2.5
+            title: A data-discovery methodology is implemented.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                PCI DSS Reference: Scope of PCI DSS Requirements.
+            controls:
+                - id: A3.2.5.1
+                  title: Data discovery methods are confirmed.
+                  levels:
+                      - base
+                  status: manual
+                  notes: |-
+                      PCI DSS Reference: Scope of PCI DSS Requirements.
+
+                - id: A3.2.5.2
+                  title: Response procedures are implemented to be initiated upon the detection of cleartext
+                      PAN outside the CDE.
+                  levels:
+                      - base
+                  status: manual
+
+          - id: A3.2.6
+            title: Mechanisms are implemented for detecting and preventing cleartext PAN from leaving
+                the CDE via an unauthorized channel, method, or process.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                PCI DSS Reference: Scope of PCI DSS Requirements, Requirement 12
+            controls:
+                - id: A3.2.6.1
+                  title: Response procedures are implemented to be initiated upon the detection of attempts
+                      to remove cleartext PAN from the CDE via an unauthorized channel, method, or process.
+                  levels:
+                      - base
+                  status: manual
+                  notes: |-
+                      PCI DSS Reference: Requirement 12
+
+    - id: A3.3
+      title: PCI DSS is incorporated into business-as-usual (BAU) activities.
+      levels:
+          - base
+      status: manual
+      controls:
+          - id: A3.3.1
+            title: Failures of critical security control systems are detected, alerted, and addressed
+                promptly.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                PCI DSS Reference: Requirement 12
+            controls:
+                - id: A3.3.1.2
+                  title: Failures of any critical security control systems are responded to promptly.
+                  levels:
+                      - base
+                  status: manual
+                  notes: |-
+                      PCI DSS Reference: Requirements 1-12
+                      If you noticed, this requirement should be A3.3.1.1 instead of A3.3.1.2 but it was kept
+                      this way to be aligned to the policy.
+
+          - id: A3.3.2
+            title: Hardware and software technologies are reviewed at least once every 12 months to confirm
+                whether they continue to meet the organization's PCI DSS requirements.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                PCI DSS Reference: Requirements 2, 6, 12.
+
+          - id: A3.3.3
+            title: Reviews are performed at least once every three months to verify BAU activities are
+                being followed.
+            description: |-
+                Reviews are performed by personnel assigned to the PCI DSS compliance program (as
+                identified in A3.1.3).
+            levels:
+                - base
+            status: manual
+            notes: |-
+                PCI DSS Reference: Requirements 1-12.
+
+    - id: A3.4
+      title: Logical access to the cardholder data environment is controlled and managed.
+      levels:
+          - base
+      status: manual
+      controls:
+          - id: A3.4.1
+            title: User accounts and access privileges to in-scope system components are reviewed at
+                least once every six months to ensure user accounts and access privileges remain appropriate
+                based on job function, and that all access is authorized.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                PCI DSS Reference: Requirement 7.
+
+    - id: A3.5
+      title: Suspicious events are identified and responded to.
+      levels:
+          - base
+      status: manual
+      controls:
+          - id: A3.5.1
+            title: A methodology is implemented for the prompt identification of attack patterns and
+                undesirable behavior across systems.
+            levels:
+                - base
+            status: manual
+            notes: |-
+                PCI DSS Reference: Requirement 10, 12.

--- a/controls/stig_rhel8.yml
+++ b/controls/stig_rhel8.yml
@@ -1,3 +1,4 @@
+---
 policy: Red Hat Enterprise Linux 8 Security Technical Implementation Guide
 title: Red Hat Enterprise Linux 8 Security Technical Implementation Guide
 id: stig_rhel8
@@ -5,3310 +6,3213 @@ version: V2R3
 source: https://public.cyber.mil/stigs/downloads/
 reference_type: stigid
 product: rhel8
+
 levels:
-    -   id: high
-    -   id: medium
-    -   id: low
+    - id: high
+    - id: medium
+    - id: low
+
 controls:
-    -   id: needed_rules
-        title: 'Variables and needed rules'
-        levels:
-            - high
-            - medium
-            - low
-        rules:
+    - id: needed_rules
+      title: 'Variables and needed rules'
+      levels:
+          - high
+          - medium
+          - low
+      rules:
             # Variables
-            - var_rekey_limit_size=1G
-            - var_rekey_limit_time=1hour
-            - var_accounts_user_umask=077
-            - var_password_pam_difok=8
-            - var_password_pam_maxrepeat=3
-            - var_password_hashing_algorithm=SHA512
-            - var_password_hashing_algorithm_pam=sha512
-            - var_password_pam_maxclassrepeat=4
-            - var_password_pam_minclass=4
-            - var_accounts_minimum_age_login_defs=1
-            - var_accounts_max_concurrent_login_sessions=10
-            - var_password_pam_remember=5
-            - var_password_pam_remember_control_flag=requisite_or_required
-            - var_selinux_state=enforcing
-            - var_selinux_policy_name=targeted
-            - var_password_hashing_min_rounds_login_defs=100000
-            - var_password_pam_minlen=15
-            - var_password_pam_ocredit=1
-            - var_password_pam_dcredit=1
-            - var_password_pam_dictcheck=1
-            - var_password_pam_ucredit=1
-            - var_password_pam_lcredit=1
-            - var_password_pam_retry=3
-            - var_password_pam_minlen=15
-            - var_sshd_set_keepalive=1
-            - sshd_approved_macs=stig_extended
-            - sshd_approved_ciphers=stig_extended
-            - sshd_idle_timeout_value=10_minutes
-            - var_accounts_authorized_local_users_regex=rhel8
-            - var_accounts_passwords_pam_faillock_deny=3
-            - var_accounts_passwords_pam_faillock_fail_interval=900
-            - var_accounts_passwords_pam_faillock_unlock_time=never
-            - var_ssh_client_rekey_limit_size=1G
-            - var_ssh_client_rekey_limit_time=1hour
-            - var_accounts_fail_delay=4
-            - var_account_disable_post_pw_expiration=35
-            - var_auditd_action_mail_acct=root
-            - var_time_service_set_maxpoll=18_hours
-            - var_accounts_maximum_age_login_defs=60
-            - var_auditd_space_left_percentage=25pc
-            - var_auditd_space_left_action=email
-            - var_auditd_disk_error_action=rhel8
-            - var_auditd_max_log_file_action=syslog
-            - var_auditd_disk_full_action=rhel8
-            - var_sssd_certificate_verification_digest_function=sha1
-            - login_banner_text=dod_banners
-            - var_authselect_profile=sssd
-            - var_multiple_time_servers=stig
-            - var_time_service_set_maxpoll=18_hours
+          - var_rekey_limit_size=1G
+          - var_rekey_limit_time=1hour
+          - var_accounts_user_umask=077
+          - var_password_pam_difok=8
+          - var_password_pam_maxrepeat=3
+          - var_password_hashing_algorithm=SHA512
+          - var_password_hashing_algorithm_pam=sha512
+          - var_password_pam_maxclassrepeat=4
+          - var_password_pam_minclass=4
+          - var_accounts_minimum_age_login_defs=1
+          - var_accounts_max_concurrent_login_sessions=10
+          - var_password_pam_remember=5
+          - var_password_pam_remember_control_flag=requisite_or_required
+          - var_selinux_state=enforcing
+          - var_selinux_policy_name=targeted
+          - var_password_hashing_min_rounds_login_defs=100000
+          - var_password_pam_minlen=15
+          - var_password_pam_ocredit=1
+          - var_password_pam_dcredit=1
+          - var_password_pam_dictcheck=1
+          - var_password_pam_ucredit=1
+          - var_password_pam_lcredit=1
+          - var_password_pam_retry=3
+          - var_password_pam_minlen=15
+          - var_sshd_set_keepalive=1
+          - sshd_approved_macs=stig_extended
+          - sshd_approved_ciphers=stig_extended
+          - sshd_idle_timeout_value=10_minutes
+          - var_accounts_authorized_local_users_regex=rhel8
+          - var_accounts_passwords_pam_faillock_deny=3
+          - var_accounts_passwords_pam_faillock_fail_interval=900
+          - var_accounts_passwords_pam_faillock_unlock_time=never
+          - var_ssh_client_rekey_limit_size=1G
+          - var_ssh_client_rekey_limit_time=1hour
+          - var_accounts_fail_delay=4
+          - var_account_disable_post_pw_expiration=35
+          - var_auditd_action_mail_acct=root
+          - var_time_service_set_maxpoll=18_hours
+          - var_accounts_maximum_age_login_defs=60
+          - var_auditd_space_left_percentage=25pc
+          - var_auditd_space_left_action=email
+          - var_auditd_disk_error_action=rhel8
+          - var_auditd_max_log_file_action=syslog
+          - var_auditd_disk_full_action=rhel8
+          - var_sssd_certificate_verification_digest_function=sha1
+          - login_banner_text=dod_banners
+          - var_authselect_profile=sssd
+          - var_multiple_time_servers=stig
+          - var_time_service_set_maxpoll=18_hours
             # Enable / Configure FIPS
-            - enable_fips_mode
-            - var_system_crypto_policy=fips
-            - configure_crypto_policy
-            - configure_bind_crypto_policy
-            - configure_libreswan_crypto_policy
-            - configure_kerberos_crypto_policy
-            - enable_dracut_fips_module
+          - enable_fips_mode
+          - var_system_crypto_policy=fips
+          - configure_crypto_policy
+          - configure_bind_crypto_policy
+          - configure_libreswan_crypto_policy
+          - configure_kerberos_crypto_policy
+          - enable_dracut_fips_module
             # Other needed rules
-            - enable_authselect
-
-
-    -   id: RHEL-08-010000
-        levels:
-            - high
-        title: RHEL 8 must be a vendor-supported release.
-        rules:
-            - installed_OS_is_vendor_supported
-        status: automated
-
-    -   id: RHEL-08-010010
-        levels:
-            - medium
-        title: RHEL 8 vendor packaged system security patches and updates must be installed
-            and up to date.
-        rules:
-            - security_patches_up_to_date
-        status: automated
-
-    -   id: RHEL-08-010020
-        levels:
-            - high
-        title: 'RHEL 8 must implement NIST FIPS-validated cryptography for the following:
-    To provision digital signatures, to generate cryptographic hashes, and to protect
-    data requiring data-at-rest protections in accordance with applicable federal
-    laws, Executive Orders, directives, policies, regulations, and standards.'
-        rules:
-            - configure_bind_crypto_policy
-            - configure_crypto_policy
-            - configure_kerberos_crypto_policy
-            - configure_libreswan_crypto_policy
-            - enable_dracut_fips_module
-            - enable_fips_mode
-            - fips_crypto_subpolicy
-            - harden_sshd_ciphers_openssh_conf_crypto_policy
-            - harden_sshd_macs_openssh_conf_crypto_policy
-            - sysctl_crypto_fips_enabled
-        status: automated
-
-    -   id: RHEL-08-010030
-        levels:
-            - high
-        title: All RHEL 8 local disk partitions must implement cryptographic mechanisms
-            to prevent unauthorized disclosure or modification of all information that requires
-            at rest protection.
-        rules:
-            - encrypt_partitions
-        status: automated
-
-    -   id: RHEL-08-010040
-        levels:
-            - medium
-        title: RHEL 8 must display the Standard Mandatory DOD Notice and Consent Banner
-            before granting local or remote access to the system via a ssh logon.
-        rules:
-            - sshd_enable_warning_banner
-        status: automated
-
-    -   id: RHEL-08-010050
-        levels:
-            - medium
-        title: RHEL 8 must display the Standard Mandatory DoD Notice and Consent Banner
-            before granting local or remote access to the system via a graphical user logon.
-        rules:
-            - dconf_gnome_login_banner_text
-        status: automated
-
-    -   id: RHEL-08-010060
-        levels:
-            - medium
-        title: RHEL 8 must display the Standard Mandatory DoD Notice and Consent Banner
-            before granting local or remote access to the system via a command line user logon.
-        rules:
-            - banner_etc_issue
-        status: automated
-
-    -   id: RHEL-08-010070
-        levels:
-            - medium
-        title: All RHEL 8 remote access methods must be monitored.
-        rules:
-            - rsyslog_remote_access_monitoring
-        status: automated
-
-    -   id: RHEL-08-010090
-        levels:
-            - medium
-        title: RHEL 8, for PKI-based authentication, must validate certificates by constructing
-            a certification path (which includes status information) to an accepted trust
-            anchor.
-        rules:
-            - sssd_has_trust_anchor
-        status: automated
-
-    -   id: RHEL-08-010100
-        levels:
-            - medium
-        title: RHEL 8, for certificate-based authentication, must enforce authorized access
-            to the corresponding private key.
-        rules:
-            - ssh_keys_passphrase_protected
-        status: automated
-
-    -   id: RHEL-08-010110
-        levels:
-            - medium
-        title: RHEL 8 must encrypt all stored passwords with a FIPS 140-2 approved cryptographic
-            hashing algorithm.
-        rules:
-            - set_password_hashing_algorithm_logindefs
-        status: automated
-
-    -   id: RHEL-08-010120
-        levels:
-            - medium
-        title: RHEL 8 must employ FIPS 140-2 approved cryptographic hashing algorithms for
-            all stored passwords.
-        rules:
-            - accounts_password_all_shadowed_sha512
-        status: automated
-
-    -   id: RHEL-08-010130
-        levels:
-            - medium
-        title: The RHEL 8 shadow password suite must be configured to use a sufficient number
-            of hashing rounds.
-        rules:
-            - set_password_hashing_min_rounds_logindefs
-        status: automated
-
-    -   id: RHEL-08-010140
-        levels:
-            - high
-        title: RHEL 8 operating systems booted with United Extensible Firmware Interface
-            (UEFI) must require authentication upon booting into single-user mode and maintenance.
-        rules:
-            - grub2_uefi_password
-        status: automated
-
-    -   id: RHEL-08-010150
-        levels:
-            - high
-        title: RHEL 8 operating systems booted with a BIOS must require authentication upon
-            booting into single-user and maintenance modes.
-        rules:
-            - grub2_password
-        status: automated
-
-    -   id: RHEL-08-010151
-        levels:
-            - medium
-        title: RHEL 8 operating systems must require authentication upon booting into rescue
-            mode.
-        rules:
-            - require_singleuser_auth
-        status: automated
-
-    -   id: RHEL-08-010160
-        levels:
-            - medium
-        title: The RHEL 8 pam_unix.so module must be configured in the password-auth file
-            to use a FIPS 140-2 approved cryptographic hashing algorithm for system authentication.
-        rules:
-            - set_password_hashing_algorithm_passwordauth
-        status: automated
-
-    -   id: RHEL-08-010161
-        levels:
-            - medium
-        title: RHEL 8 must prevent system daemons from using Kerberos for authentication.
-        rules:
-            - kerberos_disable_no_keytab
-        status: automated
-
-    -   id: RHEL-08-010162
-        levels:
-            - medium
-        title: The krb5-workstation package must not be installed on RHEL 8.
-        rules:
-            - package_krb5-workstation_removed
-        status: automated
-
-    -   id: RHEL-08-010170
-        levels:
-            - medium
-        title: RHEL 8 must use a Linux Security Module configured to enforce limits on system
-            services.
-        rules:
-            - selinux_state
-        status: automated
-
-    -   id: RHEL-08-010171
-        levels:
-            - low
-        title: RHEL 8 must have policycoreutils package installed.
-        rules:
-            - package_policycoreutils_installed
-        status: automated
-
-    -   id: RHEL-08-010190
-        levels:
-            - medium
-        title: A sticky bit must be set on all RHEL 8 public directories to prevent unauthorized
-            and unintended information transferred via shared system resources.
-        rules:
-            - dir_perms_world_writable_sticky_bits
-        status: automated
-
-    -   id: RHEL-08-010200
-        levels:
-            - medium
-        title: RHEL 8 must be configured so that all network connections associated with
-            SSH traffic terminate after becoming unresponsive.
-        rules:
-            - sshd_set_keepalive
-        status: automated
-
-    -   id: RHEL-08-010210
-        levels:
-            - medium
-        title: The RHEL 8 /var/log/messages file must have mode 0640 or less permissive.
-        rules:
-            - file_permissions_var_log_messages
-        status: automated
-
-    -   id: RHEL-08-010220
-        levels:
-            - medium
-        title: The RHEL 8 /var/log/messages file must be owned by root.
-        rules:
-            - file_owner_var_log_messages
-        status: automated
-
-    -   id: RHEL-08-010230
-        levels:
-            - medium
-        title: The RHEL 8 /var/log/messages file must be group-owned by root.
-        rules:
-            - file_groupowner_var_log_messages
-        status: automated
-
-    -   id: RHEL-08-010240
-        levels:
-            - medium
-        title: The RHEL 8 /var/log directory must have mode 0755 or less permissive.
-        rules:
-            - file_permissions_var_log
-        status: automated
-
-    -   id: RHEL-08-010250
-        levels:
-            - medium
-        title: The RHEL 8 /var/log directory must be owned by root.
-        rules:
-            - file_owner_var_log
-        status: automated
-
-    -   id: RHEL-08-010260
-        levels:
-            - medium
-        title: The RHEL 8 /var/log directory must be group-owned by root.
-        rules:
-            - file_groupowner_var_log
-        status: automated
-
-    -   id: RHEL-08-010290
-        levels:
-            - medium
-        title: The RHEL 8 SSH server must be configured to use only Message Authentication
-            Codes (MACs) employing FIPS 140-3 validated cryptographic hash algorithms.
-        rules:
-            - harden_sshd_macs_opensshserver_conf_crypto_policy
-        status: automated
-
-    -   id: RHEL-08-010291
-        levels:
-            - medium
-        title: The RHEL 8 operating system must implement DOD-approved encryption to protect
-            the confidentiality of SSH server connections.
-        rules:
-            - harden_sshd_ciphers_opensshserver_conf_crypto_policy
-        status: automated
-
-    -   id: RHEL-08-010292
-        levels:
-            - low
-        title: RHEL 8 must ensure the SSH server uses strong entropy.
-        rules:
-            - sshd_use_strong_rng
-        status: automated
-
-    -   id: RHEL-08-010293
-        levels:
-            - medium
-        title: The RHEL 8 operating system must implement DoD-approved encryption in the
-            OpenSSL package.
-        rules:
-            - configure_openssl_crypto_policy
-        status: automated
-
-    -   id: RHEL-08-010294
-        levels:
-            - medium
-        title: The RHEL 8 operating system must implement DoD-approved TLS encryption in
-            the OpenSSL package.
-        rules:
-            - configure_openssl_tls_crypto_policy
-        status: automated
-
-    -   id: RHEL-08-010295
-        levels:
-            - medium
-        title: The RHEL 8 operating system must implement DoD-approved TLS encryption in
-            the GnuTLS package.
-        rules:
-            - configure_gnutls_tls_crypto_policy
-        status: automated
-
-    -   id: RHEL-08-010300
-        levels:
-            - medium
-        title: RHEL 8 system commands must have mode 755 or less permissive.
-        rules:
-            - file_permissions_binary_dirs
-        status: automated
-
-    -   id: RHEL-08-010310
-        levels:
-            - medium
-        title: RHEL 8 system commands must be owned by root.
-        rules:
-            - file_ownership_binary_dirs
-        status: automated
-
-    -   id: RHEL-08-010320
-        levels:
-            - medium
-        title: RHEL 8 system commands must be group-owned by root or a system account.
-        rules:
-            - file_groupownership_system_commands_dirs
-        status: automated
-
-    -   id: RHEL-08-010330
-        levels:
-            - medium
-        title: RHEL 8 library files must have mode 755 or less permissive.
-        rules:
-            - file_permissions_library_dirs
-        status: automated
-
-    -   id: RHEL-08-010340
-        levels:
-            - medium
-        title: RHEL 8 library files must be owned by root.
-        rules:
-            - file_ownership_library_dirs
-        status: automated
-
-    -   id: RHEL-08-010350
-        levels:
-            - medium
-        title: RHEL 8 library files must be group-owned by root or a system account.
-        rules:
-            - root_permissions_syslibrary_files
-        status: automated
-
-    -   id: RHEL-08-010360
-        levels:
-            - medium
-        title: The RHEL 8 file integrity tool must notify the system administrator when
-            changes to the baseline configuration or anomalies in the operation of any security
-            functions are discovered within an organizationally defined frequency.
-        rules:
-            - aide_scan_notification
-        status: automated
-
-    -   id: RHEL-08-010370
-        levels:
-            - high
-        title: RHEL 8 must prevent the installation of software, patches, service packs,
-            device drivers, or operating system components from a repository without verification
-            they have been digitally signed using a certificate that is issued by a Certificate
-            Authority (CA) that is recognized and approved by the organization.
-        rules:
-            - enable_gpgcheck_for_all_repositories
-        status: automated
-
-    -   id: RHEL-08-010371
-        levels:
-            - high
-        title: RHEL 8 must prevent the installation of software, patches, service packs,
-            device drivers, or operating system components of local packages without verification
-            they have been digitally signed using a certificate that is issued by a Certificate
-            Authority (CA) that is recognized and approved by the organization.
-        rules:
-            - ensure_gpgcheck_local_packages
-        status: automated
-
-    -   id: RHEL-08-010372
-        levels:
-            - medium
-        title: RHEL 8 must prevent the loading of a new kernel for later execution.
-        rules:
-            - sysctl_kernel_kexec_load_disabled
-        status: automated
-
-    -   id: RHEL-08-010373
-        levels:
-            - medium
-        title: RHEL 8 must enable kernel parameters to enforce discretionary access control
-            on symlinks.
-        rules:
-            - sysctl_fs_protected_symlinks
-        status: automated
-
-    -   id: RHEL-08-010374
-        levels:
-            - medium
-        title: RHEL 8 must enable kernel parameters to enforce discretionary access control
-            on hardlinks.
-        rules:
-            - sysctl_fs_protected_hardlinks
-        status: automated
-
-    -   id: RHEL-08-010375
-        levels:
-            - low
-        title: RHEL 8 must restrict access to the kernel message buffer.
-        rules:
-            - sysctl_kernel_dmesg_restrict
-        status: automated
-
-    -   id: RHEL-08-010376
-        levels:
-            - low
-        title: RHEL 8 must prevent kernel profiling by unprivileged users.
-        rules:
-            - sysctl_kernel_perf_event_paranoid
-        status: automated
-
-    -   id: RHEL-08-010380
-        levels:
-            - medium
-        title: RHEL 8 must require users to provide a password for privilege escalation.
-        rules:
-            - sudo_remove_nopasswd
-        status: automated
-
-    -   id: RHEL-08-010381
-        levels:
-            - medium
-        title: RHEL 8 must require users to reauthenticate for privilege escalation.
-        rules:
-            - sudo_remove_no_authenticate
-        status: automated
-
-    -   id: RHEL-08-010390
-        levels:
-            - medium
-        title: RHEL 8 must have the packages required for multifactor authentication installed.
-        rules:
-            - install_smartcard_packages
-        status: automated
-
-    -   id: RHEL-08-010400
-        levels:
-            - medium
-        title: RHEL 8 must implement certificate status checking for multifactor authentication.
-        rules:
-            - sssd_certificate_verification
-        status: automated
-
-    -   id: RHEL-08-010410
-        levels:
-            - medium
-        title: RHEL 8 must accept Personal Identity Verification (PIV) credentials.
-        rules:
-            - package_opensc_installed
-        status: automated
-
-    -   id: RHEL-08-010420
-        levels:
-            - medium
-        title: RHEL 8 must implement non-executable data to protect its memory from unauthorized
-            code execution.
-        rules:
-            - bios_enable_execution_restrictions
-        status: automated
-
-    -   id: RHEL-08-010421
-        levels:
-            - medium
-        title: RHEL 8 must clear the page allocator to prevent use-after-free attacks.
-        rules:
-            - grub2_page_poison_argument
-        status: automated
-
-    -   id: RHEL-08-010422
-        levels:
-            - medium
-        title: RHEL 8 must disable virtual syscalls.
-        rules:
-            - grub2_vsyscall_argument
-        status: automated
-
-    -   id: RHEL-08-010423
-        levels:
-            - medium
-        title: RHEL 8 must clear memory when it is freed to prevent use-after-free attacks.
-        rules:
-            - grub2_init_on_free
-        status: automated
-
-    -   id: RHEL-08-010430
-        levels:
-            - medium
-        title: RHEL 8 must implement address space layout randomization (ASLR) to protect
-            its memory from unauthorized code execution.
-        rules:
-            - sysctl_kernel_randomize_va_space
-        status: automated
-
-    -   id: RHEL-08-010440
-        levels:
-            - low
-        title: YUM must remove all software components after updated versions have been
-            installed on RHEL 8.
-        rules:
-            - clean_components_post_updating
-        status: automated
-
-    -   id: RHEL-08-010450
-        levels:
-            - medium
-        title: RHEL 8 must enable the SELinux targeted policy.
-        rules:
-            - selinux_policytype
-        status: automated
-
-    -   id: RHEL-08-010460
-        levels:
-            - high
-        title: There must be no shosts.equiv files on the RHEL 8 operating system.
-        rules:
-            - no_host_based_files
-        status: automated
-
-    -   id: RHEL-08-010470
-        levels:
-            - high
-        title: There must be no .shosts files on the RHEL 8 operating system.
-        rules:
-            - no_user_host_based_files
-        status: automated
-
-    -   id: RHEL-08-010471
-        levels:
-            - low
-        title: RHEL 8 must enable the hardware random number generator entropy gatherer
-            service.
-        rules:
-            - service_rngd_enabled
-        status: automated
-
-    -   id: RHEL-08-010480
-        levels:
-            - medium
-        title: The RHEL 8 SSH public host key files must have mode 0644 or less permissive.
-        rules:
-            - file_permissions_sshd_pub_key
-        status: automated
-
-    -   id: RHEL-08-010490
-        levels:
-            - medium
-        title: The RHEL 8 SSH private host key files must have mode 0640 or less permissive.
-        rules:
-            - file_permissions_sshd_private_key
-        status: automated
-
-    -   id: RHEL-08-010500
-        levels:
-            - medium
-        title: The RHEL 8 SSH daemon must perform strict mode checking of home directory
-            configuration files.
-        rules:
-            - sshd_enable_strictmodes
-        status: automated
-
-    -   id: RHEL-08-010520
-        levels:
-            - medium
-        title: "The RHEL 8 SSH daemon must not allow authentication using known host\u2019\
-    s authentication."
-        rules:
-            - sshd_disable_user_known_hosts
-        status: automated
-
-    -   id: RHEL-08-010521
-        levels:
-            - medium
-        title: The RHEL 8 SSH daemon must not allow Kerberos authentication, except to fulfill
-            documented and validated mission requirements.
-        rules:
-            - sshd_disable_kerb_auth
-        status: automated
-
-    -   id: RHEL-08-010540
-        levels:
-            - low
-        title: RHEL 8 must use a separate file system for /var.
-        rules:
-            - partition_for_var
-        status: automated
-
-    -   id: RHEL-08-010541
-        levels:
-            - low
-        title: RHEL 8 must use a separate file system for /var/log.
-        rules:
-            - partition_for_var_log
-        status: automated
-
-    -   id: RHEL-08-010542
-        levels:
-            - low
-        title: RHEL 8 must use a separate file system for the system audit data path.
-        rules:
-            - partition_for_var_log_audit
-        status: automated
-
-    -   id: RHEL-08-010543
-        levels:
-            - medium
-        title: A separate RHEL 8 filesystem must be used for the /tmp directory.
-        rules:
-            - partition_for_tmp
-        status: automated
-
-    -   id: RHEL-08-010550
-        levels:
-            - medium
-        title: RHEL 8 must not permit direct logons to the root account using remote access
-            via SSH.
-        rules:
-            - sshd_disable_root_login
-        status: automated
-
-    -   id: RHEL-08-010561
-        levels:
-            - medium
-        title: The rsyslog service must be running in RHEL 8.
-        rules:
-            - service_rsyslog_enabled
-        status: automated
-
-    -   id: RHEL-08-010570
-        levels:
-            - medium
-        title: RHEL 8 must prevent files with the setuid and setgid bit set from being executed
-            on file systems that contain user home directories.
-        rules:
-            - mount_option_home_nosuid
-        status: automated
-
-    -   id: RHEL-08-010571
-        levels:
-            - medium
-        title: RHEL 8 must prevent files with the setuid and setgid bit set from being executed
-            on the /boot directory.
-        rules:
-            - mount_option_boot_nosuid
-        status: automated
-
-    -   id: RHEL-08-010580
-        levels:
-            - medium
-        title: RHEL 8 must prevent special devices on non-root local partitions.
-        rules:
-            - mount_option_nodev_nonroot_local_partitions
-        status: automated
-
-    -   id: RHEL-08-010590
-        levels:
-            - medium
-        title: RHEL 8 must prevent code from being executed on file systems that contain
-            user home directories.
-        rules:
-            - mount_option_home_noexec
-        status: automated
-
-    -   id: RHEL-08-010600
-        levels:
-            - medium
-        title: RHEL 8 must prevent special devices on file systems that are used with removable
-            media.
-        rules:
-            - mount_option_nodev_removable_partitions
-        status: automated
-
-    -   id: RHEL-08-010610
-        levels:
-            - medium
-        title: RHEL 8 must prevent code from being executed on file systems that are used
-            with removable media.
-        rules:
-            - mount_option_noexec_removable_partitions
-        status: automated
-
-    -   id: RHEL-08-010620
-        levels:
-            - medium
-        title: RHEL 8 must prevent files with the setuid and setgid bit set from being executed
-            on file systems that are used with removable media.
-        rules:
-            - mount_option_nosuid_removable_partitions
-        status: automated
-
-    -   id: RHEL-08-010630
-        levels:
-            - medium
-        title: RHEL 8 must prevent code from being executed on file systems that are imported
-            via Network File System (NFS).
-        rules:
-            - mount_option_noexec_remote_filesystems
-        status: automated
-
-    -   id: RHEL-08-010640
-        levels:
-            - medium
-        title: RHEL 8 must prevent special devices on file systems that are imported via
-            Network File System (NFS).
-        rules:
-            - mount_option_nodev_remote_filesystems
-        status: automated
-
-    -   id: RHEL-08-010650
-        levels:
-            - medium
-        title: RHEL 8 must prevent files with the setuid and setgid bit set from being executed
-            on file systems that are imported via Network File System (NFS).
-        rules:
-            - mount_option_nosuid_remote_filesystems
-        status: automated
-
-    -   id: RHEL-08-010660
-        levels:
-            - medium
-        title: Local RHEL 8 initialization files must not execute world-writable programs.
-        rules:
-            - accounts_user_dot_no_world_writable_programs
-        status: automated
-
-    -   id: RHEL-08-010670
-        levels:
-            - medium
-        title: RHEL 8 must disable kernel dumps unless needed.
-        rules:
-            - service_kdump_disabled
-        status: automated
-
-    -   id: RHEL-08-010671
-        levels:
-            - medium
-        title: RHEL 8 must disable the kernel.core_pattern.
-        rules:
-            - sysctl_kernel_core_pattern
-        status: automated
-
-    -   id: RHEL-08-010672
-        levels:
-            - medium
-        title: RHEL 8 must disable acquiring, saving, and processing core dumps.
-        rules:
-            - service_systemd-coredump_disabled
-        status: automated
-
-    -   id: RHEL-08-010673
-        levels:
-            - medium
-        title: RHEL 8 must disable core dumps for all users.
-        rules:
-            - disable_users_coredumps
-        status: automated
-
-    -   id: RHEL-08-010674
-        levels:
-            - medium
-        title: RHEL 8 must disable storing core dumps.
-        rules:
-            - coredump_disable_storage
-        status: automated
-
-    -   id: RHEL-08-010675
-        levels:
-            - medium
-        title: RHEL 8 must disable core dump backtraces.
-        rules:
-            - coredump_disable_backtraces
-        status: automated
-
-    -   id: RHEL-08-010680
-        levels:
-            - medium
-        title: For RHEL 8 systems using Domain Name Servers (DNS) resolution, at least two
-            name servers must be configured.
-        rules:
-            - network_configure_name_resolution
-        status: automated
-
-    -   id: RHEL-08-010690
-        levels:
-            - medium
-        title: Executable search paths within the initialization files of all local interactive
-            RHEL 8 users must only contain paths that resolve to the system default or the
-            users home directory.
-        rules:
-            - accounts_user_home_paths_only
-        status: automated
-
-    -   id: RHEL-08-010700
-        levels:
-            - medium
-        title: All RHEL 8 world-writable directories must be owned by root, sys, bin, or
-            an application user.
-        rules:
-            - dir_perms_world_writable_root_owned
-        status: automated
-
-    -   id: RHEL-08-010710
-        levels:
-            - medium
-        title: All RHEL 8 world-writable directories must be group-owned by root, sys, bin,
-            or an application group.
-        rules:
-            - dir_perms_world_writable_system_owned_group
-        status: automated
-
-    -   id: RHEL-08-010720
-        levels:
-            - medium
-        title: All RHEL 8 local interactive users must have a home directory assigned in
-            the /etc/passwd file.
-        rules:
-            - accounts_user_interactive_home_directory_defined
-        status: automated
-
-    -   id: RHEL-08-010730
-        levels:
-            - medium
-        title: All RHEL 8 local interactive user home directories must have mode 0750 or
-            less permissive.
-        rules:
-            - file_permissions_home_directories
-        status: automated
-
-    -   id: RHEL-08-010740
-        levels:
-            - medium
-        title: "All RHEL 8 local interactive user home directories must be group-owned by\
-    \ the home directory owner\u2019s primary group."
-        rules:
-            - file_groupownership_home_directories
-        status: automated
-
-    -   id: RHEL-08-010750
-        levels:
-            - medium
-        title: All RHEL 8 local interactive user home directories defined in the /etc/passwd
-            file must exist.
-        rules:
-            - accounts_user_interactive_home_directory_exists
-        status: automated
-
-    -   id: RHEL-08-010760
-        levels:
-            - medium
-        title: All RHEL 8 local interactive user accounts must be assigned a home directory
-            upon creation.
-        rules:
-            - accounts_have_homedir_login_defs
-        status: automated
-
-    -   id: RHEL-08-010770
-        levels:
-            - medium
-        title: All RHEL 8 local initialization files must have mode 0740 or less permissive.
-        rules:
-            - file_permission_user_init_files_root
-            - rootfiles_configured
-            - var_user_initialization_files_regex=all_dotfiles
-        status: automated
-
-    -   id: RHEL-08-010780
-        levels:
-            - medium
-        title: All RHEL 8 local files and directories must have a valid owner.
-        rules:
-            - no_files_unowned_by_user
-        status: automated
-
-    -   id: RHEL-08-010790
-        levels:
-            - medium
-        title: All RHEL 8 local files and directories must have a valid group owner.
-        rules:
-            - file_permissions_ungroupowned
-        status: automated
-
-    -   id: RHEL-08-010800
-        levels:
-            - medium
-        title: A separate RHEL 8 filesystem must be used for user home directories (such
-            as /home or an equivalent).
-        rules:
-            - partition_for_home
-        status: automated
-
-    -   id: RHEL-08-010820
-        levels:
-            - high
-        title: Unattended or automatic logon via the RHEL 8 graphical user interface must
-            not be allowed.
-        rules:
-            - gnome_gdm_disable_automatic_login
-        status: automated
-
-    -   id: RHEL-08-010830
-        levels:
-            - medium
-        title: RHEL 8 must not allow users to override SSH environment variables.
-        rules:
-            - sshd_do_not_permit_user_env
-        status: automated
-
-    -   id: RHEL-08-020000
-        levels:
-            - medium
-        title: RHEL 8 temporary user accounts must be provisioned with an expiration time
-            of 72 hours or less.
-        rules:
-            - account_temp_expire_date
-        status: automated
-
-    -   id: RHEL-08-020010
-        levels:
-            - medium
-        title: RHEL 8 must automatically lock an account when three unsuccessful logon attempts
-            occur.
-        rules: [ ]
-        status: pending
-
-    -   id: RHEL-08-020011
-        levels:
-            - medium
-        title: RHEL 8 must automatically lock an account when three unsuccessful logon attempts
-            occur.
-        rules:
-            - accounts_passwords_pam_faillock_deny
-        status: automated
-
-    -   id: RHEL-08-020012
-        levels:
-            - medium
-        title: RHEL 8 must automatically lock an account when three unsuccessful logon attempts
-            occur during a 15-minute time period.
-        rules:
-            - accounts_passwords_pam_faillock_interval
-        status: automated
-
-    -   id: RHEL-08-020013
-        levels:
-            - medium
-        title: RHEL 8 must automatically lock an account when three unsuccessful logon attempts
-            occur during a 15-minute time period.
-        rules:
-            - accounts_passwords_pam_faillock_interval
-        status: automated
-
-    -   id: RHEL-08-020014
-        levels:
-            - medium
-        title: RHEL 8 must automatically lock an account until the locked account is released
-            by an administrator when three unsuccessful logon attempts occur during a 15-minute
-            time period.
-        rules:
-            - accounts_passwords_pam_faillock_unlock_time
-        status: automated
-
-    -   id: RHEL-08-020015
-        levels:
-            - medium
-        title: RHEL 8 must automatically lock an account until the locked account is released
-            by an administrator when three unsuccessful logon attempts occur during a 15-minute
-            time period.
-        rules:
-            - accounts_passwords_pam_faillock_unlock_time
-        status: automated
-
-    -   id: RHEL-08-020016
-        levels:
-            - medium
-        title: RHEL 8 must ensure account lockouts persist.
-        rules:
-            - accounts_passwords_pam_faillock_dir
-        status: automated
-
-    -   id: RHEL-08-020017
-        levels:
-            - medium
-        title: RHEL 8 must ensure account lockouts persist.
-        rules:
-            - accounts_passwords_pam_faillock_dir
-        status: automated
-
-    -   id: RHEL-08-020018
-        levels:
-            - medium
-        title: RHEL 8 must prevent system messages from being presented when three unsuccessful
-            logon attempts occur.
-        rules:
-            - accounts_passwords_pam_faillock_silent
-        status: automated
-
-    -   id: RHEL-08-020019
-        levels:
-            - medium
-        title: RHEL 8 must prevent system messages from being presented when three unsuccessful
-            logon attempts occur.
-        rules:
-            - accounts_passwords_pam_faillock_silent
-        status: automated
-
-    -   id: RHEL-08-020020
-        levels:
-            - medium
-        title: RHEL 8 must log user name information when unsuccessful logon attempts occur.
-        rules: [ ]
-        status: pending
-
-    -   id: RHEL-08-020021
-        levels:
-            - medium
-        title: RHEL 8 must log user name information when unsuccessful logon attempts occur.
-        rules:
-            - accounts_passwords_pam_faillock_audit
-        status: automated
-
-    -   id: RHEL-08-020022
-        levels:
-            - medium
-        title: RHEL 8 must include root when automatically locking an account until the
-            locked account is released by an administrator when three unsuccessful logon attempts
-            occur during a 15-minute time period.
-        rules: [ ]
-        status: pending
-
-    -   id: RHEL-08-020023
-        levels:
-            - medium
-        title: RHEL 8 must include root when automatically locking an account until the
-            locked account is released by an administrator when three unsuccessful logon attempts
-            occur during a 15-minute time period.
-        rules:
-            - accounts_passwords_pam_faillock_deny_root
-        status: automated
-
-    -   id: RHEL-08-020024
-        levels:
-            - low
-        title: RHEL 8 must limit the number of concurrent sessions to ten for all accounts
-            and/or account types.
-        rules:
-            - accounts_max_concurrent_login_sessions
-        status: automated
-
-    -   id: RHEL-08-020030
-        levels:
-            - medium
-        title: RHEL 8 must enable a user session lock until that user re-establishes access
-            using established identification and authentication procedures for graphical user
-            sessions.
-        rules:
-            - dconf_gnome_screensaver_lock_enabled
-        status: automated
-
-    -   id: RHEL-08-020050
-        levels:
-            - medium
-        title: RHEL 8 must be able to initiate directly a session lock for all connection
-            types using smartcard when the smartcard is removed.
-        rules:
-            - dconf_gnome_lock_screen_on_smartcard_removal
-        status: automated
-
-    -   id: RHEL-08-020060
-        levels:
-            - medium
-        title: RHEL 8 must automatically lock graphical user sessions after 15 minutes of
-            inactivity.
-        rules:
-            - dconf_gnome_screensaver_idle_delay
-        status: automated
-
-    -   id: RHEL-08-020080
-        levels:
-            - medium
-        title: RHEL 8 must prevent a user from overriding the session lock-delay setting
-            for the graphical user interface.
-        rules:
-            - dconf_gnome_screensaver_user_locks
-        status: automated
-
-    -   id: RHEL-08-020090
-        levels:
-            - medium
-        title: RHEL 8 must map the authenticated identity to the user or group account for
-            PKI-based authentication.
-        rules:
-            - sssd_enable_certmap
-        status: automated
-
-    -   id: RHEL-08-020100
-        levels:
-            - medium
-        title: RHEL 8 must ensure the password complexity module is enabled in the password-auth
-            file.
-        rules:
-            - accounts_password_pam_pwquality_password_auth
-        status: automated
-
-    -   id: RHEL-08-020110
-        levels:
-            - medium
-        title: RHEL 8 must enforce password complexity by requiring that at least one uppercase
-            character be used.
-        rules:
-            - accounts_password_pam_ucredit
-        status: automated
-
-    -   id: RHEL-08-020120
-        levels:
-            - medium
-        title: RHEL 8 must enforce password complexity by requiring that at least one lower-case
-            character be used.
-        rules:
-            - accounts_password_pam_lcredit
-        status: automated
-
-    -   id: RHEL-08-020130
-        levels:
-            - medium
-        title: RHEL 8 must enforce password complexity by requiring that at least one numeric
-            character be used.
-        rules:
-            - accounts_password_pam_dcredit
-        status: automated
-
-    -   id: RHEL-08-020140
-        levels:
-            - medium
-        title: RHEL 8 must require the maximum number of repeating characters of the same
-            character class be limited to four when passwords are changed.
-        rules:
-            - accounts_password_pam_maxclassrepeat
-        status: automated
-
-    -   id: RHEL-08-020150
-        levels:
-            - medium
-        title: RHEL 8 must require the maximum number of repeating characters be limited
-            to three when passwords are changed.
-        rules:
-            - accounts_password_pam_maxrepeat
-        status: automated
-
-    -   id: RHEL-08-020160
-        levels:
-            - medium
-        title: RHEL 8 must require the change of at least four character classes when passwords
-            are changed.
-        rules:
-            - accounts_password_pam_minclass
-        status: automated
-
-    -   id: RHEL-08-020170
-        levels:
-            - medium
-        title: RHEL 8 must require the change of at least 8 characters when passwords are
-            changed.
-        rules:
-            - accounts_password_pam_difok
-        status: automated
-
-    -   id: RHEL-08-020180
-        levels:
-            - medium
-        title: RHEL 8 passwords must have a 24 hours/1 day minimum password lifetime restriction
-            in /etc/shadow.
-        rules:
-            - accounts_password_set_min_life_existing
-        status: automated
-
-    -   id: RHEL-08-020190
-        levels:
-            - medium
-        title: RHEL 8 passwords for new users or password changes must have a 24 hours/1
-            day minimum password lifetime restriction in /etc/login.defs.
-        rules:
-            - accounts_minimum_age_login_defs
-        status: automated
-
-    -   id: RHEL-08-020200
-        levels:
-            - medium
-        title: RHEL 8 user account passwords must have a 60-day maximum password lifetime
-            restriction.
-        rules:
-            - accounts_maximum_age_login_defs
-        status: automated
-
-    -   id: RHEL-08-020210
-        levels:
-            - medium
-        title: RHEL 8 user account passwords must be configured so that existing passwords
-            are restricted to a 60-day maximum lifetime.
-        rules:
-            - accounts_password_set_max_life_existing
-        status: automated
-
-    -   id: RHEL-08-020230
-        levels:
-            - medium
-        title: RHEL 8 passwords must have a minimum of 15 characters.
-        rules:
-            - accounts_password_pam_minlen
-        status: automated
-
-    -   id: RHEL-08-020231
-        levels:
-            - medium
-        title: RHEL 8 passwords for new users must have a minimum of 15 characters.
-        rules:
-            - accounts_password_minlen_login_defs
-        status: automated
-
-    -   id: RHEL-08-020240
-        levels:
-            - medium
-        title: RHEL 8 duplicate User IDs (UIDs) must not exist for interactive users.
-        rules:
-            - account_unique_id
-        status: automated
-
-    -   id: RHEL-08-020250
-        levels:
-            - medium
-        title: RHEL 8 must implement smart card logon for multifactor authentication for
-            access to interactive accounts.
-        rules:
-            - sssd_enable_smartcards
-        status: automated
-
-    -   id: RHEL-08-020260
-        levels:
-            - medium
-        title: RHEL 8 account identifiers (individuals, groups, roles, and devices) must
-            be disabled after 35 days of inactivity.
-        rules:
-            - account_disable_post_pw_expiration
-        status: automated
-
-    -   id: RHEL-08-020270
-        levels:
-            - medium
-        title: RHEL 8 must automatically expire temporary accounts within 72 hours.
-        rules:
-            - account_temp_expire_date
-        status: automated
-
-    -   id: RHEL-08-020280
-        levels:
-            - medium
-        title: All RHEL 8 passwords must contain at least one special character.
-        rules:
-            - accounts_password_pam_ocredit
-        status: automated
-
-    -   id: RHEL-08-020290
-        levels:
-            - medium
-        title: RHEL 8 must prohibit the use of cached authentications after one day.
-        rules:
-            - sssd_offline_cred_expiration
-        status: automated
-
-    -   id: RHEL-08-020300
-        levels:
-            - medium
-        title: RHEL 8 must prevent the use of dictionary words for passwords.
-        rules:
-            - accounts_password_pam_dictcheck
-        status: automated
-
-    -   id: RHEL-08-020310
-        levels:
-            - medium
-        title: RHEL 8 must enforce a delay of at least four seconds between logon prompts
-            following a failed logon attempt.
-        rules:
-            - accounts_logon_fail_delay
-        status: automated
-
-    -   id: RHEL-08-020320
-        levels:
-            - medium
-        title: RHEL 8 must not have unnecessary accounts.
-        rules:
-            - accounts_authorized_local_users
-        status: automated
-
-    -   id: RHEL-08-020330
-        levels:
-            - high
-        title: RHEL 8 must not allow accounts configured with blank or null passwords.
-        rules:
-            - sshd_disable_empty_passwords
-        status: automated
-
-    -   id: RHEL-08-020340
-        levels:
-            - low
-        title: RHEL 8 must display the date and time of the last successful account logon
-            upon logon.
-        rules:
-            - display_login_attempts
-        status: automated
-
-    -   id: RHEL-08-020350
-        levels:
-            - medium
-        title: RHEL 8 must display the date and time of the last successful account logon
-            upon an SSH logon.
-        rules:
-            - sshd_print_last_log
-        status: automated
-
-    -   id: RHEL-08-020351
-        levels:
-            - medium
-        title: RHEL 8 must define default permissions for all authenticated users in such
-            a way that the user can only read and modify their own files.
-        rules:
-            - accounts_umask_etc_login_defs
-        status: automated
-
-    -   id: RHEL-08-020352
-        levels:
-            - medium
-        title: RHEL 8 must set the umask value to 077 for all local interactive user accounts.
-        rules:
-            - accounts_umask_interactive_users
-        status: automated
-
-    -   id: RHEL-08-020353
-        levels:
-            - medium
-        title: RHEL 8 must define default permissions for logon and non-logon shells.
-        rules:
-            - accounts_umask_etc_bashrc
-            - accounts_umask_etc_csh_cshrc
-            - accounts_umask_etc_profile
-        status: automated
-
-    -   id: RHEL-08-030000
-        levels:
-            - medium
-        title: The RHEL 8 audit system must be configured to audit the execution of privileged
-            functions and prevent all software from executing at higher privilege levels than
-            users executing the software.
-        rules:
-            - audit_rules_suid_privilege_function
-        status: automated
-
-    -   id: RHEL-08-030010
-        levels:
-            - medium
-        title: Cron logging must be implemented in RHEL 8.
-        rules:
-            - rsyslog_cron_logging
-        status: automated
-
-    -   id: RHEL-08-030020
-        levels:
-            - medium
-        title: The RHEL 8 System Administrator (SA) and Information System Security Officer
-            (ISSO) (at a minimum) must be alerted of an audit processing failure event.
-        rules:
-            - auditd_data_retention_action_mail_acct
-        status: automated
-
-    -   id: RHEL-08-030030
-        levels:
-            - medium
-        title: The RHEL 8 Information System Security Officer (ISSO) and System Administrator
-            (SA) (at a minimum) must have mail aliases to be notified of an audit processing
-            failure.
-        rules:
-            - package_postfix_installed
-            - postfix_client_configure_mail_alias_postmaster
-        status: automated
-
-    -   id: RHEL-08-030040
-        levels:
-            - medium
-        title: The RHEL 8 System must take appropriate action when an audit processing failure
-            occurs.
-        rules:
-            - auditd_data_disk_error_action
-        status: automated
-
-    -   id: RHEL-08-030060
-        levels:
-            - medium
-        title: The RHEL 8 audit system must take appropriate action when the audit storage
-            volume is full.
-        rules:
-            - auditd_data_disk_full_action
-        status: automated
-
-    -   id: RHEL-08-030061
-        levels:
-            - medium
-        title: The RHEL 8 audit system must audit local events.
-        rules:
-            - auditd_local_events
-        status: automated
-
-    -   id: RHEL-08-030062
-        levels:
-            - medium
-        title: RHEL 8 must label all off-loaded audit logs before sending them to the central
-            log server.
-        rules:
-            - auditd_name_format
-            - var_auditd_name_format=stig
-        status: automated
-
-    -   id: RHEL-08-030063
-        levels:
-            - low
-        title: RHEL 8 must resolve audit information before writing to disk.
-        rules:
-            - auditd_log_format
-        status: automated
-
-    -   id: RHEL-08-030070
-        levels:
-            - medium
-        title: RHEL 8 audit logs must have a mode of 0600 or less permissive to prevent
-            unauthorized read access.
-        rules:
-            - file_permissions_var_log_audit
-        status: automated
-
-    -   id: RHEL-08-030080
-        levels:
-            - medium
-        title: RHEL 8 audit logs must be owned by root to prevent unauthorized read access.
-        rules:
-            - file_ownership_var_log_audit_stig
-        status: automated
-
-    -   id: RHEL-08-030090
-        levels:
-            - medium
-        title: RHEL 8 audit logs must be group-owned by root to prevent unauthorized read
-            access.
-        rules:
-            - file_group_ownership_var_log_audit
-        status: automated
-
-    -   id: RHEL-08-030100
-        levels:
-            - medium
-        title: RHEL 8 audit log directory must be owned by root to prevent unauthorized
-            read access.
-        rules:
-            - directory_ownership_var_log_audit
-        status: automated
-
-    -   id: RHEL-08-030110
-        levels:
-            - medium
-        title: RHEL 8 audit log directory must be group-owned by root to prevent unauthorized
-            read access.
-        rules:
-            - directory_group_ownership_var_log_audit
-        status: automated
-
-    -   id: RHEL-08-030120
-        levels:
-            - medium
-        title: RHEL 8 audit log directory must have a mode of 0700 or less permissive to
-            prevent unauthorized read access.
-        rules:
-            - directory_permissions_var_log_audit
-        status: automated
-
-    -   id: RHEL-08-030121
-        levels:
-            - medium
-        title: RHEL 8 audit system must protect auditing rules from unauthorized change.
-        rules:
-            - audit_rules_immutable
-        status: automated
-
-    -   id: RHEL-08-030122
-        levels:
-            - medium
-        title: RHEL 8 audit system must protect logon UIDs from unauthorized change.
-        rules:
-            - audit_rules_immutable_login_uids
-        status: automated
-
-    -   id: RHEL-08-030130
-        levels:
-            - medium
-        title: RHEL 8 must generate audit records for all account creations, modifications,
-            disabling, and termination events that affect /etc/shadow.
-        rules:
-            - audit_rules_usergroup_modification_shadow
-        status: automated
-
-    -   id: RHEL-08-030140
-        levels:
-            - medium
-        title: RHEL 8 must generate audit records for all account creations, modifications,
-            disabling, and termination events that affect /etc/security/opasswd.
-        rules:
-            - audit_rules_usergroup_modification_opasswd
-        status: automated
-
-    -   id: RHEL-08-030150
-        levels:
-            - medium
-        title: RHEL 8 must generate audit records for all account creations, modifications,
-            disabling, and termination events that affect /etc/passwd.
-        rules:
-            - audit_rules_usergroup_modification_passwd
-        status: automated
-
-    -   id: RHEL-08-030160
-        levels:
-            - medium
-        title: RHEL 8 must generate audit records for all account creations, modifications,
-            disabling, and termination events that affect /etc/gshadow.
-        rules:
-            - audit_rules_usergroup_modification_gshadow
-        status: automated
-
-    -   id: RHEL-08-030170
-        levels:
-            - medium
-        title: RHEL 8 must generate audit records for all account creations, modifications,
-            disabling, and termination events that affect /etc/group.
-        rules:
-            - audit_rules_usergroup_modification_group
-        status: automated
-
-    -   id: RHEL-08-030171
-        levels:
-            - medium
-        title: RHEL 8 must generate audit records for all account creations, modifications,
-            disabling, and termination events that affect /etc/sudoers.
-        rules:
-            - audit_rules_sudoers
-        status: automated
-
-    -   id: RHEL-08-030172
-        levels:
-            - medium
-        title: RHEL 8 must generate audit records for all account creations, modifications,
-            disabling, and termination events that affect /etc/sudoers.d/.
-        rules:
-            - audit_rules_sudoers_d
-        status: automated
-
-    -   id: RHEL-08-030180
-        levels:
-            - medium
-        title: The RHEL 8 audit package must be installed.
-        rules:
-            - package_audit_installed
-        status: automated
-
-    -   id: RHEL-08-030190
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of the su command in RHEL 8 must generate an
-            audit record.
-        rules:
-            - audit_rules_privileged_commands_su
-        status: automated
-
-    -   id: RHEL-08-030200
-        levels:
-            - medium
-        title: The RHEL 8 audit system must be configured to audit any usage of the setxattr,
-            fsetxattr, lsetxattr, removexattr, fremovexattr, and lremovexattr system calls.
-        rules:
-            - audit_rules_dac_modification_fremovexattr
-            - audit_rules_dac_modification_fsetxattr
-            - audit_rules_dac_modification_lremovexattr
-            - audit_rules_dac_modification_lsetxattr
-            - audit_rules_dac_modification_removexattr
-            - audit_rules_dac_modification_setxattr
-        status: automated
-
-    -   id: RHEL-08-030250
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of the chage command in RHEL 8 must generate
-            an audit record.
-        rules:
-            - audit_rules_privileged_commands_chage
-        status: automated
-
-    -   id: RHEL-08-030260
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of the chcon command in RHEL 8 must generate
-            an audit record.
-        rules:
-            - audit_rules_execution_chcon
-        status: automated
-
-    -   id: RHEL-08-030280
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of the ssh-agent in RHEL 8 must generate an
-            audit record.
-        rules:
-            - audit_rules_privileged_commands_ssh_agent
-        status: automated
-
-    -   id: RHEL-08-030290
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of the passwd command in RHEL 8 must generate
-            an audit record.
-        rules:
-            - audit_rules_privileged_commands_passwd
-        status: automated
-
-    -   id: RHEL-08-030300
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of the mount command in RHEL 8 must generate
-            an audit record.
-        rules:
-            - audit_rules_privileged_commands_mount
-        status: automated
-
-    -   id: RHEL-08-030301
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of the umount command in RHEL 8 must generate
-            an audit record.
-        rules:
-            - audit_rules_privileged_commands_umount
-        status: automated
-
-    -   id: RHEL-08-030302
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of the mount syscall in RHEL 8 must generate
-            an audit record.
-        rules:
-            - audit_rules_media_export
-        status: automated
-
-    -   id: RHEL-08-030310
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of the unix_update in RHEL 8 must generate an
-            audit record.
-        rules:
-            - audit_rules_privileged_commands_unix_update
-        status: automated
-
-    -   id: RHEL-08-030311
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of postdrop in RHEL 8 must generate an audit
-            record.
-        rules:
-            - audit_rules_privileged_commands_postdrop
-        status: automated
-
-    -   id: RHEL-08-030312
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of postqueue in RHEL 8 must generate an audit
-            record.
-        rules:
-            - audit_rules_privileged_commands_postqueue
-        status: automated
-
-    -   id: RHEL-08-030313
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of semanage in RHEL 8 must generate an audit
-            record.
-        rules:
-            - audit_rules_execution_semanage
-        status: automated
-
-    -   id: RHEL-08-030314
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of setfiles in RHEL 8 must generate an audit
-            record.
-        rules:
-            - audit_rules_execution_setfiles
-        status: automated
-
-    -   id: RHEL-08-030315
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of userhelper in RHEL 8 must generate an audit
-            record.
-        rules:
-            - audit_rules_privileged_commands_userhelper
-        status: automated
-
-    -   id: RHEL-08-030316
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of setsebool in RHEL 8 must generate an audit
-            record.
-        rules:
-            - audit_rules_execution_setsebool
-        status: automated
-
-    -   id: RHEL-08-030317
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of unix_chkpwd in RHEL 8 must generate an audit
-            record.
-        rules:
-            - audit_rules_privileged_commands_unix_chkpwd
-        status: automated
-
-    -   id: RHEL-08-030320
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of the ssh-keysign in RHEL 8 must generate an
-            audit record.
-        rules:
-            - audit_rules_privileged_commands_ssh_keysign
-        status: automated
-
-    -   id: RHEL-08-030330
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of the setfacl command in RHEL 8 must generate
-            an audit record.
-        rules:
-            - audit_rules_execution_setfacl
-        status: automated
-
-    -   id: RHEL-08-030340
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of the pam_timestamp_check command in RHEL 8
-            must generate an audit record.
-        rules:
-            - audit_rules_privileged_commands_pam_timestamp_check
-        status: automated
-
-    -   id: RHEL-08-030350
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of the newgrp command in RHEL 8 must generate
-            an audit record.
-        rules:
-            - audit_rules_privileged_commands_newgrp
-        status: automated
-
-    -   id: RHEL-08-030360
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of the init_module and finit_module system calls
-            in RHEL 8 must generate an audit record.
-        rules:
-            - audit_rules_kernel_module_loading_finit
-            - audit_rules_kernel_module_loading_init
-        status: automated
-
-    -   id: RHEL-08-030361
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of the rename, unlink, rmdir, renameat, and
-            unlinkat system calls in RHEL 8 must generate an audit record.
-        rules:
-            - audit_rules_file_deletion_events_rename
-            - audit_rules_file_deletion_events_renameat
-            - audit_rules_file_deletion_events_rmdir
-            - audit_rules_file_deletion_events_unlink
-            - audit_rules_file_deletion_events_unlinkat
-        status: automated
-
-    -   id: RHEL-08-030370
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of the gpasswd command in RHEL 8 must generate
-            an audit record.
-        rules:
-            - audit_rules_privileged_commands_gpasswd
-        status: automated
-
-    -   id: RHEL-08-030390
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of the delete_module command in RHEL 8 must
-            generate an audit record.
-        rules:
-            - audit_rules_kernel_module_loading_delete
-        status: automated
-
-    -   id: RHEL-08-030400
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of the crontab command in RHEL 8 must generate
-            an audit record.
-        rules:
-            - audit_rules_privileged_commands_crontab
-        status: automated
-
-    -   id: RHEL-08-030410
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of the chsh command in RHEL 8 must generate
-            an audit record.
-        rules:
-            - audit_rules_privileged_commands_chsh
-        status: automated
-
-    -   id: RHEL-08-030420
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of the truncate, ftruncate, creat, open, openat,
-            and open_by_handle_at system calls in RHEL 8 must generate an audit record.
-        rules:
-            - audit_rules_unsuccessful_file_modification_creat
-            - audit_rules_unsuccessful_file_modification_ftruncate
-            - audit_rules_unsuccessful_file_modification_open
-            - audit_rules_unsuccessful_file_modification_open_by_handle_at
-            - audit_rules_unsuccessful_file_modification_openat
-            - audit_rules_unsuccessful_file_modification_truncate
-        status: automated
-
-    -   id: RHEL-08-030480
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of the chown, fchown, fchownat, and lchown system
-            calls in RHEL 8 must generate an audit record.
-        rules:
-            - audit_rules_dac_modification_chown
-            - audit_rules_dac_modification_fchown
-            - audit_rules_dac_modification_fchownat
-            - audit_rules_dac_modification_lchown
-        status: automated
-
-    -   id: RHEL-08-030490
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of the chmod, fchmod, and fchmodat system calls
-            in RHEL 8 must generate an audit record.
-        rules:
-            - audit_rules_dac_modification_chmod
-            - audit_rules_dac_modification_fchmod
-            - audit_rules_dac_modification_fchmodat
-        status: automated
-
-    -   id: RHEL-08-030550
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of the sudo command in RHEL 8 must generate
-            an audit record.
-        rules:
-            - audit_rules_privileged_commands_sudo
-        status: automated
-
-    -   id: RHEL-08-030560
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of the usermod command in RHEL 8 must generate
-            an audit record.
-        rules:
-            - audit_rules_privileged_commands_usermod
-        status: automated
-
-    -   id: RHEL-08-030570
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of the chacl command in RHEL 8 must generate
-            an audit record.
-        rules:
-            - audit_rules_execution_chacl
-        status: automated
-
-    -   id: RHEL-08-030580
-        levels:
-            - medium
-        title: Successful/unsuccessful uses of the kmod command in RHEL 8 must generate
-            an audit record.
-        rules:
-            - audit_rules_privileged_commands_kmod
-        status: automated
-
-    -   id: RHEL-08-030590
-        levels:
-            - medium
-        title: Successful/unsuccessful modifications to the faillock log file in RHEL 8
-            must generate an audit record.
-        rules:
-            - audit_rules_login_events_faillock
-        status: automated
-
-    -   id: RHEL-08-030600
-        levels:
-            - medium
-        title: Successful/unsuccessful modifications to the lastlog file in RHEL 8 must
-            generate an audit record.
-        rules:
-            - audit_rules_login_events_lastlog
-        status: automated
-
-    -   id: RHEL-08-030601
-        levels:
-            - low
-        title: RHEL 8 must enable auditing of processes that start prior to the audit daemon.
-        rules:
-            - grub2_audit_argument
-        status: automated
-
-    -   id: RHEL-08-030602
-        levels:
-            - low
-        title: RHEL 8 must allocate an audit_backlog_limit of sufficient size to capture
-            processes that start prior to the audit daemon.
-        rules:
-            - grub2_audit_backlog_limit_argument
-        status: automated
-
-    -   id: RHEL-08-030603
-        levels:
-            - low
-        title: RHEL 8 must enable Linux audit logging for the USBGuard daemon.
-        rules:
-            - configure_usbguard_auditbackend
-        status: automated
-
-    -   id: RHEL-08-030610
-        levels:
-            - medium
-        title: RHEL 8 must allow only the Information System Security Manager (ISSM) (or
-            individuals or roles appointed by the ISSM) to select which auditable events are
-            to be audited.
-        rules:
-            - file_permissions_etc_audit_auditd
-            - file_permissions_etc_audit_rulesd
-        status: automated
-
-    -   id: RHEL-08-030620
-        levels:
-            - medium
-        title: RHEL 8 audit tools must have a mode of 0755 or less permissive.
-        rules:
-            - file_audit_tools_permissions
-        status: automated
-
-    -   id: RHEL-08-030630
-        levels:
-            - medium
-        title: RHEL 8 audit tools must be owned by root.
-        rules:
-            - file_audit_tools_ownership
-        status: automated
-
-    -   id: RHEL-08-030640
-        levels:
-            - medium
-        title: RHEL 8 audit tools must be group-owned by root.
-        rules:
-            - file_audit_tools_group_ownership
-        status: automated
-
-    -   id: RHEL-08-030650
-        levels:
-            - medium
-        title: RHEL 8 must use cryptographic mechanisms to protect the integrity of audit
-            tools.
-        rules:
-            - aide_check_audit_tools
-        status: automated
-
-    -   id: RHEL-08-030660
-        levels:
-            - medium
-        title: RHEL 8 must allocate audit record storage capacity to store at least one
-            week of audit records, when audit records are not immediately sent to a central
-            audit record storage facility.
-        rules:
-            - auditd_audispd_configure_sufficiently_large_partition
-        status: automated
-
-    -   id: RHEL-08-030670
-        levels:
-            - medium
-        title: RHEL 8 must have the packages required for offloading audit logs installed.
-        rules:
-            - package_rsyslog_installed
-        status: automated
-
-    -   id: RHEL-08-030680
-        levels:
-            - medium
-        title: RHEL 8 must have the packages required for encrypting offloaded audit logs
-            installed.
-        rules:
-            - package_rsyslog-gnutls_installed
-        status: automated
-
-    -   id: RHEL-08-030690
-        levels:
-            - medium
-        title: The RHEL 8 audit records must be off-loaded onto a different system or storage
-            media from the system being audited.
-        rules:
-            - rsyslog_remote_loghost
-        status: automated
-
-    -   id: RHEL-08-030700
-        levels:
-            - medium
-        title: RHEL 8 must take appropriate action when the internal event queue is full.
-        rules:
-            - auditd_overflow_action
-        status: automated
-
-    -   id: RHEL-08-030710
-        levels:
-            - medium
-        title: RHEL 8 must encrypt the transfer of audit records off-loaded onto a different
-            system or media from the system being audited.
-        rules:
-            - rsyslog_encrypt_offload_actionsendstreamdrivermode
-            - rsyslog_encrypt_offload_defaultnetstreamdriver
-        status: automated
-
-    -   id: RHEL-08-030720
-        levels:
-            - medium
-        title: RHEL 8 must authenticate the remote logging server for off-loading audit
-            logs.
-        rules:
-            - rsyslog_encrypt_offload_actionsendstreamdriverauthmode
-        status: automated
-
-    -   id: RHEL-08-030730
-        levels:
-            - medium
-        title: RHEL 8 must take action when allocated audit record storage volume reaches
-            75 percent of the repository maximum audit record storage capacity.
-        rules:
-            - auditd_data_retention_space_left_percentage
-        status: automated
-
-    -   id: RHEL-08-030740
-        levels:
-            - medium
-        title: RHEL 8 must securely compare internal information system clocks at least
-            every 24 hours with a server synchronized to an authoritative time source, such
-            as the United States Naval Observatory (USNO) time servers, or a time server designated
-            for the appropriate DoD network (NIPRNet/SIPRNet), and/or the Global Positioning
-            System (GPS).
-        rules:
-            - chronyd_or_ntpd_set_maxpoll
-            - chronyd_server_directive
-            - chronyd_specify_remote_server
-        status: automated
-
-    -   id: RHEL-08-030741
-        levels:
-            - low
-        title: RHEL 8 must disable the chrony daemon from acting as a server.
-        rules:
-            - chronyd_client_only
-        status: automated
-
-    -   id: RHEL-08-030742
-        levels:
-            - low
-        title: RHEL 8 must disable network management of the chrony daemon.
-        rules:
-            - chronyd_no_chronyc_network
-        status: automated
-
-    -   id: RHEL-08-040000
-        levels:
-            - high
-        title: RHEL 8 must not have the telnet-server package installed.
-        rules:
-            - package_telnet-server_removed
-        status: automated
-
-    -   id: RHEL-08-040001
-        levels:
-            - medium
-        title: RHEL 8 must not have any automated bug reporting tools installed.
-        rules:
-            - package_abrt-addon-ccpp_removed
-            - package_abrt-addon-kerneloops_removed
-            - package_abrt-cli_removed
-            - package_abrt-plugin-sosreport_removed
-            - package_abrt_removed
-            - package_libreport-plugin-logger_removed
-            - package_libreport-plugin-rhtsupport_removed
-            - package_python3-abrt-addon_removed
-        status: automated
-
-    -   id: RHEL-08-040002
-        levels:
-            - medium
-        title: RHEL 8 must not have the sendmail package installed.
-        rules:
-            - package_sendmail_removed
-        status: automated
-
-    -   id: RHEL-08-040004
-        levels:
-            - low
-        title: RHEL 8 must enable mitigations against processor-based vulnerabilities.
-        rules:
-            - grub2_pti_argument
-        status: automated
-
-    -   id: RHEL-08-040010
-        levels:
-            - high
-        title: RHEL 8 must not have the rsh-server package installed.
-        related_rules:
-            - package_rsh-server_removed
-        status: not applicable
-
-    -   id: RHEL-08-040020
-        levels:
-            - medium
-        title: RHEL 8 must cover or disable the built-in or attached camera when not in
-            use.
-        rules:
-            - kernel_module_uvcvideo_disabled
-        status: automated
-
-    -   id: RHEL-08-040021
-        levels:
-            - low
-        title: RHEL 8 must disable the asynchronous transfer mode (ATM) protocol.
-        rules:
-            - kernel_module_atm_disabled
-        status: automated
-
-    -   id: RHEL-08-040022
-        levels:
-            - low
-        title: RHEL 8 must disable the controller area network (CAN) protocol.
-        rules:
-            - kernel_module_can_disabled
-        status: automated
-
-    -   id: RHEL-08-040023
-        levels:
-            - low
-        title: RHEL 8 must disable the stream control transmission protocol (SCTP).
-        rules:
-            - kernel_module_sctp_disabled
-        status: automated
-
-    -   id: RHEL-08-040024
-        levels:
-            - low
-        title: RHEL 8 must disable the transparent inter-process communication (TIPC) protocol.
-        rules:
-            - kernel_module_tipc_disabled
-        status: automated
-
-    -   id: RHEL-08-040025
-        levels:
-            - low
-        title: RHEL 8 must disable mounting of cramfs.
-        rules:
-            - kernel_module_cramfs_disabled
-        status: automated
-
-    -   id: RHEL-08-040026
-        levels:
-            - low
-        title: RHEL 8 must disable IEEE 1394 (FireWire) Support.
-        rules:
-            - kernel_module_firewire-core_disabled
-        status: automated
-
-    -   id: RHEL-08-040030
-        levels:
-            - medium
-        title: RHEL 8 must be configured to prohibit or restrict the use of functions, ports,
-            protocols, and/or services, as defined in the Ports, Protocols, and Services Management
-            (PPSM) Category Assignments List (CAL) and vulnerability assessments.
-        rules:
-            - configure_firewalld_ports
-        status: automated
-
-    -   id: RHEL-08-040070
-        levels:
-            - medium
-        title: The RHEL 8 file system automounter must be disabled unless required.
-        rules:
-            - service_autofs_disabled
-        status: automated
-
-    -   id: RHEL-08-040080
-        levels:
-            - medium
-        title: RHEL 8 must be configured to disable USB mass storage.
-        rules:
-            - kernel_module_usb-storage_disabled
-        status: automated
-
-    -   id: RHEL-08-040090
-        levels:
-            - medium
-        title: A RHEL 8 firewall must employ a deny-all, allow-by-exception policy for allowing
-            connections to other systems.
-        rules:
-            - configured_firewalld_default_deny
-            - set_firewalld_default_zone
-        status: automated
-
-    -   id: RHEL-08-040100
-        levels:
-            - medium
-        title: A firewall must be installed on RHEL 8.
-        rules:
-            - package_firewalld_installed
-        status: automated
-
-    -   id: RHEL-08-040110
-        levels:
-            - medium
-        title: RHEL 8 wireless network adapters must be disabled.
-        rules:
-            - wireless_disable_interfaces
-        status: automated
-
-    -   id: RHEL-08-040111
-        levels:
-            - medium
-        title: RHEL 8 Bluetooth must be disabled.
-        rules:
-            - kernel_module_bluetooth_disabled
-        status: automated
-
-    -   id: RHEL-08-040120
-        levels:
-            - medium
-        title: RHEL 8 must mount /dev/shm with the nodev option.
-        rules:
-            - mount_option_dev_shm_nodev
-        status: automated
-
-    -   id: RHEL-08-040121
-        levels:
-            - medium
-        title: RHEL 8 must mount /dev/shm with the nosuid option.
-        rules:
-            - mount_option_dev_shm_nosuid
-        status: automated
-
-    -   id: RHEL-08-040122
-        levels:
-            - medium
-        title: RHEL 8 must mount /dev/shm with the noexec option.
-        rules:
-            - mount_option_dev_shm_noexec
-        status: automated
-
-    -   id: RHEL-08-040123
-        levels:
-            - medium
-        title: RHEL 8 must mount /tmp with the nodev option.
-        rules:
-            - mount_option_tmp_nodev
-        status: automated
-
-    -   id: RHEL-08-040124
-        levels:
-            - medium
-        title: RHEL 8 must mount /tmp with the nosuid option.
-        rules:
-            - mount_option_tmp_nosuid
-        status: automated
-
-    -   id: RHEL-08-040125
-        levels:
-            - medium
-        title: RHEL 8 must mount /tmp with the noexec option.
-        rules:
-            - mount_option_tmp_noexec
-        status: automated
-
-    -   id: RHEL-08-040126
-        levels:
-            - medium
-        title: RHEL 8 must mount /var/log with the nodev option.
-        rules:
-            - mount_option_var_log_nodev
-        status: automated
-
-    -   id: RHEL-08-040127
-        levels:
-            - medium
-        title: RHEL 8 must mount /var/log with the nosuid option.
-        rules:
-            - mount_option_var_log_nosuid
-        status: automated
-
-    -   id: RHEL-08-040128
-        levels:
-            - medium
-        title: RHEL 8 must mount /var/log with the noexec option.
-        rules:
-            - mount_option_var_log_noexec
-        status: automated
-
-    -   id: RHEL-08-040129
-        levels:
-            - medium
-        title: RHEL 8 must mount /var/log/audit with the nodev option.
-        rules:
-            - mount_option_var_log_audit_nodev
-        status: automated
-
-    -   id: RHEL-08-040130
-        levels:
-            - medium
-        title: RHEL 8 must mount /var/log/audit with the nosuid option.
-        rules:
-            - mount_option_var_log_audit_nosuid
-        status: automated
-
-    -   id: RHEL-08-040131
-        levels:
-            - medium
-        title: RHEL 8 must mount /var/log/audit with the noexec option.
-        rules:
-            - mount_option_var_log_audit_noexec
-        status: automated
-
-    -   id: RHEL-08-040132
-        levels:
-            - medium
-        title: RHEL 8 must mount /var/tmp with the nodev option.
-        rules:
-            - mount_option_var_tmp_nodev
-        status: automated
-
-    -   id: RHEL-08-040133
-        levels:
-            - medium
-        title: RHEL 8 must mount /var/tmp with the nosuid option.
-        rules:
-            - mount_option_var_tmp_nosuid
-        status: automated
-
-    -   id: RHEL-08-040134
-        levels:
-            - medium
-        title: RHEL 8 must mount /var/tmp with the noexec option.
-        rules:
-            - mount_option_var_tmp_noexec
-        status: automated
-
-    -   id: RHEL-08-040135
-        levels:
-            - medium
-        title: The RHEL 8 fapolicy module must be installed.
-        rules:
-            - package_fapolicyd_installed
-        status: automated
-
-    -   id: RHEL-08-040140
-        levels:
-            - medium
-        title: RHEL 8 must block unauthorized peripherals before establishing a connection.
-        rules:
-            - usbguard_generate_policy
-        status: automated
-
-    -   id: RHEL-08-040150
-        levels:
-            - medium
-        title: A firewall must be able to protect against or limit the effects of Denial
-            of Service (DoS) attacks by ensuring RHEL 8 can implement rate-limiting measures
-            on impacted network interfaces.
-        rules:
-            - firewalld-backend
-        status: automated
-
-    -   id: RHEL-08-040160
-        levels:
-            - medium
-        title: All RHEL 8 networked systems must have and implement SSH to protect the confidentiality
-            and integrity of transmitted and received information, as well as information
-            during preparation for transmission.
-        rules:
-            - service_sshd_enabled
-        status: automated
-
-    -   id: RHEL-08-040161
-        levels:
-            - medium
-        title: RHEL 8 must force a frequent session key renegotiation for SSH connections
-            to the server.
-        rules:
-            - sshd_rekey_limit
-        status: automated
-
-    -   id: RHEL-08-040170
-        levels:
-            - high
-        title: The x86 Ctrl-Alt-Delete key sequence must be disabled on RHEL 8.
-        rules:
-            - disable_ctrlaltdel_reboot
-        status: automated
-
-    -   id: RHEL-08-040171
-        levels:
-            - high
-        title: The x86 Ctrl-Alt-Delete key sequence in RHEL 8 must be disabled if a graphical
-            user interface is installed.
-        rules:
-            - dconf_gnome_disable_ctrlaltdel_reboot
-        status: automated
-
-    -   id: RHEL-08-040172
-        levels:
-            - high
-        title: The systemd Ctrl-Alt-Delete burst key sequence in RHEL 8 must be disabled.
-        rules:
-            - disable_ctrlaltdel_burstaction
-        status: automated
-
-    -   id: RHEL-08-040180
-        levels:
-            - medium
-        title: The debug-shell systemd service must be disabled on RHEL 8.
-        rules:
-            - service_debug-shell_disabled
-        status: automated
-
-    -   id: RHEL-08-040190
-        levels:
-            - high
-        title: The Trivial File Transfer Protocol (TFTP) server package must not be installed
-            if not required for RHEL 8 operational support.
-        rules:
-            - package_tftp-server_removed
-        status: automated
-
-    -   id: RHEL-08-040200
-        levels:
-            - high
-        title: The root account must be the only account having unrestricted access to the
-            RHEL 8 system.
-        rules:
-            - accounts_no_uid_except_zero
-        status: automated
-
-    -   id: RHEL-08-040210
-        levels:
-            - medium
-        title: RHEL 8 must prevent IPv6 Internet Control Message Protocol (ICMP) redirect
-            messages from being accepted.
-        rules:
-            - sysctl_net_ipv6_conf_default_accept_redirects
-        status: automated
-
-    -   id: RHEL-08-040220
-        levels:
-            - medium
-        title: RHEL 8 must not send Internet Control Message Protocol (ICMP) redirects.
-        rules:
-            - sysctl_net_ipv4_conf_all_send_redirects
-        status: automated
-
-    -   id: RHEL-08-040230
-        levels:
-            - medium
-        title: RHEL 8 must not respond to Internet Control Message Protocol (ICMP) echoes
-            sent to a broadcast address.
-        rules:
-            - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
-        status: automated
-
-    -   id: RHEL-08-040240
-        levels:
-            - medium
-        title: RHEL 8 must not forward IPv6 source-routed packets.
-        rules:
-            - sysctl_net_ipv6_conf_all_accept_source_route
-        status: automated
-
-    -   id: RHEL-08-040250
-        levels:
-            - medium
-        title: RHEL 8 must not forward IPv6 source-routed packets by default.
-        rules:
-            - sysctl_net_ipv6_conf_default_accept_source_route
-        status: automated
-
-    -   id: RHEL-08-040260
-        levels:
-            - medium
-        title: RHEL 8 must not enable IPv6 packet forwarding unless the system is a router.
-        rules:
-            - sysctl_net_ipv6_conf_all_forwarding
-        status: automated
-
-    -   id: RHEL-08-040261
-        levels:
-            - medium
-        title: RHEL 8 must not accept router advertisements on all IPv6 interfaces.
-        rules:
-            - sysctl_net_ipv6_conf_all_accept_ra
-        status: automated
-
-    -   id: RHEL-08-040262
-        levels:
-            - medium
-        title: RHEL 8 must not accept router advertisements on all IPv6 interfaces by default.
-        rules:
-            - sysctl_net_ipv6_conf_default_accept_ra
-        status: automated
-
-    -   id: RHEL-08-040270
-        levels:
-            - medium
-        title: RHEL 8 must not allow interfaces to perform Internet Control Message Protocol
-            (ICMP) redirects by default.
-        rules:
-            - sysctl_net_ipv4_conf_default_send_redirects
-        status: automated
-
-    -   id: RHEL-08-040280
-        levels:
-            - medium
-        title: RHEL 8 must ignore IPv6 Internet Control Message Protocol (ICMP) redirect
-            messages.
-        rules:
-            - sysctl_net_ipv6_conf_all_accept_redirects
-        status: automated
-
-    -   id: RHEL-08-040281
-        levels:
-            - medium
-        title: RHEL 8 must disable access to network bpf syscall from unprivileged processes.
-        rules:
-            - sysctl_kernel_unprivileged_bpf_disabled
-        status: automated
-
-    -   id: RHEL-08-040282
-        levels:
-            - medium
-        title: RHEL 8 must restrict usage of ptrace to descendant  processes.
-        rules:
-            - sysctl_kernel_yama_ptrace_scope
-        status: automated
-
-    -   id: RHEL-08-040283
-        levels:
-            - medium
-        title: RHEL 8 must restrict exposed kernel pointer addresses access.
-        rules:
-            - sysctl_kernel_kptr_restrict
-        status: automated
-
-    -   id: RHEL-08-040284
-        levels:
-            - medium
-        title: RHEL 8 must disable the use of user namespaces.
-        rules:
-            - sysctl_user_max_user_namespaces_no_remediation
-        status: automated
-
-    -   id: RHEL-08-040285
-        levels:
-            - medium
-        title: RHEL 8 must use reverse path filtering on all IPv4 interfaces.
-        rules:
-            - sysctl_net_ipv4_conf_all_rp_filter
-        status: automated
-
-    -   id: RHEL-08-040290
-        levels:
-            - medium
-        title: RHEL 8 must be configured to prevent unrestricted mail relaying.
-        rules:
-            - postfix_prevent_unrestricted_relay
-        status: automated
-
-    -   id: RHEL-08-040300
-        levels:
-            - low
-        title: The RHEL 8 file integrity tool must be configured to verify extended attributes.
-        rules:
-            - aide_verify_ext_attributes
-        status: automated
-
-    -   id: RHEL-08-040310
-        levels:
-            - low
-        title: The RHEL 8 file integrity tool must be configured to verify Access Control
-            Lists (ACLs).
-        rules:
-            - aide_verify_acls
-        status: automated
-
-    -   id: RHEL-08-040320
-        levels:
-            - medium
-        title: The graphical display manager must not be installed on RHEL 8 unless approved.
-        rules:
-            - xwindows_remove_packages
-        status: automated
-
-    -   id: RHEL-08-040330
-        levels:
-            - medium
-        title: RHEL 8 network interfaces must not be in promiscuous mode.
-        rules:
-            - network_sniffer_disabled
-        status: automated
-
-    -   id: RHEL-08-040340
-        levels:
-            - medium
-        title: RHEL 8 remote X connections for interactive users must be disabled unless
-            to fulfill documented and validated mission requirements.
-        rules:
-            - sshd_disable_x11_forwarding
-        status: automated
-
-    -   id: RHEL-08-040341
-        levels:
-            - medium
-        title: The RHEL 8 SSH daemon must prevent remote hosts from connecting to the proxy
-            display.
-        rules:
-            - sshd_x11_use_localhost
-        status: automated
-
-    -   id: RHEL-08-040350
-        levels:
-            - medium
-        title: If the Trivial File Transfer Protocol (TFTP) server is required, the RHEL
-            8 TFTP daemon must be configured to operate in secure mode.
-        rules:
-            - tftp_uses_secure_mode_systemd
-        status: automated
-
-    -   id: RHEL-08-040360
-        levels:
-            - high
-        title: A File Transfer Protocol (FTP) server package must not be installed unless
-            mission essential on RHEL 8.
-        rules:
-            - package_vsftpd_removed
-        status: automated
-
-    -   id: RHEL-08-040370
-        levels:
-            - medium
-        title: The gssproxy package must not be installed unless mission essential on RHEL
-            8.
-        rules:
-            - package_gssproxy_removed
-        status: automated
-
-    -   id: RHEL-08-040380
-        levels:
-            - medium
-        title: The iprutils package must not be installed unless mission essential on RHEL
-            8.
-        rules:
-            - package_iprutils_removed
-        status: automated
-
-    -   id: RHEL-08-040390
-        levels:
-            - medium
-        title: The tuned package must not be installed unless mission essential on RHEL
-            8.
-        rules:
-            - package_tuned_removed
-        status: automated
-
-    -   id: RHEL-08-010163
-        levels:
-            - medium
-        title: The krb5-server package must not be installed on RHEL 8.
-        rules:
-            - package_krb5-server_removed
-        status: automated
-
-    -   id: RHEL-08-010382
-        levels:
-            - medium
-        title: RHEL 8 must restrict privilege elevation to authorized personnel.
-        rules:
-            - sudo_restrict_privilege_elevation_to_authorized
-        status: automated
-
-    -   id: RHEL-08-010383
-        levels:
-            - medium
-        title: RHEL 8 must use the invoking user's password for privilege escalation when
-            using "sudo".
-        rules:
-            - sudoers_validate_passwd
-        status: automated
-
-    -   id: RHEL-08-010384
-        levels:
-            - medium
-        title: RHEL 8 must require re-authentication when using the "sudo" command.
-        rules:
-            - sudo_require_reauthentication
-            - var_sudo_timestamp_timeout=always_prompt
-        status: automated
-
-    -   id: RHEL-08-010049
-        levels:
-            - medium
-        title: RHEL 8 must display a banner before granting local or remote access to the
-            system via a graphical user logon.
-        rules:
-            - dconf_gnome_banner_enabled
-        status: automated
-
-    -   id: RHEL-08-010141
-        levels:
-            - medium
-        title: RHEL 8 operating systems booted with United Extensible Firmware Interface
-            (UEFI) must require a unique superusers name upon booting into single-user mode
-            and maintenance.
-        rules:
-            - grub2_uefi_admin_username
-        status: automated
-
-    -   id: RHEL-08-010149
-        levels:
-            - medium
-        title: RHEL 8 operating systems booted with a BIOS must require  a unique superusers
-            name upon booting into single-user and maintenance modes.
-        rules:
-            - grub2_admin_username
-        status: automated
-
-    -   id: RHEL-08-010152
-        levels:
-            - medium
-        title: RHEL 8 operating systems must require authentication upon booting into emergency
-            mode.
-        rules:
-            - require_emergency_target_auth
-        status: automated
-
-    -   id: RHEL-08-010159
-        levels:
-            - medium
-        title: The RHEL 8 pam_unix.so module must be configured in the system-auth file
-            to use a FIPS 140-2 approved cryptographic hashing algorithm for system authentication.
-        rules:
-            - set_password_hashing_algorithm_systemauth
-        status: automated
-
-    -   id: RHEL-08-010201
-        levels:
-            - medium
-        title: RHEL 8 must be configured so that all network connections associated with
-            SSH traffic are terminated after 10 minutes of becoming unresponsive.
-        rules:
-            - sshd_set_idle_timeout
-        status: automated
-
-    -   id: RHEL-08-010287
-        levels:
-            - medium
-        title: The RHEL 8 SSH daemon must be configured to use system-wide crypto policies.
-        rules:
-            - configure_ssh_crypto_policy
-        status: automated
-
-    -   id: RHEL-08-010472
-        levels:
-            - low
-        title: RHEL 8 must have the packages required to use the hardware random number
-            generator entropy gatherer service.
-        rules:
-            - package_rng-tools_installed
-        status: automated
-
-    -   id: RHEL-08-010522
-        levels:
-            - medium
-        title: The RHEL 8 SSH daemon must not allow GSSAPI authentication, except to fulfill
-            documented and validated mission requirements.
-        rules:
-            - sshd_disable_gssapi_auth
-        status: automated
-
-    -   id: RHEL-08-010544
-        levels:
-            - medium
-        title: RHEL 8 must use a separate file system for /var/tmp.
-        rules:
-            - partition_for_var_tmp
-        status: automated
-
-    -   id: RHEL-08-010572
-        levels:
-            - medium
-        title: RHEL 8 must prevent files with the setuid and setgid bit set from being executed
-            on the /boot/efi directory.
-        rules:
-            - mount_option_boot_efi_nosuid
-        status: automated
-
-    -   id: RHEL-08-010731
-        levels:
-            - medium
-        title: All RHEL 8 local interactive user home directory files must have mode 0750
-            or less permissive.
-        rules:
-            - accounts_users_home_files_permissions
-        status: automated
-
-    -   id: RHEL-08-010741
-        levels:
-            - medium
-        title: RHEL 8 must be configured so that all files and directories contained in
-            local interactive user home directories are group-owned by a group of which the
-            home directory owner is a member.
-        rules:
-            - accounts_users_home_files_groupownership
-        status: automated
-
-    -   id: RHEL-08-020025
-        levels:
-            - medium
-        title: RHEL 8 must configure the use of the pam_faillock.so module in the /etc/pam.d/system-auth
-            file.
-        rules:
-            - account_password_pam_faillock_system_auth
-        status: automated
-
-    -   id: RHEL-08-020026
-        levels:
-            - medium
-        title: RHEL 8 must configure the use of the pam_faillock.so module in the /etc/pam.d/password-auth
-            file.
-        rules:
-            - account_password_pam_faillock_password_auth
-        status: automated
-
-    -   id: RHEL-08-020031
-        levels:
-            - medium
-        title: RHEL 8 must initiate a session lock for graphical user interfaces when the
-            screensaver is activated.
-        rules:
-            - dconf_gnome_screensaver_lock_delay
-            - var_screensaver_lock_delay=5_seconds
-        status: automated
-
-    -   id: RHEL-08-020032
-        levels:
-            - medium
-        title: RHEL 8 must disable the user list at logon for graphical user interfaces.
-        rules:
-            - dconf_gnome_disable_user_list
-        status: automated
-
-    -   id: RHEL-08-020081
-        levels:
-            - medium
-        title: RHEL 8 must prevent a user from overriding the session idle-delay setting
-            for the graphical user interface.
-        rules:
-            - dconf_gnome_session_idle_user_locks
-        status: automated
-
-    -   id: RHEL-08-020082
-        levels:
-            - medium
-        title: RHEL 8 must prevent a user from overriding the screensaver lock-enabled setting
-            for the graphical user interface.
-        rules:
-            - dconf_gnome_screensaver_lock_locked
-        status: automated
-
-    -   id: RHEL-08-020332
-        levels:
-            - high
-        title: RHEL 8 must not allow blank or null passwords in the password-auth file.
-        rules:
-            - no_empty_passwords
-        status: automated
-
-    -   id: RHEL-08-030181
-        levels:
-            - medium
-        title: RHEL 8 audit records must contain information to establish what type of events
-            occurred, the source of events, where events occurred, and the outcome of events.
-        rules:
-            - service_auditd_enabled
-        status: automated
-
-    -   id: RHEL-08-030731
-        levels:
-            - medium
-        title: RHEL 8 must notify the System Administrator (SA) and Information System Security
-            Officer (ISSO) (at a minimum) when allocated audit record storage volume 75 percent
-            utilization.
-        rules:
-            - auditd_data_retention_space_left_action
-        status: automated
-
-    -   id: RHEL-08-040101
-        levels:
-            - medium
-        title: A firewall must be active on RHEL 8.
-        rules:
-            - service_firewalld_enabled
-        status: automated
-
-    -   id: RHEL-08-040136
-        levels:
-            - medium
-        title: The RHEL 8 fapolicy module must be enabled.
-        rules:
-            - service_fapolicyd_enabled
-        status: automated
-
-    -   id: RHEL-08-040137
-        levels:
-            - medium
-        title: The RHEL 8 fapolicy module must be configured to employ a deny-all, permit-by-exception
-            policy to allow the execution of authorized software programs.
-        rules:
-            - fapolicy_default_deny
-        status: automated
-
-    -   id: RHEL-08-040139
-        levels:
-            - medium
-        title: RHEL 8 must have the USBGuard installed.
-        rules:
-            - package_usbguard_installed
-        status: automated
-
-    -   id: RHEL-08-040141
-        levels:
-            - medium
-        title: RHEL 8 must enable the USBGuard.
-        rules:
-            - service_usbguard_enabled
-        status: automated
-
-    -   id: RHEL-08-040159
-        levels:
-            - medium
-        title: All RHEL 8 networked systems must have SSH installed.
-        rules:
-            - package_openssh-server_installed
-        status: automated
-
-    -   id: RHEL-08-040209
-        levels:
-            - medium
-        title: RHEL 8 must prevent IPv4 Internet Control Message Protocol (ICMP) redirect
-            messages from being accepted.
-        rules:
-            - sysctl_net_ipv4_conf_default_accept_redirects
-        status: automated
-
-    -   id: RHEL-08-040239
-        levels:
-            - medium
-        title: RHEL 8 must not forward IPv4 source-routed packets.
-        rules:
-            - sysctl_net_ipv4_conf_all_accept_source_route
-        status: automated
-
-    -   id: RHEL-08-040249
-        levels:
-            - medium
-        title: RHEL 8 must not forward IPv4 source-routed packets by default.
-        rules:
-            - sysctl_net_ipv4_conf_default_accept_source_route
-        status: automated
-
-    -   id: RHEL-08-040279
-        levels:
-            - medium
-        title: RHEL 8 must ignore IPv4 Internet Control Message Protocol (ICMP) redirect
-            messages.
-        rules:
-            - sysctl_net_ipv4_conf_all_accept_redirects
-        status: automated
-
-    -   id: RHEL-08-040286
-        levels:
-            - medium
-        title: RHEL 8 must enable hardening for the Berkeley Packet Filter Just-in-time
-            compiler.
-        rules:
-            - sysctl_net_core_bpf_jit_harden
-        status: automated
-
-    -   id: RHEL-08-020027
-        levels:
-            - medium
-        title: RHEL 8 systems, versions 8.2 and above, must configure SELinux context type
-            to allow the use of a non-default faillock tally directory.
-        rules:
-            - account_password_selinux_faillock_dir
-        status: automated
-
-    -   id: RHEL-08-020028
-        levels:
-            - medium
-        title: RHEL 8 systems below version 8.2 must configure SELinux context type to allow
-            the use of a non-default faillock tally directory.
-        rules:
-            - account_password_selinux_faillock_dir
-        status: automated
-
-    -   id: RHEL-08-040259
-        levels:
-            - medium
-        title: RHEL 8 must not enable IPv4 packet forwarding unless the system is a router.
-        rules:
-            - sysctl_net_ipv4_conf_all_forwarding
-        status: automated
-
-    -   id: RHEL-08-010121
-        levels:
-            - high
-        title: The RHEL 8 operating system must not have accounts configured with blank
-            or null passwords.
-        rules:
-            - no_empty_passwords_etc_shadow
-        status: automated
-
-    -   id: RHEL-08-010331
-        levels:
-            - medium
-        title: RHEL 8 library directories must have mode 755 or less permissive.
-        rules:
-            - dir_permissions_library_dirs
-        status: automated
-
-    -   id: RHEL-08-010341
-        levels:
-            - medium
-        title: RHEL 8 library directories must be owned by root.
-        rules:
-            - dir_ownership_library_dirs
-        status: automated
-
-    -   id: RHEL-08-010351
-        levels:
-            - medium
-        title: RHEL 8 library directories must be group-owned by root or a system account.
-        rules:
-            - dir_group_ownership_library_dirs
-        status: automated
-
-    -   id: RHEL-08-010359
-        levels:
-            - medium
-        title: The RHEL 8 operating system must use a file integrity tool to verify correct
-            operation of all security functions.
-        rules:
-            - aide_build_database
-            - package_aide_installed
-        status: automated
-
-    -   id: RHEL-08-010379
-        levels:
-            - medium
-        title: RHEL 8 must specify the default "include" directory for the /etc/sudoers
-            file.
-        rules:
-            - sudoers_default_includedir
-        status: automated
-
-    -   id: RHEL-08-010385
-        levels:
-            - medium
-        title: The RHEL 8 operating system must not be configured to bypass password requirements
-            for privilege escalation.
-        rules:
-            - disallow_bypass_password_sudo
-        status: automated
-
-    -   id: RHEL-08-020101
-        levels:
-            - medium
-        title: RHEL 8 must ensure the password complexity module is enabled in the system-auth
-            file.
-        rules:
-            - accounts_password_pam_pwquality_system_auth
-        status: automated
-
-    -   id: RHEL-08-020104
-        levels:
-            - medium
-        title: RHEL 8 systems, version 8.4 and above, must ensure the password complexity
-            module is configured for three retries or less.
-        rules:
-            - accounts_password_pam_retry
-        status: automated
-
-    -   id: RHEL-08-040321
-        levels:
-            - medium
-        title: The graphical display manager must not be the default target on RHEL 8 unless
-            approved.
-        rules:
-            - xwindows_runlevel_target
-        status: automated
-
-    -   id: RHEL-08-040400
-        levels:
-            - medium
-        title: RHEL 8 must prevent nonprivileged users from executing privileged functions,
-            including disabling, circumventing, or altering implemented security safeguards/countermeasures.
-        rules:
-            - selinux_user_login_roles
-        status: automated
-
-    -   id: RHEL-08-040342
-        levels:
-            - medium
-        title: RHEL 8 SSH server must be configured to use only FIPS-validated key exchange
-            algorithms.
-        rules:
-            - sshd_use_approved_kex_ordered_stig
-        status: automated
-
-    -   id: RHEL-08-010019
-        levels:
-            - medium
-        title: RHEL 8 must ensure cryptographic verification of vendor software packages.
-        rules:
-            - ensure_redhat_gpgkey_installed
-        status: automated
-
-    -   id: RHEL-08-010358
-        levels:
-            - medium
-        title: RHEL 8 must be configured to allow sending email notifications of unauthorized
-            configuration changes to designated personnel.
-        rules:
-            - package_mailx_installed
-        status: automated
-
-    -   id: RHEL-08-020035
-        levels:
-            - medium
-        title: RHEL 8.7 and higher must terminate idle user sessions.
-        rules:
-            - logind_session_timeout
-            - var_logind_session_timeout=10_minutes
-        status: automated
-
-    -   id: RHEL-08-020331
-        levels:
-            - high
-        title: RHEL 8 must not allow blank or null passwords in the system-auth file.
-        rules:
-            - no_empty_passwords
-        status: automated
-
-    -   id: RHEL-08-010296
-        levels:
-            - medium
-        title: RHEL 8 SSH client must be configured to use only Message Authentication Codes
-            (MACs) employing FIPS 140-3 validated cryptographic hash algorithms.
-        rules:
-            - harden_sshd_ciphers_openssh_conf_crypto_policy
-            - harden_sshd_macs_openssh_conf_crypto_policy
-        status: automated
-
-    -   id: RHEL-08-010297
-        levels:
-            - medium
-        title: RHEL 8 SSH client must be configured to use only ciphers employing FIPS 140-3
-            validated cryptographic hash algorithms.
-        rules: [ ]
-        status: pending
-
-    -   id: RHEL-08-010455
-        levels:
-            - medium
-        title: RHEL 8 must elevate the SELinux context when an administrator calls the sudo
-            command.
-        rules:
-            - selinux_context_elevation_for_sudo
-        status: automated
+          - enable_authselect
+
+    - id: RHEL-08-010000
+      levels:
+          - high
+      title: RHEL 8 must be a vendor-supported release.
+      rules:
+          - installed_OS_is_vendor_supported
+      status: automated
+
+    - id: RHEL-08-010010
+      levels:
+          - medium
+      title: RHEL 8 vendor packaged system security patches and updates must be installed and up to date.
+      rules:
+          - security_patches_up_to_date
+      status: automated
+
+    - id: RHEL-08-010020
+      levels:
+          - high
+      title: 'RHEL 8 must implement NIST FIPS-validated cryptography for the following: To provision
+          digital signatures, to generate cryptographic hashes, and to protect data requiring data-at-rest
+          protections in accordance with applicable federal laws, Executive Orders, directives, policies,
+          regulations, and standards.'
+      rules:
+          - configure_bind_crypto_policy
+          - configure_crypto_policy
+          - configure_kerberos_crypto_policy
+          - configure_libreswan_crypto_policy
+          - enable_dracut_fips_module
+          - enable_fips_mode
+          - fips_crypto_subpolicy
+          - harden_sshd_ciphers_openssh_conf_crypto_policy
+          - harden_sshd_macs_openssh_conf_crypto_policy
+          - sysctl_crypto_fips_enabled
+      status: automated
+
+    - id: RHEL-08-010030
+      levels:
+          - high
+      title: All RHEL 8 local disk partitions must implement cryptographic mechanisms to prevent unauthorized
+          disclosure or modification of all information that requires at rest protection.
+      rules:
+          - encrypt_partitions
+      status: automated
+
+    - id: RHEL-08-010040
+      levels:
+          - medium
+      title: RHEL 8 must display the Standard Mandatory DOD Notice and Consent Banner before granting
+          local or remote access to the system via a ssh logon.
+      rules:
+          - sshd_enable_warning_banner
+      status: automated
+
+    - id: RHEL-08-010050
+      levels:
+          - medium
+      title: RHEL 8 must display the Standard Mandatory DoD Notice and Consent Banner before granting
+          local or remote access to the system via a graphical user logon.
+      rules:
+          - dconf_gnome_login_banner_text
+      status: automated
+
+    - id: RHEL-08-010060
+      levels:
+          - medium
+      title: RHEL 8 must display the Standard Mandatory DoD Notice and Consent Banner before granting
+          local or remote access to the system via a command line user logon.
+      rules:
+          - banner_etc_issue
+      status: automated
+
+    - id: RHEL-08-010070
+      levels:
+          - medium
+      title: All RHEL 8 remote access methods must be monitored.
+      rules:
+          - rsyslog_remote_access_monitoring
+      status: automated
+
+    - id: RHEL-08-010090
+      levels:
+          - medium
+      title: RHEL 8, for PKI-based authentication, must validate certificates by constructing a certification
+          path (which includes status information) to an accepted trust anchor.
+      rules:
+          - sssd_has_trust_anchor
+      status: automated
+
+    - id: RHEL-08-010100
+      levels:
+          - medium
+      title: RHEL 8, for certificate-based authentication, must enforce authorized access to the corresponding
+          private key.
+      rules:
+          - ssh_keys_passphrase_protected
+      status: automated
+
+    - id: RHEL-08-010110
+      levels:
+          - medium
+      title: RHEL 8 must encrypt all stored passwords with a FIPS 140-2 approved cryptographic hashing
+          algorithm.
+      rules:
+          - set_password_hashing_algorithm_logindefs
+      status: automated
+
+    - id: RHEL-08-010120
+      levels:
+          - medium
+      title: RHEL 8 must employ FIPS 140-2 approved cryptographic hashing algorithms for all stored passwords.
+      rules:
+          - accounts_password_all_shadowed_sha512
+      status: automated
+
+    - id: RHEL-08-010130
+      levels:
+          - medium
+      title: The RHEL 8 shadow password suite must be configured to use a sufficient number of hashing
+          rounds.
+      rules:
+          - set_password_hashing_min_rounds_logindefs
+      status: automated
+
+    - id: RHEL-08-010140
+      levels:
+          - high
+      title: RHEL 8 operating systems booted with United Extensible Firmware Interface (UEFI) must require
+          authentication upon booting into single-user mode and maintenance.
+      rules:
+          - grub2_uefi_password
+      status: automated
+
+    - id: RHEL-08-010150
+      levels:
+          - high
+      title: RHEL 8 operating systems booted with a BIOS must require authentication upon booting into
+          single-user and maintenance modes.
+      rules:
+          - grub2_password
+      status: automated
+
+    - id: RHEL-08-010151
+      levels:
+          - medium
+      title: RHEL 8 operating systems must require authentication upon booting into rescue mode.
+      rules:
+          - require_singleuser_auth
+      status: automated
+
+    - id: RHEL-08-010160
+      levels:
+          - medium
+      title: The RHEL 8 pam_unix.so module must be configured in the password-auth file to use a FIPS
+          140-2 approved cryptographic hashing algorithm for system authentication.
+      rules:
+          - set_password_hashing_algorithm_passwordauth
+      status: automated
+
+    - id: RHEL-08-010161
+      levels:
+          - medium
+      title: RHEL 8 must prevent system daemons from using Kerberos for authentication.
+      rules:
+          - kerberos_disable_no_keytab
+      status: automated
+
+    - id: RHEL-08-010162
+      levels:
+          - medium
+      title: The krb5-workstation package must not be installed on RHEL 8.
+      rules:
+          - package_krb5-workstation_removed
+      status: automated
+
+    - id: RHEL-08-010170
+      levels:
+          - medium
+      title: RHEL 8 must use a Linux Security Module configured to enforce limits on system services.
+      rules:
+          - selinux_state
+      status: automated
+
+    - id: RHEL-08-010171
+      levels:
+          - low
+      title: RHEL 8 must have policycoreutils package installed.
+      rules:
+          - package_policycoreutils_installed
+      status: automated
+
+    - id: RHEL-08-010190
+      levels:
+          - medium
+      title: A sticky bit must be set on all RHEL 8 public directories to prevent unauthorized and unintended
+          information transferred via shared system resources.
+      rules:
+          - dir_perms_world_writable_sticky_bits
+      status: automated
+
+    - id: RHEL-08-010200
+      levels:
+          - medium
+      title: RHEL 8 must be configured so that all network connections associated with SSH traffic terminate
+          after becoming unresponsive.
+      rules:
+          - sshd_set_keepalive
+      status: automated
+
+    - id: RHEL-08-010210
+      levels:
+          - medium
+      title: The RHEL 8 /var/log/messages file must have mode 0640 or less permissive.
+      rules:
+          - file_permissions_var_log_messages
+      status: automated
+
+    - id: RHEL-08-010220
+      levels:
+          - medium
+      title: The RHEL 8 /var/log/messages file must be owned by root.
+      rules:
+          - file_owner_var_log_messages
+      status: automated
+
+    - id: RHEL-08-010230
+      levels:
+          - medium
+      title: The RHEL 8 /var/log/messages file must be group-owned by root.
+      rules:
+          - file_groupowner_var_log_messages
+      status: automated
+
+    - id: RHEL-08-010240
+      levels:
+          - medium
+      title: The RHEL 8 /var/log directory must have mode 0755 or less permissive.
+      rules:
+          - file_permissions_var_log
+      status: automated
+
+    - id: RHEL-08-010250
+      levels:
+          - medium
+      title: The RHEL 8 /var/log directory must be owned by root.
+      rules:
+          - file_owner_var_log
+      status: automated
+
+    - id: RHEL-08-010260
+      levels:
+          - medium
+      title: The RHEL 8 /var/log directory must be group-owned by root.
+      rules:
+          - file_groupowner_var_log
+      status: automated
+
+    - id: RHEL-08-010290
+      levels:
+          - medium
+      title: The RHEL 8 SSH server must be configured to use only Message Authentication Codes (MACs)
+          employing FIPS 140-3 validated cryptographic hash algorithms.
+      rules:
+          - harden_sshd_macs_opensshserver_conf_crypto_policy
+      status: automated
+
+    - id: RHEL-08-010291
+      levels:
+          - medium
+      title: The RHEL 8 operating system must implement DOD-approved encryption to protect the confidentiality
+          of SSH server connections.
+      rules:
+          - harden_sshd_ciphers_opensshserver_conf_crypto_policy
+      status: automated
+
+    - id: RHEL-08-010292
+      levels:
+          - low
+      title: RHEL 8 must ensure the SSH server uses strong entropy.
+      rules:
+          - sshd_use_strong_rng
+      status: automated
+
+    - id: RHEL-08-010293
+      levels:
+          - medium
+      title: The RHEL 8 operating system must implement DoD-approved encryption in the OpenSSL package.
+      rules:
+          - configure_openssl_crypto_policy
+      status: automated
+
+    - id: RHEL-08-010294
+      levels:
+          - medium
+      title: The RHEL 8 operating system must implement DoD-approved TLS encryption in the OpenSSL package.
+      rules:
+          - configure_openssl_tls_crypto_policy
+      status: automated
+
+    - id: RHEL-08-010295
+      levels:
+          - medium
+      title: The RHEL 8 operating system must implement DoD-approved TLS encryption in the GnuTLS package.
+      rules:
+          - configure_gnutls_tls_crypto_policy
+      status: automated
+
+    - id: RHEL-08-010300
+      levels:
+          - medium
+      title: RHEL 8 system commands must have mode 755 or less permissive.
+      rules:
+          - file_permissions_binary_dirs
+      status: automated
+
+    - id: RHEL-08-010310
+      levels:
+          - medium
+      title: RHEL 8 system commands must be owned by root.
+      rules:
+          - file_ownership_binary_dirs
+      status: automated
+
+    - id: RHEL-08-010320
+      levels:
+          - medium
+      title: RHEL 8 system commands must be group-owned by root or a system account.
+      rules:
+          - file_groupownership_system_commands_dirs
+      status: automated
+
+    - id: RHEL-08-010330
+      levels:
+          - medium
+      title: RHEL 8 library files must have mode 755 or less permissive.
+      rules:
+          - file_permissions_library_dirs
+      status: automated
+
+    - id: RHEL-08-010340
+      levels:
+          - medium
+      title: RHEL 8 library files must be owned by root.
+      rules:
+          - file_ownership_library_dirs
+      status: automated
+
+    - id: RHEL-08-010350
+      levels:
+          - medium
+      title: RHEL 8 library files must be group-owned by root or a system account.
+      rules:
+          - root_permissions_syslibrary_files
+      status: automated
+
+    - id: RHEL-08-010360
+      levels:
+          - medium
+      title: The RHEL 8 file integrity tool must notify the system administrator when changes to the
+          baseline configuration or anomalies in the operation of any security functions are discovered
+          within an organizationally defined frequency.
+      rules:
+          - aide_scan_notification
+      status: automated
+
+    - id: RHEL-08-010370
+      levels:
+          - high
+      title: RHEL 8 must prevent the installation of software, patches, service packs, device drivers,
+          or operating system components from a repository without verification they have been digitally
+          signed using a certificate that is issued by a Certificate Authority (CA) that is recognized
+          and approved by the organization.
+      rules:
+          - enable_gpgcheck_for_all_repositories
+      status: automated
+
+    - id: RHEL-08-010371
+      levels:
+          - high
+      title: RHEL 8 must prevent the installation of software, patches, service packs, device drivers,
+          or operating system components of local packages without verification they have been digitally
+          signed using a certificate that is issued by a Certificate Authority (CA) that is recognized
+          and approved by the organization.
+      rules:
+          - ensure_gpgcheck_local_packages
+      status: automated
+
+    - id: RHEL-08-010372
+      levels:
+          - medium
+      title: RHEL 8 must prevent the loading of a new kernel for later execution.
+      rules:
+          - sysctl_kernel_kexec_load_disabled
+      status: automated
+
+    - id: RHEL-08-010373
+      levels:
+          - medium
+      title: RHEL 8 must enable kernel parameters to enforce discretionary access control on symlinks.
+      rules:
+          - sysctl_fs_protected_symlinks
+      status: automated
+
+    - id: RHEL-08-010374
+      levels:
+          - medium
+      title: RHEL 8 must enable kernel parameters to enforce discretionary access control on hardlinks.
+      rules:
+          - sysctl_fs_protected_hardlinks
+      status: automated
+
+    - id: RHEL-08-010375
+      levels:
+          - low
+      title: RHEL 8 must restrict access to the kernel message buffer.
+      rules:
+          - sysctl_kernel_dmesg_restrict
+      status: automated
+
+    - id: RHEL-08-010376
+      levels:
+          - low
+      title: RHEL 8 must prevent kernel profiling by unprivileged users.
+      rules:
+          - sysctl_kernel_perf_event_paranoid
+      status: automated
+
+    - id: RHEL-08-010380
+      levels:
+          - medium
+      title: RHEL 8 must require users to provide a password for privilege escalation.
+      rules:
+          - sudo_remove_nopasswd
+      status: automated
+
+    - id: RHEL-08-010381
+      levels:
+          - medium
+      title: RHEL 8 must require users to reauthenticate for privilege escalation.
+      rules:
+          - sudo_remove_no_authenticate
+      status: automated
+
+    - id: RHEL-08-010390
+      levels:
+          - medium
+      title: RHEL 8 must have the packages required for multifactor authentication installed.
+      rules:
+          - install_smartcard_packages
+      status: automated
+
+    - id: RHEL-08-010400
+      levels:
+          - medium
+      title: RHEL 8 must implement certificate status checking for multifactor authentication.
+      rules:
+          - sssd_certificate_verification
+      status: automated
+
+    - id: RHEL-08-010410
+      levels:
+          - medium
+      title: RHEL 8 must accept Personal Identity Verification (PIV) credentials.
+      rules:
+          - package_opensc_installed
+      status: automated
+
+    - id: RHEL-08-010420
+      levels:
+          - medium
+      title: RHEL 8 must implement non-executable data to protect its memory from unauthorized code execution.
+      rules:
+          - bios_enable_execution_restrictions
+      status: automated
+
+    - id: RHEL-08-010421
+      levels:
+          - medium
+      title: RHEL 8 must clear the page allocator to prevent use-after-free attacks.
+      rules:
+          - grub2_page_poison_argument
+      status: automated
+
+    - id: RHEL-08-010422
+      levels:
+          - medium
+      title: RHEL 8 must disable virtual syscalls.
+      rules:
+          - grub2_vsyscall_argument
+      status: automated
+
+    - id: RHEL-08-010423
+      levels:
+          - medium
+      title: RHEL 8 must clear memory when it is freed to prevent use-after-free attacks.
+      rules:
+          - grub2_init_on_free
+      status: automated
+
+    - id: RHEL-08-010430
+      levels:
+          - medium
+      title: RHEL 8 must implement address space layout randomization (ASLR) to protect its memory from
+          unauthorized code execution.
+      rules:
+          - sysctl_kernel_randomize_va_space
+      status: automated
+
+    - id: RHEL-08-010440
+      levels:
+          - low
+      title: YUM must remove all software components after updated versions have been installed on RHEL
+          8.
+      rules:
+          - clean_components_post_updating
+      status: automated
+
+    - id: RHEL-08-010450
+      levels:
+          - medium
+      title: RHEL 8 must enable the SELinux targeted policy.
+      rules:
+          - selinux_policytype
+      status: automated
+
+    - id: RHEL-08-010460
+      levels:
+          - high
+      title: There must be no shosts.equiv files on the RHEL 8 operating system.
+      rules:
+          - no_host_based_files
+      status: automated
+
+    - id: RHEL-08-010470
+      levels:
+          - high
+      title: There must be no .shosts files on the RHEL 8 operating system.
+      rules:
+          - no_user_host_based_files
+      status: automated
+
+    - id: RHEL-08-010471
+      levels:
+          - low
+      title: RHEL 8 must enable the hardware random number generator entropy gatherer service.
+      rules:
+          - service_rngd_enabled
+      status: automated
+
+    - id: RHEL-08-010480
+      levels:
+          - medium
+      title: The RHEL 8 SSH public host key files must have mode 0644 or less permissive.
+      rules:
+          - file_permissions_sshd_pub_key
+      status: automated
+
+    - id: RHEL-08-010490
+      levels:
+          - medium
+      title: The RHEL 8 SSH private host key files must have mode 0640 or less permissive.
+      rules:
+          - file_permissions_sshd_private_key
+      status: automated
+
+    - id: RHEL-08-010500
+      levels:
+          - medium
+      title: The RHEL 8 SSH daemon must perform strict mode checking of home directory configuration
+          files.
+      rules:
+          - sshd_enable_strictmodes
+      status: automated
+
+    - id: RHEL-08-010520
+      levels:
+          - medium
+      title: "The RHEL 8 SSH daemon must not allow authentication using known host’s authentication."
+      rules:
+          - sshd_disable_user_known_hosts
+      status: automated
+
+    - id: RHEL-08-010521
+      levels:
+          - medium
+      title: The RHEL 8 SSH daemon must not allow Kerberos authentication, except to fulfill documented
+          and validated mission requirements.
+      rules:
+          - sshd_disable_kerb_auth
+      status: automated
+
+    - id: RHEL-08-010540
+      levels:
+          - low
+      title: RHEL 8 must use a separate file system for /var.
+      rules:
+          - partition_for_var
+      status: automated
+
+    - id: RHEL-08-010541
+      levels:
+          - low
+      title: RHEL 8 must use a separate file system for /var/log.
+      rules:
+          - partition_for_var_log
+      status: automated
+
+    - id: RHEL-08-010542
+      levels:
+          - low
+      title: RHEL 8 must use a separate file system for the system audit data path.
+      rules:
+          - partition_for_var_log_audit
+      status: automated
+
+    - id: RHEL-08-010543
+      levels:
+          - medium
+      title: A separate RHEL 8 filesystem must be used for the /tmp directory.
+      rules:
+          - partition_for_tmp
+      status: automated
+
+    - id: RHEL-08-010550
+      levels:
+          - medium
+      title: RHEL 8 must not permit direct logons to the root account using remote access via SSH.
+      rules:
+          - sshd_disable_root_login
+      status: automated
+
+    - id: RHEL-08-010561
+      levels:
+          - medium
+      title: The rsyslog service must be running in RHEL 8.
+      rules:
+          - service_rsyslog_enabled
+      status: automated
+
+    - id: RHEL-08-010570
+      levels:
+          - medium
+      title: RHEL 8 must prevent files with the setuid and setgid bit set from being executed on file
+          systems that contain user home directories.
+      rules:
+          - mount_option_home_nosuid
+      status: automated
+
+    - id: RHEL-08-010571
+      levels:
+          - medium
+      title: RHEL 8 must prevent files with the setuid and setgid bit set from being executed on the
+          /boot directory.
+      rules:
+          - mount_option_boot_nosuid
+      status: automated
+
+    - id: RHEL-08-010580
+      levels:
+          - medium
+      title: RHEL 8 must prevent special devices on non-root local partitions.
+      rules:
+          - mount_option_nodev_nonroot_local_partitions
+      status: automated
+
+    - id: RHEL-08-010590
+      levels:
+          - medium
+      title: RHEL 8 must prevent code from being executed on file systems that contain user home directories.
+      rules:
+          - mount_option_home_noexec
+      status: automated
+
+    - id: RHEL-08-010600
+      levels:
+          - medium
+      title: RHEL 8 must prevent special devices on file systems that are used with removable media.
+      rules:
+          - mount_option_nodev_removable_partitions
+      status: automated
+
+    - id: RHEL-08-010610
+      levels:
+          - medium
+      title: RHEL 8 must prevent code from being executed on file systems that are used with removable
+          media.
+      rules:
+          - mount_option_noexec_removable_partitions
+      status: automated
+
+    - id: RHEL-08-010620
+      levels:
+          - medium
+      title: RHEL 8 must prevent files with the setuid and setgid bit set from being executed on file
+          systems that are used with removable media.
+      rules:
+          - mount_option_nosuid_removable_partitions
+      status: automated
+
+    - id: RHEL-08-010630
+      levels:
+          - medium
+      title: RHEL 8 must prevent code from being executed on file systems that are imported via Network
+          File System (NFS).
+      rules:
+          - mount_option_noexec_remote_filesystems
+      status: automated
+
+    - id: RHEL-08-010640
+      levels:
+          - medium
+      title: RHEL 8 must prevent special devices on file systems that are imported via Network File System
+          (NFS).
+      rules:
+          - mount_option_nodev_remote_filesystems
+      status: automated
+
+    - id: RHEL-08-010650
+      levels:
+          - medium
+      title: RHEL 8 must prevent files with the setuid and setgid bit set from being executed on file
+          systems that are imported via Network File System (NFS).
+      rules:
+          - mount_option_nosuid_remote_filesystems
+      status: automated
+
+    - id: RHEL-08-010660
+      levels:
+          - medium
+      title: Local RHEL 8 initialization files must not execute world-writable programs.
+      rules:
+          - accounts_user_dot_no_world_writable_programs
+      status: automated
+
+    - id: RHEL-08-010670
+      levels:
+          - medium
+      title: RHEL 8 must disable kernel dumps unless needed.
+      rules:
+          - service_kdump_disabled
+      status: automated
+
+    - id: RHEL-08-010671
+      levels:
+          - medium
+      title: RHEL 8 must disable the kernel.core_pattern.
+      rules:
+          - sysctl_kernel_core_pattern
+      status: automated
+
+    - id: RHEL-08-010672
+      levels:
+          - medium
+      title: RHEL 8 must disable acquiring, saving, and processing core dumps.
+      rules:
+          - service_systemd-coredump_disabled
+      status: automated
+
+    - id: RHEL-08-010673
+      levels:
+          - medium
+      title: RHEL 8 must disable core dumps for all users.
+      rules:
+          - disable_users_coredumps
+      status: automated
+
+    - id: RHEL-08-010674
+      levels:
+          - medium
+      title: RHEL 8 must disable storing core dumps.
+      rules:
+          - coredump_disable_storage
+      status: automated
+
+    - id: RHEL-08-010675
+      levels:
+          - medium
+      title: RHEL 8 must disable core dump backtraces.
+      rules:
+          - coredump_disable_backtraces
+      status: automated
+
+    - id: RHEL-08-010680
+      levels:
+          - medium
+      title: For RHEL 8 systems using Domain Name Servers (DNS) resolution, at least two name servers
+          must be configured.
+      rules:
+          - network_configure_name_resolution
+      status: automated
+
+    - id: RHEL-08-010690
+      levels:
+          - medium
+      title: Executable search paths within the initialization files of all local interactive RHEL 8
+          users must only contain paths that resolve to the system default or the users home directory.
+      rules:
+          - accounts_user_home_paths_only
+      status: automated
+
+    - id: RHEL-08-010700
+      levels:
+          - medium
+      title: All RHEL 8 world-writable directories must be owned by root, sys, bin, or an application
+          user.
+      rules:
+          - dir_perms_world_writable_root_owned
+      status: automated
+
+    - id: RHEL-08-010710
+      levels:
+          - medium
+      title: All RHEL 8 world-writable directories must be group-owned by root, sys, bin, or an application
+          group.
+      rules:
+          - dir_perms_world_writable_system_owned_group
+      status: automated
+
+    - id: RHEL-08-010720
+      levels:
+          - medium
+      title: All RHEL 8 local interactive users must have a home directory assigned in the /etc/passwd
+          file.
+      rules:
+          - accounts_user_interactive_home_directory_defined
+      status: automated
+
+    - id: RHEL-08-010730
+      levels:
+          - medium
+      title: All RHEL 8 local interactive user home directories must have mode 0750 or less permissive.
+      rules:
+          - file_permissions_home_directories
+      status: automated
+
+    - id: RHEL-08-010740
+      levels:
+          - medium
+      title: "All RHEL 8 local interactive user home directories must be group-owned by the home directory\
+          \ owner’s primary group."
+      rules:
+          - file_groupownership_home_directories
+      status: automated
+
+    - id: RHEL-08-010750
+      levels:
+          - medium
+      title: All RHEL 8 local interactive user home directories defined in the /etc/passwd file must
+          exist.
+      rules:
+          - accounts_user_interactive_home_directory_exists
+      status: automated
+
+    - id: RHEL-08-010760
+      levels:
+          - medium
+      title: All RHEL 8 local interactive user accounts must be assigned a home directory upon creation.
+      rules:
+          - accounts_have_homedir_login_defs
+      status: automated
+
+    - id: RHEL-08-010770
+      levels:
+          - medium
+      title: All RHEL 8 local initialization files must have mode 0740 or less permissive.
+      rules:
+          - file_permission_user_init_files_root
+          - rootfiles_configured
+          - var_user_initialization_files_regex=all_dotfiles
+      status: automated
+
+    - id: RHEL-08-010780
+      levels:
+          - medium
+      title: All RHEL 8 local files and directories must have a valid owner.
+      rules:
+          - no_files_unowned_by_user
+      status: automated
+
+    - id: RHEL-08-010790
+      levels:
+          - medium
+      title: All RHEL 8 local files and directories must have a valid group owner.
+      rules:
+          - file_permissions_ungroupowned
+      status: automated
+
+    - id: RHEL-08-010800
+      levels:
+          - medium
+      title: A separate RHEL 8 filesystem must be used for user home directories (such as /home or an
+          equivalent).
+      rules:
+          - partition_for_home
+      status: automated
+
+    - id: RHEL-08-010820
+      levels:
+          - high
+      title: Unattended or automatic logon via the RHEL 8 graphical user interface must not be allowed.
+      rules:
+          - gnome_gdm_disable_automatic_login
+      status: automated
+
+    - id: RHEL-08-010830
+      levels:
+          - medium
+      title: RHEL 8 must not allow users to override SSH environment variables.
+      rules:
+          - sshd_do_not_permit_user_env
+      status: automated
+
+    - id: RHEL-08-020000
+      levels:
+          - medium
+      title: RHEL 8 temporary user accounts must be provisioned with an expiration time of 72 hours or
+          less.
+      rules:
+          - account_temp_expire_date
+      status: automated
+
+    - id: RHEL-08-020010
+      levels:
+          - medium
+      title: RHEL 8 must automatically lock an account when three unsuccessful logon attempts occur.
+      rules: []
+      status: pending
+
+    - id: RHEL-08-020011
+      levels:
+          - medium
+      title: RHEL 8 must automatically lock an account when three unsuccessful logon attempts occur.
+      rules:
+          - accounts_passwords_pam_faillock_deny
+      status: automated
+
+    - id: RHEL-08-020012
+      levels:
+          - medium
+      title: RHEL 8 must automatically lock an account when three unsuccessful logon attempts occur during
+          a 15-minute time period.
+      rules:
+          - accounts_passwords_pam_faillock_interval
+      status: automated
+
+    - id: RHEL-08-020013
+      levels:
+          - medium
+      title: RHEL 8 must automatically lock an account when three unsuccessful logon attempts occur during
+          a 15-minute time period.
+      rules:
+          - accounts_passwords_pam_faillock_interval
+      status: automated
+
+    - id: RHEL-08-020014
+      levels:
+          - medium
+      title: RHEL 8 must automatically lock an account until the locked account is released by an administrator
+          when three unsuccessful logon attempts occur during a 15-minute time period.
+      rules:
+          - accounts_passwords_pam_faillock_unlock_time
+      status: automated
+
+    - id: RHEL-08-020015
+      levels:
+          - medium
+      title: RHEL 8 must automatically lock an account until the locked account is released by an administrator
+          when three unsuccessful logon attempts occur during a 15-minute time period.
+      rules:
+          - accounts_passwords_pam_faillock_unlock_time
+      status: automated
+
+    - id: RHEL-08-020016
+      levels:
+          - medium
+      title: RHEL 8 must ensure account lockouts persist.
+      rules:
+          - accounts_passwords_pam_faillock_dir
+      status: automated
+
+    - id: RHEL-08-020017
+      levels:
+          - medium
+      title: RHEL 8 must ensure account lockouts persist.
+      rules:
+          - accounts_passwords_pam_faillock_dir
+      status: automated
+
+    - id: RHEL-08-020018
+      levels:
+          - medium
+      title: RHEL 8 must prevent system messages from being presented when three unsuccessful logon attempts
+          occur.
+      rules:
+          - accounts_passwords_pam_faillock_silent
+      status: automated
+
+    - id: RHEL-08-020019
+      levels:
+          - medium
+      title: RHEL 8 must prevent system messages from being presented when three unsuccessful logon attempts
+          occur.
+      rules:
+          - accounts_passwords_pam_faillock_silent
+      status: automated
+
+    - id: RHEL-08-020020
+      levels:
+          - medium
+      title: RHEL 8 must log user name information when unsuccessful logon attempts occur.
+      rules: []
+      status: pending
+
+    - id: RHEL-08-020021
+      levels:
+          - medium
+      title: RHEL 8 must log user name information when unsuccessful logon attempts occur.
+      rules:
+          - accounts_passwords_pam_faillock_audit
+      status: automated
+
+    - id: RHEL-08-020022
+      levels:
+          - medium
+      title: RHEL 8 must include root when automatically locking an account until the locked account
+          is released by an administrator when three unsuccessful logon attempts occur during a 15-minute
+          time period.
+      rules: []
+      status: pending
+
+    - id: RHEL-08-020023
+      levels:
+          - medium
+      title: RHEL 8 must include root when automatically locking an account until the locked account
+          is released by an administrator when three unsuccessful logon attempts occur during a 15-minute
+          time period.
+      rules:
+          - accounts_passwords_pam_faillock_deny_root
+      status: automated
+
+    - id: RHEL-08-020024
+      levels:
+          - low
+      title: RHEL 8 must limit the number of concurrent sessions to ten for all accounts and/or account
+          types.
+      rules:
+          - accounts_max_concurrent_login_sessions
+      status: automated
+
+    - id: RHEL-08-020030
+      levels:
+          - medium
+      title: RHEL 8 must enable a user session lock until that user re-establishes access using established
+          identification and authentication procedures for graphical user sessions.
+      rules:
+          - dconf_gnome_screensaver_lock_enabled
+      status: automated
+
+    - id: RHEL-08-020050
+      levels:
+          - medium
+      title: RHEL 8 must be able to initiate directly a session lock for all connection types using smartcard
+          when the smartcard is removed.
+      rules:
+          - dconf_gnome_lock_screen_on_smartcard_removal
+      status: automated
+
+    - id: RHEL-08-020060
+      levels:
+          - medium
+      title: RHEL 8 must automatically lock graphical user sessions after 15 minutes of inactivity.
+      rules:
+          - dconf_gnome_screensaver_idle_delay
+      status: automated
+
+    - id: RHEL-08-020080
+      levels:
+          - medium
+      title: RHEL 8 must prevent a user from overriding the session lock-delay setting for the graphical
+          user interface.
+      rules:
+          - dconf_gnome_screensaver_user_locks
+      status: automated
+
+    - id: RHEL-08-020090
+      levels:
+          - medium
+      title: RHEL 8 must map the authenticated identity to the user or group account for PKI-based authentication.
+      rules:
+          - sssd_enable_certmap
+      status: automated
+
+    - id: RHEL-08-020100
+      levels:
+          - medium
+      title: RHEL 8 must ensure the password complexity module is enabled in the password-auth file.
+      rules:
+          - accounts_password_pam_pwquality_password_auth
+      status: automated
+
+    - id: RHEL-08-020110
+      levels:
+          - medium
+      title: RHEL 8 must enforce password complexity by requiring that at least one uppercase character
+          be used.
+      rules:
+          - accounts_password_pam_ucredit
+      status: automated
+
+    - id: RHEL-08-020120
+      levels:
+          - medium
+      title: RHEL 8 must enforce password complexity by requiring that at least one lower-case character
+          be used.
+      rules:
+          - accounts_password_pam_lcredit
+      status: automated
+
+    - id: RHEL-08-020130
+      levels:
+          - medium
+      title: RHEL 8 must enforce password complexity by requiring that at least one numeric character
+          be used.
+      rules:
+          - accounts_password_pam_dcredit
+      status: automated
+
+    - id: RHEL-08-020140
+      levels:
+          - medium
+      title: RHEL 8 must require the maximum number of repeating characters of the same character class
+          be limited to four when passwords are changed.
+      rules:
+          - accounts_password_pam_maxclassrepeat
+      status: automated
+
+    - id: RHEL-08-020150
+      levels:
+          - medium
+      title: RHEL 8 must require the maximum number of repeating characters be limited to three when
+          passwords are changed.
+      rules:
+          - accounts_password_pam_maxrepeat
+      status: automated
+
+    - id: RHEL-08-020160
+      levels:
+          - medium
+      title: RHEL 8 must require the change of at least four character classes when passwords are changed.
+      rules:
+          - accounts_password_pam_minclass
+      status: automated
+
+    - id: RHEL-08-020170
+      levels:
+          - medium
+      title: RHEL 8 must require the change of at least 8 characters when passwords are changed.
+      rules:
+          - accounts_password_pam_difok
+      status: automated
+
+    - id: RHEL-08-020180
+      levels:
+          - medium
+      title: RHEL 8 passwords must have a 24 hours/1 day minimum password lifetime restriction in /etc/shadow.
+      rules:
+          - accounts_password_set_min_life_existing
+      status: automated
+
+    - id: RHEL-08-020190
+      levels:
+          - medium
+      title: RHEL 8 passwords for new users or password changes must have a 24 hours/1 day minimum password
+          lifetime restriction in /etc/login.defs.
+      rules:
+          - accounts_minimum_age_login_defs
+      status: automated
+
+    - id: RHEL-08-020200
+      levels:
+          - medium
+      title: RHEL 8 user account passwords must have a 60-day maximum password lifetime restriction.
+      rules:
+          - accounts_maximum_age_login_defs
+      status: automated
+
+    - id: RHEL-08-020210
+      levels:
+          - medium
+      title: RHEL 8 user account passwords must be configured so that existing passwords are restricted
+          to a 60-day maximum lifetime.
+      rules:
+          - accounts_password_set_max_life_existing
+      status: automated
+
+    - id: RHEL-08-020230
+      levels:
+          - medium
+      title: RHEL 8 passwords must have a minimum of 15 characters.
+      rules:
+          - accounts_password_pam_minlen
+      status: automated
+
+    - id: RHEL-08-020231
+      levels:
+          - medium
+      title: RHEL 8 passwords for new users must have a minimum of 15 characters.
+      rules:
+          - accounts_password_minlen_login_defs
+      status: automated
+
+    - id: RHEL-08-020240
+      levels:
+          - medium
+      title: RHEL 8 duplicate User IDs (UIDs) must not exist for interactive users.
+      rules:
+          - account_unique_id
+      status: automated
+
+    - id: RHEL-08-020250
+      levels:
+          - medium
+      title: RHEL 8 must implement smart card logon for multifactor authentication for access to interactive
+          accounts.
+      rules:
+          - sssd_enable_smartcards
+      status: automated
+
+    - id: RHEL-08-020260
+      levels:
+          - medium
+      title: RHEL 8 account identifiers (individuals, groups, roles, and devices) must be disabled after
+          35 days of inactivity.
+      rules:
+          - account_disable_post_pw_expiration
+      status: automated
+
+    - id: RHEL-08-020270
+      levels:
+          - medium
+      title: RHEL 8 must automatically expire temporary accounts within 72 hours.
+      rules:
+          - account_temp_expire_date
+      status: automated
+
+    - id: RHEL-08-020280
+      levels:
+          - medium
+      title: All RHEL 8 passwords must contain at least one special character.
+      rules:
+          - accounts_password_pam_ocredit
+      status: automated
+
+    - id: RHEL-08-020290
+      levels:
+          - medium
+      title: RHEL 8 must prohibit the use of cached authentications after one day.
+      rules:
+          - sssd_offline_cred_expiration
+      status: automated
+
+    - id: RHEL-08-020300
+      levels:
+          - medium
+      title: RHEL 8 must prevent the use of dictionary words for passwords.
+      rules:
+          - accounts_password_pam_dictcheck
+      status: automated
+
+    - id: RHEL-08-020310
+      levels:
+          - medium
+      title: RHEL 8 must enforce a delay of at least four seconds between logon prompts following a failed
+          logon attempt.
+      rules:
+          - accounts_logon_fail_delay
+      status: automated
+
+    - id: RHEL-08-020320
+      levels:
+          - medium
+      title: RHEL 8 must not have unnecessary accounts.
+      rules:
+          - accounts_authorized_local_users
+      status: automated
+
+    - id: RHEL-08-020330
+      levels:
+          - high
+      title: RHEL 8 must not allow accounts configured with blank or null passwords.
+      rules:
+          - sshd_disable_empty_passwords
+      status: automated
+
+    - id: RHEL-08-020340
+      levels:
+          - low
+      title: RHEL 8 must display the date and time of the last successful account logon upon logon.
+      rules:
+          - display_login_attempts
+      status: automated
+
+    - id: RHEL-08-020350
+      levels:
+          - medium
+      title: RHEL 8 must display the date and time of the last successful account logon upon an SSH logon.
+      rules:
+          - sshd_print_last_log
+      status: automated
+
+    - id: RHEL-08-020351
+      levels:
+          - medium
+      title: RHEL 8 must define default permissions for all authenticated users in such a way that the
+          user can only read and modify their own files.
+      rules:
+          - accounts_umask_etc_login_defs
+      status: automated
+
+    - id: RHEL-08-020352
+      levels:
+          - medium
+      title: RHEL 8 must set the umask value to 077 for all local interactive user accounts.
+      rules:
+          - accounts_umask_interactive_users
+      status: automated
+
+    - id: RHEL-08-020353
+      levels:
+          - medium
+      title: RHEL 8 must define default permissions for logon and non-logon shells.
+      rules:
+          - accounts_umask_etc_bashrc
+          - accounts_umask_etc_csh_cshrc
+          - accounts_umask_etc_profile
+      status: automated
+
+    - id: RHEL-08-030000
+      levels:
+          - medium
+      title: The RHEL 8 audit system must be configured to audit the execution of privileged functions
+          and prevent all software from executing at higher privilege levels than users executing the
+          software.
+      rules:
+          - audit_rules_suid_privilege_function
+      status: automated
+
+    - id: RHEL-08-030010
+      levels:
+          - medium
+      title: Cron logging must be implemented in RHEL 8.
+      rules:
+          - rsyslog_cron_logging
+      status: automated
+
+    - id: RHEL-08-030020
+      levels:
+          - medium
+      title: The RHEL 8 System Administrator (SA) and Information System Security Officer (ISSO) (at
+          a minimum) must be alerted of an audit processing failure event.
+      rules:
+          - auditd_data_retention_action_mail_acct
+      status: automated
+
+    - id: RHEL-08-030030
+      levels:
+          - medium
+      title: The RHEL 8 Information System Security Officer (ISSO) and System Administrator (SA) (at
+          a minimum) must have mail aliases to be notified of an audit processing failure.
+      rules:
+          - package_postfix_installed
+          - postfix_client_configure_mail_alias_postmaster
+      status: automated
+
+    - id: RHEL-08-030040
+      levels:
+          - medium
+      title: The RHEL 8 System must take appropriate action when an audit processing failure occurs.
+      rules:
+          - auditd_data_disk_error_action
+      status: automated
+
+    - id: RHEL-08-030060
+      levels:
+          - medium
+      title: The RHEL 8 audit system must take appropriate action when the audit storage volume is full.
+      rules:
+          - auditd_data_disk_full_action
+      status: automated
+
+    - id: RHEL-08-030061
+      levels:
+          - medium
+      title: The RHEL 8 audit system must audit local events.
+      rules:
+          - auditd_local_events
+      status: automated
+
+    - id: RHEL-08-030062
+      levels:
+          - medium
+      title: RHEL 8 must label all off-loaded audit logs before sending them to the central log server.
+      rules:
+          - auditd_name_format
+          - var_auditd_name_format=stig
+      status: automated
+
+    - id: RHEL-08-030063
+      levels:
+          - low
+      title: RHEL 8 must resolve audit information before writing to disk.
+      rules:
+          - auditd_log_format
+      status: automated
+
+    - id: RHEL-08-030070
+      levels:
+          - medium
+      title: RHEL 8 audit logs must have a mode of 0600 or less permissive to prevent unauthorized read
+          access.
+      rules:
+          - file_permissions_var_log_audit
+      status: automated
+
+    - id: RHEL-08-030080
+      levels:
+          - medium
+      title: RHEL 8 audit logs must be owned by root to prevent unauthorized read access.
+      rules:
+          - file_ownership_var_log_audit_stig
+      status: automated
+
+    - id: RHEL-08-030090
+      levels:
+          - medium
+      title: RHEL 8 audit logs must be group-owned by root to prevent unauthorized read access.
+      rules:
+          - file_group_ownership_var_log_audit
+      status: automated
+
+    - id: RHEL-08-030100
+      levels:
+          - medium
+      title: RHEL 8 audit log directory must be owned by root to prevent unauthorized read access.
+      rules:
+          - directory_ownership_var_log_audit
+      status: automated
+
+    - id: RHEL-08-030110
+      levels:
+          - medium
+      title: RHEL 8 audit log directory must be group-owned by root to prevent unauthorized read access.
+      rules:
+          - directory_group_ownership_var_log_audit
+      status: automated
+
+    - id: RHEL-08-030120
+      levels:
+          - medium
+      title: RHEL 8 audit log directory must have a mode of 0700 or less permissive to prevent unauthorized
+          read access.
+      rules:
+          - directory_permissions_var_log_audit
+      status: automated
+
+    - id: RHEL-08-030121
+      levels:
+          - medium
+      title: RHEL 8 audit system must protect auditing rules from unauthorized change.
+      rules:
+          - audit_rules_immutable
+      status: automated
+
+    - id: RHEL-08-030122
+      levels:
+          - medium
+      title: RHEL 8 audit system must protect logon UIDs from unauthorized change.
+      rules:
+          - audit_rules_immutable_login_uids
+      status: automated
+
+    - id: RHEL-08-030130
+      levels:
+          - medium
+      title: RHEL 8 must generate audit records for all account creations, modifications, disabling,
+          and termination events that affect /etc/shadow.
+      rules:
+          - audit_rules_usergroup_modification_shadow
+      status: automated
+
+    - id: RHEL-08-030140
+      levels:
+          - medium
+      title: RHEL 8 must generate audit records for all account creations, modifications, disabling,
+          and termination events that affect /etc/security/opasswd.
+      rules:
+          - audit_rules_usergroup_modification_opasswd
+      status: automated
+
+    - id: RHEL-08-030150
+      levels:
+          - medium
+      title: RHEL 8 must generate audit records for all account creations, modifications, disabling,
+          and termination events that affect /etc/passwd.
+      rules:
+          - audit_rules_usergroup_modification_passwd
+      status: automated
+
+    - id: RHEL-08-030160
+      levels:
+          - medium
+      title: RHEL 8 must generate audit records for all account creations, modifications, disabling,
+          and termination events that affect /etc/gshadow.
+      rules:
+          - audit_rules_usergroup_modification_gshadow
+      status: automated
+
+    - id: RHEL-08-030170
+      levels:
+          - medium
+      title: RHEL 8 must generate audit records for all account creations, modifications, disabling,
+          and termination events that affect /etc/group.
+      rules:
+          - audit_rules_usergroup_modification_group
+      status: automated
+
+    - id: RHEL-08-030171
+      levels:
+          - medium
+      title: RHEL 8 must generate audit records for all account creations, modifications, disabling,
+          and termination events that affect /etc/sudoers.
+      rules:
+          - audit_rules_sudoers
+      status: automated
+
+    - id: RHEL-08-030172
+      levels:
+          - medium
+      title: RHEL 8 must generate audit records for all account creations, modifications, disabling,
+          and termination events that affect /etc/sudoers.d/.
+      rules:
+          - audit_rules_sudoers_d
+      status: automated
+
+    - id: RHEL-08-030180
+      levels:
+          - medium
+      title: The RHEL 8 audit package must be installed.
+      rules:
+          - package_audit_installed
+      status: automated
+
+    - id: RHEL-08-030190
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the su command in RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_privileged_commands_su
+      status: automated
+
+    - id: RHEL-08-030200
+      levels:
+          - medium
+      title: The RHEL 8 audit system must be configured to audit any usage of the setxattr, fsetxattr,
+          lsetxattr, removexattr, fremovexattr, and lremovexattr system calls.
+      rules:
+          - audit_rules_dac_modification_fremovexattr
+          - audit_rules_dac_modification_fsetxattr
+          - audit_rules_dac_modification_lremovexattr
+          - audit_rules_dac_modification_lsetxattr
+          - audit_rules_dac_modification_removexattr
+          - audit_rules_dac_modification_setxattr
+      status: automated
+
+    - id: RHEL-08-030250
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the chage command in RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_privileged_commands_chage
+      status: automated
+
+    - id: RHEL-08-030260
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the chcon command in RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_execution_chcon
+      status: automated
+
+    - id: RHEL-08-030280
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the ssh-agent in RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_privileged_commands_ssh_agent
+      status: automated
+
+    - id: RHEL-08-030290
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the passwd command in RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_privileged_commands_passwd
+      status: automated
+
+    - id: RHEL-08-030300
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the mount command in RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_privileged_commands_mount
+      status: automated
+
+    - id: RHEL-08-030301
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the umount command in RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_privileged_commands_umount
+      status: automated
+
+    - id: RHEL-08-030302
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the mount syscall in RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_media_export
+      status: automated
+
+    - id: RHEL-08-030310
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the unix_update in RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_privileged_commands_unix_update
+      status: automated
+
+    - id: RHEL-08-030311
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of postdrop in RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_privileged_commands_postdrop
+      status: automated
+
+    - id: RHEL-08-030312
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of postqueue in RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_privileged_commands_postqueue
+      status: automated
+
+    - id: RHEL-08-030313
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of semanage in RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_execution_semanage
+      status: automated
+
+    - id: RHEL-08-030314
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of setfiles in RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_execution_setfiles
+      status: automated
+
+    - id: RHEL-08-030315
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of userhelper in RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_privileged_commands_userhelper
+      status: automated
+
+    - id: RHEL-08-030316
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of setsebool in RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_execution_setsebool
+      status: automated
+
+    - id: RHEL-08-030317
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of unix_chkpwd in RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_privileged_commands_unix_chkpwd
+      status: automated
+
+    - id: RHEL-08-030320
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the ssh-keysign in RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_privileged_commands_ssh_keysign
+      status: automated
+
+    - id: RHEL-08-030330
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the setfacl command in RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_execution_setfacl
+      status: automated
+
+    - id: RHEL-08-030340
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the pam_timestamp_check command in RHEL 8 must generate
+          an audit record.
+      rules:
+          - audit_rules_privileged_commands_pam_timestamp_check
+      status: automated
+
+    - id: RHEL-08-030350
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the newgrp command in RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_privileged_commands_newgrp
+      status: automated
+
+    - id: RHEL-08-030360
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the init_module and finit_module system calls in RHEL 8
+          must generate an audit record.
+      rules:
+          - audit_rules_kernel_module_loading_finit
+          - audit_rules_kernel_module_loading_init
+      status: automated
+
+    - id: RHEL-08-030361
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the rename, unlink, rmdir, renameat, and unlinkat system
+          calls in RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_file_deletion_events_rename
+          - audit_rules_file_deletion_events_renameat
+          - audit_rules_file_deletion_events_rmdir
+          - audit_rules_file_deletion_events_unlink
+          - audit_rules_file_deletion_events_unlinkat
+      status: automated
+
+    - id: RHEL-08-030370
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the gpasswd command in RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_privileged_commands_gpasswd
+      status: automated
+
+    - id: RHEL-08-030390
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the delete_module command in RHEL 8 must generate an audit
+          record.
+      rules:
+          - audit_rules_kernel_module_loading_delete
+      status: automated
+
+    - id: RHEL-08-030400
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the crontab command in RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_privileged_commands_crontab
+      status: automated
+
+    - id: RHEL-08-030410
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the chsh command in RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_privileged_commands_chsh
+      status: automated
+
+    - id: RHEL-08-030420
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the truncate, ftruncate, creat, open, openat, and open_by_handle_at
+          system calls in RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_unsuccessful_file_modification_creat
+          - audit_rules_unsuccessful_file_modification_ftruncate
+          - audit_rules_unsuccessful_file_modification_open
+          - audit_rules_unsuccessful_file_modification_open_by_handle_at
+          - audit_rules_unsuccessful_file_modification_openat
+          - audit_rules_unsuccessful_file_modification_truncate
+      status: automated
+
+    - id: RHEL-08-030480
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the chown, fchown, fchownat, and lchown system calls in
+          RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_dac_modification_chown
+          - audit_rules_dac_modification_fchown
+          - audit_rules_dac_modification_fchownat
+          - audit_rules_dac_modification_lchown
+      status: automated
+
+    - id: RHEL-08-030490
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the chmod, fchmod, and fchmodat system calls in RHEL 8 must
+          generate an audit record.
+      rules:
+          - audit_rules_dac_modification_chmod
+          - audit_rules_dac_modification_fchmod
+          - audit_rules_dac_modification_fchmodat
+      status: automated
+
+    - id: RHEL-08-030550
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the sudo command in RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_privileged_commands_sudo
+      status: automated
+
+    - id: RHEL-08-030560
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the usermod command in RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_privileged_commands_usermod
+      status: automated
+
+    - id: RHEL-08-030570
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the chacl command in RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_execution_chacl
+      status: automated
+
+    - id: RHEL-08-030580
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the kmod command in RHEL 8 must generate an audit record.
+      rules:
+          - audit_rules_privileged_commands_kmod
+      status: automated
+
+    - id: RHEL-08-030590
+      levels:
+          - medium
+      title: Successful/unsuccessful modifications to the faillock log file in RHEL 8 must generate an
+          audit record.
+      rules:
+          - audit_rules_login_events_faillock
+      status: automated
+
+    - id: RHEL-08-030600
+      levels:
+          - medium
+      title: Successful/unsuccessful modifications to the lastlog file in RHEL 8 must generate an audit
+          record.
+      rules:
+          - audit_rules_login_events_lastlog
+      status: automated
+
+    - id: RHEL-08-030601
+      levels:
+          - low
+      title: RHEL 8 must enable auditing of processes that start prior to the audit daemon.
+      rules:
+          - grub2_audit_argument
+      status: automated
+
+    - id: RHEL-08-030602
+      levels:
+          - low
+      title: RHEL 8 must allocate an audit_backlog_limit of sufficient size to capture processes that
+          start prior to the audit daemon.
+      rules:
+          - grub2_audit_backlog_limit_argument
+      status: automated
+
+    - id: RHEL-08-030603
+      levels:
+          - low
+      title: RHEL 8 must enable Linux audit logging for the USBGuard daemon.
+      rules:
+          - configure_usbguard_auditbackend
+      status: automated
+
+    - id: RHEL-08-030610
+      levels:
+          - medium
+      title: RHEL 8 must allow only the Information System Security Manager (ISSM) (or individuals or
+          roles appointed by the ISSM) to select which auditable events are to be audited.
+      rules:
+          - file_permissions_etc_audit_auditd
+          - file_permissions_etc_audit_rulesd
+      status: automated
+
+    - id: RHEL-08-030620
+      levels:
+          - medium
+      title: RHEL 8 audit tools must have a mode of 0755 or less permissive.
+      rules:
+          - file_audit_tools_permissions
+      status: automated
+
+    - id: RHEL-08-030630
+      levels:
+          - medium
+      title: RHEL 8 audit tools must be owned by root.
+      rules:
+          - file_audit_tools_ownership
+      status: automated
+
+    - id: RHEL-08-030640
+      levels:
+          - medium
+      title: RHEL 8 audit tools must be group-owned by root.
+      rules:
+          - file_audit_tools_group_ownership
+      status: automated
+
+    - id: RHEL-08-030650
+      levels:
+          - medium
+      title: RHEL 8 must use cryptographic mechanisms to protect the integrity of audit tools.
+      rules:
+          - aide_check_audit_tools
+      status: automated
+
+    - id: RHEL-08-030660
+      levels:
+          - medium
+      title: RHEL 8 must allocate audit record storage capacity to store at least one week of audit records,
+          when audit records are not immediately sent to a central audit record storage facility.
+      rules:
+          - auditd_audispd_configure_sufficiently_large_partition
+      status: automated
+
+    - id: RHEL-08-030670
+      levels:
+          - medium
+      title: RHEL 8 must have the packages required for offloading audit logs installed.
+      rules:
+          - package_rsyslog_installed
+      status: automated
+
+    - id: RHEL-08-030680
+      levels:
+          - medium
+      title: RHEL 8 must have the packages required for encrypting offloaded audit logs installed.
+      rules:
+          - package_rsyslog-gnutls_installed
+      status: automated
+
+    - id: RHEL-08-030690
+      levels:
+          - medium
+      title: The RHEL 8 audit records must be off-loaded onto a different system or storage media from
+          the system being audited.
+      rules:
+          - rsyslog_remote_loghost
+      status: automated
+
+    - id: RHEL-08-030700
+      levels:
+          - medium
+      title: RHEL 8 must take appropriate action when the internal event queue is full.
+      rules:
+          - auditd_overflow_action
+      status: automated
+
+    - id: RHEL-08-030710
+      levels:
+          - medium
+      title: RHEL 8 must encrypt the transfer of audit records off-loaded onto a different system or
+          media from the system being audited.
+      rules:
+          - rsyslog_encrypt_offload_actionsendstreamdrivermode
+          - rsyslog_encrypt_offload_defaultnetstreamdriver
+      status: automated
+
+    - id: RHEL-08-030720
+      levels:
+          - medium
+      title: RHEL 8 must authenticate the remote logging server for off-loading audit logs.
+      rules:
+          - rsyslog_encrypt_offload_actionsendstreamdriverauthmode
+      status: automated
+
+    - id: RHEL-08-030730
+      levels:
+          - medium
+      title: RHEL 8 must take action when allocated audit record storage volume reaches 75 percent of
+          the repository maximum audit record storage capacity.
+      rules:
+          - auditd_data_retention_space_left_percentage
+      status: automated
+
+    - id: RHEL-08-030740
+      levels:
+          - medium
+      title: RHEL 8 must securely compare internal information system clocks at least every 24 hours
+          with a server synchronized to an authoritative time source, such as the United States Naval
+          Observatory (USNO) time servers, or a time server designated for the appropriate DoD network
+          (NIPRNet/SIPRNet), and/or the Global Positioning System (GPS).
+      rules:
+          - chronyd_or_ntpd_set_maxpoll
+          - chronyd_server_directive
+          - chronyd_specify_remote_server
+      status: automated
+
+    - id: RHEL-08-030741
+      levels:
+          - low
+      title: RHEL 8 must disable the chrony daemon from acting as a server.
+      rules:
+          - chronyd_client_only
+      status: automated
+
+    - id: RHEL-08-030742
+      levels:
+          - low
+      title: RHEL 8 must disable network management of the chrony daemon.
+      rules:
+          - chronyd_no_chronyc_network
+      status: automated
+
+    - id: RHEL-08-040000
+      levels:
+          - high
+      title: RHEL 8 must not have the telnet-server package installed.
+      rules:
+          - package_telnet-server_removed
+      status: automated
+
+    - id: RHEL-08-040001
+      levels:
+          - medium
+      title: RHEL 8 must not have any automated bug reporting tools installed.
+      rules:
+          - package_abrt-addon-ccpp_removed
+          - package_abrt-addon-kerneloops_removed
+          - package_abrt-cli_removed
+          - package_abrt-plugin-sosreport_removed
+          - package_abrt_removed
+          - package_libreport-plugin-logger_removed
+          - package_libreport-plugin-rhtsupport_removed
+          - package_python3-abrt-addon_removed
+      status: automated
+
+    - id: RHEL-08-040002
+      levels:
+          - medium
+      title: RHEL 8 must not have the sendmail package installed.
+      rules:
+          - package_sendmail_removed
+      status: automated
+
+    - id: RHEL-08-040004
+      levels:
+          - low
+      title: RHEL 8 must enable mitigations against processor-based vulnerabilities.
+      rules:
+          - grub2_pti_argument
+      status: automated
+
+    - id: RHEL-08-040010
+      levels:
+          - high
+      title: RHEL 8 must not have the rsh-server package installed.
+      related_rules:
+          - package_rsh-server_removed
+      status: not applicable
+
+    - id: RHEL-08-040020
+      levels:
+          - medium
+      title: RHEL 8 must cover or disable the built-in or attached camera when not in use.
+      rules:
+          - kernel_module_uvcvideo_disabled
+      status: automated
+
+    - id: RHEL-08-040021
+      levels:
+          - low
+      title: RHEL 8 must disable the asynchronous transfer mode (ATM) protocol.
+      rules:
+          - kernel_module_atm_disabled
+      status: automated
+
+    - id: RHEL-08-040022
+      levels:
+          - low
+      title: RHEL 8 must disable the controller area network (CAN) protocol.
+      rules:
+          - kernel_module_can_disabled
+      status: automated
+
+    - id: RHEL-08-040023
+      levels:
+          - low
+      title: RHEL 8 must disable the stream control transmission protocol (SCTP).
+      rules:
+          - kernel_module_sctp_disabled
+      status: automated
+
+    - id: RHEL-08-040024
+      levels:
+          - low
+      title: RHEL 8 must disable the transparent inter-process communication (TIPC) protocol.
+      rules:
+          - kernel_module_tipc_disabled
+      status: automated
+
+    - id: RHEL-08-040025
+      levels:
+          - low
+      title: RHEL 8 must disable mounting of cramfs.
+      rules:
+          - kernel_module_cramfs_disabled
+      status: automated
+
+    - id: RHEL-08-040026
+      levels:
+          - low
+      title: RHEL 8 must disable IEEE 1394 (FireWire) Support.
+      rules:
+          - kernel_module_firewire-core_disabled
+      status: automated
+
+    - id: RHEL-08-040030
+      levels:
+          - medium
+      title: RHEL 8 must be configured to prohibit or restrict the use of functions, ports, protocols,
+          and/or services, as defined in the Ports, Protocols, and Services Management (PPSM) Category
+          Assignments List (CAL) and vulnerability assessments.
+      rules:
+          - configure_firewalld_ports
+      status: automated
+
+    - id: RHEL-08-040070
+      levels:
+          - medium
+      title: The RHEL 8 file system automounter must be disabled unless required.
+      rules:
+          - service_autofs_disabled
+      status: automated
+
+    - id: RHEL-08-040080
+      levels:
+          - medium
+      title: RHEL 8 must be configured to disable USB mass storage.
+      rules:
+          - kernel_module_usb-storage_disabled
+      status: automated
+
+    - id: RHEL-08-040090
+      levels:
+          - medium
+      title: A RHEL 8 firewall must employ a deny-all, allow-by-exception policy for allowing connections
+          to other systems.
+      rules:
+          - configured_firewalld_default_deny
+          - set_firewalld_default_zone
+      status: automated
+
+    - id: RHEL-08-040100
+      levels:
+          - medium
+      title: A firewall must be installed on RHEL 8.
+      rules:
+          - package_firewalld_installed
+      status: automated
+
+    - id: RHEL-08-040110
+      levels:
+          - medium
+      title: RHEL 8 wireless network adapters must be disabled.
+      rules:
+          - wireless_disable_interfaces
+      status: automated
+
+    - id: RHEL-08-040111
+      levels:
+          - medium
+      title: RHEL 8 Bluetooth must be disabled.
+      rules:
+          - kernel_module_bluetooth_disabled
+      status: automated
+
+    - id: RHEL-08-040120
+      levels:
+          - medium
+      title: RHEL 8 must mount /dev/shm with the nodev option.
+      rules:
+          - mount_option_dev_shm_nodev
+      status: automated
+
+    - id: RHEL-08-040121
+      levels:
+          - medium
+      title: RHEL 8 must mount /dev/shm with the nosuid option.
+      rules:
+          - mount_option_dev_shm_nosuid
+      status: automated
+
+    - id: RHEL-08-040122
+      levels:
+          - medium
+      title: RHEL 8 must mount /dev/shm with the noexec option.
+      rules:
+          - mount_option_dev_shm_noexec
+      status: automated
+
+    - id: RHEL-08-040123
+      levels:
+          - medium
+      title: RHEL 8 must mount /tmp with the nodev option.
+      rules:
+          - mount_option_tmp_nodev
+      status: automated
+
+    - id: RHEL-08-040124
+      levels:
+          - medium
+      title: RHEL 8 must mount /tmp with the nosuid option.
+      rules:
+          - mount_option_tmp_nosuid
+      status: automated
+
+    - id: RHEL-08-040125
+      levels:
+          - medium
+      title: RHEL 8 must mount /tmp with the noexec option.
+      rules:
+          - mount_option_tmp_noexec
+      status: automated
+
+    - id: RHEL-08-040126
+      levels:
+          - medium
+      title: RHEL 8 must mount /var/log with the nodev option.
+      rules:
+          - mount_option_var_log_nodev
+      status: automated
+
+    - id: RHEL-08-040127
+      levels:
+          - medium
+      title: RHEL 8 must mount /var/log with the nosuid option.
+      rules:
+          - mount_option_var_log_nosuid
+      status: automated
+
+    - id: RHEL-08-040128
+      levels:
+          - medium
+      title: RHEL 8 must mount /var/log with the noexec option.
+      rules:
+          - mount_option_var_log_noexec
+      status: automated
+
+    - id: RHEL-08-040129
+      levels:
+          - medium
+      title: RHEL 8 must mount /var/log/audit with the nodev option.
+      rules:
+          - mount_option_var_log_audit_nodev
+      status: automated
+
+    - id: RHEL-08-040130
+      levels:
+          - medium
+      title: RHEL 8 must mount /var/log/audit with the nosuid option.
+      rules:
+          - mount_option_var_log_audit_nosuid
+      status: automated
+
+    - id: RHEL-08-040131
+      levels:
+          - medium
+      title: RHEL 8 must mount /var/log/audit with the noexec option.
+      rules:
+          - mount_option_var_log_audit_noexec
+      status: automated
+
+    - id: RHEL-08-040132
+      levels:
+          - medium
+      title: RHEL 8 must mount /var/tmp with the nodev option.
+      rules:
+          - mount_option_var_tmp_nodev
+      status: automated
+
+    - id: RHEL-08-040133
+      levels:
+          - medium
+      title: RHEL 8 must mount /var/tmp with the nosuid option.
+      rules:
+          - mount_option_var_tmp_nosuid
+      status: automated
+
+    - id: RHEL-08-040134
+      levels:
+          - medium
+      title: RHEL 8 must mount /var/tmp with the noexec option.
+      rules:
+          - mount_option_var_tmp_noexec
+      status: automated
+
+    - id: RHEL-08-040135
+      levels:
+          - medium
+      title: The RHEL 8 fapolicy module must be installed.
+      rules:
+          - package_fapolicyd_installed
+      status: automated
+
+    - id: RHEL-08-040140
+      levels:
+          - medium
+      title: RHEL 8 must block unauthorized peripherals before establishing a connection.
+      rules:
+          - usbguard_generate_policy
+      status: automated
+
+    - id: RHEL-08-040150
+      levels:
+          - medium
+      title: A firewall must be able to protect against or limit the effects of Denial of Service (DoS)
+          attacks by ensuring RHEL 8 can implement rate-limiting measures on impacted network interfaces.
+      rules:
+          - firewalld-backend
+      status: automated
+
+    - id: RHEL-08-040160
+      levels:
+          - medium
+      title: All RHEL 8 networked systems must have and implement SSH to protect the confidentiality
+          and integrity of transmitted and received information, as well as information during preparation
+          for transmission.
+      rules:
+          - service_sshd_enabled
+      status: automated
+
+    - id: RHEL-08-040161
+      levels:
+          - medium
+      title: RHEL 8 must force a frequent session key renegotiation for SSH connections to the server.
+      rules:
+          - sshd_rekey_limit
+      status: automated
+
+    - id: RHEL-08-040170
+      levels:
+          - high
+      title: The x86 Ctrl-Alt-Delete key sequence must be disabled on RHEL 8.
+      rules:
+          - disable_ctrlaltdel_reboot
+      status: automated
+
+    - id: RHEL-08-040171
+      levels:
+          - high
+      title: The x86 Ctrl-Alt-Delete key sequence in RHEL 8 must be disabled if a graphical user interface
+          is installed.
+      rules:
+          - dconf_gnome_disable_ctrlaltdel_reboot
+      status: automated
+
+    - id: RHEL-08-040172
+      levels:
+          - high
+      title: The systemd Ctrl-Alt-Delete burst key sequence in RHEL 8 must be disabled.
+      rules:
+          - disable_ctrlaltdel_burstaction
+      status: automated
+
+    - id: RHEL-08-040180
+      levels:
+          - medium
+      title: The debug-shell systemd service must be disabled on RHEL 8.
+      rules:
+          - service_debug-shell_disabled
+      status: automated
+
+    - id: RHEL-08-040190
+      levels:
+          - high
+      title: The Trivial File Transfer Protocol (TFTP) server package must not be installed if not required
+          for RHEL 8 operational support.
+      rules:
+          - package_tftp-server_removed
+      status: automated
+
+    - id: RHEL-08-040200
+      levels:
+          - high
+      title: The root account must be the only account having unrestricted access to the RHEL 8 system.
+      rules:
+          - accounts_no_uid_except_zero
+      status: automated
+
+    - id: RHEL-08-040210
+      levels:
+          - medium
+      title: RHEL 8 must prevent IPv6 Internet Control Message Protocol (ICMP) redirect messages from
+          being accepted.
+      rules:
+          - sysctl_net_ipv6_conf_default_accept_redirects
+      status: automated
+
+    - id: RHEL-08-040220
+      levels:
+          - medium
+      title: RHEL 8 must not send Internet Control Message Protocol (ICMP) redirects.
+      rules:
+          - sysctl_net_ipv4_conf_all_send_redirects
+      status: automated
+
+    - id: RHEL-08-040230
+      levels:
+          - medium
+      title: RHEL 8 must not respond to Internet Control Message Protocol (ICMP) echoes sent to a broadcast
+          address.
+      rules:
+          - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+      status: automated
+
+    - id: RHEL-08-040240
+      levels:
+          - medium
+      title: RHEL 8 must not forward IPv6 source-routed packets.
+      rules:
+          - sysctl_net_ipv6_conf_all_accept_source_route
+      status: automated
+
+    - id: RHEL-08-040250
+      levels:
+          - medium
+      title: RHEL 8 must not forward IPv6 source-routed packets by default.
+      rules:
+          - sysctl_net_ipv6_conf_default_accept_source_route
+      status: automated
+
+    - id: RHEL-08-040260
+      levels:
+          - medium
+      title: RHEL 8 must not enable IPv6 packet forwarding unless the system is a router.
+      rules:
+          - sysctl_net_ipv6_conf_all_forwarding
+      status: automated
+
+    - id: RHEL-08-040261
+      levels:
+          - medium
+      title: RHEL 8 must not accept router advertisements on all IPv6 interfaces.
+      rules:
+          - sysctl_net_ipv6_conf_all_accept_ra
+      status: automated
+
+    - id: RHEL-08-040262
+      levels:
+          - medium
+      title: RHEL 8 must not accept router advertisements on all IPv6 interfaces by default.
+      rules:
+          - sysctl_net_ipv6_conf_default_accept_ra
+      status: automated
+
+    - id: RHEL-08-040270
+      levels:
+          - medium
+      title: RHEL 8 must not allow interfaces to perform Internet Control Message Protocol (ICMP) redirects
+          by default.
+      rules:
+          - sysctl_net_ipv4_conf_default_send_redirects
+      status: automated
+
+    - id: RHEL-08-040280
+      levels:
+          - medium
+      title: RHEL 8 must ignore IPv6 Internet Control Message Protocol (ICMP) redirect messages.
+      rules:
+          - sysctl_net_ipv6_conf_all_accept_redirects
+      status: automated
+
+    - id: RHEL-08-040281
+      levels:
+          - medium
+      title: RHEL 8 must disable access to network bpf syscall from unprivileged processes.
+      rules:
+          - sysctl_kernel_unprivileged_bpf_disabled
+      status: automated
+
+    - id: RHEL-08-040282
+      levels:
+          - medium
+      title: RHEL 8 must restrict usage of ptrace to descendant  processes.
+      rules:
+          - sysctl_kernel_yama_ptrace_scope
+      status: automated
+
+    - id: RHEL-08-040283
+      levels:
+          - medium
+      title: RHEL 8 must restrict exposed kernel pointer addresses access.
+      rules:
+          - sysctl_kernel_kptr_restrict
+      status: automated
+
+    - id: RHEL-08-040284
+      levels:
+          - medium
+      title: RHEL 8 must disable the use of user namespaces.
+      rules:
+          - sysctl_user_max_user_namespaces_no_remediation
+      status: automated
+
+    - id: RHEL-08-040285
+      levels:
+          - medium
+      title: RHEL 8 must use reverse path filtering on all IPv4 interfaces.
+      rules:
+          - sysctl_net_ipv4_conf_all_rp_filter
+      status: automated
+
+    - id: RHEL-08-040290
+      levels:
+          - medium
+      title: RHEL 8 must be configured to prevent unrestricted mail relaying.
+      rules:
+          - postfix_prevent_unrestricted_relay
+      status: automated
+
+    - id: RHEL-08-040300
+      levels:
+          - low
+      title: The RHEL 8 file integrity tool must be configured to verify extended attributes.
+      rules:
+          - aide_verify_ext_attributes
+      status: automated
+
+    - id: RHEL-08-040310
+      levels:
+          - low
+      title: The RHEL 8 file integrity tool must be configured to verify Access Control Lists (ACLs).
+      rules:
+          - aide_verify_acls
+      status: automated
+
+    - id: RHEL-08-040320
+      levels:
+          - medium
+      title: The graphical display manager must not be installed on RHEL 8 unless approved.
+      rules:
+          - xwindows_remove_packages
+      status: automated
+
+    - id: RHEL-08-040330
+      levels:
+          - medium
+      title: RHEL 8 network interfaces must not be in promiscuous mode.
+      rules:
+          - network_sniffer_disabled
+      status: automated
+
+    - id: RHEL-08-040340
+      levels:
+          - medium
+      title: RHEL 8 remote X connections for interactive users must be disabled unless to fulfill documented
+          and validated mission requirements.
+      rules:
+          - sshd_disable_x11_forwarding
+      status: automated
+
+    - id: RHEL-08-040341
+      levels:
+          - medium
+      title: The RHEL 8 SSH daemon must prevent remote hosts from connecting to the proxy display.
+      rules:
+          - sshd_x11_use_localhost
+      status: automated
+
+    - id: RHEL-08-040350
+      levels:
+          - medium
+      title: If the Trivial File Transfer Protocol (TFTP) server is required, the RHEL 8 TFTP daemon
+          must be configured to operate in secure mode.
+      rules:
+          - tftp_uses_secure_mode_systemd
+      status: automated
+
+    - id: RHEL-08-040360
+      levels:
+          - high
+      title: A File Transfer Protocol (FTP) server package must not be installed unless mission essential
+          on RHEL 8.
+      rules:
+          - package_vsftpd_removed
+      status: automated
+
+    - id: RHEL-08-040370
+      levels:
+          - medium
+      title: The gssproxy package must not be installed unless mission essential on RHEL 8.
+      rules:
+          - package_gssproxy_removed
+      status: automated
+
+    - id: RHEL-08-040380
+      levels:
+          - medium
+      title: The iprutils package must not be installed unless mission essential on RHEL 8.
+      rules:
+          - package_iprutils_removed
+      status: automated
+
+    - id: RHEL-08-040390
+      levels:
+          - medium
+      title: The tuned package must not be installed unless mission essential on RHEL 8.
+      rules:
+          - package_tuned_removed
+      status: automated
+
+    - id: RHEL-08-010163
+      levels:
+          - medium
+      title: The krb5-server package must not be installed on RHEL 8.
+      rules:
+          - package_krb5-server_removed
+      status: automated
+
+    - id: RHEL-08-010382
+      levels:
+          - medium
+      title: RHEL 8 must restrict privilege elevation to authorized personnel.
+      rules:
+          - sudo_restrict_privilege_elevation_to_authorized
+      status: automated
+
+    - id: RHEL-08-010383
+      levels:
+          - medium
+      title: RHEL 8 must use the invoking user's password for privilege escalation when using "sudo".
+      rules:
+          - sudoers_validate_passwd
+      status: automated
+
+    - id: RHEL-08-010384
+      levels:
+          - medium
+      title: RHEL 8 must require re-authentication when using the "sudo" command.
+      rules:
+          - sudo_require_reauthentication
+          - var_sudo_timestamp_timeout=always_prompt
+      status: automated
+
+    - id: RHEL-08-010049
+      levels:
+          - medium
+      title: RHEL 8 must display a banner before granting local or remote access to the system via a
+          graphical user logon.
+      rules:
+          - dconf_gnome_banner_enabled
+      status: automated
+
+    - id: RHEL-08-010141
+      levels:
+          - medium
+      title: RHEL 8 operating systems booted with United Extensible Firmware Interface (UEFI) must require
+          a unique superusers name upon booting into single-user mode and maintenance.
+      rules:
+          - grub2_uefi_admin_username
+      status: automated
+
+    - id: RHEL-08-010149
+      levels:
+          - medium
+      title: RHEL 8 operating systems booted with a BIOS must require  a unique superusers name upon
+          booting into single-user and maintenance modes.
+      rules:
+          - grub2_admin_username
+      status: automated
+
+    - id: RHEL-08-010152
+      levels:
+          - medium
+      title: RHEL 8 operating systems must require authentication upon booting into emergency mode.
+      rules:
+          - require_emergency_target_auth
+      status: automated
+
+    - id: RHEL-08-010159
+      levels:
+          - medium
+      title: The RHEL 8 pam_unix.so module must be configured in the system-auth file to use a FIPS 140-2
+          approved cryptographic hashing algorithm for system authentication.
+      rules:
+          - set_password_hashing_algorithm_systemauth
+      status: automated
+
+    - id: RHEL-08-010201
+      levels:
+          - medium
+      title: RHEL 8 must be configured so that all network connections associated with SSH traffic are
+          terminated after 10 minutes of becoming unresponsive.
+      rules:
+          - sshd_set_idle_timeout
+      status: automated
+
+    - id: RHEL-08-010287
+      levels:
+          - medium
+      title: The RHEL 8 SSH daemon must be configured to use system-wide crypto policies.
+      rules:
+          - configure_ssh_crypto_policy
+      status: automated
+
+    - id: RHEL-08-010472
+      levels:
+          - low
+      title: RHEL 8 must have the packages required to use the hardware random number generator entropy
+          gatherer service.
+      rules:
+          - package_rng-tools_installed
+      status: automated
+
+    - id: RHEL-08-010522
+      levels:
+          - medium
+      title: The RHEL 8 SSH daemon must not allow GSSAPI authentication, except to fulfill documented
+          and validated mission requirements.
+      rules:
+          - sshd_disable_gssapi_auth
+      status: automated
+
+    - id: RHEL-08-010544
+      levels:
+          - medium
+      title: RHEL 8 must use a separate file system for /var/tmp.
+      rules:
+          - partition_for_var_tmp
+      status: automated
+
+    - id: RHEL-08-010572
+      levels:
+          - medium
+      title: RHEL 8 must prevent files with the setuid and setgid bit set from being executed on the
+          /boot/efi directory.
+      rules:
+          - mount_option_boot_efi_nosuid
+      status: automated
+
+    - id: RHEL-08-010731
+      levels:
+          - medium
+      title: All RHEL 8 local interactive user home directory files must have mode 0750 or less permissive.
+      rules:
+          - accounts_users_home_files_permissions
+      status: automated
+
+    - id: RHEL-08-010741
+      levels:
+          - medium
+      title: RHEL 8 must be configured so that all files and directories contained in local interactive
+          user home directories are group-owned by a group of which the home directory owner is a member.
+      rules:
+          - accounts_users_home_files_groupownership
+      status: automated
+
+    - id: RHEL-08-020025
+      levels:
+          - medium
+      title: RHEL 8 must configure the use of the pam_faillock.so module in the /etc/pam.d/system-auth
+          file.
+      rules:
+          - account_password_pam_faillock_system_auth
+      status: automated
+
+    - id: RHEL-08-020026
+      levels:
+          - medium
+      title: RHEL 8 must configure the use of the pam_faillock.so module in the /etc/pam.d/password-auth
+          file.
+      rules:
+          - account_password_pam_faillock_password_auth
+      status: automated
+
+    - id: RHEL-08-020031
+      levels:
+          - medium
+      title: RHEL 8 must initiate a session lock for graphical user interfaces when the screensaver is
+          activated.
+      rules:
+          - dconf_gnome_screensaver_lock_delay
+          - var_screensaver_lock_delay=5_seconds
+      status: automated
+
+    - id: RHEL-08-020032
+      levels:
+          - medium
+      title: RHEL 8 must disable the user list at logon for graphical user interfaces.
+      rules:
+          - dconf_gnome_disable_user_list
+      status: automated
+
+    - id: RHEL-08-020081
+      levels:
+          - medium
+      title: RHEL 8 must prevent a user from overriding the session idle-delay setting for the graphical
+          user interface.
+      rules:
+          - dconf_gnome_session_idle_user_locks
+      status: automated
+
+    - id: RHEL-08-020082
+      levels:
+          - medium
+      title: RHEL 8 must prevent a user from overriding the screensaver lock-enabled setting for the
+          graphical user interface.
+      rules:
+          - dconf_gnome_screensaver_lock_locked
+      status: automated
+
+    - id: RHEL-08-020332
+      levels:
+          - high
+      title: RHEL 8 must not allow blank or null passwords in the password-auth file.
+      rules:
+          - no_empty_passwords
+      status: automated
+
+    - id: RHEL-08-030181
+      levels:
+          - medium
+      title: RHEL 8 audit records must contain information to establish what type of events occurred,
+          the source of events, where events occurred, and the outcome of events.
+      rules:
+          - service_auditd_enabled
+      status: automated
+
+    - id: RHEL-08-030731
+      levels:
+          - medium
+      title: RHEL 8 must notify the System Administrator (SA) and Information System Security Officer
+          (ISSO) (at a minimum) when allocated audit record storage volume 75 percent utilization.
+      rules:
+          - auditd_data_retention_space_left_action
+      status: automated
+
+    - id: RHEL-08-040101
+      levels:
+          - medium
+      title: A firewall must be active on RHEL 8.
+      rules:
+          - service_firewalld_enabled
+      status: automated
+
+    - id: RHEL-08-040136
+      levels:
+          - medium
+      title: The RHEL 8 fapolicy module must be enabled.
+      rules:
+          - service_fapolicyd_enabled
+      status: automated
+
+    - id: RHEL-08-040137
+      levels:
+          - medium
+      title: The RHEL 8 fapolicy module must be configured to employ a deny-all, permit-by-exception
+          policy to allow the execution of authorized software programs.
+      rules:
+          - fapolicy_default_deny
+      status: automated
+
+    - id: RHEL-08-040139
+      levels:
+          - medium
+      title: RHEL 8 must have the USBGuard installed.
+      rules:
+          - package_usbguard_installed
+      status: automated
+
+    - id: RHEL-08-040141
+      levels:
+          - medium
+      title: RHEL 8 must enable the USBGuard.
+      rules:
+          - service_usbguard_enabled
+      status: automated
+
+    - id: RHEL-08-040159
+      levels:
+          - medium
+      title: All RHEL 8 networked systems must have SSH installed.
+      rules:
+          - package_openssh-server_installed
+      status: automated
+
+    - id: RHEL-08-040209
+      levels:
+          - medium
+      title: RHEL 8 must prevent IPv4 Internet Control Message Protocol (ICMP) redirect messages from
+          being accepted.
+      rules:
+          - sysctl_net_ipv4_conf_default_accept_redirects
+      status: automated
+
+    - id: RHEL-08-040239
+      levels:
+          - medium
+      title: RHEL 8 must not forward IPv4 source-routed packets.
+      rules:
+          - sysctl_net_ipv4_conf_all_accept_source_route
+      status: automated
+
+    - id: RHEL-08-040249
+      levels:
+          - medium
+      title: RHEL 8 must not forward IPv4 source-routed packets by default.
+      rules:
+          - sysctl_net_ipv4_conf_default_accept_source_route
+      status: automated
+
+    - id: RHEL-08-040279
+      levels:
+          - medium
+      title: RHEL 8 must ignore IPv4 Internet Control Message Protocol (ICMP) redirect messages.
+      rules:
+          - sysctl_net_ipv4_conf_all_accept_redirects
+      status: automated
+
+    - id: RHEL-08-040286
+      levels:
+          - medium
+      title: RHEL 8 must enable hardening for the Berkeley Packet Filter Just-in-time compiler.
+      rules:
+          - sysctl_net_core_bpf_jit_harden
+      status: automated
+
+    - id: RHEL-08-020027
+      levels:
+          - medium
+      title: RHEL 8 systems, versions 8.2 and above, must configure SELinux context type to allow the
+          use of a non-default faillock tally directory.
+      rules:
+          - account_password_selinux_faillock_dir
+      status: automated
+
+    - id: RHEL-08-020028
+      levels:
+          - medium
+      title: RHEL 8 systems below version 8.2 must configure SELinux context type to allow the use of
+          a non-default faillock tally directory.
+      rules:
+          - account_password_selinux_faillock_dir
+      status: automated
+
+    - id: RHEL-08-040259
+      levels:
+          - medium
+      title: RHEL 8 must not enable IPv4 packet forwarding unless the system is a router.
+      rules:
+          - sysctl_net_ipv4_conf_all_forwarding
+      status: automated
+
+    - id: RHEL-08-010121
+      levels:
+          - high
+      title: The RHEL 8 operating system must not have accounts configured with blank or null passwords.
+      rules:
+          - no_empty_passwords_etc_shadow
+      status: automated
+
+    - id: RHEL-08-010331
+      levels:
+          - medium
+      title: RHEL 8 library directories must have mode 755 or less permissive.
+      rules:
+          - dir_permissions_library_dirs
+      status: automated
+
+    - id: RHEL-08-010341
+      levels:
+          - medium
+      title: RHEL 8 library directories must be owned by root.
+      rules:
+          - dir_ownership_library_dirs
+      status: automated
+
+    - id: RHEL-08-010351
+      levels:
+          - medium
+      title: RHEL 8 library directories must be group-owned by root or a system account.
+      rules:
+          - dir_group_ownership_library_dirs
+      status: automated
+
+    - id: RHEL-08-010359
+      levels:
+          - medium
+      title: The RHEL 8 operating system must use a file integrity tool to verify correct operation of
+          all security functions.
+      rules:
+          - aide_build_database
+          - package_aide_installed
+      status: automated
+
+    - id: RHEL-08-010379
+      levels:
+          - medium
+      title: RHEL 8 must specify the default "include" directory for the /etc/sudoers file.
+      rules:
+          - sudoers_default_includedir
+      status: automated
+
+    - id: RHEL-08-010385
+      levels:
+          - medium
+      title: The RHEL 8 operating system must not be configured to bypass password requirements for privilege
+          escalation.
+      rules:
+          - disallow_bypass_password_sudo
+      status: automated
+
+    - id: RHEL-08-020101
+      levels:
+          - medium
+      title: RHEL 8 must ensure the password complexity module is enabled in the system-auth file.
+      rules:
+          - accounts_password_pam_pwquality_system_auth
+      status: automated
+
+    - id: RHEL-08-020104
+      levels:
+          - medium
+      title: RHEL 8 systems, version 8.4 and above, must ensure the password complexity module is configured
+          for three retries or less.
+      rules:
+          - accounts_password_pam_retry
+      status: automated
+
+    - id: RHEL-08-040321
+      levels:
+          - medium
+      title: The graphical display manager must not be the default target on RHEL 8 unless approved.
+      rules:
+          - xwindows_runlevel_target
+      status: automated
+
+    - id: RHEL-08-040400
+      levels:
+          - medium
+      title: RHEL 8 must prevent nonprivileged users from executing privileged functions, including disabling,
+          circumventing, or altering implemented security safeguards/countermeasures.
+      rules:
+          - selinux_user_login_roles
+      status: automated
+
+    - id: RHEL-08-040342
+      levels:
+          - medium
+      title: RHEL 8 SSH server must be configured to use only FIPS-validated key exchange algorithms.
+      rules:
+          - sshd_use_approved_kex_ordered_stig
+      status: automated
+
+    - id: RHEL-08-010019
+      levels:
+          - medium
+      title: RHEL 8 must ensure cryptographic verification of vendor software packages.
+      rules:
+          - ensure_redhat_gpgkey_installed
+      status: automated
+
+    - id: RHEL-08-010358
+      levels:
+          - medium
+      title: RHEL 8 must be configured to allow sending email notifications of unauthorized configuration
+          changes to designated personnel.
+      rules:
+          - package_mailx_installed
+      status: automated
+
+    - id: RHEL-08-020035
+      levels:
+          - medium
+      title: RHEL 8.7 and higher must terminate idle user sessions.
+      rules:
+          - logind_session_timeout
+          - var_logind_session_timeout=10_minutes
+      status: automated
+
+    - id: RHEL-08-020331
+      levels:
+          - high
+      title: RHEL 8 must not allow blank or null passwords in the system-auth file.
+      rules:
+          - no_empty_passwords
+      status: automated
+
+    - id: RHEL-08-010296
+      levels:
+          - medium
+      title: RHEL 8 SSH client must be configured to use only Message Authentication Codes (MACs) employing
+          FIPS 140-3 validated cryptographic hash algorithms.
+      rules:
+          - harden_sshd_ciphers_openssh_conf_crypto_policy
+          - harden_sshd_macs_openssh_conf_crypto_policy
+      status: automated
+
+    - id: RHEL-08-010297
+      levels:
+          - medium
+      title: RHEL 8 SSH client must be configured to use only ciphers employing FIPS 140-3 validated
+          cryptographic hash algorithms.
+      rules: []
+      status: pending
+
+    - id: RHEL-08-010455
+      levels:
+          - medium
+      title: RHEL 8 must elevate the SELinux context when an administrator calls the sudo command.
+      rules:
+          - selinux_context_elevation_for_sudo
+      status: automated

--- a/products/rhel8/profiles/anssi_bp28_enhanced.profile
+++ b/products/rhel8/profiles/anssi_bp28_enhanced.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel8/profiles/anssi_bp28_high.profile
+++ b/products/rhel8/profiles/anssi_bp28_high.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel8/profiles/anssi_bp28_intermediary.profile
+++ b/products/rhel8/profiles/anssi_bp28_intermediary.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel8/profiles/anssi_bp28_minimal.profile
+++ b/products/rhel8/profiles/anssi_bp28_minimal.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel8/profiles/cis.profile
+++ b/products/rhel8/profiles/cis.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel8/profiles/cis_server_l1.profile
+++ b/products/rhel8/profiles/cis_server_l1.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel8/profiles/cis_workstation_l1.profile
+++ b/products/rhel8/profiles/cis_workstation_l1.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel8/profiles/cis_workstation_l2.profile
+++ b/products/rhel8/profiles/cis_workstation_l2.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel8/profiles/cjis.profile
+++ b/products/rhel8/profiles/cjis.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 hidden: true

--- a/products/rhel8/profiles/cui.profile
+++ b/products/rhel8/profiles/cui.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel8/profiles/default.profile
+++ b/products/rhel8/profiles/default.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 hidden: true

--- a/products/rhel8/profiles/e8.profile
+++ b/products/rhel8/profiles/e8.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:
@@ -10,13 +11,13 @@ reference: https://www.cyber.gov.au/acsc/view-all-content/publications/hardening
 title: 'Australian Cyber Security Centre (ACSC) Essential Eight'
 
 description: |-
-  This profile contains configuration checks for Red Hat Enterprise Linux 8
-  that align to the Australian Cyber Security Centre (ACSC) Essential Eight.
+    This profile contains configuration checks for Red Hat Enterprise Linux 8
+    that align to the Australian Cyber Security Centre (ACSC) Essential Eight.
 
-  A copy of the Essential Eight in Linux Environments guide can be found at the
-  ACSC website:
+    A copy of the Essential Eight in Linux Environments guide can be found at the
+    ACSC website:
 
-  https://www.cyber.gov.au/acsc/view-all-content/publications/hardening-linux-workstations-and-servers
+    https://www.cyber.gov.au/acsc/view-all-content/publications/hardening-linux-workstations-and-servers
 
 selections:
     - e8:all

--- a/products/rhel8/profiles/hipaa.profile
+++ b/products/rhel8/profiles/hipaa.profile
@@ -1,4 +1,5 @@
-documentation_complete: True
+---
+documentation_complete: true
 
 metadata:
     SMEs:

--- a/products/rhel8/profiles/ism_o.profile
+++ b/products/rhel8/profiles/ism_o.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:
@@ -13,17 +14,17 @@ reference: https://www.cyber.gov.au/ism
 title: 'Australian Cyber Security Centre (ACSC) ISM Official'
 
 description: |-
-  This profile contains configuration checks for Red Hat Enterprise Linux 8
-  that align to the Australian Cyber Security Centre (ACSC) Information Security Manual (ISM)
-  with the applicability marking of OFFICIAL.
+    This profile contains configuration checks for Red Hat Enterprise Linux 8
+    that align to the Australian Cyber Security Centre (ACSC) Information Security Manual (ISM)
+    with the applicability marking of OFFICIAL.
 
-  The ISM uses a risk-based approach to cyber security. This profile provides a guide to aligning
-  Red Hat Enterprise Linux security controls with the ISM, which can be used to select controls
-  specific to an organisation's security posture and risk profile.
+    The ISM uses a risk-based approach to cyber security. This profile provides a guide to aligning
+    Red Hat Enterprise Linux security controls with the ISM, which can be used to select controls
+    specific to an organisation's security posture and risk profile.
 
-  A copy of the ISM can be found at the ACSC website:
+    A copy of the ISM can be found at the ACSC website:
 
-  https://www.cyber.gov.au/ism
+    https://www.cyber.gov.au/ism
 
 extends: e8
 

--- a/products/rhel8/profiles/ospp.profile
+++ b/products/rhel8/profiles/ospp.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:
@@ -241,7 +242,6 @@ selections:
     - configure_usbguard_auditbackend
     - usbguard_allow_hid_and_hub
 
-
     ### Enable / Configure FIPS
     - enable_fips_mode
     - var_system_crypto_policy=fips_ospp
@@ -414,7 +414,6 @@ selections:
 
     # Enable dnf-automatic Timer
     - timer_dnf-automatic_enabled
-
 
     # Prevent Kerberos use by system daemons
     - kerberos_disable_no_keytab

--- a/products/rhel8/profiles/pci-dss.profile
+++ b/products/rhel8/profiles/pci-dss.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel8/profiles/rht-ccp.profile
+++ b/products/rhel8/profiles/rht-ccp.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 hidden: true

--- a/products/rhel8/profiles/standard.profile
+++ b/products/rhel8/profiles/standard.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 hidden: true

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel8/profiles/stig_gui.profile
+++ b/products/rhel8/profiles/stig_gui.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:


### PR DESCRIPTION
#### Description:

Format rhel8 related yaml file using yamlfix command, yamlfix.toml as config file.

#### Rationale:

The reason to format yaml file is to unify all yaml file format. So that external library change can be minimal, real change can be easily spotted instead of seeing a lots of format change.

Currently, when update cac content yaml file content, i found the yaml file format is chaotic. It will cause irrelevant format changes and let reviewer hard to focus what's really changed. We need to unify cac content yaml file format, update style guide of yaml.

#### Review Hints:

Format rhel8 related yaml file using yamlfix command, [yamlfix.toml](https://github.com/ComplianceAsCode/content/blob/master/yamlfix.toml) as config file.

```shell
yamlfix -c yamlfix.toml file_path
```
