### PR TITLE
Fix lint issues in cusp_fedora

### DIFF
--- a/controls/cusp_fedora.yml
+++ b/controls/cusp_fedora.yml
@@ -6,505 +6,514 @@ version: '1.0.0'
 source: "jodehnal's bachelor thesis on creating a SCAP profile for common users of Fedora workstation - link will be added after publication"
 
 controls:
-  ###
-  ### 1. Hardware and its configuration
-  ###
-  - id: '1.1'
-    title: Protection of the BIOS or UEFI
-    description: >-
-      Users should protect their BIOS or UEFI with a password.
-    status: manual
+    ###
+    ### 1. Hardware and its configuration
+    ###
+    - id: '1.1'
+      title: Protection of the BIOS or UEFI
+      description: >-
+          Users should protect their BIOS or UEFI with a password.
+      status: manual
 
-  - id: '1.2'
-    title: Proper BIOS or UEFI Configuration
-    description: >-
-      Users should disable features and devices in the BIOS or UEFI that are not in use and should only include trusted devices in the boot order.
-    status: manual
+    - id: '1.2'
+      title: Proper BIOS or UEFI Configuration
+      description: >-
+          Users should disable features and devices in the BIOS or UEFI that are not in use and should
+          only include trusted devices in the boot order.
+      status: manual
 
-  - id: '1.3'
-    title: 64-bit OS
-    description: >-
-      When possible, users should use a 64-bit system and hardware that supports it.
-    status: manual
-  ###
-  ### 2. System installation
-  ###
-  - id: '2.1'
-    title: Security Policy Selection
-    description: >-
-      Users should apply the Fedora Common User Security Policy in the installer.
-    status: manual
+    - id: '1.3'
+      title: 64-bit OS
+      description: >-
+          When possible, users should use a 64-bit system and hardware that supports it.
+      status: manual
+    ###
+    ### 2. System installation
+    ###
+    - id: '2.1'
+      title: Security Policy Selection
+      description: >-
+          Users should apply the Fedora Common User Security Policy in the installer.
+      status: manual
 
-  - id: '2.2'
-    title: Disk Partitioning
-    description: >-
-      Users should put the /home, /tmp, /var, /var/tmp and /var/log directories on separate partitions.
-    status: manual
+    - id: '2.2'
+      title: Disk Partitioning
+      description: >-
+          Users should put the /home, /tmp, /var, /var/tmp and /var/log directories on separate partitions.
+      status: manual
 
-  - id: '2.3'
-    title: Password Security
-    description: >-
-      Users should ensure that all account passwords adhere to the password rules in rule 4.1.
-    status: manual
+    - id: '2.3'
+      title: Password Security
+      description: >-
+          Users should ensure that all account passwords adhere to the password rules in rule 4.1.
+      status: manual
 
-  - id: '2.4'
-    title: Disk Encryption
-    description: >-
-      Users should encrypt their disk with a passphrase that adheres to the password rules in rule 4.1.
-    status: manual
-  ###
-  ### 3. General system configuration
-  ###
-  - id: '3.1'
-    title: Bootloader Security
-    description: >-
-      If the BIOS or UEFI does not allow password protection of the boot process, users should set a bootloader password.
-    status: partial
-    rules:
-      # BIOS
-      - file_groupowner_grub2_cfg
-      - file_groupowner_user_cfg
-      - file_owner_grub2_cfg
-      - file_owner_user_cfg
-      - file_permissions_grub2_cfg
-      - file_permissions_user_cfg
-      - grub2_password
-      # UEFI
-      - file_groupowner_efi_grub2_cfg
-      - file_groupowner_efi_user_cfg
-      - file_owner_efi_grub2_cfg
-      - file_owner_efi_user_cfg
-      - file_permissions_efi_grub2_cfg
-      - file_permissions_efi_user_cfg
-      - grub2_uefi_password
+    - id: '2.4'
+      title: Disk Encryption
+      description: >-
+          Users should encrypt their disk with a passphrase that adheres to the password rules in rule
+          4.1.
+      status: manual
+    ###
+    ### 3. General system configuration
+    ###
+    - id: '3.1'
+      title: Bootloader Security
+      description: >-
+          If the BIOS or UEFI does not allow password protection of the boot process, users should set
+          a bootloader password.
+      status: partial
+      rules:
+          # BIOS
+          - file_groupowner_grub2_cfg
+          - file_groupowner_user_cfg
+          - file_owner_grub2_cfg
+          - file_owner_user_cfg
+          - file_permissions_grub2_cfg
+          - file_permissions_user_cfg
+          - grub2_password
+          # UEFI
+          - file_groupowner_efi_grub2_cfg
+          - file_groupowner_efi_user_cfg
+          - file_owner_efi_grub2_cfg
+          - file_owner_efi_user_cfg
+          - file_permissions_efi_grub2_cfg
+          - file_permissions_efi_user_cfg
+          - grub2_uefi_password
 
-  - id: '3.2'
-    title: Software Updates
-    description: >-
-      Users should apply updates from the GNOME Software application at least once per day.
-    status: partial
-    rules:
-      - package_gnome_software_installed
+    - id: '3.2'
+      title: Software Updates
+      description: >-
+          Users should apply updates from the GNOME Software application at least once per day.
+      status: partial
+      rules:
+          - package_gnome_software_installed
 
-  - id: '3.3'
-    title: Filesystem Configuration
-    description: >-
-      Directories /home (-noexec), /tmp, /var, /var/tmp and /var/log mount option configuration.
-    status: automated
-    rules:
-      - mount_option_home_nodev
-      - mount_option_home_nosuid
-      - kernel_module_cramfs_disabled
-      - kernel_module_squashfs_disabled
-      - kernel_module_udf_disabled
+    - id: '3.3'
+      title: Filesystem Configuration
+      description: >-
+          Directories /home (-noexec), /tmp, /var, /var/tmp and /var/log mount option configuration.
+      status: automated
+      rules:
+          - mount_option_home_nodev
+          - mount_option_home_nosuid
+          - kernel_module_cramfs_disabled
+          - kernel_module_squashfs_disabled
+          - kernel_module_udf_disabled
 
-  - id: '3.4'
-    title: Crypto Policy
-    description: >-
-      System cryto policy configuation and ensuring it is not overridden in critical components.
-    status: automated
-    rules:
-      - configure_crypto_policy
-      - var_system_crypto_policy=default_policy
-      - configure_bind_crypto_policy
-      - configure_kerberos_crypto_policy
-      - configure_libreswan_crypto_policy
-      - configure_openssl_crypto_policy
-      - configure_ssh_crypto_policy
+    - id: '3.4'
+      title: Crypto Policy
+      description: >-
+          System cryto policy configuation and ensuring it is not overridden in critical components.
+      status: automated
+      rules:
+          - configure_crypto_policy
+          - var_system_crypto_policy=default_policy
+          - configure_bind_crypto_policy
+          - configure_kerberos_crypto_policy
+          - configure_libreswan_crypto_policy
+          - configure_openssl_crypto_policy
+          - configure_ssh_crypto_policy
 
-  - id: '3.5'
-    title: Auditing and Logging
-    description: >-
-      Auditd and journald configutation.
-    status: automated
-    rules:
-      # auditd config
-      - package_audit_installed
-      - service_auditd_enabled
-      - grub2_audit_argument
-      - grub2_audit_backlog_limit_argument
-      - auditd_data_retention_max_log_file
-      - var_auditd_max_log_file=6
-      - auditd_data_retention_max_log_file_action
-      - var_auditd_max_log_file_action=rotate
-      - audit_rules_immutable
-      # auditd rules
-      - audit_rules_sysadmin_actions
-      - audit_rules_suid_privilege_function
-      - audit_sudo_log_events
-      - audit_rules_time_adjtimex
-      - audit_rules_time_settimeofday
-      - audit_rules_time_clock_settime
-      - audit_rules_time_stime
-      - audit_rules_time_watch_localtime
-      - audit_rules_networkconfig_modification
-      - audit_rules_privileged_commands
-      - audit_rules_unsuccessful_file_modification_creat
-      - audit_rules_unsuccessful_file_modification_ftruncate
-      - audit_rules_unsuccessful_file_modification_open
-      - audit_rules_unsuccessful_file_modification_openat
-      - audit_rules_unsuccessful_file_modification_truncate
-      - audit_rules_usergroup_modification_group
-      - audit_rules_usergroup_modification_gshadow
-      - audit_rules_usergroup_modification_opasswd
-      - audit_rules_usergroup_modification_passwd
-      - audit_rules_usergroup_modification_shadow
-      - audit_rules_dac_modification_chmod
-      - audit_rules_dac_modification_chown
-      - audit_rules_dac_modification_fchmod
-      - audit_rules_dac_modification_fchmodat
-      - audit_rules_dac_modification_fchown
-      - audit_rules_dac_modification_fchownat
-      - audit_rules_dac_modification_fremovexattr
-      - audit_rules_dac_modification_fsetxattr
-      - audit_rules_dac_modification_lchown
-      - audit_rules_dac_modification_lremovexattr
-      - audit_rules_dac_modification_lsetxattr
-      - audit_rules_dac_modification_removexattr
-      - audit_rules_dac_modification_setxattr
-      - audit_rules_media_export
-      - audit_rules_session_events
-      - audit_rules_login_events_faillock
-      - audit_rules_login_events_lastlog
-      - audit_rules_file_deletion_events_rename
-      - audit_rules_file_deletion_events_renameat
-      - audit_rules_file_deletion_events_unlink
-      - audit_rules_file_deletion_events_unlinkat
-      - audit_rules_mac_modification
-      - audit_rules_mac_modification_usr_share
-      - audit_rules_execution_chcon
-      - audit_rules_execution_setfacl
-      - audit_rules_execution_chacl
-      - audit_rules_privileged_commands_usermod
-      - audit_rules_kernel_module_loading_delete
-      - audit_rules_kernel_module_loading_init
-      - audit_rules_sudoers
-      - audit_rules_sudoers_d
-      # journald config
-      - socket_systemd-journal-remote_disabled
-      - service_systemd-journald_enabled
-      - journald_compress
-      - journald_storage
+    - id: '3.5'
+      title: Auditing and Logging
+      description: >-
+          Auditd and journald configutation.
+      status: automated
+      rules:
+          # auditd config
+          - package_audit_installed
+          - service_auditd_enabled
+          - grub2_audit_argument
+          - grub2_audit_backlog_limit_argument
+          - auditd_data_retention_max_log_file
+          - var_auditd_max_log_file=6
+          - auditd_data_retention_max_log_file_action
+          - var_auditd_max_log_file_action=rotate
+          - audit_rules_immutable
+          # auditd rules
+          - audit_rules_sysadmin_actions
+          - audit_rules_suid_privilege_function
+          - audit_sudo_log_events
+          - audit_rules_time_adjtimex
+          - audit_rules_time_settimeofday
+          - audit_rules_time_clock_settime
+          - audit_rules_time_stime
+          - audit_rules_time_watch_localtime
+          - audit_rules_networkconfig_modification
+          - audit_rules_privileged_commands
+          - audit_rules_unsuccessful_file_modification_creat
+          - audit_rules_unsuccessful_file_modification_ftruncate
+          - audit_rules_unsuccessful_file_modification_open
+          - audit_rules_unsuccessful_file_modification_openat
+          - audit_rules_unsuccessful_file_modification_truncate
+          - audit_rules_usergroup_modification_group
+          - audit_rules_usergroup_modification_gshadow
+          - audit_rules_usergroup_modification_opasswd
+          - audit_rules_usergroup_modification_passwd
+          - audit_rules_usergroup_modification_shadow
+          - audit_rules_dac_modification_chmod
+          - audit_rules_dac_modification_chown
+          - audit_rules_dac_modification_fchmod
+          - audit_rules_dac_modification_fchmodat
+          - audit_rules_dac_modification_fchown
+          - audit_rules_dac_modification_fchownat
+          - audit_rules_dac_modification_fremovexattr
+          - audit_rules_dac_modification_fsetxattr
+          - audit_rules_dac_modification_lchown
+          - audit_rules_dac_modification_lremovexattr
+          - audit_rules_dac_modification_lsetxattr
+          - audit_rules_dac_modification_removexattr
+          - audit_rules_dac_modification_setxattr
+          - audit_rules_media_export
+          - audit_rules_session_events
+          - audit_rules_login_events_faillock
+          - audit_rules_login_events_lastlog
+          - audit_rules_file_deletion_events_rename
+          - audit_rules_file_deletion_events_renameat
+          - audit_rules_file_deletion_events_unlink
+          - audit_rules_file_deletion_events_unlinkat
+          - audit_rules_mac_modification
+          - audit_rules_mac_modification_usr_share
+          - audit_rules_execution_chcon
+          - audit_rules_execution_setfacl
+          - audit_rules_execution_chacl
+          - audit_rules_privileged_commands_usermod
+          - audit_rules_kernel_module_loading_delete
+          - audit_rules_kernel_module_loading_init
+          - audit_rules_sudoers
+          - audit_rules_sudoers_d
+          # journald config
+          - socket_systemd-journal-remote_disabled
+          - service_systemd-journald_enabled
+          - journald_compress
+          - journald_storage
 
-  - id: '3.6'
-    title: Files, Permissions, and Ownership
-    description: >-
-      User and critical system file permissions and ownership, user and group file and directory ownership, identifiers.
-    status: partial
-    rules:
-      #  file config
-      - dir_perms_world_writable_sticky_bits
-      - file_permissions_unauthorized_world_writable
-      - no_files_unowned_by_user
-      - file_permissions_ungroupowned
-      #  permission and ownership of critical files
-      - file_groupowner_etc_passwd
-      - file_owner_etc_passwd
-      - file_permissions_etc_passwd
-      - file_groupowner_etc_shadow
-      - file_owner_etc_shadow
-      - file_permissions_etc_shadow
-      - file_groupowner_etc_group
-      - file_owner_etc_group
-      - file_permissions_etc_group
-      - file_groupowner_etc_gshadow
-      - file_owner_etc_gshadow
-      - file_permissions_etc_gshadow
-      - file_groupowner_backup_etc_passwd
-      - file_owner_backup_etc_passwd
-      - file_permissions_backup_etc_passwd
-      - file_groupowner_backup_etc_shadow
-      - file_owner_backup_etc_shadow
-      - file_permissions_backup_etc_shadow
-      - file_groupowner_backup_etc_group
-      - file_owner_backup_etc_group
-      - file_permissions_backup_etc_group
-      - file_groupowner_backup_etc_gshadow
-      - file_owner_backup_etc_gshadow
-      - file_permissions_backup_etc_gshadow
-      #  user and group config
-      - no_empty_passwords_etc_shadow
-      - gid_passwd_group_same
-      - account_unique_id
-      - group_unique_id
-      - account_unique_name
-      - group_unique_name
-      - accounts_root_path_dirs_no_write
-      - accounts_no_uid_except_zero
-      - accounts_user_interactive_home_directory_exists
-      - file_ownership_home_directories
-      - file_groupownership_home_directories
-      - file_permissions_home_directories
-      - accounts_user_dot_no_world_writable_programs
+    - id: '3.6'
+      title: Files, Permissions, and Ownership
+      description: >-
+          User and critical system file permissions and ownership, user and group file and directory
+          ownership, identifiers.
+      status: partial
+      rules:
+          # file config
+          - dir_perms_world_writable_sticky_bits
+          - file_permissions_unauthorized_world_writable
+          - no_files_unowned_by_user
+          - file_permissions_ungroupowned
+          # permission and ownership of critical files
+          - file_groupowner_etc_passwd
+          - file_owner_etc_passwd
+          - file_permissions_etc_passwd
+          - file_groupowner_etc_shadow
+          - file_owner_etc_shadow
+          - file_permissions_etc_shadow
+          - file_groupowner_etc_group
+          - file_owner_etc_group
+          - file_permissions_etc_group
+          - file_groupowner_etc_gshadow
+          - file_owner_etc_gshadow
+          - file_permissions_etc_gshadow
+          - file_groupowner_backup_etc_passwd
+          - file_owner_backup_etc_passwd
+          - file_permissions_backup_etc_passwd
+          - file_groupowner_backup_etc_shadow
+          - file_owner_backup_etc_shadow
+          - file_permissions_backup_etc_shadow
+          - file_groupowner_backup_etc_group
+          - file_owner_backup_etc_group
+          - file_permissions_backup_etc_group
+          - file_groupowner_backup_etc_gshadow
+          - file_owner_backup_etc_gshadow
+          - file_permissions_backup_etc_gshadow
+          # user and group config
+          - no_empty_passwords_etc_shadow
+          - gid_passwd_group_same
+          - account_unique_id
+          - group_unique_id
+          - account_unique_name
+          - group_unique_name
+          - accounts_root_path_dirs_no_write
+          - accounts_no_uid_except_zero
+          - accounts_user_interactive_home_directory_exists
+          - file_ownership_home_directories
+          - file_groupownership_home_directories
+          - file_permissions_home_directories
+          - accounts_user_dot_no_world_writable_programs
 
-  - id: '3.7'
-    title: Memory Protection
-    description: >-
-      Enable ASLR and ExecShield, restrict exposed kernel pointer.
-    status: automated
-    rules:
-      - sysctl_kernel_randomize_va_space
-      - sysctl_kernel_exec_shield
-      - sysctl_kernel_kptr_restrict
+    - id: '3.7'
+      title: Memory Protection
+      description: >-
+          Enable ASLR and ExecShield, restrict exposed kernel pointer.
+      status: automated
+      rules:
+          - sysctl_kernel_randomize_va_space
+          - sysctl_kernel_exec_shield
+          - sysctl_kernel_kptr_restrict
 
-  - id: '3.8'
-    title: GUI Configuration
-    description: >-
-      Do not show user list, disable xdmpc and auto login, set up idle lock and protect the settings.
-    status: automated
-    rules:
-      - gnome_gdm_disable_xdmcp
-      - gnome_gdm_disable_automatic_login
+    - id: '3.8'
+      title: GUI Configuration
+      description: >-
+          Do not show user list, disable xdmpc and auto login, set up idle lock and protect the settings.
+      status: automated
+      rules:
+          - gnome_gdm_disable_xdmcp
+          - gnome_gdm_disable_automatic_login
 
-  - id: '3.9'
-    title: Time and Schedulers
-    description: >-
-      Chrony and time-based scheduler security configuration.
-    status: automated
-    rules:
-      #  chrony
-      - chronyd_client_only
-      - chronyd_no_chronyc_network
-      - chronyd_or_ntpd_set_maxpoll
-      - chronyd_run_as_chrony_user
-      - chronyd_specify_remote_server
-      #  file permissions
-      - file_owner_crontab
-      - file_groupowner_crontab
-      - file_permissions_crontab
-      - file_owner_cron_hourly
-      - file_groupowner_cron_hourly
-      - file_permissions_cron_hourly
-      - file_owner_cron_daily
-      - file_groupowner_cron_daily
-      - file_permissions_cron_daily
-      - file_owner_cron_weekly
-      - file_groupowner_cron_weekly
-      - file_permissions_cron_weekly
-      - file_owner_cron_monthly
-      - file_groupowner_cron_monthly
-      - file_permissions_cron_monthly
-      - file_owner_cron_d
-      - file_groupowner_cron_d
-      - file_permissions_cron_d
-      - file_owner_cron_allow
-      - file_groupowner_cron_allow
-      - file_permissions_cron_allow
-      - file_owner_at_allow
-      - file_groupowner_at_allow
-      - file_permissions_at_allow
+    - id: '3.9'
+      title: Time and Schedulers
+      description: >-
+          Chrony and time-based scheduler security configuration.
+      status: automated
+      rules:
+          # chrony
+          - chronyd_client_only
+          - chronyd_no_chronyc_network
+          - chronyd_or_ntpd_set_maxpoll
+          - chronyd_run_as_chrony_user
+          - chronyd_specify_remote_server
+          # file permissions
+          - file_owner_crontab
+          - file_groupowner_crontab
+          - file_permissions_crontab
+          - file_owner_cron_hourly
+          - file_groupowner_cron_hourly
+          - file_permissions_cron_hourly
+          - file_owner_cron_daily
+          - file_groupowner_cron_daily
+          - file_permissions_cron_daily
+          - file_owner_cron_weekly
+          - file_groupowner_cron_weekly
+          - file_permissions_cron_weekly
+          - file_owner_cron_monthly
+          - file_groupowner_cron_monthly
+          - file_permissions_cron_monthly
+          - file_owner_cron_d
+          - file_groupowner_cron_d
+          - file_permissions_cron_d
+          - file_owner_cron_allow
+          - file_groupowner_cron_allow
+          - file_permissions_cron_allow
+          - file_owner_at_allow
+          - file_groupowner_at_allow
+          - file_permissions_at_allow
 
-  - id: '3.10'
-    title: Service Minimization
-    description: >-
-      Users should remove any services that are not necessary for normal system usage.
-    status: partial
-    rules:
-      - package_xinetd_removed
-      - package_dhcp_removed
-      - package_bind_removed
-      - package_vsftpd_removed
-      - package_tftp-server_removed
-      - package_tftp_removed
-      - package_httpd_removed
-      - package_nginx_removed
-      - package_cyrus-imapd_removed
-      - package_dovecot_removed
-      - package_samba_removed
-      - package_squid_removed
-      - package_net-snmp_removed
-      - package_ypserv_removed
-      - package_telnet_removed
-      - package_telnet-server_removed
-      - service_nfs_disabled
-      - service_rpcbind_disabled
-      - package_rsync_removed
-      - package_rsh_removed
-      - package_rsh-server_removed
-      - package_sendmail_removed
-      - package_ypbind_removed
-      - package_talk-server_removed
-      - package_talk_removed
-  ###
-  ### 4. User access and control
-  ###
-  - id: '4.1'
-    title: Account Protection
-    description: >-
-      All account passwords must be passphrases of at least 4 words and 15 characters with at least three character classes, generated with a large wordlist and a source of randomness.
-    status: partial
-    rules:
-      - no_empty_passwords
-      - set_password_hashing_algorithm_systemauth
-      - set_password_hashing_algorithm_passwordauth
-      - set_password_hashing_algorithm_logindefs
-      - var_password_hashing_algorithm=SHA512
-      - var_password_hashing_algorithm_pam=sha512
-      - accounts_tmout
-      - var_accounts_tmout=15_min
-      - accounts_root_gid_zero
-      - accounts_umask_etc_bashrc
-      - accounts_umask_etc_login_defs
-      - accounts_umask_etc_profile
-      - var_accounts_user_umask=027
-      - account_password_selinux_faillock_dir
-      - enable_authselect
-      #  password requirements
-      - accounts_password_pam_pwquality_password_auth
-      - accounts_password_pam_pwquality_system_auth
-      - accounts_password_pam_maxrepeat
-      - accounts_password_pam_minclass
-      - accounts_password_pam_minlen
-      - accounts_password_pam_retry
-      - var_password_pam_minclass=3
-      - var_password_pam_minlen=15
-      #  password reuse
-      - var_password_pam_remember_control_flag=requisite_or_required
-      - var_password_pam_remember=5
-      - accounts_password_pam_difok
-      - var_password_pam_difok=8
+    - id: '3.10'
+      title: Service Minimization
+      description: >-
+          Users should remove any services that are not necessary for normal system usage.
+      status: partial
+      rules:
+          - package_xinetd_removed
+          - package_dhcp_removed
+          - package_bind_removed
+          - package_vsftpd_removed
+          - package_tftp-server_removed
+          - package_tftp_removed
+          - package_httpd_removed
+          - package_nginx_removed
+          - package_cyrus-imapd_removed
+          - package_dovecot_removed
+          - package_samba_removed
+          - package_squid_removed
+          - package_net-snmp_removed
+          - package_ypserv_removed
+          - package_telnet_removed
+          - package_telnet-server_removed
+          - service_nfs_disabled
+          - service_rpcbind_disabled
+          - package_rsync_removed
+          - package_rsh_removed
+          - package_rsh-server_removed
+          - package_sendmail_removed
+          - package_ypbind_removed
+          - package_talk-server_removed
+          - package_talk_removed
+    ###
+    ### 4. User access and control
+    ###
+    - id: '4.1'
+      title: Account Protection
+      description: >-
+          All account passwords must be passphrases of at least 4 words and 15 characters with at least
+          three character classes, generated with a large wordlist and a source of randomness.
+      status: partial
+      rules:
+          - no_empty_passwords
+          - set_password_hashing_algorithm_systemauth
+          - set_password_hashing_algorithm_passwordauth
+          - set_password_hashing_algorithm_logindefs
+          - var_password_hashing_algorithm=SHA512
+          - var_password_hashing_algorithm_pam=sha512
+          - accounts_tmout
+          - var_accounts_tmout=15_min
+          - accounts_root_gid_zero
+          - accounts_umask_etc_bashrc
+          - accounts_umask_etc_login_defs
+          - accounts_umask_etc_profile
+          - var_accounts_user_umask=027
+          - account_password_selinux_faillock_dir
+          - enable_authselect
+          # password requirements
+          - accounts_password_pam_pwquality_password_auth
+          - accounts_password_pam_pwquality_system_auth
+          - accounts_password_pam_maxrepeat
+          - accounts_password_pam_minclass
+          - accounts_password_pam_minlen
+          - accounts_password_pam_retry
+          - var_password_pam_minclass=3
+          - var_password_pam_minlen=15
+          # password reuse
+          - var_password_pam_remember_control_flag=requisite_or_required
+          - var_password_pam_remember=5
+          - accounts_password_pam_difok
+          - var_password_pam_difok=8
 
-  - id: '4.2'
-    title: Sudo
-    description: >-
-      Secure sudo configuration.
-    status: automated
-    rules:
-      - package_sudo_installed
-      - sudo_add_use_pty
-      - sudo_custom_logfile
-      - sudo_require_authentication
-      - sudo_require_reauthentication
-      - use_pam_wheel_for_su
-      - sudoers_default_includedir
+    - id: '4.2'
+      title: Sudo
+      description: >-
+          Secure sudo configuration.
+      status: automated
+      rules:
+          - package_sudo_installed
+          - sudo_add_use_pty
+          - sudo_custom_logfile
+          - sudo_require_authentication
+          - sudo_require_reauthentication
+          - use_pam_wheel_for_su
+          - sudoers_default_includedir
 
-  - id: '4.3'
-    title: SSH Server
-    description: >-
-      Secure ssh server configuration.
-    status: automated
-    rules:
-      - file_groupowner_sshd_config
-      - file_owner_sshd_config
-      - file_permissions_sshd_config
-      - file_permissions_sshd_private_key
-      - file_permissions_sshd_pub_key
-      - sshd_set_loglevel_verbose
-      - sshd_enable_pam
-      - sshd_disable_root_login
-      - disable_host_auth
-      - sshd_disable_empty_passwords
-      - sshd_do_not_permit_user_env
-      - sshd_disable_rhosts
-      - sshd_disable_x11_forwarding
-      - sshd_disable_tcp_forwarding
-      - sshd_max_auth_tries_value=4
-      - sshd_set_max_auth_tries
-      - sshd_set_maxstartups
-      - var_sshd_set_maxstartups=10:30:60
-      - sshd_set_max_sessions
-      - var_sshd_max_sessions=10
-      - sshd_set_login_grace_time
-      - var_sshd_set_login_grace_time=60
-      - sshd_idle_timeout_value=15_minutes
-      - sshd_set_idle_timeout
-      - sshd_set_keepalive
-      - var_sshd_set_keepalive=0
-      - sshd_x11_use_localhost
-      - sshd_disable_kerb_auth
-      - sshd_disable_gssapi_auth
-      - sshd_enable_strictmodes
-      - sshd_rekey_limit
-      - var_rekey_limit_size=1G
-      - var_rekey_limit_time=1hour
-      - sshd_use_strong_rng
-      - sshd_set_keepalive_0
-  ###
-  ### 5. Networking
-  ###
-  - id: '5.1'
-    title: General Network Configuration
-    description: >-
-      If users did not configure IPv6 on the system and it is not needed, it should be disabled.
-    status: partial
-    rules:
-      - kernel_module_sctp_disabled
-      - kernel_module_dccp_disabled
-      - sysctl_net_ipv4_conf_all_send_redirects
-      - sysctl_net_ipv4_conf_default_send_redirects
-      - sysctl_net_ipv4_conf_all_accept_source_route
-      - sysctl_net_ipv4_conf_all_accept_source_route_value=disabled
-      - sysctl_net_ipv4_conf_default_accept_source_route
-      - sysctl_net_ipv4_conf_default_accept_source_route_value=disabled
-      - sysctl_net_ipv6_conf_all_accept_source_route
-      - sysctl_net_ipv6_conf_all_accept_source_route_value=disabled
-      - sysctl_net_ipv6_conf_default_accept_source_route
-      - sysctl_net_ipv6_conf_default_accept_source_route_value=disabled
-      - sysctl_net_ipv4_conf_all_accept_redirects
-      - sysctl_net_ipv4_conf_all_accept_redirects_value=disabled
-      - sysctl_net_ipv4_conf_default_accept_redirects
-      - sysctl_net_ipv4_conf_default_accept_redirects_value=disabled
-      - sysctl_net_ipv6_conf_all_accept_redirects
-      - sysctl_net_ipv6_conf_all_accept_redirects_value=disabled
-      - sysctl_net_ipv6_conf_default_accept_redirects
-      - sysctl_net_ipv6_conf_default_accept_redirects_value=disabled
-      - sysctl_net_ipv4_conf_all_secure_redirects
-      - sysctl_net_ipv4_conf_all_secure_redirects_value=disabled
-      - sysctl_net_ipv4_conf_default_secure_redirects
-      - sysctl_net_ipv4_conf_default_secure_redirects_value=disabled
-      - sysctl_net_ipv4_conf_all_log_martians
-      - sysctl_net_ipv4_conf_all_log_martians_value=enabled
-      - sysctl_net_ipv4_conf_default_log_martians
-      - sysctl_net_ipv4_conf_default_log_martians_value=enabled
-      - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
-      - sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value=enabled
-      - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
-      - sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value=enabled
-      - sysctl_net_ipv4_conf_all_rp_filter
-      - sysctl_net_ipv4_conf_all_rp_filter_value=enabled
-      - sysctl_net_ipv4_conf_default_rp_filter
-      - sysctl_net_ipv4_conf_default_rp_filter_value=enabled
-      - sysctl_net_ipv4_tcp_syncookies
-      - sysctl_net_ipv4_tcp_syncookies_value=enabled
+    - id: '4.3'
+      title: SSH Server
+      description: >-
+          Secure ssh server configuration.
+      status: automated
+      rules:
+          - file_groupowner_sshd_config
+          - file_owner_sshd_config
+          - file_permissions_sshd_config
+          - file_permissions_sshd_private_key
+          - file_permissions_sshd_pub_key
+          - sshd_set_loglevel_verbose
+          - sshd_enable_pam
+          - sshd_disable_root_login
+          - disable_host_auth
+          - sshd_disable_empty_passwords
+          - sshd_do_not_permit_user_env
+          - sshd_disable_rhosts
+          - sshd_disable_x11_forwarding
+          - sshd_disable_tcp_forwarding
+          - sshd_max_auth_tries_value=4
+          - sshd_set_max_auth_tries
+          - sshd_set_maxstartups
+          - var_sshd_set_maxstartups=10:30:60
+          - sshd_set_max_sessions
+          - var_sshd_max_sessions=10
+          - sshd_set_login_grace_time
+          - var_sshd_set_login_grace_time=60
+          - sshd_idle_timeout_value=15_minutes
+          - sshd_set_idle_timeout
+          - sshd_set_keepalive
+          - var_sshd_set_keepalive=0
+          - sshd_x11_use_localhost
+          - sshd_disable_kerb_auth
+          - sshd_disable_gssapi_auth
+          - sshd_enable_strictmodes
+          - sshd_rekey_limit
+          - var_rekey_limit_size=1G
+          - var_rekey_limit_time=1hour
+          - sshd_use_strong_rng
+          - sshd_set_keepalive_0
+    ###
+    ### 5. Networking
+    ###
+    - id: '5.1'
+      title: General Network Configuration
+      description: >-
+          If users did not configure IPv6 on the system and it is not needed, it should be disabled.
+      status: partial
+      rules:
+          - kernel_module_sctp_disabled
+          - kernel_module_dccp_disabled
+          - sysctl_net_ipv4_conf_all_send_redirects
+          - sysctl_net_ipv4_conf_default_send_redirects
+          - sysctl_net_ipv4_conf_all_accept_source_route
+          - sysctl_net_ipv4_conf_all_accept_source_route_value=disabled
+          - sysctl_net_ipv4_conf_default_accept_source_route
+          - sysctl_net_ipv4_conf_default_accept_source_route_value=disabled
+          - sysctl_net_ipv6_conf_all_accept_source_route
+          - sysctl_net_ipv6_conf_all_accept_source_route_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_source_route
+          - sysctl_net_ipv6_conf_default_accept_source_route_value=disabled
+          - sysctl_net_ipv4_conf_all_accept_redirects
+          - sysctl_net_ipv4_conf_all_accept_redirects_value=disabled
+          - sysctl_net_ipv4_conf_default_accept_redirects
+          - sysctl_net_ipv4_conf_default_accept_redirects_value=disabled
+          - sysctl_net_ipv6_conf_all_accept_redirects
+          - sysctl_net_ipv6_conf_all_accept_redirects_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_redirects
+          - sysctl_net_ipv6_conf_default_accept_redirects_value=disabled
+          - sysctl_net_ipv4_conf_all_secure_redirects
+          - sysctl_net_ipv4_conf_all_secure_redirects_value=disabled
+          - sysctl_net_ipv4_conf_default_secure_redirects
+          - sysctl_net_ipv4_conf_default_secure_redirects_value=disabled
+          - sysctl_net_ipv4_conf_all_log_martians
+          - sysctl_net_ipv4_conf_all_log_martians_value=enabled
+          - sysctl_net_ipv4_conf_default_log_martians
+          - sysctl_net_ipv4_conf_default_log_martians_value=enabled
+          - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+          - sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value=enabled
+          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
+          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value=enabled
+          - sysctl_net_ipv4_conf_all_rp_filter
+          - sysctl_net_ipv4_conf_all_rp_filter_value=enabled
+          - sysctl_net_ipv4_conf_default_rp_filter
+          - sysctl_net_ipv4_conf_default_rp_filter_value=enabled
+          - sysctl_net_ipv4_tcp_syncookies
+          - sysctl_net_ipv4_tcp_syncookies_value=enabled
 
-  - id: '5.2'
-    title: Firewall Configuration
-    description: >-
-      Users should ensure that all network interfaces are in the appropriate firewall zone and that ports and services allowed by the firewall are reduced to the necessary minimum.
-    status: partial
-    rules:
-      - package_firewalld_installed
-      - service_nftables_disabled
-      - service_firewalld_enabled
-  ###
-  ### 6. User applications
-  ###
-  - id: '6.1'
-    title: Web Browser
-    description: >-
-      Users should install the Firefox Flatpak from FlatHub and use it instead of the default Firefox application. If the default Firefox application must be used, the users should apply the Common User Security Profile for Mozilla Firefox CaC profile.
-    status: manual
-  ###
-  ### 7. Advanced security features
-  ###
-  - id: '7.1'
-    title: Mandatory Access Control
-    description: >-
-      Ensure SELinux is installed and enabled, in enforcing mode using targeted policy.
-    status: partial
-    rules:
-      - package_libselinux_installed
-      - grub2_enable_selinux
-      - var_selinux_policy_name=targeted
-      - selinux_policytype
-      - var_selinux_state=enforcing
-      - selinux_state
-      - package_mcstrans_removed
-      - sysctl_fs_protected_hardlinks
-      - sysctl_fs_protected_symlinks
+    - id: '5.2'
+      title: Firewall Configuration
+      description: >-
+          Users should ensure that all network interfaces are in the appropriate firewall zone and that
+          ports and services allowed by the firewall are reduced to the necessary minimum.
+      status: partial
+      rules:
+          - package_firewalld_installed
+          - service_nftables_disabled
+          - service_firewalld_enabled
+    ###
+    ### 6. User applications
+    ###
+    - id: '6.1'
+      title: Web Browser
+      description: >-
+          Users should install the Firefox Flatpak from FlatHub and use it instead of the default Firefox
+          application. If the default Firefox application must be used, the users should apply the Common
+          User Security Profile for Mozilla Firefox CaC profile.
+      status: manual
+    ###
+    ### 7. Advanced security features
+    ###
+    - id: '7.1'
+      title: Mandatory Access Control
+      description: >-
+          Ensure SELinux is installed and enabled, in enforcing mode using targeted policy.
+      status: partial
+      rules:
+          - package_libselinux_installed
+          - grub2_enable_selinux
+          - var_selinux_policy_name=targeted
+          - selinux_policytype
+          - var_selinux_state=enforcing
+          - selinux_state
+          - package_mcstrans_removed
+          - sysctl_fs_protected_hardlinks
+          - sysctl_fs_protected_symlinks
 
-  - id: '7.2'
-    title: Periodic Compliance Scans
-    description: >-
-      Users should perform periodic system scans and remediations with the Common User Security Profile by using the oscap tool or SCAP Workbench.
-    status: manual
+    - id: '7.2'
+      title: Periodic Compliance Scans
+      description: >-
+          Users should perform periodic system scans and remediations with the Common User Security Profile
+          by using the oscap tool or SCAP Workbench.
+      status: manual

--- a/controls/cusp_fedora.yml
+++ b/controls/cusp_fedora.yml
@@ -9,19 +9,19 @@ controls:
   ###
   ### 1. Hardware and its configuration
   ###
-  - id: 1.1
+  - id: '1.1'
     title: Protection of the BIOS or UEFI
     description: >-
       Users should protect their BIOS or UEFI with a password.
     status: manual
 
-  - id: 1.2
+  - id: '1.2'
     title: Proper BIOS or UEFI Configuration
     description: >-
       Users should disable features and devices in the BIOS or UEFI that are not in use and should only include trusted devices in the boot order.
     status: manual
 
-  - id: 1.3
+  - id: '1.3'
     title: 64-bit OS
     description: >-
       When possible, users should use a 64-bit system and hardware that supports it.
@@ -29,25 +29,25 @@ controls:
   ###
   ### 2. System installation
   ###
-  - id: 2.1
+  - id: '2.1'
     title: Security Policy Selection
     description: >-
       Users should apply the Fedora Common User Security Policy in the installer.
     status: manual
 
-  - id: 2.2
+  - id: '2.2'
     title: Disk Partitioning
     description: >-
       Users should put the /home, /tmp, /var, /var/tmp and /var/log directories on separate partitions.
     status: manual
 
-  - id: 2.3
+  - id: '2.3'
     title: Password Security
     description: >-
       Users should ensure that all account passwords adhere to the password rules in rule 4.1.
     status: manual
 
-  - id: 2.4
+  - id: '2.4'
     title: Disk Encryption
     description: >-
       Users should encrypt their disk with a passphrase that adheres to the password rules in rule 4.1.
@@ -55,7 +55,7 @@ controls:
   ###
   ### 3. General system configuration
   ###
-  - id: 3.1
+  - id: '3.1'
     title: Bootloader Security
     description: >-
       If the BIOS or UEFI does not allow password protection of the boot process, users should set a bootloader password.
@@ -78,7 +78,7 @@ controls:
       - file_permissions_efi_user_cfg
       - grub2_uefi_password
 
-  - id: 3.2
+  - id: '3.2'
     title: Software Updates
     description: >-
       Users should apply updates from the GNOME Software application at least once per day.
@@ -86,7 +86,7 @@ controls:
     rules:
       - package_gnome_software_installed
 
-  - id: 3.3
+  - id: '3.3'
     title: Filesystem Configuration
     description: >-
       Directories /home (-noexec), /tmp, /var, /var/tmp and /var/log mount option configuration.
@@ -98,7 +98,7 @@ controls:
       - kernel_module_squashfs_disabled
       - kernel_module_udf_disabled
 
-  - id: 3.4
+  - id: '3.4'
     title: Crypto Policy
     description: >-
       System cryto policy configuation and ensuring it is not overridden in critical components.
@@ -112,7 +112,7 @@ controls:
       - configure_openssl_crypto_policy
       - configure_ssh_crypto_policy
 
-  - id: 3.5
+  - id: '3.5'
     title: Auditing and Logging
     description: >-
       Auditd and journald configutation.
@@ -186,7 +186,7 @@ controls:
       - journald_compress
       - journald_storage
 
-  - id: 3.6
+  - id: '3.6'
     title: Files, Permissions, and Ownership
     description: >-
       User and critical system file permissions and ownership, user and group file and directory ownership, identifiers.
@@ -237,7 +237,7 @@ controls:
       - file_permissions_home_directories
       - accounts_user_dot_no_world_writable_programs
 
-  - id: 3.7
+  - id: '3.7'
     title: Memory Protection
     description: >-
       Enable ASLR and ExecShield, restrict exposed kernel pointer.
@@ -247,7 +247,7 @@ controls:
       - sysctl_kernel_exec_shield
       - sysctl_kernel_kptr_restrict
 
-  - id: 3.8
+  - id: '3.8'
     title: GUI Configuration
     description: >-
       Do not show user list, disable xdmpc and auto login, set up idle lock and protect the settings.
@@ -256,7 +256,7 @@ controls:
       - gnome_gdm_disable_xdmcp
       - gnome_gdm_disable_automatic_login
 
-  - id: 3.9
+  - id: '3.9'
     title: Time and Schedulers
     description: >-
       Chrony and time-based scheduler security configuration.
@@ -294,7 +294,7 @@ controls:
       - file_groupowner_at_allow
       - file_permissions_at_allow
 
-  - id: "3.10"
+  - id: '3.10'
     title: Service Minimization
     description: >-
       Users should remove any services that are not necessary for normal system usage.
@@ -328,7 +328,7 @@ controls:
   ###
   ### 4. User access and control
   ###
-  - id: 4.1
+  - id: '4.1'
     title: Account Protection
     description: >-
       All account passwords must be passphrases of at least 4 words and 15 characters with at least three character classes, generated with a large wordlist and a source of randomness.
@@ -364,7 +364,7 @@ controls:
       - accounts_password_pam_difok
       - var_password_pam_difok=8
 
-  - id: 4.2
+  - id: '4.2'
     title: Sudo
     description: >-
       Secure sudo configuration.
@@ -378,7 +378,7 @@ controls:
       - use_pam_wheel_for_su
       - sudoers_default_includedir
 
-  - id: 4.3
+  - id: '4.3'
     title: SSH Server
     description: >-
       Secure ssh server configuration.
@@ -422,7 +422,7 @@ controls:
   ###
   ### 5. Networking
   ###
-  - id: 5.1
+  - id: '5.1'
     title: General Network Configuration
     description: >-
       If users did not configure IPv6 on the system and it is not needed, it should be disabled.
@@ -467,7 +467,7 @@ controls:
       - sysctl_net_ipv4_tcp_syncookies
       - sysctl_net_ipv4_tcp_syncookies_value=enabled
 
-  - id: 5.2
+  - id: '5.2'
     title: Firewall Configuration
     description: >-
       Users should ensure that all network interfaces are in the appropriate firewall zone and that ports and services allowed by the firewall are reduced to the necessary minimum.
@@ -479,7 +479,7 @@ controls:
   ###
   ### 6. User applications
   ###
-  - id: 6.1
+  - id: '6.1'
     title: Web Browser
     description: >-
       Users should install the Firefox Flatpak from FlatHub and use it instead of the default Firefox application. If the default Firefox application must be used, the users should apply the Common User Security Profile for Mozilla Firefox CaC profile.
@@ -487,7 +487,7 @@ controls:
   ###
   ### 7. Advanced security features
   ###
-  - id: 7.1
+  - id: '7.1'
     title: Mandatory Access Control
     description: >-
       Ensure SELinux is installed and enabled, in enforcing mode using targeted policy.
@@ -503,7 +503,7 @@ controls:
       - sysctl_fs_protected_hardlinks
       - sysctl_fs_protected_symlinks
 
-  - id: 7.2
+  - id: '7.2'
     title: Periodic Compliance Scans
     description: >-
       Users should perform periodic system scans and remediations with the Common User Security Profile by using the oscap tool or SCAP Workbench.


### PR DESCRIPTION
#### Description:

Besides the lint issues, it was also included quotes in float-like ids to avoid issues when processing the file.

#### Rationale:

- YAML syntax standardized.
- This is the only control file currently used by Fedora product, so we are testing it with [complyscribe](https://github.com/complytime/complyscribe) and found these issues.

#### Review Hints:

This should not have any impact so checking the indentation and quotes should be fine.
`yamllint -c .yamllint controls/cusp_fedora.yml`

These issues were hit when trying to process this control file with [complyscribe](https://github.com/complytime/complyscribe).
