### PR TITLE
Format rhel9 related yaml file

### DIFF
--- a/controls/ccn_rhel9.yml
+++ b/controls/ccn_rhel9.yml
@@ -4,828 +4,841 @@ title: Security Profile Application Guide for Red Hat Enterprise Linux 9
 id: ccn_rhel9
 version: '2022-10'
 source: https://www.ccn-cert.cni.es/pdf/guias/series-ccn-stic/guias-de-acceso-publico-ccn-stic/6768-ccn-stic-610a22-perfilado-de-seguridad-red-hat-enterprise-linux-9-0/file.html
+
 levels:
-  - id: basic
-  - id: intermediate
-    inherits_from:
-      - basic
-  - id: advanced
-    inherits_from:
-      - intermediate
+    - id: basic
+    - id: intermediate
+      inherits_from:
+          - basic
+    - id: advanced
+      inherits_from:
+          - intermediate
+
 reference_type: ccn
 product: rhel9
 
 controls:
-  - id: reload_dconf_db
-    title: Reload Dconf Database
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    notes: |-
-      This is a helper rule to reload Dconf database correctly.
-    status: automated
-    rules:
-      - dconf_db_up_to_date
+    - id: reload_dconf_db
+      title: Reload Dconf Database
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      notes: |-
+          This is a helper rule to reload Dconf database correctly.
+      status: automated
+      rules:
+          - dconf_db_up_to_date
 
-  - id: enable_authselect
-    title: Enable Authselect
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    notes: |-
-      The policy doesn't have any section where this would fit better.
-    status: automated
-    rules:
-      - var_authselect_profile=sssd
-      - enable_authselect
+    - id: enable_authselect
+      title: Enable Authselect
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      notes: |-
+          The policy doesn't have any section where this would fit better.
+      status: automated
+      rules:
+          - var_authselect_profile=sssd
+          - enable_authselect
 
-  - id: A.3.SEC-RHEL1
-    title: Session Initiation is Audited
-    original_title: Se auditan los inicios de sesión.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: automated
-    rules:
-      - audit_rules_session_events_utmp
-      - audit_rules_session_events_btmp
-      - audit_rules_session_events_wtmp
-      - audit_rules_login_events_faillock
-      - audit_rules_login_events_lastlog
+    - id: A.3.SEC-RHEL1
+      title: Session Initiation is Audited
+      original_title: Se auditan los inicios de sesión.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: automated
+      rules:
+          - audit_rules_session_events_utmp
+          - audit_rules_session_events_btmp
+          - audit_rules_session_events_wtmp
+          - audit_rules_login_events_faillock
+          - audit_rules_login_events_lastlog
 
-  - id: A.3.SEC-RHEL2
-    title: Control Who Can Access Security and Audit Logs
-    original_title: Se controla quien puede acceder a los registros de seguridad y auditoría.
-    levels:
-      - intermediate
-      - advanced
-    status: automated
-    rules:
-      - file_permissions_var_log_audit
-      - file_ownership_var_log_audit
-      - file_group_ownership_var_log_audit
-      - directory_permissions_var_log_audit
+    - id: A.3.SEC-RHEL2
+      title: Control Who Can Access Security and Audit Logs
+      original_title: Se controla quien puede acceder a los registros de seguridad y auditoría.
+      levels:
+          - intermediate
+          - advanced
+      status: automated
+      rules:
+          - file_permissions_var_log_audit
+          - file_ownership_var_log_audit
+          - file_group_ownership_var_log_audit
+          - directory_permissions_var_log_audit
 
-  - id: A.3.SEC-RHEL3
-    title: System Time Change is Controlled
-    original_title: Se controla el cambio de hora del sistema.
-    levels:
-      - intermediate
-      - advanced
-    status: automated
-    rules:
-      - package_chrony_installed
-      - chronyd_specify_remote_server
-      - chronyd_run_as_chrony_user
-      - var_multiple_time_servers=rhel
+    - id: A.3.SEC-RHEL3
+      title: System Time Change is Controlled
+      original_title: Se controla el cambio de hora del sistema.
+      levels:
+          - intermediate
+          - advanced
+      status: automated
+      rules:
+          - package_chrony_installed
+          - chronyd_specify_remote_server
+          - chronyd_run_as_chrony_user
+          - var_multiple_time_servers=rhel
 
-  - id: A.3.SEC-RHEL4
-    title: Control Who Can Generate or Modify Audit Rules
-    original_title: Se controla quién puede generar o modificar reglas de audit.
-    levels:
-      - intermediate
-      - advanced
-    status: automated
-    rules:
-      - file_permissions_audit_configuration
-      - file_ownership_audit_configuration
-      - file_groupownership_audit_configuration
+    - id: A.3.SEC-RHEL4
+      title: Control Who Can Generate or Modify Audit Rules
+      original_title: Se controla quién puede generar o modificar reglas de audit.
+      levels:
+          - intermediate
+          - advanced
+      status: automated
+      rules:
+          - file_permissions_audit_configuration
+          - file_ownership_audit_configuration
+          - file_groupownership_audit_configuration
 
-  - id: A.3.SEC-RHEL5
-    title: A Detailed Audit Has Been Implemented Based on Subcategories
-    original_title: Se ha implementado la auditoría detallada basada en subcategorías.
-    levels:
-      - intermediate
-      - advanced
-    status: pending
-    notes: |-
-      It is not clear the intention of this requirement since there is no definition of these
-      subcategories. The project has many audit related rules. Clarifying these subcategories
-      we can select the proper rules.
+    - id: A.3.SEC-RHEL5
+      title: A Detailed Audit Has Been Implemented Based on Subcategories
+      original_title: Se ha implementado la auditoría detallada basada en subcategorías.
+      levels:
+          - intermediate
+          - advanced
+      status: pending
+      notes: |-
+          It is not clear the intention of this requirement since there is no definition of these
+          subcategories. The project has many audit related rules. Clarifying these subcategories
+          we can select the proper rules.
 
-  - id: A.3.SEC-RHEL6
-    title: At Least 90 Days of Activity Logs Are Guaranteed
-    original_title: Se garantiza al menos 90 días de registros de actividad.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: automated
-    rules:
-      - auditd_data_retention_max_log_file_action
-      - var_auditd_max_log_file_action=keep_logs
+    - id: A.3.SEC-RHEL6
+      title: At Least 90 Days of Activity Logs Are Guaranteed
+      original_title: Se garantiza al menos 90 días de registros de actividad.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: automated
+      rules:
+          - auditd_data_retention_max_log_file_action
+          - var_auditd_max_log_file_action=keep_logs
 
-  - id: A.3.SEC-RHEL7
-    title: Modifications to the Sudoers File Are Audited, As Are Changes to Permissions, Users, Groups, and Passwords
-    original_title: Se auditan las modificaciones del fichero sudoers, así como los cambios en permisos, usuarios, grupos y contraseñas.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: automated
-    rules:
-      - audit_sudo_log_events
-      - audit_rules_usergroup_modification_group
-      - audit_rules_usergroup_modification_gshadow
-      - audit_rules_usergroup_modification_opasswd
-      - audit_rules_usergroup_modification_passwd
-      - audit_rules_usergroup_modification_shadow
-      - audit_rules_sysadmin_actions
-      - audit_rules_dac_modification_chmod
-      - audit_rules_dac_modification_chown
-      - audit_rules_dac_modification_fchmod
-      - audit_rules_dac_modification_fchmodat
-      - audit_rules_dac_modification_fchown
-      - audit_rules_dac_modification_fchownat
-      - audit_rules_dac_modification_fremovexattr
-      - audit_rules_dac_modification_fsetxattr
-      - audit_rules_dac_modification_lchown
-      - audit_rules_dac_modification_lremovexattr
-      - audit_rules_dac_modification_lsetxattr
-      - audit_rules_dac_modification_removexattr
-      - audit_rules_dac_modification_setxattr
+    - id: A.3.SEC-RHEL7
+      title: Modifications to the Sudoers File Are Audited, As Are Changes to Permissions, Users, Groups,
+          and Passwords
+      original_title: Se auditan las modificaciones del fichero sudoers, así como los cambios en permisos,
+          usuarios, grupos y contraseñas.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: automated
+      rules:
+          - audit_sudo_log_events
+          - audit_rules_usergroup_modification_group
+          - audit_rules_usergroup_modification_gshadow
+          - audit_rules_usergroup_modification_opasswd
+          - audit_rules_usergroup_modification_passwd
+          - audit_rules_usergroup_modification_shadow
+          - audit_rules_sysadmin_actions
+          - audit_rules_dac_modification_chmod
+          - audit_rules_dac_modification_chown
+          - audit_rules_dac_modification_fchmod
+          - audit_rules_dac_modification_fchmodat
+          - audit_rules_dac_modification_fchown
+          - audit_rules_dac_modification_fchownat
+          - audit_rules_dac_modification_fremovexattr
+          - audit_rules_dac_modification_fsetxattr
+          - audit_rules_dac_modification_lchown
+          - audit_rules_dac_modification_lremovexattr
+          - audit_rules_dac_modification_lsetxattr
+          - audit_rules_dac_modification_removexattr
+          - audit_rules_dac_modification_setxattr
 
-  - id: A.3.SEC-RHEL8
-    title: Changes to Cron Settings and Scheduled Tasks Including Startup Scripts Are Audited
-    original_title: Se auditan los cambios en la configuración de Cron y en tareas programadas incluyendo los de scripts de inicio.
-    levels:
-      - advanced
-    status: pending
-    notes: |-
-      Some possible rules were included here but it is not clear if the requirement intends to
-      check more than these rules. We can see if more related rules are available in the project
-      and include everything that makes sense in the context of cron and chrony.
-    related_rules:
-      - audit_rules_time_adjtimex
-      - audit_rules_time_settimeofday
-      - audit_rules_time_clock_settime
-      - audit_rules_time_stime
-      - audit_rules_time_watch_localtime
+    - id: A.3.SEC-RHEL8
+      title: Changes to Cron Settings and Scheduled Tasks Including Startup Scripts Are Audited
+      original_title: Se auditan los cambios en la configuración de Cron y en tareas programadas incluyendo
+          los de scripts de inicio.
+      levels:
+          - advanced
+      status: pending
+      notes: |-
+          Some possible rules were included here but it is not clear if the requirement intends to
+          check more than these rules. We can see if more related rules are available in the project
+          and include everything that makes sense in the context of cron and chrony.
+      related_rules:
+          - audit_rules_time_adjtimex
+          - audit_rules_time_settimeofday
+          - audit_rules_time_clock_settime
+          - audit_rules_time_stime
+          - audit_rules_time_watch_localtime
 
-  - id: A.3.SEC-RHEL9
-    title: Attempts to Access Critical Items Are Audited
-    original_title: Se auditan los intentos de acceso a elementos críticos.
-    levels:
-      - advanced
-    status: automated
-    rules:
-      - audit_rules_unsuccessful_file_modification_creat
-      - audit_rules_unsuccessful_file_modification_ftruncate
-      - audit_rules_unsuccessful_file_modification_open
-      - audit_rules_unsuccessful_file_modification_openat
-      - audit_rules_unsuccessful_file_modification_truncate
+    - id: A.3.SEC-RHEL9
+      title: Attempts to Access Critical Items Are Audited
+      original_title: Se auditan los intentos de acceso a elementos críticos.
+      levels:
+          - advanced
+      status: automated
+      rules:
+          - audit_rules_unsuccessful_file_modification_creat
+          - audit_rules_unsuccessful_file_modification_ftruncate
+          - audit_rules_unsuccessful_file_modification_open
+          - audit_rules_unsuccessful_file_modification_openat
+          - audit_rules_unsuccessful_file_modification_truncate
 
-  - id: A.3.SEC-RHEL10
-    title: All Mount Operations on the System and Changes to the Swap Are Audited
-    original_title: Se audita toda operación de montaje en el sistema y modificaciones en la memoria de intercambio.
-    levels:
-      - intermediate
-      - advanced
-    status: partial
-    notes: |-
-      We probably have audit related rule to monitor mount related syscalls, but it is not clear
-      about the swap. Is the intention to monitor when swap is changed?
-    rules:
-      - audit_rules_media_export
+    - id: A.3.SEC-RHEL10
+      title: All Mount Operations on the System and Changes to the Swap Are Audited
+      original_title: Se audita toda operación de montaje en el sistema y modificaciones en la memoria
+          de intercambio.
+      levels:
+          - intermediate
+          - advanced
+      status: partial
+      notes: |-
+          We probably have audit related rule to monitor mount related syscalls, but it is not clear
+          about the swap. Is the intention to monitor when swap is changed?
+      rules:
+          - audit_rules_media_export
 
-  - id: A.3.SEC-RHEL11
-    title: Modifications in PAM Files Are Audited
-    original_title: Se auditan modificaciones en ficheros PAM.
-    levels:
-      - advanced
-    status: pending
-    notes: |-
-      The intention here is probably to audit changes in /etc/pam.d files, but we need to confirm
-      this assumption and get more context.
+    - id: A.3.SEC-RHEL11
+      title: Modifications in PAM Files Are Audited
+      original_title: Se auditan modificaciones en ficheros PAM.
+      levels:
+          - advanced
+      status: pending
+      notes: |-
+          The intention here is probably to audit changes in /etc/pam.d files, but we need to confirm
+          this assumption and get more context.
 
-  - id: A.4.SEC-RHEL1
-    title: Common Users Do Dot Have Local Administrator Permissions and Are Not Included in a Sudo Group
-    original_title: Los usuarios estándar no disponen de permisos de administrador local ni se encuentran incluidos en un grupo sudoer.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: pending
-    notes: |-
-      It is a little tricky to interpret this requirement. Assuming the "Common users" are actually
-      interactive users, this requirement would automatically enforce all admin actions to be
-      performed only by the root user. I am not sure if this is the intetion here.
+    - id: A.4.SEC-RHEL1
+      title: Common Users Do Dot Have Local Administrator Permissions and Are Not Included in a Sudo
+          Group
+      original_title: Los usuarios estándar no disponen de permisos de administrador local ni se encuentran
+          incluidos en un grupo sudoer.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: pending
+      notes: |-
+          It is a little tricky to interpret this requirement. Assuming the "Common users" are actually
+          interactive users, this requirement would automatically enforce all admin actions to be
+          performed only by the root user. I am not sure if this is the intetion here.
 
-  - id: A.4.SEC-RHEL2
-    title: The System Has an Updated Antivirus
-    original_title: El sistema tiene un antivirus y este está actualizado.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: pending
-    notes: |-
-      New templated rule is necessary to install the package. But to ensure the chosen antivirus
-      is actually updated would demand a more complex rule. Maybe this requirement can have at
-      leastthe partial status after the templated rule.
+    - id: A.4.SEC-RHEL2
+      title: The System Has an Updated Antivirus
+      original_title: El sistema tiene un antivirus y este está actualizado.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: pending
+      notes: |-
+          New templated rule is necessary to install the package. But to ensure the chosen antivirus
+          is actually updated would demand a more complex rule. Maybe this requirement can have at
+          leastthe partial status after the templated rule.
 
-  - id: A.4.SEC-RHEL3
-    title: Permissions by Partitions Are Modified
-    original_title: Se modifican los permisos por particiones.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: pending
-    notes: |-
-      Related to nosuid, noexec and nodev options but in /boot. More context is needed.
+    - id: A.4.SEC-RHEL3
+      title: Permissions by Partitions Are Modified
+      original_title: Se modifican los permisos por particiones.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: pending
+      notes: |-
+          Related to nosuid, noexec and nodev options but in /boot. More context is needed.
 
-  - id: A.5.SEC-RHEL1
-    title: Login and Impersonation Permissions Are Controlled
-    original_title: Se controlan los permisos de inicio de sesión y suplantación de identidad.
-    levels:
-      - intermediate
-      - advanced
-    status: automated
-    rules:
-      - sudo_add_use_pty
-      - use_pam_wheel_for_su
+    - id: A.5.SEC-RHEL1
+      title: Login and Impersonation Permissions Are Controlled
+      original_title: Se controlan los permisos de inicio de sesión y suplantación de identidad.
+      levels:
+          - intermediate
+          - advanced
+      status: automated
+      rules:
+          - sudo_add_use_pty
+          - use_pam_wheel_for_su
 
-  - id: A.5.SEC-RHEL2
-    title: Elevation Attempts Are Controlled by Defining Users and Sudoer Groups
-    original_title: Se controlan los intentos de elevación mediante definición de usuarios y grupos sudoers.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: automated
-    rules:
-      - sudo_require_authentication
-      - sudo_require_reauthentication
+    - id: A.5.SEC-RHEL2
+      title: Elevation Attempts Are Controlled by Defining Users and Sudoer Groups
+      original_title: Se controlan los intentos de elevación mediante definición de usuarios y grupos
+          sudoers.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: automated
+      rules:
+          - sudo_require_authentication
+          - sudo_require_reauthentication
 
-  - id: A.5.SEC-RHEL3
-    title: Access to Encryption Keys is Controlled
-    original_title: Se controla el acceso a las claves de cifrado.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: pending
-    notes: |-
-      There are rules for ssh_keys, for example. We need to confirm the scope of this requirement
+    - id: A.5.SEC-RHEL3
+      title: Access to Encryption Keys is Controlled
+      original_title: Se controla el acceso a las claves de cifrado.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: pending
+      notes: |-
+          There are rules for ssh_keys, for example. We need to confirm the scope of this requirement
 
-  - id: A.5.SEC-RHEL4
-    title: Disable Insecure Encryption Algorithms
-    original_title: Se han deshabilitado los algoritmos de cifrado inseguros.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: automated
-    rules:
-      - configure_crypto_policy
-      - var_system_crypto_policy=default_policy
+    - id: A.5.SEC-RHEL4
+      title: Disable Insecure Encryption Algorithms
+      original_title: Se han deshabilitado los algoritmos de cifrado inseguros.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: automated
+      rules:
+          - configure_crypto_policy
+          - var_system_crypto_policy=default_policy
 
-  - id: A.5.SEC-RHEL5
-    title: Recurring Password Change is Required
-    original_title: Se exige el cambio de contraseña de forma recurrente.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: automated
-    rules:
-      - accounts_maximum_age_login_defs
-      - accounts_minimum_age_login_defs
-      - accounts_password_set_max_life_existing
-      - accounts_password_set_min_life_existing
-      - accounts_password_set_warn_age_existing
-      - accounts_password_warn_age_login_defs
-      - var_accounts_maximum_age_login_defs=45
-      - var_accounts_minimum_age_login_defs=2
-      - var_accounts_password_warn_age_login_defs=10
+    - id: A.5.SEC-RHEL5
+      title: Recurring Password Change is Required
+      original_title: Se exige el cambio de contraseña de forma recurrente.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: automated
+      rules:
+          - accounts_maximum_age_login_defs
+          - accounts_minimum_age_login_defs
+          - accounts_password_set_max_life_existing
+          - accounts_password_set_min_life_existing
+          - accounts_password_set_warn_age_existing
+          - accounts_password_warn_age_login_defs
+          - var_accounts_maximum_age_login_defs=45
+          - var_accounts_minimum_age_login_defs=2
+          - var_accounts_password_warn_age_login_defs=10
 
-  - id: A.5.SEC-RHEL6
-    title: Secure Protocols Are Used For the Network Authentication Processes
-    original_title: Se hace uso de protocolos seguros para los procesos de autenticación de red.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: automated
-    rules:
-      - configure_ssh_crypto_policy
+    - id: A.5.SEC-RHEL6
+      title: Secure Protocols Are Used For the Network Authentication Processes
+      original_title: Se hace uso de protocolos seguros para los procesos de autenticación de red.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: automated
+      rules:
+          - configure_ssh_crypto_policy
 
-  - id: A.5.SEC-RHEL7
-    title: Network Session Inactivity is Controlled
-    original_title: Se controla la inactividad de la sesión de red.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: automated
-    rules:
-      - sshd_idle_timeout_value=15_minutes
-      - sshd_set_idle_timeout
-      - sshd_set_keepalive
-      - var_sshd_set_keepalive=1
+    - id: A.5.SEC-RHEL7
+      title: Network Session Inactivity is Controlled
+      original_title: Se controla la inactividad de la sesión de red.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: automated
+      rules:
+          - sshd_idle_timeout_value=15_minutes
+          - sshd_set_idle_timeout
+          - sshd_set_keepalive
+          - var_sshd_set_keepalive=1
 
-  - id: A.5.SEC-RHEL8
-    title: Local and Remote Console Inactivity is Controlled
-    original_title: Se controla la inactividad de consola local y remota.
-    levels:
-      - advanced
-    status: automated
-    rules:
-      - accounts_tmout
-      - var_accounts_tmout=5_min
+    - id: A.5.SEC-RHEL8
+      title: Local and Remote Console Inactivity is Controlled
+      original_title: Se controla la inactividad de consola local y remota.
+      levels:
+          - advanced
+      status: automated
+      rules:
+          - accounts_tmout
+          - var_accounts_tmout=5_min
 
-  - id: A.6.SEC-RHEL1
-    title: The Security of Sensitive System Objects is Reinforced
-    original_title: Se refuerza la seguridad de los objetos sensibles del sistema.
-    levels:
-      - intermediate
-      - advanced
-    status: automated
-    rules:
-      - grub2_enable_selinux
-      - package_libselinux_installed
-      - selinux_policytype
-      - selinux_state
-      - var_selinux_policy_name=targeted
-      - var_selinux_state=enforcing
+    - id: A.6.SEC-RHEL1
+      title: The Security of Sensitive System Objects is Reinforced
+      original_title: Se refuerza la seguridad de los objetos sensibles del sistema.
+      levels:
+          - intermediate
+          - advanced
+      status: automated
+      rules:
+          - grub2_enable_selinux
+          - package_libselinux_installed
+          - selinux_policytype
+          - selinux_state
+          - var_selinux_policy_name=targeted
+          - var_selinux_state=enforcing
 
-  - id: A.6.SEC-RHEL2
-    title: Access in Recovery Mode Including Grub Boot Modification Mode is Restricted
-    original_title: Se restringen accesos en modo recuperación incluido el modo modificación de inicio de grub.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: automated
-    rules:
-      - file_groupowner_grub2_cfg
-      - file_groupowner_user_cfg
-      - file_owner_grub2_cfg
-      - file_owner_user_cfg
-      - file_permissions_grub2_cfg
-      - file_permissions_user_cfg
+    - id: A.6.SEC-RHEL2
+      title: Access in Recovery Mode Including Grub Boot Modification Mode is Restricted
+      original_title: Se restringen accesos en modo recuperación incluido el modo modificación de inicio
+          de grub.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: automated
+      rules:
+          - file_groupowner_grub2_cfg
+          - file_groupowner_user_cfg
+          - file_owner_grub2_cfg
+          - file_owner_user_cfg
+          - file_permissions_grub2_cfg
+          - file_permissions_user_cfg
 
-  - id: A.6.SEC-RHEL3
-    title: Service Users Shell is Limited to "/bin/false"
-    original_title: Se limita la shell de usuarios de servicio a "/bin/false".
-    levels:
-      - intermediate
-      - advanced
-    status: automated
-    notes: |-
-      "/sbin/nologin" might be a better option
-    rules:
-      - no_password_auth_for_systemaccounts
-      - no_shelllogin_for_systemaccounts
+    - id: A.6.SEC-RHEL3
+      title: Service Users Shell is Limited to "/bin/false"
+      original_title: Se limita la shell de usuarios de servicio a "/bin/false".
+      levels:
+          - intermediate
+          - advanced
+      status: automated
+      notes: |-
+          "/sbin/nologin" might be a better option
+      rules:
+          - no_password_auth_for_systemaccounts
+          - no_shelllogin_for_systemaccounts
 
-  - id: A.6.SEC-RHEL4
-    title: The Use of Sessions With the "root" User is Restricted
-    original_title: Se restringe el uso de sesiones con usuario "root".
-    levels:
-      - intermediate
-      - advanced
-    status: automated
-    rules:
-      - ensure_root_password_configured
-      - no_empty_passwords_etc_shadow
+    - id: A.6.SEC-RHEL4
+      title: The Use of Sessions With the "root" User is Restricted
+      original_title: Se restringe el uso de sesiones con usuario "root".
+      levels:
+          - intermediate
+          - advanced
+      status: automated
+      rules:
+          - ensure_root_password_configured
+          - no_empty_passwords_etc_shadow
 
-  - id: A.6.SEC-RHEL5
-    title: The Global System Mask is Modified To Be More Restrictive
-    original_title: Se modifica la máscara global del sistema para ser más restrictiva.
-    levels:
-      - advanced
-    status: automated
-    rules:
-      - accounts_umask_etc_bashrc
-      - accounts_umask_etc_login_defs
-      - accounts_umask_etc_profile
-      - var_accounts_user_umask=027
+    - id: A.6.SEC-RHEL5
+      title: The Global System Mask is Modified To Be More Restrictive
+      original_title: Se modifica la máscara global del sistema para ser más restrictiva.
+      levels:
+          - advanced
+      status: automated
+      rules:
+          - accounts_umask_etc_bashrc
+          - accounts_umask_etc_login_defs
+          - accounts_umask_etc_profile
+          - var_accounts_user_umask=027
 
-  - id: A.6.SEC-RHEL6
-    title: Unnecessary Groups and Users are Removed From the System
-    original_title: Se eliminan los grupos y usuarios innecesarios del sistema.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: manual
+    - id: A.6.SEC-RHEL6
+      title: Unnecessary Groups and Users are Removed From the System
+      original_title: Se eliminan los grupos y usuarios innecesarios del sistema.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: manual
 
-  - id: A.8.SEC-RHEL1
-    title: Control Who Can Install Software on the System
-    original_title: Se controla quién puede instalar software en el sistema.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: pending
+    - id: A.8.SEC-RHEL1
+      title: Control Who Can Install Software on the System
+      original_title: Se controla quién puede instalar software en el sistema.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: pending
 
-  - id: A.8.SEC-RHEL2
-    title: The Operating System is Updated
-    original_title: El sistema operativo está actualizado.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: manual
-    related_rules:
-      - security_patches_up_to_date
+    - id: A.8.SEC-RHEL2
+      title: The Operating System is Updated
+      original_title: El sistema operativo está actualizado.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: manual
+      related_rules:
+          - security_patches_up_to_date
 
-  - id: A.8.SEC-RHEL3
-    title: The System Has an Activated Local Firewall
-    original_title: El sistema tiene un firewall local activado.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: automated
-    rules:
-      - firewalld_loopback_traffic_restricted
-      - firewalld_loopback_traffic_trusted
-      - service_firewalld_enabled
-      - package_firewalld_installed
-      - service_nftables_disabled
-      - set_firewalld_default_zone
+    - id: A.8.SEC-RHEL3
+      title: The System Has an Activated Local Firewall
+      original_title: El sistema tiene un firewall local activado.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: automated
+      rules:
+          - firewalld_loopback_traffic_restricted
+          - firewalld_loopback_traffic_trusted
+          - service_firewalld_enabled
+          - package_firewalld_installed
+          - service_nftables_disabled
+          - set_firewalld_default_zone
 
-  - id: A.8.SEC-RHEL4
-    title: Unnecessary Services are Disabled, Reducing the Attack Surface
-    original_title: Se deshabilitan servicios innecesarios, reduciendo la superficie de exposición.
-    levels:
-      - intermediate
-      - advanced
-    status: automated
-    rules:
-      - kernel_module_squashfs_disabled
-      - kernel_module_udf_disabled
-      - package_bind_removed
-      - package_cyrus-imapd_removed
-      - package_dovecot_removed
-      - package_net-snmp_removed
-      - package_squid_removed
-      - package_telnet-server_removed
-      - package_tftp-server_removed
-      - package_vsftpd_removed
+    - id: A.8.SEC-RHEL4
+      title: Unnecessary Services are Disabled, Reducing the Attack Surface
+      original_title: Se deshabilitan servicios innecesarios, reduciendo la superficie de exposición.
+      levels:
+          - intermediate
+          - advanced
+      status: automated
+      rules:
+          - kernel_module_squashfs_disabled
+          - kernel_module_udf_disabled
+          - package_bind_removed
+          - package_cyrus-imapd_removed
+          - package_dovecot_removed
+          - package_net-snmp_removed
+          - package_squid_removed
+          - package_telnet-server_removed
+          - package_tftp-server_removed
+          - package_vsftpd_removed
 
-  - id: A.8.SEC-RHEL5
-    title: Application Execution is Controlled
-    original_title: Se controla la ejecución de aplicaciones.
-    levels:
-      - advanced
-    status: pending
-    notes: |-
-      This might be related to SELinux or fapolicyd.
-      We need more context to confirm the intention of this requirement
+    - id: A.8.SEC-RHEL5
+      title: Application Execution is Controlled
+      original_title: Se controla la ejecución de aplicaciones.
+      levels:
+          - advanced
+      status: pending
+      notes: |-
+          This might be related to SELinux or fapolicyd.
+          We need more context to confirm the intention of this requirement
 
-  - id: A.8.SEC-RHEL6
-    title: Anti-Ransomware Measures are Enabled
-    original_title: Se dispone de medidas anti ransomware habilitadas.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: partial
-    notes: |-
-      These are mentioned to be reviewed but not enforced:
-      #net.ipv4.icmp_echo_ignore_all = 1
-      #net.ipv4.tcp_timestamps = 0
-      #net.ipv4.tcp_max_syn_backlog = 1280
-      #sysctl_net_ipv6_conf_all_disable_ipv6
-      #sysctl_net_ipv6_conf_default_disable_ipv6
-    rules:
-      - sysctl_net_ipv4_conf_all_send_redirects
-      - sysctl_net_ipv4_conf_all_accept_redirects
-      - sysctl_net_ipv4_conf_all_secure_redirects
-      - sysctl_net_ipv4_conf_all_accept_source_route
-      - sysctl_net_ipv4_conf_all_log_martians
-      - sysctl_net_ipv4_conf_default_send_redirects
-      - sysctl_net_ipv4_conf_default_accept_redirects
-      - sysctl_net_ipv4_conf_default_secure_redirects
-      - sysctl_net_ipv4_conf_default_accept_source_route
-      - sysctl_net_ipv4_conf_default_log_martians
-      - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
-      - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
-      - sysctl_net_ipv4_tcp_syncookies
-      - sysctl_net_ipv6_conf_all_accept_source_route
-      - sysctl_net_ipv6_conf_all_accept_redirects
-      - sysctl_net_ipv6_conf_all_accept_ra
-      - sysctl_net_ipv6_conf_default_accept_source_route
-      - sysctl_net_ipv6_conf_default_accept_redirects
-      - sysctl_net_ipv6_conf_default_accept_ra
-      - sysctl_fs_suid_dumpable
-      - sysctl_net_ipv4_ip_forward
-      - sysctl_net_ipv4_conf_all_rp_filter
-      - sysctl_net_ipv4_conf_default_rp_filter
+    - id: A.8.SEC-RHEL6
+      title: Anti-Ransomware Measures are Enabled
+      original_title: Se dispone de medidas anti ransomware habilitadas.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: partial
+      notes: |-
+          These are mentioned to be reviewed but not enforced:
+          # net.ipv4.icmp_echo_ignore_all = 1
+          # net.ipv4.tcp_timestamps = 0
+          # net.ipv4.tcp_max_syn_backlog = 1280
+          # sysctl_net_ipv6_conf_all_disable_ipv6
+          # sysctl_net_ipv6_conf_default_disable_ipv6
+      rules:
+          - sysctl_net_ipv4_conf_all_send_redirects
+          - sysctl_net_ipv4_conf_all_accept_redirects
+          - sysctl_net_ipv4_conf_all_secure_redirects
+          - sysctl_net_ipv4_conf_all_accept_source_route
+          - sysctl_net_ipv4_conf_all_log_martians
+          - sysctl_net_ipv4_conf_default_send_redirects
+          - sysctl_net_ipv4_conf_default_accept_redirects
+          - sysctl_net_ipv4_conf_default_secure_redirects
+          - sysctl_net_ipv4_conf_default_accept_source_route
+          - sysctl_net_ipv4_conf_default_log_martians
+          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
+          - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+          - sysctl_net_ipv4_tcp_syncookies
+          - sysctl_net_ipv6_conf_all_accept_source_route
+          - sysctl_net_ipv6_conf_all_accept_redirects
+          - sysctl_net_ipv6_conf_all_accept_ra
+          - sysctl_net_ipv6_conf_default_accept_source_route
+          - sysctl_net_ipv6_conf_default_accept_redirects
+          - sysctl_net_ipv6_conf_default_accept_ra
+          - sysctl_fs_suid_dumpable
+          - sysctl_net_ipv4_ip_forward
+          - sysctl_net_ipv4_conf_all_rp_filter
+          - sysctl_net_ipv4_conf_default_rp_filter
 
-  - id: A.8.SEC-RHEL7
-    title: Password Encrypted Boot That Prevents Modification is Enabled (Protected GRUB)
-    original_title: Está habilitado el arranque cifrado con contraseña que evite modificaciones (GRUB protegido).
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: automated
-    rules:
-      - grub2_password
+    - id: A.8.SEC-RHEL7
+      title: Password Encrypted Boot That Prevents Modification is Enabled (Protected GRUB)
+      original_title: Está habilitado el arranque cifrado con contraseña que evite modificaciones (GRUB
+          protegido).
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: automated
+      rules:
+          - grub2_password
 
-  - id: A.8.SEC-RHEL8
-    title: File Download is Audited
-    original_title: Se audita la descarga de archivos.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: pending
-    notes: |-
-      Is it related to downloads from the Internet to the system or from the system to an external
-      storage, for example?
-    related_rules:
-      - audit_rules_file_deletion_events_rename
-      - audit_rules_file_deletion_events_renameat
-      - audit_rules_file_deletion_events_unlink
-      - audit_rules_file_deletion_events_unlinkat
+    - id: A.8.SEC-RHEL8
+      title: File Download is Audited
+      original_title: Se audita la descarga de archivos.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: pending
+      notes: |-
+          Is it related to downloads from the Internet to the system or from the system to an external
+          storage, for example?
+      related_rules:
+          - audit_rules_file_deletion_events_rename
+          - audit_rules_file_deletion_events_renameat
+          - audit_rules_file_deletion_events_unlink
+          - audit_rules_file_deletion_events_unlinkat
 
-  - id: A.8.SEC-RHEL9
-    title: System Compilers are Disabled
-    original_title: Están deshabilitados los compiladores del sistema.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: pending
-    notes: |-
-      Maybe simply removing the packages is enough.
+    - id: A.8.SEC-RHEL9
+      title: System Compilers are Disabled
+      original_title: Están deshabilitados los compiladores del sistema.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: pending
+      notes: |-
+          Maybe simply removing the packages is enough.
 
-  - id: A.11.SEC-RHEL1
-    title: Local Log On To the System is Controlled
-    original_title: Se controla el inicio de sesión local en el sistema.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: pending
-    notes: |-
-      Is it related to TTY access, physical access, local users authentication, etc?
-      It is not not clear the scope.
+    - id: A.11.SEC-RHEL1
+      title: Local Log On To the System is Controlled
+      original_title: Se controla el inicio de sesión local en el sistema.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: pending
+      notes: |-
+          Is it related to TTY access, physical access, local users authentication, etc?
+          It is not not clear the scope.
 
-  - id: A.11.SEC-RHEL2
-    title: The Security of the SSH Protocol is Strengthened
-    original_title: Se ha reforzado la seguridad del protocolo SSH.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: automated
-    rules:
-      - sshd_limit_user_access
+    - id: A.11.SEC-RHEL2
+      title: The Security of the SSH Protocol is Strengthened
+      original_title: Se ha reforzado la seguridad del protocolo SSH.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: automated
+      rules:
+          - sshd_limit_user_access
 
-  - id: A.11.SEC-RHEL3
-    title: A Robust Credential Policy is In Place
-    original_title: Se dispone de una política de credenciales robusta.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: automated
-    rules:
-      - accounts_password_pam_minclass
-      - accounts_password_pam_minlen
-      - accounts_password_pam_retry
-      - var_password_pam_minclass=4
-      - var_password_pam_minlen=14
+    - id: A.11.SEC-RHEL3
+      title: A Robust Credential Policy is In Place
+      original_title: Se dispone de una política de credenciales robusta.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: automated
+      rules:
+          - accounts_password_pam_minclass
+          - accounts_password_pam_minlen
+          - accounts_password_pam_retry
+          - var_password_pam_minclass=4
+          - var_password_pam_minlen=14
 
-  - id: A.11.SEC-RHEL4
-    title: During Login, the System Displays a Text in Compliance With the Organization's Standards or Directives
-    original_title: Durante el inicio de sesión, el sistema muestra un texto en cumplimiento con las normas o directivas de la organización.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: automated
-    rules:
-      - banner_etc_issue
-      - banner_etc_issue_net
-      - banner_etc_motd
-      - dconf_gnome_banner_enabled
-      - dconf_gnome_login_banner_text
-      - sshd_enable_warning_banner_net
-      - login_banner_text=cis_banners
-      - motd_banner_text=cis_banners
-      - remote_login_banner_text=cis_banners
+    - id: A.11.SEC-RHEL4
+      title: During Login, the System Displays a Text in Compliance With the Organization's Standards
+          or Directives
+      original_title: Durante el inicio de sesión, el sistema muestra un texto en cumplimiento con las
+          normas o directivas de la organización.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: automated
+      rules:
+          - banner_etc_issue
+          - banner_etc_issue_net
+          - banner_etc_motd
+          - dconf_gnome_banner_enabled
+          - dconf_gnome_login_banner_text
+          - sshd_enable_warning_banner_net
+          - login_banner_text=cis_banners
+          - motd_banner_text=cis_banners
+          - remote_login_banner_text=cis_banners
 
-  - id: A.11.SEC-RHEL5
-    title: Network Acess to the System is Controlled
-    original_title: Se controla el acceso al sistema a través de la red.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: manual
-    related_rules:
-      - configure_firewalld_ports
+    - id: A.11.SEC-RHEL5
+      title: Network Acess to the System is Controlled
+      original_title: Se controla el acceso al sistema a través de la red.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: manual
+      related_rules:
+          - configure_firewalld_ports
 
-  - id: A.11.SEC-RHEL6
-    title: Only Strong Encryption Algorithms are Allowed in Accesses to the System
-    original_title: Sólo se permiten algoritmos de cifrado robustos en accesos al sistema.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: automated
-    notes: |-
-      It overlaps the rule in A.5.SEC-RHEL6 requirement
-    related_rules:
-      - configure_ssh_crypto_policy
+    - id: A.11.SEC-RHEL6
+      title: Only Strong Encryption Algorithms are Allowed in Accesses to the System
+      original_title: Sólo se permiten algoritmos de cifrado robustos en accesos al sistema.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: automated
+      notes: |-
+          It overlaps the rule in A.5.SEC-RHEL6 requirement
+      related_rules:
+          - configure_ssh_crypto_policy
 
-  - id: A.11.SEC-RHEL7
-    title: GUI Idle Time is Limited
-    original_title: Se limita el tiempo de inactividad del GUI.
-    levels:
-      - intermediate
-      - advanced
-    status: automated
-    rules:
-      - dconf_gnome_screensaver_idle_delay
-      - dconf_gnome_screensaver_lock_delay
-      - inactivity_timeout_value=5_minutes
-      - var_screensaver_lock_delay=immediate
+    - id: A.11.SEC-RHEL7
+      title: GUI Idle Time is Limited
+      original_title: Se limita el tiempo de inactividad del GUI.
+      levels:
+          - intermediate
+          - advanced
+      status: automated
+      rules:
+          - dconf_gnome_screensaver_idle_delay
+          - dconf_gnome_screensaver_lock_delay
+          - inactivity_timeout_value=5_minutes
+          - var_screensaver_lock_delay=immediate
 
-  - id: A.11.SEC-RHEL8
-    title: A Dissuasive Banner is Displayed
-    original_title: Se muestra un banner disuasorio.
-    levels:
-      - intermediate
-      - advanced
-    status: pending
-    notes: |-
-      It seems to duplicate the A.11.SEC-RHEL4 requirement
+    - id: A.11.SEC-RHEL8
+      title: A Dissuasive Banner is Displayed
+      original_title: Se muestra un banner disuasorio.
+      levels:
+          - intermediate
+          - advanced
+      status: pending
+      notes: |-
+          It seems to duplicate the A.11.SEC-RHEL4 requirement
 
-  - id: A.11.SEC-RHEL9
-    title: The User List is Disabled
-    original_title: Se deshabilita la lista de usuarios.
-    levels:
-      - intermediate
-      - advanced
-    status: automated
-    rules:
-      - dconf_gnome_disable_user_list
+    - id: A.11.SEC-RHEL9
+      title: The User List is Disabled
+      original_title: Se deshabilita la lista de usuarios.
+      levels:
+          - intermediate
+          - advanced
+      status: automated
+      rules:
+          - dconf_gnome_disable_user_list
 
-  - id: A.11.SEC-RHEL10
-    title: File History is Disabled
-    original_title: Se deshabilita recordar el historial de ficheros.
-    levels:
-      - intermediate
-      - advanced
-    status: pending
-    notes: |-
-      New rules might be necessary.
+    - id: A.11.SEC-RHEL10
+      title: File History is Disabled
+      original_title: Se deshabilita recordar el historial de ficheros.
+      levels:
+          - intermediate
+          - advanced
+      status: pending
+      notes: |-
+          New rules might be necessary.
 
-  - id: A.11.SEC-RHEL11
-    title: Key Combination to Launch GTK Inspector is Disabled
-    original_title: Se deshabilita combinación de teclas para iniciar el inspector GTK
-    levels:
-      - intermediate
-      - advanced
-    status: pending
-    notes: |-
-      New rules might be necessary.
+    - id: A.11.SEC-RHEL11
+      title: Key Combination to Launch GTK Inspector is Disabled
+      original_title: Se deshabilita combinación de teclas para iniciar el inspector GTK
+      levels:
+          - intermediate
+          - advanced
+      status: pending
+      notes: |-
+          New rules might be necessary.
 
-  - id: A.11.SEC-RHEL12
-    title: Auto-Mounting of Removable Devices on the System is Disabled
-    original_title: Se deshabilita el auto montaje de dispositivos extraíbles en el sistema.
-    levels:
-      - intermediate
-      - advanced
-    status: automated
-    rules:
-      - dconf_gnome_disable_automount
-      - dconf_gnome_disable_automount_open
-      - dconf_gnome_disable_autorun
+    - id: A.11.SEC-RHEL12
+      title: Auto-Mounting of Removable Devices on the System is Disabled
+      original_title: Se deshabilita el auto montaje de dispositivos extraíbles en el sistema.
+      levels:
+          - intermediate
+          - advanced
+      status: automated
+      rules:
+          - dconf_gnome_disable_automount
+          - dconf_gnome_disable_automount_open
+          - dconf_gnome_disable_autorun
 
-  - id: A.15.SEC-RHEL1
-    title: The Use of Removable Storage Media is Controlled
-    original_title: Se controla el uso de medios de almacenamiento extraíbles.
-    levels:
-      - intermediate
-      - advanced
-    status: automated
-    rules:
-      - kernel_module_usb-storage_disabled
+    - id: A.15.SEC-RHEL1
+      title: The Use of Removable Storage Media is Controlled
+      original_title: Se controla el uso de medios de almacenamiento extraíbles.
+      levels:
+          - intermediate
+          - advanced
+      status: automated
+      rules:
+          - kernel_module_usb-storage_disabled
 
-  - id: A.19.SEC-RHEL1
-    title: Access to the Folder and File Tree is Controlled
-    original_title: Se controla el acceso al árbol de carpetas y ficheros.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: pending
-    notes: |-
-      More context should be provided to clarify this requirement
+    - id: A.19.SEC-RHEL1
+      title: Access to the Folder and File Tree is Controlled
+      original_title: Se controla el acceso al árbol de carpetas y ficheros.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: pending
+      notes: |-
+          More context should be provided to clarify this requirement
 
-  - id: A.19.SEC-RHEL2
-    title: Measures Are Applied to Protect Accounts
-    original_title: Se aplican medidas para la protección de las cuentas.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: pending
-    notes: |-
-      This is already covered by other requirements. Maybe more rules could be included here.
+    - id: A.19.SEC-RHEL2
+      title: Measures Are Applied to Protect Accounts
+      original_title: Se aplican medidas para la protección de las cuentas.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: pending
+      notes: |-
+          This is already covered by other requirements. Maybe more rules could be included here.
 
-  - id: A.19.SEC-RHEL3
-    title: A Robust Algorithm and Password Complexity Are Enabled
-    original_title: Está habilitado un algoritmo robusto y la complejidad de contraseñas.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: automated
-    rules:
-      - set_password_hashing_algorithm_systemauth
-      - set_password_hashing_algorithm_passwordauth
-      - set_password_hashing_algorithm_logindefs
-      - var_password_hashing_algorithm=SHA512
-      - var_password_hashing_algorithm_pam=sha512
+    - id: A.19.SEC-RHEL3
+      title: A Robust Algorithm and Password Complexity Are Enabled
+      original_title: Está habilitado un algoritmo robusto y la complejidad de contraseñas.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: automated
+      rules:
+          - set_password_hashing_algorithm_systemauth
+          - set_password_hashing_algorithm_passwordauth
+          - set_password_hashing_algorithm_logindefs
+          - var_password_hashing_algorithm=SHA512
+          - var_password_hashing_algorithm_pam=sha512
 
-  - id: A.23.SEC-RHEL1
-    title: The Installation And Use of Any Device Connected to the Equipment is Controlled
-    original_title: Se controla la instalación y uso de cualquier dispositivo conectado al equipo.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: automated
-    rules:
-      - package_usbguard_installed
-      - service_usbguard_enabled
-      - usbguard_generate_policy
+    - id: A.23.SEC-RHEL1
+      title: The Installation And Use of Any Device Connected to the Equipment is Controlled
+      original_title: Se controla la instalación y uso de cualquier dispositivo conectado al equipo.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: automated
+      rules:
+          - package_usbguard_installed
+          - service_usbguard_enabled
+          - usbguard_generate_policy
 
-  - id: A.23.SEC-RHEL2
-    title: The Dynamic Mounting and Unmounting of File Systems is Restricted
-    original_title: Se restringe el montaje y desmontaje dinámico de sistemas de archivos.
-    levels:
-      - basic
-      - intermediate
-      - advanced
-    status: pending
-    notes: |-
-      It seems to duplicate the A.11.SEC-RHEL12 requirement.
+    - id: A.23.SEC-RHEL2
+      title: The Dynamic Mounting and Unmounting of File Systems is Restricted
+      original_title: Se restringe el montaje y desmontaje dinámico de sistemas de archivos.
+      levels:
+          - basic
+          - intermediate
+          - advanced
+      status: pending
+      notes: |-
+          It seems to duplicate the A.11.SEC-RHEL12 requirement.
 
-  - id: A.24.SEC-RHEL1
-    title: Privileges That Affect System Performance Are Controlled
-    original_title: Se controlan los privilegios que afectan al rendimiento del sistema.
-    levels:
-      - intermediate
-      - advanced
-    status: pending
-    notes: |-
-      Is it about system limits?
+    - id: A.24.SEC-RHEL1
+      title: Privileges That Affect System Performance Are Controlled
+      original_title: Se controlan los privilegios que afectan al rendimiento del sistema.
+      levels:
+          - intermediate
+          - advanced
+      status: pending
+      notes: |-
+          Is it about system limits?
 
-  - id: A.24.SEC-RHEL2
-    title: Control Who Can Turn Off the System
-    original_title: Se controla quien puede apagar el sistema.
-    levels:
-      - intermediate
-      - advanced
-    status: pending
-    related_rules:
-      - disable_ctrlaltdel_burstaction
-      - disable_ctrlaltdel_reboot
+    - id: A.24.SEC-RHEL2
+      title: Control Who Can Turn Off the System
+      original_title: Se controla quien puede apagar el sistema.
+      levels:
+          - intermediate
+          - advanced
+      status: pending
+      related_rules:
+          - disable_ctrlaltdel_burstaction
+          - disable_ctrlaltdel_reboot
 
-  - id: A.25.SEC-RHEL1
-    title: System Disk is Encrypted
-    original_title: El disco del sistema está cifrado.
-    levels:
-      - advanced
-    status: automated
-    rules:
-      - encrypt_partitions
-      - package_cryptsetup-luks_installed
+    - id: A.25.SEC-RHEL1
+      title: System Disk is Encrypted
+      original_title: El disco del sistema está cifrado.
+      levels:
+          - advanced
+      status: automated
+      rules:
+          - encrypt_partitions
+          - package_cryptsetup-luks_installed
 
-  - id: A.25.SEC-RHEL2
-    title: The Data Disk is Encrypted
-    original_title: El disco de datos está cifrado.
-    levels:
-      - advanced
-    status: automated
-    notes: |-
-      The rules in this requirement overlaps the A.25.SEC-RHEL1 requirement
-    related_rules:
-      - package_cryptsetup-luks_installed
-      - encrypt_partitions
+    - id: A.25.SEC-RHEL2
+      title: The Data Disk is Encrypted
+      original_title: El disco de datos está cifrado.
+      levels:
+          - advanced
+      status: automated
+      notes: |-
+          The rules in this requirement overlaps the A.25.SEC-RHEL1 requirement
+      related_rules:
+          - package_cryptsetup-luks_installed
+          - encrypt_partitions
 
-  - id: A.30.SEC-RHEL1
-    title: There Is an Account Lockout Policy for Incorrect Logins
-    original_title: Existe una política de bloqueo de cuentas ante inicios de sesión incorrectos.
-    levels:
-      - advanced
-    status: automated
-    rules:
-      - accounts_passwords_pam_faillock_deny
-      - accounts_passwords_pam_faillock_unlock_time
-      - var_accounts_passwords_pam_faillock_deny=8
-      - var_accounts_passwords_pam_faillock_unlock_time=never
+    - id: A.30.SEC-RHEL1
+      title: There Is an Account Lockout Policy for Incorrect Logins
+      original_title: Existe una política de bloqueo de cuentas ante inicios de sesión incorrectos.
+      levels:
+          - advanced
+      status: automated
+      rules:
+          - accounts_passwords_pam_faillock_deny
+          - accounts_passwords_pam_faillock_unlock_time
+          - var_accounts_passwords_pam_faillock_deny=8
+          - var_accounts_passwords_pam_faillock_unlock_time=never

--- a/controls/cis_rhel9.yml
+++ b/controls/cis_rhel9.yml
@@ -4,3122 +4,3121 @@ title: 'CIS Benchmark for Red Hat Enterprise Linux 9'
 id: cis_rhel9
 version: '2.0.0'
 source: https://www.cisecurity.org/cis-benchmarks/#red_hat_linux
+
 levels:
-  - id: l1_server
-  - id: l2_server
-    inherits_from:
-      - l1_server
-  - id: l1_workstation
-  - id: l2_workstation
-    inherits_from:
-      - l1_workstation
+    - id: l1_server
+    - id: l2_server
+      inherits_from:
+          - l1_server
+    - id: l1_workstation
+    - id: l2_workstation
+      inherits_from:
+          - l1_workstation
+
 reference_type: cis
 product: rhel9
 
 controls:
-  - id: reload_dconf_db
-    title: Reload Dconf database
-    levels:
-      - l1_server
-      - l1_workstation
-    notes: <-
-      This is a helper rule to reload Dconf database correctly.
-    status: automated
-    rules:
-      - dconf_db_up_to_date
-
-  - id: enable_authselect
-    title: Enable Authselect
-    levels:
-      - l1_server
-      - l1_workstation
-    notes: <-
-      We need this in all CIS versions, but the policy doesn't have any section where this would fit better.
-    status: automated
-    rules:
-      - var_authselect_profile=sssd
-      - enable_authselect
-
-  - id: 1.1.1.1
-    title: Ensure cramfs kernel module is not available (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - kernel_module_cramfs_disabled
-
-  - id: 1.1.1.2
-    title: Ensure freevxfs kernel module is not available (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - kernel_module_freevxfs_disabled
-
-  - id: 1.1.1.3
-    title: Ensure hfs kernel module is not available (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - kernel_module_hfs_disabled
-
-  - id: 1.1.1.4
-    title: Ensure hfsplus kernel module is not available (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - kernel_module_hfsplus_disabled
-
-  - id: 1.1.1.5
-    title: Ensure jffs2 kernel module is not available (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - kernel_module_jffs2_disabled
-
-  - id: 1.1.1.6
-    title: Ensure squashfs kernel module is not available (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - kernel_module_squashfs_disabled
-
-  - id: 1.1.1.7
-    title: Ensure udf kernel module is not available (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - kernel_module_udf_disabled
-
-  - id: 1.1.1.8
-    title: Ensure usb-storage kernel module is not available (Automated)
-    levels:
-      - l1_server
-      - l2_workstation
-    status: automated
-    rules:
-      - kernel_module_usb-storage_disabled
-
-  - id: 1.1.1.9
-    title: Ensure unused filesystems kernel modules are not available (Manual)
-    levels:
-      - l1_server
-      - l2_workstation
-    status: manual
-
-  - id: 1.1.2.1.1
-    title: Ensure /tmp is a separate partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - partition_for_tmp
-
-  - id: 1.1.2.1.2
-    title: Ensure nodev option set on /tmp partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_tmp_nodev
-
-  - id: 1.1.2.1.3
-    title: Ensure nosuid option set on /tmp partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_tmp_nosuid
-
-  - id: 1.1.2.1.4
-    title: Ensure noexec option set on /tmp partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_tmp_noexec
-
-  - id: 1.1.2.2.1
-    title: Ensure /dev/shm is a separate partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - partition_for_dev_shm
-
-  - id: 1.1.2.2.2
-    title: Ensure nodev option set on /dev/shm partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_dev_shm_nodev
-
-  - id: 1.1.2.2.3
-    title: Ensure nosuid option set on /dev/shm partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_dev_shm_nosuid
-
-  - id: 1.1.2.2.4
-    title: Ensure noexec option set on /dev/shm partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_dev_shm_noexec
-
-  - id: 1.1.2.3.1
-    title: Ensure separate partition exists for /home (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - partition_for_home
-
-  - id: 1.1.2.3.2
-    title: Ensure nodev option set on /home partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_home_nodev
-
-  - id: 1.1.2.3.3
-    title: Ensure nosuid option set on /home partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_home_nosuid
-
-  - id: 1.1.2.4.1
-    title: Ensure separate partition exists for /var (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - partition_for_var
-
-  - id: 1.1.2.4.2
-    title: Ensure nodev option set on /var partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_nodev
-
-  - id: 1.1.2.4.3
-    title: Ensure nosuid option set on /var partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_nosuid
-
-  - id: 1.1.2.5.1
-    title: Ensure separate partition exists for /var/tmp (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - partition_for_var_tmp
-
-  - id: 1.1.2.5.2
-    title: Ensure nodev option set on /var/tmp partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_tmp_nodev
-
-  - id: 1.1.2.5.3
-    title: Ensure nosuid option set on /var/tmp partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_tmp_nosuid
-
-  - id: 1.1.2.5.4
-    title: Ensure noexec option set on /var/tmp partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_tmp_noexec
-
-  - id: 1.1.2.6.1
-    title: Ensure separate partition exists for /var/log (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - partition_for_var_log
-
-  - id: 1.1.2.6.2
-    title: Ensure nodev option set on /var/log partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_log_nodev
-
-  - id: 1.1.2.6.3
-    title: Ensure nosuid option set on /var/log partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_log_nosuid
-
-  - id: 1.1.2.6.4
-    title: Ensure noexec option set on /var/log partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_log_noexec
-
-  - id: 1.1.2.7.1
-    title: Ensure separate partition exists for /var/log/audit (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - partition_for_var_log_audit
-
-  - id: 1.1.2.7.2
-    title: Ensure nodev option set on /var/log/audit partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_log_audit_nodev
-
-  - id: 1.1.2.7.3
-    title: Ensure nosuid option set on /var/log/audit partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_log_audit_nosuid
-
-  - id: 1.1.2.7.4
-    title: Ensure noexec option set on /var/log/audit partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_log_audit_noexec
-
-  - id: 1.2.1.1
-    title: Ensure GPG keys are configured (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-    related_rules:
-      - ensure_redhat_gpgkey_installed
-
-  - id: 1.2.1.2
-    title: Ensure gpgcheck is globally activated (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - ensure_gpgcheck_globally_activated
-
-  - id: 1.2.1.3
-    title: Ensure repo_gpgcheck is globally activated (Manual)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: manual
-
-  - id: 1.2.1.4
-    title: Ensure package manager repositories are configured (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 1.2.2.1
-    title: Ensure updates, patches, and additional security software are installed (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-    related_rules:
-      - security_patches_up_to_date
-
-  - id: 1.3.1.1
-    title: Ensure SELinux is installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_libselinux_installed
-
-  - id: 1.3.1.2
-    title: Ensure SELinux is not disabled in bootloader configuration (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - grub2_enable_selinux
-
-  - id: 1.3.1.3
-    title: Ensure SELinux policy is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - var_selinux_policy_name=targeted
-      - selinux_policytype
-
-  - id: 1.3.1.4
-    title: Ensure the SELinux mode is not disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - selinux_not_disabled
-
-  - id: 1.3.1.5
-    title: Ensure the SELinux mode is enforcing (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - var_selinux_state=enforcing
-      - selinux_state
-
-  - id: 1.3.1.6
-    title: Ensure no unconfined services exist (Manual)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: manual
-    related_rules:
-      - selinux_confinement_of_daemons
-
-  - id: 1.3.1.7
-    title: Ensure the MCS Translation Service (mcstrans) is not installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_mcstrans_removed
-
-  - id: 1.3.1.8
-    title: Ensure SETroubleshoot is not installed (Automated)
-    levels:
-      - l1_server
-    status: automated
-    rules:
-      - package_setroubleshoot_removed
-
-  - id: 1.4.1
-    title: Ensure bootloader password is set (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: <-
-      RHEL9 unified the paths for grub2 files.
-    rules:
-      - grub2_password
-    related_rules:
-      - grub2_uefi_password
-
-  - id: 1.4.2
-    title: Ensure access to bootloader config is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: <-
-      RHEL9 unified the paths for grub2 files.
-      This requirement demands a deeper review of the rules.
-    rules:
-      - file_groupowner_grub2_cfg
-      - file_owner_grub2_cfg
-      - file_permissions_grub2_cfg
-      - file_groupowner_user_cfg
-      - file_owner_user_cfg
-      - file_permissions_user_cfg
-    related_rules:
-      - file_groupowner_efi_grub2_cfg
-      - file_owner_efi_grub2_cfg
-      - file_permissions_efi_grub2_cfg
-      - file_groupowner_efi_user_cfg
-      - file_owner_efi_user_cfg
-      - file_permissions_efi_user_cfg
-
-  - id: 1.5.1
-    title: Ensure address space layout randomization is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      Address Space Layout Randomization (ASLR)
-    rules:
-      - sysctl_kernel_randomize_va_space
-
-  - id: 1.5.2
-    title: Ensure ptrace_scope is restricted (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_kernel_yama_ptrace_scope
-
-  - id: 1.5.3
-    title: Ensure core dump backtraces are disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - coredump_disable_backtraces
-
-  - id: 1.5.4
-    title: Ensure core dump storage is disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - coredump_disable_storage
-
-  - id: 1.6.1
-    title: Ensure system wide crypto policy is not set to legacy (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - configure_crypto_policy
-      - var_system_crypto_policy=default_nosha1
-
-  - id: 1.6.2
-    title: Ensure system wide crypto policy is not set in sshd configuration (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - configure_ssh_crypto_policy
-
-  - id: 1.6.3
-    title: Ensure system wide crypto policy disables sha1 hash and signature support (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      This requirement is already satisfied by 1.6.1.
-    related_rules:
-      - configure_crypto_policy
-
-  - id: 1.6.4
-    title: Ensure system wide crypto policy disables macs less than 128 bits (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      It is necessary a new rule to ensure a module disabling weak MACs in
-      /etc/crypto-policies/policies/modules/ so it can be used by update-crypto-policies command.
-    related_rules:
-      - configure_crypto_policy
-
-  - id: 1.6.5
-    title: Ensure system wide crypto policy disables cbc for ssh (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      It is necessary a new rule to ensure a module disabling CBC in
-      /etc/crypto-policies/policies/modules/ so it can be used by update-crypto-policies command.
-    related_rules:
-      - configure_crypto_policy
-
-  - id: 1.6.6
-    title: Ensure system wide crypto policy disables chacha20-poly1305 for ssh (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-    notes: |-
-        User should manually ensure that CVE-2023-48795 is addressed.
-        This is not automated and it might be difficult to automate actually.
-        Therefore, keeping this control as manual.
-  - id: 1.6.7
-    title: Ensure system wide crypto policy disables EtM for ssh (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 1.7.1
-    title: Ensure message of the day is configured properly (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - banner_etc_motd_cis
-      - cis_banner_text=cis
-
-  - id: 1.7.2
-    title: Ensure local login warning banner is configured properly (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - banner_etc_issue_cis
-      - cis_banner_text=cis
-
-  - id: 1.7.3
-    title: Ensure remote login warning banner is configured properly (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - banner_etc_issue_net_cis
-      - cis_banner_text=cis
-
-  - id: 1.7.4
-    title: Ensure access to /etc/motd is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_etc_motd
-      - file_owner_etc_motd
-      - file_permissions_etc_motd
-
-  - id: 1.7.5
-    title: Ensure access to /etc/issue is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_etc_issue
-      - file_owner_etc_issue
-      - file_permissions_etc_issue
-
-  - id: 1.7.6
-    title: Ensure access to /etc/issue.net is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_etc_issue_net
-      - file_owner_etc_issue_net
-      - file_permissions_etc_issue_net
-
-  - id: 1.8.1
-    title: Ensure GNOME Display Manager is removed (Automated)
-    levels:
-      - l2_server
-    status: automated
-    rules:
-      - package_gdm_removed
-
-  - id: 1.8.2
-    title: Ensure GDM login banner is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - dconf_gnome_banner_enabled
-      - dconf_gnome_login_banner_text
-      - login_banner_text=cis_banners
-
-  - id: 1.8.3
-    title: Ensure GDM disable-user-list option is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - dconf_gnome_disable_user_list
-
-  - id: 1.8.4
-    title: Ensure GDM screen locks when the user is idle (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - dconf_gnome_screensaver_idle_delay
-      - dconf_gnome_screensaver_lock_delay
-      - inactivity_timeout_value=15_minutes
-      - var_screensaver_lock_delay=5_seconds
-
-  - id: 1.8.5
-    title: Ensure GDM screen locks cannot be overridden (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - dconf_gnome_session_idle_user_locks
-      - dconf_gnome_screensaver_user_locks
-
-  - id: 1.8.6
-    title: Ensure GDM automatic mounting of removable media is disabled (Automated)
-    levels:
-      - l1_server
-      - l2_workstation
-    status: automated
-    rules:
-      - dconf_gnome_disable_automount
-      - dconf_gnome_disable_automount_open
-
-  - id: 1.8.7
-    title: Ensure GDM disabling automatic mounting of removable media is not overridden (Automated)
-    levels:
-      - l1_server
-      - l2_workstation
-    status: automated
-    rules:
-      - dconf_gnome_disable_automount
-      - dconf_gnome_disable_automount_open
-
-  - id: 1.8.8
-    title: Ensure GDM autorun-never is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - dconf_gnome_disable_autorun
-
-  - id: 1.8.9
-    title: Ensure GDM autorun-never is not overridden (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - dconf_gnome_disable_autorun
-
-  - id: 1.8.10
-    title: Ensure XDMCP is not enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - gnome_gdm_disable_xdmcp
-
-  - id: 2.1.1
-    title: Ensure autofs services are not in use (Automated)
-    levels:
-      - l1_server
-      - l2_workstation
-    status: automated
-    rules:
-      - service_autofs_disabled
-
-  - id: 2.1.2
-    title: Ensure avahi daemon services are not in use (Automated)
-    levels:
-      - l1_server
-      - l2_workstation
-    status: automated
-    rules:
-      - service_avahi-daemon_disabled
-    related_rules:
-      - package_avahi_removed
-
-  - id: 2.1.3
-    title: Ensure dhcp server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_dhcp_removed
-    related_rules:
-      - service_dhcpd_disabled
-
-  - id: 2.1.4
-    title: Ensure dns server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_bind_removed
-    related_rules:
-      - service_named_disabled
-
-  - id: 2.1.5
-    title: Ensure dnsmasq services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_dnsmasq_removed
-
-  - id: 2.1.6
-    title: Ensure samba file server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_samba_removed
-    related_rules:
-      - service_smb_disabled
-
-  - id: 2.1.7
-    title: Ensure ftp server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_vsftpd_removed
-    related_rules:
-      - service_vsftpd_disabled
-
-  - id: 2.1.8
-    title: Ensure message access server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_dovecot_removed
-      - package_cyrus-imapd_removed
-    related_rules:
-      - service_dovecot_disabled
+    - id: reload_dconf_db
+      title: Reload Dconf database
+      levels:
+          - l1_server
+          - l1_workstation
+      notes: <- This is a helper rule to reload Dconf database correctly.
+      status: automated
+      rules:
+          - dconf_db_up_to_date
+
+    - id: enable_authselect
+      title: Enable Authselect
+      levels:
+          - l1_server
+          - l1_workstation
+      notes: <- We need this in all CIS versions, but the policy doesn't have any section where this
+          would fit better.
+      status: automated
+      rules:
+          - var_authselect_profile=sssd
+          - enable_authselect
+
+    - id: 1.1.1.1
+      title: Ensure cramfs kernel module is not available (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - kernel_module_cramfs_disabled
+
+    - id: 1.1.1.2
+      title: Ensure freevxfs kernel module is not available (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - kernel_module_freevxfs_disabled
+
+    - id: 1.1.1.3
+      title: Ensure hfs kernel module is not available (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - kernel_module_hfs_disabled
+
+    - id: 1.1.1.4
+      title: Ensure hfsplus kernel module is not available (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - kernel_module_hfsplus_disabled
+
+    - id: 1.1.1.5
+      title: Ensure jffs2 kernel module is not available (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - kernel_module_jffs2_disabled
+
+    - id: 1.1.1.6
+      title: Ensure squashfs kernel module is not available (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - kernel_module_squashfs_disabled
+
+    - id: 1.1.1.7
+      title: Ensure udf kernel module is not available (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - kernel_module_udf_disabled
+
+    - id: 1.1.1.8
+      title: Ensure usb-storage kernel module is not available (Automated)
+      levels:
+          - l1_server
+          - l2_workstation
+      status: automated
+      rules:
+          - kernel_module_usb-storage_disabled
+
+    - id: 1.1.1.9
+      title: Ensure unused filesystems kernel modules are not available (Manual)
+      levels:
+          - l1_server
+          - l2_workstation
+      status: manual
+
+    - id: 1.1.2.1.1
+      title: Ensure /tmp is a separate partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - partition_for_tmp
+
+    - id: 1.1.2.1.2
+      title: Ensure nodev option set on /tmp partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_tmp_nodev
+
+    - id: 1.1.2.1.3
+      title: Ensure nosuid option set on /tmp partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_tmp_nosuid
+
+    - id: 1.1.2.1.4
+      title: Ensure noexec option set on /tmp partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_tmp_noexec
+
+    - id: 1.1.2.2.1
+      title: Ensure /dev/shm is a separate partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - partition_for_dev_shm
+
+    - id: 1.1.2.2.2
+      title: Ensure nodev option set on /dev/shm partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_dev_shm_nodev
+
+    - id: 1.1.2.2.3
+      title: Ensure nosuid option set on /dev/shm partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_dev_shm_nosuid
+
+    - id: 1.1.2.2.4
+      title: Ensure noexec option set on /dev/shm partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_dev_shm_noexec
+
+    - id: 1.1.2.3.1
+      title: Ensure separate partition exists for /home (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - partition_for_home
+
+    - id: 1.1.2.3.2
+      title: Ensure nodev option set on /home partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_home_nodev
+
+    - id: 1.1.2.3.3
+      title: Ensure nosuid option set on /home partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_home_nosuid
+
+    - id: 1.1.2.4.1
+      title: Ensure separate partition exists for /var (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - partition_for_var
+
+    - id: 1.1.2.4.2
+      title: Ensure nodev option set on /var partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_nodev
+
+    - id: 1.1.2.4.3
+      title: Ensure nosuid option set on /var partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_nosuid
+
+    - id: 1.1.2.5.1
+      title: Ensure separate partition exists for /var/tmp (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - partition_for_var_tmp
+
+    - id: 1.1.2.5.2
+      title: Ensure nodev option set on /var/tmp partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_tmp_nodev
+
+    - id: 1.1.2.5.3
+      title: Ensure nosuid option set on /var/tmp partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_tmp_nosuid
+
+    - id: 1.1.2.5.4
+      title: Ensure noexec option set on /var/tmp partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_tmp_noexec
+
+    - id: 1.1.2.6.1
+      title: Ensure separate partition exists for /var/log (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - partition_for_var_log
+
+    - id: 1.1.2.6.2
+      title: Ensure nodev option set on /var/log partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_log_nodev
+
+    - id: 1.1.2.6.3
+      title: Ensure nosuid option set on /var/log partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_log_nosuid
+
+    - id: 1.1.2.6.4
+      title: Ensure noexec option set on /var/log partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_log_noexec
+
+    - id: 1.1.2.7.1
+      title: Ensure separate partition exists for /var/log/audit (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - partition_for_var_log_audit
+
+    - id: 1.1.2.7.2
+      title: Ensure nodev option set on /var/log/audit partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_log_audit_nodev
+
+    - id: 1.1.2.7.3
+      title: Ensure nosuid option set on /var/log/audit partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_log_audit_nosuid
+
+    - id: 1.1.2.7.4
+      title: Ensure noexec option set on /var/log/audit partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_log_audit_noexec
+
+    - id: 1.2.1.1
+      title: Ensure GPG keys are configured (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+      related_rules:
+          - ensure_redhat_gpgkey_installed
+
+    - id: 1.2.1.2
+      title: Ensure gpgcheck is globally activated (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - ensure_gpgcheck_globally_activated
+
+    - id: 1.2.1.3
+      title: Ensure repo_gpgcheck is globally activated (Manual)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: manual
+
+    - id: 1.2.1.4
+      title: Ensure package manager repositories are configured (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 1.2.2.1
+      title: Ensure updates, patches, and additional security software are installed (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+      related_rules:
+          - security_patches_up_to_date
+
+    - id: 1.3.1.1
+      title: Ensure SELinux is installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_libselinux_installed
+
+    - id: 1.3.1.2
+      title: Ensure SELinux is not disabled in bootloader configuration (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - grub2_enable_selinux
+
+    - id: 1.3.1.3
+      title: Ensure SELinux policy is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - var_selinux_policy_name=targeted
+          - selinux_policytype
+
+    - id: 1.3.1.4
+      title: Ensure the SELinux mode is not disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - selinux_not_disabled
+
+    - id: 1.3.1.5
+      title: Ensure the SELinux mode is enforcing (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - var_selinux_state=enforcing
+          - selinux_state
+
+    - id: 1.3.1.6
+      title: Ensure no unconfined services exist (Manual)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: manual
+      related_rules:
+          - selinux_confinement_of_daemons
+
+    - id: 1.3.1.7
+      title: Ensure the MCS Translation Service (mcstrans) is not installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_mcstrans_removed
+
+    - id: 1.3.1.8
+      title: Ensure SETroubleshoot is not installed (Automated)
+      levels:
+          - l1_server
+      status: automated
+      rules:
+          - package_setroubleshoot_removed
+
+    - id: 1.4.1
+      title: Ensure bootloader password is set (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: <- RHEL9 unified the paths for grub2 files.
+      rules:
+          - grub2_password
+      related_rules:
+          - grub2_uefi_password
+
+    - id: 1.4.2
+      title: Ensure access to bootloader config is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: <- RHEL9 unified the paths for grub2 files. This requirement demands a deeper review of
+          the rules.
+      rules:
+          - file_groupowner_grub2_cfg
+          - file_owner_grub2_cfg
+          - file_permissions_grub2_cfg
+          - file_groupowner_user_cfg
+          - file_owner_user_cfg
+          - file_permissions_user_cfg
+      related_rules:
+          - file_groupowner_efi_grub2_cfg
+          - file_owner_efi_grub2_cfg
+          - file_permissions_efi_grub2_cfg
+          - file_groupowner_efi_user_cfg
+          - file_owner_efi_user_cfg
+          - file_permissions_efi_user_cfg
+
+    - id: 1.5.1
+      title: Ensure address space layout randomization is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          Address Space Layout Randomization (ASLR)
+      rules:
+          - sysctl_kernel_randomize_va_space
+
+    - id: 1.5.2
+      title: Ensure ptrace_scope is restricted (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_kernel_yama_ptrace_scope
+
+    - id: 1.5.3
+      title: Ensure core dump backtraces are disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - coredump_disable_backtraces
+
+    - id: 1.5.4
+      title: Ensure core dump storage is disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - coredump_disable_storage
+
+    - id: 1.6.1
+      title: Ensure system wide crypto policy is not set to legacy (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - configure_crypto_policy
+          - var_system_crypto_policy=default_nosha1
+
+    - id: 1.6.2
+      title: Ensure system wide crypto policy is not set in sshd configuration (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - configure_ssh_crypto_policy
+
+    - id: 1.6.3
+      title: Ensure system wide crypto policy disables sha1 hash and signature support (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          This requirement is already satisfied by 1.6.1.
+      related_rules:
+          - configure_crypto_policy
+
+    - id: 1.6.4
+      title: Ensure system wide crypto policy disables macs less than 128 bits (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          It is necessary a new rule to ensure a module disabling weak MACs in
+          /etc/crypto-policies/policies/modules/ so it can be used by update-crypto-policies command.
+      related_rules:
+          - configure_crypto_policy
+
+    - id: 1.6.5
+      title: Ensure system wide crypto policy disables cbc for ssh (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          It is necessary a new rule to ensure a module disabling CBC in
+          /etc/crypto-policies/policies/modules/ so it can be used by update-crypto-policies command.
+      related_rules:
+          - configure_crypto_policy
+
+    - id: 1.6.6
+      title: Ensure system wide crypto policy disables chacha20-poly1305 for ssh (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+      notes: |-
+          User should manually ensure that CVE-2023-48795 is addressed.
+          This is not automated and it might be difficult to automate actually.
+          Therefore, keeping this control as manual.
+    - id: 1.6.7
+      title: Ensure system wide crypto policy disables EtM for ssh (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 1.7.1
+      title: Ensure message of the day is configured properly (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - banner_etc_motd_cis
+          - cis_banner_text=cis
+
+    - id: 1.7.2
+      title: Ensure local login warning banner is configured properly (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - banner_etc_issue_cis
+          - cis_banner_text=cis
+
+    - id: 1.7.3
+      title: Ensure remote login warning banner is configured properly (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - banner_etc_issue_net_cis
+          - cis_banner_text=cis
+
+    - id: 1.7.4
+      title: Ensure access to /etc/motd is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_etc_motd
+          - file_owner_etc_motd
+          - file_permissions_etc_motd
+
+    - id: 1.7.5
+      title: Ensure access to /etc/issue is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_etc_issue
+          - file_owner_etc_issue
+          - file_permissions_etc_issue
+
+    - id: 1.7.6
+      title: Ensure access to /etc/issue.net is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_etc_issue_net
+          - file_owner_etc_issue_net
+          - file_permissions_etc_issue_net
+
+    - id: 1.8.1
+      title: Ensure GNOME Display Manager is removed (Automated)
+      levels:
+          - l2_server
+      status: automated
+      rules:
+          - package_gdm_removed
+
+    - id: 1.8.2
+      title: Ensure GDM login banner is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - dconf_gnome_banner_enabled
+          - dconf_gnome_login_banner_text
+          - login_banner_text=cis_banners
+
+    - id: 1.8.3
+      title: Ensure GDM disable-user-list option is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - dconf_gnome_disable_user_list
+
+    - id: 1.8.4
+      title: Ensure GDM screen locks when the user is idle (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - dconf_gnome_screensaver_idle_delay
+          - dconf_gnome_screensaver_lock_delay
+          - inactivity_timeout_value=15_minutes
+          - var_screensaver_lock_delay=5_seconds
+
+    - id: 1.8.5
+      title: Ensure GDM screen locks cannot be overridden (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - dconf_gnome_session_idle_user_locks
+          - dconf_gnome_screensaver_user_locks
+
+    - id: 1.8.6
+      title: Ensure GDM automatic mounting of removable media is disabled (Automated)
+      levels:
+          - l1_server
+          - l2_workstation
+      status: automated
+      rules:
+          - dconf_gnome_disable_automount
+          - dconf_gnome_disable_automount_open
+
+    - id: 1.8.7
+      title: Ensure GDM disabling automatic mounting of removable media is not overridden (Automated)
+      levels:
+          - l1_server
+          - l2_workstation
+      status: automated
+      rules:
+          - dconf_gnome_disable_automount
+          - dconf_gnome_disable_automount_open
+
+    - id: 1.8.8
+      title: Ensure GDM autorun-never is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - dconf_gnome_disable_autorun
+
+    - id: 1.8.9
+      title: Ensure GDM autorun-never is not overridden (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - dconf_gnome_disable_autorun
+
+    - id: 1.8.10
+      title: Ensure XDMCP is not enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - gnome_gdm_disable_xdmcp
+
+    - id: 2.1.1
+      title: Ensure autofs services are not in use (Automated)
+      levels:
+          - l1_server
+          - l2_workstation
+      status: automated
+      rules:
+          - service_autofs_disabled
+
+    - id: 2.1.2
+      title: Ensure avahi daemon services are not in use (Automated)
+      levels:
+          - l1_server
+          - l2_workstation
+      status: automated
+      rules:
+          - service_avahi-daemon_disabled
+      related_rules:
+          - package_avahi_removed
+
+    - id: 2.1.3
+      title: Ensure dhcp server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_dhcp_removed
+      related_rules:
+          - service_dhcpd_disabled
+
+    - id: 2.1.4
+      title: Ensure dns server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_bind_removed
+      related_rules:
+          - service_named_disabled
+
+    - id: 2.1.5
+      title: Ensure dnsmasq services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_dnsmasq_removed
+
+    - id: 2.1.6
+      title: Ensure samba file server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_samba_removed
+      related_rules:
+          - service_smb_disabled
+
+    - id: 2.1.7
+      title: Ensure ftp server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_vsftpd_removed
+      related_rules:
+          - service_vsftpd_disabled
+
+    - id: 2.1.8
+      title: Ensure message access server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_dovecot_removed
+          - package_cyrus-imapd_removed
+      related_rules:
+          - service_dovecot_disabled
     # new rule would be nice to disable cyrus-imapd service
 
-  - id: 2.1.9
-    title: Ensure network file system services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      Many of the libvirt packages used by Enterprise Linux virtualization are dependent on the
-      nfs-utils package.
-    rules:
-      - service_nfs_disabled
-    related_rules:
-      - package_nfs-utils_removed
+    - id: 2.1.9
+      title: Ensure network file system services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          Many of the libvirt packages used by Enterprise Linux virtualization are dependent on the
+          nfs-utils package.
+      rules:
+          - service_nfs_disabled
+      related_rules:
+          - package_nfs-utils_removed
 
-  - id: 2.1.10
-    title: Ensure nis server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: It appears that the ypserv package was never in RHEL 9.
-    related_rules:
-      - service_ypserv_disabled
-      - package_ypserv_removed
+    - id: 2.1.10
+      title: Ensure nis server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: It appears that the ypserv package was never in RHEL 9.
+      related_rules:
+          - service_ypserv_disabled
+          - package_ypserv_removed
 
-  - id: 2.1.11
-    title: Ensure print server services are not in use (Automated)
-    levels:
-      - l1_server
-    status: automated
-    rules:
-      - service_cups_disabled
-    related_rules:
-      - package_cups_removed
+    - id: 2.1.11
+      title: Ensure print server services are not in use (Automated)
+      levels:
+          - l1_server
+      status: automated
+      rules:
+          - service_cups_disabled
+      related_rules:
+          - package_cups_removed
 
-  - id: 2.1.12
-    title: Ensure rpcbind services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      Many of the libvirt packages used by Enterprise Linux virtualization, and the nfs-utils
-      package used for The Network File System (NFS), are dependent on the rpcbind package.
-    rules:
-      - service_rpcbind_disabled
-    related_rules:
-      - package_rpcbind_removed
+    - id: 2.1.12
+      title: Ensure rpcbind services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          Many of the libvirt packages used by Enterprise Linux virtualization, and the nfs-utils
+          package used for The Network File System (NFS), are dependent on the rpcbind package.
+      rules:
+          - service_rpcbind_disabled
+      related_rules:
+          - package_rpcbind_removed
 
-  - id: 2.1.13
-    title: Ensure rsync services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_rsync_removed
-    related_rules:
-      - service_rsyncd_disabled
+    - id: 2.1.13
+      title: Ensure rsync services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_rsync_removed
+      related_rules:
+          - service_rsyncd_disabled
 
-  - id: 2.1.14
-    title: Ensure snmp services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_net-snmp_removed
-    related_rules:
-      - service_snmpd_disabled
+    - id: 2.1.14
+      title: Ensure snmp services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_net-snmp_removed
+      related_rules:
+          - service_snmpd_disabled
 
-  - id: 2.1.15
-    title: Ensure telnet server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_telnet-server_removed
-    related_rules:
-      - service_telnet_disabled
+    - id: 2.1.15
+      title: Ensure telnet server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_telnet-server_removed
+      related_rules:
+          - service_telnet_disabled
 
-  - id: 2.1.16
-    title: Ensure tftp server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_tftp-server_removed
-    related_rules:
-      - service_tftp_disabled
+    - id: 2.1.16
+      title: Ensure tftp server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_tftp-server_removed
+      related_rules:
+          - service_tftp_disabled
 
-  - id: 2.1.17
-    title: Ensure web proxy server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_squid_removed
-    related_rules:
-      - service_squid_disabled
+    - id: 2.1.17
+      title: Ensure web proxy server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_squid_removed
+      related_rules:
+          - service_squid_disabled
 
-  - id: 2.1.18
-    title: Ensure web server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_httpd_removed
-      - package_nginx_removed
-    related_rules:
-      - service_httpd_disabled
+    - id: 2.1.18
+      title: Ensure web server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_httpd_removed
+          - package_nginx_removed
+      related_rules:
+          - service_httpd_disabled
     # rule would be nice to disable nginx service
 
-  - id: 2.1.19
-    title: Ensure xinetd services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: The xinetd appears to never have been in RHEL 9.
-    related_rules:
-      - package_xinetd_removed
-      - service_xinetd_disabled
-
-  - id: 2.1.20
-    title: Ensure X window server services are not in use (Automated)
-    levels:
-      - l2_server
-    status: automated
-    notes: |-
-      The rule also configures correct run level to prevent unbootable system.
-    rules:
-      - package_xorg-x11-server-common_removed
-      - xwindows_runlevel_target
-
-  - id: 2.1.21
-    title: Ensure mail transfer agents are configured for local-only mode (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: partial
-    notes:  |-
-      The rule has_nonlocal_mta currently checks for services listening only on port 25,
-      but the policy checks also for ports 465 and 587
-    rules:
-      - postfix_network_listening_disabled
-      - var_postfix_inet_interfaces=loopback-only
-      - has_nonlocal_mta
-
-  - id: 2.1.22
-    title: Ensure only approved services are listening on a network interface (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 2.2.1
-    title: Ensure ftp client is not installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_ftp_removed
-
-  - id: 2.2.2
-    title: Ensure ldap client is not installed (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - package_openldap-clients_removed
-
-  - id: 2.2.3
-    title: Ensure nis client is not installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: It appears this package was never in RHEL 9.
-    related_rules:
-      - package_ypbind_removed
-
-  - id: 2.2.4
-    title: Ensure telnet client is not installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_telnet_removed
-
-  - id: 2.2.5
-    title: Ensure tftp client is not installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_tftp_removed
-
-  - id: 2.3.1
-    title: Ensure time synchronization is in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_chrony_installed
-
-  - id: 2.3.2
-    title: Ensure chrony is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - chronyd_specify_remote_server
-      - var_multiple_time_servers=rhel
-
-  - id: 2.3.3
-    title: Ensure chrony is not run as the root user (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - chronyd_run_as_chrony_user
-
-  - id: 2.4.1.1
-    title: Ensure cron daemon is enabled and active (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_cron_installed
-      - service_crond_enabled
-
-  - id: 2.4.1.2
-    title: Ensure permissions on /etc/crontab are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_crontab
-      - file_owner_crontab
-      - file_permissions_crontab
-
-  - id: 2.4.1.3
-    title: Ensure permissions on /etc/cron.hourly are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_cron_hourly
-      - file_owner_cron_hourly
-      - file_permissions_cron_hourly
-
-  - id: 2.4.1.4
-    title: Ensure permissions on /etc/cron.daily are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_cron_daily
-      - file_owner_cron_daily
-      - file_permissions_cron_daily
-
-  - id: 2.4.1.5
-    title: Ensure permissions on /etc/cron.weekly are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_cron_weekly
-      - file_owner_cron_weekly
-      - file_permissions_cron_weekly
-
-  - id: 2.4.1.6
-    title: Ensure permissions on /etc/cron.monthly are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_cron_monthly
-      - file_owner_cron_monthly
-      - file_permissions_cron_monthly
-
-  - id: 2.4.1.7
-    title: Ensure permissions on /etc/cron.d are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_cron_d
-      - file_owner_cron_d
-      - file_permissions_cron_d
-
-  - id: 2.4.1.8
-    title: Ensure crontab is restricted to authorized users (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_cron_deny_not_exist
-      - file_cron_allow_exists
-      - file_groupowner_cron_allow
-      - file_owner_cron_allow
-      - file_permissions_cron_allow
-
-  - id: 2.4.2.1
-    title: Ensure at is restricted to authorized users (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: partial
-    notes: |-
-      It is necessary to create a rule to ensure the existence of at.allow.
-      file_cron_allow_exists can be used as reference for a new templated rule.
-    rules:
-      - file_at_deny_not_exist
-      - file_groupowner_at_allow
-      - file_owner_at_allow
-      - file_permissions_at_allow
-
-  - id: 3.1.1
-    title: Ensure IPv6 status is identified (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 3.1.2
-    title: Ensure wireless interfaces are disabled (Automated)
-    levels:
-      - l1_server
-    status: automated
-    rules:
-      - wireless_disable_interfaces
-
-  - id: 3.1.3
-    title: Ensure bluetooth services are not in use (Automated)
-    levels:
-      - l1_server
-      - l2_workstation
-    status: automated
-    rules:
-      - service_bluetooth_disabled
-
-  - id: 3.2.1
-    title: Ensure dccp kernel module is not available (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - kernel_module_dccp_disabled
-
-  - id: 3.2.2
-    title: Ensure tipc kernel module is not available (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - kernel_module_tipc_disabled
-
-  - id: 3.2.3
-    title: Ensure rds kernel module is not available (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - kernel_module_rds_disabled
-
-  - id: 3.2.4
-    title: Ensure sctp kernel module is not available (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - kernel_module_sctp_disabled
-
-  - id: 3.3.1
-    title: Ensure IP forwarding is disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_ip_forward
-      - sysctl_net_ipv6_conf_all_forwarding
-      - sysctl_net_ipv6_conf_all_forwarding_value=disabled
-
-  - id: 3.3.2
-    title: Ensure packet redirect sending is disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_conf_all_send_redirects
-      - sysctl_net_ipv4_conf_default_send_redirects
-
-  - id: 3.3.3
-    title: Ensure bogus icmp responses are ignored (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
-      - sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value=enabled
-
-  - id: 3.3.4
-    title: Ensure broadcast icmp requests are ignored (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
-      - sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value=enabled
-
-  - id: 3.3.5
-    title: Ensure icmp redirects are not accepted (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_conf_all_accept_redirects
-      - sysctl_net_ipv4_conf_all_accept_redirects_value=disabled
-      - sysctl_net_ipv4_conf_default_accept_redirects
-      - sysctl_net_ipv4_conf_default_accept_redirects_value=disabled
-      - sysctl_net_ipv6_conf_all_accept_redirects
-      - sysctl_net_ipv6_conf_all_accept_redirects_value=disabled
-      - sysctl_net_ipv6_conf_default_accept_redirects
-      - sysctl_net_ipv6_conf_default_accept_redirects_value=disabled
-
-  - id: 3.3.6
-    title: Ensure secure icmp redirects are not accepted (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_conf_all_secure_redirects
-      - sysctl_net_ipv4_conf_all_secure_redirects_value=disabled
-      - sysctl_net_ipv4_conf_default_secure_redirects
-      - sysctl_net_ipv4_conf_default_secure_redirects_value=disabled
-
-  - id: 3.3.7
-    title: Ensure reverse path filtering is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_conf_all_rp_filter
-      - sysctl_net_ipv4_conf_all_rp_filter_value=enabled
-      - sysctl_net_ipv4_conf_default_rp_filter
-      - sysctl_net_ipv4_conf_default_rp_filter_value=enabled
-
-  - id: 3.3.8
-    title: Ensure source routed packets are not accepted (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_conf_all_accept_source_route
-      - sysctl_net_ipv4_conf_all_accept_source_route_value=disabled
-      - sysctl_net_ipv4_conf_default_accept_source_route
-      - sysctl_net_ipv4_conf_default_accept_source_route_value=disabled
-      - sysctl_net_ipv6_conf_all_accept_source_route
-      - sysctl_net_ipv6_conf_all_accept_source_route_value=disabled
-      - sysctl_net_ipv6_conf_default_accept_source_route
-      - sysctl_net_ipv6_conf_default_accept_source_route_value=disabled
-
-  - id: 3.3.9
-    title: Ensure suspicious packets are logged (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_conf_all_log_martians
-      - sysctl_net_ipv4_conf_all_log_martians_value=enabled
-      - sysctl_net_ipv4_conf_default_log_martians
-      - sysctl_net_ipv4_conf_default_log_martians_value=enabled
-
-  - id: 3.3.10
-    title: Ensure tcp syn cookies is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_tcp_syncookies
-      - sysctl_net_ipv4_tcp_syncookies_value=enabled
-
-  - id: 3.3.11
-    title: Ensure IPv6 router advertisements are not accepted (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv6_conf_all_accept_ra
-      - sysctl_net_ipv6_conf_all_accept_ra_value=disabled
-      - sysctl_net_ipv6_conf_default_accept_ra
-      - sysctl_net_ipv6_conf_default_accept_ra_value=disabled
-
-  - id: 4.1.1
-    title: Ensure nftables is installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_nftables_installed
-
-  - id: 4.1.2
-    title: Ensure a single firewall configuration utility is in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - service_firewalld_enabled
-      - package_firewalld_installed
-      - service_nftables_disabled
-
-  - id: 4.2.1
-    title: Ensure firewalld drops unnecessary services and ports (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-    related_rules:
-      - configure_firewalld_ports
-
-  - id: 4.2.2
-    title: Ensure firewalld loopback traffic is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - firewalld_loopback_traffic_trusted
-      - firewalld_loopback_traffic_restricted
-
-  - id: 4.3.1
-    title: Ensure nftables base chains exist (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: supported
-    notes: |-
-      RHEL systems use firewalld for firewall management. Although nftables is the default
-      back-end for firewalld, it is not recommended to use nftables directly when firewalld
-      is in use. When using firewalld the base chains are installed by default.
-    related_rules:
-      - set_nftables_base_chain
-      - var_nftables_table=firewalld
-      - var_nftables_family=inet
-      - var_nftables_base_chain_names=chain_names
-      - var_nftables_base_chain_types=chain_types
-      - var_nftables_base_chain_hooks=chain_hooks
-      - var_nftables_base_chain_priorities=chain_priorities
-      - var_nftables_base_chain_policies=chain_policies
-
-  - id: 4.3.2
-    title: Ensure nftables established connections are configured (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 4.3.3
-    title: Ensure nftables default deny firewall policy (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: supported
-    notes: |-
-      RHEL systems use firewalld for firewall management. Although nftables is the default
-      back-end for firewalld, it is not recommended to use nftables directly when firewalld
-      is in use.
-    related_rules:
-      - nftables_ensure_default_deny_policy
-
-  - id: 4.3.4
-    title: Ensure nftables loopback traffic is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: supported
-    notes: |-
-      RHEL systems use firewalld for firewall management. Although nftables is the default
-      back-end for firewalld, it is not recommended to use nftables directly when firewalld
-      is in use.
-    related_rules:
-      - set_nftables_loopback_traffic
-
-  - id: 5.1.1
-    title: Ensure permissions on /etc/ssh/sshd_config are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_sshd_config
-      - file_owner_sshd_config
-      - file_permissions_sshd_config
-
-  - id: 5.1.2
-    title: Ensure permissions on SSH private host key files are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_permissions_sshd_private_key
-      - file_ownership_sshd_private_key
-      - file_groupownership_sshd_private_key
-
-  - id: 5.1.3
-    title: Ensure permissions on SSH public host key files are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_permissions_sshd_pub_key
-      - file_ownership_sshd_pub_key
-      - file_groupownership_sshd_pub_key
-
-  - id: 5.1.4
-    title: Ensure sshd Ciphers are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      Introduced in CIS RHEL9 v2.0.0
-      The status was automated but we need to double check the approach used in this rule.
-      Therefore I moved it to pending until deeper investigation.
-    related_rules:
-      - sshd_use_approved_ciphers
-      - sshd_approved_ciphers=cis_rhel9
-
-  - id: 5.1.5
-    title: Ensure sshd KexAlgorithms is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      The status was automated but we need to double check the approach used in this rule.
-      Therefore I moved it to pending until deeper investigation.
-    rules:
-      - sshd_use_strong_kex
-      - sshd_strong_kex=cis_rhel9
-
-  - id: 5.1.6
-    title: Ensure sshd MACs are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      The status was automated but we need to double check the approach used in this rule.
-      Therefore I moved it to pending until deeper investigation.
-    rules:
-      - sshd_use_strong_macs
-      - sshd_strong_macs=cis_rhel9
-
-  - id: 5.1.7
-    title: Ensure sshd access is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_limit_user_access
-
-  - id: 5.1.8
-    title: Ensure sshd Banner is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_enable_warning_banner_net
-    related_rules:
-      - sshd_enable_warning_banner
-
-  - id: 5.1.9
-    title: Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      The requirement gives an example of 45 seconds, but is flexible about the values. It is only
-      necessary to ensure there is a timeout configured in alignment to the site policy.
-    rules:
-      - sshd_idle_timeout_value=5_minutes
-      - sshd_set_idle_timeout
-      - sshd_set_keepalive
-      - var_sshd_set_keepalive=1
-
-  - id: 5.1.10
-    title: Ensure sshd DisableForwarding is enabled (Automated)
-    levels:
-      - l2_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      New templated rule is necessary for "disableforwarding" option.
-    related_rules:
-      - sshd_disable_tcp_forwarding
-      - sshd_disable_x11_forwarding
-
-  - id: 5.1.11
-    title: Ensure sshd GSSAPIAuthentication is disabled (Automated)
-    levels:
-      - l2_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      Introduced in CIS RHEL9 v2.0.0
-    rules:
-      - sshd_disable_gssapi_auth
-
-  - id: 5.1.12
-    title: Ensure sshd HostbasedAuthentication is disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - disable_host_auth
-
-  - id: 5.1.13
-    title: Ensure sshd IgnoreRhosts is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_disable_rhosts
-
-  - id: 5.1.14
-    title: Ensure sshd LoginGraceTime is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_set_login_grace_time
-      - var_sshd_set_login_grace_time=60
-
-  - id: 5.1.15
-    title: Ensure sshd LogLevel is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      The CIS benchmark is not opinionated about which loglevel is selected here. Here, this
-      profile uses VERBOSE by default, as it allows for the capture of login and logout activity
-      as well as key fingerprints.
-    rules:
-      - sshd_set_loglevel_verbose
-    related_rules:
-      - sshd_set_loglevel_info
-
-  - id: 5.1.16
-    title: Ensure sshd MaxAuthTries is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_max_auth_tries_value=4
-      - sshd_set_max_auth_tries
-
-  - id: 5.1.17
-    title: Ensure sshd MaxStartups is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_set_maxstartups
-      - var_sshd_set_maxstartups=10:30:60
-
-  - id: 5.1.18
-    title: Ensure sshd MaxSessions is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_set_max_sessions
-      - var_sshd_max_sessions=10
-
-  - id: 5.1.19
-    title: Ensure sshd PermitEmptyPasswords is disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_disable_empty_passwords
-
-  - id: 5.1.20
-    title: Ensure sshd PermitRootLogin is disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_disable_root_login
-
-  - id: 5.1.21
-    title: Ensure sshd PermitUserEnvironment is disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_do_not_permit_user_env
-
-  - id: 5.1.22
-    title: Ensure sshd UsePAM is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_enable_pam
-
-  - id: 5.2.1
-    title: Ensure sudo is installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_sudo_installed
-
-  - id: 5.2.2
-    title: Ensure sudo commands use pty (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sudo_add_use_pty
-
-  - id: 5.2.3
-    title: Ensure sudo log file exists (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sudo_custom_logfile
-
-  - id: 5.2.4
-    title: Ensure users must provide password for escalation (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - sudo_require_authentication
-
-  - id: 5.2.5
-    title: Ensure re-authentication for privilege escalation is not disabled globally (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sudo_require_reauthentication
-
-  - id: 5.2.6
-    title: Ensure sudo authentication timeout is configured correctly (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sudo_require_reauthentication
-
-  - id: 5.2.7
-    title: Ensure access to the su command is restricted (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      Members of "wheel" or GID 0 groups are checked by default if the group option is not set for
-      pam_wheel.so module. The recommendation states the group should be empty to reinforce the
-      use of "sudo" for privileged access. Therefore, members of these groups should be manually
-      checked or a different group should be informed.
-    rules:
-      - var_pam_wheel_group_for_su=cis
-      - use_pam_wheel_group_for_su
-      - ensure_pam_wheel_group_empty
-
-  - id: 5.3.1.1
-    title: Ensure latest version of pam is installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      It is necessary a new rule to ensure PAM package is updated.
-
-  - id: 5.3.1.2
-    title: Ensure latest version of authselect is installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      It is necessary a new rule to ensure authselect package is updated.
-
-  - id: 5.3.1.3
-    title: Ensure latest version of libpwquality is installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      It is necessary a new rule to ensure libpwquality package is updated.
-    rules:
-      - package_pam_pwquality_installed
-
-  - id: 5.3.2.1
-    title: Ensure active authselect profile includes pam modules (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: partial
-    notes: |-
-      This requirement is hard to be automated without any specific requirement. The policy even
-      states that provided commands are examples, other custom settings might be in place and the
-      settings might be different depending on site policies. The other rules will already make
-      sure there is a correct autheselect profile regardless of the existing settings. It is
-      necessary to better discuss with CIS Community.
-    related_rules:
-      - no_empty_passwords
-
-  - id: 5.3.2.2
-    title: Ensure pam_faillock module is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      This requirement is also indirectly satisfied by the requirement 5.3.3.1.
-    rules:
-      - account_password_pam_faillock_password_auth
-      - account_password_pam_faillock_system_auth
-
-  - id: 5.3.2.3
-    title: Ensure pam_pwquality module is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      This requirement is also indirectly satisfied by the requirement 5.3.3.2.
-    related_rules:
-      - package_pam_pwquality_installed
-
-  - id: 5.3.2.4
-    title: Ensure pam_pwhistory module is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      The module is properly enabled by the rules mentioned in related_rules.
-      Requirements in 5.3.3.3 use these rules.
-    related_rules:
-      - accounts_password_pam_pwhistory_remember_password_auth
-      - accounts_password_pam_pwhistory_remember_system_auth
-
-  - id: 5.3.2.5
-    title: Ensure pam_unix module is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: partial
-    notes: |-
-      This module is always present by default. It is necessary to investigate if a new rule to
-      check its existence needs to be created. But so far the rule no_empty_passwords, used in
-      5.3.3.4 can ensure this requirement is attended.
-    related_rules:
-      - no_empty_passwords
-
-  - id: 5.3.3.1.1
-    title: Ensure password failed attempts lockout is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_passwords_pam_faillock_deny
-      - var_accounts_passwords_pam_faillock_deny=5
-
-  - id: 5.3.3.1.2
-    title: Ensure password unlock time is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      The policy also accepts value 0, which means the locked accounts should be manually unlocked
-      by an administrator. However, it also mentions that using value 0 can facilitate a DoS
-      attack to legitimate users.
-    rules:
-      - accounts_passwords_pam_faillock_unlock_time
-      - var_accounts_passwords_pam_faillock_unlock_time=900
-
-  - id: 5.3.3.1.3
-    title: Ensure password failed attempts lockout includes root account (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - accounts_passwords_pam_faillock_deny_root
-
-  - id: 5.3.3.2.1
-    title: Ensure password number of changed characters is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_password_pam_difok
-      - var_password_pam_difok=2
-
-  - id: 5.3.3.2.2
-    title: Ensure password length is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_password_pam_minlen
-      - var_password_pam_minlen=14
-
-  - id: 5.3.3.2.3
-    title: Ensure password complexity is configured (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      This requirement is expected to be manual. However, in previous versions of the policy
-      it was already automated the configuration of "minclass" option. This posture was kept for
-      RHEL 9 in this new version. Rules related to other options are informed in related_rules.
-      In short, minclass=4 alone can achieve the same result achieved by the combination of the
-      other 4 options mentioned in the policy.
-    rules:
-      - accounts_password_pam_minclass
-      - var_password_pam_minclass=4
-    related_rules:
-      - accounts_password_pam_dcredit
-      - accounts_password_pam_lcredit
-      - accounts_password_pam_ocredit
-      - accounts_password_pam_ucredit
-
-  - id: 5.3.3.2.4
-    title: Ensure password same consecutive characters is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_password_pam_maxrepeat
-      - var_password_pam_maxrepeat=3
-
-  - id: 5.3.3.2.5
-    title: Ensure password maximum sequential characters is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: planned
-    notes: |-
-      A new templated rule and variable are necessary for the maxsequence option.
-
-  - id: 5.3.3.2.6
-    title: Ensure password dictionary check is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_password_pam_dictcheck
-      - var_password_pam_dictcheck=1
-
-  - id: 5.3.3.2.7
-    title: Ensure password quality is enforced for the root user (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_password_pam_enforce_root
-
-  - id: 5.3.3.3.1
-    title: Ensure password history remember is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      Although mentioned in the section 5.3.3.3, there is no explicit requirement to configure
-      retry option of pam_pwhistory. If come in the future, the rule accounts_password_pam_retry
-      can be used.
-    rules:
-      - accounts_password_pam_pwhistory_remember_password_auth
-      - accounts_password_pam_pwhistory_remember_system_auth
-      - var_password_pam_remember_control_flag=requisite_or_required
-      - var_password_pam_remember=24
-    related_rules:
-      - accounts_password_pam_retry
-
-  - id: 5.3.3.3.2
-    title: Ensure password history is enforced for the root user (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: planned
-    notes: |-
-      A new rule needs to be created to check and remediate the enforce_for_root option in
-      /etc/security/pwhistory.conf. accounts_password_pam_enforce_root can be used as reference.
-
-  - id: 5.3.3.3.3
-    title: Ensure pam_pwhistory includes use_authtok (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: partial
-    notes: |-
-      In RHEL 9 pam_pwhistory is enabled via authselect feature, as required in 5.3.2.4. The
-      feature automatically set "use_authok" option. In any case, we don't have a rule to check
-      this option specifically.
-    related_rules:
-      - accounts_password_pam_pwhistory_remember_password_auth
-      - accounts_password_pam_pwhistory_remember_system_auth
-
-  - id: 5.3.3.4.1
-    title: Ensure pam_unix does not include nullok (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      The rule more specifically used in this requirement also satify the requirement 5.3.2.5.
-    rules:
-      - no_empty_passwords
-
-  - id: 5.3.3.4.2
-    title: Ensure pam_unix does not include remember (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      Usage of pam_unix.so module together with "remember" option is deprecated and is not
-      recommened by this policy. Instead, it should be used remember option of pam_pwhistory
-      module, as required in 5.3.3.3.1. See here for more details about pam_unix.so:
-      https://bugzilla.redhat.com/show_bug.cgi?id=1778929
-      A new rule needs to be created to remove the remember option from pam_unix module.
-
-  - id: 5.3.3.4.3
-    title: Ensure pam_unix includes a strong password hashing algorithm (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      Changes in logindefs mentioned in this requirement are more specifically covered by 5.4.1.4
-    rules:
-      - set_password_hashing_algorithm_systemauth
-      - set_password_hashing_algorithm_passwordauth
-      - var_password_hashing_algorithm_pam=sha512
-
-  - id: 5.3.3.4.4
-    title: Ensure pam_unix includes use_authtok (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: partial
-    notes: |-
-      In RHEL 9 pam_unix is enabled by default in all authselect profiles already with the
-      use_authtok option set. In any case, we don't have a rule to check this option specifically,
-      like in 5.3.3.3.3.
-
-  - id: 5.4.1.1
-    title: Ensure password expiration is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_maximum_age_login_defs
-      - var_accounts_maximum_age_login_defs=365
-      - accounts_password_set_max_life_existing
-
-  - id: 5.4.1.2
-    title: Ensure minimum password days is configured (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - accounts_minimum_age_login_defs
-      - var_accounts_minimum_age_login_defs=1
-      - accounts_password_set_min_life_existing
-
-  - id: 5.4.1.3
-    title: Ensure password expiration warning days is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_password_warn_age_login_defs
-      - var_accounts_password_warn_age_login_defs=7
-      - accounts_password_set_warn_age_existing
-
-  - id: 5.4.1.4
-    title: Ensure strong password hashing algorithm is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - set_password_hashing_algorithm_libuserconf
-      - set_password_hashing_algorithm_logindefs
-      - var_password_hashing_algorithm=SHA512
-      - var_password_hashing_algorithm_pam=sha512
-
-  - id: 5.4.1.5
-    title: Ensure inactive password lock is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - account_disable_post_pw_expiration
-      - accounts_set_post_pw_existing
-      - var_account_disable_post_pw_expiration=45
-
-  - id: 5.4.1.6
-    title: Ensure all users last password change date is in the past (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_password_last_change_is_in_past
-
-  - id: 5.4.2.1
-    title: Ensure root is the only UID 0 account (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_no_uid_except_zero
-
-  - id: 5.4.2.2
-    title: Ensure root is the only GID 0 account (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: partial
-    notes: |-
-      The rule confirms the primary group for root, but doesn't check if any other user are also
-      using GID 0. New rule is necessary.
-      There is assessment but no automated remediation for this rule and this sounds reasonable.
-    rules:
-      - accounts_root_gid_zero
-
-  - id: 5.4.2.3
-    title: Ensure group root is the only GID 0 group (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      Introduced in CIS RHEL9 v2.0.0.
-      New rule is necessary.
-
-  - id: 5.4.2.4
-    title: Ensure root account access is controlled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - ensure_root_password_configured
-
-  - id: 5.4.2.5
-    title: Ensure root path integrity (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_root_path_dirs_no_write
-      - root_path_no_dot
-
-  - id: 5.4.2.6
-    title: Ensure root user umask is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      There is no rule to ensure umask in /root/.bash_profile and /root/.bashrc. A new rule have
-      to be created. It can be based on accounts_umask_interactive_users.
-
-  - id: 5.4.2.7
-    title: Ensure system accounts do not have a valid login shell (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - no_password_auth_for_systemaccounts
-      - no_shelllogin_for_systemaccounts
-
-  - id: 5.4.2.8
-    title: Ensure accounts without a valid login shell are locked (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      Introduced in CIS RHEL9 v2.0.0.
-      New rule is necessary.
-
-  - id: 5.4.3.1
-    title: Ensure nologin is not listed in /etc/shells (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: pending
-    notes: |-
-      It is necessary to create a new rule to check and remove nologin from /etc/shells.
-      The no_tmux_in_shells rule can be used as referece.
-
-  - id: 5.4.3.2
-    title: Ensure default user shell timeout is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_tmout
-      - var_accounts_tmout=15_min
-
-  - id: 5.4.3.3
-    title: Ensure default user umask is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_umask_etc_bashrc
-      - accounts_umask_etc_login_defs
-      - accounts_umask_etc_profile
-      - var_accounts_user_umask=027
-
-  - id: 6.1.1
-    title: Ensure AIDE is installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_aide_installed
-      - aide_build_database
-
-  - id: 6.1.2
-    title: Ensure filesystem integrity is regularly checked (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - aide_periodic_cron_checking
-
-  - id: 6.1.3
-    title: Ensure cryptographic mechanisms are used to protect the integrity of audit tools (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - aide_check_audit_tools
-    related_rules:
-      - aide_use_fips_hashes
-
-  - id: 6.2.1.1
-    title: Ensure journald service is enabled and active (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - service_systemd-journald_enabled
-
-  - id: 6.2.1.2
-    title: Ensure journald log file access is configured (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 6.2.1.3
-    title: Ensure journald log file rotation is configured (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 6.2.1.4
-    title: Ensure only one logging system is in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      It is necessary to create a new rule to check the status of journald and rsyslog.
-      It would also be necessary a new rule to disable or remove rsyslog.
-
-  - id: 6.2.2.1.1
-    title: Ensure systemd-journal-remote is installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_systemd-journal-remote_installed
-
-  - id: 6.2.2.1.2
-    title: Ensure systemd-journal-upload authentication is configured (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 6.2.2.1.3
-    title: Ensure systemd-journal-upload is enabled and active (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      Introduced in CIS RHEL9 v2.0.0.
-      New templated rule is necessary.
-
-  - id: 6.2.2.1.4
-    title: Ensure systemd-journal-remote service is not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - socket_systemd-journal-remote_disabled
-
-  - id: 6.2.2.2
-    title: Ensure journald ForwardToSyslog is disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      This rule conflicts with 6.2.3.3. More investigation is needed to properly solve this.
-    related_rules:
-      - journald_forward_to_syslog
-
-  - id: 6.2.2.3
-    title: Ensure journald Compress is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - journald_compress
-
-  - id: 6.2.2.4
-    title: Ensure journald Storage is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - journald_storage
-
-  - id: 6.2.3.1
-    title: Ensure rsyslog is installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: supported
-    related_rules:
-      - package_rsyslog_installed
-
-  - id: 6.2.3.2
-    title: Ensure rsyslog service is enabled and active (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: supported
-    related_rules:
-      - service_rsyslog_enabled
-
-  - id: 6.2.3.3
-    title: Ensure journald is configured to send logs to rsyslog (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: supported
-    related_rules:
-      - journald_forward_to_syslog
-
-  - id: 6.2.3.4
-    title: Ensure rsyslog log file creation mode is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: supported
-    related_rules:
-      - rsyslog_filecreatemode
-
-  - id: 6.2.3.5
-    title: Ensure rsyslog logging is configured (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 6.2.3.6
-    title: Ensure rsyslog is configured to send logs to a remote log host (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-    related_rules:
-      - rsyslog_remote_loghost
-
-  - id: 6.2.3.7
-    title: Ensure rsyslog is not configured to receive logs from a remote client (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: supported
-    related_rules:
-      - rsyslog_nolisten
-
-  - id: 6.2.3.8
-    title: Ensure rsyslog logrotate is configured (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-    related_rules:
-      - ensure_logrotate_activated
-      - package_logrotate_installed
-      - timer_logrotate_enabled
-
-  - id: 6.2.4.1
-    title: Ensure access to all logfiles has been configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      It is not harmful to run these rules even if rsyslog is not installed or active.
-    rules:
-      - rsyslog_files_groupownership
-      - rsyslog_files_ownership
-      - rsyslog_files_permissions
-
-  - id: 6.3.1.1
-    title: Ensure auditd packages are installed (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - package_audit_installed
-      - package_audit-libs_installed
-
-  - id: 6.3.1.2
-    title: Ensure auditing for processes that start prior to auditd is enabled (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - grub2_audit_argument
-
-  - id: 6.3.1.3
-    title: Ensure audit_backlog_limit is sufficient (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - grub2_audit_backlog_limit_argument
-
-  - id: 6.3.1.4
-    title: Ensure auditd service is enabled and active (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - service_auditd_enabled
-
-  - id: 6.3.2.1
-    title: Ensure audit log storage size is configured (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - auditd_data_retention_max_log_file
-      - var_auditd_max_log_file=6
-
-  - id: 6.3.2.2
-    title: Ensure audit logs are not automatically deleted (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - auditd_data_retention_max_log_file_action
-      - var_auditd_max_log_file_action=keep_logs
-
-  - id: 6.3.2.3
-    title: Ensure system is disabled when audit logs are full (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - auditd_data_disk_error_action
-      - auditd_data_disk_full_action
-      - var_auditd_disk_error_action=cis_rhel9
-      - var_auditd_disk_full_action=cis_rhel9
-
-  - id: 6.3.2.4
-    title: Ensure system warns when audit logs are low on space (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - auditd_data_retention_action_mail_acct
-      - auditd_data_retention_admin_space_left_action
-      - auditd_data_retention_space_left_action
-      - var_auditd_action_mail_acct=root
-      - var_auditd_admin_space_left_action=cis_rhel9
-      - var_auditd_space_left_action=cis_rhel9
-
-  - id: 6.3.3.1
-    title: Ensure changes to system administration scope (sudoers) is collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_sysadmin_actions
-
-  - id: 6.3.3.2
-    title: Ensure actions as another user are always logged (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_suid_auid_privilege_function
-
-  - id: 6.3.3.3
-    title: Ensure events that modify the sudo log file are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_sudo_log_events
-
-  - id: 6.3.3.4
-    title: Ensure events that modify date and time information are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_time_adjtimex
-      - audit_rules_time_settimeofday
-      - audit_rules_time_clock_settime
-      - audit_rules_time_watch_localtime
-    related_rules:
-      - audit_rules_time_stime
-
-  - id: 6.3.3.5
-    title: Ensure events that modify the system's network environment are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: partial
-    notes: |-
-      These rules are not covering "/etc/hostname" and "/etc/NetworkManager/".
-    rules:
-      - audit_rules_networkconfig_modification
-      - audit_rules_networkconfig_modification_network_scripts
-
-  - id: 6.3.3.6
-    title: Ensure use of privileged commands are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_privileged_commands
-
-  - id: 6.3.3.7
-    title: Ensure unsuccessful file access attempts are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_unsuccessful_file_modification_creat
-      - audit_rules_unsuccessful_file_modification_ftruncate
-      - audit_rules_unsuccessful_file_modification_open
-      - audit_rules_unsuccessful_file_modification_openat
-      - audit_rules_unsuccessful_file_modification_truncate
-
-  - id: 6.3.3.8
-    title: Ensure events that modify user/group information are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: partial
-    notes: |-
-      Missing rules to check "/etc/nsswitch.conf", "/etc/pam.conf" and "/etc/pam.d"
-    rules:
-      - audit_rules_usergroup_modification_group
-      - audit_rules_usergroup_modification_gshadow
-      - audit_rules_usergroup_modification_opasswd
-      - audit_rules_usergroup_modification_passwd
-      - audit_rules_usergroup_modification_shadow
-
-  - id: 6.3.3.9
-    title: Ensure discretionary access control permission modification events are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_dac_modification_chmod
-      - audit_rules_dac_modification_chown
-      - audit_rules_dac_modification_fchmod
-      - audit_rules_dac_modification_fchmodat
-      - audit_rules_dac_modification_fchown
-      - audit_rules_dac_modification_fchownat
-      - audit_rules_dac_modification_fremovexattr
-      - audit_rules_dac_modification_fsetxattr
-      - audit_rules_dac_modification_lchown
-      - audit_rules_dac_modification_lremovexattr
-      - audit_rules_dac_modification_lsetxattr
-      - audit_rules_dac_modification_removexattr
-      - audit_rules_dac_modification_setxattr
-
-  - id: 6.3.3.10
-    title: Ensure successful file system mounts are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_media_export
-
-  - id: 6.3.3.11
-    title: Ensure session initiation information is collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_session_events_utmp
-      - audit_rules_session_events_btmp
-      - audit_rules_session_events_wtmp
-
-  - id: 6.3.3.12
-    title: Ensure login and logout events are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_login_events_faillock
-      - audit_rules_login_events_lastlog
-      - var_accounts_passwords_pam_faillock_dir=run
-
-  - id: 6.3.3.13
-    title: Ensure file deletion events by users are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_file_deletion_events_rename
-      - audit_rules_file_deletion_events_renameat
-      - audit_rules_file_deletion_events_unlink
-      - audit_rules_file_deletion_events_unlinkat
-
-  - id: 6.3.3.14
-    title: Ensure events that modify the system's Mandatory Access Controls are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_mac_modification
-      - audit_rules_mac_modification_usr_share
-
-  - id: 6.3.3.15
-    title: Ensure successful and unsuccessful attempts to use the chcon command are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_execution_chcon
-
-  - id: 6.3.3.16
-    title: Ensure successful and unsuccessful attempts to use the setfacl command are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_execution_setfacl
-
-  - id: 6.3.3.17
-    title: Ensure successful and unsuccessful attempts to use the chacl command are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_execution_chacl
-
-  - id: 6.3.3.18
-    title: Ensure successful and unsuccessful attempts to use the usermod command are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_privileged_commands_usermod
-
-  - id: 6.3.3.19
-    title: Ensure kernel module loading unloading and modification is collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_kernel_module_loading_create
-      - audit_rules_kernel_module_loading_delete
-      - audit_rules_kernel_module_loading_finit
-      - audit_rules_kernel_module_loading_init
-      - audit_rules_kernel_module_loading_query
-      - audit_rules_privileged_commands_kmod
-
-  - id: 6.3.3.20
-    title: Ensure the audit configuration is immutable (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_immutable
-
-  - id: 6.3.3.21
-    title: Ensure the running and on disk configuration is the same (Manual)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: manual
-
-  - id: 6.3.4.1
-    title: Ensure the audit log file directory mode is configured (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - directory_permissions_var_log_audit
-
-  - id: 6.3.4.2
-    title: Ensure audit log files mode is configured (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - file_permissions_var_log_audit
-
-  - id: 6.3.4.3
-    title: Ensure audit log files owner is configured (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - file_ownership_var_log_audit_stig
-
-  - id: 6.3.4.4
-    title: Ensure audit log files group owner is configured (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - file_group_ownership_var_log_audit
-
-  - id: 6.3.4.5
-    title: Ensure audit configuration files mode is configured (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - file_permissions_audit_configuration
-
-  - id: 6.3.4.6
-    title: Ensure audit configuration files owner is configured (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - file_ownership_audit_configuration
-
-  - id: 6.3.4.7
-    title: Ensure audit configuration files group owner is configured (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - file_groupownership_audit_configuration
-
-  - id: 6.3.4.8
-    title: Ensure audit tools mode is configured (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - file_permissions_audit_binaries
-
-  - id: 6.3.4.9
-    title: Ensure audit tools owner is configured (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - file_ownership_audit_binaries
-
-  - id: 6.3.4.10
-    title: Ensure audit tools group owner is configured (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - file_groupownership_audit_binaries
-
-  - id: 7.1.1
-    title: Ensure permissions on /etc/passwd are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_etc_passwd
-      - file_owner_etc_passwd
-      - file_permissions_etc_passwd
-
-  - id: 7.1.2
-    title: Ensure permissions on /etc/passwd- are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_backup_etc_passwd
-      - file_owner_backup_etc_passwd
-      - file_permissions_backup_etc_passwd
-
-  - id: 7.1.3
-    title: Ensure permissions on /etc/group are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_etc_group
-      - file_owner_etc_group
-      - file_permissions_etc_group
-
-  - id: 7.1.4
-    title: Ensure permissions on /etc/group- are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_backup_etc_group
-      - file_owner_backup_etc_group
-      - file_permissions_backup_etc_group
-
-  - id: 7.1.5
-    title: Ensure permissions on /etc/shadow are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_owner_etc_shadow
-      - file_groupowner_etc_shadow
-      - file_permissions_etc_shadow
-
-  - id: 7.1.6
-    title: Ensure permissions on /etc/shadow- are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_backup_etc_shadow
-      - file_owner_backup_etc_shadow
-      - file_permissions_backup_etc_shadow
-
-  - id: 7.1.7
-    title: Ensure permissions on /etc/gshadow are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_etc_gshadow
-      - file_owner_etc_gshadow
-      - file_permissions_etc_gshadow
-
-  - id: 7.1.8
-    title: Ensure permissions on /etc/gshadow- are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_backup_etc_gshadow
-      - file_owner_backup_etc_gshadow
-      - file_permissions_backup_etc_gshadow
-
-  - id: 7.1.9
-    title: Ensure permissions on /etc/shells are configured (Automated)
-    levels:
-    - l1_server
-    - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_etc_shells
-      - file_owner_etc_shells
-      - file_permissions_etc_shells
-
-  - id: 7.1.10
-    title: Ensure permissions on /etc/security/opasswd are configured (Automated)
-    levels:
-    - l1_server
-    - l1_workstation
-    status: partial
-    rules:
+    - id: 2.1.19
+      title: Ensure xinetd services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: The xinetd appears to never have been in RHEL 9.
+      related_rules:
+          - package_xinetd_removed
+          - service_xinetd_disabled
+
+    - id: 2.1.20
+      title: Ensure X window server services are not in use (Automated)
+      levels:
+          - l2_server
+      status: automated
+      notes: |-
+          The rule also configures correct run level to prevent unbootable system.
+      rules:
+          - package_xorg-x11-server-common_removed
+          - xwindows_runlevel_target
+
+    - id: 2.1.21
+      title: Ensure mail transfer agents are configured for local-only mode (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: partial
+      notes: |-
+          The rule has_nonlocal_mta currently checks for services listening only on port 25,
+          but the policy checks also for ports 465 and 587
+      rules:
+          - postfix_network_listening_disabled
+          - var_postfix_inet_interfaces=loopback-only
+          - has_nonlocal_mta
+
+    - id: 2.1.22
+      title: Ensure only approved services are listening on a network interface (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 2.2.1
+      title: Ensure ftp client is not installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_ftp_removed
+
+    - id: 2.2.2
+      title: Ensure ldap client is not installed (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - package_openldap-clients_removed
+
+    - id: 2.2.3
+      title: Ensure nis client is not installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: It appears this package was never in RHEL 9.
+      related_rules:
+          - package_ypbind_removed
+
+    - id: 2.2.4
+      title: Ensure telnet client is not installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_telnet_removed
+
+    - id: 2.2.5
+      title: Ensure tftp client is not installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_tftp_removed
+
+    - id: 2.3.1
+      title: Ensure time synchronization is in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_chrony_installed
+
+    - id: 2.3.2
+      title: Ensure chrony is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - chronyd_specify_remote_server
+          - var_multiple_time_servers=rhel
+
+    - id: 2.3.3
+      title: Ensure chrony is not run as the root user (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - chronyd_run_as_chrony_user
+
+    - id: 2.4.1.1
+      title: Ensure cron daemon is enabled and active (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_cron_installed
+          - service_crond_enabled
+
+    - id: 2.4.1.2
+      title: Ensure permissions on /etc/crontab are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_crontab
+          - file_owner_crontab
+          - file_permissions_crontab
+
+    - id: 2.4.1.3
+      title: Ensure permissions on /etc/cron.hourly are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_cron_hourly
+          - file_owner_cron_hourly
+          - file_permissions_cron_hourly
+
+    - id: 2.4.1.4
+      title: Ensure permissions on /etc/cron.daily are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_cron_daily
+          - file_owner_cron_daily
+          - file_permissions_cron_daily
+
+    - id: 2.4.1.5
+      title: Ensure permissions on /etc/cron.weekly are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_cron_weekly
+          - file_owner_cron_weekly
+          - file_permissions_cron_weekly
+
+    - id: 2.4.1.6
+      title: Ensure permissions on /etc/cron.monthly are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_cron_monthly
+          - file_owner_cron_monthly
+          - file_permissions_cron_monthly
+
+    - id: 2.4.1.7
+      title: Ensure permissions on /etc/cron.d are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_cron_d
+          - file_owner_cron_d
+          - file_permissions_cron_d
+
+    - id: 2.4.1.8
+      title: Ensure crontab is restricted to authorized users (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_cron_deny_not_exist
+          - file_cron_allow_exists
+          - file_groupowner_cron_allow
+          - file_owner_cron_allow
+          - file_permissions_cron_allow
+
+    - id: 2.4.2.1
+      title: Ensure at is restricted to authorized users (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: partial
+      notes: |-
+          It is necessary to create a rule to ensure the existence of at.allow.
+          file_cron_allow_exists can be used as reference for a new templated rule.
+      rules:
+          - file_at_deny_not_exist
+          - file_groupowner_at_allow
+          - file_owner_at_allow
+          - file_permissions_at_allow
+
+    - id: 3.1.1
+      title: Ensure IPv6 status is identified (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 3.1.2
+      title: Ensure wireless interfaces are disabled (Automated)
+      levels:
+          - l1_server
+      status: automated
+      rules:
+          - wireless_disable_interfaces
+
+    - id: 3.1.3
+      title: Ensure bluetooth services are not in use (Automated)
+      levels:
+          - l1_server
+          - l2_workstation
+      status: automated
+      rules:
+          - service_bluetooth_disabled
+
+    - id: 3.2.1
+      title: Ensure dccp kernel module is not available (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - kernel_module_dccp_disabled
+
+    - id: 3.2.2
+      title: Ensure tipc kernel module is not available (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - kernel_module_tipc_disabled
+
+    - id: 3.2.3
+      title: Ensure rds kernel module is not available (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - kernel_module_rds_disabled
+
+    - id: 3.2.4
+      title: Ensure sctp kernel module is not available (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - kernel_module_sctp_disabled
+
+    - id: 3.3.1
+      title: Ensure IP forwarding is disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_ip_forward
+          - sysctl_net_ipv6_conf_all_forwarding
+          - sysctl_net_ipv6_conf_all_forwarding_value=disabled
+
+    - id: 3.3.2
+      title: Ensure packet redirect sending is disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_conf_all_send_redirects
+          - sysctl_net_ipv4_conf_default_send_redirects
+
+    - id: 3.3.3
+      title: Ensure bogus icmp responses are ignored (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
+          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value=enabled
+
+    - id: 3.3.4
+      title: Ensure broadcast icmp requests are ignored (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+          - sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value=enabled
+
+    - id: 3.3.5
+      title: Ensure icmp redirects are not accepted (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_conf_all_accept_redirects
+          - sysctl_net_ipv4_conf_all_accept_redirects_value=disabled
+          - sysctl_net_ipv4_conf_default_accept_redirects
+          - sysctl_net_ipv4_conf_default_accept_redirects_value=disabled
+          - sysctl_net_ipv6_conf_all_accept_redirects
+          - sysctl_net_ipv6_conf_all_accept_redirects_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_redirects
+          - sysctl_net_ipv6_conf_default_accept_redirects_value=disabled
+
+    - id: 3.3.6
+      title: Ensure secure icmp redirects are not accepted (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_conf_all_secure_redirects
+          - sysctl_net_ipv4_conf_all_secure_redirects_value=disabled
+          - sysctl_net_ipv4_conf_default_secure_redirects
+          - sysctl_net_ipv4_conf_default_secure_redirects_value=disabled
+
+    - id: 3.3.7
+      title: Ensure reverse path filtering is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_conf_all_rp_filter
+          - sysctl_net_ipv4_conf_all_rp_filter_value=enabled
+          - sysctl_net_ipv4_conf_default_rp_filter
+          - sysctl_net_ipv4_conf_default_rp_filter_value=enabled
+
+    - id: 3.3.8
+      title: Ensure source routed packets are not accepted (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_conf_all_accept_source_route
+          - sysctl_net_ipv4_conf_all_accept_source_route_value=disabled
+          - sysctl_net_ipv4_conf_default_accept_source_route
+          - sysctl_net_ipv4_conf_default_accept_source_route_value=disabled
+          - sysctl_net_ipv6_conf_all_accept_source_route
+          - sysctl_net_ipv6_conf_all_accept_source_route_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_source_route
+          - sysctl_net_ipv6_conf_default_accept_source_route_value=disabled
+
+    - id: 3.3.9
+      title: Ensure suspicious packets are logged (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_conf_all_log_martians
+          - sysctl_net_ipv4_conf_all_log_martians_value=enabled
+          - sysctl_net_ipv4_conf_default_log_martians
+          - sysctl_net_ipv4_conf_default_log_martians_value=enabled
+
+    - id: 3.3.10
+      title: Ensure tcp syn cookies is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_tcp_syncookies
+          - sysctl_net_ipv4_tcp_syncookies_value=enabled
+
+    - id: 3.3.11
+      title: Ensure IPv6 router advertisements are not accepted (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv6_conf_all_accept_ra
+          - sysctl_net_ipv6_conf_all_accept_ra_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_ra
+          - sysctl_net_ipv6_conf_default_accept_ra_value=disabled
+
+    - id: 4.1.1
+      title: Ensure nftables is installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_nftables_installed
+
+    - id: 4.1.2
+      title: Ensure a single firewall configuration utility is in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - service_firewalld_enabled
+          - package_firewalld_installed
+          - service_nftables_disabled
+
+    - id: 4.2.1
+      title: Ensure firewalld drops unnecessary services and ports (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+      related_rules:
+          - configure_firewalld_ports
+
+    - id: 4.2.2
+      title: Ensure firewalld loopback traffic is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - firewalld_loopback_traffic_trusted
+          - firewalld_loopback_traffic_restricted
+
+    - id: 4.3.1
+      title: Ensure nftables base chains exist (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: supported
+      notes: |-
+          RHEL systems use firewalld for firewall management. Although nftables is the default
+          back-end for firewalld, it is not recommended to use nftables directly when firewalld
+          is in use. When using firewalld the base chains are installed by default.
+      related_rules:
+          - set_nftables_base_chain
+          - var_nftables_table=firewalld
+          - var_nftables_family=inet
+          - var_nftables_base_chain_names=chain_names
+          - var_nftables_base_chain_types=chain_types
+          - var_nftables_base_chain_hooks=chain_hooks
+          - var_nftables_base_chain_priorities=chain_priorities
+          - var_nftables_base_chain_policies=chain_policies
+
+    - id: 4.3.2
+      title: Ensure nftables established connections are configured (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 4.3.3
+      title: Ensure nftables default deny firewall policy (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: supported
+      notes: |-
+          RHEL systems use firewalld for firewall management. Although nftables is the default
+          back-end for firewalld, it is not recommended to use nftables directly when firewalld
+          is in use.
+      related_rules:
+          - nftables_ensure_default_deny_policy
+
+    - id: 4.3.4
+      title: Ensure nftables loopback traffic is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: supported
+      notes: |-
+          RHEL systems use firewalld for firewall management. Although nftables is the default
+          back-end for firewalld, it is not recommended to use nftables directly when firewalld
+          is in use.
+      related_rules:
+          - set_nftables_loopback_traffic
+
+    - id: 5.1.1
+      title: Ensure permissions on /etc/ssh/sshd_config are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_sshd_config
+          - file_owner_sshd_config
+          - file_permissions_sshd_config
+
+    - id: 5.1.2
+      title: Ensure permissions on SSH private host key files are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_permissions_sshd_private_key
+          - file_ownership_sshd_private_key
+          - file_groupownership_sshd_private_key
+
+    - id: 5.1.3
+      title: Ensure permissions on SSH public host key files are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_permissions_sshd_pub_key
+          - file_ownership_sshd_pub_key
+          - file_groupownership_sshd_pub_key
+
+    - id: 5.1.4
+      title: Ensure sshd Ciphers are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          Introduced in CIS RHEL9 v2.0.0
+          The status was automated but we need to double check the approach used in this rule.
+          Therefore I moved it to pending until deeper investigation.
+      related_rules:
+          - sshd_use_approved_ciphers
+          - sshd_approved_ciphers=cis_rhel9
+
+    - id: 5.1.5
+      title: Ensure sshd KexAlgorithms is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          The status was automated but we need to double check the approach used in this rule.
+          Therefore I moved it to pending until deeper investigation.
+      rules:
+          - sshd_use_strong_kex
+          - sshd_strong_kex=cis_rhel9
+
+    - id: 5.1.6
+      title: Ensure sshd MACs are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          The status was automated but we need to double check the approach used in this rule.
+          Therefore I moved it to pending until deeper investigation.
+      rules:
+          - sshd_use_strong_macs
+          - sshd_strong_macs=cis_rhel9
+
+    - id: 5.1.7
+      title: Ensure sshd access is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_limit_user_access
+
+    - id: 5.1.8
+      title: Ensure sshd Banner is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_enable_warning_banner_net
+      related_rules:
+          - sshd_enable_warning_banner
+
+    - id: 5.1.9
+      title: Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          The requirement gives an example of 45 seconds, but is flexible about the values. It is only
+          necessary to ensure there is a timeout configured in alignment to the site policy.
+      rules:
+          - sshd_idle_timeout_value=5_minutes
+          - sshd_set_idle_timeout
+          - sshd_set_keepalive
+          - var_sshd_set_keepalive=1
+
+    - id: 5.1.10
+      title: Ensure sshd DisableForwarding is enabled (Automated)
+      levels:
+          - l2_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          New templated rule is necessary for "disableforwarding" option.
+      related_rules:
+          - sshd_disable_tcp_forwarding
+          - sshd_disable_x11_forwarding
+
+    - id: 5.1.11
+      title: Ensure sshd GSSAPIAuthentication is disabled (Automated)
+      levels:
+          - l2_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          Introduced in CIS RHEL9 v2.0.0
+      rules:
+          - sshd_disable_gssapi_auth
+
+    - id: 5.1.12
+      title: Ensure sshd HostbasedAuthentication is disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - disable_host_auth
+
+    - id: 5.1.13
+      title: Ensure sshd IgnoreRhosts is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_disable_rhosts
+
+    - id: 5.1.14
+      title: Ensure sshd LoginGraceTime is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_set_login_grace_time
+          - var_sshd_set_login_grace_time=60
+
+    - id: 5.1.15
+      title: Ensure sshd LogLevel is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          The CIS benchmark is not opinionated about which loglevel is selected here. Here, this
+          profile uses VERBOSE by default, as it allows for the capture of login and logout activity
+          as well as key fingerprints.
+      rules:
+          - sshd_set_loglevel_verbose
+      related_rules:
+          - sshd_set_loglevel_info
+
+    - id: 5.1.16
+      title: Ensure sshd MaxAuthTries is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_max_auth_tries_value=4
+          - sshd_set_max_auth_tries
+
+    - id: 5.1.17
+      title: Ensure sshd MaxStartups is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_set_maxstartups
+          - var_sshd_set_maxstartups=10:30:60
+
+    - id: 5.1.18
+      title: Ensure sshd MaxSessions is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_set_max_sessions
+          - var_sshd_max_sessions=10
+
+    - id: 5.1.19
+      title: Ensure sshd PermitEmptyPasswords is disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_disable_empty_passwords
+
+    - id: 5.1.20
+      title: Ensure sshd PermitRootLogin is disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_disable_root_login
+
+    - id: 5.1.21
+      title: Ensure sshd PermitUserEnvironment is disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_do_not_permit_user_env
+
+    - id: 5.1.22
+      title: Ensure sshd UsePAM is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_enable_pam
+
+    - id: 5.2.1
+      title: Ensure sudo is installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_sudo_installed
+
+    - id: 5.2.2
+      title: Ensure sudo commands use pty (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sudo_add_use_pty
+
+    - id: 5.2.3
+      title: Ensure sudo log file exists (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sudo_custom_logfile
+
+    - id: 5.2.4
+      title: Ensure users must provide password for escalation (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - sudo_require_authentication
+
+    - id: 5.2.5
+      title: Ensure re-authentication for privilege escalation is not disabled globally (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sudo_require_reauthentication
+
+    - id: 5.2.6
+      title: Ensure sudo authentication timeout is configured correctly (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sudo_require_reauthentication
+
+    - id: 5.2.7
+      title: Ensure access to the su command is restricted (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          Members of "wheel" or GID 0 groups are checked by default if the group option is not set for
+          pam_wheel.so module. The recommendation states the group should be empty to reinforce the
+          use of "sudo" for privileged access. Therefore, members of these groups should be manually
+          checked or a different group should be informed.
+      rules:
+          - var_pam_wheel_group_for_su=cis
+          - use_pam_wheel_group_for_su
+          - ensure_pam_wheel_group_empty
+
+    - id: 5.3.1.1
+      title: Ensure latest version of pam is installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          It is necessary a new rule to ensure PAM package is updated.
+
+    - id: 5.3.1.2
+      title: Ensure latest version of authselect is installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          It is necessary a new rule to ensure authselect package is updated.
+
+    - id: 5.3.1.3
+      title: Ensure latest version of libpwquality is installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          It is necessary a new rule to ensure libpwquality package is updated.
+      rules:
+          - package_pam_pwquality_installed
+
+    - id: 5.3.2.1
+      title: Ensure active authselect profile includes pam modules (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: partial
+      notes: |-
+          This requirement is hard to be automated without any specific requirement. The policy even
+          states that provided commands are examples, other custom settings might be in place and the
+          settings might be different depending on site policies. The other rules will already make
+          sure there is a correct autheselect profile regardless of the existing settings. It is
+          necessary to better discuss with CIS Community.
+      related_rules:
+          - no_empty_passwords
+
+    - id: 5.3.2.2
+      title: Ensure pam_faillock module is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          This requirement is also indirectly satisfied by the requirement 5.3.3.1.
+      rules:
+          - account_password_pam_faillock_password_auth
+          - account_password_pam_faillock_system_auth
+
+    - id: 5.3.2.3
+      title: Ensure pam_pwquality module is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          This requirement is also indirectly satisfied by the requirement 5.3.3.2.
+      related_rules:
+          - package_pam_pwquality_installed
+
+    - id: 5.3.2.4
+      title: Ensure pam_pwhistory module is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          The module is properly enabled by the rules mentioned in related_rules.
+          Requirements in 5.3.3.3 use these rules.
+      related_rules:
+          - accounts_password_pam_pwhistory_remember_password_auth
+          - accounts_password_pam_pwhistory_remember_system_auth
+
+    - id: 5.3.2.5
+      title: Ensure pam_unix module is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: partial
+      notes: |-
+          This module is always present by default. It is necessary to investigate if a new rule to
+          check its existence needs to be created. But so far the rule no_empty_passwords, used in
+          5.3.3.4 can ensure this requirement is attended.
+      related_rules:
+          - no_empty_passwords
+
+    - id: 5.3.3.1.1
+      title: Ensure password failed attempts lockout is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_passwords_pam_faillock_deny
+          - var_accounts_passwords_pam_faillock_deny=5
+
+    - id: 5.3.3.1.2
+      title: Ensure password unlock time is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          The policy also accepts value 0, which means the locked accounts should be manually unlocked
+          by an administrator. However, it also mentions that using value 0 can facilitate a DoS
+          attack to legitimate users.
+      rules:
+          - accounts_passwords_pam_faillock_unlock_time
+          - var_accounts_passwords_pam_faillock_unlock_time=900
+
+    - id: 5.3.3.1.3
+      title: Ensure password failed attempts lockout includes root account (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - accounts_passwords_pam_faillock_deny_root
+
+    - id: 5.3.3.2.1
+      title: Ensure password number of changed characters is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_password_pam_difok
+          - var_password_pam_difok=2
+
+    - id: 5.3.3.2.2
+      title: Ensure password length is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_password_pam_minlen
+          - var_password_pam_minlen=14
+
+    - id: 5.3.3.2.3
+      title: Ensure password complexity is configured (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          This requirement is expected to be manual. However, in previous versions of the policy
+          it was already automated the configuration of "minclass" option. This posture was kept for
+          RHEL 9 in this new version. Rules related to other options are informed in related_rules.
+          In short, minclass=4 alone can achieve the same result achieved by the combination of the
+          other 4 options mentioned in the policy.
+      rules:
+          - accounts_password_pam_minclass
+          - var_password_pam_minclass=4
+      related_rules:
+          - accounts_password_pam_dcredit
+          - accounts_password_pam_lcredit
+          - accounts_password_pam_ocredit
+          - accounts_password_pam_ucredit
+
+    - id: 5.3.3.2.4
+      title: Ensure password same consecutive characters is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_password_pam_maxrepeat
+          - var_password_pam_maxrepeat=3
+
+    - id: 5.3.3.2.5
+      title: Ensure password maximum sequential characters is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: planned
+      notes: |-
+          A new templated rule and variable are necessary for the maxsequence option.
+
+    - id: 5.3.3.2.6
+      title: Ensure password dictionary check is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_password_pam_dictcheck
+          - var_password_pam_dictcheck=1
+
+    - id: 5.3.3.2.7
+      title: Ensure password quality is enforced for the root user (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_password_pam_enforce_root
+
+    - id: 5.3.3.3.1
+      title: Ensure password history remember is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          Although mentioned in the section 5.3.3.3, there is no explicit requirement to configure
+          retry option of pam_pwhistory. If come in the future, the rule accounts_password_pam_retry
+          can be used.
+      rules:
+          - accounts_password_pam_pwhistory_remember_password_auth
+          - accounts_password_pam_pwhistory_remember_system_auth
+          - var_password_pam_remember_control_flag=requisite_or_required
+          - var_password_pam_remember=24
+      related_rules:
+          - accounts_password_pam_retry
+
+    - id: 5.3.3.3.2
+      title: Ensure password history is enforced for the root user (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: planned
+      notes: |-
+          A new rule needs to be created to check and remediate the enforce_for_root option in
+          /etc/security/pwhistory.conf. accounts_password_pam_enforce_root can be used as reference.
+
+    - id: 5.3.3.3.3
+      title: Ensure pam_pwhistory includes use_authtok (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: partial
+      notes: |-
+          In RHEL 9 pam_pwhistory is enabled via authselect feature, as required in 5.3.2.4. The
+          feature automatically set "use_authok" option. In any case, we don't have a rule to check
+          this option specifically.
+      related_rules:
+          - accounts_password_pam_pwhistory_remember_password_auth
+          - accounts_password_pam_pwhistory_remember_system_auth
+
+    - id: 5.3.3.4.1
+      title: Ensure pam_unix does not include nullok (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          The rule more specifically used in this requirement also satify the requirement 5.3.2.5.
+      rules:
+          - no_empty_passwords
+
+    - id: 5.3.3.4.2
+      title: Ensure pam_unix does not include remember (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          Usage of pam_unix.so module together with "remember" option is deprecated and is not
+          recommened by this policy. Instead, it should be used remember option of pam_pwhistory
+          module, as required in 5.3.3.3.1. See here for more details about pam_unix.so:
+          https://bugzilla.redhat.com/show_bug.cgi?id=1778929
+          A new rule needs to be created to remove the remember option from pam_unix module.
+
+    - id: 5.3.3.4.3
+      title: Ensure pam_unix includes a strong password hashing algorithm (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          Changes in logindefs mentioned in this requirement are more specifically covered by 5.4.1.4
+      rules:
+          - set_password_hashing_algorithm_systemauth
+          - set_password_hashing_algorithm_passwordauth
+          - var_password_hashing_algorithm_pam=sha512
+
+    - id: 5.3.3.4.4
+      title: Ensure pam_unix includes use_authtok (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: partial
+      notes: |-
+          In RHEL 9 pam_unix is enabled by default in all authselect profiles already with the
+          use_authtok option set. In any case, we don't have a rule to check this option specifically,
+          like in 5.3.3.3.3.
+
+    - id: 5.4.1.1
+      title: Ensure password expiration is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_maximum_age_login_defs
+          - var_accounts_maximum_age_login_defs=365
+          - accounts_password_set_max_life_existing
+
+    - id: 5.4.1.2
+      title: Ensure minimum password days is configured (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - accounts_minimum_age_login_defs
+          - var_accounts_minimum_age_login_defs=1
+          - accounts_password_set_min_life_existing
+
+    - id: 5.4.1.3
+      title: Ensure password expiration warning days is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_password_warn_age_login_defs
+          - var_accounts_password_warn_age_login_defs=7
+          - accounts_password_set_warn_age_existing
+
+    - id: 5.4.1.4
+      title: Ensure strong password hashing algorithm is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - set_password_hashing_algorithm_libuserconf
+          - set_password_hashing_algorithm_logindefs
+          - var_password_hashing_algorithm=SHA512
+          - var_password_hashing_algorithm_pam=sha512
+
+    - id: 5.4.1.5
+      title: Ensure inactive password lock is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - account_disable_post_pw_expiration
+          - accounts_set_post_pw_existing
+          - var_account_disable_post_pw_expiration=45
+
+    - id: 5.4.1.6
+      title: Ensure all users last password change date is in the past (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_password_last_change_is_in_past
+
+    - id: 5.4.2.1
+      title: Ensure root is the only UID 0 account (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_no_uid_except_zero
+
+    - id: 5.4.2.2
+      title: Ensure root is the only GID 0 account (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: partial
+      notes: |-
+          The rule confirms the primary group for root, but doesn't check if any other user are also
+          using GID 0. New rule is necessary.
+          There is assessment but no automated remediation for this rule and this sounds reasonable.
+      rules:
+          - accounts_root_gid_zero
+
+    - id: 5.4.2.3
+      title: Ensure group root is the only GID 0 group (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          Introduced in CIS RHEL9 v2.0.0.
+          New rule is necessary.
+
+    - id: 5.4.2.4
+      title: Ensure root account access is controlled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - ensure_root_password_configured
+
+    - id: 5.4.2.5
+      title: Ensure root path integrity (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_root_path_dirs_no_write
+          - root_path_no_dot
+
+    - id: 5.4.2.6
+      title: Ensure root user umask is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          There is no rule to ensure umask in /root/.bash_profile and /root/.bashrc. A new rule have
+          to be created. It can be based on accounts_umask_interactive_users.
+
+    - id: 5.4.2.7
+      title: Ensure system accounts do not have a valid login shell (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - no_password_auth_for_systemaccounts
+          - no_shelllogin_for_systemaccounts
+
+    - id: 5.4.2.8
+      title: Ensure accounts without a valid login shell are locked (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          Introduced in CIS RHEL9 v2.0.0.
+          New rule is necessary.
+
+    - id: 5.4.3.1
+      title: Ensure nologin is not listed in /etc/shells (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: pending
+      notes: |-
+          It is necessary to create a new rule to check and remove nologin from /etc/shells.
+          The no_tmux_in_shells rule can be used as referece.
+
+    - id: 5.4.3.2
+      title: Ensure default user shell timeout is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_tmout
+          - var_accounts_tmout=15_min
+
+    - id: 5.4.3.3
+      title: Ensure default user umask is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_umask_etc_bashrc
+          - accounts_umask_etc_login_defs
+          - accounts_umask_etc_profile
+          - var_accounts_user_umask=027
+
+    - id: 6.1.1
+      title: Ensure AIDE is installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_aide_installed
+          - aide_build_database
+
+    - id: 6.1.2
+      title: Ensure filesystem integrity is regularly checked (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - aide_periodic_cron_checking
+
+    - id: 6.1.3
+      title: Ensure cryptographic mechanisms are used to protect the integrity of audit tools (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - aide_check_audit_tools
+      related_rules:
+          - aide_use_fips_hashes
+
+    - id: 6.2.1.1
+      title: Ensure journald service is enabled and active (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - service_systemd-journald_enabled
+
+    - id: 6.2.1.2
+      title: Ensure journald log file access is configured (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 6.2.1.3
+      title: Ensure journald log file rotation is configured (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 6.2.1.4
+      title: Ensure only one logging system is in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          It is necessary to create a new rule to check the status of journald and rsyslog.
+          It would also be necessary a new rule to disable or remove rsyslog.
+
+    - id: 6.2.2.1.1
+      title: Ensure systemd-journal-remote is installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_systemd-journal-remote_installed
+
+    - id: 6.2.2.1.2
+      title: Ensure systemd-journal-upload authentication is configured (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 6.2.2.1.3
+      title: Ensure systemd-journal-upload is enabled and active (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          Introduced in CIS RHEL9 v2.0.0.
+          New templated rule is necessary.
+
+    - id: 6.2.2.1.4
+      title: Ensure systemd-journal-remote service is not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - socket_systemd-journal-remote_disabled
+
+    - id: 6.2.2.2
+      title: Ensure journald ForwardToSyslog is disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          This rule conflicts with 6.2.3.3. More investigation is needed to properly solve this.
+      related_rules:
+          - journald_forward_to_syslog
+
+    - id: 6.2.2.3
+      title: Ensure journald Compress is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - journald_compress
+
+    - id: 6.2.2.4
+      title: Ensure journald Storage is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - journald_storage
+
+    - id: 6.2.3.1
+      title: Ensure rsyslog is installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: supported
+      related_rules:
+          - package_rsyslog_installed
+
+    - id: 6.2.3.2
+      title: Ensure rsyslog service is enabled and active (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: supported
+      related_rules:
+          - service_rsyslog_enabled
+
+    - id: 6.2.3.3
+      title: Ensure journald is configured to send logs to rsyslog (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: supported
+      related_rules:
+          - journald_forward_to_syslog
+
+    - id: 6.2.3.4
+      title: Ensure rsyslog log file creation mode is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: supported
+      related_rules:
+          - rsyslog_filecreatemode
+
+    - id: 6.2.3.5
+      title: Ensure rsyslog logging is configured (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 6.2.3.6
+      title: Ensure rsyslog is configured to send logs to a remote log host (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+      related_rules:
+          - rsyslog_remote_loghost
+
+    - id: 6.2.3.7
+      title: Ensure rsyslog is not configured to receive logs from a remote client (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: supported
+      related_rules:
+          - rsyslog_nolisten
+
+    - id: 6.2.3.8
+      title: Ensure rsyslog logrotate is configured (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+      related_rules:
+          - ensure_logrotate_activated
+          - package_logrotate_installed
+          - timer_logrotate_enabled
+
+    - id: 6.2.4.1
+      title: Ensure access to all logfiles has been configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          It is not harmful to run these rules even if rsyslog is not installed or active.
+      rules:
+          - rsyslog_files_groupownership
+          - rsyslog_files_ownership
+          - rsyslog_files_permissions
+
+    - id: 6.3.1.1
+      title: Ensure auditd packages are installed (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - package_audit_installed
+          - package_audit-libs_installed
+
+    - id: 6.3.1.2
+      title: Ensure auditing for processes that start prior to auditd is enabled (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - grub2_audit_argument
+
+    - id: 6.3.1.3
+      title: Ensure audit_backlog_limit is sufficient (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - grub2_audit_backlog_limit_argument
+
+    - id: 6.3.1.4
+      title: Ensure auditd service is enabled and active (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - service_auditd_enabled
+
+    - id: 6.3.2.1
+      title: Ensure audit log storage size is configured (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - auditd_data_retention_max_log_file
+          - var_auditd_max_log_file=6
+
+    - id: 6.3.2.2
+      title: Ensure audit logs are not automatically deleted (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - auditd_data_retention_max_log_file_action
+          - var_auditd_max_log_file_action=keep_logs
+
+    - id: 6.3.2.3
+      title: Ensure system is disabled when audit logs are full (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - auditd_data_disk_error_action
+          - auditd_data_disk_full_action
+          - var_auditd_disk_error_action=cis_rhel9
+          - var_auditd_disk_full_action=cis_rhel9
+
+    - id: 6.3.2.4
+      title: Ensure system warns when audit logs are low on space (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - auditd_data_retention_action_mail_acct
+          - auditd_data_retention_admin_space_left_action
+          - auditd_data_retention_space_left_action
+          - var_auditd_action_mail_acct=root
+          - var_auditd_admin_space_left_action=cis_rhel9
+          - var_auditd_space_left_action=cis_rhel9
+
+    - id: 6.3.3.1
+      title: Ensure changes to system administration scope (sudoers) is collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_sysadmin_actions
+
+    - id: 6.3.3.2
+      title: Ensure actions as another user are always logged (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_suid_auid_privilege_function
+
+    - id: 6.3.3.3
+      title: Ensure events that modify the sudo log file are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_sudo_log_events
+
+    - id: 6.3.3.4
+      title: Ensure events that modify date and time information are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_time_adjtimex
+          - audit_rules_time_settimeofday
+          - audit_rules_time_clock_settime
+          - audit_rules_time_watch_localtime
+      related_rules:
+          - audit_rules_time_stime
+
+    - id: 6.3.3.5
+      title: Ensure events that modify the system's network environment are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: partial
+      notes: |-
+          These rules are not covering "/etc/hostname" and "/etc/NetworkManager/".
+      rules:
+          - audit_rules_networkconfig_modification
+          - audit_rules_networkconfig_modification_network_scripts
+
+    - id: 6.3.3.6
+      title: Ensure use of privileged commands are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_privileged_commands
+
+    - id: 6.3.3.7
+      title: Ensure unsuccessful file access attempts are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_unsuccessful_file_modification_creat
+          - audit_rules_unsuccessful_file_modification_ftruncate
+          - audit_rules_unsuccessful_file_modification_open
+          - audit_rules_unsuccessful_file_modification_openat
+          - audit_rules_unsuccessful_file_modification_truncate
+
+    - id: 6.3.3.8
+      title: Ensure events that modify user/group information are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: partial
+      notes: |-
+          Missing rules to check "/etc/nsswitch.conf", "/etc/pam.conf" and "/etc/pam.d"
+      rules:
+          - audit_rules_usergroup_modification_group
+          - audit_rules_usergroup_modification_gshadow
+          - audit_rules_usergroup_modification_opasswd
+          - audit_rules_usergroup_modification_passwd
+          - audit_rules_usergroup_modification_shadow
+
+    - id: 6.3.3.9
+      title: Ensure discretionary access control permission modification events are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_dac_modification_chmod
+          - audit_rules_dac_modification_chown
+          - audit_rules_dac_modification_fchmod
+          - audit_rules_dac_modification_fchmodat
+          - audit_rules_dac_modification_fchown
+          - audit_rules_dac_modification_fchownat
+          - audit_rules_dac_modification_fremovexattr
+          - audit_rules_dac_modification_fsetxattr
+          - audit_rules_dac_modification_lchown
+          - audit_rules_dac_modification_lremovexattr
+          - audit_rules_dac_modification_lsetxattr
+          - audit_rules_dac_modification_removexattr
+          - audit_rules_dac_modification_setxattr
+
+    - id: 6.3.3.10
+      title: Ensure successful file system mounts are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_media_export
+
+    - id: 6.3.3.11
+      title: Ensure session initiation information is collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_session_events_utmp
+          - audit_rules_session_events_btmp
+          - audit_rules_session_events_wtmp
+
+    - id: 6.3.3.12
+      title: Ensure login and logout events are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_login_events_faillock
+          - audit_rules_login_events_lastlog
+          - var_accounts_passwords_pam_faillock_dir=run
+
+    - id: 6.3.3.13
+      title: Ensure file deletion events by users are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_file_deletion_events_rename
+          - audit_rules_file_deletion_events_renameat
+          - audit_rules_file_deletion_events_unlink
+          - audit_rules_file_deletion_events_unlinkat
+
+    - id: 6.3.3.14
+      title: Ensure events that modify the system's Mandatory Access Controls are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_mac_modification
+          - audit_rules_mac_modification_usr_share
+
+    - id: 6.3.3.15
+      title: Ensure successful and unsuccessful attempts to use the chcon command are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_execution_chcon
+
+    - id: 6.3.3.16
+      title: Ensure successful and unsuccessful attempts to use the setfacl command are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_execution_setfacl
+
+    - id: 6.3.3.17
+      title: Ensure successful and unsuccessful attempts to use the chacl command are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_execution_chacl
+
+    - id: 6.3.3.18
+      title: Ensure successful and unsuccessful attempts to use the usermod command are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_privileged_commands_usermod
+
+    - id: 6.3.3.19
+      title: Ensure kernel module loading unloading and modification is collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_kernel_module_loading_create
+          - audit_rules_kernel_module_loading_delete
+          - audit_rules_kernel_module_loading_finit
+          - audit_rules_kernel_module_loading_init
+          - audit_rules_kernel_module_loading_query
+          - audit_rules_privileged_commands_kmod
+
+    - id: 6.3.3.20
+      title: Ensure the audit configuration is immutable (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_immutable
+
+    - id: 6.3.3.21
+      title: Ensure the running and on disk configuration is the same (Manual)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: manual
+
+    - id: 6.3.4.1
+      title: Ensure the audit log file directory mode is configured (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - directory_permissions_var_log_audit
+
+    - id: 6.3.4.2
+      title: Ensure audit log files mode is configured (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - file_permissions_var_log_audit
+
+    - id: 6.3.4.3
+      title: Ensure audit log files owner is configured (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - file_ownership_var_log_audit_stig
+
+    - id: 6.3.4.4
+      title: Ensure audit log files group owner is configured (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - file_group_ownership_var_log_audit
+
+    - id: 6.3.4.5
+      title: Ensure audit configuration files mode is configured (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - file_permissions_audit_configuration
+
+    - id: 6.3.4.6
+      title: Ensure audit configuration files owner is configured (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - file_ownership_audit_configuration
+
+    - id: 6.3.4.7
+      title: Ensure audit configuration files group owner is configured (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - file_groupownership_audit_configuration
+
+    - id: 6.3.4.8
+      title: Ensure audit tools mode is configured (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - file_permissions_audit_binaries
+
+    - id: 6.3.4.9
+      title: Ensure audit tools owner is configured (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - file_ownership_audit_binaries
+
+    - id: 6.3.4.10
+      title: Ensure audit tools group owner is configured (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - file_groupownership_audit_binaries
+
+    - id: 7.1.1
+      title: Ensure permissions on /etc/passwd are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_etc_passwd
+          - file_owner_etc_passwd
+          - file_permissions_etc_passwd
+
+    - id: 7.1.2
+      title: Ensure permissions on /etc/passwd- are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_backup_etc_passwd
+          - file_owner_backup_etc_passwd
+          - file_permissions_backup_etc_passwd
+
+    - id: 7.1.3
+      title: Ensure permissions on /etc/group are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_etc_group
+          - file_owner_etc_group
+          - file_permissions_etc_group
+
+    - id: 7.1.4
+      title: Ensure permissions on /etc/group- are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_backup_etc_group
+          - file_owner_backup_etc_group
+          - file_permissions_backup_etc_group
+
+    - id: 7.1.5
+      title: Ensure permissions on /etc/shadow are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_owner_etc_shadow
+          - file_groupowner_etc_shadow
+          - file_permissions_etc_shadow
+
+    - id: 7.1.6
+      title: Ensure permissions on /etc/shadow- are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_backup_etc_shadow
+          - file_owner_backup_etc_shadow
+          - file_permissions_backup_etc_shadow
+
+    - id: 7.1.7
+      title: Ensure permissions on /etc/gshadow are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_etc_gshadow
+          - file_owner_etc_gshadow
+          - file_permissions_etc_gshadow
+
+    - id: 7.1.8
+      title: Ensure permissions on /etc/gshadow- are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_backup_etc_gshadow
+          - file_owner_backup_etc_gshadow
+          - file_permissions_backup_etc_gshadow
+
+    - id: 7.1.9
+      title: Ensure permissions on /etc/shells are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_etc_shells
+          - file_owner_etc_shells
+          - file_permissions_etc_shells
+
+    - id: 7.1.10
+      title: Ensure permissions on /etc/security/opasswd are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: partial
+      rules:
     # TODO: We need another rule that checks /etc/security/opasswd.old
-    - file_etc_security_opasswd
+          - file_etc_security_opasswd
 
-  - id: 7.1.11
-    title: Ensure world writable files and directories are secured (Automated)
-    levels:
-    - l1_server
-    - l1_workstation
-    status: automated
-    rules:
-    - file_permissions_unauthorized_world_writable
-    - dir_perms_world_writable_sticky_bits
+    - id: 7.1.11
+      title: Ensure world writable files and directories are secured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_permissions_unauthorized_world_writable
+          - dir_perms_world_writable_sticky_bits
 
-  - id: 7.1.12
-    title: Ensure no files or directories without an owner and a group exist (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: partial
-    rules:
+    - id: 7.1.12
+      title: Ensure no files or directories without an owner and a group exist (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: partial
+      rules:
     # TODO: add rules for unowned/ungrouped directories
-    - no_files_unowned_by_user
-    - file_permissions_ungroupowned
+          - no_files_unowned_by_user
+          - file_permissions_ungroupowned
 
-  - id: 7.1.13
-    title: Ensure SUID and SGID files are reviewed (Manual)
-    levels:
-    - l1_server
-    - l1_workstation
-    status: manual
-    related_rules:
-      - file_permissions_unauthorized_suid
-      - file_permissions_unauthorized_sgid
+    - id: 7.1.13
+      title: Ensure SUID and SGID files are reviewed (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+      related_rules:
+          - file_permissions_unauthorized_suid
+          - file_permissions_unauthorized_sgid
 
-  - id: 7.1.14
-    title: Audit system file permissions (Manual)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: manual
-    related_rules:
-      - rpm_verify_permissions
-      - rpm_verify_ownership
+    - id: 7.1.14
+      title: Audit system file permissions (Manual)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: manual
+      related_rules:
+          - rpm_verify_permissions
+          - rpm_verify_ownership
 
-  - id: 7.2.1
-    title: Ensure accounts in /etc/passwd use shadowed passwords (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_password_all_shadowed
+    - id: 7.2.1
+      title: Ensure accounts in /etc/passwd use shadowed passwords (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_password_all_shadowed
 
-  - id: 7.2.2
-    title: Ensure /etc/shadow password fields are not empty (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - no_empty_passwords_etc_shadow
+    - id: 7.2.2
+      title: Ensure /etc/shadow password fields are not empty (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - no_empty_passwords_etc_shadow
 
-  - id: 7.2.3
-    title: Ensure all groups in /etc/passwd exist in /etc/group (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - gid_passwd_group_same
+    - id: 7.2.3
+      title: Ensure all groups in /etc/passwd exist in /etc/group (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - gid_passwd_group_same
 
-  - id: 7.2.4
-    title: Ensure no duplicate UIDs exist (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - account_unique_id
+    - id: 7.2.4
+      title: Ensure no duplicate UIDs exist (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - account_unique_id
 
-  - id: 7.2.5
-    title: Ensure no duplicate GIDs exist (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - group_unique_id
+    - id: 7.2.5
+      title: Ensure no duplicate GIDs exist (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - group_unique_id
 
-  - id: 7.2.6
-    title: Ensure no duplicate user names exist (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - account_unique_name
+    - id: 7.2.6
+      title: Ensure no duplicate user names exist (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - account_unique_name
 
-  - id: 7.2.7
-    title: Ensure no duplicate group names exist (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - group_unique_name
+    - id: 7.2.7
+      title: Ensure no duplicate group names exist (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - group_unique_name
 
-  - id: 7.2.8
-    title: Ensure local interactive user home directories are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_user_interactive_home_directory_exists
-      - file_ownership_home_directories
-      - file_permissions_home_directories
-    related_rules:
-      - file_groupownership_home_directories
+    - id: 7.2.8
+      title: Ensure local interactive user home directories are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_user_interactive_home_directory_exists
+          - file_ownership_home_directories
+          - file_permissions_home_directories
+      related_rules:
+          - file_groupownership_home_directories
 
-  - id: 7.2.9
-    title: Ensure local interactive user dot files access is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    notes: |-
-      Missing a rule to check that .bash_history is mode 0600 or more restrictive.
-    status: partial
-    rules:
-      - accounts_user_dot_group_ownership
-      - accounts_user_dot_user_ownership
-      - accounts_user_dot_no_world_writable_programs
-      - file_permission_user_init_files
-      - var_user_initialization_files_regex=all_dotfiles
-      - no_forward_files
-      - no_netrc_files
-      - no_rsh_trust_files
-    related_rules:
-      - accounts_users_netrc_file_permissions
+    - id: 7.2.9
+      title: Ensure local interactive user dot files access is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      notes: |-
+          Missing a rule to check that .bash_history is mode 0600 or more restrictive.
+      status: partial
+      rules:
+          - accounts_user_dot_group_ownership
+          - accounts_user_dot_user_ownership
+          - accounts_user_dot_no_world_writable_programs
+          - file_permission_user_init_files
+          - var_user_initialization_files_regex=all_dotfiles
+          - no_forward_files
+          - no_netrc_files
+          - no_rsh_trust_files
+      related_rules:
+          - accounts_users_netrc_file_permissions

--- a/controls/ospp.yml
+++ b/controls/ospp.yml
@@ -1,520 +1,523 @@
+---
 id: ospp
 title: 'Protection Profile for General Purpose Operating Systems'
 policy: 'Common Criteria'
 source: 'https://www.niap-ccevs.org/Profile/Info.cfm?PPID=469&id=469'
 version: '4.3'
+
 levels:
-    -   id: base
+    - id: base
+
 controls:
-    -   id: AGD_OPE.1
-        title: 'Operational User Guidance'
-        levels:
-            - base
-        rules:
-            - package_openscap-scanner_installed
-            - package_scap-security-guide_installed
-        status: automated
-    -   id: AGD_PRE.1
-        title: 'Preparative Procedures'
-        levels:
-            - base
-        rules:
-            - package_openscap-scanner_installed
-            - package_scap-security-guide_installed
-        status: automated
-    -   id: FAU_GEN.1
-        title: 'Audit Data Generation (Refined)'
-        levels:
-            - base
-        rules:
-            - auditd_data_retention_flush
-            - auditd_freq
-            - grub2_audit_argument
-            - package_audit_installed
-            - audit_basic_configuration
-            - service_auditd_enabled
-            - var_auditd_flush=incremental_async
-            - sshd_disable_root_login
-            - zipl_audit_argument
-        status: automated
-    -   id: FAU_GEN.1.1
-        title: 'Audit Data Generation - Event Types to be Audited'
-        levels:
-            - base
-        rules:
-            - audit_access_failed
-            - audit_access_failed_aarch64
-            - audit_access_failed_ppc64le
-            - audit_access_success
-            - audit_access_success.role=unscored
-            - audit_access_success.severity=info
-            - audit_access_success_aarch64
-            - audit_access_success_aarch64.role=unscored
-            - audit_access_success_aarch64.severity=info
-            - audit_access_success_ppc64le
-            - audit_access_success_ppc64le.role=unscored
-            - audit_access_success_ppc64le.severity=info
-            - audit_create_failed
-            - audit_create_failed_aarch64
-            - audit_create_failed_ppc64le
-            - audit_create_success
-            - audit_create_success_aarch64
-            - audit_create_success_ppc64le
-            - audit_delete_failed
-            - audit_delete_failed_aarch64
-            - audit_delete_failed_ppc64le
-            - audit_delete_success
-            - audit_delete_success_aarch64
-            - audit_delete_success_ppc64le
-            - audit_modify_failed
-            - audit_modify_failed_aarch64
-            - audit_modify_failed_ppc64le
-            - audit_modify_success
-            - audit_modify_success_aarch64
-            - audit_modify_success_ppc64le
-            - audit_module_load
-            - audit_module_load_ppc64le
-            - audit_ospp_general
-            - audit_ospp_general_aarch64
-            - audit_ospp_general_ppc64le
-            - audit_owner_change_failed
-            - audit_owner_change_failed_aarch64
-            - audit_owner_change_failed_ppc64le
-            - audit_owner_change_success
-            - audit_owner_change_success_aarch64
-            - audit_owner_change_success_ppc64le
-            - audit_perm_change_failed
-            - audit_perm_change_failed_aarch64
-            - audit_perm_change_failed_ppc64le
-            - audit_perm_change_success
-            - audit_perm_change_success_aarch64
-            - audit_perm_change_success_ppc64le
-        status: automated
-    -   id: FAU_GEN.1.2
-        title: 'Audit Data Generation - Audit Event Format'
-        levels:
-            - base
-        rules:
-            - auditd_log_format
-            - auditd_name_format
-            - audit_immutable_login_uids
-            - disable_ctrlaltdel_burstaction
-            - disable_ctrlaltdel_reboot
-        status: automated
-    -   id: FAU_STG.1
-        title: 'Protected audit trail storage'
-        levels:
-            - base
-        rules:
-            - grub2_audit_backlog_limit_argument
-            - zipl_audit_backlog_limit_argument
-        status: automated
-    -   id: FCS_CKM.1
-        title: 'Cryptographic Key Generation'
-        levels:
-            - base
-        rules:
-            - configure_crypto_policy
-            - package_crypto-policies_installed
-            - enable_fips_mode
-            - var_system_crypto_policy=fips_ospp
-            - configure_openssl_crypto_policy
-        status: automated
-    -   id: FCS_CKM.1.1
-        title: 'Cryptographic Key Generation - asymmetric cryptographic'
-        levels:
-            - base
-        rules:
-            - configure_crypto_policy
-            - package_crypto-policies_installed
-            - enable_fips_mode
-            - var_system_crypto_policy=fips_ospp
-            - configure_openssl_crypto_policy
-        status: automated
-    -   id: FCS_CKM.2
-        title: 'Cryptographic Key Establishment'
-        levels:
-            - base
-        rules:
-            - configure_crypto_policy
-            - package_crypto-policies_installed
-            - enable_fips_mode
-            - var_system_crypto_policy=fips_ospp
-            - configure_openssl_crypto_policy
-        status: automated
-    -   id: FCS_COP.1/ENCRYPT
-        title: 'Cryptographic Operation - Encryption/Decryption'
-        levels:
-            - base
-        rules:
-            - configure_crypto_policy
-            - package_crypto-policies_installed
-            - enable_fips_mode
-            - var_system_crypto_policy=fips_ospp
-            - configure_openssl_crypto_policy
-        status: automated
-    -   id: FCS_COP.1/HASH
-        title: 'Cryptographic Operation - Hashing'
-        levels:
-            - base
-        rules:
-            - configure_crypto_policy
-            - package_crypto-policies_installed
-            - enable_fips_mode
-            - var_system_crypto_policy=fips_ospp
-            - configure_openssl_crypto_policy
-        status: automated
+    - id: AGD_OPE.1
+      title: 'Operational User Guidance'
+      levels:
+          - base
+      rules:
+          - package_openscap-scanner_installed
+          - package_scap-security-guide_installed
+      status: automated
+    - id: AGD_PRE.1
+      title: 'Preparative Procedures'
+      levels:
+          - base
+      rules:
+          - package_openscap-scanner_installed
+          - package_scap-security-guide_installed
+      status: automated
+    - id: FAU_GEN.1
+      title: 'Audit Data Generation (Refined)'
+      levels:
+          - base
+      rules:
+          - auditd_data_retention_flush
+          - auditd_freq
+          - grub2_audit_argument
+          - package_audit_installed
+          - audit_basic_configuration
+          - service_auditd_enabled
+          - var_auditd_flush=incremental_async
+          - sshd_disable_root_login
+          - zipl_audit_argument
+      status: automated
+    - id: FAU_GEN.1.1
+      title: 'Audit Data Generation - Event Types to be Audited'
+      levels:
+          - base
+      rules:
+          - audit_access_failed
+          - audit_access_failed_aarch64
+          - audit_access_failed_ppc64le
+          - audit_access_success
+          - audit_access_success.role=unscored
+          - audit_access_success.severity=info
+          - audit_access_success_aarch64
+          - audit_access_success_aarch64.role=unscored
+          - audit_access_success_aarch64.severity=info
+          - audit_access_success_ppc64le
+          - audit_access_success_ppc64le.role=unscored
+          - audit_access_success_ppc64le.severity=info
+          - audit_create_failed
+          - audit_create_failed_aarch64
+          - audit_create_failed_ppc64le
+          - audit_create_success
+          - audit_create_success_aarch64
+          - audit_create_success_ppc64le
+          - audit_delete_failed
+          - audit_delete_failed_aarch64
+          - audit_delete_failed_ppc64le
+          - audit_delete_success
+          - audit_delete_success_aarch64
+          - audit_delete_success_ppc64le
+          - audit_modify_failed
+          - audit_modify_failed_aarch64
+          - audit_modify_failed_ppc64le
+          - audit_modify_success
+          - audit_modify_success_aarch64
+          - audit_modify_success_ppc64le
+          - audit_module_load
+          - audit_module_load_ppc64le
+          - audit_ospp_general
+          - audit_ospp_general_aarch64
+          - audit_ospp_general_ppc64le
+          - audit_owner_change_failed
+          - audit_owner_change_failed_aarch64
+          - audit_owner_change_failed_ppc64le
+          - audit_owner_change_success
+          - audit_owner_change_success_aarch64
+          - audit_owner_change_success_ppc64le
+          - audit_perm_change_failed
+          - audit_perm_change_failed_aarch64
+          - audit_perm_change_failed_ppc64le
+          - audit_perm_change_success
+          - audit_perm_change_success_aarch64
+          - audit_perm_change_success_ppc64le
+      status: automated
+    - id: FAU_GEN.1.2
+      title: 'Audit Data Generation - Audit Event Format'
+      levels:
+          - base
+      rules:
+          - auditd_log_format
+          - auditd_name_format
+          - audit_immutable_login_uids
+          - disable_ctrlaltdel_burstaction
+          - disable_ctrlaltdel_reboot
+      status: automated
+    - id: FAU_STG.1
+      title: 'Protected audit trail storage'
+      levels:
+          - base
+      rules:
+          - grub2_audit_backlog_limit_argument
+          - zipl_audit_backlog_limit_argument
+      status: automated
+    - id: FCS_CKM.1
+      title: 'Cryptographic Key Generation'
+      levels:
+          - base
+      rules:
+          - configure_crypto_policy
+          - package_crypto-policies_installed
+          - enable_fips_mode
+          - var_system_crypto_policy=fips_ospp
+          - configure_openssl_crypto_policy
+      status: automated
+    - id: FCS_CKM.1.1
+      title: 'Cryptographic Key Generation - asymmetric cryptographic'
+      levels:
+          - base
+      rules:
+          - configure_crypto_policy
+          - package_crypto-policies_installed
+          - enable_fips_mode
+          - var_system_crypto_policy=fips_ospp
+          - configure_openssl_crypto_policy
+      status: automated
+    - id: FCS_CKM.2
+      title: 'Cryptographic Key Establishment'
+      levels:
+          - base
+      rules:
+          - configure_crypto_policy
+          - package_crypto-policies_installed
+          - enable_fips_mode
+          - var_system_crypto_policy=fips_ospp
+          - configure_openssl_crypto_policy
+      status: automated
+    - id: FCS_COP.1/ENCRYPT
+      title: 'Cryptographic Operation - Encryption/Decryption'
+      levels:
+          - base
+      rules:
+          - configure_crypto_policy
+          - package_crypto-policies_installed
+          - enable_fips_mode
+          - var_system_crypto_policy=fips_ospp
+          - configure_openssl_crypto_policy
+      status: automated
+    - id: FCS_COP.1/HASH
+      title: 'Cryptographic Operation - Hashing'
+      levels:
+          - base
+      rules:
+          - configure_crypto_policy
+          - package_crypto-policies_installed
+          - enable_fips_mode
+          - var_system_crypto_policy=fips_ospp
+          - configure_openssl_crypto_policy
+      status: automated
 
-    -   id: FCS_COP.1/SIGN
-        title: 'Cryptographic Operation - Signing'
-        levels:
-            - base
-        rules:
-            - configure_crypto_policy
-            - package_crypto-policies_installed
-            - enable_fips_mode
-            - var_system_crypto_policy=fips_ospp
-            - configure_openssl_crypto_policy
-        status: automated
-    -   id: FCS_COP.1/KEYHMAC
-        title: 'Keyed-Hash Message Authentication'
-        levels:
-            - base
-        rules:
-            - configure_crypto_policy
-            - package_crypto-policies_installed
-            - enable_fips_mode
-            - var_system_crypto_policy=fips_ospp
-            - configure_openssl_crypto_policy
-        status: automated
+    - id: FCS_COP.1/SIGN
+      title: 'Cryptographic Operation - Signing'
+      levels:
+          - base
+      rules:
+          - configure_crypto_policy
+          - package_crypto-policies_installed
+          - enable_fips_mode
+          - var_system_crypto_policy=fips_ospp
+          - configure_openssl_crypto_policy
+      status: automated
+    - id: FCS_COP.1/KEYHMAC
+      title: 'Keyed-Hash Message Authentication'
+      levels:
+          - base
+      rules:
+          - configure_crypto_policy
+          - package_crypto-policies_installed
+          - enable_fips_mode
+          - var_system_crypto_policy=fips_ospp
+          - configure_openssl_crypto_policy
+      status: automated
 
-    -   id: FCS_RBG_EXT.1
-        title: 'Random Bit Generation'
-        levels:
-            - base
-        rules:
-            - enable_dracut_fips_module
-            - enable_fips_mode
-            - var_system_crypto_policy=fips_ospp
-        status: automated
-    -   id: FCS_RBG_EXT.1.1
-        title: 'Random Bit Generation - deterministic random bit generation'
-        levels:
-            - base
-        rules:
-            - enable_dracut_fips_module
-            - enable_fips_mode
-            - var_system_crypto_policy=fips_ospp
-        status: automated
+    - id: FCS_RBG_EXT.1
+      title: 'Random Bit Generation'
+      levels:
+          - base
+      rules:
+          - enable_dracut_fips_module
+          - enable_fips_mode
+          - var_system_crypto_policy=fips_ospp
+      status: automated
+    - id: FCS_RBG_EXT.1.1
+      title: 'Random Bit Generation - deterministic random bit generation'
+      levels:
+          - base
+      rules:
+          - enable_dracut_fips_module
+          - enable_fips_mode
+          - var_system_crypto_policy=fips_ospp
+      status: automated
 
-    -   id: FCS_RBG_EXT.1.2
-        title: 'Random Bit Generation - entropy source'
-        levels:
-            - base
-        rules:
-            - enable_dracut_fips_module
-            - enable_fips_mode
-            - var_system_crypto_policy=fips_ospp
-        status: automated
+    - id: FCS_RBG_EXT.1.2
+      title: 'Random Bit Generation - entropy source'
+      levels:
+          - base
+      rules:
+          - enable_dracut_fips_module
+          - enable_fips_mode
+          - var_system_crypto_policy=fips_ospp
+      status: automated
 
-    -   id: FCS_SSHC_EXT.1
-        title: 'SSH Client Protocol'
-        levels:
-            - base
-        rules:
-            - package_openssh-clients_installed
-            - configure_ssh_crypto_policy
-        status: automated
-    -   id: FCS_SSHS_EXT.1
-        title: 'SSH Server Protocol'
-        levels:
-            - base
-        rules:
-            - package_openssh-server_installed
-            - configure_ssh_crypto_policy
-        status: automated
+    - id: FCS_SSHC_EXT.1
+      title: 'SSH Client Protocol'
+      levels:
+          - base
+      rules:
+          - package_openssh-clients_installed
+          - configure_ssh_crypto_policy
+      status: automated
+    - id: FCS_SSHS_EXT.1
+      title: 'SSH Server Protocol'
+      levels:
+          - base
+      rules:
+          - package_openssh-server_installed
+          - configure_ssh_crypto_policy
+      status: automated
 
-    -   id: FCS_SSH_EXT.1
-        title: 'SSH Protocol'
-        levels:
-            - base
-        rules:
-            - package_openssh-clients_installed
-            - package_openssh-server_installed
-            - configure_ssh_crypto_policy
-            - sshd_use_directory_configuration
-        status: automated
+    - id: FCS_SSH_EXT.1
+      title: 'SSH Protocol'
+      levels:
+          - base
+      rules:
+          - package_openssh-clients_installed
+          - package_openssh-server_installed
+          - configure_ssh_crypto_policy
+          - sshd_use_directory_configuration
+      status: automated
 
-    -   id: FCS_SSH_EXT.1.2
-        title: 'SSH Protocol - Authentication Methods'
-        levels:
-            - base
-        rules:
-            - sshd_disable_gssapi_auth
-            - sshd_disable_kerb_auth
-        status: automated
+    - id: FCS_SSH_EXT.1.2
+      title: 'SSH Protocol - Authentication Methods'
+      levels:
+          - base
+      rules:
+          - sshd_disable_gssapi_auth
+          - sshd_disable_kerb_auth
+      status: automated
 
-    -   id: FCS_SSH_EXT.1.8
-        title: 'SSH Protocol - Session'
-        levels:
-            - base
-        rules:
-            - ssh_client_rekey_limit
-            - var_ssh_client_rekey_limit_size=1G
-            - var_ssh_client_rekey_limit_time=1hour
-            - sshd_rekey_limit
-            - var_rekey_limit_size=1G
-            - var_rekey_limit_time=1hour
-        status: automated
+    - id: FCS_SSH_EXT.1.8
+      title: 'SSH Protocol - Session'
+      levels:
+          - base
+      rules:
+          - ssh_client_rekey_limit
+          - var_ssh_client_rekey_limit_size=1G
+          - var_ssh_client_rekey_limit_time=1hour
+          - sshd_rekey_limit
+          - var_rekey_limit_size=1G
+          - var_rekey_limit_time=1hour
+      status: automated
 
-    -   id: FCS_TLSC_EXT.1
-        title: 'TLS Client Protocol'
-        levels:
-            - base
-        rules:
-            - configure_crypto_policy
-            - package_crypto-policies_installed
-            - enable_fips_mode
-            - configure_openssl_crypto_policy
-        status: automated
+    - id: FCS_TLSC_EXT.1
+      title: 'TLS Client Protocol'
+      levels:
+          - base
+      rules:
+          - configure_crypto_policy
+          - package_crypto-policies_installed
+          - enable_fips_mode
+          - configure_openssl_crypto_policy
+      status: automated
 
-    -   id: FCS_TLSC_EXT.1.1
-        title: 'Allowed Cipher Suites'
-        levels:
-            - base
-        rules:
-            - configure_crypto_policy
-            - package_crypto-policies_installed
-            - enable_fips_mode
-            - configure_openssl_crypto_policy
-        status: automated
-    -   id: FIA_AFL.1
-        title: 'Authentication failure handling'
-        levels:
-            - base
-        rules:
-            - accounts_passwords_pam_faillock_deny
-            - var_accounts_passwords_pam_faillock_deny=3
-            - accounts_passwords_pam_faillock_interval
-            - var_accounts_passwords_pam_faillock_fail_interval=900
-            - accounts_passwords_pam_faillock_unlock_time
-            - var_accounts_passwords_pam_faillock_unlock_time=never
-        status: automated
+    - id: FCS_TLSC_EXT.1.1
+      title: 'Allowed Cipher Suites'
+      levels:
+          - base
+      rules:
+          - configure_crypto_policy
+          - package_crypto-policies_installed
+          - enable_fips_mode
+          - configure_openssl_crypto_policy
+      status: automated
+    - id: FIA_AFL.1
+      title: 'Authentication failure handling'
+      levels:
+          - base
+      rules:
+          - accounts_passwords_pam_faillock_deny
+          - var_accounts_passwords_pam_faillock_deny=3
+          - accounts_passwords_pam_faillock_interval
+          - var_accounts_passwords_pam_faillock_fail_interval=900
+          - accounts_passwords_pam_faillock_unlock_time
+          - var_accounts_passwords_pam_faillock_unlock_time=never
+      status: automated
 
-    -   id: FIA_UAU.1
-        title: 'Timing of authentication'
-        levels:
-            - base
-        rules:
-            - disable_host_auth
-            - sshd_disable_empty_passwords
-            - require_singleuser_auth
-            - service_debug-shell_disabled
-            - no_empty_passwords
-            - grub2_disable_recovery
-            - grub2_systemd_debug-shell_argument_absent
-            - grub2_password
-            - zipl_systemd_debug-shell_argument_absent
-        status: automated
+    - id: FIA_UAU.1
+      title: 'Timing of authentication'
+      levels:
+          - base
+      rules:
+          - disable_host_auth
+          - sshd_disable_empty_passwords
+          - require_singleuser_auth
+          - service_debug-shell_disabled
+          - no_empty_passwords
+          - grub2_disable_recovery
+          - grub2_systemd_debug-shell_argument_absent
+          - grub2_password
+          - zipl_systemd_debug-shell_argument_absent
+      status: automated
 
-    -   id: FIA_UAU.5
-        title: 'Multiple Authentication Mechanisms'
-        levels:
-            - base
-        rules:
-            - package_openssh-clients_installed
-            - package_openssh-server_installed
-        status: automated
+    - id: FIA_UAU.5
+      title: 'Multiple Authentication Mechanisms'
+      levels:
+          - base
+      rules:
+          - package_openssh-clients_installed
+          - package_openssh-server_installed
+      status: automated
 
-    -   id: FIA_X509_EXT.1
-        title: 'X.509 Certificate Validation'
-        levels:
-            - base
-        rules:
-            - package_gnutls-utils_installed
-        status: automated
+    - id: FIA_X509_EXT.1
+      title: 'X.509 Certificate Validation'
+      levels:
+          - base
+      rules:
+          - package_gnutls-utils_installed
+      status: automated
 
-    -   id: FIA_X509_EXT.1.1
-        title: 'X.509 Certificate Validation - Valid Certificates'
-        levels:
-            - base
-        rules:
-            - package_gnutls-utils_installed
-        status: automated
+    - id: FIA_X509_EXT.1.1
+      title: 'X.509 Certificate Validation - Valid Certificates'
+      levels:
+          - base
+      rules:
+          - package_gnutls-utils_installed
+      status: automated
 
-    -   id: FIA_X509_EXT.2
-        title: 'X.509 Certificate Validation - basicConstraints'
-        levels:
-            - base
-        rules:
-            - package_gnutls-utils_installed
-        status: automated
+    - id: FIA_X509_EXT.2
+      title: 'X.509 Certificate Validation - basicConstraints'
+      levels:
+          - base
+      rules:
+          - package_gnutls-utils_installed
+      status: automated
 
-    -   id: FMT_MOF_EXT.1
-        title: 'Management of security functions behavior'
-        levels:
-            - base
-        rules:
-            - package_sudo_installed
-            - logind_session_timeout
-            - var_logind_session_timeout=30_minutes
-            - selinux_policytype # SELinux doesn't have a SFR associated, this one seems the least controversial
-            - selinux_state
-            - var_selinux_state=enforcing
-            - var_selinux_policy_name=targeted
-        status: automated
+    - id: FMT_MOF_EXT.1
+      title: 'Management of security functions behavior'
+      levels:
+          - base
+      rules:
+          - package_sudo_installed
+          - logind_session_timeout
+          - var_logind_session_timeout=30_minutes
+          - selinux_policytype  # SELinux doesn't have a SFR associated, this one seems the least controversial
+          - selinux_state
+          - var_selinux_state=enforcing
+          - var_selinux_policy_name=targeted
+      status: automated
 
-    -   id: FMT_SMF_EXT.1
-        title: 'Specification of Management Functions'
-        levels:
-            - base
-        rules:
-            - package_fapolicyd_installed
-            - service_fapolicyd_enabled
-            - chronyd_client_only
-            - package_chrony_installed
-            - configure_usbguard_auditbackend
-            - package_usbguard_installed
-            - service_usbguard_enabled
-            - usbguard_allow_hid_and_hub
-            - accounts_password_pam_dcredit
-            - accounts_password_pam_lcredit
-            - accounts_password_pam_minlen
-            - accounts_password_pam_ocredit
-            - accounts_password_pam_ucredit
-            - var_password_pam_minlen=12
-            - var_password_pam_ocredit=1
-            - var_password_pam_dcredit=1
-            - var_password_pam_ucredit=1
-            - var_password_pam_lcredit=1
-            - package_firewalld_installed
-            - service_firewalld_enabled
-            - kernel_module_can_disabled
-            - kernel_module_tipc_disabled
-            - kernel_module_bluetooth_disabled
-            - kernel_module_sctp_disabled
-            - service_systemd-coredump_disabled
-            - sysctl_kernel_core_pattern_empty_string
-            - sysctl_kernel_core_uses_pid
-            - sysctl_kernel_perf_event_paranoid
-            - sysctl_kernel_unprivileged_bpf_disabled_accept_default
-            - sysctl_kernel_unprivileged_bpf_disabled_value=2
-            - sysctl_kernel_dmesg_restrict
-            - sysctl_kernel_kptr_restrict
-            - sysctl_kernel_kexec_load_disabled
-            - sysctl_kernel_yama_ptrace_scope
-            - sysctl_user_max_user_namespaces
-            - partition_for_var_log_audit
-            - mount_option_var_log_audit_nodev
-            - mount_option_var_log_audit_nosuid
-            - mount_option_var_log_audit_noexec
-            - dnf-automatic_apply_updates
-            - timer_dnf-automatic_enabled
-            - logind_session_timeout
-            - var_logind_session_timeout=30_minutes
-        status: automated
+    - id: FMT_SMF_EXT.1
+      title: 'Specification of Management Functions'
+      levels:
+          - base
+      rules:
+          - package_fapolicyd_installed
+          - service_fapolicyd_enabled
+          - chronyd_client_only
+          - package_chrony_installed
+          - configure_usbguard_auditbackend
+          - package_usbguard_installed
+          - service_usbguard_enabled
+          - usbguard_allow_hid_and_hub
+          - accounts_password_pam_dcredit
+          - accounts_password_pam_lcredit
+          - accounts_password_pam_minlen
+          - accounts_password_pam_ocredit
+          - accounts_password_pam_ucredit
+          - var_password_pam_minlen=12
+          - var_password_pam_ocredit=1
+          - var_password_pam_dcredit=1
+          - var_password_pam_ucredit=1
+          - var_password_pam_lcredit=1
+          - package_firewalld_installed
+          - service_firewalld_enabled
+          - kernel_module_can_disabled
+          - kernel_module_tipc_disabled
+          - kernel_module_bluetooth_disabled
+          - kernel_module_sctp_disabled
+          - service_systemd-coredump_disabled
+          - sysctl_kernel_core_pattern_empty_string
+          - sysctl_kernel_core_uses_pid
+          - sysctl_kernel_perf_event_paranoid
+          - sysctl_kernel_unprivileged_bpf_disabled_accept_default
+          - sysctl_kernel_unprivileged_bpf_disabled_value=2
+          - sysctl_kernel_dmesg_restrict
+          - sysctl_kernel_kptr_restrict
+          - sysctl_kernel_kexec_load_disabled
+          - sysctl_kernel_yama_ptrace_scope
+          - sysctl_user_max_user_namespaces
+          - partition_for_var_log_audit
+          - mount_option_var_log_audit_nodev
+          - mount_option_var_log_audit_nosuid
+          - mount_option_var_log_audit_noexec
+          - dnf-automatic_apply_updates
+          - timer_dnf-automatic_enabled
+          - logind_session_timeout
+          - var_logind_session_timeout=30_minutes
+      status: automated
 
-    -   id: FMT_SMF_EXT.1.1
-        title: 'Management of security functions behavior - Restrict Administrator Functions'
-        levels:
-            - base
-        rules:
-            - service_kdump_disabled
-            - logind_session_timeout
-            - use_pam_wheel_for_su
-        status: automated
+    - id: FMT_SMF_EXT.1.1
+      title: 'Management of security functions behavior - Restrict Administrator Functions'
+      levels:
+          - base
+      rules:
+          - service_kdump_disabled
+          - logind_session_timeout
+          - use_pam_wheel_for_su
+      status: automated
 
-    -   id: FPT_ASLR_EXT.1
-        title: 'Address Space Layout Randomization'
-        levels:
-            - base
-        rules:
-            - grub2_vsyscall_argument
-        status: automated
+    - id: FPT_ASLR_EXT.1
+      title: 'Address Space Layout Randomization'
+      levels:
+          - base
+      rules:
+          - grub2_vsyscall_argument
+      status: automated
 
-    -   id: FPT_TUD_EXT.1
-        title: 'Trusted Update'
-        levels:
-            - base
-        rules:
-            - package_dnf-plugin-subscription-manager_installed
-            - package_dnf-automatic_installed
-            - package_subscription-manager_installed
-            - ensure_gpgcheck_globally_activated
-            - ensure_gpgcheck_local_packages
-            - ensure_gpgcheck_never_disabled
-            - ensure_redhat_gpgkey_installed
-        status: automated
+    - id: FPT_TUD_EXT.1
+      title: 'Trusted Update'
+      levels:
+          - base
+      rules:
+          - package_dnf-plugin-subscription-manager_installed
+          - package_dnf-automatic_installed
+          - package_subscription-manager_installed
+          - ensure_gpgcheck_globally_activated
+          - ensure_gpgcheck_local_packages
+          - ensure_gpgcheck_never_disabled
+          - ensure_redhat_gpgkey_installed
+      status: automated
 
-    -   id: FPT_TUD_EXT.2
-        title: 'Trusted Update for Application Software'
-        levels:
-            - base
-        rules:
-            - package_dnf-plugin-subscription-manager_installed
-            - package_dnf-automatic_installed
-            - package_subscription-manager_installed
-            - ensure_gpgcheck_globally_activated
-            - ensure_gpgcheck_local_packages
-            - ensure_gpgcheck_never_disabled
-            - ensure_redhat_gpgkey_installed
-        status: automated
+    - id: FPT_TUD_EXT.2
+      title: 'Trusted Update for Application Software'
+      levels:
+          - base
+      rules:
+          - package_dnf-plugin-subscription-manager_installed
+          - package_dnf-automatic_installed
+          - package_subscription-manager_installed
+          - ensure_gpgcheck_globally_activated
+          - ensure_gpgcheck_local_packages
+          - ensure_gpgcheck_never_disabled
+          - ensure_redhat_gpgkey_installed
+      status: automated
 
-    -   id: FPT_TST_EXT.1
-        title: Boot Integrity
-        levels:
-            - base
-        rules:
-            - zipl_bls_entries_only
-            - zipl_bootmap_is_up_to_date
-        status: automated
+    - id: FPT_TST_EXT.1
+      title: Boot Integrity
+      levels:
+          - base
+      rules:
+          - zipl_bls_entries_only
+          - zipl_bootmap_is_up_to_date
+      status: automated
 
-    -   id: FTA_SSL.1
-        title: 'TSF-initiated session locking'
-        levels:
-            - base
-        rules:
-            - logind_session_timeout
-            - var_logind_session_timeout=30_minutes
-        status: automated
+    - id: FTA_SSL.1
+      title: 'TSF-initiated session locking'
+      levels:
+          - base
+      rules:
+          - logind_session_timeout
+          - var_logind_session_timeout=30_minutes
+      status: automated
 
-    -   id: FTA_TAB.1
-        title: 'Default TOE access banners'
-        levels:
-            - base
-        rules:
-            - sshd_enable_warning_banner
-        status: automated
+    - id: FTA_TAB.1
+      title: 'Default TOE access banners'
+      levels:
+          - base
+      rules:
+          - sshd_enable_warning_banner
+      status: automated
 
-    -   id: FTP_ITC_EXT.1
-        title: 'Trusted channel communication'
-        levels:
-            - base
-        rules:
-            - package_openssh-clients_installed
-            - package_openssh-server_installed
-            - sshd_disable_gssapi_auth
-            - sshd_disable_kerb_auth
-        status: automated
+    - id: FTP_ITC_EXT.1
+      title: 'Trusted channel communication'
+      levels:
+          - base
+      rules:
+          - package_openssh-clients_installed
+          - package_openssh-server_installed
+          - sshd_disable_gssapi_auth
+          - sshd_disable_kerb_auth
+      status: automated
 
-    -   id: FTP_ITC_EXT.1.1
-        title: 'Trusted channel communication - TLS'
-        levels:
-            - base
-        rules:
-            - package_openssh-clients_installed
-            - package_openssh-server_installed
-            - sshd_disable_gssapi_auth
-            - sshd_disable_kerb_auth
-        status: automated
+    - id: FTP_ITC_EXT.1.1
+      title: 'Trusted channel communication - TLS'
+      levels:
+          - base
+      rules:
+          - package_openssh-clients_installed
+          - package_openssh-server_installed
+          - sshd_disable_gssapi_auth
+          - sshd_disable_kerb_auth
+      status: automated
 
-    -   id: AVA_VAN.1
-        title: 'Vulnerability Assessment'
-        levels:
-            - base
-        rules:
-            - grub2_init_on_alloc_argument
-            - grub2_page_alloc_shuffle_argument
-            - zipl_init_on_alloc_argument
-            - zipl_page_alloc_shuffle_argument
-        status: automated
+    - id: AVA_VAN.1
+      title: 'Vulnerability Assessment'
+      levels:
+          - base
+      rules:
+          - grub2_init_on_alloc_argument
+          - grub2_page_alloc_shuffle_argument
+          - zipl_init_on_alloc_argument
+          - zipl_page_alloc_shuffle_argument
+      status: automated

--- a/controls/stig_rhel9.yml
+++ b/controls/stig_rhel9.yml
@@ -1,3 +1,4 @@
+---
 policy: 'Red Hat Enterprise Linux 9 Security Technical Implementation Guide'
 title: 'Red Hat Enterprise Linux 9 Security Technical Implementation Guide'
 id: stig_rhel9
@@ -5,4133 +6,3870 @@ source: https://public.cyber.mil/stigs/downloads/
 version: V2R4
 reference_type: stigid
 product: rhel9
+
 levels:
-    -   id: high
-    -   id: medium
-    -   id: low
+    - id: high
+    - id: medium
+    - id: low
+
 controls:
-    -   id: needed_rules
-        levels:
-            - medium
-        rules:
-            - enable_authselect
-            - var_authselect_profile=sssd
-
-    -   id: RHEL-09-171011
-        levels:
-            - medium
-        rules:
-            - dconf_gnome_login_banner_text
-    -   id: RHEL-09-211010
-        levels:
-            - high
-        title: RHEL 9 must be a vendor-supported release.
-        rules:
-            - installed_OS_is_vendor_supported
-        status: automated
-
-    -   id: RHEL-09-211015
-        levels:
-            - medium
-        title:
-            RHEL 9 vendor packaged system security patches and updates must be installed
-            and up to date.
-        rules:
-            - security_patches_up_to_date
-        status: automated
-
-    -   id: RHEL-09-211020
-        levels:
-            - medium
-        title:
-            RHEL 9 must display the Standard Mandatory DOD Notice and Consent Banner
-            before granting local or remote access to the system via a command line user logon.
-        rules:
-            - banner_etc_issue
-            - login_banner_text=dod_banners
-        status: automated
-
-    -   id: RHEL-09-211030
-        levels:
-            - medium
-        title:
-            The graphical display manager must not be the default target on RHEL 9 unless
-            approved.
-        rules:
-            - xwindows_runlevel_target
-        status: automated
-
-    -   id: RHEL-09-211035
-        levels:
-            - low
-        title:
-            RHEL 9 must enable the hardware random number generator entropy gatherer
-            service.
-        related_rules:
-            - service_rngd_enabled # This rule is causing test failures, See https://github.com/ComplianceAsCode/content/pull/10153
-        status: pending
-
-    -   id: RHEL-09-211040
-        levels:
-            - medium
-        title: RHEL 9 systemd-journald service must be enabled.
-        rules:
-            - service_systemd-journald_enabled
-        status: automated
-
-    -   id: RHEL-09-211045
-        levels:
-            - high
-        title: The systemd Ctrl-Alt-Delete burst key sequence in RHEL 9 must be disabled.
-        rules:
-            - disable_ctrlaltdel_burstaction
-        status: automated
-
-    -   id: RHEL-09-211050
-        levels:
-            - high
-        title: The x86 Ctrl-Alt-Delete key sequence must be disabled on RHEL 9.
-        rules:
-            - disable_ctrlaltdel_reboot
-        status: automated
-
-    -   id: RHEL-09-211055
-        levels:
-            - medium
-        title: RHEL 9 debug-shell systemd service must be disabled.
-        status: automated
-        rules:
-            - service_debug-shell_disabled
-
-    -   id: RHEL-09-212010
-        levels:
-            - medium
-        title: RHEL 9 must require a boot loader superuser password.
-        rules:
-            - grub2_password
-        status: automated
-
-    -   id: RHEL-09-212015
-        levels:
-            - medium
-        title: RHEL 9 must disable the ability of systemd to spawn an interactive boot process.
-        rules:
-            - grub2_disable_interactive_boot
-        status: automated
-
-    -   id: RHEL-09-212020
-        levels:
-            - high
-        title:
-            RHEL 9 must require a unique superusers name upon booting into single-user
-            and maintenance modes.
-        rules:
-            - grub2_admin_username
-        status: automated
-
-    -   id: RHEL-09-212025
-        levels:
-            - medium
-        title: RHEL 9 /boot/grub2/grub.cfg file must be group-owned by root.
-        rules:
-            - file_groupowner_grub2_cfg
-        status: automated
-
-    -   id: RHEL-09-212030
-        levels:
-            - medium
-        title: RHEL 9 /boot/grub2/grub.cfg file must be owned by root.
-        rules:
-            - file_owner_grub2_cfg
-        status: automated
-
-    -   id: RHEL-09-212035
-        levels:
-            - medium
-        title: RHEL 9 must disable virtual system calls.
-        rules:
-            - grub2_vsyscall_argument
-        status: automated
-
-    -   id: RHEL-09-212040
-        levels:
-            - medium
-        title: RHEL 9 must clear the page allocator to prevent use-after-free attacks.
-        rules:
-            - grub2_page_poison_argument
-        status: automated
-
-    -   id: RHEL-09-212045
-        levels:
-            - medium
-        title: RHEL 9 must clear SLUB/SLAB objects to prevent use-after-free attacks.
-        rules:
-            - grub2_init_on_free
-        status: automated
-
-    -   id: RHEL-09-212050
-        levels:
-            - low
-        title: RHEL 9 must enable mitigations against processor-based vulnerabilities.
-        rules:
-            - grub2_pti_argument
-        status: automated
-
-    -   id: RHEL-09-212055
-        levels:
-            - low
-        title: RHEL 9 must enable auditing of processes that start prior to the audit daemon.
-        rules:
-            - grub2_audit_argument
-        status: automated
-
-    -   id: RHEL-09-213010
-        levels:
-            - medium
-        title: RHEL 9 must restrict access to the kernel message buffer.
-        rules:
-            - sysctl_kernel_dmesg_restrict
-        status: automated
-
-    -   id: RHEL-09-213015
-        levels:
-            - medium
-        title: RHEL 9 must prevent kernel profiling by nonprivileged users.
-        rules:
-            - sysctl_kernel_perf_event_paranoid
-        status: automated
-
-    -   id: RHEL-09-213020
-        levels:
-            - medium
-        title: RHEL 9 must prevent the loading of a new kernel for later execution.
-        rules:
-            - sysctl_kernel_kexec_load_disabled
-        status: automated
-
-    -   id: RHEL-09-213025
-        levels:
-            - medium
-        title: RHEL 9 must restrict exposed kernel pointer addresses access.
-        rules:
-            - sysctl_kernel_kptr_restrict
-        status: automated
-
-    -   id: RHEL-09-213030
-        levels:
-            - medium
-        title:
-            RHEL 9 must enable kernel parameters to enforce discretionary access control
-            on hardlinks.
-        rules:
-            - sysctl_fs_protected_hardlinks
-        status: automated
-
-    -   id: RHEL-09-213035
-        levels:
-            - medium
-        title:
-            RHEL 9 must enable kernel parameters to enforce discretionary access control
-            on symlinks.
-        rules:
-            - sysctl_fs_protected_symlinks
-        status: automated
-
-    -   id: RHEL-09-213040
-        levels:
-            - medium
-        title: RHEL 9 must disable the kernel.core_pattern.
-        rules:
-            - sysctl_kernel_core_pattern
-        status: automated
-
-    -   id: RHEL-09-213045
-        levels:
-            - medium
-        title:
-            RHEL 9 must be configured to disable the Asynchronous Transfer Mode kernel
-            module.
-        rules:
-            - kernel_module_atm_disabled
-        status: automated
-
-    -   id: RHEL-09-213050
-        levels:
-            - medium
-        title: RHEL 9 must be configured to disable the Controller Area Network kernel module.
-        rules:
-            - kernel_module_can_disabled
-        status: automated
-
-    -   id: RHEL-09-213055
-        levels:
-            - medium
-        title: RHEL 9 must be configured to disable the FireWire kernel module.
-        rules:
-            - kernel_module_firewire-core_disabled
-        status: automated
-
-    -   id: RHEL-09-213060
-        levels:
-            - medium
-        title:
-            RHEL 9 must disable the Stream Control Transmission Protocol (SCTP) kernel
-            module.
-        rules:
-            - kernel_module_sctp_disabled
-        status: automated
-
-    -   id: RHEL-09-213065
-        levels:
-            - medium
-        title:
-            RHEL 9 must disable the Transparent Inter Process Communication (TIPC) kernel
-            module.
-        rules:
-            - kernel_module_tipc_disabled
-        status: automated
-
-    -   id: RHEL-09-213070
-        levels:
-            - medium
-        title:
-            RHEL 9 must implement address space layout randomization (ASLR) to protect
-            its memory from unauthorized code execution.
-        rules:
-            - sysctl_kernel_randomize_va_space
-        status: automated
-
-    -   id: RHEL-09-213075
-        levels:
-            - medium
-        title:
-            RHEL 9 must disable access to network bpf system call from nonprivileged
-            processes.
-        rules:
-            - sysctl_kernel_unprivileged_bpf_disabled
-        status: automated
-
-    -   id: RHEL-09-213080
-        levels:
-            - medium
-        title: RHEL 9 must restrict usage of ptrace to descendant processes.
-        rules:
-            - sysctl_kernel_yama_ptrace_scope
-        status: automated
-
-    -   id: RHEL-09-213085
-        levels:
-            - medium
-        title: RHEL 9 must disable core dump backtraces.
-        rules:
-            - coredump_disable_backtraces
-        status: automated
-
-    -   id: RHEL-09-213090
-        levels:
-            - medium
-        title: RHEL 9 must disable storing core dumps.
-        rules:
-            - coredump_disable_storage
-        status: automated
-
-    -   id: RHEL-09-213095
-        levels:
-            - medium
-        title: RHEL 9 must disable core dumps for all users.
-        rules:
-            - disable_users_coredumps
-        status: automated
-
-    -   id: RHEL-09-213100
-        levels:
-            - medium
-        title: RHEL 9 must disable acquiring, saving, and processing core dumps.
-        rules:
-            - service_systemd-coredump_disabled
-        status: automated
-
-    -   id: RHEL-09-213105
-        levels:
-            - medium
-        title: RHEL 9 must disable the use of user namespaces.
-        rules:
-            - sysctl_user_max_user_namespaces_no_remediation
-        status: automated
-
-    -   id: RHEL-09-213110
-        levels:
-            - medium
-        title:
-            RHEL 9 must implement nonexecutable data to protect its memory from unauthorized
-            code execution.
-        rules:
-            - sysctl_kernel_exec_shield
-        status: automated
-
-    -   id: RHEL-09-213115
-        levels:
-            - medium
-        title: The kdump service on RHEL 9 must be disabled.
-        rules:
-            - service_kdump_disabled
-        status: automated
-
-    -   id: RHEL-09-214010
-        levels:
-            - medium
-        title: RHEL 9 must ensure cryptographic verification of vendor software packages.
-        rules:
-            - ensure_redhat_gpgkey_installed
-        status: automated
-
-    -   id: RHEL-09-214015
-        levels:
-            - high
-        title:
-            RHEL 9 must check the GPG signature of software packages originating from
-            external software repositories before installation.
-        rules:
-            - ensure_gpgcheck_globally_activated
-        status: automated
-
-    -   id: RHEL-09-214020
-        levels:
-            - high
-        title:
-            RHEL 9 must check the GPG signature of locally installed software packages
-            before installation.
-        rules:
-            - ensure_gpgcheck_local_packages
-        status: automated
-
-    -   id: RHEL-09-214025
-        levels:
-            - high
-        title: RHEL 9 must have GPG signature verification enabled for all software repositories.
-        rules:
-            - ensure_gpgcheck_never_disabled
-        status: automated
-
-    -   id: RHEL-09-214030
-        levels:
-            - medium
-        title:
-            RHEL 9 must be configured so that the cryptographic hashes of system files
-            match vendor values.
-        related_rules:
-            - rpm_verify_hashes # Due to crypto policies this cannot be selected at this time
-        status: pending
-
-    -   id: RHEL-09-214035
-        levels:
-            - low
-        title:
-            RHEL 9 must remove all software components after updated versions have been
-            installed.
-        rules:
-            - clean_components_post_updating
-        status: automated
-
-    -   id: RHEL-09-215010
-        levels:
-            - medium
-        title: RHEL 9 subscription-manager package must be installed.
-        rules:
-            - package_subscription-manager_installed
-        status: automated
-
-    -   id: RHEL-09-215015
-        levels:
-            - high
-        title: RHEL 9 must not have a File Transfer Protocol (FTP) server package installed.
-        rules:
-            - package_vsftpd_removed
-        status: automated
-
-    -   id: RHEL-09-215020
-        levels:
-            - medium
-        title: RHEL 9 must not have the sendmail package installed.
-        rules:
-            - package_sendmail_removed
-        status: automated
-
-    -   id: RHEL-09-215025
-        levels:
-            - medium
-        title: RHEL 9 must not have the nfs-utils package installed.
-        rules:
-            - package_nfs-utils_removed
-        status: automated
-
-    -   id: RHEL-09-215030
-        levels:
-            - medium
-        title: RHEL 9 must not have the ypserv package installed.
-        related_rules:
-            - package_ypserv_removed
-        status: not applicable # The ypserv package is not available in RHEL 9
-
-    -   id: RHEL-09-215035
-        levels:
-            - medium
-        title: RHEL 9 must not have the rsh-server package installed.
-        related_rules:
-            - package_rsh-server_removed
-        status: not applicable # The rsh-server package is not available in RHEL 9
-
-    -   id: RHEL-09-215040
-        levels:
-            - medium
-        title: RHEL 9 must not have the telnet-server package installed.
-        rules:
-            - package_telnet-server_removed
-        status: automated
-
-    -   id: RHEL-09-215045
-        levels:
-            - medium
-        title: RHEL 9 must not have the gssproxy package installed.
-        rules:
-            - package_gssproxy_removed
-        status: automated
-
-    -   id: RHEL-09-215050
-        levels:
-            - medium
-        title: RHEL 9 must not have the iprutils package installed.
-        rules:
-            - package_iprutils_removed
-        status: automated
-
-    -   id: RHEL-09-215055
-        levels:
-            - medium
-        title: RHEL 9 must not have the tuned package installed.
-        rules:
-            - package_tuned_removed
-        status: automated
-
-    -   id: RHEL-09-215060
-        levels:
-            - high
-        title:
-            RHEL 9 must not have a Trivial File Transfer Protocol (TFTP) server package
-            installed.
-        rules:
-            - package_tftp-server_removed
-        status: automated
-
-    -   id: RHEL-09-215065
-        levels:
-            - medium
-        title: RHEL 9 must not have the quagga package installed.
-        related_rules:
-            - package_quagga_removed
-        status: not applicable # The quagga package is not available in RHEL 9
-
-    -   id: RHEL-09-215070
-        levels:
-            - medium
-        title: A graphical display manager must not be installed on RHEL 9 unless approved.
-        rules:
-            - xwindows_remove_packages
-        status: automated
-
-    -   id: RHEL-09-215075
-        levels:
-            - medium
-        title: RHEL 9 must have the openssl-pkcs11 package installed.
-        rules:
-            - install_smartcard_packages
-        status: automated
-
-    -   id: RHEL-09-215080
-        levels:
-            - medium
-        title: RHEL 9 must have the gnutls-utils package installed.
-        rules:
-            - package_gnutls-utils_installed
-        status: automated
-
-    -   id: RHEL-09-215085
-        levels:
-            - medium
-        title: RHEL 9 must have the nss-tools package installed.
-        rules:
-            - package_nss-tools_installed
-        status: automated
-
-    -   id: RHEL-09-215090
-        levels:
-            - medium
-        title: RHEL 9 must have the rng-tools package installed.
-        rules:
-            - package_rng-tools_installed
-        status: automated
-
-    -   id: RHEL-09-215095
-        levels:
-            - medium
-        title: RHEL 9 must have the s-nail package installed.
-        rules:
-            - package_s-nail_installed
-        status: automated
-
-    -   id: RHEL-09-215100
-        levels:
-            - medium
-        title: RHEL 9 must have the crypto-policies package installed.
-        rules:
-            - package_crypto-policies_installed
-        status: automated
-
-    -   id: RHEL-09-215101
-        levels:
-            - medium
-        title: RHEL 9 must have the Postfix package installed.
-        status: automated
-        rules:
-            - package_postfix_installed
-
-
-    -   id: RHEL-09-215105
-        levels:
-            - medium
-        title: RHEL 9 must implement a FIPS 140-3 compliant systemwide cryptographic policy.
-        rules:
-            - configure_crypto_policy
-            - fips_crypto_subpolicy
-        status: automated
-
-    -   id: RHEL-09-231010
-        levels:
-            - medium
-        title:
-            A separate RHEL 9 file system must be used for user home directories (such
-            as /home or an equivalent).
-        rules:
-            - partition_for_home
-        status: automated
-
-    -   id: RHEL-09-231015
-        levels:
-            - medium
-        title: RHEL 9 must use a separate file system for /tmp.
-        rules:
-            - partition_for_tmp
-        status: automated
-
-    -   id: RHEL-09-231020
-        levels:
-            - low
-        title: RHEL 9 must use a separate file system for /var.
-        rules:
-            - partition_for_var
-        status: automated
-
-    -   id: RHEL-09-231025
-        levels:
-            - low
-        title: RHEL 9 must use a separate file system for /var/log.
-        rules:
-            - partition_for_var_log
-        status: automated
-
-    -   id: RHEL-09-231030
-        levels:
-            - low
-        title: RHEL 9 must use a separate file system for the system audit data path.
-        rules:
-            - partition_for_var_log_audit
-        status: automated
-
-    -   id: RHEL-09-231035
-        levels:
-            - medium
-        title: RHEL 9 must use a separate file system for /var/tmp.
-        rules:
-            - partition_for_var_tmp
-        status: automated
-
-    -   id: RHEL-09-231040
-        levels:
-            - medium
-        title: RHEL 9 file system automount function must be disabled unless required.
-        rules:
-            - service_autofs_disabled
-        status: automated
-
-    -   id: RHEL-09-231045
-        levels:
-            - medium
-        title:
-            RHEL 9 must prevent device files from being interpreted on file systems that
-            contain user home directories.
-        rules:
-            - mount_option_home_nodev
-        status: automated
-
-    -   id: RHEL-09-231050
-        levels:
-            - medium
-        title:
-            RHEL 9 must prevent files with the setuid and setgid bit set from being executed
-            on file systems that contain user home directories.
-        rules:
-            - mount_option_home_nosuid
-        status: automated
-
-    -   id: RHEL-09-231055
-        levels:
-            - medium
-        title:
-            RHEL 9 must prevent code from being executed on file systems that contain
-            user home directories.
-        rules:
-            - mount_option_home_noexec
-        status: automated
-
-    -   id: RHEL-09-231065
-        levels:
-            - medium
-        title:
-            RHEL 9 must prevent special devices on file systems that are imported via
-            Network File System (NFS).
-        rules:
-            - mount_option_nodev_remote_filesystems
-        status: automated
-
-    -   id: RHEL-09-231070
-        levels:
-            - medium
-        title:
-            RHEL 9  must prevent code from being executed on file systems that are imported
-            via Network File System (NFS).
-        rules:
-            - mount_option_noexec_remote_filesystems
-        status: automated
-
-    -   id: RHEL-09-231075
-        levels:
-            - medium
-        title:
-            RHEL 9 must prevent files with the setuid and setgid bit set from being executed
-            on file systems that are imported via Network File System (NFS).
-        rules:
-            - mount_option_nosuid_remote_filesystems
-        status: automated
-
-    -   id: RHEL-09-231080
-        levels:
-            - medium
-        title:
-            RHEL 9 must prevent code from being executed on file systems that are used
-            with removable media.
-        rules:
-            - mount_option_noexec_removable_partitions
-        status: automated
-
-    -   id: RHEL-09-231085
-        levels:
-            - medium
-        title:
-            RHEL 9 must prevent special devices on file systems that are used with removable
-            media.
-        rules:
-            - mount_option_nodev_removable_partitions
-        status: automated
-
-    -   id: RHEL-09-231090
-        levels:
-            - medium
-        title:
-            RHEL 9 must prevent files with the setuid and setgid bit set from being executed
-            on file systems that are used with removable media.
-        rules:
-            - mount_option_nosuid_removable_partitions
-        status: automated
-
-    -   id: RHEL-09-231095
-        levels:
-            - medium
-        title: RHEL 9 must mount /boot with the nodev option.
-        rules:
-            - mount_option_boot_nodev
-        status: automated
-
-    -   id: RHEL-09-231100
-        levels:
-            - medium
-        title:
-            RHEL 9 must prevent files with the setuid and setgid bit set from being executed
-            on the /boot directory.
-        rules:
-            - mount_option_boot_nosuid
-        status: automated
-
-    -   id: RHEL-09-231105
-        levels:
-            - medium
-        title:
-            RHEL 9 must prevent files with the setuid and setgid bit set from being executed
-            on the /boot/efi directory.
-        rules:
-            - mount_option_boot_efi_nosuid
-        status: automated
-
-    -   id: RHEL-09-231110
-        levels:
-            - medium
-        title: RHEL 9 must mount /dev/shm with the nodev option.
-        rules:
-            - mount_option_dev_shm_nodev
-        status: automated
-
-    -   id: RHEL-09-231115
-        levels:
-            - medium
-        title: RHEL 9 must mount /dev/shm with the noexec option.
-        rules:
-            - mount_option_dev_shm_noexec
-        status: automated
-
-    -   id: RHEL-09-231120
-        levels:
-            - medium
-        title: RHEL 9 must mount /dev/shm with the nosuid option.
-        rules:
-            - mount_option_dev_shm_nosuid
-        status: automated
-
-    -   id: RHEL-09-231125
-        levels:
-            - medium
-        title: RHEL 9 must mount /tmp with the nodev option.
-        rules:
-            - mount_option_tmp_nodev
-        status: automated
-
-    -   id: RHEL-09-231130
-        levels:
-            - medium
-        title: RHEL 9 must mount /tmp with the noexec option.
-        rules:
-            - mount_option_tmp_noexec
-        status: automated
-
-    -   id: RHEL-09-231135
-        levels:
-            - medium
-        title: RHEL 9 must mount /tmp with the nosuid option.
-        rules:
-            - mount_option_tmp_nosuid
-        status: automated
-
-    -   id: RHEL-09-231140
-        levels:
-            - medium
-        title: RHEL 9 must mount /var with the nodev option.
-        rules:
-            - mount_option_var_nodev
-        status: automated
-
-    -   id: RHEL-09-231145
-        levels:
-            - medium
-        title: RHEL 9 must mount /var/log with the nodev option.
-        rules:
-            - mount_option_var_log_nodev
-        status: automated
-
-    -   id: RHEL-09-231150
-        levels:
-            - medium
-        title: RHEL 9 must mount /var/log with the noexec option.
-        rules:
-            - mount_option_var_log_noexec
-        status: automated
-
-    -   id: RHEL-09-231155
-        levels:
-            - medium
-        title: RHEL 9 must mount /var/log with the nosuid option.
-        rules:
-            - mount_option_var_log_nosuid
-        status: automated
-
-    -   id: RHEL-09-231160
-        levels:
-            - medium
-        title: RHEL 9 must mount /var/log/audit with the nodev option.
-        rules:
-            - mount_option_var_log_audit_nodev
-        status: automated
-
-    -   id: RHEL-09-231165
-        levels:
-            - medium
-        title: RHEL 9 must mount /var/log/audit with the noexec option.
-        rules:
-            - mount_option_var_log_audit_noexec
-        status: automated
-
-    -   id: RHEL-09-231170
-        levels:
-            - medium
-        title: RHEL 9 must mount /var/log/audit with the nosuid option.
-        rules:
-            - mount_option_var_log_audit_nosuid
-        status: automated
-
-    -   id: RHEL-09-231175
-        levels:
-            - medium
-        title: RHEL 9 must mount /var/tmp with the nodev option.
-        rules:
-            - mount_option_var_tmp_nodev
-        status: automated
-
-    -   id: RHEL-09-231180
-        levels:
-            - medium
-        title: RHEL 9 must mount /var/tmp with the noexec option.
-        rules:
-            - mount_option_var_tmp_noexec
-        status: automated
-
-    -   id: RHEL-09-231185
-        levels:
-            - medium
-        title: RHEL 9 must mount /var/tmp with the nosuid option.
-        rules:
-            - mount_option_var_tmp_nosuid
-        status: automated
-
-    -   id: RHEL-09-231190
-        levels:
-            - high
-        title:
-            RHEL 9 local disk partitions must implement cryptographic mechanisms to prevent
-            unauthorized disclosure or modification of all information that requires at rest
-            protection.
-        rules:
-            - encrypt_partitions
-        status: automated
-
-    -   id: RHEL-09-231195
-        levels:
-            - low
-        title: RHEL 9 must disable mounting of cramfs.
-        rules:
-            - kernel_module_cramfs_disabled
-        status: automated
-
-    -   id: RHEL-09-231200
-        levels:
-            - medium
-        title: RHEL 9 must prevent special devices on non-root local partitions.
-        rules:
-            - mount_option_nodev_nonroot_local_partitions
-        status: automated
-
-    -   id: RHEL-09-232010
-        levels:
-            - medium
-        title: RHEL 9 system commands must have mode 755 or less permissive.
-        rules:
-            - file_permissions_binary_dirs
-        status: automated
-
-    -   id: RHEL-09-232015
-        levels:
-            - medium
-        title: RHEL 9 library directories must have mode 755 or less permissive.
-        rules:
-            - dir_permissions_library_dirs
-        status: automated
-
-    -   id: RHEL-09-232020
-        levels:
-            - medium
-        title: RHEL 9 library files must have mode 755 or less permissive.
-        rules:
-            - file_permissions_library_dirs
-        status: automated
-
-    -   id: RHEL-09-232025
-        levels:
-            - medium
-        title: RHEL 9 /var/log directory must have mode 0755 or less permissive.
-        rules:
-            - file_permissions_var_log
-        status: automated
-
-    -   id: RHEL-09-232030
-        levels:
-            - medium
-        title: RHEL 9 /var/log/messages file must have mode 0640 or less permissive.
-        rules:
-            - file_permissions_var_log_messages
-        status: automated
-
-    -   id: RHEL-09-232035
-        levels:
-            - medium
-        title: RHEL 9 audit tools must have a mode of 0755 or less permissive.
-        rules:
-            - file_audit_tools_permissions
-        status: automated
-
-    -   id: RHEL-09-232040
-        levels:
-            - medium
-        title: RHEL 9 cron configuration directories must have a mode of 0700 or less permissive.
-        rules:
-            - package_cron_installed
-            - file_permissions_cron_d
-            - file_permissions_cron_daily
-            - file_permissions_cron_hourly
-            - file_permissions_cron_monthly
-            - file_permissions_cron_weekly
-        status: automated
-
-    -   id: RHEL-09-232045
-        levels:
-            - medium
-        title: All RHEL 9 local initialization files must have mode 0740 or less permissive.
-        rules:
-            - file_permission_user_init_files_root
-            - var_user_initialization_files_regex=all_dotfiles
-            - rootfiles_configured
-        status: automated
-
-    -   id: RHEL-09-232050
-        levels:
-            - medium
-        title:
-            All RHEL 9 local interactive user home directories must have mode 0750 or
-            less permissive.
-        rules:
-            - file_permissions_home_directories
-        status: automated
-
-    -   id: RHEL-09-232055
-        levels:
-            - medium
-        title:
-            RHEL 9 /etc/group file must have mode 0644 or less permissive to prevent
-            unauthorized access.
-        rules:
-            - file_permissions_etc_group
-        status: automated
-
-    -   id: RHEL-09-232060
-        levels:
-            - medium
-        title:
-            RHEL 9 /etc/group- file must have mode 0644 or less permissive to prevent
-            unauthorized access.
-        rules:
-            - file_permissions_backup_etc_group
-        status: automated
-
-    -   id: RHEL-09-232065
-        levels:
-            - medium
-        title:
-            RHEL 9 /etc/gshadow file must have mode 0000 or less permissive to prevent
-            unauthorized access.
-        rules:
-            - file_permissions_etc_gshadow
-        status: automated
-
-    -   id: RHEL-09-232070
-        levels:
-            - medium
-        title:
-            RHEL 9 /etc/gshadow- file must have mode 0000 or less permissive to prevent
-            unauthorized access.
-        rules:
-            - file_permissions_backup_etc_gshadow
-        status: automated
-
-    -   id: RHEL-09-232075
-        levels:
-            - medium
-        title:
-            RHEL 9 /etc/passwd file must have mode 0644 or less permissive to prevent
-            unauthorized access.
-        rules:
-            - file_permissions_etc_passwd
-        status: automated
-
-    -   id: RHEL-09-232080
-        levels:
-            - medium
-        title:
-            RHEL 9 /etc/passwd- file must have mode 0644 or less permissive to prevent
-            unauthorized access.
-        rules:
-            - file_permissions_backup_etc_passwd
-        status: automated
-
-    -   id: RHEL-09-232085
-        levels:
-            - medium
-        title:
-            RHEL 9 /etc/shadow- file must have mode 0000 or less permissive to prevent
-            unauthorized access.
-        rules:
-            - file_permissions_backup_etc_shadow
-        status: automated
-
-    -   id: RHEL-09-232090
-        levels:
-            - medium
-        title: RHEL 9 /etc/group file must be owned by root.
-        rules:
-            - file_owner_etc_group
-        status: automated
-
-    -   id: RHEL-09-232095
-        levels:
-            - medium
-        title: RHEL 9 /etc/group file must be group-owned by root.
-        rules:
-            - file_groupowner_etc_group
-        status: automated
-
-    -   id: RHEL-09-232100
-        levels:
-            - medium
-        title: RHEL 9 /etc/group- file must be owned by root.
-        rules:
-            - file_owner_backup_etc_group
-
-    -   id: RHEL-09-232103
-        title: RHEL 9 "/etc/audit/" must be owned by root.
-        levels:
-        - medium
-        rules:
-            - file_ownership_audit_configuration
-        status: automated
-
-    -   id: RHEL-09-232104
-        title: RHEL 9 "/etc/audit/" must be group-owned by root.
-        levels:
-            - medium
-        rules:
-            - file_groupownership_audit_configuration
-
-    -   id: RHEL-09-232105
-        levels:
-            - medium
-        title: RHEL 9 /etc/group- file must be group-owned by root.
-        rules:
-            - file_groupowner_backup_etc_group
-        status: automated
-
-    -   id: RHEL-09-232110
-        levels:
-            - medium
-        title: RHEL 9 /etc/gshadow file must be owned by root.
-        rules:
-            - file_owner_etc_gshadow
-        status: automated
-
-    -   id: RHEL-09-232115
-        levels:
-            - medium
-        title: RHEL 9 /etc/gshadow file must be group-owned by root.
-        rules:
-            - file_groupowner_etc_gshadow
-        status: automated
-
-    -   id: RHEL-09-232120
-        levels:
-            - medium
-        title: RHEL 9 /etc/gshadow- file must be owned by root.
-        rules:
-            - file_owner_backup_etc_gshadow
-        status: automated
-
-    -   id: RHEL-09-232125
-        levels:
-            - medium
-        title: RHEL 9 /etc/gshadow- file must be group-owned by root.
-        rules:
-            - file_groupowner_backup_etc_gshadow
-        status: automated
-
-    -   id: RHEL-09-232130
-        levels:
-            - medium
-        title: RHEL 9 /etc/passwd file must be owned by root.
-        rules:
-            - file_owner_etc_passwd
-        status: automated
-
-    -   id: RHEL-09-232135
-        levels:
-            - medium
-        title: RHEL 9 /etc/passwd file must be group-owned by root.
-        rules:
-            - file_groupowner_etc_passwd
-        status: automated
-
-    -   id: RHEL-09-232140
-        levels:
-            - medium
-        title: RHEL 9 /etc/passwd- file must be owned by root.
-        rules:
-            - file_owner_backup_etc_passwd
-        status: automated
-
-    -   id: RHEL-09-232145
-        levels:
-            - medium
-        title: RHEL 9 /etc/passwd- file must be group-owned by root.
-        rules:
-            - file_groupowner_backup_etc_passwd
-        status: automated
-
-    -   id: RHEL-09-232150
-        levels:
-            - medium
-        title: RHEL 9 /etc/shadow file must be owned by root.
-        rules:
-            - file_owner_etc_shadow
-        status: automated
-
-    -   id: RHEL-09-232155
-        levels:
-            - medium
-        title: RHEL 9 /etc/shadow file must be group-owned by root.
-        rules:
-            - file_groupowner_etc_shadow
-        status: automated
-
-    -   id: RHEL-09-232160
-        levels:
-            - medium
-        title: RHEL 9 /etc/shadow- file must be owned by root.
-        rules:
-            - file_owner_backup_etc_shadow
-        status: automated
-
-    -   id: RHEL-09-232165
-        levels:
-            - medium
-        title: RHEL 9 /etc/shadow- file must be group-owned by root.
-        rules:
-            - file_groupowner_backup_etc_shadow
-        status: automated
-
-    -   id: RHEL-09-232170
-        levels:
-            - medium
-        title: RHEL 9 /var/log directory must be owned by root.
-        rules:
-            - file_owner_var_log
-        status: automated
-
-    -   id: RHEL-09-232175
-        levels:
-            - medium
-        title: RHEL 9 /var/log directory must be group-owned by root.
-        rules:
-            - file_groupowner_var_log
-        status: automated
-
-    -   id: RHEL-09-232180
-        levels:
-            - medium
-        title: RHEL 9 /var/log/messages file must be owned by root.
-        rules:
-            - file_owner_var_log_messages
-        status: automated
-
-    -   id: RHEL-09-232185
-        levels:
-            - medium
-        title: RHEL 9 /var/log/messages file must be group-owned by root.
-        rules:
-            - file_groupowner_var_log_messages
-        status: automated
-
-    -   id: RHEL-09-232190
-        levels:
-            - medium
-        title: RHEL 9 system commands must be owned by root.
-        rules:
-            - file_ownership_binary_dirs
-        status: automated
-
-    -   id: RHEL-09-232195
-        levels:
-            - medium
-        title: RHEL 9 system commands must be group-owned by root or a system account.
-        rules:
-            - file_groupownership_system_commands_dirs
-        status: automated
-
-    -   id: RHEL-09-232200
-        levels:
-            - medium
-        title: RHEL 9 library files must be owned by root.
-        rules:
-            - file_ownership_library_dirs
-        status: automated
-
-    -   id: RHEL-09-232205
-        levels:
-            - medium
-        title: RHEL 9 library files must be group-owned by root or a system account.
-        rules:
-            - root_permissions_syslibrary_files
-        status: automated
-
-    -   id: RHEL-09-232210
-        levels:
-            - medium
-        title: RHEL 9 library directories must be owned by root.
-        rules:
-            - dir_ownership_library_dirs
-        status: automated
-
-    -   id: RHEL-09-232215
-        levels:
-            - medium
-        title: RHEL 9 library directories must be group-owned by root or a system account.
-        rules:
-            - dir_group_ownership_library_dirs
-        status: automated
-
-    -   id: RHEL-09-232220
-        levels:
-            - medium
-        title: RHEL 9 audit tools must be owned by root.
-        rules:
-            - file_audit_tools_ownership
-        status: automated
-
-    -   id: RHEL-09-232225
-        levels:
-            - medium
-        title: RHEL 9 audit tools must be group-owned by root.
-        rules:
-            - file_audit_tools_group_ownership
-        status: automated
-
-    -   id: RHEL-09-232230
-        levels:
-            - medium
-        title: RHEL 9 cron configuration files directory must be owned by root.
-        rules:
-            - file_owner_cron_d
-            - file_owner_cron_daily
-            - file_owner_cron_hourly
-            - file_owner_cron_monthly
-            - file_owner_cron_weekly
-            - file_owner_crontab
-            - file_owner_cron_deny
-        status: automated
-
-    -   id: RHEL-09-232235
-        levels:
-            - medium
-        title: RHEL 9 cron configuration files directory must be group-owned by root.
-        rules:
-            - file_groupowner_cron_d
-            - file_groupowner_cron_daily
-            - file_groupowner_cron_hourly
-            - file_groupowner_cron_monthly
-            - file_groupowner_cron_weekly
-            - file_groupowner_crontab
-            - file_groupowner_cron_deny
-        status: automated
-
-    -   id: RHEL-09-232240
-        levels:
-            - medium
-        title:
-            All RHEL 9 world-writable directories must be owned by root, sys, bin, or
-            an application user.
-        rules:
-            - dir_perms_world_writable_root_owned
-        status: automated
-
-    -   id: RHEL-09-232245
-        levels:
-            - medium
-        title: A sticky bit must be set on all RHEL 9 public directories.
-        rules:
-            - dir_perms_world_writable_sticky_bits
-        status: automated
-
-    -   id: RHEL-09-232250
-        levels:
-            - medium
-        title: All RHEL 9 local files and directories must have a valid group owner.
-        rules:
-            - file_permissions_ungroupowned
-        status: automated
-
-    -   id: RHEL-09-232255
-        levels:
-            - medium
-        title: All RHEL 9 local files and directories must have a valid owner.
-        rules:
-            - no_files_unowned_by_user
-        status: automated
-
-    -   id: RHEL-09-232260
-        levels:
-            - medium
-        title:
-            RHEL 9 must be configured so that all system device files are correctly labeled
-            to prevent unauthorized modification.
-        rules:
-            - selinux_all_devicefiles_labeled
-        status: automated
-
-    -   id: RHEL-09-232270
-        levels:
-            - medium
-        title: RHEL 9 /etc/shadow file must have mode 0000 to prevent unauthorized access.
-        rules:
-            - file_permissions_etc_shadow
-        status: automated
-
-    -   id: RHEL-09-251010
-        levels:
-            - medium
-        title: RHEL 9 must have the firewalld package installed.
-        rules:
-            - package_firewalld_installed
-        status: automated
-
-    -   id: RHEL-09-251015
-        levels:
-            - medium
-        title: The firewalld service on RHEL 9 must be active.
-        rules:
-            - service_firewalld_enabled
-        status: automated
-
-    -   id: RHEL-09-251020
-        levels:
-            - medium
-        title:
-            A RHEL 9 firewall must employ a deny-all, allow-by-exception policy for allowing
-            connections to other systems.
-        rules:
-            - configured_firewalld_default_deny
-        status: automated
-
-    -   id: RHEL-09-251030
-        levels:
-            - medium
-        title:
-            RHEL 9 must protect against or limit the effects of denial-of-service (DoS)
-            attacks by ensuring rate-limiting measures on impacted network interfaces are
-            implemented.
-        rules:
-            - firewalld-backend
-        status: automated
-
-    -   id: RHEL-09-251035
-        levels:
-            - medium
-        title:
-            RHEL 9 must be configured to prohibit or restrict the use of functions, ports,
-            protocols, and/or services, as defined in the Ports, Protocols, and Services Management
-            (PPSM) Category Assignments List (CAL) and vulnerability assessments.
-        rules:
-            - firewalld_sshd_port_enabled
-        status: automated
-
-    -   id: RHEL-09-251040
-        levels:
-            - medium
-        title: RHEL 9 network interfaces must not be in promiscuous mode.
-        rules:
-            - network_sniffer_disabled
-        status: automated
-
-    -   id: RHEL-09-251045
-        levels:
-            - medium
-        title:
-            RHEL 9 must enable hardening for the Berkeley Packet Filter just-in-time
-            compiler.
-        rules:
-            - sysctl_net_core_bpf_jit_harden
-        status: automated
-
-    -   id: RHEL-09-252010
-        levels:
-            - medium
-        title: RHEL 9 must have the chrony package installed.
-        rules:
-            - package_chrony_installed
-        status: automated
-
-    -   id: RHEL-09-252015
-        levels:
-            - medium
-        title: RHEL 9 chronyd service must be enabled.
-        rules:
-            - service_chronyd_enabled
-        status: automated
-
-    -   id: RHEL-09-252020
-        levels:
-            - medium
-        title:
-            RHEL 9 must securely compare internal information system clocks at least
-            every 24 hours.
-        rules:
-            - chronyd_or_ntpd_set_maxpoll
-            - chronyd_server_directive
-            - chronyd_specify_remote_server
-            - var_multiple_time_servers=stig
-            - var_time_service_set_maxpoll=18_hours
-        status: automated
-
-    -   id: RHEL-09-252025
-        levels:
-            - low
-        title: RHEL 9 must disable the chrony daemon from acting as a server.
-        rules:
-            - chronyd_client_only
-        status: automated
-
-    -   id: RHEL-09-252030
-        levels:
-            - low
-        title: RHEL 9 must disable network management of the chrony daemon.
-        rules:
-            - chronyd_no_chronyc_network
-        status: automated
-
-    -   id: RHEL-09-252035
-        levels:
-            - medium
-        title:
-            RHEL 9 systems using Domain Name Servers (DNS) resolution must have at least
-            two name servers configured.
-        rules:
-            - network_configure_name_resolution
-        status: automated
-
-    -   id: RHEL-09-252040
-        levels:
-            - medium
-        title: RHEL 9 must configure a DNS processing mode set be Network Manager.
-        rules:
-            - networkmanager_dns_mode
-            - var_networkmanager_dns_mode=explicit_default
-        status: automated
-
-    -   id: RHEL-09-252045
-        levels:
-            - medium
-        title: RHEL 9 must not have unauthorized IP tunnels configured.
-        rules:
-            - libreswan_approved_tunnels
-        status: automated
-
-    -   id: RHEL-09-252050
-        levels:
-            - medium
-        title: RHEL 9 must be configured to prevent unrestricted mail relaying.
-        rules:
-            - postfix_prevent_unrestricted_relay
-        status: automated
-
-    -   id: RHEL-09-252060
-        levels:
-            - medium
-        title:
-            RHEL 9 must forward mail from postmaster to the root account using a postfix
-            alias.
-        rules:
-            - postfix_client_configure_mail_alias_postmaster
-        status: automated
-
-    -   id: RHEL-09-252065
-        levels:
-            - medium
-        title: RHEL 9 libreswan package must be installed.
-        rules:
-            - package_libreswan_installed
-        status: automated
-
-    -   id: RHEL-09-252070
-        levels:
-            - high
-        title: There must be no shosts.equiv files on RHEL 9.
-        rules:
-            - no_host_based_files
-        status: automated
-
-    -   id: RHEL-09-252075
-        levels:
-            - high
-        title: There must be no .shosts files on RHEL 9.
-        rules:
-            - no_user_host_based_files
-        status: automated
-
-    -   id: RHEL-09-253010
-        levels:
-            - medium
-        title: RHEL 9 must be configured to use TCP syncookies.
-        rules:
-            - sysctl_net_ipv4_tcp_syncookies
-        status: automated
-
-    -   id: RHEL-09-253015
-        levels:
-            - medium
-        title:
-            RHEL 9 must ignore Internet Protocol version 4 (IPv4) Internet Control Message
-            Protocol (ICMP) redirect messages.
-        rules:
-            - sysctl_net_ipv4_conf_all_accept_redirects
-        status: automated
-
-    -   id: RHEL-09-253020
-        levels:
-            - medium
-        title:
-            RHEL 9 must not forward Internet Protocol version 4 (IPv4) source-routed
-            packets.
-        rules:
-            - sysctl_net_ipv4_conf_all_accept_source_route
-        status: automated
-
-    -   id: RHEL-09-253025
-        levels:
-            - medium
-        title: RHEL 9 must log IPv4 packets with impossible addresses.
-        rules:
-            - sysctl_net_ipv4_conf_all_log_martians
-        status: automated
-
-    -   id: RHEL-09-253030
-        levels:
-            - medium
-        title: RHEL 9 must log IPv4 packets with impossible addresses by default.
-        rules:
-            - sysctl_net_ipv4_conf_default_log_martians
-        status: automated
-
-    -   id: RHEL-09-253035
-        levels:
-            - medium
-        title: RHEL 9 must use reverse path filtering on all IPv4 interfaces.
-        rules:
-            - sysctl_net_ipv4_conf_all_rp_filter
-        status: automated
-
-    -   id: RHEL-09-253040
-        levels:
-            - medium
-        title:
-            RHEL 9 must prevent IPv4 Internet Control Message Protocol (ICMP) redirect
-            messages from being accepted.
-        rules:
-            - sysctl_net_ipv4_conf_default_accept_redirects
-        status: automated
-
-    -   id: RHEL-09-253045
-        levels:
-            - medium
-        title: RHEL 9 must not forward IPv4 source-routed packets by default.
-        rules:
-            - sysctl_net_ipv4_conf_default_accept_source_route
-        status: automated
-
-    -   id: RHEL-09-253050
-        levels:
-            - medium
-        title:
-            RHEL 9 must use a reverse-path filter for IPv4 network traffic when possible
-            by default.
-        rules:
-            - sysctl_net_ipv4_conf_default_rp_filter
-        status: automated
-
-    -   id: RHEL-09-253055
-        levels:
-            - medium
-        title:
-            RHEL 9 must not respond to Internet Control Message Protocol (ICMP) echoes
-            sent to a broadcast address.
-        rules:
-            - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
-        status: automated
-
-    -   id: RHEL-09-253060
-        levels:
-            - medium
-        title:
-            RHEL 9 must limit the number of bogus Internet Control Message Protocol (ICMP)
-            response errors logs.
-        rules:
-            - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
-        status: automated
-
-    -   id: RHEL-09-253065
-        levels:
-            - medium
-        title: RHEL 9 must not send Internet Control Message Protocol (ICMP) redirects.
-        rules:
-            - sysctl_net_ipv4_conf_all_send_redirects
-        status: automated
-
-    -   id: RHEL-09-253070
-        levels:
-            - medium
-        title:
-            RHEL 9 must not allow interfaces to perform Internet Control Message Protocol
-            (ICMP) redirects by default.
-        rules:
-            - sysctl_net_ipv4_conf_default_send_redirects
-        status: automated
-
-    -   id: RHEL-09-253075
-        levels:
-            - medium
-        title: RHEL 9 must not enable IPv4 packet forwarding unless the system is a router.
-        rules:
-            - sysctl_net_ipv4_conf_all_forwarding
-        status: automated
-
-    -   id: RHEL-09-254010
-        levels:
-            - medium
-        title: RHEL 9 must not accept router advertisements on all IPv6 interfaces.
-        rules:
-            - sysctl_net_ipv6_conf_all_accept_ra
-        status: automated
-
-    -   id: RHEL-09-254015
-        levels:
-            - medium
-        title:
-            RHEL 9 must ignore IPv6 Internet Control Message Protocol (ICMP) redirect
-            messages.
-        rules:
-            - sysctl_net_ipv6_conf_all_accept_redirects
-        status: automated
-
-    -   id: RHEL-09-254020
-        levels:
-            - medium
-        title: RHEL 9 must not forward IPv6 source-routed packets.
-        rules:
-            - sysctl_net_ipv6_conf_all_accept_source_route
-        status: automated
-
-    -   id: RHEL-09-254025
-        levels:
-            - medium
-        title: RHEL 9 must not enable IPv6 packet forwarding unless the system is a router.
-        rules:
-            - sysctl_net_ipv6_conf_all_forwarding
-        status: automated
-
-    -   id: RHEL-09-254030
-        levels:
-            - medium
-        title: RHEL 9 must not accept router advertisements on all IPv6 interfaces by default.
-        rules:
-            - sysctl_net_ipv6_conf_default_accept_ra
-        status: automated
-
-    -   id: RHEL-09-254035
-        levels:
-            - medium
-        title:
-            RHEL 9 must prevent IPv6 Internet Control Message Protocol (ICMP) redirect
-            messages from being accepted.
-        rules:
-            - sysctl_net_ipv6_conf_default_accept_redirects
-        status: automated
-
-    -   id: RHEL-09-254040
-        levels:
-            - medium
-        title: RHEL 9 must not forward IPv6 source-routed packets by default.
-        rules:
-            - sysctl_net_ipv6_conf_default_accept_source_route
-        status: automated
-
-    -   id: RHEL-09-255010
-        levels:
-            - medium
-        title: All RHEL 9 networked systems must have SSH installed.
-        rules:
-            - package_openssh-server_installed
-        status: automated
-
-    -   id: RHEL-09-255015
-        levels:
-            - medium
-        title:
-            All RHEL 9 networked systems must have and implement SSH to protect the confidentiality
-            and integrity of transmitted and received information, as well as information
-            during preparation for transmission.
-        rules:
-            - service_sshd_enabled
-        status: automated
-
-    -   id: RHEL-09-255020
-        levels:
-            - medium
-        title: RHEL 9 must have the openssh-clients package installed.
-        rules:
-            - package_openssh-clients_installed
-        status: automated
-
-    -   id: RHEL-09-255025
-        levels:
-            - medium
-        title:
-            RHEL 9 must display the Standard Mandatory DOD Notice and Consent Banner
-            before granting local or remote access to the system via a SSH logon.
-        rules:
-            - sshd_enable_warning_banner
-        status: automated
-
-    -   id: RHEL-09-255030
-        levels:
-            - medium
-        title: RHEL 9 must log SSH connection attempts and failures to the server.
-        rules:
-            - sshd_set_loglevel_verbose
-        status: automated
-
-    -   id: RHEL-09-255035
-        levels:
-            - medium
-        title: RHEL 9 SSHD must accept public key authentication.
-        rules:
-            - sshd_enable_pubkey_auth
-        status: automated
-
-    -   id: RHEL-09-255040
-        levels:
-            - high
-        title: RHEL 9 SSHD must not allow blank passwords.
-        rules:
-            - sshd_disable_empty_passwords
-        status: automated
-
-    -   id: RHEL-09-255045
-        levels:
-            - medium
-        title:
-            RHEL 9 must not permit direct logons to the root account using remote access
-            via SSH.
-        rules:
-            - sshd_disable_root_login
-        status: automated
-
-    -   id: RHEL-09-255050
-        levels:
-            - high
-        title:
-            RHEL 9 must enable the Pluggable Authentication Module (PAM) interface for
-            SSHD.
-        rules:
-            - sshd_enable_pam
-        status: automated
-
-    -   id: RHEL-09-255055
-        levels:
-            - medium
-        title: RHEL 9 SSH daemon must be configured to use system-wide crypto policies.
-        rules:
-            - file_sshd_50_redhat_exists
-            - sshd_include_crypto_policy
-        status: automated
-
-    -   id: RHEL-09-255060
-        levels:
-            - medium
-        title:
-            RHEL 9 must implement DOD-approved encryption ciphers to protect the confidentiality
-            of SSH client connections.
-        rules:
-            - sshd_include_crypto_policy
-        status: automated
-    -   id: RHEL-09-255064
-        title: The RHEL 9 SSH client must be configured to use only DOD-approved encryption ciphers employing FIPS 140-3 validated cryptographic hash algorithms to protect the confidentiality of SSH client connections.
-        levels:
-            - medium
-        rules:
-            - harden_sshd_ciphers_openssh_conf_crypto_policy
-            - sshd_approved_ciphers=stig_rhel9
-    -   id: RHEL-09-255065
-        levels:
-            - medium
-        title:
-            RHEL 9 must implement DOD-approved encryption ciphers to protect the confidentiality
-            of SSH server connections.
-        rules:
-            - harden_sshd_ciphers_opensshserver_conf_crypto_policy
-            - sshd_approved_ciphers=stig_rhel9
-        status: automated
-    -   id: RHEL-09-255070
-        levels:
-            - medium
-        title: The RHEL 9 SSH client must be configured to use only DOD-approved Message Authentication Codes (MACs) employing FIPS 140-3 validated cryptographic hash algorithms to protect the confidentiality of SSH client connections.
-        rules:
-            - harden_sshd_macs_openssh_conf_crypto_policy
-            - sshd_approved_macs=stig_rhel9
-
-    -   id: RHEL-09-255075
-        levels:
-            - medium
-        title:
-            RHEL 9 SSH server must be configured to use only Message Authentication Codes
-            (MACs) employing FIPS 140-3 validated cryptographic hash algorithms.
-        status: automated
-        rules:
-            - harden_sshd_macs_opensshserver_conf_crypto_policy
-            - sshd_approved_macs=stig_rhel9
-
-    -   id: RHEL-09-255080
-        levels:
-            - medium
-        title: RHEL 9 must not allow a noncertificate trusted host SSH logon to the system.
-        rules:
-            - disable_host_auth
-        status: automated
-
-    -   id: RHEL-09-255085
-        levels:
-            - medium
-        title: RHEL 9 must not allow users to override SSH environment variables.
-        rules:
-            - sshd_do_not_permit_user_env
-        status: automated
-
-    -   id: RHEL-09-255090
-        levels:
-            - medium
-        title:
-            RHEL 9 must force a frequent session key renegotiation for SSH connections
-            to the server.
-        rules:
-            - sshd_rekey_limit
-            - var_rekey_limit_size=1G
-            - var_rekey_limit_time=1hour
-        status: automated
-
-    -   id: RHEL-09-255095
-        levels:
-            - medium
-        title:
-            RHEL 9 must be configured so that all network connections associated with
-            SSH traffic terminate after becoming unresponsive.
-        rules:
-            - sshd_set_keepalive
-            - var_sshd_set_keepalive=1
-        status: automated
-
-    -   id: RHEL-09-255100
-        levels:
-            - medium
-        title:
-            RHEL 9 must be configured so that all network connections associated with
-            SSH traffic are terminated after 10 minutes of becoming unresponsive.
-        rules:
-            - sshd_set_idle_timeout
-            - sshd_idle_timeout_value=10_minutes
-        status: automated
-
-    -   id: RHEL-09-255105
-        levels:
-            - medium
-        title: RHEL 9 SSH server configuration file must be group-owned by root.
-        rules:
-            - file_groupowner_sshd_config
-            - directory_groupowner_sshd_config_d
-            - file_groupowner_sshd_drop_in_config
-        status: automated
-
-    -   id: RHEL-09-255110
-        levels:
-            - medium
-        title: RHEL 9 SSH server configuration file must be owned by root.
-        rules:
-            - file_owner_sshd_config
-            - directory_owner_sshd_config_d
-            - file_owner_sshd_drop_in_config
-        status: automated
-
-    -   id: RHEL-09-255115
-        levels:
-            - medium
-        title: RHEL 9 SSH server configuration file must have mode 0600 or less permissive.
-        rules:
-            - file_permissions_sshd_config
-            - directory_permissions_sshd_config_d
-            - file_permissions_sshd_drop_in_config
-        status: automated
-
-    -   id: RHEL-09-255120
-        levels:
-            - medium
-        title: RHEL 9 SSH private host key files must have mode 0640 or less permissive.
-        rules:
-            - file_permissions_sshd_private_key
-        status: automated
-
-    -   id: RHEL-09-255125
-        levels:
-            - medium
-        title: RHEL 9 SSH public host key files must have mode 0644 or less permissive.
-        rules:
-            - file_permissions_sshd_pub_key
-        status: automated
-
-    -   id: RHEL-09-255130
-        levels:
-            - medium
-        title:
-            RHEL 9 SSH daemon must not allow compression or must only allow compression
-            after successful authentication.
-        rules:
-            - sshd_disable_compression
-            - var_sshd_disable_compression=no
-        status: automated
-
-    -   id: RHEL-09-255135
-        levels:
-            - medium
-        title: RHEL 9 SSH daemon must not allow GSSAPI authentication.
-        rules:
-            - sshd_disable_gssapi_auth
-        status: automated
-
-    -   id: RHEL-09-255140
-        levels:
-            - medium
-        title: RHEL 9 SSH daemon must not allow Kerberos authentication.
-        rules:
-            - sshd_disable_kerb_auth
-        status: automated
-
-    -   id: RHEL-09-255145
-        levels:
-            - medium
-        title: RHEL 9 SSH daemon must not allow rhosts authentication.
-        rules:
-            - sshd_disable_rhosts
-        status: automated
-
-    -   id: RHEL-09-255150
-        levels:
-            - medium
-        title: RHEL 9 SSH daemon must not allow known hosts authentication.
-        rules:
-            - sshd_disable_user_known_hosts
-        status: automated
-
-    -   id: RHEL-09-255155
-        levels:
-            - medium
-        title: RHEL 9 SSH daemon must disable remote X connections for interactive users.
-        rules:
-            - sshd_disable_x11_forwarding
-        status: automated
-
-    -   id: RHEL-09-255160
-        levels:
-            - medium
-        title:
-            RHEL 9 SSH daemon must perform strict mode checking of home directory configuration
-            files.
-        rules:
-            - sshd_enable_strictmodes
-        status: automated
-
-    -   id: RHEL-09-255165
-        levels:
-            - medium
-        title:
-            RHEL 9 SSH daemon must display the date and time of the last successful account
-            logon upon an SSH logon.
-        rules:
-            - sshd_print_last_log
-        status: automated
-
-    -   id: RHEL-09-255175
-        levels:
-            - medium
-        title:
-            RHEL 9 SSH daemon must prevent remote hosts from connecting to the proxy
-            display.
-        rules:
-            - sshd_x11_use_localhost
-        status: automated
-
-    -   id: RHEL-09-271010
-        levels:
-            - medium
-        title:
-            RHEL 9 must display the Standard Mandatory DOD Notice and Consent Banner
-            before granting local or remote access to the system via a graphical user logon.
-        rules:
-            - dconf_gnome_banner_enabled
-        status: automated
-
-    -   id: RHEL-09-271015
-        levels:
-            - medium
-        title:
-            RHEL 9 must prevent a user from overriding the banner-message-enable setting
-            for the graphical user interface.
-        rules:
-            - dconf_gnome_banner_enabled
-        status: automated
-
-    -   id: RHEL-09-271020
-        levels:
-            - medium
-        title:
-            RHEL 9 must disable the graphical user interface automount function unless
-            required.
-        rules:
-            - dconf_gnome_disable_automount_open
-        status: automated
-
-    -   id: RHEL-09-271025
-        levels:
-            - medium
-        title:
-            RHEL 9 must prevent a user from overriding the disabling of the graphical
-            user interface automount function.
-        rules:
-            - dconf_gnome_disable_automount_open
-        status: automated
-
-    -   id: RHEL-09-271030
-        levels:
-            - medium
-        title:
-            RHEL 9 must disable the graphical user interface autorun function unless
-            required.
-        rules:
-            - dconf_gnome_disable_autorun
-        status: automated
-
-    -   id: RHEL-09-271035
-        levels:
-            - medium
-        title:
-            RHEL 9 must prevent a user from overriding the disabling of the graphical
-            user interface autorun function.
-        rules:
-            - dconf_gnome_disable_autorun
-        status: automated
-
-    -   id: RHEL-09-271040
-        levels:
-            - high
-        title:
-            RHEL 9 must not allow unattended or automatic logon via the graphical user
-            interface.
-        rules:
-            - gnome_gdm_disable_automatic_login
-        status: automated
-
-    -   id: RHEL-09-271045
-        levels:
-            - medium
-        title:
-            RHEL 9 must be able to initiate directly a session lock for all connection
-            types using smart card when the smart card is removed.
-        rules:
-            - dconf_gnome_lock_screen_on_smartcard_removal
-        status: automated
-
-    -   id: RHEL-09-271050
-        levels:
-            - medium
-        title:
-            RHEL 9 must prevent a user from overriding the disabling of the graphical
-            user smart card removal action.
-        rules:
-            - dconf_gnome_lock_screen_on_smartcard_removal
-        status: automated
-
-    -   id: RHEL-09-271055
-        levels:
-            - medium
-        title:
-            RHEL 9 must enable a user session lock until that user re-establishes access
-            using established identification and authentication procedures for graphical user
-            sessions.
-        rules:
-            - dconf_gnome_screensaver_lock_enabled
-        status: automated
-
-    -   id: RHEL-09-271060
-        levels:
-            - medium
-        title:
-            RHEL 9 must prevent a user from overriding the screensaver lock-enabled setting
-            for the graphical user interface.
-        rules:
-            - dconf_gnome_screensaver_lock_enabled
-        status: automated
-
-    -   id: RHEL-09-271065
-        levels:
-            - medium
-        title:
-            RHEL 9 must automatically lock graphical user sessions after 15 minutes of
-            inactivity.
-        rules:
-            - dconf_gnome_screensaver_idle_delay
-        status: automated
-
-    -   id: RHEL-09-271070
-        levels:
-            - medium
-        title:
-            RHEL 9 must prevent a user from overriding the session idle-delay setting
-            for the graphical user interface.
-        rules:
-            - dconf_gnome_session_idle_user_locks
-        status: automated
-
-    -   id: RHEL-09-271075
-        levels:
-            - medium
-        title:
-            RHEL 9 must initiate a session lock for graphical user interfaces when the
-            screensaver is activated.
-        rules:
-            - dconf_gnome_screensaver_lock_delay
-        status: automated
-
-    -   id: RHEL-09-271080
-        levels:
-            - medium
-        title:
-            RHEL 9 must prevent a user from overriding the session lock-delay setting
-            for the graphical user interface.
-        rules:
-            - dconf_gnome_screensaver_user_locks
-        status: automated
-
-    -   id: RHEL-09-271085
-        levels:
-            - medium
-        title:
-            RHEL 9 must conceal, via the session lock, information previously visible
-            on the display with a publicly viewable image.
-        rules:
-            - dconf_gnome_screensaver_mode_blank
-        status: automated
-
-    -   id: RHEL-09-271090
-        levels:
-            - medium
-        title: RHEL 9 effective dconf policy must match the policy keyfiles.
-        rules:
-            - dconf_db_up_to_date
-        status: automated
-
-    -   id: RHEL-09-271095
-        levels:
-            - medium
-        title:
-            RHEL 9 must disable the ability of a user to restart the system from the
-            login screen.
-        rules:
-            - dconf_gnome_disable_restart_shutdown
-        status: automated
-
-    -   id: RHEL-09-271100
-        levels:
-            - medium
-        title:
-            RHEL 9 must prevent a user from overriding the disable-restart-buttons setting
-            for the graphical user interface.
-        rules:
-            - dconf_gnome_disable_restart_shutdown
-        status: automated
-
-    -   id: RHEL-09-271105
-        levels:
-            - medium
-        title:
-            RHEL 9 must disable the ability of a user to accidentally press Ctrl-Alt-Del
-            and cause a system to shut down or reboot.
-        rules:
-            - dconf_gnome_disable_ctrlaltdel_reboot
-        status: automated
-
-    -   id: RHEL-09-271110
-        levels:
-            - medium
-        title:
-            RHEL 9 must prevent a user from overriding the Ctrl-Alt-Del sequence settings
-            for the graphical user interface.
-        rules:
-            - dconf_gnome_disable_ctrlaltdel_reboot
-        status: automated
-
-    -   id: RHEL-09-271115
-        levels:
-            - medium
-        title: RHEL 9 must disable the user list at logon for graphical user interfaces.
-        rules:
-            - dconf_gnome_disable_user_list
-        status: automated
-
-    -   id: RHEL-09-291010
-        levels:
-            - medium
-        title: RHEL 9 must be configured to disable USB mass storage.
-        rules:
-            - kernel_module_usb-storage_disabled
-        status: automated
-
-    -   id: RHEL-09-291015
-        levels:
-            - medium
-        title: RHEL 9 must have the USBGuard package installed.
-        rules:
-            - package_usbguard_installed
-        status: automated
-
-    -   id: RHEL-09-291020
-        levels:
-            - medium
-        title: RHEL 9 must have the USBGuard package enabled.
-        rules:
-            - service_usbguard_enabled
-        status: automated
-
-    -   id: RHEL-09-291025
-        levels:
-            - low
-        title: RHEL 9 must enable Linux audit logging for the USBGuard daemon.
-        rules:
-            - configure_usbguard_auditbackend
-        status: automated
-
-    -   id: RHEL-09-291030
-        levels:
-            - medium
-        title: RHEL 9 must block unauthorized peripherals before establishing a connection.
-        rules:
-            - usbguard_generate_policy
-        status: automated
-
-    -   id: RHEL-09-291035
-        levels:
-            - medium
-        title: RHEL 9 Bluetooth must be disabled.
-        rules:
-            - kernel_module_bluetooth_disabled
-        status: automated
-
-    -   id: RHEL-09-291040
-        levels:
-            - medium
-        title: RHEL 9 wireless network adapters must be disabled.
-        rules:
-            - wireless_disable_interfaces
-        status: automated
-
-    -   id: RHEL-09-411010
-        levels:
-            - medium
-        title:
-            RHEL 9 user account passwords for new users or password changes must have
-            a 60-day maximum password lifetime restriction in /etc/login.defs.
-        rules:
-            - accounts_maximum_age_login_defs
-        status: automated
-
-    -   id: RHEL-09-411015
-        levels:
-            - medium
-        title:
-            RHEL 9 user account passwords must have a 60-day maximum password lifetime
-            restriction.
-        rules:
-            - accounts_password_set_max_life_existing
-            - var_accounts_maximum_age_login_defs=60
-        status: automated
-
-    -   id: RHEL-09-411020
-        levels:
-            - medium
-        title:
-            All RHEL 9 local interactive user accounts must be assigned a home directory
-            upon creation.
-        rules:
-            - accounts_have_homedir_login_defs
-        status: automated
-
-    -   id: RHEL-09-411025
-        levels:
-            - medium
-        title: RHEL 9 must set the umask value to 077 for all local interactive user accounts.
-        rules:
-            - accounts_umask_interactive_users
-            - var_accounts_user_umask=077
-        status: automated
-
-    -   id: RHEL-09-411030
-        levels:
-            - medium
-        title: RHEL 9 duplicate User IDs (UIDs) must not exist for interactive users.
-        rules:
-            - account_unique_id
-        status: automated
-
-    -   id: RHEL-09-411035
-        levels:
-            - medium
-        title: RHEL 9 system accounts must not have an interactive login shell.
-        rules:
-            - no_shelllogin_for_systemaccounts
-        status: automated
-
-    -   id: RHEL-09-411040
-        levels:
-            - medium
-        title: RHEL 9 must automatically expire temporary accounts within 72 hours.
-        rules:
-            - account_temp_expire_date
-        status: automated
-
-    -   id: RHEL-09-411045
-        levels:
-            - medium
-        title: All RHEL 9 interactive users must have a primary group that exists.
-        rules:
-            - gid_passwd_group_same
-        status: automated
-
-    -   id: RHEL-09-411050
-        levels:
-            - medium
-        title:
-            RHEL 9 must disable account identifiers (individuals, groups, roles, and
-            devices) after 35 days of inactivity.
-        rules:
-            - account_disable_post_pw_expiration
-            - var_account_disable_post_pw_expiration=35
-        status: automated
-
-    -   id: RHEL-09-411055
-        levels:
-            - medium
-        title:
-            Executable search paths within the initialization files of all local interactive
-            RHEL 9 users must only contain paths that resolve to the system default or the
-            users home directory.
-        rules:
-            - accounts_user_home_paths_only
-        status: automated
-
-    -   id: RHEL-09-411060
-        levels:
-            - medium
-        title:
-            All RHEL 9 local interactive users must have a home directory assigned in
-            the /etc/passwd file.
-        rules:
-            - accounts_user_interactive_home_directory_defined
-        status: automated
-
-    -   id: RHEL-09-411065
-        levels:
-            - medium
-        title:
-            All RHEL 9 local interactive user home directories defined in the /etc/passwd
-            file must exist.
-        rules:
-            - accounts_user_interactive_home_directory_exists
-        status: automated
-
-    -   id: RHEL-09-411070
-        levels:
-            - medium
-        title:
-            All RHEL 9 local interactive user home directories must be group-owned by
-            the home directory owner's primary group.
-        rules:
-            - file_groupownership_home_directories
-        status: automated
-
-    -   id: RHEL-09-411075
-        levels:
-            - medium
-        title:
-            RHEL 9 must automatically lock an account when three unsuccessful logon attempts
-            occur.
-        rules:
-            - accounts_passwords_pam_faillock_deny
-            - var_accounts_passwords_pam_faillock_deny=3
-        status: automated
-
-    -   id: RHEL-09-411080
-        levels:
-            - medium
-        title:
-            RHEL 9 must automatically lock the root account until the root account is
-            released by an administrator when three unsuccessful logon attempts occur during
-            a 15-minute time period.
-        rules:
-            - accounts_passwords_pam_faillock_deny_root
-        status: automated
-
-    -   id: RHEL-09-411085
-        levels:
-            - medium
-        title:
-            RHEL 9 must automatically lock an account when three unsuccessful logon attempts
-            occur during a 15-minute time period.
-        rules:
-            - accounts_passwords_pam_faillock_interval
-            - var_accounts_passwords_pam_faillock_fail_interval=900
-        status: automated
-
-    -   id: RHEL-09-411090
-        levels:
-            - medium
-        title:
-            RHEL 9 must maintain an account lock until the locked account is released
-            by an administrator.
-        rules:
-            - accounts_passwords_pam_faillock_unlock_time
-            - var_accounts_passwords_pam_faillock_unlock_time=never
-        status: automated
-
-    -   id: RHEL-09-411095
-        levels:
-            - medium
-        title: RHEL 9 must not have unauthorized accounts.
-        rules:
-            - accounts_authorized_local_users
-            - var_accounts_authorized_local_users_regex=rhel9
-        status: automated
-
-    -   id: RHEL-09-411100
-        levels:
-            - high
-        title:
-            The root account must be the only account having unrestricted access to RHEL
-            9 system.
-        rules:
-            - accounts_no_uid_except_zero
-        status: automated
-
-    -   id: RHEL-09-411105
-        levels:
-            - medium
-        title: RHEL 9 must ensure account lockouts persist.
-        rules:
-            - accounts_passwords_pam_faillock_dir
-        status: automated
-
-    -   id: RHEL-09-411110
-        levels:
-            - medium
-        title: RHEL 9 groups must have unique Group ID (GID).
-        rules:
-            - group_unique_id
-        status: automated
-
-    -   id: RHEL-09-411115
-        levels:
-            - medium
-        title: Local RHEL 9 initialization files must not execute world-writable programs.
-        rules:
-            - accounts_user_dot_no_world_writable_programs
-        status: automated
-
-    -   id: RHEL-09-412035
-        levels:
-            - medium
-        title:
-            RHEL 9 must automatically exit interactive command shell user sessions after
-            15 minutes of inactivity.
-        rules:
-            - accounts_tmout
-            - var_accounts_tmout=10_min
-        status: automated
-
-    -   id: RHEL-09-412040
-        levels:
-            - low
-        title:
-            RHEL 9 must limit the number of concurrent sessions to ten for all accounts
-            and/or account types.
-        rules:
-            - accounts_max_concurrent_login_sessions
-            - var_accounts_max_concurrent_login_sessions=10
-        status: automated
-
-    -   id: RHEL-09-412045
-        levels:
-            - medium
-        title: RHEL 9 must log username information when unsuccessful logon attempts occur.
-        rules:
-            - accounts_passwords_pam_faillock_audit
-        status: automated
-
-    -   id: RHEL-09-412050
-        levels:
-            - medium
-        title:
-            RHEL 9 must enforce a delay of at least four seconds between logon prompts
-            following a failed logon attempt.
-        rules:
-            - accounts_logon_fail_delay
-            - var_accounts_fail_delay=4
-        status: automated
-
-    -   id: RHEL-09-412055
-        levels:
-            - medium
-        title: RHEL 9 must define default permissions for the bash shell.
-        rules:
-            - accounts_umask_etc_bashrc
-        status: automated
-
-    -   id: RHEL-09-412060
-        levels:
-            - medium
-        title: RHEL 9 must define default permissions for the c shell.
-        rules:
-            - accounts_umask_etc_csh_cshrc
-        status: automated
-
-    -   id: RHEL-09-412065
-        levels:
-            - medium
-        title:
-            RHEL 9 must define default permissions for all authenticated users in such
-            a way that the user can only read and modify their own files.
-        rules:
-            - accounts_umask_etc_login_defs
-        status: automated
-
-    -   id: RHEL-09-412070
-        levels:
-            - medium
-        title: RHEL 9 must define default permissions for the system default profile.
-        rules:
-            - accounts_umask_etc_profile
-        status: automated
-
-    -   id: RHEL-09-412075
-        levels:
-            - low
-        title:
-            RHEL 9 must display the date and time of the last successful account logon
-            upon logon.
-        rules:
-            - display_login_attempts
-        status: automated
-
-    -   id: RHEL-09-412080
-        levels:
-            - medium
-        title: RHEL 9 must terminate idle user sessions.
-        rules:
-            - logind_session_timeout
-            - var_logind_session_timeout=10_minutes
-        status: automated
-
-    -   id: RHEL-09-431010
-        levels:
-            - high
-        title:
-            RHEL 9 must use a Linux Security Module configured to enforce limits on system
-            services.
-        rules:
-            - selinux_state
-            - var_selinux_state=enforcing
-        status: automated
-
-    -   id: RHEL-09-431015
-        levels:
-            - medium
-        title: RHEL 9 must enable the SELinux targeted policy.
-        rules:
-            - selinux_policytype
-            - var_selinux_policy_name=targeted
-        status: automated
-
-
-    -   id: RHEL-09-431016
-        title: 'RHEL 9 must elevate the SELinux context when an administrator calls the sudo command.'
-        rules:
-            - selinux_context_elevation_for_sudo
-        status: automated
-
-
-    -   id: RHEL-09-431020
-        levels:
-            - medium
-        title:
-            RHEL 9 must configure SELinux context type to allow the use of a nondefault
-            faillock tally directory.
-        rules:
-            - account_password_selinux_faillock_dir
-        status: automated
-
-    -   id: RHEL-09-431025
-        levels:
-            - medium
-        title: RHEL 9 must have policycoreutils package installed.
-        rules:
-            - package_policycoreutils_installed
-        status: automated
-
-    -   id: RHEL-09-431030
-        levels:
-            - medium
-        title: RHEL 9 policycoreutils-python-utils package must be installed.
-        rules:
-            - package_policycoreutils-python-utils_installed
-        status: automated
-
-    -   id: RHEL-09-432010
-        levels:
-            - medium
-        title: RHEL 9 must have the sudo package installed.
-        rules:
-            - package_sudo_installed
-        status: automated
-
-    -   id: RHEL-09-432015
-        levels:
-            - medium
-        title: RHEL 9 must require reauthentication when using the "sudo" command.
-        rules:
-            - sudo_require_reauthentication
-            - var_sudo_timestamp_timeout=always_prompt
-        status: automated
-
-    -   id: RHEL-09-432020
-        levels:
-            - medium
-        title:
-            RHEL 9 must use the invoking user's password for privilege escalation when
-            using "sudo".
-        rules:
-            - sudoers_validate_passwd
-        status: automated
-
-    -   id: RHEL-09-432025
-        levels:
-            - medium
-        title: RHEL 9 must require users to reauthenticate for privilege escalation.
-        rules:
-            - sudo_remove_no_authenticate
-        status: automated
-
-    -   id: RHEL-09-432030
-        levels:
-            - medium
-        title: RHEL 9 must restrict privilege elevation to authorized personnel.
-        rules:
-            - sudo_restrict_privilege_elevation_to_authorized
-        status: automated
-
-    -   id: RHEL-09-432035
-        levels:
-            - medium
-        title: RHEL 9 must restrict the use of the "su" command.
-        rules:
-            - use_pam_wheel_for_su
-        status: automated
-
-    -   id: RHEL-09-433010
-        levels:
-            - medium
-        title: RHEL 9 fapolicy module must be installed.
-        rules:
-            - package_fapolicyd_installed
-        status: automated
-
-    -   id: RHEL-09-433015
-        levels:
-            - medium
-        title: RHEL 9 fapolicy module must be enabled.
-        rules:
-            - service_fapolicyd_enabled
-        status: automated
-
-    -   id: RHEL-09-433016
-        levels:
-            - medium
-        title: The RHEL 9 fapolicy module must be configured to employ a deny-all, permit-by-exception policy to allow the execution of authorized software programs.
-        rules:
-            - fapolicy_default_deny
-        status: automated
-
-    -   id: RHEL-09-611010
-        levels:
-            - medium
-        title:
-            RHEL 9 must ensure the password complexity module in the system-auth file
-            is configured for three retries or less.
-        rules:
-            - accounts_password_pam_pwquality_retry
-            - var_password_pam_retry=3
-        status: automated
-
-    -   id: RHEL-09-611025
-        levels:
-            - high
-        title: RHEL 9 must not allow blank or null passwords.
-        rules:
-            - no_empty_passwords
-        status: automated
-
-    -   id: RHEL-09-611030
-        levels:
-            - medium
-        title:
-            RHEL 9 must configure the use of the pam_faillock.so module in the /etc/pam.d/system-auth
-            file.
-        rules:
-            - account_password_pam_faillock_system_auth
-        status: automated
-
-    -   id: RHEL-09-611035
-        levels:
-            - medium
-        title:
-            RHEL 9 must configure the use of the pam_faillock.so module in the /etc/pam.d/password-auth
-            file.
-        rules:
-            - account_password_pam_faillock_password_auth
-        status: automated
-
-    -   id: RHEL-09-611040
-        levels:
-            - medium
-        title:
-            RHEL 9 must ensure the password complexity module is enabled in the password-auth
-            file.
-        rules:
-            - accounts_password_pam_pwquality_password_auth
-        status: automated
-
-    -   id: RHEL-09-611045
-        levels:
-            - medium
-        title:
-            RHEL 9 must ensure the password complexity module is enabled in the system-auth
-            file.
-        rules:
-            - accounts_password_pam_pwquality_system_auth
-        status: automated
-
-    -   id: RHEL-09-611050
-        levels:
-            - medium
-        title:
-            RHEL 9 password-auth must be configured to use a sufficient number of hashing
-            rounds.
-        rules:
-            - accounts_password_pam_unix_rounds_password_auth
-            - var_password_pam_unix_rounds=100000
-        status: automated
-
-    -   id: RHEL-09-611055
-        levels:
-            - medium
-        title:
-            RHEL 9 system-auth must be configured to use a sufficient number of hashing
-            rounds.
-        rules:
-            - accounts_password_pam_unix_rounds_system_auth
-        status: automated
-
-    -   id: RHEL-09-611060
-        levels:
-            - medium
-        title: RHEL 9 must enforce password complexity rules for the root account.
-        rules:
-            - accounts_password_pam_enforce_root
-        status: automated
-
-    -   id: RHEL-09-611065
-        levels:
-            - medium
-        title:
-            RHEL 9 must enforce password complexity by requiring that at least one lowercase
-            character be used.
-        rules:
-            - accounts_password_pam_lcredit
-            - var_password_pam_lcredit=1
-        status: automated
-
-    -   id: RHEL-09-611070
-        levels:
-            - medium
-        title:
-            RHEL 9 must enforce password complexity by requiring that at least one numeric
-            character be used.
-        rules:
-            - accounts_password_pam_dcredit
-            - var_password_pam_dcredit=1
-        status: automated
-
-    -   id: RHEL-09-611075
-        levels:
-            - medium
-        title:
-            RHEL 9 passwords for new users or password changes must have a 24 hours minimum
-            password lifetime restriction in /etc/login.defs.
-        rules:
-            - accounts_minimum_age_login_defs
-        status: automated
-
-    -   id: RHEL-09-611080
-        levels:
-            - medium
-        title:
-            RHEL 9 passwords must have a 24 hours minimum password lifetime restriction
-            in /etc/shadow.
-        rules:
-            - accounts_password_set_min_life_existing
-            - var_accounts_minimum_age_login_defs=1
-        status: automated
-
-    -   id: RHEL-09-611085
-        levels:
-            - medium
-        title: RHEL 9 must require users to provide a password for privilege escalation.
-        rules:
-            - sudo_remove_nopasswd
-        status: automated
-
-    -   id: RHEL-09-611090
-        levels:
-            - medium
-        title: RHEL 9 passwords must be created with a minimum of 15 characters.
-        rules:
-            - accounts_password_pam_minlen
-            - var_password_pam_minlen=15
-        status: automated
-
-    -   id: RHEL-09-611100
-        levels:
-            - medium
-        title:
-            RHEL 9 must enforce password complexity by requiring that at least one special
-            character be used.
-        rules:
-            - accounts_password_pam_ocredit
-            - var_password_pam_ocredit=1
-        status: automated
-
-    -   id: RHEL-09-611105
-        levels:
-            - medium
-        title: RHEL 9 must prevent the use of dictionary words for passwords.
-        rules:
-            - accounts_password_pam_dictcheck
-            - var_password_pam_dictcheck=1
-        status: automated
-
-    -   id: RHEL-09-611110
-        levels:
-            - medium
-        title:
-            RHEL 9 must enforce password complexity by requiring that at least one uppercase
-            character be used.
-        rules:
-            - accounts_password_pam_ucredit
-            - var_password_pam_ucredit=1
-        status: automated
-
-    -   id: RHEL-09-611115
-        levels:
-            - medium
-        title:
-            RHEL 9 must require the change of at least eight characters when passwords
-            are changed.
-        rules:
-            - accounts_password_pam_difok
-            - var_password_pam_difok=8
-        status: automated
-
-    -   id: RHEL-09-611120
-        levels:
-            - medium
-        title:
-            RHEL 9 must require the maximum number of repeating characters of the same
-            character class be limited to four when passwords are changed.
-        rules:
-            - accounts_password_pam_maxclassrepeat
-            - var_password_pam_maxclassrepeat=4
-        status: automated
-
-    -   id: RHEL-09-611125
-        levels:
-            - medium
-        title:
-            RHEL 9 must require the maximum number of repeating characters be limited
-            to three when passwords are changed.
-        rules:
-            - accounts_password_pam_maxrepeat
-            - var_password_pam_maxrepeat=3
-        status: automated
-
-    -   id: RHEL-09-611130
-        levels:
-            - medium
-        title:
-            RHEL 9 must require the change of at least four character classes when passwords
-            are changed.
-        rules:
-            - accounts_password_pam_minclass
-            - var_password_pam_minclass=4
-        status: automated
-
-    -   id: RHEL-09-611135
-        levels:
-            - medium
-        title:
-            RHEL 9 must be configured so that user and group account administration utilities
-            are configured to store only encrypted representations of passwords.
-        rules:
-            - set_password_hashing_algorithm_libuserconf
-            - var_password_hashing_algorithm_pam=sha512
-        status: automated
-
-    -   id: RHEL-09-611140
-        levels:
-            - medium
-        title:
-            RHEL 9 must be configured to use the shadow file to store only encrypted
-            representations of passwords.
-        rules:
-            - set_password_hashing_algorithm_logindefs
-            - var_password_hashing_algorithm=SHA512
-        status: automated
-
-    -   id: RHEL-09-611145
-        levels:
-            - medium
-        title:
-            RHEL 9 must not be configured to bypass password requirements for privilege
-            escalation.
-        rules:
-            - disallow_bypass_password_sudo
-        status: automated
-
-    -   id: RHEL-09-611155
-        levels:
-            - medium
-        title: RHEL 9 must not have accounts configured with blank or null passwords.
-        rules:
-            - no_empty_passwords_etc_shadow
-        status: automated
-
-    -   id: RHEL-09-611160
-        levels:
-            - medium
-        title: RHEL 9 must use the CAC smart card driver.
-        rules:
-            - configure_opensc_card_drivers
-            - var_smartcard_drivers=cac
-        status: automated
-
-    -   id: RHEL-09-611165
-        levels:
-            - medium
-        title: RHEL 9 must enable certificate based smart card authentication.
-        rules:
-            - sssd_enable_smartcards
-        status: automated
-
-    -   id: RHEL-09-611170
-        levels:
-            - medium
-        title: RHEL 9 must implement certificate status checking for multifactor authentication.
-        rules:
-            - sssd_certificate_verification
-            - var_sssd_certificate_verification_digest_function=sha512
-        status: automated
-
-    -   id: RHEL-09-611175
-        levels:
-            - medium
-        title: RHEL 9 must have the pcsc-lite package installed.
-        rules:
-            - package_pcsc-lite_installed
-        status: automated
-
-    -   id: RHEL-09-611180
-        levels:
-            - medium
-        title: The pcscd service on RHEL 9 must be active.
-        rules:
-            - service_pcscd_enabled
-        status: automated
-
-    -   id: RHEL-09-611185
-        levels:
-            - medium
-        title: RHEL 9 must have the opensc package installed.
-        rules:
-            - package_opensc_installed
-        status: automated
-
-    -   id: RHEL-09-611190
-        levels:
-            - medium
-        title:
-            RHEL 9, for PKI-based authentication, must enforce authorized access to the
-            corresponding private key.
-        rules:
-            - ssh_keys_passphrase_protected
-        status: automated
-
-    -   id: RHEL-09-611195
-        levels:
-            - medium
-        title: RHEL 9 must require authentication to access emergency mode.
-        rules:
-            - require_emergency_target_auth
-        status: automated
-
-    -   id: RHEL-09-611200
-        levels:
-            - medium
-        title: RHEL 9 must require authentication to access single-user mode.
-        rules:
-            - require_singleuser_auth
-        status: automated
-
-    -   id: RHEL-09-631010
-        levels:
-            - medium
-        title:
-            RHEL 9, for PKI-based authentication, must validate certificates by constructing
-            a certification path (which includes status information) to an accepted trust
-            anchor.
-        rules:
-            - sssd_has_trust_anchor
-        status: automated
-
-    -   id: RHEL-09-631015
-        levels:
-            - medium
-        title:
-            RHEL 9 must map the authenticated identity to the user or group account for
-            PKI-based authentication.
-        rules:
-            - sssd_enable_certmap
-        status: automated
-
-    -   id: RHEL-09-631020
-        levels:
-            - medium
-        title: RHEL 9 must prohibit the use of cached authenticators after one day.
-        rules:
-            - sssd_offline_cred_expiration
-        status: automated
-
-    -   id: RHEL-09-651010
-        levels:
-            - medium
-        title: RHEL 9 must have the AIDE package installed.
-        rules:
-            - package_aide_installed
-            - aide_build_database
-        status: automated
-
-    -   id: RHEL-09-651015
-        levels:
-            - medium
-        title:
-            RHEL 9 must routinely check the baseline configuration for unauthorized changes
-            and notify the system administrator when anomalies in the operation of any security
-            functions are discovered.
-        rules:
-            - aide_periodic_cron_checking
-            - aide_scan_notification
-        status: automated
-
-    -   id: RHEL-09-651020
-        levels:
-            - medium
-        title:
-            RHEL 9 must use a file integrity tool that is configured to use FIPS 140-3-approved
-            cryptographic hashes for validating file contents and directories.
-        rules:
-            - aide_use_fips_hashes
-        status: automated
-
-    -   id: RHEL-09-651025
-        levels:
-            - medium
-        title:
-            RHEL 9 must use cryptographic mechanisms to protect the integrity of audit
-            tools.
-        rules:
-            - aide_check_audit_tools
-        status: automated
-
-    -   id: RHEL-09-651030
-        levels:
-            - low
-        title:
-            RHEL 9 must be configured so that the file integrity tool verifies Access
-            Control Lists (ACLs).
-        rules:
-            - aide_verify_acls
-        status: automated
-
-    -   id: RHEL-09-651035
-        levels:
-            - low
-        title:
-            RHEL 9 must be configured so that the file integrity tool verifies extended
-            attributes.
-        rules:
-            - aide_verify_ext_attributes
-        status: automated
-
-    -   id: RHEL-09-652010
-        levels:
-            - medium
-        title: RHEL 9 must have the rsyslog package installed.
-        rules:
-            - package_rsyslog_installed
-        status: automated
-
-    -   id: RHEL-09-652015
-        levels:
-            - medium
-        title:
-            RHEL 9 must have the packages required for encrypting offloaded audit logs
-            installed.
-        rules:
-            - package_rsyslog-gnutls_installed
-        status: automated
-
-    -   id: RHEL-09-652020
-        levels:
-            - medium
-        title: The rsyslog service on RHEL 9 must be active.
-        rules:
-            - service_rsyslog_enabled
-        status: automated
-
-    -   id: RHEL-09-652025
-        levels:
-            - medium
-        title:
-            RHEL 9 must be configured so that the rsyslog daemon does not accept log
-            messages from other servers unless the server is being used for log aggregation.
-        rules:
-            - rsyslog_nolisten
-        status: automated
-
-    -   id: RHEL-09-652030
-        levels:
-            - medium
-        title: All RHEL 9 remote access methods must be monitored.
-        rules:
-            - rsyslog_remote_access_monitoring
-        status: automated
-
-    -   id: RHEL-09-652040
-        levels:
-            - medium
-        title:
-            RHEL 9 must authenticate the remote logging server for offloading audit logs
-            via rsyslog.
-        rules:
-            - rsyslog_encrypt_offload_actionsendstreamdriverauthmode
-        status: automated
-
-    -   id: RHEL-09-652045
-        levels:
-            - medium
-        title:
-            RHEL 9 must encrypt the transfer of audit records offloaded onto a different
-            system or media from the system being audited via rsyslog.
-        rules:
-            - rsyslog_encrypt_offload_actionsendstreamdrivermode
-        status: automated
-
-    -   id: RHEL-09-652050
-        levels:
-            - medium
-        title:
-            RHEL 9 must encrypt via the gtls driver the transfer of audit records offloaded
-            onto a different system or media from the system being audited via rsyslog.
-        rules:
-            - rsyslog_encrypt_offload_defaultnetstreamdriver
-        status: automated
-
-    -   id: RHEL-09-652055
-        levels:
-            - medium
-        title:
-            RHEL 9 must be configured to forward audit records via TCP to a different
-            system or media from the system being audited via rsyslog.
-        rules:
-            - rsyslog_remote_loghost
-        status: automated
-
-    -   id: RHEL-09-652060
-        levels:
-            - medium
-        title: RHEL 9 must use cron logging.
-        rules:
-            - rsyslog_cron_logging
-        status: automated
-
-    -   id: RHEL-09-653010
-        levels:
-            - medium
-        title: RHEL 9 audit package must be installed.
-        rules:
-            - package_audit_installed
-        status: automated
-
-    -   id: RHEL-09-653015
-        levels:
-            - medium
-        title: RHEL 9 audit service must be enabled.
-        rules:
-            - service_auditd_enabled
-        status: automated
-
-    -   id: RHEL-09-653020
-        levels:
-            - medium
-        title:
-            RHEL 9 audit system must take appropriate action when an error writing to
-            the audit storage volume occurs.
-        rules:
-            - auditd_data_disk_error_action_stig
-            - var_auditd_disk_error_action=halt
-        status: automated
-
-    -   id: RHEL-09-653025
-        levels:
-            - medium
-        title:
-            RHEL 9 audit system must take appropriate action when the audit storage volume
-            is full.
-        rules:
-            - auditd_data_disk_full_action_stig
-            - var_auditd_disk_full_action=halt
-        status: automated
-
-    -   id: RHEL-09-653030
-        levels:
-            - medium
-        title:
-            RHEL 9 must allocate audit record storage capacity to store at least one
-            week's worth of audit records.
-        rules:
-            - auditd_audispd_configure_sufficiently_large_partition
-        status: automated
-
-    -   id: RHEL-09-653035
-        levels:
-            - medium
-        title:
-            RHEL 9 must take action when allocated audit record storage volume reaches
-            75 percent of the repository maximum audit record storage capacity.
-        rules:
-            - auditd_data_retention_space_left_percentage
-            - var_auditd_space_left_percentage=25pc
-        status: automated
-
-    -   id: RHEL-09-653040
-        levels:
-            - medium
-        title:
-            RHEL 9 must notify the system administrator (SA) and information system security
-            officer (ISSO) (at a minimum) when allocated audit record storage volume 75 percent
-            utilization.
-        rules:
-            - auditd_data_retention_space_left_action
-            - var_auditd_space_left_action=email
-        status: automated
-
-    -   id: RHEL-09-653045
-        levels:
-            - medium
-        title:
-            RHEL 9 must take action when allocated audit record storage volume reaches
-            95 percent of the audit record storage capacity.
-        rules:
-            - auditd_data_retention_admin_space_left_percentage
-            - var_auditd_admin_space_left_percentage=5pc
-        status: automated
-
-    -   id: RHEL-09-653050
-        levels:
-            - medium
-        title:
-            RHEL 9 must take action when allocated audit record storage volume reaches
-            95 percent of the repository maximum audit record storage capacity.
-        rules:
-            - auditd_data_retention_admin_space_left_action
-            - var_auditd_admin_space_left_action=single
-        status: automated
-
-    -   id: RHEL-09-653055
-        levels:
-            - medium
-        title:
-            RHEL 9 audit system must take appropriate action when the audit files have
-            reached maximum size.
-        rules:
-            - auditd_data_retention_max_log_file_action_stig
-            - var_auditd_max_log_file_action=rotate
-        status: automated
-
-    -   id: RHEL-09-653060
-        levels:
-            - medium
-        title:
-            RHEL 9 must label all offloaded audit logs before sending them to the central
-            log server.
-        rules:
-            - auditd_name_format
-            - var_auditd_name_format=stig
-        status: automated
-
-    -   id: RHEL-09-653065
-        levels:
-            - medium
-        title: RHEL 9 must take appropriate action when the internal event queue is full.
-        rules:
-            - auditd_overflow_action
-        status: automated
-
-    -   id: RHEL-09-653070
-        levels:
-            - medium
-        title:
-            RHEL 9 System Administrator (SA) and/or information system security officer
-            (ISSO) (at a minimum) must be alerted of an audit processing failure event.
-        rules:
-            - auditd_data_retention_action_mail_acct
-            - var_auditd_action_mail_acct=root
-        status: automated
-
-    -   id: RHEL-09-653075
-        levels:
-            - medium
-        title: RHEL 9 audit system must audit local events.
-        rules:
-            - auditd_local_events
-        status: automated
-
-    -   id: RHEL-09-653080
-        levels:
-            - medium
-        title:
-            RHEL 9 audit logs must be group-owned by root or by a restricted logging
-            group to prevent unauthorized read access.
-        rules:
-            - directory_group_ownership_var_log_audit
-        status: automated
-
-    -   id: RHEL-09-653085
-        levels:
-            - medium
-        title:
-            RHEL 9 audit log directory must be owned by root to prevent unauthorized
-            read access.
-        rules:
-            - directory_ownership_var_log_audit
-        status: automated
-
-    -   id: RHEL-09-653090
-        levels:
-            - medium
-        title:
-            RHEL 9 audit logs file must have mode 0600 or less permissive to prevent
-            unauthorized access to the audit log.
-        rules:
-            - file_permissions_var_log_audit
-        status: automated
-
-    -   id: RHEL-09-653095
-        levels:
-            - medium
-        title:
-            RHEL 9 must periodically flush audit records to disk to prevent the loss
-            of audit records.
-        rules:
-            - auditd_freq
-            - var_auditd_freq=100
-        status: automated
-
-    -   id: RHEL-09-653100
-        levels:
-            - medium
-        title:
-            RHEL 9 must produce audit records containing information to establish the
-            identity of any individual or process associated with the event.
-        rules:
-            - auditd_log_format
-        status: automated
-
-    -   id: RHEL-09-653105
-        levels:
-            - medium
-        title: RHEL 9 must write audit records to disk.
-        rules:
-            - auditd_write_logs
-        status: automated
-
-    -   id: RHEL-09-653110
-        levels:
-            - medium
-        title:
-            RHEL 9 must allow only the information system security manager (ISSM) (or
-            individuals or roles appointed by the ISSM) to select which auditable events are
-            to be audited.
-        rules:
-            - file_permissions_audit_configuration
-        status: automated
-
-    -   id: RHEL-09-653115
-        levels:
-            - medium
-        title:
-            RHEL 9 /etc/audit/auditd.conf file must have 0640 or less permissive to prevent
-            unauthorized access.
-        rules:
-            - file_permissions_etc_audit_auditd
-        status: automated
-
-    -   id: RHEL-09-653120
-        levels:
-            - low
-        title:
-            RHEL 9 must allocate an audit_backlog_limit of sufficient size to capture
-            processes that start prior to the audit daemon.
-        rules:
-            - grub2_audit_backlog_limit_argument
-        status: automated
-
-    -   id: RHEL-09-653125
-        levels:
-            - medium
-        title:
-            RHEL 9 must have mail aliases to notify the information system security officer
-            (ISSO) and system administrator (SA) (at a minimum) in the event of an audit processing
-            failure.
-        rules:
-            - postfix_client_configure_mail_alias
-        status: automated
-
-    -   id: RHEL-09-653130
-        levels:
-            - medium
-        title: RHEL 9 audispd-plugins package must be installed.
-        rules:
-            - package_audispd-plugins_installed
-        status: automated
-
-    -   id: RHEL-09-654010
-        levels:
-            - medium
-        title: RHEL 9 must audit uses of the "execve" system call.
-        rules:
-            - audit_rules_suid_privilege_function
-        status: automated
-
-    -   id: RHEL-09-654015
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the chmod, fchmod, and fchmodat system calls.
-        rules:
-            - audit_rules_dac_modification_chmod
-            - audit_rules_dac_modification_fchmod
-            - audit_rules_dac_modification_fchmodat
-        status: automated
-
-    -   id: RHEL-09-654020
-        levels:
-            - medium
-        title:
-            RHEL 9 must audit all uses of the chown, fchown, fchownat, and lchown system
-            calls.
-        rules:
-            - audit_rules_dac_modification_chown
-            - audit_rules_dac_modification_fchown
-            - audit_rules_dac_modification_fchownat
-            - audit_rules_dac_modification_lchown
-        status: automated
-
-    -   id: RHEL-09-654025
-        levels:
-            - medium
-        title:
-            RHEL 9 must audit all uses of the setxattr, fsetxattr, lsetxattr, removexattr,
-            fremovexattr, and lremovexattr system calls.
-        rules:
-            - audit_rules_dac_modification_setxattr
-            - audit_rules_dac_modification_fsetxattr
-            - audit_rules_dac_modification_lsetxattr
-            - audit_rules_dac_modification_removexattr
-            - audit_rules_dac_modification_fremovexattr
-            - audit_rules_dac_modification_lremovexattr
-        status: automated
-
-    -   id: RHEL-09-654030
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of umount system calls.
-        rules:
-            - audit_rules_privileged_commands_umount
-        status: automated
-
-    -   id: RHEL-09-654035
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the chacl command.
-        rules:
-            - audit_rules_execution_chacl
-        status: automated
-
-    -   id: RHEL-09-654040
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the setfacl command.
-        rules:
-            - audit_rules_execution_setfacl
-        status: automated
-
-    -   id: RHEL-09-654045
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the chcon command.
-        rules:
-            - audit_rules_execution_chcon
-        status: automated
-
-    -   id: RHEL-09-654050
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the semanage command.
-        rules:
-            - audit_rules_execution_semanage
-        status: automated
-
-    -   id: RHEL-09-654055
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the setfiles command.
-        rules:
-            - audit_rules_execution_setfiles
-        status: automated
-
-    -   id: RHEL-09-654060
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the setsebool command.
-        rules:
-            - audit_rules_execution_setsebool
-        status: automated
-
-    -   id: RHEL-09-654065
-        levels:
-            - medium
-        title:
-            RHEL 9 must audit all uses of the rename, unlink, rmdir, renameat, and unlinkat
-            system calls.
-        rules:
-            - audit_rules_file_deletion_events_rename
-            - audit_rules_file_deletion_events_unlink
-            - audit_rules_file_deletion_events_rmdir
-            - audit_rules_file_deletion_events_renameat
-            - audit_rules_file_deletion_events_unlinkat
-        status: automated
-
-    -   id: RHEL-09-654070
-        levels:
-            - medium
-        title:
-            RHEL 9 must audit all uses of the truncate, ftruncate, creat, open, openat,
-            and open_by_handle_at system calls.
-        rules:
-            - audit_rules_unsuccessful_file_modification_creat
-            - audit_rules_unsuccessful_file_modification_truncate
-            - audit_rules_unsuccessful_file_modification_ftruncate
-            - audit_rules_unsuccessful_file_modification_open
-            - audit_rules_unsuccessful_file_modification_openat
-            - audit_rules_unsuccessful_file_modification_open_by_handle_at
-        status: automated
-
-    -   id: RHEL-09-654075
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the delete_module system call.
-        rules:
-            - audit_rules_kernel_module_loading_delete
-        status: automated
-
-    -   id: RHEL-09-654080
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the init_module and finit_module system calls.
-        rules:
-            - audit_rules_kernel_module_loading_finit
-            - audit_rules_kernel_module_loading_init
-        status: automated
-
-    -   id: RHEL-09-654085
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the chage command.
-        rules:
-            - audit_rules_privileged_commands_chage
-        status: automated
-
-    -   id: RHEL-09-654090
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the chsh command.
-        rules:
-            - audit_rules_privileged_commands_chsh
-        status: automated
-
-    -   id: RHEL-09-654095
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the crontab command.
-        rules:
-            - audit_rules_privileged_commands_crontab
-        status: automated
-
-    -   id: RHEL-09-654100
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the gpasswd command.
-        rules:
-            - audit_rules_privileged_commands_gpasswd
-        status: automated
-
-    -   id: RHEL-09-654105
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the kmod command.
-        rules:
-            - audit_rules_privileged_commands_kmod
-        status: automated
-
-    -   id: RHEL-09-654110
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the newgrp command.
-        rules:
-            - audit_rules_privileged_commands_newgrp
-        status: automated
-
-    -   id: RHEL-09-654115
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the pam_timestamp_check command.
-        rules:
-            - audit_rules_privileged_commands_pam_timestamp_check
-        status: automated
-
-    -   id: RHEL-09-654120
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the passwd command.
-        rules:
-            - audit_rules_privileged_commands_passwd
-        status: automated
-
-    -   id: RHEL-09-654125
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the postdrop command.
-        rules:
-            - audit_rules_privileged_commands_postdrop
-        status: automated
-
-    -   id: RHEL-09-654130
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the postqueue command.
-        rules:
-            - audit_rules_privileged_commands_postqueue
-        status: automated
-
-    -   id: RHEL-09-654135
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the ssh-agent command.
-        rules:
-            - audit_rules_privileged_commands_ssh_agent
-        status: automated
-
-    -   id: RHEL-09-654140
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the ssh-keysign command.
-        rules:
-            - audit_rules_privileged_commands_ssh_keysign
-        status: automated
-
-    -   id: RHEL-09-654145
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the su command.
-        rules:
-            - audit_rules_privileged_commands_su
-        status: automated
-
-    -   id: RHEL-09-654150
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the sudo command.
-        rules:
-            - audit_rules_privileged_commands_sudo
-        status: automated
-
-    -   id: RHEL-09-654155
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the sudoedit command.
-        rules:
-            - audit_rules_privileged_commands_sudoedit
-        status: automated
-
-    -   id: RHEL-09-654160
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the unix_chkpwd command.
-        rules:
-            - audit_rules_privileged_commands_unix_chkpwd
-        status: automated
-
-    -   id: RHEL-09-654165
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the unix_update command.
-        rules:
-            - audit_rules_privileged_commands_unix_update
-        status: automated
-
-    -   id: RHEL-09-654170
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the userhelper command.
-        rules:
-            - audit_rules_privileged_commands_userhelper
-        status: automated
-
-    -   id: RHEL-09-654175
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the usermod command.
-        rules:
-            - audit_rules_privileged_commands_usermod
-        status: automated
-
-    -   id: RHEL-09-654180
-        levels:
-            - medium
-        title: RHEL 9 must audit all uses of the mount command.
-        rules:
-            - audit_rules_privileged_commands_mount
-        status: automated
-
-    -   id: RHEL-09-654185
-        levels:
-            - medium
-        title:
-            Successful/unsuccessful uses of the init command in RHEL 9 must generate
-            an audit record.
-        rules:
-            - audit_privileged_commands_init
-        status: automated
-
-    -   id: RHEL-09-654190
-        levels:
-            - medium
-        title:
-            Successful/unsuccessful uses of the poweroff command in RHEL 9 must generate
-            an audit record.
-        rules:
-            - audit_privileged_commands_poweroff
-        status: automated
-
-    -   id: RHEL-09-654195
-        levels:
-            - medium
-        title:
-            Successful/unsuccessful uses of the reboot command in RHEL 9 must generate
-            an audit record.
-        rules:
-            - audit_privileged_commands_reboot
-        status: automated
-
-    -   id: RHEL-09-654200
-        levels:
-            - medium
-        title:
-            Successful/unsuccessful uses of the shutdown command in RHEL 9 must generate
-            an audit record.
-        rules:
-            - audit_privileged_commands_shutdown
-        status: automated
-
-    -   id: RHEL-09-654205
-        levels:
-            - medium
-        title:
-            Successful/unsuccessful uses of the umount system call in RHEL 9 must generate
-            an audit record.
-        rules:
-            - audit_rules_dac_modification_umount
-        status: automated
-
-    -   id: RHEL-09-654210
-        levels:
-            - medium
-        title:
-            Successful/unsuccessful uses of the umount2 system call in RHEL 9 must generate
-            an audit record.
-        rules:
-            - audit_rules_dac_modification_umount2
-        status: automated
-
-    -   id: RHEL-09-654215
-        levels:
-            - medium
-        title:
-            RHEL 9 must generate audit records for all account creations, modifications,
-            disabling, and termination events that affect /etc/sudoers.
-        rules:
-            - audit_rules_sudoers
-        status: automated
-
-    -   id: RHEL-09-654220
-        levels:
-            - medium
-        title:
-            RHEL 9 must generate audit records for all account creations, modifications,
-            disabling, and termination events that affect /etc/sudoers.d/ directory.
-        rules:
-            - audit_rules_sudoers_d
-        status: automated
-
-    -   id: RHEL-09-654225
-        levels:
-            - medium
-        title:
-            RHEL 9 must generate audit records for all account creations, modifications,
-            disabling, and termination events that affect /etc/group.
-        rules:
-            - audit_rules_usergroup_modification_group
-        status: automated
-
-    -   id: RHEL-09-654230
-        levels:
-            - medium
-        title:
-            RHEL 9 must generate audit records for all account creations, modifications,
-            disabling, and termination events that affect /etc/gshadow.
-        rules:
-            - audit_rules_usergroup_modification_gshadow
-        status: automated
-
-    -   id: RHEL-09-654235
-        levels:
-            - medium
-        title:
-            RHEL 9 must generate audit records for all account creations, modifications,
-            disabling, and termination events that affect /etc/opasswd.
-        rules:
-            - audit_rules_usergroup_modification_opasswd
-        status: automated
-
-    -   id: RHEL-09-654240
-        levels:
-            - medium
-        title:
-            RHEL 9 must generate audit records for all account creations, modifications,
-            disabling, and termination events that affect /etc/passwd.
-        rules:
-            - audit_rules_usergroup_modification_passwd
-        status: automated
-
-    -   id: RHEL-09-654245
-        levels:
-            - medium
-        title:
-            RHEL 9 must generate audit records for all account creations, modifications,
-            disabling, and termination events that affect /etc/shadow.
-        rules:
-            - audit_rules_usergroup_modification_shadow
-        status: automated
-
-    -   id: RHEL-09-654250
-        levels:
-            - medium
-        title:
-            RHEL 9 must generate audit records for all account creations, modifications,
-            disabling, and termination events that affect /var/log/faillock.
-        rules:
-            - audit_rules_login_events_faillock
-        status: automated
-
-    -   id: RHEL-09-654255
-        levels:
-            - medium
-        title:
-            RHEL 9 must generate audit records for all account creations, modifications,
-            disabling, and termination events that affect /var/log/lastlog.
-        rules:
-            - audit_rules_login_events_lastlog
-        status: automated
-
-    -   id: RHEL-09-654260
-        levels:
-            - medium
-        title:
-            RHEL 9 must generate audit records for all account creations, modifications,
-            disabling, and termination events that affect /var/log/tallylog.
-        rules:
-            - audit_rules_login_events_tallylog
-        status: automated
-
-    -   id: RHEL-09-654265
-        levels:
-            - medium
-        title:
-            RHEL 9 must take appropriate action when a critical audit processing failure
-            occurs.
-        rules:
-            - audit_rules_system_shutdown
-        status: automated
-
-    -   id: RHEL-09-654270
-        levels:
-            - medium
-        title: RHEL 9 audit system must protect logon UIDs from unauthorized change.
-        rules:
-            - audit_rules_immutable_login_uids
-        status: automated
-
-    -   id: RHEL-09-654275
-        levels:
-            - medium
-        title: RHEL 9 audit system must protect auditing rules from unauthorized change.
-        rules:
-            - audit_rules_immutable
-        status: automated
-
-    -   id: RHEL-09-671010
-        levels:
-            - high
-        title: RHEL 9 must enable FIPS mode.
-        rules:
-            - enable_fips_mode
-            - sysctl_crypto_fips_enabled
-            - var_system_crypto_policy=fips
-            - configure_crypto_policy
-            - enable_dracut_fips_module
-        status: automated
-
-    -   id: RHEL-09-671015
-        levels:
-            - medium
-        title:
-            RHEL 9 must employ FIPS 140-3 approved cryptographic hashing algorithms for
-            all stored passwords.
-        rules:
-            - accounts_password_all_shadowed_sha512
-        status: automated
-
-    -   id: RHEL-09-671020
-        levels:
-            - medium
-        title: RHEL 9 IP tunnels must use FIPS 140-2/140-3 approved cryptographic algorithms.
-        rules:
-            - configure_libreswan_crypto_policy
-        status: automated
-
-    -   id: RHEL-09-671025
-        levels:
-            - medium
-        title:
-            RHEL 9 pam_unix.so module must be configured in the password-auth file to
-            use a FIPS 140-3 approved cryptographic hashing algorithm for system authentication.
-        rules:
-            - set_password_hashing_algorithm_passwordauth
-        status: automated
-
-    -   id: RHEL-09-672015
-        levels:
-            - high
-        title: RHEL 9 crypto policy files must match files shipped with the operating system.
-        status: pending
-
-    -   id: RHEL-09-672020
-        levels:
-            - medium
-        title: RHEL 9 crypto policy must not be overridden.
-        status: pending
-
-    -   id: RHEL-09-672025
-        levels:
-            - medium
-        title:
-            RHEL 9 must use mechanisms meeting the requirements of applicable federal
-            laws, executive orders, directives, policies, regulations, standards, and guidance
-            for authentication to a cryptographic module.
-        rules:
-            - configure_kerberos_crypto_policy
-        status: automated
-
-    -   id: RHEL-09-672030
-        levels:
-            - high
-        title: RHEL 9 must implement DOD-approved TLS encryption in the GnuTLS package.
-        rules:
-            - configure_crypto_policy
-        status: automated
-
-    -   id: RHEL-09-672050
-        levels:
-            - medium
-        title: RHEL 9 must implement DOD-approved encryption in the bind package.
-        rules:
-            - configure_bind_crypto_policy
-        status: automated
+    - id: needed_rules
+      levels:
+          - medium
+      rules:
+          - enable_authselect
+          - var_authselect_profile=sssd
+
+    - id: RHEL-09-171011
+      levels:
+          - medium
+      rules:
+          - dconf_gnome_login_banner_text
+    - id: RHEL-09-211010
+      levels:
+          - high
+      title: RHEL 9 must be a vendor-supported release.
+      rules:
+          - installed_OS_is_vendor_supported
+      status: automated
+
+    - id: RHEL-09-211015
+      levels:
+          - medium
+      title: RHEL 9 vendor packaged system security patches and updates must be installed and up to date.
+      rules:
+          - security_patches_up_to_date
+      status: automated
+
+    - id: RHEL-09-211020
+      levels:
+          - medium
+      title: RHEL 9 must display the Standard Mandatory DOD Notice and Consent Banner before granting
+          local or remote access to the system via a command line user logon.
+      rules:
+          - banner_etc_issue
+          - login_banner_text=dod_banners
+      status: automated
+
+    - id: RHEL-09-211030
+      levels:
+          - medium
+      title: The graphical display manager must not be the default target on RHEL 9 unless approved.
+      rules:
+          - xwindows_runlevel_target
+      status: automated
+
+    - id: RHEL-09-211035
+      levels:
+          - low
+      title: RHEL 9 must enable the hardware random number generator entropy gatherer service.
+      related_rules:
+          - service_rngd_enabled  # This rule is causing test failures, See https://github.com/ComplianceAsCode/content/pull/10153
+      status: pending
+
+    - id: RHEL-09-211040
+      levels:
+          - medium
+      title: RHEL 9 systemd-journald service must be enabled.
+      rules:
+          - service_systemd-journald_enabled
+      status: automated
+
+    - id: RHEL-09-211045
+      levels:
+          - high
+      title: The systemd Ctrl-Alt-Delete burst key sequence in RHEL 9 must be disabled.
+      rules:
+          - disable_ctrlaltdel_burstaction
+      status: automated
+
+    - id: RHEL-09-211050
+      levels:
+          - high
+      title: The x86 Ctrl-Alt-Delete key sequence must be disabled on RHEL 9.
+      rules:
+          - disable_ctrlaltdel_reboot
+      status: automated
+
+    - id: RHEL-09-211055
+      levels:
+          - medium
+      title: RHEL 9 debug-shell systemd service must be disabled.
+      status: automated
+      rules:
+          - service_debug-shell_disabled
+
+    - id: RHEL-09-212010
+      levels:
+          - medium
+      title: RHEL 9 must require a boot loader superuser password.
+      rules:
+          - grub2_password
+      status: automated
+
+    - id: RHEL-09-212015
+      levels:
+          - medium
+      title: RHEL 9 must disable the ability of systemd to spawn an interactive boot process.
+      rules:
+          - grub2_disable_interactive_boot
+      status: automated
+
+    - id: RHEL-09-212020
+      levels:
+          - high
+      title: RHEL 9 must require a unique superusers name upon booting into single-user and maintenance
+          modes.
+      rules:
+          - grub2_admin_username
+      status: automated
+
+    - id: RHEL-09-212025
+      levels:
+          - medium
+      title: RHEL 9 /boot/grub2/grub.cfg file must be group-owned by root.
+      rules:
+          - file_groupowner_grub2_cfg
+      status: automated
+
+    - id: RHEL-09-212030
+      levels:
+          - medium
+      title: RHEL 9 /boot/grub2/grub.cfg file must be owned by root.
+      rules:
+          - file_owner_grub2_cfg
+      status: automated
+
+    - id: RHEL-09-212035
+      levels:
+          - medium
+      title: RHEL 9 must disable virtual system calls.
+      rules:
+          - grub2_vsyscall_argument
+      status: automated
+
+    - id: RHEL-09-212040
+      levels:
+          - medium
+      title: RHEL 9 must clear the page allocator to prevent use-after-free attacks.
+      rules:
+          - grub2_page_poison_argument
+      status: automated
+
+    - id: RHEL-09-212045
+      levels:
+          - medium
+      title: RHEL 9 must clear SLUB/SLAB objects to prevent use-after-free attacks.
+      rules:
+          - grub2_init_on_free
+      status: automated
+
+    - id: RHEL-09-212050
+      levels:
+          - low
+      title: RHEL 9 must enable mitigations against processor-based vulnerabilities.
+      rules:
+          - grub2_pti_argument
+      status: automated
+
+    - id: RHEL-09-212055
+      levels:
+          - low
+      title: RHEL 9 must enable auditing of processes that start prior to the audit daemon.
+      rules:
+          - grub2_audit_argument
+      status: automated
+
+    - id: RHEL-09-213010
+      levels:
+          - medium
+      title: RHEL 9 must restrict access to the kernel message buffer.
+      rules:
+          - sysctl_kernel_dmesg_restrict
+      status: automated
+
+    - id: RHEL-09-213015
+      levels:
+          - medium
+      title: RHEL 9 must prevent kernel profiling by nonprivileged users.
+      rules:
+          - sysctl_kernel_perf_event_paranoid
+      status: automated
+
+    - id: RHEL-09-213020
+      levels:
+          - medium
+      title: RHEL 9 must prevent the loading of a new kernel for later execution.
+      rules:
+          - sysctl_kernel_kexec_load_disabled
+      status: automated
+
+    - id: RHEL-09-213025
+      levels:
+          - medium
+      title: RHEL 9 must restrict exposed kernel pointer addresses access.
+      rules:
+          - sysctl_kernel_kptr_restrict
+      status: automated
+
+    - id: RHEL-09-213030
+      levels:
+          - medium
+      title: RHEL 9 must enable kernel parameters to enforce discretionary access control on hardlinks.
+      rules:
+          - sysctl_fs_protected_hardlinks
+      status: automated
+
+    - id: RHEL-09-213035
+      levels:
+          - medium
+      title: RHEL 9 must enable kernel parameters to enforce discretionary access control on symlinks.
+      rules:
+          - sysctl_fs_protected_symlinks
+      status: automated
+
+    - id: RHEL-09-213040
+      levels:
+          - medium
+      title: RHEL 9 must disable the kernel.core_pattern.
+      rules:
+          - sysctl_kernel_core_pattern
+      status: automated
+
+    - id: RHEL-09-213045
+      levels:
+          - medium
+      title: RHEL 9 must be configured to disable the Asynchronous Transfer Mode kernel module.
+      rules:
+          - kernel_module_atm_disabled
+      status: automated
+
+    - id: RHEL-09-213050
+      levels:
+          - medium
+      title: RHEL 9 must be configured to disable the Controller Area Network kernel module.
+      rules:
+          - kernel_module_can_disabled
+      status: automated
+
+    - id: RHEL-09-213055
+      levels:
+          - medium
+      title: RHEL 9 must be configured to disable the FireWire kernel module.
+      rules:
+          - kernel_module_firewire-core_disabled
+      status: automated
+
+    - id: RHEL-09-213060
+      levels:
+          - medium
+      title: RHEL 9 must disable the Stream Control Transmission Protocol (SCTP) kernel module.
+      rules:
+          - kernel_module_sctp_disabled
+      status: automated
+
+    - id: RHEL-09-213065
+      levels:
+          - medium
+      title: RHEL 9 must disable the Transparent Inter Process Communication (TIPC) kernel module.
+      rules:
+          - kernel_module_tipc_disabled
+      status: automated
+
+    - id: RHEL-09-213070
+      levels:
+          - medium
+      title: RHEL 9 must implement address space layout randomization (ASLR) to protect its memory from
+          unauthorized code execution.
+      rules:
+          - sysctl_kernel_randomize_va_space
+      status: automated
+
+    - id: RHEL-09-213075
+      levels:
+          - medium
+      title: RHEL 9 must disable access to network bpf system call from nonprivileged processes.
+      rules:
+          - sysctl_kernel_unprivileged_bpf_disabled
+      status: automated
+
+    - id: RHEL-09-213080
+      levels:
+          - medium
+      title: RHEL 9 must restrict usage of ptrace to descendant processes.
+      rules:
+          - sysctl_kernel_yama_ptrace_scope
+      status: automated
+
+    - id: RHEL-09-213085
+      levels:
+          - medium
+      title: RHEL 9 must disable core dump backtraces.
+      rules:
+          - coredump_disable_backtraces
+      status: automated
+
+    - id: RHEL-09-213090
+      levels:
+          - medium
+      title: RHEL 9 must disable storing core dumps.
+      rules:
+          - coredump_disable_storage
+      status: automated
+
+    - id: RHEL-09-213095
+      levels:
+          - medium
+      title: RHEL 9 must disable core dumps for all users.
+      rules:
+          - disable_users_coredumps
+      status: automated
+
+    - id: RHEL-09-213100
+      levels:
+          - medium
+      title: RHEL 9 must disable acquiring, saving, and processing core dumps.
+      rules:
+          - service_systemd-coredump_disabled
+      status: automated
+
+    - id: RHEL-09-213105
+      levels:
+          - medium
+      title: RHEL 9 must disable the use of user namespaces.
+      rules:
+          - sysctl_user_max_user_namespaces_no_remediation
+      status: automated
+
+    - id: RHEL-09-213110
+      levels:
+          - medium
+      title: RHEL 9 must implement nonexecutable data to protect its memory from unauthorized code execution.
+      rules:
+          - sysctl_kernel_exec_shield
+      status: automated
+
+    - id: RHEL-09-213115
+      levels:
+          - medium
+      title: The kdump service on RHEL 9 must be disabled.
+      rules:
+          - service_kdump_disabled
+      status: automated
+
+    - id: RHEL-09-214010
+      levels:
+          - medium
+      title: RHEL 9 must ensure cryptographic verification of vendor software packages.
+      rules:
+          - ensure_redhat_gpgkey_installed
+      status: automated
+
+    - id: RHEL-09-214015
+      levels:
+          - high
+      title: RHEL 9 must check the GPG signature of software packages originating from external software
+          repositories before installation.
+      rules:
+          - ensure_gpgcheck_globally_activated
+      status: automated
+
+    - id: RHEL-09-214020
+      levels:
+          - high
+      title: RHEL 9 must check the GPG signature of locally installed software packages before installation.
+      rules:
+          - ensure_gpgcheck_local_packages
+      status: automated
+
+    - id: RHEL-09-214025
+      levels:
+          - high
+      title: RHEL 9 must have GPG signature verification enabled for all software repositories.
+      rules:
+          - ensure_gpgcheck_never_disabled
+      status: automated
+
+    - id: RHEL-09-214030
+      levels:
+          - medium
+      title: RHEL 9 must be configured so that the cryptographic hashes of system files match vendor
+          values.
+      related_rules:
+          - rpm_verify_hashes  # Due to crypto policies this cannot be selected at this time
+      status: pending
+
+    - id: RHEL-09-214035
+      levels:
+          - low
+      title: RHEL 9 must remove all software components after updated versions have been installed.
+      rules:
+          - clean_components_post_updating
+      status: automated
+
+    - id: RHEL-09-215010
+      levels:
+          - medium
+      title: RHEL 9 subscription-manager package must be installed.
+      rules:
+          - package_subscription-manager_installed
+      status: automated
+
+    - id: RHEL-09-215015
+      levels:
+          - high
+      title: RHEL 9 must not have a File Transfer Protocol (FTP) server package installed.
+      rules:
+          - package_vsftpd_removed
+      status: automated
+
+    - id: RHEL-09-215020
+      levels:
+          - medium
+      title: RHEL 9 must not have the sendmail package installed.
+      rules:
+          - package_sendmail_removed
+      status: automated
+
+    - id: RHEL-09-215025
+      levels:
+          - medium
+      title: RHEL 9 must not have the nfs-utils package installed.
+      rules:
+          - package_nfs-utils_removed
+      status: automated
+
+    - id: RHEL-09-215030
+      levels:
+          - medium
+      title: RHEL 9 must not have the ypserv package installed.
+      related_rules:
+          - package_ypserv_removed
+      status: not applicable  # The ypserv package is not available in RHEL 9
+
+    - id: RHEL-09-215035
+      levels:
+          - medium
+      title: RHEL 9 must not have the rsh-server package installed.
+      related_rules:
+          - package_rsh-server_removed
+      status: not applicable  # The rsh-server package is not available in RHEL 9
+
+    - id: RHEL-09-215040
+      levels:
+          - medium
+      title: RHEL 9 must not have the telnet-server package installed.
+      rules:
+          - package_telnet-server_removed
+      status: automated
+
+    - id: RHEL-09-215045
+      levels:
+          - medium
+      title: RHEL 9 must not have the gssproxy package installed.
+      rules:
+          - package_gssproxy_removed
+      status: automated
+
+    - id: RHEL-09-215050
+      levels:
+          - medium
+      title: RHEL 9 must not have the iprutils package installed.
+      rules:
+          - package_iprutils_removed
+      status: automated
+
+    - id: RHEL-09-215055
+      levels:
+          - medium
+      title: RHEL 9 must not have the tuned package installed.
+      rules:
+          - package_tuned_removed
+      status: automated
+
+    - id: RHEL-09-215060
+      levels:
+          - high
+      title: RHEL 9 must not have a Trivial File Transfer Protocol (TFTP) server package installed.
+      rules:
+          - package_tftp-server_removed
+      status: automated
+
+    - id: RHEL-09-215065
+      levels:
+          - medium
+      title: RHEL 9 must not have the quagga package installed.
+      related_rules:
+          - package_quagga_removed
+      status: not applicable  # The quagga package is not available in RHEL 9
+
+    - id: RHEL-09-215070
+      levels:
+          - medium
+      title: A graphical display manager must not be installed on RHEL 9 unless approved.
+      rules:
+          - xwindows_remove_packages
+      status: automated
+
+    - id: RHEL-09-215075
+      levels:
+          - medium
+      title: RHEL 9 must have the openssl-pkcs11 package installed.
+      rules:
+          - install_smartcard_packages
+      status: automated
+
+    - id: RHEL-09-215080
+      levels:
+          - medium
+      title: RHEL 9 must have the gnutls-utils package installed.
+      rules:
+          - package_gnutls-utils_installed
+      status: automated
+
+    - id: RHEL-09-215085
+      levels:
+          - medium
+      title: RHEL 9 must have the nss-tools package installed.
+      rules:
+          - package_nss-tools_installed
+      status: automated
+
+    - id: RHEL-09-215090
+      levels:
+          - medium
+      title: RHEL 9 must have the rng-tools package installed.
+      rules:
+          - package_rng-tools_installed
+      status: automated
+
+    - id: RHEL-09-215095
+      levels:
+          - medium
+      title: RHEL 9 must have the s-nail package installed.
+      rules:
+          - package_s-nail_installed
+      status: automated
+
+    - id: RHEL-09-215100
+      levels:
+          - medium
+      title: RHEL 9 must have the crypto-policies package installed.
+      rules:
+          - package_crypto-policies_installed
+      status: automated
+
+    - id: RHEL-09-215101
+      levels:
+          - medium
+      title: RHEL 9 must have the Postfix package installed.
+      status: automated
+      rules:
+          - package_postfix_installed
+
+    - id: RHEL-09-215105
+      levels:
+          - medium
+      title: RHEL 9 must implement a FIPS 140-3 compliant systemwide cryptographic policy.
+      rules:
+          - configure_crypto_policy
+          - fips_crypto_subpolicy
+      status: automated
+
+    - id: RHEL-09-231010
+      levels:
+          - medium
+      title: A separate RHEL 9 file system must be used for user home directories (such as /home or an
+          equivalent).
+      rules:
+          - partition_for_home
+      status: automated
+
+    - id: RHEL-09-231015
+      levels:
+          - medium
+      title: RHEL 9 must use a separate file system for /tmp.
+      rules:
+          - partition_for_tmp
+      status: automated
+
+    - id: RHEL-09-231020
+      levels:
+          - low
+      title: RHEL 9 must use a separate file system for /var.
+      rules:
+          - partition_for_var
+      status: automated
+
+    - id: RHEL-09-231025
+      levels:
+          - low
+      title: RHEL 9 must use a separate file system for /var/log.
+      rules:
+          - partition_for_var_log
+      status: automated
+
+    - id: RHEL-09-231030
+      levels:
+          - low
+      title: RHEL 9 must use a separate file system for the system audit data path.
+      rules:
+          - partition_for_var_log_audit
+      status: automated
+
+    - id: RHEL-09-231035
+      levels:
+          - medium
+      title: RHEL 9 must use a separate file system for /var/tmp.
+      rules:
+          - partition_for_var_tmp
+      status: automated
+
+    - id: RHEL-09-231040
+      levels:
+          - medium
+      title: RHEL 9 file system automount function must be disabled unless required.
+      rules:
+          - service_autofs_disabled
+      status: automated
+
+    - id: RHEL-09-231045
+      levels:
+          - medium
+      title: RHEL 9 must prevent device files from being interpreted on file systems that contain user
+          home directories.
+      rules:
+          - mount_option_home_nodev
+      status: automated
+
+    - id: RHEL-09-231050
+      levels:
+          - medium
+      title: RHEL 9 must prevent files with the setuid and setgid bit set from being executed on file
+          systems that contain user home directories.
+      rules:
+          - mount_option_home_nosuid
+      status: automated
+
+    - id: RHEL-09-231055
+      levels:
+          - medium
+      title: RHEL 9 must prevent code from being executed on file systems that contain user home directories.
+      rules:
+          - mount_option_home_noexec
+      status: automated
+
+    - id: RHEL-09-231065
+      levels:
+          - medium
+      title: RHEL 9 must prevent special devices on file systems that are imported via Network File System
+          (NFS).
+      rules:
+          - mount_option_nodev_remote_filesystems
+      status: automated
+
+    - id: RHEL-09-231070
+      levels:
+          - medium
+      title: RHEL 9  must prevent code from being executed on file systems that are imported via Network
+          File System (NFS).
+      rules:
+          - mount_option_noexec_remote_filesystems
+      status: automated
+
+    - id: RHEL-09-231075
+      levels:
+          - medium
+      title: RHEL 9 must prevent files with the setuid and setgid bit set from being executed on file
+          systems that are imported via Network File System (NFS).
+      rules:
+          - mount_option_nosuid_remote_filesystems
+      status: automated
+
+    - id: RHEL-09-231080
+      levels:
+          - medium
+      title: RHEL 9 must prevent code from being executed on file systems that are used with removable
+          media.
+      rules:
+          - mount_option_noexec_removable_partitions
+      status: automated
+
+    - id: RHEL-09-231085
+      levels:
+          - medium
+      title: RHEL 9 must prevent special devices on file systems that are used with removable media.
+      rules:
+          - mount_option_nodev_removable_partitions
+      status: automated
+
+    - id: RHEL-09-231090
+      levels:
+          - medium
+      title: RHEL 9 must prevent files with the setuid and setgid bit set from being executed on file
+          systems that are used with removable media.
+      rules:
+          - mount_option_nosuid_removable_partitions
+      status: automated
+
+    - id: RHEL-09-231095
+      levels:
+          - medium
+      title: RHEL 9 must mount /boot with the nodev option.
+      rules:
+          - mount_option_boot_nodev
+      status: automated
+
+    - id: RHEL-09-231100
+      levels:
+          - medium
+      title: RHEL 9 must prevent files with the setuid and setgid bit set from being executed on the
+          /boot directory.
+      rules:
+          - mount_option_boot_nosuid
+      status: automated
+
+    - id: RHEL-09-231105
+      levels:
+          - medium
+      title: RHEL 9 must prevent files with the setuid and setgid bit set from being executed on the
+          /boot/efi directory.
+      rules:
+          - mount_option_boot_efi_nosuid
+      status: automated
+
+    - id: RHEL-09-231110
+      levels:
+          - medium
+      title: RHEL 9 must mount /dev/shm with the nodev option.
+      rules:
+          - mount_option_dev_shm_nodev
+      status: automated
+
+    - id: RHEL-09-231115
+      levels:
+          - medium
+      title: RHEL 9 must mount /dev/shm with the noexec option.
+      rules:
+          - mount_option_dev_shm_noexec
+      status: automated
+
+    - id: RHEL-09-231120
+      levels:
+          - medium
+      title: RHEL 9 must mount /dev/shm with the nosuid option.
+      rules:
+          - mount_option_dev_shm_nosuid
+      status: automated
+
+    - id: RHEL-09-231125
+      levels:
+          - medium
+      title: RHEL 9 must mount /tmp with the nodev option.
+      rules:
+          - mount_option_tmp_nodev
+      status: automated
+
+    - id: RHEL-09-231130
+      levels:
+          - medium
+      title: RHEL 9 must mount /tmp with the noexec option.
+      rules:
+          - mount_option_tmp_noexec
+      status: automated
+
+    - id: RHEL-09-231135
+      levels:
+          - medium
+      title: RHEL 9 must mount /tmp with the nosuid option.
+      rules:
+          - mount_option_tmp_nosuid
+      status: automated
+
+    - id: RHEL-09-231140
+      levels:
+          - medium
+      title: RHEL 9 must mount /var with the nodev option.
+      rules:
+          - mount_option_var_nodev
+      status: automated
+
+    - id: RHEL-09-231145
+      levels:
+          - medium
+      title: RHEL 9 must mount /var/log with the nodev option.
+      rules:
+          - mount_option_var_log_nodev
+      status: automated
+
+    - id: RHEL-09-231150
+      levels:
+          - medium
+      title: RHEL 9 must mount /var/log with the noexec option.
+      rules:
+          - mount_option_var_log_noexec
+      status: automated
+
+    - id: RHEL-09-231155
+      levels:
+          - medium
+      title: RHEL 9 must mount /var/log with the nosuid option.
+      rules:
+          - mount_option_var_log_nosuid
+      status: automated
+
+    - id: RHEL-09-231160
+      levels:
+          - medium
+      title: RHEL 9 must mount /var/log/audit with the nodev option.
+      rules:
+          - mount_option_var_log_audit_nodev
+      status: automated
+
+    - id: RHEL-09-231165
+      levels:
+          - medium
+      title: RHEL 9 must mount /var/log/audit with the noexec option.
+      rules:
+          - mount_option_var_log_audit_noexec
+      status: automated
+
+    - id: RHEL-09-231170
+      levels:
+          - medium
+      title: RHEL 9 must mount /var/log/audit with the nosuid option.
+      rules:
+          - mount_option_var_log_audit_nosuid
+      status: automated
+
+    - id: RHEL-09-231175
+      levels:
+          - medium
+      title: RHEL 9 must mount /var/tmp with the nodev option.
+      rules:
+          - mount_option_var_tmp_nodev
+      status: automated
+
+    - id: RHEL-09-231180
+      levels:
+          - medium
+      title: RHEL 9 must mount /var/tmp with the noexec option.
+      rules:
+          - mount_option_var_tmp_noexec
+      status: automated
+
+    - id: RHEL-09-231185
+      levels:
+          - medium
+      title: RHEL 9 must mount /var/tmp with the nosuid option.
+      rules:
+          - mount_option_var_tmp_nosuid
+      status: automated
+
+    - id: RHEL-09-231190
+      levels:
+          - high
+      title: RHEL 9 local disk partitions must implement cryptographic mechanisms to prevent unauthorized
+          disclosure or modification of all information that requires at rest protection.
+      rules:
+          - encrypt_partitions
+      status: automated
+
+    - id: RHEL-09-231195
+      levels:
+          - low
+      title: RHEL 9 must disable mounting of cramfs.
+      rules:
+          - kernel_module_cramfs_disabled
+      status: automated
+
+    - id: RHEL-09-231200
+      levels:
+          - medium
+      title: RHEL 9 must prevent special devices on non-root local partitions.
+      rules:
+          - mount_option_nodev_nonroot_local_partitions
+      status: automated
+
+    - id: RHEL-09-232010
+      levels:
+          - medium
+      title: RHEL 9 system commands must have mode 755 or less permissive.
+      rules:
+          - file_permissions_binary_dirs
+      status: automated
+
+    - id: RHEL-09-232015
+      levels:
+          - medium
+      title: RHEL 9 library directories must have mode 755 or less permissive.
+      rules:
+          - dir_permissions_library_dirs
+      status: automated
+
+    - id: RHEL-09-232020
+      levels:
+          - medium
+      title: RHEL 9 library files must have mode 755 or less permissive.
+      rules:
+          - file_permissions_library_dirs
+      status: automated
+
+    - id: RHEL-09-232025
+      levels:
+          - medium
+      title: RHEL 9 /var/log directory must have mode 0755 or less permissive.
+      rules:
+          - file_permissions_var_log
+      status: automated
+
+    - id: RHEL-09-232030
+      levels:
+          - medium
+      title: RHEL 9 /var/log/messages file must have mode 0640 or less permissive.
+      rules:
+          - file_permissions_var_log_messages
+      status: automated
+
+    - id: RHEL-09-232035
+      levels:
+          - medium
+      title: RHEL 9 audit tools must have a mode of 0755 or less permissive.
+      rules:
+          - file_audit_tools_permissions
+      status: automated
+
+    - id: RHEL-09-232040
+      levels:
+          - medium
+      title: RHEL 9 cron configuration directories must have a mode of 0700 or less permissive.
+      rules:
+          - package_cron_installed
+          - file_permissions_cron_d
+          - file_permissions_cron_daily
+          - file_permissions_cron_hourly
+          - file_permissions_cron_monthly
+          - file_permissions_cron_weekly
+      status: automated
+
+    - id: RHEL-09-232045
+      levels:
+          - medium
+      title: All RHEL 9 local initialization files must have mode 0740 or less permissive.
+      rules:
+          - file_permission_user_init_files_root
+          - var_user_initialization_files_regex=all_dotfiles
+          - rootfiles_configured
+      status: automated
+
+    - id: RHEL-09-232050
+      levels:
+          - medium
+      title: All RHEL 9 local interactive user home directories must have mode 0750 or less permissive.
+      rules:
+          - file_permissions_home_directories
+      status: automated
+
+    - id: RHEL-09-232055
+      levels:
+          - medium
+      title: RHEL 9 /etc/group file must have mode 0644 or less permissive to prevent unauthorized access.
+      rules:
+          - file_permissions_etc_group
+      status: automated
+
+    - id: RHEL-09-232060
+      levels:
+          - medium
+      title: RHEL 9 /etc/group- file must have mode 0644 or less permissive to prevent unauthorized access.
+      rules:
+          - file_permissions_backup_etc_group
+      status: automated
+
+    - id: RHEL-09-232065
+      levels:
+          - medium
+      title: RHEL 9 /etc/gshadow file must have mode 0000 or less permissive to prevent unauthorized
+          access.
+      rules:
+          - file_permissions_etc_gshadow
+      status: automated
+
+    - id: RHEL-09-232070
+      levels:
+          - medium
+      title: RHEL 9 /etc/gshadow- file must have mode 0000 or less permissive to prevent unauthorized
+          access.
+      rules:
+          - file_permissions_backup_etc_gshadow
+      status: automated
+
+    - id: RHEL-09-232075
+      levels:
+          - medium
+      title: RHEL 9 /etc/passwd file must have mode 0644 or less permissive to prevent unauthorized access.
+      rules:
+          - file_permissions_etc_passwd
+      status: automated
+
+    - id: RHEL-09-232080
+      levels:
+          - medium
+      title: RHEL 9 /etc/passwd- file must have mode 0644 or less permissive to prevent unauthorized
+          access.
+      rules:
+          - file_permissions_backup_etc_passwd
+      status: automated
+
+    - id: RHEL-09-232085
+      levels:
+          - medium
+      title: RHEL 9 /etc/shadow- file must have mode 0000 or less permissive to prevent unauthorized
+          access.
+      rules:
+          - file_permissions_backup_etc_shadow
+      status: automated
+
+    - id: RHEL-09-232090
+      levels:
+          - medium
+      title: RHEL 9 /etc/group file must be owned by root.
+      rules:
+          - file_owner_etc_group
+      status: automated
+
+    - id: RHEL-09-232095
+      levels:
+          - medium
+      title: RHEL 9 /etc/group file must be group-owned by root.
+      rules:
+          - file_groupowner_etc_group
+      status: automated
+
+    - id: RHEL-09-232100
+      levels:
+          - medium
+      title: RHEL 9 /etc/group- file must be owned by root.
+      rules:
+          - file_owner_backup_etc_group
+
+    - id: RHEL-09-232103
+      title: RHEL 9 "/etc/audit/" must be owned by root.
+      levels:
+          - medium
+      rules:
+          - file_ownership_audit_configuration
+      status: automated
+
+    - id: RHEL-09-232104
+      title: RHEL 9 "/etc/audit/" must be group-owned by root.
+      levels:
+          - medium
+      rules:
+          - file_groupownership_audit_configuration
+
+    - id: RHEL-09-232105
+      levels:
+          - medium
+      title: RHEL 9 /etc/group- file must be group-owned by root.
+      rules:
+          - file_groupowner_backup_etc_group
+      status: automated
+
+    - id: RHEL-09-232110
+      levels:
+          - medium
+      title: RHEL 9 /etc/gshadow file must be owned by root.
+      rules:
+          - file_owner_etc_gshadow
+      status: automated
+
+    - id: RHEL-09-232115
+      levels:
+          - medium
+      title: RHEL 9 /etc/gshadow file must be group-owned by root.
+      rules:
+          - file_groupowner_etc_gshadow
+      status: automated
+
+    - id: RHEL-09-232120
+      levels:
+          - medium
+      title: RHEL 9 /etc/gshadow- file must be owned by root.
+      rules:
+          - file_owner_backup_etc_gshadow
+      status: automated
+
+    - id: RHEL-09-232125
+      levels:
+          - medium
+      title: RHEL 9 /etc/gshadow- file must be group-owned by root.
+      rules:
+          - file_groupowner_backup_etc_gshadow
+      status: automated
+
+    - id: RHEL-09-232130
+      levels:
+          - medium
+      title: RHEL 9 /etc/passwd file must be owned by root.
+      rules:
+          - file_owner_etc_passwd
+      status: automated
+
+    - id: RHEL-09-232135
+      levels:
+          - medium
+      title: RHEL 9 /etc/passwd file must be group-owned by root.
+      rules:
+          - file_groupowner_etc_passwd
+      status: automated
+
+    - id: RHEL-09-232140
+      levels:
+          - medium
+      title: RHEL 9 /etc/passwd- file must be owned by root.
+      rules:
+          - file_owner_backup_etc_passwd
+      status: automated
+
+    - id: RHEL-09-232145
+      levels:
+          - medium
+      title: RHEL 9 /etc/passwd- file must be group-owned by root.
+      rules:
+          - file_groupowner_backup_etc_passwd
+      status: automated
+
+    - id: RHEL-09-232150
+      levels:
+          - medium
+      title: RHEL 9 /etc/shadow file must be owned by root.
+      rules:
+          - file_owner_etc_shadow
+      status: automated
+
+    - id: RHEL-09-232155
+      levels:
+          - medium
+      title: RHEL 9 /etc/shadow file must be group-owned by root.
+      rules:
+          - file_groupowner_etc_shadow
+      status: automated
+
+    - id: RHEL-09-232160
+      levels:
+          - medium
+      title: RHEL 9 /etc/shadow- file must be owned by root.
+      rules:
+          - file_owner_backup_etc_shadow
+      status: automated
+
+    - id: RHEL-09-232165
+      levels:
+          - medium
+      title: RHEL 9 /etc/shadow- file must be group-owned by root.
+      rules:
+          - file_groupowner_backup_etc_shadow
+      status: automated
+
+    - id: RHEL-09-232170
+      levels:
+          - medium
+      title: RHEL 9 /var/log directory must be owned by root.
+      rules:
+          - file_owner_var_log
+      status: automated
+
+    - id: RHEL-09-232175
+      levels:
+          - medium
+      title: RHEL 9 /var/log directory must be group-owned by root.
+      rules:
+          - file_groupowner_var_log
+      status: automated
+
+    - id: RHEL-09-232180
+      levels:
+          - medium
+      title: RHEL 9 /var/log/messages file must be owned by root.
+      rules:
+          - file_owner_var_log_messages
+      status: automated
+
+    - id: RHEL-09-232185
+      levels:
+          - medium
+      title: RHEL 9 /var/log/messages file must be group-owned by root.
+      rules:
+          - file_groupowner_var_log_messages
+      status: automated
+
+    - id: RHEL-09-232190
+      levels:
+          - medium
+      title: RHEL 9 system commands must be owned by root.
+      rules:
+          - file_ownership_binary_dirs
+      status: automated
+
+    - id: RHEL-09-232195
+      levels:
+          - medium
+      title: RHEL 9 system commands must be group-owned by root or a system account.
+      rules:
+          - file_groupownership_system_commands_dirs
+      status: automated
+
+    - id: RHEL-09-232200
+      levels:
+          - medium
+      title: RHEL 9 library files must be owned by root.
+      rules:
+          - file_ownership_library_dirs
+      status: automated
+
+    - id: RHEL-09-232205
+      levels:
+          - medium
+      title: RHEL 9 library files must be group-owned by root or a system account.
+      rules:
+          - root_permissions_syslibrary_files
+      status: automated
+
+    - id: RHEL-09-232210
+      levels:
+          - medium
+      title: RHEL 9 library directories must be owned by root.
+      rules:
+          - dir_ownership_library_dirs
+      status: automated
+
+    - id: RHEL-09-232215
+      levels:
+          - medium
+      title: RHEL 9 library directories must be group-owned by root or a system account.
+      rules:
+          - dir_group_ownership_library_dirs
+      status: automated
+
+    - id: RHEL-09-232220
+      levels:
+          - medium
+      title: RHEL 9 audit tools must be owned by root.
+      rules:
+          - file_audit_tools_ownership
+      status: automated
+
+    - id: RHEL-09-232225
+      levels:
+          - medium
+      title: RHEL 9 audit tools must be group-owned by root.
+      rules:
+          - file_audit_tools_group_ownership
+      status: automated
+
+    - id: RHEL-09-232230
+      levels:
+          - medium
+      title: RHEL 9 cron configuration files directory must be owned by root.
+      rules:
+          - file_owner_cron_d
+          - file_owner_cron_daily
+          - file_owner_cron_hourly
+          - file_owner_cron_monthly
+          - file_owner_cron_weekly
+          - file_owner_crontab
+          - file_owner_cron_deny
+      status: automated
+
+    - id: RHEL-09-232235
+      levels:
+          - medium
+      title: RHEL 9 cron configuration files directory must be group-owned by root.
+      rules:
+          - file_groupowner_cron_d
+          - file_groupowner_cron_daily
+          - file_groupowner_cron_hourly
+          - file_groupowner_cron_monthly
+          - file_groupowner_cron_weekly
+          - file_groupowner_crontab
+          - file_groupowner_cron_deny
+      status: automated
+
+    - id: RHEL-09-232240
+      levels:
+          - medium
+      title: All RHEL 9 world-writable directories must be owned by root, sys, bin, or an application
+          user.
+      rules:
+          - dir_perms_world_writable_root_owned
+      status: automated
+
+    - id: RHEL-09-232245
+      levels:
+          - medium
+      title: A sticky bit must be set on all RHEL 9 public directories.
+      rules:
+          - dir_perms_world_writable_sticky_bits
+      status: automated
+
+    - id: RHEL-09-232250
+      levels:
+          - medium
+      title: All RHEL 9 local files and directories must have a valid group owner.
+      rules:
+          - file_permissions_ungroupowned
+      status: automated
+
+    - id: RHEL-09-232255
+      levels:
+          - medium
+      title: All RHEL 9 local files and directories must have a valid owner.
+      rules:
+          - no_files_unowned_by_user
+      status: automated
+
+    - id: RHEL-09-232260
+      levels:
+          - medium
+      title: RHEL 9 must be configured so that all system device files are correctly labeled to prevent
+          unauthorized modification.
+      rules:
+          - selinux_all_devicefiles_labeled
+      status: automated
+
+    - id: RHEL-09-232270
+      levels:
+          - medium
+      title: RHEL 9 /etc/shadow file must have mode 0000 to prevent unauthorized access.
+      rules:
+          - file_permissions_etc_shadow
+      status: automated
+
+    - id: RHEL-09-251010
+      levels:
+          - medium
+      title: RHEL 9 must have the firewalld package installed.
+      rules:
+          - package_firewalld_installed
+      status: automated
+
+    - id: RHEL-09-251015
+      levels:
+          - medium
+      title: The firewalld service on RHEL 9 must be active.
+      rules:
+          - service_firewalld_enabled
+      status: automated
+
+    - id: RHEL-09-251020
+      levels:
+          - medium
+      title: A RHEL 9 firewall must employ a deny-all, allow-by-exception policy for allowing connections
+          to other systems.
+      rules:
+          - configured_firewalld_default_deny
+      status: automated
+
+    - id: RHEL-09-251030
+      levels:
+          - medium
+      title: RHEL 9 must protect against or limit the effects of denial-of-service (DoS) attacks by ensuring
+          rate-limiting measures on impacted network interfaces are implemented.
+      rules:
+          - firewalld-backend
+      status: automated
+
+    - id: RHEL-09-251035
+      levels:
+          - medium
+      title: RHEL 9 must be configured to prohibit or restrict the use of functions, ports, protocols,
+          and/or services, as defined in the Ports, Protocols, and Services Management (PPSM) Category
+          Assignments List (CAL) and vulnerability assessments.
+      rules:
+          - firewalld_sshd_port_enabled
+      status: automated
+
+    - id: RHEL-09-251040
+      levels:
+          - medium
+      title: RHEL 9 network interfaces must not be in promiscuous mode.
+      rules:
+          - network_sniffer_disabled
+      status: automated
+
+    - id: RHEL-09-251045
+      levels:
+          - medium
+      title: RHEL 9 must enable hardening for the Berkeley Packet Filter just-in-time compiler.
+      rules:
+          - sysctl_net_core_bpf_jit_harden
+      status: automated
+
+    - id: RHEL-09-252010
+      levels:
+          - medium
+      title: RHEL 9 must have the chrony package installed.
+      rules:
+          - package_chrony_installed
+      status: automated
+
+    - id: RHEL-09-252015
+      levels:
+          - medium
+      title: RHEL 9 chronyd service must be enabled.
+      rules:
+          - service_chronyd_enabled
+      status: automated
+
+    - id: RHEL-09-252020
+      levels:
+          - medium
+      title: RHEL 9 must securely compare internal information system clocks at least every 24 hours.
+      rules:
+          - chronyd_or_ntpd_set_maxpoll
+          - chronyd_server_directive
+          - chronyd_specify_remote_server
+          - var_multiple_time_servers=stig
+          - var_time_service_set_maxpoll=18_hours
+      status: automated
+
+    - id: RHEL-09-252025
+      levels:
+          - low
+      title: RHEL 9 must disable the chrony daemon from acting as a server.
+      rules:
+          - chronyd_client_only
+      status: automated
+
+    - id: RHEL-09-252030
+      levels:
+          - low
+      title: RHEL 9 must disable network management of the chrony daemon.
+      rules:
+          - chronyd_no_chronyc_network
+      status: automated
+
+    - id: RHEL-09-252035
+      levels:
+          - medium
+      title: RHEL 9 systems using Domain Name Servers (DNS) resolution must have at least two name servers
+          configured.
+      rules:
+          - network_configure_name_resolution
+      status: automated
+
+    - id: RHEL-09-252040
+      levels:
+          - medium
+      title: RHEL 9 must configure a DNS processing mode set be Network Manager.
+      rules:
+          - networkmanager_dns_mode
+          - var_networkmanager_dns_mode=explicit_default
+      status: automated
+
+    - id: RHEL-09-252045
+      levels:
+          - medium
+      title: RHEL 9 must not have unauthorized IP tunnels configured.
+      rules:
+          - libreswan_approved_tunnels
+      status: automated
+
+    - id: RHEL-09-252050
+      levels:
+          - medium
+      title: RHEL 9 must be configured to prevent unrestricted mail relaying.
+      rules:
+          - postfix_prevent_unrestricted_relay
+      status: automated
+
+    - id: RHEL-09-252060
+      levels:
+          - medium
+      title: RHEL 9 must forward mail from postmaster to the root account using a postfix alias.
+      rules:
+          - postfix_client_configure_mail_alias_postmaster
+      status: automated
+
+    - id: RHEL-09-252065
+      levels:
+          - medium
+      title: RHEL 9 libreswan package must be installed.
+      rules:
+          - package_libreswan_installed
+      status: automated
+
+    - id: RHEL-09-252070
+      levels:
+          - high
+      title: There must be no shosts.equiv files on RHEL 9.
+      rules:
+          - no_host_based_files
+      status: automated
+
+    - id: RHEL-09-252075
+      levels:
+          - high
+      title: There must be no .shosts files on RHEL 9.
+      rules:
+          - no_user_host_based_files
+      status: automated
+
+    - id: RHEL-09-253010
+      levels:
+          - medium
+      title: RHEL 9 must be configured to use TCP syncookies.
+      rules:
+          - sysctl_net_ipv4_tcp_syncookies
+      status: automated
+
+    - id: RHEL-09-253015
+      levels:
+          - medium
+      title: RHEL 9 must ignore Internet Protocol version 4 (IPv4) Internet Control Message Protocol
+          (ICMP) redirect messages.
+      rules:
+          - sysctl_net_ipv4_conf_all_accept_redirects
+      status: automated
+
+    - id: RHEL-09-253020
+      levels:
+          - medium
+      title: RHEL 9 must not forward Internet Protocol version 4 (IPv4) source-routed packets.
+      rules:
+          - sysctl_net_ipv4_conf_all_accept_source_route
+      status: automated
+
+    - id: RHEL-09-253025
+      levels:
+          - medium
+      title: RHEL 9 must log IPv4 packets with impossible addresses.
+      rules:
+          - sysctl_net_ipv4_conf_all_log_martians
+      status: automated
+
+    - id: RHEL-09-253030
+      levels:
+          - medium
+      title: RHEL 9 must log IPv4 packets with impossible addresses by default.
+      rules:
+          - sysctl_net_ipv4_conf_default_log_martians
+      status: automated
+
+    - id: RHEL-09-253035
+      levels:
+          - medium
+      title: RHEL 9 must use reverse path filtering on all IPv4 interfaces.
+      rules:
+          - sysctl_net_ipv4_conf_all_rp_filter
+      status: automated
+
+    - id: RHEL-09-253040
+      levels:
+          - medium
+      title: RHEL 9 must prevent IPv4 Internet Control Message Protocol (ICMP) redirect messages from
+          being accepted.
+      rules:
+          - sysctl_net_ipv4_conf_default_accept_redirects
+      status: automated
+
+    - id: RHEL-09-253045
+      levels:
+          - medium
+      title: RHEL 9 must not forward IPv4 source-routed packets by default.
+      rules:
+          - sysctl_net_ipv4_conf_default_accept_source_route
+      status: automated
+
+    - id: RHEL-09-253050
+      levels:
+          - medium
+      title: RHEL 9 must use a reverse-path filter for IPv4 network traffic when possible by default.
+      rules:
+          - sysctl_net_ipv4_conf_default_rp_filter
+      status: automated
+
+    - id: RHEL-09-253055
+      levels:
+          - medium
+      title: RHEL 9 must not respond to Internet Control Message Protocol (ICMP) echoes sent to a broadcast
+          address.
+      rules:
+          - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+      status: automated
+
+    - id: RHEL-09-253060
+      levels:
+          - medium
+      title: RHEL 9 must limit the number of bogus Internet Control Message Protocol (ICMP) response
+          errors logs.
+      rules:
+          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
+      status: automated
+
+    - id: RHEL-09-253065
+      levels:
+          - medium
+      title: RHEL 9 must not send Internet Control Message Protocol (ICMP) redirects.
+      rules:
+          - sysctl_net_ipv4_conf_all_send_redirects
+      status: automated
+
+    - id: RHEL-09-253070
+      levels:
+          - medium
+      title: RHEL 9 must not allow interfaces to perform Internet Control Message Protocol (ICMP) redirects
+          by default.
+      rules:
+          - sysctl_net_ipv4_conf_default_send_redirects
+      status: automated
+
+    - id: RHEL-09-253075
+      levels:
+          - medium
+      title: RHEL 9 must not enable IPv4 packet forwarding unless the system is a router.
+      rules:
+          - sysctl_net_ipv4_conf_all_forwarding
+      status: automated
+
+    - id: RHEL-09-254010
+      levels:
+          - medium
+      title: RHEL 9 must not accept router advertisements on all IPv6 interfaces.
+      rules:
+          - sysctl_net_ipv6_conf_all_accept_ra
+      status: automated
+
+    - id: RHEL-09-254015
+      levels:
+          - medium
+      title: RHEL 9 must ignore IPv6 Internet Control Message Protocol (ICMP) redirect messages.
+      rules:
+          - sysctl_net_ipv6_conf_all_accept_redirects
+      status: automated
+
+    - id: RHEL-09-254020
+      levels:
+          - medium
+      title: RHEL 9 must not forward IPv6 source-routed packets.
+      rules:
+          - sysctl_net_ipv6_conf_all_accept_source_route
+      status: automated
+
+    - id: RHEL-09-254025
+      levels:
+          - medium
+      title: RHEL 9 must not enable IPv6 packet forwarding unless the system is a router.
+      rules:
+          - sysctl_net_ipv6_conf_all_forwarding
+      status: automated
+
+    - id: RHEL-09-254030
+      levels:
+          - medium
+      title: RHEL 9 must not accept router advertisements on all IPv6 interfaces by default.
+      rules:
+          - sysctl_net_ipv6_conf_default_accept_ra
+      status: automated
+
+    - id: RHEL-09-254035
+      levels:
+          - medium
+      title: RHEL 9 must prevent IPv6 Internet Control Message Protocol (ICMP) redirect messages from
+          being accepted.
+      rules:
+          - sysctl_net_ipv6_conf_default_accept_redirects
+      status: automated
+
+    - id: RHEL-09-254040
+      levels:
+          - medium
+      title: RHEL 9 must not forward IPv6 source-routed packets by default.
+      rules:
+          - sysctl_net_ipv6_conf_default_accept_source_route
+      status: automated
+
+    - id: RHEL-09-255010
+      levels:
+          - medium
+      title: All RHEL 9 networked systems must have SSH installed.
+      rules:
+          - package_openssh-server_installed
+      status: automated
+
+    - id: RHEL-09-255015
+      levels:
+          - medium
+      title: All RHEL 9 networked systems must have and implement SSH to protect the confidentiality
+          and integrity of transmitted and received information, as well as information during preparation
+          for transmission.
+      rules:
+          - service_sshd_enabled
+      status: automated
+
+    - id: RHEL-09-255020
+      levels:
+          - medium
+      title: RHEL 9 must have the openssh-clients package installed.
+      rules:
+          - package_openssh-clients_installed
+      status: automated
+
+    - id: RHEL-09-255025
+      levels:
+          - medium
+      title: RHEL 9 must display the Standard Mandatory DOD Notice and Consent Banner before granting
+          local or remote access to the system via a SSH logon.
+      rules:
+          - sshd_enable_warning_banner
+      status: automated
+
+    - id: RHEL-09-255030
+      levels:
+          - medium
+      title: RHEL 9 must log SSH connection attempts and failures to the server.
+      rules:
+          - sshd_set_loglevel_verbose
+      status: automated
+
+    - id: RHEL-09-255035
+      levels:
+          - medium
+      title: RHEL 9 SSHD must accept public key authentication.
+      rules:
+          - sshd_enable_pubkey_auth
+      status: automated
+
+    - id: RHEL-09-255040
+      levels:
+          - high
+      title: RHEL 9 SSHD must not allow blank passwords.
+      rules:
+          - sshd_disable_empty_passwords
+      status: automated
+
+    - id: RHEL-09-255045
+      levels:
+          - medium
+      title: RHEL 9 must not permit direct logons to the root account using remote access via SSH.
+      rules:
+          - sshd_disable_root_login
+      status: automated
+
+    - id: RHEL-09-255050
+      levels:
+          - high
+      title: RHEL 9 must enable the Pluggable Authentication Module (PAM) interface for SSHD.
+      rules:
+          - sshd_enable_pam
+      status: automated
+
+    - id: RHEL-09-255055
+      levels:
+          - medium
+      title: RHEL 9 SSH daemon must be configured to use system-wide crypto policies.
+      rules:
+          - file_sshd_50_redhat_exists
+          - sshd_include_crypto_policy
+      status: automated
+
+    - id: RHEL-09-255060
+      levels:
+          - medium
+      title: RHEL 9 must implement DOD-approved encryption ciphers to protect the confidentiality of
+          SSH client connections.
+      rules:
+          - sshd_include_crypto_policy
+      status: automated
+    - id: RHEL-09-255064
+      title: The RHEL 9 SSH client must be configured to use only DOD-approved encryption ciphers employing
+          FIPS 140-3 validated cryptographic hash algorithms to protect the confidentiality of SSH client
+          connections.
+      levels:
+          - medium
+      rules:
+          - harden_sshd_ciphers_openssh_conf_crypto_policy
+          - sshd_approved_ciphers=stig_rhel9
+    - id: RHEL-09-255065
+      levels:
+          - medium
+      title: RHEL 9 must implement DOD-approved encryption ciphers to protect the confidentiality of
+          SSH server connections.
+      rules:
+          - harden_sshd_ciphers_opensshserver_conf_crypto_policy
+          - sshd_approved_ciphers=stig_rhel9
+      status: automated
+    - id: RHEL-09-255070
+      levels:
+          - medium
+      title: The RHEL 9 SSH client must be configured to use only DOD-approved Message Authentication
+          Codes (MACs) employing FIPS 140-3 validated cryptographic hash algorithms to protect the confidentiality
+          of SSH client connections.
+      rules:
+          - harden_sshd_macs_openssh_conf_crypto_policy
+          - sshd_approved_macs=stig_rhel9
+
+    - id: RHEL-09-255075
+      levels:
+          - medium
+      title: RHEL 9 SSH server must be configured to use only Message Authentication Codes (MACs) employing
+          FIPS 140-3 validated cryptographic hash algorithms.
+      status: automated
+      rules:
+          - harden_sshd_macs_opensshserver_conf_crypto_policy
+          - sshd_approved_macs=stig_rhel9
+
+    - id: RHEL-09-255080
+      levels:
+          - medium
+      title: RHEL 9 must not allow a noncertificate trusted host SSH logon to the system.
+      rules:
+          - disable_host_auth
+      status: automated
+
+    - id: RHEL-09-255085
+      levels:
+          - medium
+      title: RHEL 9 must not allow users to override SSH environment variables.
+      rules:
+          - sshd_do_not_permit_user_env
+      status: automated
+
+    - id: RHEL-09-255090
+      levels:
+          - medium
+      title: RHEL 9 must force a frequent session key renegotiation for SSH connections to the server.
+      rules:
+          - sshd_rekey_limit
+          - var_rekey_limit_size=1G
+          - var_rekey_limit_time=1hour
+      status: automated
+
+    - id: RHEL-09-255095
+      levels:
+          - medium
+      title: RHEL 9 must be configured so that all network connections associated with SSH traffic terminate
+          after becoming unresponsive.
+      rules:
+          - sshd_set_keepalive
+          - var_sshd_set_keepalive=1
+      status: automated
+
+    - id: RHEL-09-255100
+      levels:
+          - medium
+      title: RHEL 9 must be configured so that all network connections associated with SSH traffic are
+          terminated after 10 minutes of becoming unresponsive.
+      rules:
+          - sshd_set_idle_timeout
+          - sshd_idle_timeout_value=10_minutes
+      status: automated
+
+    - id: RHEL-09-255105
+      levels:
+          - medium
+      title: RHEL 9 SSH server configuration file must be group-owned by root.
+      rules:
+          - file_groupowner_sshd_config
+          - directory_groupowner_sshd_config_d
+          - file_groupowner_sshd_drop_in_config
+      status: automated
+
+    - id: RHEL-09-255110
+      levels:
+          - medium
+      title: RHEL 9 SSH server configuration file must be owned by root.
+      rules:
+          - file_owner_sshd_config
+          - directory_owner_sshd_config_d
+          - file_owner_sshd_drop_in_config
+      status: automated
+
+    - id: RHEL-09-255115
+      levels:
+          - medium
+      title: RHEL 9 SSH server configuration file must have mode 0600 or less permissive.
+      rules:
+          - file_permissions_sshd_config
+          - directory_permissions_sshd_config_d
+          - file_permissions_sshd_drop_in_config
+      status: automated
+
+    - id: RHEL-09-255120
+      levels:
+          - medium
+      title: RHEL 9 SSH private host key files must have mode 0640 or less permissive.
+      rules:
+          - file_permissions_sshd_private_key
+      status: automated
+
+    - id: RHEL-09-255125
+      levels:
+          - medium
+      title: RHEL 9 SSH public host key files must have mode 0644 or less permissive.
+      rules:
+          - file_permissions_sshd_pub_key
+      status: automated
+
+    - id: RHEL-09-255130
+      levels:
+          - medium
+      title: RHEL 9 SSH daemon must not allow compression or must only allow compression after successful
+          authentication.
+      rules:
+          - sshd_disable_compression
+          - var_sshd_disable_compression=no
+      status: automated
+
+    - id: RHEL-09-255135
+      levels:
+          - medium
+      title: RHEL 9 SSH daemon must not allow GSSAPI authentication.
+      rules:
+          - sshd_disable_gssapi_auth
+      status: automated
+
+    - id: RHEL-09-255140
+      levels:
+          - medium
+      title: RHEL 9 SSH daemon must not allow Kerberos authentication.
+      rules:
+          - sshd_disable_kerb_auth
+      status: automated
+
+    - id: RHEL-09-255145
+      levels:
+          - medium
+      title: RHEL 9 SSH daemon must not allow rhosts authentication.
+      rules:
+          - sshd_disable_rhosts
+      status: automated
+
+    - id: RHEL-09-255150
+      levels:
+          - medium
+      title: RHEL 9 SSH daemon must not allow known hosts authentication.
+      rules:
+          - sshd_disable_user_known_hosts
+      status: automated
+
+    - id: RHEL-09-255155
+      levels:
+          - medium
+      title: RHEL 9 SSH daemon must disable remote X connections for interactive users.
+      rules:
+          - sshd_disable_x11_forwarding
+      status: automated
+
+    - id: RHEL-09-255160
+      levels:
+          - medium
+      title: RHEL 9 SSH daemon must perform strict mode checking of home directory configuration files.
+      rules:
+          - sshd_enable_strictmodes
+      status: automated
+
+    - id: RHEL-09-255165
+      levels:
+          - medium
+      title: RHEL 9 SSH daemon must display the date and time of the last successful account logon upon
+          an SSH logon.
+      rules:
+          - sshd_print_last_log
+      status: automated
+
+    - id: RHEL-09-255175
+      levels:
+          - medium
+      title: RHEL 9 SSH daemon must prevent remote hosts from connecting to the proxy display.
+      rules:
+          - sshd_x11_use_localhost
+      status: automated
+
+    - id: RHEL-09-271010
+      levels:
+          - medium
+      title: RHEL 9 must display the Standard Mandatory DOD Notice and Consent Banner before granting
+          local or remote access to the system via a graphical user logon.
+      rules:
+          - dconf_gnome_banner_enabled
+      status: automated
+
+    - id: RHEL-09-271015
+      levels:
+          - medium
+      title: RHEL 9 must prevent a user from overriding the banner-message-enable setting for the graphical
+          user interface.
+      rules:
+          - dconf_gnome_banner_enabled
+      status: automated
+
+    - id: RHEL-09-271020
+      levels:
+          - medium
+      title: RHEL 9 must disable the graphical user interface automount function unless required.
+      rules:
+          - dconf_gnome_disable_automount_open
+      status: automated
+
+    - id: RHEL-09-271025
+      levels:
+          - medium
+      title: RHEL 9 must prevent a user from overriding the disabling of the graphical user interface
+          automount function.
+      rules:
+          - dconf_gnome_disable_automount_open
+      status: automated
+
+    - id: RHEL-09-271030
+      levels:
+          - medium
+      title: RHEL 9 must disable the graphical user interface autorun function unless required.
+      rules:
+          - dconf_gnome_disable_autorun
+      status: automated
+
+    - id: RHEL-09-271035
+      levels:
+          - medium
+      title: RHEL 9 must prevent a user from overriding the disabling of the graphical user interface
+          autorun function.
+      rules:
+          - dconf_gnome_disable_autorun
+      status: automated
+
+    - id: RHEL-09-271040
+      levels:
+          - high
+      title: RHEL 9 must not allow unattended or automatic logon via the graphical user interface.
+      rules:
+          - gnome_gdm_disable_automatic_login
+      status: automated
+
+    - id: RHEL-09-271045
+      levels:
+          - medium
+      title: RHEL 9 must be able to initiate directly a session lock for all connection types using smart
+          card when the smart card is removed.
+      rules:
+          - dconf_gnome_lock_screen_on_smartcard_removal
+      status: automated
+
+    - id: RHEL-09-271050
+      levels:
+          - medium
+      title: RHEL 9 must prevent a user from overriding the disabling of the graphical user smart card
+          removal action.
+      rules:
+          - dconf_gnome_lock_screen_on_smartcard_removal
+      status: automated
+
+    - id: RHEL-09-271055
+      levels:
+          - medium
+      title: RHEL 9 must enable a user session lock until that user re-establishes access using established
+          identification and authentication procedures for graphical user sessions.
+      rules:
+          - dconf_gnome_screensaver_lock_enabled
+      status: automated
+
+    - id: RHEL-09-271060
+      levels:
+          - medium
+      title: RHEL 9 must prevent a user from overriding the screensaver lock-enabled setting for the
+          graphical user interface.
+      rules:
+          - dconf_gnome_screensaver_lock_enabled
+      status: automated
+
+    - id: RHEL-09-271065
+      levels:
+          - medium
+      title: RHEL 9 must automatically lock graphical user sessions after 15 minutes of inactivity.
+      rules:
+          - dconf_gnome_screensaver_idle_delay
+      status: automated
+
+    - id: RHEL-09-271070
+      levels:
+          - medium
+      title: RHEL 9 must prevent a user from overriding the session idle-delay setting for the graphical
+          user interface.
+      rules:
+          - dconf_gnome_session_idle_user_locks
+      status: automated
+
+    - id: RHEL-09-271075
+      levels:
+          - medium
+      title: RHEL 9 must initiate a session lock for graphical user interfaces when the screensaver is
+          activated.
+      rules:
+          - dconf_gnome_screensaver_lock_delay
+      status: automated
+
+    - id: RHEL-09-271080
+      levels:
+          - medium
+      title: RHEL 9 must prevent a user from overriding the session lock-delay setting for the graphical
+          user interface.
+      rules:
+          - dconf_gnome_screensaver_user_locks
+      status: automated
+
+    - id: RHEL-09-271085
+      levels:
+          - medium
+      title: RHEL 9 must conceal, via the session lock, information previously visible on the display
+          with a publicly viewable image.
+      rules:
+          - dconf_gnome_screensaver_mode_blank
+      status: automated
+
+    - id: RHEL-09-271090
+      levels:
+          - medium
+      title: RHEL 9 effective dconf policy must match the policy keyfiles.
+      rules:
+          - dconf_db_up_to_date
+      status: automated
+
+    - id: RHEL-09-271095
+      levels:
+          - medium
+      title: RHEL 9 must disable the ability of a user to restart the system from the login screen.
+      rules:
+          - dconf_gnome_disable_restart_shutdown
+      status: automated
+
+    - id: RHEL-09-271100
+      levels:
+          - medium
+      title: RHEL 9 must prevent a user from overriding the disable-restart-buttons setting for the graphical
+          user interface.
+      rules:
+          - dconf_gnome_disable_restart_shutdown
+      status: automated
+
+    - id: RHEL-09-271105
+      levels:
+          - medium
+      title: RHEL 9 must disable the ability of a user to accidentally press Ctrl-Alt-Del and cause a
+          system to shut down or reboot.
+      rules:
+          - dconf_gnome_disable_ctrlaltdel_reboot
+      status: automated
+
+    - id: RHEL-09-271110
+      levels:
+          - medium
+      title: RHEL 9 must prevent a user from overriding the Ctrl-Alt-Del sequence settings for the graphical
+          user interface.
+      rules:
+          - dconf_gnome_disable_ctrlaltdel_reboot
+      status: automated
+
+    - id: RHEL-09-271115
+      levels:
+          - medium
+      title: RHEL 9 must disable the user list at logon for graphical user interfaces.
+      rules:
+          - dconf_gnome_disable_user_list
+      status: automated
+
+    - id: RHEL-09-291010
+      levels:
+          - medium
+      title: RHEL 9 must be configured to disable USB mass storage.
+      rules:
+          - kernel_module_usb-storage_disabled
+      status: automated
+
+    - id: RHEL-09-291015
+      levels:
+          - medium
+      title: RHEL 9 must have the USBGuard package installed.
+      rules:
+          - package_usbguard_installed
+      status: automated
+
+    - id: RHEL-09-291020
+      levels:
+          - medium
+      title: RHEL 9 must have the USBGuard package enabled.
+      rules:
+          - service_usbguard_enabled
+      status: automated
+
+    - id: RHEL-09-291025
+      levels:
+          - low
+      title: RHEL 9 must enable Linux audit logging for the USBGuard daemon.
+      rules:
+          - configure_usbguard_auditbackend
+      status: automated
+
+    - id: RHEL-09-291030
+      levels:
+          - medium
+      title: RHEL 9 must block unauthorized peripherals before establishing a connection.
+      rules:
+          - usbguard_generate_policy
+      status: automated
+
+    - id: RHEL-09-291035
+      levels:
+          - medium
+      title: RHEL 9 Bluetooth must be disabled.
+      rules:
+          - kernel_module_bluetooth_disabled
+      status: automated
+
+    - id: RHEL-09-291040
+      levels:
+          - medium
+      title: RHEL 9 wireless network adapters must be disabled.
+      rules:
+          - wireless_disable_interfaces
+      status: automated
+
+    - id: RHEL-09-411010
+      levels:
+          - medium
+      title: RHEL 9 user account passwords for new users or password changes must have a 60-day maximum
+          password lifetime restriction in /etc/login.defs.
+      rules:
+          - accounts_maximum_age_login_defs
+      status: automated
+
+    - id: RHEL-09-411015
+      levels:
+          - medium
+      title: RHEL 9 user account passwords must have a 60-day maximum password lifetime restriction.
+      rules:
+          - accounts_password_set_max_life_existing
+          - var_accounts_maximum_age_login_defs=60
+      status: automated
+
+    - id: RHEL-09-411020
+      levels:
+          - medium
+      title: All RHEL 9 local interactive user accounts must be assigned a home directory upon creation.
+      rules:
+          - accounts_have_homedir_login_defs
+      status: automated
+
+    - id: RHEL-09-411025
+      levels:
+          - medium
+      title: RHEL 9 must set the umask value to 077 for all local interactive user accounts.
+      rules:
+          - accounts_umask_interactive_users
+          - var_accounts_user_umask=077
+      status: automated
+
+    - id: RHEL-09-411030
+      levels:
+          - medium
+      title: RHEL 9 duplicate User IDs (UIDs) must not exist for interactive users.
+      rules:
+          - account_unique_id
+      status: automated
+
+    - id: RHEL-09-411035
+      levels:
+          - medium
+      title: RHEL 9 system accounts must not have an interactive login shell.
+      rules:
+          - no_shelllogin_for_systemaccounts
+      status: automated
+
+    - id: RHEL-09-411040
+      levels:
+          - medium
+      title: RHEL 9 must automatically expire temporary accounts within 72 hours.
+      rules:
+          - account_temp_expire_date
+      status: automated
+
+    - id: RHEL-09-411045
+      levels:
+          - medium
+      title: All RHEL 9 interactive users must have a primary group that exists.
+      rules:
+          - gid_passwd_group_same
+      status: automated
+
+    - id: RHEL-09-411050
+      levels:
+          - medium
+      title: RHEL 9 must disable account identifiers (individuals, groups, roles, and devices) after
+          35 days of inactivity.
+      rules:
+          - account_disable_post_pw_expiration
+          - var_account_disable_post_pw_expiration=35
+      status: automated
+
+    - id: RHEL-09-411055
+      levels:
+          - medium
+      title: Executable search paths within the initialization files of all local interactive RHEL 9
+          users must only contain paths that resolve to the system default or the users home directory.
+      rules:
+          - accounts_user_home_paths_only
+      status: automated
+
+    - id: RHEL-09-411060
+      levels:
+          - medium
+      title: All RHEL 9 local interactive users must have a home directory assigned in the /etc/passwd
+          file.
+      rules:
+          - accounts_user_interactive_home_directory_defined
+      status: automated
+
+    - id: RHEL-09-411065
+      levels:
+          - medium
+      title: All RHEL 9 local interactive user home directories defined in the /etc/passwd file must
+          exist.
+      rules:
+          - accounts_user_interactive_home_directory_exists
+      status: automated
+
+    - id: RHEL-09-411070
+      levels:
+          - medium
+      title: All RHEL 9 local interactive user home directories must be group-owned by the home directory
+          owner's primary group.
+      rules:
+          - file_groupownership_home_directories
+      status: automated
+
+    - id: RHEL-09-411075
+      levels:
+          - medium
+      title: RHEL 9 must automatically lock an account when three unsuccessful logon attempts occur.
+      rules:
+          - accounts_passwords_pam_faillock_deny
+          - var_accounts_passwords_pam_faillock_deny=3
+      status: automated
+
+    - id: RHEL-09-411080
+      levels:
+          - medium
+      title: RHEL 9 must automatically lock the root account until the root account is released by an
+          administrator when three unsuccessful logon attempts occur during a 15-minute time period.
+      rules:
+          - accounts_passwords_pam_faillock_deny_root
+      status: automated
+
+    - id: RHEL-09-411085
+      levels:
+          - medium
+      title: RHEL 9 must automatically lock an account when three unsuccessful logon attempts occur during
+          a 15-minute time period.
+      rules:
+          - accounts_passwords_pam_faillock_interval
+          - var_accounts_passwords_pam_faillock_fail_interval=900
+      status: automated
+
+    - id: RHEL-09-411090
+      levels:
+          - medium
+      title: RHEL 9 must maintain an account lock until the locked account is released by an administrator.
+      rules:
+          - accounts_passwords_pam_faillock_unlock_time
+          - var_accounts_passwords_pam_faillock_unlock_time=never
+      status: automated
+
+    - id: RHEL-09-411095
+      levels:
+          - medium
+      title: RHEL 9 must not have unauthorized accounts.
+      rules:
+          - accounts_authorized_local_users
+          - var_accounts_authorized_local_users_regex=rhel9
+      status: automated
+
+    - id: RHEL-09-411100
+      levels:
+          - high
+      title: The root account must be the only account having unrestricted access to RHEL 9 system.
+      rules:
+          - accounts_no_uid_except_zero
+      status: automated
+
+    - id: RHEL-09-411105
+      levels:
+          - medium
+      title: RHEL 9 must ensure account lockouts persist.
+      rules:
+          - accounts_passwords_pam_faillock_dir
+      status: automated
+
+    - id: RHEL-09-411110
+      levels:
+          - medium
+      title: RHEL 9 groups must have unique Group ID (GID).
+      rules:
+          - group_unique_id
+      status: automated
+
+    - id: RHEL-09-411115
+      levels:
+          - medium
+      title: Local RHEL 9 initialization files must not execute world-writable programs.
+      rules:
+          - accounts_user_dot_no_world_writable_programs
+      status: automated
+
+    - id: RHEL-09-412035
+      levels:
+          - medium
+      title: RHEL 9 must automatically exit interactive command shell user sessions after 15 minutes
+          of inactivity.
+      rules:
+          - accounts_tmout
+          - var_accounts_tmout=10_min
+      status: automated
+
+    - id: RHEL-09-412040
+      levels:
+          - low
+      title: RHEL 9 must limit the number of concurrent sessions to ten for all accounts and/or account
+          types.
+      rules:
+          - accounts_max_concurrent_login_sessions
+          - var_accounts_max_concurrent_login_sessions=10
+      status: automated
+
+    - id: RHEL-09-412045
+      levels:
+          - medium
+      title: RHEL 9 must log username information when unsuccessful logon attempts occur.
+      rules:
+          - accounts_passwords_pam_faillock_audit
+      status: automated
+
+    - id: RHEL-09-412050
+      levels:
+          - medium
+      title: RHEL 9 must enforce a delay of at least four seconds between logon prompts following a failed
+          logon attempt.
+      rules:
+          - accounts_logon_fail_delay
+          - var_accounts_fail_delay=4
+      status: automated
+
+    - id: RHEL-09-412055
+      levels:
+          - medium
+      title: RHEL 9 must define default permissions for the bash shell.
+      rules:
+          - accounts_umask_etc_bashrc
+      status: automated
+
+    - id: RHEL-09-412060
+      levels:
+          - medium
+      title: RHEL 9 must define default permissions for the c shell.
+      rules:
+          - accounts_umask_etc_csh_cshrc
+      status: automated
+
+    - id: RHEL-09-412065
+      levels:
+          - medium
+      title: RHEL 9 must define default permissions for all authenticated users in such a way that the
+          user can only read and modify their own files.
+      rules:
+          - accounts_umask_etc_login_defs
+      status: automated
+
+    - id: RHEL-09-412070
+      levels:
+          - medium
+      title: RHEL 9 must define default permissions for the system default profile.
+      rules:
+          - accounts_umask_etc_profile
+      status: automated
+
+    - id: RHEL-09-412075
+      levels:
+          - low
+      title: RHEL 9 must display the date and time of the last successful account logon upon logon.
+      rules:
+          - display_login_attempts
+      status: automated
+
+    - id: RHEL-09-412080
+      levels:
+          - medium
+      title: RHEL 9 must terminate idle user sessions.
+      rules:
+          - logind_session_timeout
+          - var_logind_session_timeout=10_minutes
+      status: automated
+
+    - id: RHEL-09-431010
+      levels:
+          - high
+      title: RHEL 9 must use a Linux Security Module configured to enforce limits on system services.
+      rules:
+          - selinux_state
+          - var_selinux_state=enforcing
+      status: automated
+
+    - id: RHEL-09-431015
+      levels:
+          - medium
+      title: RHEL 9 must enable the SELinux targeted policy.
+      rules:
+          - selinux_policytype
+          - var_selinux_policy_name=targeted
+      status: automated
+
+    - id: RHEL-09-431016
+      title: 'RHEL 9 must elevate the SELinux context when an administrator calls the sudo command.'
+      rules:
+          - selinux_context_elevation_for_sudo
+      status: automated
+
+    - id: RHEL-09-431020
+      levels:
+          - medium
+      title: RHEL 9 must configure SELinux context type to allow the use of a nondefault faillock tally
+          directory.
+      rules:
+          - account_password_selinux_faillock_dir
+      status: automated
+
+    - id: RHEL-09-431025
+      levels:
+          - medium
+      title: RHEL 9 must have policycoreutils package installed.
+      rules:
+          - package_policycoreutils_installed
+      status: automated
+
+    - id: RHEL-09-431030
+      levels:
+          - medium
+      title: RHEL 9 policycoreutils-python-utils package must be installed.
+      rules:
+          - package_policycoreutils-python-utils_installed
+      status: automated
+
+    - id: RHEL-09-432010
+      levels:
+          - medium
+      title: RHEL 9 must have the sudo package installed.
+      rules:
+          - package_sudo_installed
+      status: automated
+
+    - id: RHEL-09-432015
+      levels:
+          - medium
+      title: RHEL 9 must require reauthentication when using the "sudo" command.
+      rules:
+          - sudo_require_reauthentication
+          - var_sudo_timestamp_timeout=always_prompt
+      status: automated
+
+    - id: RHEL-09-432020
+      levels:
+          - medium
+      title: RHEL 9 must use the invoking user's password for privilege escalation when using "sudo".
+      rules:
+          - sudoers_validate_passwd
+      status: automated
+
+    - id: RHEL-09-432025
+      levels:
+          - medium
+      title: RHEL 9 must require users to reauthenticate for privilege escalation.
+      rules:
+          - sudo_remove_no_authenticate
+      status: automated
+
+    - id: RHEL-09-432030
+      levels:
+          - medium
+      title: RHEL 9 must restrict privilege elevation to authorized personnel.
+      rules:
+          - sudo_restrict_privilege_elevation_to_authorized
+      status: automated
+
+    - id: RHEL-09-432035
+      levels:
+          - medium
+      title: RHEL 9 must restrict the use of the "su" command.
+      rules:
+          - use_pam_wheel_for_su
+      status: automated
+
+    - id: RHEL-09-433010
+      levels:
+          - medium
+      title: RHEL 9 fapolicy module must be installed.
+      rules:
+          - package_fapolicyd_installed
+      status: automated
+
+    - id: RHEL-09-433015
+      levels:
+          - medium
+      title: RHEL 9 fapolicy module must be enabled.
+      rules:
+          - service_fapolicyd_enabled
+      status: automated
+
+    - id: RHEL-09-433016
+      levels:
+          - medium
+      title: The RHEL 9 fapolicy module must be configured to employ a deny-all, permit-by-exception
+          policy to allow the execution of authorized software programs.
+      rules:
+          - fapolicy_default_deny
+      status: automated
+
+    - id: RHEL-09-611010
+      levels:
+          - medium
+      title: RHEL 9 must ensure the password complexity module in the system-auth file is configured
+          for three retries or less.
+      rules:
+          - accounts_password_pam_pwquality_retry
+          - var_password_pam_retry=3
+      status: automated
+
+    - id: RHEL-09-611025
+      levels:
+          - high
+      title: RHEL 9 must not allow blank or null passwords.
+      rules:
+          - no_empty_passwords
+      status: automated
+
+    - id: RHEL-09-611030
+      levels:
+          - medium
+      title: RHEL 9 must configure the use of the pam_faillock.so module in the /etc/pam.d/system-auth
+          file.
+      rules:
+          - account_password_pam_faillock_system_auth
+      status: automated
+
+    - id: RHEL-09-611035
+      levels:
+          - medium
+      title: RHEL 9 must configure the use of the pam_faillock.so module in the /etc/pam.d/password-auth
+          file.
+      rules:
+          - account_password_pam_faillock_password_auth
+      status: automated
+
+    - id: RHEL-09-611040
+      levels:
+          - medium
+      title: RHEL 9 must ensure the password complexity module is enabled in the password-auth file.
+      rules:
+          - accounts_password_pam_pwquality_password_auth
+      status: automated
+
+    - id: RHEL-09-611045
+      levels:
+          - medium
+      title: RHEL 9 must ensure the password complexity module is enabled in the system-auth file.
+      rules:
+          - accounts_password_pam_pwquality_system_auth
+      status: automated
+
+    - id: RHEL-09-611050
+      levels:
+          - medium
+      title: RHEL 9 password-auth must be configured to use a sufficient number of hashing rounds.
+      rules:
+          - accounts_password_pam_unix_rounds_password_auth
+          - var_password_pam_unix_rounds=100000
+      status: automated
+
+    - id: RHEL-09-611055
+      levels:
+          - medium
+      title: RHEL 9 system-auth must be configured to use a sufficient number of hashing rounds.
+      rules:
+          - accounts_password_pam_unix_rounds_system_auth
+      status: automated
+
+    - id: RHEL-09-611060
+      levels:
+          - medium
+      title: RHEL 9 must enforce password complexity rules for the root account.
+      rules:
+          - accounts_password_pam_enforce_root
+      status: automated
+
+    - id: RHEL-09-611065
+      levels:
+          - medium
+      title: RHEL 9 must enforce password complexity by requiring that at least one lowercase character
+          be used.
+      rules:
+          - accounts_password_pam_lcredit
+          - var_password_pam_lcredit=1
+      status: automated
+
+    - id: RHEL-09-611070
+      levels:
+          - medium
+      title: RHEL 9 must enforce password complexity by requiring that at least one numeric character
+          be used.
+      rules:
+          - accounts_password_pam_dcredit
+          - var_password_pam_dcredit=1
+      status: automated
+
+    - id: RHEL-09-611075
+      levels:
+          - medium
+      title: RHEL 9 passwords for new users or password changes must have a 24 hours minimum password
+          lifetime restriction in /etc/login.defs.
+      rules:
+          - accounts_minimum_age_login_defs
+      status: automated
+
+    - id: RHEL-09-611080
+      levels:
+          - medium
+      title: RHEL 9 passwords must have a 24 hours minimum password lifetime restriction in /etc/shadow.
+      rules:
+          - accounts_password_set_min_life_existing
+          - var_accounts_minimum_age_login_defs=1
+      status: automated
+
+    - id: RHEL-09-611085
+      levels:
+          - medium
+      title: RHEL 9 must require users to provide a password for privilege escalation.
+      rules:
+          - sudo_remove_nopasswd
+      status: automated
+
+    - id: RHEL-09-611090
+      levels:
+          - medium
+      title: RHEL 9 passwords must be created with a minimum of 15 characters.
+      rules:
+          - accounts_password_pam_minlen
+          - var_password_pam_minlen=15
+      status: automated
+
+    - id: RHEL-09-611100
+      levels:
+          - medium
+      title: RHEL 9 must enforce password complexity by requiring that at least one special character
+          be used.
+      rules:
+          - accounts_password_pam_ocredit
+          - var_password_pam_ocredit=1
+      status: automated
+
+    - id: RHEL-09-611105
+      levels:
+          - medium
+      title: RHEL 9 must prevent the use of dictionary words for passwords.
+      rules:
+          - accounts_password_pam_dictcheck
+          - var_password_pam_dictcheck=1
+      status: automated
+
+    - id: RHEL-09-611110
+      levels:
+          - medium
+      title: RHEL 9 must enforce password complexity by requiring that at least one uppercase character
+          be used.
+      rules:
+          - accounts_password_pam_ucredit
+          - var_password_pam_ucredit=1
+      status: automated
+
+    - id: RHEL-09-611115
+      levels:
+          - medium
+      title: RHEL 9 must require the change of at least eight characters when passwords are changed.
+      rules:
+          - accounts_password_pam_difok
+          - var_password_pam_difok=8
+      status: automated
+
+    - id: RHEL-09-611120
+      levels:
+          - medium
+      title: RHEL 9 must require the maximum number of repeating characters of the same character class
+          be limited to four when passwords are changed.
+      rules:
+          - accounts_password_pam_maxclassrepeat
+          - var_password_pam_maxclassrepeat=4
+      status: automated
+
+    - id: RHEL-09-611125
+      levels:
+          - medium
+      title: RHEL 9 must require the maximum number of repeating characters be limited to three when
+          passwords are changed.
+      rules:
+          - accounts_password_pam_maxrepeat
+          - var_password_pam_maxrepeat=3
+      status: automated
+
+    - id: RHEL-09-611130
+      levels:
+          - medium
+      title: RHEL 9 must require the change of at least four character classes when passwords are changed.
+      rules:
+          - accounts_password_pam_minclass
+          - var_password_pam_minclass=4
+      status: automated
+
+    - id: RHEL-09-611135
+      levels:
+          - medium
+      title: RHEL 9 must be configured so that user and group account administration utilities are configured
+          to store only encrypted representations of passwords.
+      rules:
+          - set_password_hashing_algorithm_libuserconf
+          - var_password_hashing_algorithm_pam=sha512
+      status: automated
+
+    - id: RHEL-09-611140
+      levels:
+          - medium
+      title: RHEL 9 must be configured to use the shadow file to store only encrypted representations
+          of passwords.
+      rules:
+          - set_password_hashing_algorithm_logindefs
+          - var_password_hashing_algorithm=SHA512
+      status: automated
+
+    - id: RHEL-09-611145
+      levels:
+          - medium
+      title: RHEL 9 must not be configured to bypass password requirements for privilege escalation.
+      rules:
+          - disallow_bypass_password_sudo
+      status: automated
+
+    - id: RHEL-09-611155
+      levels:
+          - medium
+      title: RHEL 9 must not have accounts configured with blank or null passwords.
+      rules:
+          - no_empty_passwords_etc_shadow
+      status: automated
+
+    - id: RHEL-09-611160
+      levels:
+          - medium
+      title: RHEL 9 must use the CAC smart card driver.
+      rules:
+          - configure_opensc_card_drivers
+          - var_smartcard_drivers=cac
+      status: automated
+
+    - id: RHEL-09-611165
+      levels:
+          - medium
+      title: RHEL 9 must enable certificate based smart card authentication.
+      rules:
+          - sssd_enable_smartcards
+      status: automated
+
+    - id: RHEL-09-611170
+      levels:
+          - medium
+      title: RHEL 9 must implement certificate status checking for multifactor authentication.
+      rules:
+          - sssd_certificate_verification
+          - var_sssd_certificate_verification_digest_function=sha512
+      status: automated
+
+    - id: RHEL-09-611175
+      levels:
+          - medium
+      title: RHEL 9 must have the pcsc-lite package installed.
+      rules:
+          - package_pcsc-lite_installed
+      status: automated
+
+    - id: RHEL-09-611180
+      levels:
+          - medium
+      title: The pcscd service on RHEL 9 must be active.
+      rules:
+          - service_pcscd_enabled
+      status: automated
+
+    - id: RHEL-09-611185
+      levels:
+          - medium
+      title: RHEL 9 must have the opensc package installed.
+      rules:
+          - package_opensc_installed
+      status: automated
+
+    - id: RHEL-09-611190
+      levels:
+          - medium
+      title: RHEL 9, for PKI-based authentication, must enforce authorized access to the corresponding
+          private key.
+      rules:
+          - ssh_keys_passphrase_protected
+      status: automated
+
+    - id: RHEL-09-611195
+      levels:
+          - medium
+      title: RHEL 9 must require authentication to access emergency mode.
+      rules:
+          - require_emergency_target_auth
+      status: automated
+
+    - id: RHEL-09-611200
+      levels:
+          - medium
+      title: RHEL 9 must require authentication to access single-user mode.
+      rules:
+          - require_singleuser_auth
+      status: automated
+
+    - id: RHEL-09-631010
+      levels:
+          - medium
+      title: RHEL 9, for PKI-based authentication, must validate certificates by constructing a certification
+          path (which includes status information) to an accepted trust anchor.
+      rules:
+          - sssd_has_trust_anchor
+      status: automated
+
+    - id: RHEL-09-631015
+      levels:
+          - medium
+      title: RHEL 9 must map the authenticated identity to the user or group account for PKI-based authentication.
+      rules:
+          - sssd_enable_certmap
+      status: automated
+
+    - id: RHEL-09-631020
+      levels:
+          - medium
+      title: RHEL 9 must prohibit the use of cached authenticators after one day.
+      rules:
+          - sssd_offline_cred_expiration
+      status: automated
+
+    - id: RHEL-09-651010
+      levels:
+          - medium
+      title: RHEL 9 must have the AIDE package installed.
+      rules:
+          - package_aide_installed
+          - aide_build_database
+      status: automated
+
+    - id: RHEL-09-651015
+      levels:
+          - medium
+      title: RHEL 9 must routinely check the baseline configuration for unauthorized changes and notify
+          the system administrator when anomalies in the operation of any security functions are discovered.
+      rules:
+          - aide_periodic_cron_checking
+          - aide_scan_notification
+      status: automated
+
+    - id: RHEL-09-651020
+      levels:
+          - medium
+      title: RHEL 9 must use a file integrity tool that is configured to use FIPS 140-3-approved cryptographic
+          hashes for validating file contents and directories.
+      rules:
+          - aide_use_fips_hashes
+      status: automated
+
+    - id: RHEL-09-651025
+      levels:
+          - medium
+      title: RHEL 9 must use cryptographic mechanisms to protect the integrity of audit tools.
+      rules:
+          - aide_check_audit_tools
+      status: automated
+
+    - id: RHEL-09-651030
+      levels:
+          - low
+      title: RHEL 9 must be configured so that the file integrity tool verifies Access Control Lists
+          (ACLs).
+      rules:
+          - aide_verify_acls
+      status: automated
+
+    - id: RHEL-09-651035
+      levels:
+          - low
+      title: RHEL 9 must be configured so that the file integrity tool verifies extended attributes.
+      rules:
+          - aide_verify_ext_attributes
+      status: automated
+
+    - id: RHEL-09-652010
+      levels:
+          - medium
+      title: RHEL 9 must have the rsyslog package installed.
+      rules:
+          - package_rsyslog_installed
+      status: automated
+
+    - id: RHEL-09-652015
+      levels:
+          - medium
+      title: RHEL 9 must have the packages required for encrypting offloaded audit logs installed.
+      rules:
+          - package_rsyslog-gnutls_installed
+      status: automated
+
+    - id: RHEL-09-652020
+      levels:
+          - medium
+      title: The rsyslog service on RHEL 9 must be active.
+      rules:
+          - service_rsyslog_enabled
+      status: automated
+
+    - id: RHEL-09-652025
+      levels:
+          - medium
+      title: RHEL 9 must be configured so that the rsyslog daemon does not accept log messages from other
+          servers unless the server is being used for log aggregation.
+      rules:
+          - rsyslog_nolisten
+      status: automated
+
+    - id: RHEL-09-652030
+      levels:
+          - medium
+      title: All RHEL 9 remote access methods must be monitored.
+      rules:
+          - rsyslog_remote_access_monitoring
+      status: automated
+
+    - id: RHEL-09-652040
+      levels:
+          - medium
+      title: RHEL 9 must authenticate the remote logging server for offloading audit logs via rsyslog.
+      rules:
+          - rsyslog_encrypt_offload_actionsendstreamdriverauthmode
+      status: automated
+
+    - id: RHEL-09-652045
+      levels:
+          - medium
+      title: RHEL 9 must encrypt the transfer of audit records offloaded onto a different system or media
+          from the system being audited via rsyslog.
+      rules:
+          - rsyslog_encrypt_offload_actionsendstreamdrivermode
+      status: automated
+
+    - id: RHEL-09-652050
+      levels:
+          - medium
+      title: RHEL 9 must encrypt via the gtls driver the transfer of audit records offloaded onto a different
+          system or media from the system being audited via rsyslog.
+      rules:
+          - rsyslog_encrypt_offload_defaultnetstreamdriver
+      status: automated
+
+    - id: RHEL-09-652055
+      levels:
+          - medium
+      title: RHEL 9 must be configured to forward audit records via TCP to a different system or media
+          from the system being audited via rsyslog.
+      rules:
+          - rsyslog_remote_loghost
+      status: automated
+
+    - id: RHEL-09-652060
+      levels:
+          - medium
+      title: RHEL 9 must use cron logging.
+      rules:
+          - rsyslog_cron_logging
+      status: automated
+
+    - id: RHEL-09-653010
+      levels:
+          - medium
+      title: RHEL 9 audit package must be installed.
+      rules:
+          - package_audit_installed
+      status: automated
+
+    - id: RHEL-09-653015
+      levels:
+          - medium
+      title: RHEL 9 audit service must be enabled.
+      rules:
+          - service_auditd_enabled
+      status: automated
+
+    - id: RHEL-09-653020
+      levels:
+          - medium
+      title: RHEL 9 audit system must take appropriate action when an error writing to the audit storage
+          volume occurs.
+      rules:
+          - auditd_data_disk_error_action_stig
+          - var_auditd_disk_error_action=halt
+      status: automated
+
+    - id: RHEL-09-653025
+      levels:
+          - medium
+      title: RHEL 9 audit system must take appropriate action when the audit storage volume is full.
+      rules:
+          - auditd_data_disk_full_action_stig
+          - var_auditd_disk_full_action=halt
+      status: automated
+
+    - id: RHEL-09-653030
+      levels:
+          - medium
+      title: RHEL 9 must allocate audit record storage capacity to store at least one week's worth of
+          audit records.
+      rules:
+          - auditd_audispd_configure_sufficiently_large_partition
+      status: automated
+
+    - id: RHEL-09-653035
+      levels:
+          - medium
+      title: RHEL 9 must take action when allocated audit record storage volume reaches 75 percent of
+          the repository maximum audit record storage capacity.
+      rules:
+          - auditd_data_retention_space_left_percentage
+          - var_auditd_space_left_percentage=25pc
+      status: automated
+
+    - id: RHEL-09-653040
+      levels:
+          - medium
+      title: RHEL 9 must notify the system administrator (SA) and information system security officer
+          (ISSO) (at a minimum) when allocated audit record storage volume 75 percent utilization.
+      rules:
+          - auditd_data_retention_space_left_action
+          - var_auditd_space_left_action=email
+      status: automated
+
+    - id: RHEL-09-653045
+      levels:
+          - medium
+      title: RHEL 9 must take action when allocated audit record storage volume reaches 95 percent of
+          the audit record storage capacity.
+      rules:
+          - auditd_data_retention_admin_space_left_percentage
+          - var_auditd_admin_space_left_percentage=5pc
+      status: automated
+
+    - id: RHEL-09-653050
+      levels:
+          - medium
+      title: RHEL 9 must take action when allocated audit record storage volume reaches 95 percent of
+          the repository maximum audit record storage capacity.
+      rules:
+          - auditd_data_retention_admin_space_left_action
+          - var_auditd_admin_space_left_action=single
+      status: automated
+
+    - id: RHEL-09-653055
+      levels:
+          - medium
+      title: RHEL 9 audit system must take appropriate action when the audit files have reached maximum
+          size.
+      rules:
+          - auditd_data_retention_max_log_file_action_stig
+          - var_auditd_max_log_file_action=rotate
+      status: automated
+
+    - id: RHEL-09-653060
+      levels:
+          - medium
+      title: RHEL 9 must label all offloaded audit logs before sending them to the central log server.
+      rules:
+          - auditd_name_format
+          - var_auditd_name_format=stig
+      status: automated
+
+    - id: RHEL-09-653065
+      levels:
+          - medium
+      title: RHEL 9 must take appropriate action when the internal event queue is full.
+      rules:
+          - auditd_overflow_action
+      status: automated
+
+    - id: RHEL-09-653070
+      levels:
+          - medium
+      title: RHEL 9 System Administrator (SA) and/or information system security officer (ISSO) (at a
+          minimum) must be alerted of an audit processing failure event.
+      rules:
+          - auditd_data_retention_action_mail_acct
+          - var_auditd_action_mail_acct=root
+      status: automated
+
+    - id: RHEL-09-653075
+      levels:
+          - medium
+      title: RHEL 9 audit system must audit local events.
+      rules:
+          - auditd_local_events
+      status: automated
+
+    - id: RHEL-09-653080
+      levels:
+          - medium
+      title: RHEL 9 audit logs must be group-owned by root or by a restricted logging group to prevent
+          unauthorized read access.
+      rules:
+          - directory_group_ownership_var_log_audit
+      status: automated
+
+    - id: RHEL-09-653085
+      levels:
+          - medium
+      title: RHEL 9 audit log directory must be owned by root to prevent unauthorized read access.
+      rules:
+          - directory_ownership_var_log_audit
+      status: automated
+
+    - id: RHEL-09-653090
+      levels:
+          - medium
+      title: RHEL 9 audit logs file must have mode 0600 or less permissive to prevent unauthorized access
+          to the audit log.
+      rules:
+          - file_permissions_var_log_audit
+      status: automated
+
+    - id: RHEL-09-653095
+      levels:
+          - medium
+      title: RHEL 9 must periodically flush audit records to disk to prevent the loss of audit records.
+      rules:
+          - auditd_freq
+          - var_auditd_freq=100
+      status: automated
+
+    - id: RHEL-09-653100
+      levels:
+          - medium
+      title: RHEL 9 must produce audit records containing information to establish the identity of any
+          individual or process associated with the event.
+      rules:
+          - auditd_log_format
+      status: automated
+
+    - id: RHEL-09-653105
+      levels:
+          - medium
+      title: RHEL 9 must write audit records to disk.
+      rules:
+          - auditd_write_logs
+      status: automated
+
+    - id: RHEL-09-653110
+      levels:
+          - medium
+      title: RHEL 9 must allow only the information system security manager (ISSM) (or individuals or
+          roles appointed by the ISSM) to select which auditable events are to be audited.
+      rules:
+          - file_permissions_audit_configuration
+      status: automated
+
+    - id: RHEL-09-653115
+      levels:
+          - medium
+      title: RHEL 9 /etc/audit/auditd.conf file must have 0640 or less permissive to prevent unauthorized
+          access.
+      rules:
+          - file_permissions_etc_audit_auditd
+      status: automated
+
+    - id: RHEL-09-653120
+      levels:
+          - low
+      title: RHEL 9 must allocate an audit_backlog_limit of sufficient size to capture processes that
+          start prior to the audit daemon.
+      rules:
+          - grub2_audit_backlog_limit_argument
+      status: automated
+
+    - id: RHEL-09-653125
+      levels:
+          - medium
+      title: RHEL 9 must have mail aliases to notify the information system security officer (ISSO) and
+          system administrator (SA) (at a minimum) in the event of an audit processing failure.
+      rules:
+          - postfix_client_configure_mail_alias
+      status: automated
+
+    - id: RHEL-09-653130
+      levels:
+          - medium
+      title: RHEL 9 audispd-plugins package must be installed.
+      rules:
+          - package_audispd-plugins_installed
+      status: automated
+
+    - id: RHEL-09-654010
+      levels:
+          - medium
+      title: RHEL 9 must audit uses of the "execve" system call.
+      rules:
+          - audit_rules_suid_privilege_function
+      status: automated
+
+    - id: RHEL-09-654015
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the chmod, fchmod, and fchmodat system calls.
+      rules:
+          - audit_rules_dac_modification_chmod
+          - audit_rules_dac_modification_fchmod
+          - audit_rules_dac_modification_fchmodat
+      status: automated
+
+    - id: RHEL-09-654020
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the chown, fchown, fchownat, and lchown system calls.
+      rules:
+          - audit_rules_dac_modification_chown
+          - audit_rules_dac_modification_fchown
+          - audit_rules_dac_modification_fchownat
+          - audit_rules_dac_modification_lchown
+      status: automated
+
+    - id: RHEL-09-654025
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the setxattr, fsetxattr, lsetxattr, removexattr, fremovexattr,
+          and lremovexattr system calls.
+      rules:
+          - audit_rules_dac_modification_setxattr
+          - audit_rules_dac_modification_fsetxattr
+          - audit_rules_dac_modification_lsetxattr
+          - audit_rules_dac_modification_removexattr
+          - audit_rules_dac_modification_fremovexattr
+          - audit_rules_dac_modification_lremovexattr
+      status: automated
+
+    - id: RHEL-09-654030
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of umount system calls.
+      rules:
+          - audit_rules_privileged_commands_umount
+      status: automated
+
+    - id: RHEL-09-654035
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the chacl command.
+      rules:
+          - audit_rules_execution_chacl
+      status: automated
+
+    - id: RHEL-09-654040
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the setfacl command.
+      rules:
+          - audit_rules_execution_setfacl
+      status: automated
+
+    - id: RHEL-09-654045
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the chcon command.
+      rules:
+          - audit_rules_execution_chcon
+      status: automated
+
+    - id: RHEL-09-654050
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the semanage command.
+      rules:
+          - audit_rules_execution_semanage
+      status: automated
+
+    - id: RHEL-09-654055
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the setfiles command.
+      rules:
+          - audit_rules_execution_setfiles
+      status: automated
+
+    - id: RHEL-09-654060
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the setsebool command.
+      rules:
+          - audit_rules_execution_setsebool
+      status: automated
+
+    - id: RHEL-09-654065
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the rename, unlink, rmdir, renameat, and unlinkat system calls.
+      rules:
+          - audit_rules_file_deletion_events_rename
+          - audit_rules_file_deletion_events_unlink
+          - audit_rules_file_deletion_events_rmdir
+          - audit_rules_file_deletion_events_renameat
+          - audit_rules_file_deletion_events_unlinkat
+      status: automated
+
+    - id: RHEL-09-654070
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the truncate, ftruncate, creat, open, openat, and open_by_handle_at
+          system calls.
+      rules:
+          - audit_rules_unsuccessful_file_modification_creat
+          - audit_rules_unsuccessful_file_modification_truncate
+          - audit_rules_unsuccessful_file_modification_ftruncate
+          - audit_rules_unsuccessful_file_modification_open
+          - audit_rules_unsuccessful_file_modification_openat
+          - audit_rules_unsuccessful_file_modification_open_by_handle_at
+      status: automated
+
+    - id: RHEL-09-654075
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the delete_module system call.
+      rules:
+          - audit_rules_kernel_module_loading_delete
+      status: automated
+
+    - id: RHEL-09-654080
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the init_module and finit_module system calls.
+      rules:
+          - audit_rules_kernel_module_loading_finit
+          - audit_rules_kernel_module_loading_init
+      status: automated
+
+    - id: RHEL-09-654085
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the chage command.
+      rules:
+          - audit_rules_privileged_commands_chage
+      status: automated
+
+    - id: RHEL-09-654090
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the chsh command.
+      rules:
+          - audit_rules_privileged_commands_chsh
+      status: automated
+
+    - id: RHEL-09-654095
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the crontab command.
+      rules:
+          - audit_rules_privileged_commands_crontab
+      status: automated
+
+    - id: RHEL-09-654100
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the gpasswd command.
+      rules:
+          - audit_rules_privileged_commands_gpasswd
+      status: automated
+
+    - id: RHEL-09-654105
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the kmod command.
+      rules:
+          - audit_rules_privileged_commands_kmod
+      status: automated
+
+    - id: RHEL-09-654110
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the newgrp command.
+      rules:
+          - audit_rules_privileged_commands_newgrp
+      status: automated
+
+    - id: RHEL-09-654115
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the pam_timestamp_check command.
+      rules:
+          - audit_rules_privileged_commands_pam_timestamp_check
+      status: automated
+
+    - id: RHEL-09-654120
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the passwd command.
+      rules:
+          - audit_rules_privileged_commands_passwd
+      status: automated
+
+    - id: RHEL-09-654125
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the postdrop command.
+      rules:
+          - audit_rules_privileged_commands_postdrop
+      status: automated
+
+    - id: RHEL-09-654130
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the postqueue command.
+      rules:
+          - audit_rules_privileged_commands_postqueue
+      status: automated
+
+    - id: RHEL-09-654135
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the ssh-agent command.
+      rules:
+          - audit_rules_privileged_commands_ssh_agent
+      status: automated
+
+    - id: RHEL-09-654140
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the ssh-keysign command.
+      rules:
+          - audit_rules_privileged_commands_ssh_keysign
+      status: automated
+
+    - id: RHEL-09-654145
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the su command.
+      rules:
+          - audit_rules_privileged_commands_su
+      status: automated
+
+    - id: RHEL-09-654150
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the sudo command.
+      rules:
+          - audit_rules_privileged_commands_sudo
+      status: automated
+
+    - id: RHEL-09-654155
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the sudoedit command.
+      rules:
+          - audit_rules_privileged_commands_sudoedit
+      status: automated
+
+    - id: RHEL-09-654160
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the unix_chkpwd command.
+      rules:
+          - audit_rules_privileged_commands_unix_chkpwd
+      status: automated
+
+    - id: RHEL-09-654165
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the unix_update command.
+      rules:
+          - audit_rules_privileged_commands_unix_update
+      status: automated
+
+    - id: RHEL-09-654170
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the userhelper command.
+      rules:
+          - audit_rules_privileged_commands_userhelper
+      status: automated
+
+    - id: RHEL-09-654175
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the usermod command.
+      rules:
+          - audit_rules_privileged_commands_usermod
+      status: automated
+
+    - id: RHEL-09-654180
+      levels:
+          - medium
+      title: RHEL 9 must audit all uses of the mount command.
+      rules:
+          - audit_rules_privileged_commands_mount
+      status: automated
+
+    - id: RHEL-09-654185
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the init command in RHEL 9 must generate an audit record.
+      rules:
+          - audit_privileged_commands_init
+      status: automated
+
+    - id: RHEL-09-654190
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the poweroff command in RHEL 9 must generate an audit record.
+      rules:
+          - audit_privileged_commands_poweroff
+      status: automated
+
+    - id: RHEL-09-654195
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the reboot command in RHEL 9 must generate an audit record.
+      rules:
+          - audit_privileged_commands_reboot
+      status: automated
+
+    - id: RHEL-09-654200
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the shutdown command in RHEL 9 must generate an audit record.
+      rules:
+          - audit_privileged_commands_shutdown
+      status: automated
+
+    - id: RHEL-09-654205
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the umount system call in RHEL 9 must generate an audit
+          record.
+      rules:
+          - audit_rules_dac_modification_umount
+      status: automated
+
+    - id: RHEL-09-654210
+      levels:
+          - medium
+      title: Successful/unsuccessful uses of the umount2 system call in RHEL 9 must generate an audit
+          record.
+      rules:
+          - audit_rules_dac_modification_umount2
+      status: automated
+
+    - id: RHEL-09-654215
+      levels:
+          - medium
+      title: RHEL 9 must generate audit records for all account creations, modifications, disabling,
+          and termination events that affect /etc/sudoers.
+      rules:
+          - audit_rules_sudoers
+      status: automated
+
+    - id: RHEL-09-654220
+      levels:
+          - medium
+      title: RHEL 9 must generate audit records for all account creations, modifications, disabling,
+          and termination events that affect /etc/sudoers.d/ directory.
+      rules:
+          - audit_rules_sudoers_d
+      status: automated
+
+    - id: RHEL-09-654225
+      levels:
+          - medium
+      title: RHEL 9 must generate audit records for all account creations, modifications, disabling,
+          and termination events that affect /etc/group.
+      rules:
+          - audit_rules_usergroup_modification_group
+      status: automated
+
+    - id: RHEL-09-654230
+      levels:
+          - medium
+      title: RHEL 9 must generate audit records for all account creations, modifications, disabling,
+          and termination events that affect /etc/gshadow.
+      rules:
+          - audit_rules_usergroup_modification_gshadow
+      status: automated
+
+    - id: RHEL-09-654235
+      levels:
+          - medium
+      title: RHEL 9 must generate audit records for all account creations, modifications, disabling,
+          and termination events that affect /etc/opasswd.
+      rules:
+          - audit_rules_usergroup_modification_opasswd
+      status: automated
+
+    - id: RHEL-09-654240
+      levels:
+          - medium
+      title: RHEL 9 must generate audit records for all account creations, modifications, disabling,
+          and termination events that affect /etc/passwd.
+      rules:
+          - audit_rules_usergroup_modification_passwd
+      status: automated
+
+    - id: RHEL-09-654245
+      levels:
+          - medium
+      title: RHEL 9 must generate audit records for all account creations, modifications, disabling,
+          and termination events that affect /etc/shadow.
+      rules:
+          - audit_rules_usergroup_modification_shadow
+      status: automated
+
+    - id: RHEL-09-654250
+      levels:
+          - medium
+      title: RHEL 9 must generate audit records for all account creations, modifications, disabling,
+          and termination events that affect /var/log/faillock.
+      rules:
+          - audit_rules_login_events_faillock
+      status: automated
+
+    - id: RHEL-09-654255
+      levels:
+          - medium
+      title: RHEL 9 must generate audit records for all account creations, modifications, disabling,
+          and termination events that affect /var/log/lastlog.
+      rules:
+          - audit_rules_login_events_lastlog
+      status: automated
+
+    - id: RHEL-09-654260
+      levels:
+          - medium
+      title: RHEL 9 must generate audit records for all account creations, modifications, disabling,
+          and termination events that affect /var/log/tallylog.
+      rules:
+          - audit_rules_login_events_tallylog
+      status: automated
+
+    - id: RHEL-09-654265
+      levels:
+          - medium
+      title: RHEL 9 must take appropriate action when a critical audit processing failure occurs.
+      rules:
+          - audit_rules_system_shutdown
+      status: automated
+
+    - id: RHEL-09-654270
+      levels:
+          - medium
+      title: RHEL 9 audit system must protect logon UIDs from unauthorized change.
+      rules:
+          - audit_rules_immutable_login_uids
+      status: automated
+
+    - id: RHEL-09-654275
+      levels:
+          - medium
+      title: RHEL 9 audit system must protect auditing rules from unauthorized change.
+      rules:
+          - audit_rules_immutable
+      status: automated
+
+    - id: RHEL-09-671010
+      levels:
+          - high
+      title: RHEL 9 must enable FIPS mode.
+      rules:
+          - enable_fips_mode
+          - sysctl_crypto_fips_enabled
+          - var_system_crypto_policy=fips
+          - configure_crypto_policy
+          - enable_dracut_fips_module
+      status: automated
+
+    - id: RHEL-09-671015
+      levels:
+          - medium
+      title: RHEL 9 must employ FIPS 140-3 approved cryptographic hashing algorithms for all stored passwords.
+      rules:
+          - accounts_password_all_shadowed_sha512
+      status: automated
+
+    - id: RHEL-09-671020
+      levels:
+          - medium
+      title: RHEL 9 IP tunnels must use FIPS 140-2/140-3 approved cryptographic algorithms.
+      rules:
+          - configure_libreswan_crypto_policy
+      status: automated
+
+    - id: RHEL-09-671025
+      levels:
+          - medium
+      title: RHEL 9 pam_unix.so module must be configured in the password-auth file to use a FIPS 140-3
+          approved cryptographic hashing algorithm for system authentication.
+      rules:
+          - set_password_hashing_algorithm_passwordauth
+      status: automated
+
+    - id: RHEL-09-672015
+      levels:
+          - high
+      title: RHEL 9 crypto policy files must match files shipped with the operating system.
+      status: pending
+
+    - id: RHEL-09-672020
+      levels:
+          - medium
+      title: RHEL 9 crypto policy must not be overridden.
+      status: pending
+
+    - id: RHEL-09-672025
+      levels:
+          - medium
+      title: RHEL 9 must use mechanisms meeting the requirements of applicable federal laws, executive
+          orders, directives, policies, regulations, standards, and guidance for authentication to a
+          cryptographic module.
+      rules:
+          - configure_kerberos_crypto_policy
+      status: automated
+
+    - id: RHEL-09-672030
+      levels:
+          - high
+      title: RHEL 9 must implement DOD-approved TLS encryption in the GnuTLS package.
+      rules:
+          - configure_crypto_policy
+      status: automated
+
+    - id: RHEL-09-672050
+      levels:
+          - medium
+      title: RHEL 9 must implement DOD-approved encryption in the bind package.
+      rules:
+          - configure_bind_crypto_policy
+      status: automated

--- a/products/rhel9/profiles/anssi_bp28_enhanced.profile
+++ b/products/rhel9/profiles/anssi_bp28_enhanced.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel9/profiles/anssi_bp28_high.profile
+++ b/products/rhel9/profiles/anssi_bp28_high.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel9/profiles/anssi_bp28_intermediary.profile
+++ b/products/rhel9/profiles/anssi_bp28_intermediary.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel9/profiles/anssi_bp28_minimal.profile
+++ b/products/rhel9/profiles/anssi_bp28_minimal.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel9/profiles/ccn_advanced.profile
+++ b/products/rhel9/profiles/ccn_advanced.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel9/profiles/ccn_basic.profile
+++ b/products/rhel9/profiles/ccn_basic.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel9/profiles/ccn_intermediate.profile
+++ b/products/rhel9/profiles/ccn_intermediate.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel9/profiles/cis.profile
+++ b/products/rhel9/profiles/cis.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel9/profiles/cis_server_l1.profile
+++ b/products/rhel9/profiles/cis_server_l1.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel9/profiles/cis_workstation_l1.profile
+++ b/products/rhel9/profiles/cis_workstation_l1.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel9/profiles/cis_workstation_l2.profile
+++ b/products/rhel9/profiles/cis_workstation_l2.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel9/profiles/cui.profile
+++ b/products/rhel9/profiles/cui.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel9/profiles/default.profile
+++ b/products/rhel9/profiles/default.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 hidden: true

--- a/products/rhel9/profiles/e8.profile
+++ b/products/rhel9/profiles/e8.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:
@@ -10,13 +11,13 @@ reference: https://www.cyber.gov.au/acsc/view-all-content/publications/hardening
 title: 'Australian Cyber Security Centre (ACSC) Essential Eight'
 
 description: |-
-  This profile contains configuration checks for Red Hat Enterprise Linux 9
-  that align to the Australian Cyber Security Centre (ACSC) Essential Eight.
+    This profile contains configuration checks for Red Hat Enterprise Linux 9
+    that align to the Australian Cyber Security Centre (ACSC) Essential Eight.
 
-  A copy of the Essential Eight in Linux Environments guide can be found at the
-  ACSC website:
+    A copy of the Essential Eight in Linux Environments guide can be found at the
+    ACSC website:
 
-  https://www.cyber.gov.au/acsc/view-all-content/publications/hardening-linux-workstations-and-servers
+    https://www.cyber.gov.au/acsc/view-all-content/publications/hardening-linux-workstations-and-servers
 
 selections:
     - e8:all

--- a/products/rhel9/profiles/hipaa.profile
+++ b/products/rhel9/profiles/hipaa.profile
@@ -1,4 +1,5 @@
-documentation_complete: True
+---
+documentation_complete: true
 
 metadata:
     SMEs:
@@ -18,7 +19,7 @@ description: |-
 
     This profile configures Red Hat Enterprise Linux 9 to the HIPAA Security
     Rule identified for securing of electronic protected health information.
-    Use of this profile in no way guarantees or makes claims against legal compliance against the HIPAA Security Rule(s).   
+    Use of this profile in no way guarantees or makes claims against legal compliance against the HIPAA Security Rule(s).
 
 selections:
     - hipaa:all

--- a/products/rhel9/profiles/ism_o.profile
+++ b/products/rhel9/profiles/ism_o.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:
@@ -13,17 +14,17 @@ reference: https://www.cyber.gov.au/ism
 title: 'Australian Cyber Security Centre (ACSC) ISM Official'
 
 description: |-
-  This profile contains configuration checks for Red Hat Enterprise Linux 9
-  that align to the Australian Cyber Security Centre (ACSC) Information Security Manual (ISM)
-  with the applicability marking of OFFICIAL.
+    This profile contains configuration checks for Red Hat Enterprise Linux 9
+    that align to the Australian Cyber Security Centre (ACSC) Information Security Manual (ISM)
+    with the applicability marking of OFFICIAL.
 
-  The ISM uses a risk-based approach to cyber security. This profile provides a guide to aligning
-  Red Hat Enterprise Linux security controls with the ISM, which can be used to select controls
-  specific to an organisation's security posture and risk profile.
+    The ISM uses a risk-based approach to cyber security. This profile provides a guide to aligning
+    Red Hat Enterprise Linux security controls with the ISM, which can be used to select controls
+    specific to an organisation's security posture and risk profile.
 
-  A copy of the ISM can be found at the ACSC website:
+    A copy of the ISM can be found at the ACSC website:
 
-  https://www.cyber.gov.au/ism
+    https://www.cyber.gov.au/ism
 
 extends: e8
 

--- a/products/rhel9/profiles/ospp.profile
+++ b/products/rhel9/profiles/ospp.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel9/profiles/pci-dss.profile
+++ b/products/rhel9/profiles/pci-dss.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel9/profiles/stig.profile
+++ b/products/rhel9/profiles/stig.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:
@@ -25,6 +26,6 @@ description: |-
     - Red Hat Containers with a Red Hat Enterprise Linux 9 image
 
 selections:
-  - stig_rhel9:all
+    - stig_rhel9:all
   # Following rules once had a prodtype incompatible with the rhel9 product
-  - '!audit_rules_immutable_login_uids'
+    - '!audit_rules_immutable_login_uids'

--- a/products/rhel9/profiles/stig_gui.profile
+++ b/products/rhel9/profiles/stig_gui.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:
@@ -13,7 +14,6 @@ title: 'DISA STIG with GUI for Red Hat Enterprise Linux 9'
 description: |-
     This profile contains configuration checks that align to the
     DISA STIG for Red Hat Enterprise Linux 9 V2R4.
-
 
     In addition to being applicable to Red Hat Enterprise Linux 9, this
     configuration baseline is applicable to the operating system tier of


### PR DESCRIPTION
Description:

Format rhel9 related yaml file using yamlfix command, yamlfix.toml as config file.

Rationale:

The reason to format yaml file is to unify all yaml file format. So that external library change can be minimal, real change can be easily spotted instead of seeing a lots of format change.

Currently, when update cac content yaml file content, i found the yaml file format is chaotic. It will cause irrelevant format changes and let reviewer hard to focus what's really changed. We need to unify cac content yaml file format, update style guide of yaml.

Review Hints:

Format rhel9 related yaml file using yamlfix command, [yamlfix.toml](https://github.com/ComplianceAsCode/content/blob/master/yamlfix.toml) as config file.

```shell
yamlfix -c yamlfix.toml file_path
```