### PR TITLE
Add OL9 to rsyslog_cron_logging tests

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/tests/all_facilities_set_rsyslog_conf.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/tests/all_facilities_set_rsyslog_conf.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = rsyslog
-# platform = Oracle Linux 7,Oracle Linux 8
+# platform = multi_platform_ol
 
 . set_cron_logging.sh
 

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/tests/all_facilities_set_rsyslog_d.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/tests/all_facilities_set_rsyslog_d.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = rsyslog
-# platform = Oracle Linux 7,Oracle Linux 8
+# platform = multi_platform_ol
 . set_cron_logging.sh
 
 RSYSLOG_CONF='/etc/rsyslog.conf'


### PR DESCRIPTION
#### Description:

Add OL9 to rsyslog_cron_logging tests

#### Rationale:

Align OL9 STIG profile with DISA STIG OL9 V1R1
