### PR TITLE
Fix several issues in file_owner template remediation

### DIFF
--- a/shared/templates/file_owner/bash.template
+++ b/shared/templates/file_owner/bash.template
@@ -27,22 +27,20 @@ else
 
 {{%- if RECURSIVE %}}
 {{%- set FIND_RECURSE_ARGS_DEP="" %}}
-{{%- set FIND_RECURSE_ARGS_SYM="" %}}
 {{%- else %}}
 {{%- set FIND_RECURSE_ARGS_DEP="-maxdepth 1" %}}
-{{%- set FIND_RECURSE_ARGS_SYM="-L" %}}
 {{%- endif %}}
 
 {{%- for path in FILEPATH %}}
 {{%- if IS_DIRECTORY %}}
 {{%- if FILE_REGEX %}}
 
-find {{{ FIND_RECURSE_ARGS_SYM }}} {{{ path }}} {{{ FIND_RECURSE_ARGS_DEP }}} -type f {{{ ns.find_users }}} -regextype posix-extended -regex '{{{ FILE_REGEX[loop.index0] }}}' -exec chown -L "$newown" {} \;
+find -P {{{ path }}} {{{ FIND_RECURSE_ARGS_DEP }}} -type f {{{ ns.find_users }}} -regextype posix-extended -regex '{{{ FILE_REGEX[loop.index0] }}}' -exec chown --no-dereference "$newown" {} \;
 {{%- else %}}
-find -H {{{ path }}} {{{ FIND_RECURSE_ARGS_DEP }}} -type d {{{ ns.find_users }}} -exec chown -L "$newown" {} \;
+find -P {{{ path }}} {{{ FIND_RECURSE_ARGS_DEP }}} -type d {{{ ns.find_users }}} -exec chown --no-dereference "$newown" {} \;
 {{%- endif %}}
 {{%- else %}}
-chown "$newown" {{{ path }}}
+chown --no-dereference "$newown" {{{ path }}}
 {{%- endif %}}
 {{%- endfor %}}
 

--- a/shared/templates/file_owner/bash.template
+++ b/shared/templates/file_owner/bash.template
@@ -40,7 +40,9 @@ find -P {{{ path }}} {{{ FIND_RECURSE_ARGS_DEP }}} -type f {{{ ns.find_users }}}
 find -P {{{ path }}} {{{ FIND_RECURSE_ARGS_DEP }}} -type d {{{ ns.find_users }}} -exec chown --no-dereference "$newown" {} \;
 {{%- endif %}}
 {{%- else %}}
-chown --no-dereference "$newown" {{{ path }}}
+if ! stat -c "%u %U" "{{{ path }}}" | grep -E -w -q "{{{ UID_OR_NAME }}}"; then
+    chown --no-dereference "$newown" {{{ path }}}
+fi
 {{%- endif %}}
 {{%- endfor %}}
 

--- a/shared/templates/file_owner/bash.template
+++ b/shared/templates/file_owner/bash.template
@@ -4,6 +4,7 @@
 # complexity = low
 # disruption = low
 
+newown=""
 {{%- set ns=namespace(find_users="") %}}
 {{%- set OWNERS=UID_OR_NAME.split("|") %}}
 {{%- for own in OWNERS %}}
@@ -19,10 +20,10 @@ elif id "{{{ own }}}" >/dev/null 2>&1; then
 fi
 {{%- endif %}}
 {{%- endfor %}}
-if [[ -z ${newown} ]]; then
-  echo "{{{ UID_OR_NAME|replace("|", " and ") }}} is not a defined user on the system"
-  exit 1
-fi
+
+if [[ -z "$newown" ]]; then
+  >&2 echo "{{{ UID_OR_NAME|replace("|", " and ") }}} is not a defined user on the system"
+else
 
 {{%- if RECURSIVE %}}
 {{%- set FIND_RECURSE_ARGS_DEP="" %}}
@@ -36,11 +37,13 @@ fi
 {{%- if IS_DIRECTORY %}}
 {{%- if FILE_REGEX %}}
 
-find {{{ FIND_RECURSE_ARGS_SYM }}} {{{ path }}} {{{ FIND_RECURSE_ARGS_DEP }}} -type f {{{ ns.find_users }}} -regextype posix-extended -regex '{{{ FILE_REGEX[loop.index0] }}}' -exec chown -L $newown {} \;
+find {{{ FIND_RECURSE_ARGS_SYM }}} {{{ path }}} {{{ FIND_RECURSE_ARGS_DEP }}} -type f {{{ ns.find_users }}} -regextype posix-extended -regex '{{{ FILE_REGEX[loop.index0] }}}' -exec chown -L "$newown" {} \;
 {{%- else %}}
-find -H {{{ path }}} {{{ FIND_RECURSE_ARGS_DEP }}} -type d {{{ ns.find_users }}} -exec chown -L $newown {} \;
+find -H {{{ path }}} {{{ FIND_RECURSE_ARGS_DEP }}} -type d {{{ ns.find_users }}} -exec chown -L "$newown" {} \;
 {{%- endif %}}
 {{%- else %}}
-chown $newown {{{ path }}}
+chown "$newown" {{{ path }}}
 {{%- endif %}}
 {{%- endfor %}}
+
+fi


### PR DESCRIPTION
#### Description:

- Initialize newowner variable  to avoid reuse (see commit messsage)
- Disable symlink dereference in `find` and in `chown` to avoid symlink attacks
- Set ownership only when current owner is invalid (see commit message)