### PR TITLE
fix: Update some DoD verbiage in rules.yml to make it more organization agnostic

### DIFF
--- a/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_configure_firewall/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_configure_os_protect_web_server/httpd_configure_firewall/rule.yml
@@ -10,7 +10,7 @@ description: |-
     {{{ describe_iptables_allow(proto="tcp", port=443) }}}
 
 rationale: |-
-    Failure to comply with DoD ports, protocols, and services (PPS) requirements
+    Failure to properly manage and restricts ports, protocols, and services (PPS)
     can result in compromise of enclave boundary protections and/or functionality
     of the AIS.
 
@@ -20,7 +20,7 @@ ocil_clause: 'it is not'
 
 ocil: |-
     Review the web site to determine if HTTP and HTTPs are used in accordance with
-    well known ports (e.g., 80 and 443) or those ports and services as registered
-    and approved for use by the DoD PPSM.
+    well known ports (e.g., 80 and 443) or over alternate ports that are explicitly registered
+    and approved for use by the organization's network security policy.
     {{{ describe_firewalld_allow_service(service="http") }}}
     {{{ describe_firewalld_allow_service(service="https") }}}

--- a/linux_os/guide/services/http/securing_httpd/httpd_modules_improve_security/httpd_deploy_mod_ssl/httpd_require_client_certs/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_modules_improve_security/httpd_deploy_mod_ssl/httpd_require_client_certs/rule.yml
@@ -9,7 +9,7 @@ description: |-
     <pre>SSLVerifyClient require</pre>
 
 rationale: |-
-    Web sites requiring authentication within the DoD must utilize PKI as an
+    Web sites requiring authentication must utilize PKI as an
     authentication mechanism for web users. Information systems residing behind web
     servers requiring authorization based on individual identity must use the
     identity provided by certificate-based authentication to support access control

--- a/linux_os/guide/services/http/securing_httpd/httpd_public_resources_not_shared/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_public_resources_not_shared/rule.yml
@@ -5,7 +5,7 @@ title: 'Public web server resources must not be shared with private assets'
 
 description: |-
     It is important to segregate public web server resources from private
-    resources located behind the DoD DMZ in order to protect private
+    resources located behind a DMZ in order to protect private
     assets.
 
 rationale: |-

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_pubkey_auth/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_pubkey_auth/rule.yml
@@ -18,8 +18,8 @@ rationale: |-
     requires using two or more factors to achieve authentication.
     A privileged account is defined as an information system account with
     authorizations of a privileged user. 
-    The DoD CAC with DoD-approved PKI is an example of multifactor
-    authentication.
+    Smart cards or hardware tokens paired with digital certificates are
+    common examples of multifactor implementations.
 
 severity: medium
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/rule.yml
@@ -53,14 +53,14 @@ references:
 {{{ complete_ocil_entry_sshd_option(default="no", option="Banner", value="/etc/issue") }}}
 
 fixtext: |-
-    Configure {{{ full_name }}} to display the Standard Mandatory DoD Notice and Consent Banner before granting access to the system via the ssh.
+    Configure {{{ full_name }}} to display the Standard Mandatory Notice and Consent Banner before granting access to the system via the ssh.
 
     Edit the "/etc/ssh/sshd_config" file to uncomment the banner keyword and configure it to point to a file that will contain the logon banner (this file may be named differently or be in a different location if using a version of SSH that is provided by a third-party vendor).
     An example configuration line is:
 
     Banner /etc/issue
 
-srg_requirement: '{{{ full_name }}} must display the Standard Mandatory DoD Notice and Consent Banner before granting local or remote access to the system via a ssh logon.'
+srg_requirement: '{{{ full_name }}} must display the Standard Mandatory Notice and Consent Banner before granting local or remote access to the system via a ssh logon.'
 
 {{% if 'ubuntu' not in product %}}
 conflicts:

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/rule.yml
@@ -28,7 +28,7 @@ description: |-
     order of algorithms.
 
 rationale: |-
-    DoD information systems are required to use FIPS-approved key exchange algorithms.
+    FIPS-approved key exchange algorithms are required to be used.
     The system will attempt to use the first algorithm presented by the client that matches
     the server list. Listing the values "strongest to weakest" is a method to ensure the use
     of the strongest algorithm available to secure the SSH connection.

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/rule.yml
@@ -34,8 +34,8 @@ description: |-
     The rule is parametrized to use the following MACs: <code>{{{ xccdf_value("sshd_approved_macs") }}}</code>.
 
 rationale: |-
-    DoD Information Systems are required to use FIPS-approved cryptographic hash
-    functions. The only SSHv2 hash algorithms meeting this requirement is SHA2.
+    FIPS-approved cryptographic hash functions are required to be used.
+    The only SSHv2 hash algorithms meeting this requirement is SHA2.
 
 severity: medium
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/rule.yml
@@ -17,8 +17,8 @@ description: |-
     {{%- endif %}}
 
 rationale: |-
-    DoD Information Systems are required to use FIPS-approved cryptographic hash
-    functions. The only SSHv2 hash algorithms meeting this requirement is SHA2.
+    FIPS-approved cryptographic hash functions are required to be used.
+    The only SSHv2 hash algorithms meeting this requirement is SHA2.
 
 severity: medium
 

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/rule.yml
@@ -29,9 +29,8 @@ rationale: |-
     <br /><br />
     Multi-Factor Authentication (MFA) solutions that require devices separate from
     information systems gaining access include, for example, hardware tokens
-    providing time-based or challenge-response authenticators and smart cards such
-    as the U.S. Government Personal Identity Verification card and the DoD Common
-    Access Card.
+    providing time-based or challenge-response authenticators and smart cards
+    or similar secure authentication devices issued by an organization or identity provider.
 
 severity: medium
 

--- a/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/rule.yml
+++ b/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/rule.yml
@@ -47,7 +47,7 @@ fixtext: |-
 
     AuditBackend=LinuxAudit
 
-srg_requirement: {{{ full_name }}} Must Provide Audit Record Generation Capability For Dod-Defined Auditable Events For All Operating System Components
+srg_requirement: {{{ full_name }}} Must Provide Audit Record Generation Capability For Organization Defined Auditable Events For All Operating System Components
 
 template:
     name: key_value_pair_in_file

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/rule.yml
@@ -70,7 +70,7 @@ ocil: |-
     If properly configured, the output should be <tt>/org/gnome/login-screen/banner-message-enable</tt>.
 
 fixtext: |-
-    Configure {{{ full_name }}} to display the Standard Mandatory DoD Notice and Consent Banner before granting access to the system.
+    Configure {{{ full_name }}} to display the Standard Mandatory Notice and Consent Banner before granting access to the system.
 
     Note: If the system does not have a graphical user interface installed, this requirement is Not Applicable.
 

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/rule.yml
@@ -80,7 +80,7 @@ ocil: |-
     {{% endif %}}
 
 fixtext: |-
-    Configure {{{ full_name }}} to display the Standard Mandatory DoD Notice and Consent Banner before granting access to the system.
+    Configure {{{ full_name }}} to display the Standard Mandatory Notice and Consent Banner before granting access to the system.
 
     Note: If the system does not have a graphical user interface installed, this requirement is Not Applicable.
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/rule.yml
@@ -12,7 +12,7 @@ description: |-
     <tt>remember</tt> and <tt>use_authtok</tt> are present, and that the value
     for the <tt>remember</tt> parameter is {{{ xccdf_value("var_password_pam_remember") }}} or greater. For example:
     <pre>password requisite pam_pwhistory.so <i>...existing_options...</i> remember={{{ xccdf_value("var_password_pam_remember") }}} use_authtok</pre>
-    The DoD STIG requirement is 5 passwords.
+    The profile requirement is {{{ xccdf_value("var_password_pam_remember") }}} passwords.
 
 rationale: 'Preventing re-use of previous passwords helps ensure that a compromised password is not re-used by a user.'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_dcredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_dcredit/rule.yml
@@ -42,8 +42,8 @@ ocil: |-
     password requisite pam_cracklib.so dcredit={{{ xccdf_value("var_password_pam_dcredit") }}}</pre>
     The <tt>dcredit</tt> parameter (as a negative number) will indicate how
     many digits are required.
-    The DoD requires at least one digit in a password.
-    This would appear as <tt>dcredit=-1</tt>.
+    The profile requires at least {{{ xccdf_value("var_password_pam_dcredit") }}} digit in a password.
+    This would appear as <tt>dcredit=-{{{ xccdf_value("var_password_pam_dcredit") }}}</tt>.
 
 template:
     name: pam_options

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_difok/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_difok/rule.yml
@@ -42,8 +42,8 @@ ocil: |-
     <pre># grep pam_cracklib.so /etc/pam.d/common-password
     password requisite pam_cracklib.so difok={{{ xccdf_value("var_password_pam_difok") }}}</pre>
     The <tt>difok</tt> parameter will indicate how many characters must differ.
-    The DoD requires at least eight characters differ during a password change.
-    This would appear as <tt>difok=8</tt>.
+    The profile requires at least {{{ xccdf_value("var_password_pam_difok") }}} characters differ during a password change.
+    This would appear as <tt>difok={{{ xccdf_value("var_password_pam_difok") }}}</tt>.
 
 template:
     name: pam_options

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_lcredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_lcredit/rule.yml
@@ -49,8 +49,8 @@ ocil: |-
     out, or has a second column value different from "requisite", or does not
     contain <tt>lcredit={{{ xccdf_value("var_password_pam_lcredit") }}}</tt>, this is a finding.
 
-    The DoD and FISMA require at least one lowercase character in a password.
-    This would appear as <tt>lcredit=-1</tt>.
+    The profile requires at least {{{ xccdf_value("var_password_pam_lcredit") }}} lowercase character in a password.
+    This would appear as <tt>lcredit=-{{{ xccdf_value("var_password_pam_lcredit") }}}</tt>.
 
 template:
     name: pam_options

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_ocredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_ocredit/rule.yml
@@ -43,8 +43,8 @@ ocil: |-
     password requisite pam_cracklib.so ocredit={{{ xccdf_value("var_password_pam_ocredit") }}}</pre>
     The <tt>ocredit</tt> parameter (as a negative number) will indicate how
     many special characters are required.
-    The DoD and FISMA require at least one special character in a password.
-    This would appear as <tt>ocredit=-1</tt>.
+    The profile requires at least {{{ xccdf_value("var_password_pam_ocredit") }}} special character in a password.
+    This would appear as <tt>ocredit=-{{{ xccdf_value("var_password_pam_ocredit") }}}</tt>.
 
 template:
     name: pam_options

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_ucredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pamcracklib/cracklib_accounts_password_pam_ucredit/rule.yml
@@ -45,8 +45,8 @@ ocil: |-
     password requisite pam_cracklib.so ucredit={{{ xccdf_value("var_password_pam_ucredit") }}}</pre>
     The <tt>ucredit</tt> parameter (as a negative number) will indicate how
     many uppercase characters are required.
-    The DoD and FISMA require at least one uppercase character in a password.
-    This would appear as <tt>ucredit=-1</tt>.
+    The profile require at least {{{ xccdf_value("var_password_pam_ucredit") }}} uppercase character in a password.
+    This would appear as <tt>ucredit=-{{{ xccdf_value("var_password_pam_ucredit") }}}</tt>.
 
 template:
     name: pam_options

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_retry/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_retry/rule.yml
@@ -7,7 +7,7 @@ description: |-
     To configure the number of retry prompts that are permitted per-session:
     Edit the <tt>/etc/security/pwquality.conf</tt> to include
     <tt>retry={{{xccdf_value("var_password_pam_retry") }}}</tt>, or a lower value if site
-    policy is more restrictive. The DoD requirement is a maximum of 3 prompts
+    policy is more restrictive. The profile requirement is a maximum of <tt>retry={{{xccdf_value("var_password_pam_retry") }}}</tt> prompts
     per session.
 
 rationale: |-

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/rule.yml
@@ -16,7 +16,7 @@ description: |-
     {{% endif %}}
     {{% endif %}}
     <tt>retry={{{xccdf_value("var_password_pam_retry") }}}</tt>, or a lower value if site
-    policy is more restrictive. The DoD requirement is a maximum of 3 prompts
+    policy is more restrictive. The profile requirement is a maximum of <tt>retry={{{xccdf_value("var_password_pam_retry") }}}</tt> prompts
     per session.
 
 rationale: |-

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/rule.yml
@@ -32,9 +32,8 @@ rationale: |-
     <br /><br />
     Multifactor solutions that require devices separate from
     information systems gaining access include, for example, hardware tokens
-    providing time-based or challenge-response authenticators and smart cards such
-    as the U.S. Government Personal Identity Verification card and the DoD Common
-    Access Card.
+    providing time-based or challenge-response authenticators and smart cards
+    or similar secure authentication devices issued by an organization or identity provider.
 
 severity: medium
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_opensc_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_opensc_installed/rule.yml
@@ -18,9 +18,8 @@ rationale: |-
     <br /><br />
     Multifactor solutions that require devices separate from
     information systems gaining access include, for example, hardware tokens
-    providing time-based or challenge-response authenticators and smart cards such
-    as the U.S. Government Personal Identity Verification card and the DoD Common
-    Access Card.
+    providing time-based or challenge-response authenticators and smart cards
+    or similar secure authentication devices issued by an organization or identity provider.
 
 severity: medium
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/service_pcscd_enabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/service_pcscd_enabled/rule.yml
@@ -14,9 +14,8 @@ rationale: |-
     <br /><br />
     Multifactor solutions that require devices separate from
     information systems gaining access include, for example, hardware tokens
-    providing time-based or challenge-response authenticators and smart cards such
-    as the U.S. Government Personal Identity Verification card and the DoD Common
-    Access Card.
+    providing time-based or challenge-response authenticators and smart cards
+    or similar secure authentication devices issued by an organization or identity provider.
 
 severity: medium
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_ca/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_ca/rule.yml
@@ -17,9 +17,8 @@ rationale: |-
     <br /><br />
     Multifactor solutions that require devices separate from
     information systems gaining access include, for example, hardware tokens
-    providing time-based or challenge-response authenticators and smart cards such
-    as the U.S. Government Personal Identity Verification card and the DoD Common
-    Access Card.
+    providing time-based or challenge-response authenticators and smart cards
+    or similar secure authentication devices issued by an organization or identity provider.
 
 severity: medium
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/rule.yml
@@ -17,9 +17,8 @@ rationale: |-
     <br /><br />
     Multifactor solutions that require devices separate from
     information systems gaining access include, for example, hardware tokens
-    providing time-based or challenge-response authenticators and smart cards such
-    as the U.S. Government Personal Identity Verification card and the DoD Common
-    Access Card.
+    providing time-based or challenge-response authenticators and smart cards
+    or similar secure authentication devices issued by an organization or identity provider.
 
 severity: medium
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/rule.yml
@@ -46,9 +46,8 @@ rationale: |-
 
     Multifactor solutions that require devices separate from information
     systems gaining access include, for example, hardware tokens providing
-    time-based or challenge-response authenticators and smart cards such as the
-    U.S. Government Personal Identity Verification card and the DoD Common
-    Access Card.
+    time-based or challenge-response authenticators and smart cards
+    or similar secure authentication devices issued by an organization or identity provider.
 
 severity: medium
 
@@ -69,7 +68,7 @@ references:
 ocil_clause: 'non-exempt accounts are not using CAC authentication'
 
 ocil: |-
-    Remote access is access to DoD nonpublic information systems by an
+    Remote access is access to nonpublic information systems by an
     authorized user (or an information system) communicating through an
     external, non-organization-controlled network. Remote access methods
     include, for example, dial-up, broadband, and wireless.

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/rule.yml
@@ -7,8 +7,6 @@ description: |-
     edit the file <tt>/etc/login.defs</tt>
     and add or correct the following line:
     <pre>PASS_MAX_DAYS {{{ xccdf_value("var_accounts_maximum_age_login_defs") }}}</pre>
-    A value of 180 days is sufficient for many environments.
-    The DoD requirement is 60.
     The profile requirement is <tt>{{{ xccdf_value("var_accounts_maximum_age_login_defs") }}}</tt>.
 
 rationale: |-

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_minimum_age_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_minimum_age_login_defs/rule.yml
@@ -8,7 +8,7 @@ description: |-
     and add or correct the following line:
     <pre>PASS_MIN_DAYS {{{ xccdf_value("var_accounts_minimum_age_login_defs") }}}</pre>
     A value of 1 day is considered sufficient for many
-    environments. The DoD requirement is 1.
+    environments.
     The profile requirement is <tt>{{{ xccdf_value("var_accounts_minimum_age_login_defs") }}}</tt>.
 
 rationale: |-

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/rule.yml
@@ -7,8 +7,6 @@ description: |-
     <tt>/etc/login.defs</tt> and add or correct the following line:
     <pre>PASS_MIN_LEN {{{ xccdf_value("var_accounts_password_minlen_login_defs") }}}</pre>
     <br /><br />
-    The DoD requirement is <tt>15</tt>.
-    The FISMA requirement is <tt>12</tt>.
     The profile requirement is
     <tt>{{{ xccdf_value("var_accounts_password_minlen_login_defs") }}}</tt>.
     If a program consults <tt>/etc/login.defs</tt> and also another PAM module
@@ -53,7 +51,8 @@ ocil_clause: 'it is not set to the required value'
 ocil: |-
     To check the minimum password length, run the command:
     <pre>$ grep PASS_MIN_LEN /etc/login.defs</pre>
-    The DoD requirement is <tt>15</tt>.
+    The profile requirement is
+    <tt>{{{ xccdf_value("var_accounts_password_minlen_login_defs") }}}</tt>.
 
 fixtext: |-
     Configure {{{ full_name }}} to enforce a minimum 15-character password length for new user accounts.

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_warn_age_existing/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_warn_age_existing/rule.yml
@@ -7,7 +7,6 @@ description: |-
     To configure how many days prior to password expiration that a warning will be issued to
     users, run the command:
     <pre>$ sudo chage --warndays {{{ xccdf_value("var_accounts_password_warn_age_login_defs") }}} <i>USER</i></pre>
-    The DoD requirement is 7, and CIS recommendation is no less than 7 days.
     This profile requirement is <tt>{{{ xccdf_value("var_accounts_password_warn_age_login_defs") }}}</tt>.
 
 rationale: |-

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/rule.yml
@@ -8,7 +8,6 @@ description: |-
     edit the file <tt>/etc/login.defs</tt> and add or correct
      the following line:
     <pre>PASS_WARN_AGE {{{ xccdf_value("var_accounts_password_warn_age_login_defs") }}}</pre>
-    The DoD requirement is 7.
     The profile requirement is <tt>{{{ xccdf_value("var_accounts_password_warn_age_login_defs") }}}</tt>.
 
 rationale: |-
@@ -47,6 +46,6 @@ ocil_clause: 'it is not set to the required value'
 ocil: |-
     To check the password warning age, run the command:
     <pre>$ grep PASS_WARN_AGE /etc/login.defs</pre>
-    The DoD requirement is 7.
+    This profile requirement is <tt>{{{ xccdf_value("var_accounts_password_warn_age_login_defs") }}}</tt>.
 
 platform: package[shadow-utils]

--- a/linux_os/guide/system/network/network-firewalld/firewalld_activation/package_firewalld_installed/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_activation/package_firewalld_installed/rule.yml
@@ -11,7 +11,7 @@ rationale: |-
 
     Remote access services, such as those providing remote access to network devices and information systems, which lack automated control capabilities, increase risk and make remote user access management difficult at best.
 
-    Remote access is access to DoD nonpublic information systems by an authorized user (or an information system) communicating through an external, non-organization-controlled network. Remote access methods include, for example, dial-up, broadband, and wireless.
+    Remote access is access to nonpublic information systems by an authorized user (or an information system) communicating through an external, non-organization-controlled network. Remote access methods include, for example, dial-up, broadband, and wireless.
 
     {{{ full_name }}} functionality (e.g., SSH) must be capable of taking enforcement action if the audit reveals unauthorized activity.
     Automated control of remote access sessions allows organizations to ensure ongoing compliance with remote access policies by enforcing connection rules of remote access applications on a variety of information system components (e.g., servers, workstations, notebook computers, smartphones, and tablets)."

--- a/linux_os/guide/system/network/network-ufw/check_ufw_active/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/check_ufw_active/rule.yml
@@ -10,7 +10,7 @@ description: |-
 rationale: |-
     Remote access services, such as those providing remote access to network devices and information systems, 
     which lack automated control capabilities, increase risk and make remote user access management difficult at best.  
-    Remote access is access to DOD nonpublic information systems by an authorized user (or an information system) communicating 
+    Remote access is access to nonpublic information systems by an authorized user (or an information system) communicating 
     through an external, nonorganization-controlled network. Remote access methods include, for example, dial-up, broadband, and wireless.  
     Ubuntu 22.04 LTS functionality (e.g., RDP) must be capable of taking enforcement action if the audit reveals unauthorized activity. 
     Automated control of remote access sessions allows organizations to ensure ongoing compliance with remote access policies by 

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/rule.yml
@@ -67,4 +67,4 @@ fixtext: |-
     {{{ include_directive }}}
 
 srg_requirement: |-
-    {{{ full_name }}} must implement DoD-approved encryption in the OpenSSL package.
+    {{{ full_name }}} must implement approved encryption in the OpenSSL package.

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/rule.yml
@@ -54,4 +54,4 @@ fixtext: |-
     $ sudo sed -i "/^\s*CRYPTO_POLICY.*$/Id" /etc/sysconfig/sshd
 
 srg_requirement: |-
-    {{{ full_name }}} must implement DoD-approved encryption in the OpenSSH package.
+    {{{ full_name }}} must implement approved encryption in the OpenSSH package.

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/install_mcafee_antivirus/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/install_mcafee_antivirus/rule.yml
@@ -5,7 +5,7 @@ title: 'Install McAfee Virus Scanning Software'
 
 description: |-
     Install McAfee VirusScan Enterprise for Linux antivirus software
-    which is provided for DoD systems and uses signatures to search for the
+    which is provided for systems and uses signatures to search for the
     presence of viruses on the filesystem.
 
 rationale: |-

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_endpoint_security_software/agent_mfetpd_running/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_endpoint_security_software/agent_mfetpd_running/rule.yml
@@ -5,7 +5,7 @@ title: 'Ensure McAfee Endpoint Security for Linux (ENSL) is running'
 
 description: |-
     Install McAfee Endpoint Security for Linux antivirus software
-    which is provided for DoD systems and uses signatures to search for the
+    which is provided for systems and uses signatures to search for the
     presence of viruses on the filesystem.
 
 rationale: |-

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_endpoint_security_software/package_mcafeetp_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_endpoint_security_software/package_mcafeetp_installed/rule.yml
@@ -11,7 +11,7 @@ title: 'Install McAfee Endpoint Security for Linux (ENSL)'
 
 description: |-
     Install McAfee Endpoint Security for Linux antivirus software
-    which is provided for DoD systems and uses signatures to search for the
+    which is provided for systems and uses signatures to search for the
     presence of viruses on the filesystem.
 
     {{{ describe_package_install(package=pkg) }}}

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_hbss_software/package_MFEhiplsm_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_hbss_software/package_MFEhiplsm_installed/rule.yml
@@ -48,7 +48,7 @@ conflicts:
 warnings:
     - functionality: |-
         Installing and enabling this module conflicts with SELinux.
-        Per DoD/DISA guidance, SELinux takes precedence over this module.
+        Per profile guidance, SELinux takes precedence over this module.
     - general: |-
         Due to McAfee HIPS being 3rd party software, automated
         remediation is not available for this configuration check.

--- a/products/firefox/guide/firefox/firefox_policy-disable_pocket/rule.yml
+++ b/products/firefox/guide/firefox/firefox_policy-disable_pocket/rule.yml
@@ -10,7 +10,7 @@ description: |-
 
 rationale: |-
     Pocket is a social bookmarking service for storing, sharing, and discovering web bookmarks.
-    Data gathering cloud services such as Pocket are generally disabled in the DoD.
+    Data gathering cloud services such as Pocket are generally disabled in some organizations such as the DoD.
 
 severity: medium
 

--- a/products/firefox/guide/firefox/firefox_policy-disable_studies/rule.yml
+++ b/products/firefox/guide/firefox/firefox_policy-disable_studies/rule.yml
@@ -9,7 +9,7 @@ description: |-
     in the policies file.
 
 rationale: |-
-    Studies try out different features and ideas prior to release to all Firefox users. Testing beta software is not in the DoD user's mission.
+    Studies try out different features and ideas prior to release to all Firefox users. Testing beta software is not in the profile user's mission.
 
 severity: medium
 

--- a/products/firefox/guide/firefox/firefox_policy-password_manager/rule.yml
+++ b/products/firefox/guide/firefox/firefox_policy-password_manager/rule.yml
@@ -8,7 +8,7 @@ description: |-
     the <tt>PasswordManager</tt> key under <tt>policies</tt> to <tt>false</tt>.
 
 rationale: |-
-    Firefox can be set to store passwords for sites visited by the user. These individual passwords are stored in a file and can be protected by a master password. Autofill of the password can then be enabled when the site is visited. This feature could also be used to autofill the certificate PIN, which could lead to compromise of DoD information.
+    Firefox can be set to store passwords for sites visited by the user. These individual passwords are stored in a file and can be protected by a master password. Autofill of the password can then be enabled when the site is visited. This feature could also be used to autofill the certificate PIN, which could lead to compromise of information.
 severity: medium
 
 references:

--- a/products/firefox/guide/firefox/firefox_policy-verification/rule.yml
+++ b/products/firefox/guide/firefox/firefox_policy-verification/rule.yml
@@ -10,8 +10,8 @@ description: |-
     in an administrative policies file
 
 rationale: |-
-    Websites within DoD require user authentication for access which increases
-    security for DoD information. Access will be denied to the user if
+    Websites within the organization require user authentication for access which increases
+    security for the information within. Access will be denied to the user if
     certificate management is not configured.
 
 severity: medium


### PR DESCRIPTION


#### Description:

-  Addresses Issue #8709 

#### Rationale:

- Make the text more agnostic 

- Updates #8709 with latest changes but does not fully close it out



