### PR TITLE
[Ubuntu] Chrony related rule fix

### DIFF
--- a/controls/stig_ubuntu2404.yml
+++ b/controls/stig_ubuntu2404.yml
@@ -1010,6 +1010,7 @@ controls:
       - var_multiple_time_servers=stig
       - chronyd_configure_pool_and_server
       - chronyd_or_ntpd_set_maxpoll
+      - chronyd_server_directive
     status: automated
 
   - id: UBTU-24-600180

--- a/controls/stig_ubuntu2404.yml
+++ b/controls/stig_ubuntu2404.yml
@@ -1007,6 +1007,8 @@ controls:
       - low
     rules:
       - var_time_service_set_maxpoll=18_hours
+      - var_multiple_time_servers=stig
+      - chronyd_configure_pool_and_server
       - chronyd_or_ntpd_set_maxpoll
     status: automated
 

--- a/linux_os/guide/services/ntp/chronyd_server_directive/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_server_directive/oval/shared.xml
@@ -7,6 +7,8 @@
     </criteria>
   </definition>
 
+  {{% set filepath_regex = "^(" + chrony_conf_path | replace(".", "\.") + "|" + chrony_d_path | replace(".", "\.") + ".+\.conf)$" %}}
+
   <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists"
   comment="Ensure at least one time source is set with server directive" id="test_chronyd_server_directive_with_server"
   version="1">
@@ -14,7 +16,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object comment="Matches server entries in Chrony conf files"
   id="object_chronyd_server_directive" version="1">
-    <ind:filepath operation="pattern match">^/etc/chrony\.(conf|d/.+\.conf)$</ind:filepath>
+    <ind:filepath operation="pattern match">{{{ filepath_regex }}}</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*server.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
@@ -26,7 +28,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object comment="Matches pool entires in Chrony conf files"
   id="object_chronyd_no_pool_directive" version="1">
-    <ind:filepath operation="pattern match">^/etc/chrony\.(conf|d/.+\.conf)$</ind:filepath>
+    <ind:filepath operation="pattern match">{{{ filepath_regex }}}</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]+pool.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/services/ntp/chronyd_server_directive/tests/file_empty.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_server_directive/tests/file_empty.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = chrony
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux,multi_platform_ubuntu
 # remediation = none
 
 echo "" > {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_server_directive/tests/file_missing.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_server_directive/tests/file_missing.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = chrony
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux,multi_platform_ubuntu
 # remediation = none
 
 rm -f {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_server_directive/tests/line_missing.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_server_directive/tests/line_missing.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = chrony
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux,multi_platform_ubuntu
 # remediation = none
 
 echo "some line" > {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_server_directive/tests/multiple_servers.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_server_directive/tests/multiple_servers.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = chrony
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux,multi_platform_ubuntu
 
 sed -i "^pool.*" {{{ chrony_conf_path }}}
 echo "server 0.pool.ntp.org" > {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_server_directive/tests/only_pool.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_server_directive/tests/only_pool.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = chrony
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux,multi_platform_ubuntu
 # remediation = none
 
 sed -i "^server.*" {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_server_directive/tests/only_server.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_server_directive/tests/only_server.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = chrony
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux,multi_platform_ubuntu
 
 sed -i "^pool.*" {{{ chrony_conf_path }}}
 echo "server 0.pool.ntp.org" > {{{ chrony_conf_path }}}


### PR DESCRIPTION
#### Description:

- Specify the time server by rule chronyd_configure_pool_and_server
- Check the directive using rule chronyd_server_directive
- Fix chrony regex

#### Rationale:

- STIG reuqires `Organizations must consider endpoints that may not have regular access to the authoritative time server`
- The current regex cannot capture `/etc/chrony/chrony.conf` which is the path of Ubuntu chrony configuration