### PR TITLE
Format rhel10 related yaml file

### DIFF
--- a/controls/cis_rhel10.yml
+++ b/controls/cis_rhel10.yml
@@ -4,3022 +4,3023 @@ title: 'DRAFT - CIS Benchmark for Red Hat Enterprise Linux 10'
 id: cis_rhel10
 version: 'Draft'
 source: https://www.cisecurity.org/cis-benchmarks/#red_hat_linux
+
 levels:
-  - id: l1_server
-  - id: l2_server
-    inherits_from:
-      - l1_server
-  - id: l1_workstation
-  - id: l2_workstation
-    inherits_from:
-      - l1_workstation
+    - id: l1_server
+    - id: l2_server
+      inherits_from:
+          - l1_server
+    - id: l1_workstation
+    - id: l2_workstation
+      inherits_from:
+          - l1_workstation
+
 reference_type: cis
 product: rhel10
 
 controls:
-  - id: reload_dconf_db
-    title: Reload Dconf database
-    levels:
-      - l1_server
-      - l1_workstation
-    notes: <-
-      This is a helper rule to reload Dconf database correctly.
-    status: automated
-    rules:
-      - dconf_db_up_to_date
-
-  - id: 1.1.1.6
-    title: Ensure squashfs kernel module is not available (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - kernel_module_squashfs_disabled
-
-  - id: 1.1.1.7
-    title: Ensure udf kernel module is not available (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - kernel_module_udf_disabled
-
-  - id: 1.1.1.8
-    title: Ensure usb-storage kernel module is not available (Automated)
-    levels:
-      - l1_server
-      - l2_workstation
-    status: automated
-    rules:
-      - kernel_module_usb-storage_disabled
-
-  - id: 1.1.1.9
-    title: Ensure unused filesystems kernel modules are not available (Manual)
-    levels:
-      - l1_server
-      - l2_workstation
-    status: manual
-
-  - id: 1.1.2.1.1
-    title: Ensure /tmp is a separate partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - partition_for_tmp
-
-  - id: 1.1.2.1.2
-    title: Ensure nodev option set on /tmp partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_tmp_nodev
-
-  - id: 1.1.2.1.3
-    title: Ensure nosuid option set on /tmp partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_tmp_nosuid
-
-  - id: 1.1.2.1.4
-    title: Ensure noexec option set on /tmp partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_tmp_noexec
-
-  - id: 1.1.2.2.1
-    title: Ensure /dev/shm is a separate partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - partition_for_dev_shm
-
-  - id: 1.1.2.2.2
-    title: Ensure nodev option set on /dev/shm partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_dev_shm_nodev
-
-  - id: 1.1.2.2.3
-    title: Ensure nosuid option set on /dev/shm partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_dev_shm_nosuid
-
-  - id: 1.1.2.2.4
-    title: Ensure noexec option set on /dev/shm partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_dev_shm_noexec
-
-  - id: 1.1.2.3.1
-    title: Ensure separate partition exists for /home (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - partition_for_home
-
-  - id: 1.1.2.3.2
-    title: Ensure nodev option set on /home partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_home_nodev
-
-  - id: 1.1.2.3.3
-    title: Ensure nosuid option set on /home partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_home_nosuid
-
-  - id: 1.1.2.4.1
-    title: Ensure separate partition exists for /var (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - partition_for_var
-
-  - id: 1.1.2.4.2
-    title: Ensure nodev option set on /var partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_nodev
-
-  - id: 1.1.2.4.3
-    title: Ensure nosuid option set on /var partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_nosuid
-
-  - id: 1.1.2.5.1
-    title: Ensure separate partition exists for /var/tmp (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - partition_for_var_tmp
-
-  - id: 1.1.2.5.2
-    title: Ensure nodev option set on /var/tmp partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_tmp_nodev
-
-  - id: 1.1.2.5.3
-    title: Ensure nosuid option set on /var/tmp partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_tmp_nosuid
-
-  - id: 1.1.2.5.4
-    title: Ensure noexec option set on /var/tmp partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_tmp_noexec
-
-  - id: 1.1.2.6.1
-    title: Ensure separate partition exists for /var/log (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - partition_for_var_log
-
-  - id: 1.1.2.6.2
-    title: Ensure nodev option set on /var/log partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_log_nodev
-
-  - id: 1.1.2.6.3
-    title: Ensure nosuid option set on /var/log partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_log_nosuid
-
-  - id: 1.1.2.6.4
-    title: Ensure noexec option set on /var/log partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_log_noexec
-
-  - id: 1.1.2.7.1
-    title: Ensure separate partition exists for /var/log/audit (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - partition_for_var_log_audit
-
-  - id: 1.1.2.7.2
-    title: Ensure nodev option set on /var/log/audit partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_log_audit_nodev
-
-  - id: 1.1.2.7.3
-    title: Ensure nosuid option set on /var/log/audit partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_log_audit_nosuid
-
-  - id: 1.1.2.7.4
-    title: Ensure noexec option set on /var/log/audit partition (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - mount_option_var_log_audit_noexec
-
-  - id: 1.2.1.1
-    title: Ensure GPG keys are configured (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-    related_rules:
-      - ensure_redhat_gpgkey_installed
-
-  - id: 1.2.1.2
-    title: Ensure gpgcheck is globally activated (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - ensure_gpgcheck_globally_activated
-
-  - id: 1.2.1.3
-    title: Ensure repo_gpgcheck is globally activated (Manual)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: manual
-
-  - id: 1.2.1.4
-    title: Ensure package manager repositories are configured (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 1.2.2.1
-    title: Ensure updates, patches, and additional security software are installed (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 1.3.1.1
-    title: Ensure SELinux is installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_libselinux_installed
-
-  - id: 1.3.1.2
-    title: Ensure SELinux is not disabled in bootloader configuration (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - grub2_enable_selinux
-
-  - id: 1.3.1.3
-    title: Ensure SELinux policy is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - var_selinux_policy_name=targeted
-      - selinux_policytype
-
-  - id: 1.3.1.4
-    title: Ensure the SELinux mode is not disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - selinux_not_disabled
-
-  - id: 1.3.1.5
-    title: Ensure the SELinux mode is enforcing (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - var_selinux_state=enforcing
-      - selinux_state
-
-  - id: 1.3.1.6
-    title: Ensure no unconfined services exist (Manual)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: manual
-    related_rules:
-      - selinux_confinement_of_daemons
-
-  - id: 1.3.1.7
-    title: Ensure the MCS Translation Service (mcstrans) is not installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_mcstrans_removed
-
-  - id: 1.3.1.8
-    title: Ensure SETroubleshoot is not installed (Automated)
-    levels:
-      - l1_server
-    status: automated
-    rules:
-      - package_setroubleshoot_removed
-
-  - id: 1.4.1
-    title: Ensure bootloader password is set (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      There is no automated remediation for this rule and this is intentional.
-      More details in the rule description.
-    rules:
-      - grub2_password
-
-  - id: 1.4.2
-    title: Ensure access to bootloader config is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      This requirement demands a deeper review of the rules.
-    rules:
-      - file_groupowner_grub2_cfg
-      - file_owner_grub2_cfg
-      - file_permissions_grub2_cfg
-      - file_groupowner_user_cfg
-      - file_owner_user_cfg
-      - file_permissions_user_cfg
-
-  - id: 1.5.1
-    title: Ensure address space layout randomization is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      Address Space Layout Randomization (ASLR)
-    rules:
-      - sysctl_kernel_randomize_va_space
-
-  - id: 1.5.2
-    title: Ensure ptrace_scope is restricted (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_kernel_yama_ptrace_scope
-
-  - id: 1.5.3
-    title: Ensure core dump backtraces are disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - coredump_disable_backtraces
-
-  - id: 1.5.4
-    title: Ensure core dump storage is disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - coredump_disable_storage
-
-  - id: 1.6.1
-    title: Ensure system wide crypto policy is not set to legacy (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - configure_crypto_policy
-      - var_system_crypto_policy=default_policy
-
-  - id: 1.6.2
-    title: Ensure system wide crypto policy is not set in sshd configuration (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - configure_ssh_crypto_policy
-
-  - id: 1.6.3
-    title: Ensure system wide crypto policy disables sha1 hash and signature support (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      This requirement is already satisfied by 1.6.1.
-    related_rules:
-      - configure_crypto_policy
-
-  - id: 1.6.4
-    title: Ensure system wide crypto policy disables macs less than 128 bits (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      It is necessary a new rule to ensure a module disabling weak MACs in
-      /etc/crypto-policies/policies/modules/ so it can be used by update-crypto-policies command.
-    related_rules:
-      - configure_crypto_policy
-
-  - id: 1.6.5
-    title: Ensure system wide crypto policy disables cbc for ssh (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      It is necessary a new rule to ensure a module disabling CBC in
-      /etc/crypto-policies/policies/modules/ so it can be used by update-crypto-policies command.
-    related_rules:
-      - configure_crypto_policy
-
-  - id: 1.6.6
-    title: Ensure system wide crypto policy disables chacha20-poly1305 for ssh (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 1.6.7
-    title: Ensure system wide crypto policy disables EtM for ssh (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 1.7.1
-    title: Ensure message of the day is configured properly (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - banner_etc_motd_cis
-      - cis_banner_text=cis
-
-  - id: 1.7.2
-    title: Ensure local login warning banner is configured properly (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - banner_etc_issue_cis
-      - cis_banner_text=cis
-
-  - id: 1.7.3
-    title: Ensure remote login warning banner is configured properly (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - banner_etc_issue_net_cis
-      - cis_banner_text=cis
-
-  - id: 1.7.4
-    title: Ensure access to /etc/motd is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_etc_motd
-      - file_owner_etc_motd
-      - file_permissions_etc_motd
-
-  - id: 1.7.5
-    title: Ensure access to /etc/issue is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_etc_issue
-      - file_owner_etc_issue
-      - file_permissions_etc_issue
-
-  - id: 1.7.6
-    title: Ensure access to /etc/issue.net is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_etc_issue_net
-      - file_owner_etc_issue_net
-      - file_permissions_etc_issue_net
-
-  - id: 1.8.1
-    title: Ensure GNOME Display Manager is removed (Automated)
-    levels:
-      - l2_server
-    status: automated
-    rules:
-      - package_gdm_removed
-
-  - id: 1.8.2
-    title: Ensure GDM login banner is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - dconf_gnome_banner_enabled
-      - dconf_gnome_login_banner_text
-      - login_banner_text=cis_banners
-
-  - id: 1.8.3
-    title: Ensure GDM disable-user-list option is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - dconf_gnome_disable_user_list
-
-  - id: 1.8.4
-    title: Ensure GDM screen locks when the user is idle (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - dconf_gnome_screensaver_idle_delay
-      - dconf_gnome_screensaver_lock_delay
-      - inactivity_timeout_value=15_minutes
-      - var_screensaver_lock_delay=5_seconds
-
-  - id: 1.8.5
-    title: Ensure GDM screen locks cannot be overridden (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - dconf_gnome_session_idle_user_locks
-      - dconf_gnome_screensaver_user_locks
-
-  - id: 1.8.6
-    title: Ensure GDM automatic mounting of removable media is disabled (Automated)
-    levels:
-      - l1_server
-      - l2_workstation
-    status: automated
-    rules:
-      - dconf_gnome_disable_automount
-      - dconf_gnome_disable_automount_open
-
-  - id: 1.8.7
-    title: Ensure GDM disabling automatic mounting of removable media is not overridden (Automated)
-    levels:
-      - l1_server
-      - l2_workstation
-    status: automated
-    rules:
-      - dconf_gnome_disable_automount
-      - dconf_gnome_disable_automount_open
-
-  - id: 1.8.8
-    title: Ensure GDM autorun-never is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - dconf_gnome_disable_autorun
-
-  - id: 1.8.9
-    title: Ensure GDM autorun-never is not overridden (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - dconf_gnome_disable_autorun
-
-  - id: 1.8.10
-    title: Ensure XDMCP is not enabled (Automated)
-    notes: |-
-        This was inherited from the RHEL 9 profile.
-        However, it was reported that XDMCP is no
-        longer in RHEL 10.
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    related_rules:
-      - gnome_gdm_disable_xdmcp
-
-  - id: 2.1.1
-    title: Ensure autofs services are not in use (Automated)
-    levels:
-      - l1_server
-      - l2_workstation
-    status: automated
-    rules:
-      - service_autofs_disabled
-
-  - id: 2.1.2
-    title: Ensure avahi daemon services are not in use (Automated)
-    levels:
-      - l1_server
-      - l2_workstation
-    status: automated
-    rules:
-      - service_avahi-daemon_disabled
-    related_rules:
-      - package_avahi_removed
-
-  - id: 2.1.3
-    title: Ensure dhcp server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_kea_removed
-    related_rules:
-      - service_dhcpd_disabled
-
-  - id: 2.1.4
-    title: Ensure dns server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_bind_removed
-    related_rules:
-      - service_named_disabled
-
-  - id: 2.1.5
-    title: Ensure dnsmasq services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_dnsmasq_removed
-
-  - id: 2.1.6
-    title: Ensure samba file server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_samba_removed
-    related_rules:
-      - service_smb_disabled
-
-  - id: 2.1.7
-    title: Ensure ftp server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_vsftpd_removed
-    related_rules:
-      - service_vsftpd_disabled
-
-  - id: 2.1.8
-    title: Ensure message access server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_dovecot_removed
-      - package_cyrus-imapd_removed
-    related_rules:
-      - service_dovecot_disabled
+    - id: reload_dconf_db
+      title: Reload Dconf database
+      levels:
+          - l1_server
+          - l1_workstation
+      notes: <- This is a helper rule to reload Dconf database correctly.
+      status: automated
+      rules:
+          - dconf_db_up_to_date
+
+    - id: 1.1.1.6
+      title: Ensure squashfs kernel module is not available (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - kernel_module_squashfs_disabled
+
+    - id: 1.1.1.7
+      title: Ensure udf kernel module is not available (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - kernel_module_udf_disabled
+
+    - id: 1.1.1.8
+      title: Ensure usb-storage kernel module is not available (Automated)
+      levels:
+          - l1_server
+          - l2_workstation
+      status: automated
+      rules:
+          - kernel_module_usb-storage_disabled
+
+    - id: 1.1.1.9
+      title: Ensure unused filesystems kernel modules are not available (Manual)
+      levels:
+          - l1_server
+          - l2_workstation
+      status: manual
+
+    - id: 1.1.2.1.1
+      title: Ensure /tmp is a separate partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - partition_for_tmp
+
+    - id: 1.1.2.1.2
+      title: Ensure nodev option set on /tmp partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_tmp_nodev
+
+    - id: 1.1.2.1.3
+      title: Ensure nosuid option set on /tmp partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_tmp_nosuid
+
+    - id: 1.1.2.1.4
+      title: Ensure noexec option set on /tmp partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_tmp_noexec
+
+    - id: 1.1.2.2.1
+      title: Ensure /dev/shm is a separate partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - partition_for_dev_shm
+
+    - id: 1.1.2.2.2
+      title: Ensure nodev option set on /dev/shm partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_dev_shm_nodev
+
+    - id: 1.1.2.2.3
+      title: Ensure nosuid option set on /dev/shm partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_dev_shm_nosuid
+
+    - id: 1.1.2.2.4
+      title: Ensure noexec option set on /dev/shm partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_dev_shm_noexec
+
+    - id: 1.1.2.3.1
+      title: Ensure separate partition exists for /home (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - partition_for_home
+
+    - id: 1.1.2.3.2
+      title: Ensure nodev option set on /home partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_home_nodev
+
+    - id: 1.1.2.3.3
+      title: Ensure nosuid option set on /home partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_home_nosuid
+
+    - id: 1.1.2.4.1
+      title: Ensure separate partition exists for /var (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - partition_for_var
+
+    - id: 1.1.2.4.2
+      title: Ensure nodev option set on /var partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_nodev
+
+    - id: 1.1.2.4.3
+      title: Ensure nosuid option set on /var partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_nosuid
+
+    - id: 1.1.2.5.1
+      title: Ensure separate partition exists for /var/tmp (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - partition_for_var_tmp
+
+    - id: 1.1.2.5.2
+      title: Ensure nodev option set on /var/tmp partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_tmp_nodev
+
+    - id: 1.1.2.5.3
+      title: Ensure nosuid option set on /var/tmp partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_tmp_nosuid
+
+    - id: 1.1.2.5.4
+      title: Ensure noexec option set on /var/tmp partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_tmp_noexec
+
+    - id: 1.1.2.6.1
+      title: Ensure separate partition exists for /var/log (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - partition_for_var_log
+
+    - id: 1.1.2.6.2
+      title: Ensure nodev option set on /var/log partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_log_nodev
+
+    - id: 1.1.2.6.3
+      title: Ensure nosuid option set on /var/log partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_log_nosuid
+
+    - id: 1.1.2.6.4
+      title: Ensure noexec option set on /var/log partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_log_noexec
+
+    - id: 1.1.2.7.1
+      title: Ensure separate partition exists for /var/log/audit (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - partition_for_var_log_audit
+
+    - id: 1.1.2.7.2
+      title: Ensure nodev option set on /var/log/audit partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_log_audit_nodev
+
+    - id: 1.1.2.7.3
+      title: Ensure nosuid option set on /var/log/audit partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_log_audit_nosuid
+
+    - id: 1.1.2.7.4
+      title: Ensure noexec option set on /var/log/audit partition (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - mount_option_var_log_audit_noexec
+
+    - id: 1.2.1.1
+      title: Ensure GPG keys are configured (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+      related_rules:
+          - ensure_redhat_gpgkey_installed
+
+    - id: 1.2.1.2
+      title: Ensure gpgcheck is globally activated (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - ensure_gpgcheck_globally_activated
+
+    - id: 1.2.1.3
+      title: Ensure repo_gpgcheck is globally activated (Manual)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: manual
+
+    - id: 1.2.1.4
+      title: Ensure package manager repositories are configured (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 1.2.2.1
+      title: Ensure updates, patches, and additional security software are installed (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 1.3.1.1
+      title: Ensure SELinux is installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_libselinux_installed
+
+    - id: 1.3.1.2
+      title: Ensure SELinux is not disabled in bootloader configuration (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - grub2_enable_selinux
+
+    - id: 1.3.1.3
+      title: Ensure SELinux policy is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - var_selinux_policy_name=targeted
+          - selinux_policytype
+
+    - id: 1.3.1.4
+      title: Ensure the SELinux mode is not disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - selinux_not_disabled
+
+    - id: 1.3.1.5
+      title: Ensure the SELinux mode is enforcing (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - var_selinux_state=enforcing
+          - selinux_state
+
+    - id: 1.3.1.6
+      title: Ensure no unconfined services exist (Manual)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: manual
+      related_rules:
+          - selinux_confinement_of_daemons
+
+    - id: 1.3.1.7
+      title: Ensure the MCS Translation Service (mcstrans) is not installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_mcstrans_removed
+
+    - id: 1.3.1.8
+      title: Ensure SETroubleshoot is not installed (Automated)
+      levels:
+          - l1_server
+      status: automated
+      rules:
+          - package_setroubleshoot_removed
+
+    - id: 1.4.1
+      title: Ensure bootloader password is set (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          There is no automated remediation for this rule and this is intentional.
+          More details in the rule description.
+      rules:
+          - grub2_password
+
+    - id: 1.4.2
+      title: Ensure access to bootloader config is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          This requirement demands a deeper review of the rules.
+      rules:
+          - file_groupowner_grub2_cfg
+          - file_owner_grub2_cfg
+          - file_permissions_grub2_cfg
+          - file_groupowner_user_cfg
+          - file_owner_user_cfg
+          - file_permissions_user_cfg
+
+    - id: 1.5.1
+      title: Ensure address space layout randomization is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          Address Space Layout Randomization (ASLR)
+      rules:
+          - sysctl_kernel_randomize_va_space
+
+    - id: 1.5.2
+      title: Ensure ptrace_scope is restricted (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_kernel_yama_ptrace_scope
+
+    - id: 1.5.3
+      title: Ensure core dump backtraces are disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - coredump_disable_backtraces
+
+    - id: 1.5.4
+      title: Ensure core dump storage is disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - coredump_disable_storage
+
+    - id: 1.6.1
+      title: Ensure system wide crypto policy is not set to legacy (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - configure_crypto_policy
+          - var_system_crypto_policy=default_policy
+
+    - id: 1.6.2
+      title: Ensure system wide crypto policy is not set in sshd configuration (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - configure_ssh_crypto_policy
+
+    - id: 1.6.3
+      title: Ensure system wide crypto policy disables sha1 hash and signature support (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          This requirement is already satisfied by 1.6.1.
+      related_rules:
+          - configure_crypto_policy
+
+    - id: 1.6.4
+      title: Ensure system wide crypto policy disables macs less than 128 bits (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          It is necessary a new rule to ensure a module disabling weak MACs in
+          /etc/crypto-policies/policies/modules/ so it can be used by update-crypto-policies command.
+      related_rules:
+          - configure_crypto_policy
+
+    - id: 1.6.5
+      title: Ensure system wide crypto policy disables cbc for ssh (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          It is necessary a new rule to ensure a module disabling CBC in
+          /etc/crypto-policies/policies/modules/ so it can be used by update-crypto-policies command.
+      related_rules:
+          - configure_crypto_policy
+
+    - id: 1.6.6
+      title: Ensure system wide crypto policy disables chacha20-poly1305 for ssh (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 1.6.7
+      title: Ensure system wide crypto policy disables EtM for ssh (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 1.7.1
+      title: Ensure message of the day is configured properly (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - banner_etc_motd_cis
+          - cis_banner_text=cis
+
+    - id: 1.7.2
+      title: Ensure local login warning banner is configured properly (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - banner_etc_issue_cis
+          - cis_banner_text=cis
+
+    - id: 1.7.3
+      title: Ensure remote login warning banner is configured properly (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - banner_etc_issue_net_cis
+          - cis_banner_text=cis
+
+    - id: 1.7.4
+      title: Ensure access to /etc/motd is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_etc_motd
+          - file_owner_etc_motd
+          - file_permissions_etc_motd
+
+    - id: 1.7.5
+      title: Ensure access to /etc/issue is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_etc_issue
+          - file_owner_etc_issue
+          - file_permissions_etc_issue
+
+    - id: 1.7.6
+      title: Ensure access to /etc/issue.net is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_etc_issue_net
+          - file_owner_etc_issue_net
+          - file_permissions_etc_issue_net
+
+    - id: 1.8.1
+      title: Ensure GNOME Display Manager is removed (Automated)
+      levels:
+          - l2_server
+      status: automated
+      rules:
+          - package_gdm_removed
+
+    - id: 1.8.2
+      title: Ensure GDM login banner is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - dconf_gnome_banner_enabled
+          - dconf_gnome_login_banner_text
+          - login_banner_text=cis_banners
+
+    - id: 1.8.3
+      title: Ensure GDM disable-user-list option is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - dconf_gnome_disable_user_list
+
+    - id: 1.8.4
+      title: Ensure GDM screen locks when the user is idle (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - dconf_gnome_screensaver_idle_delay
+          - dconf_gnome_screensaver_lock_delay
+          - inactivity_timeout_value=15_minutes
+          - var_screensaver_lock_delay=5_seconds
+
+    - id: 1.8.5
+      title: Ensure GDM screen locks cannot be overridden (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - dconf_gnome_session_idle_user_locks
+          - dconf_gnome_screensaver_user_locks
+
+    - id: 1.8.6
+      title: Ensure GDM automatic mounting of removable media is disabled (Automated)
+      levels:
+          - l1_server
+          - l2_workstation
+      status: automated
+      rules:
+          - dconf_gnome_disable_automount
+          - dconf_gnome_disable_automount_open
+
+    - id: 1.8.7
+      title: Ensure GDM disabling automatic mounting of removable media is not overridden (Automated)
+      levels:
+          - l1_server
+          - l2_workstation
+      status: automated
+      rules:
+          - dconf_gnome_disable_automount
+          - dconf_gnome_disable_automount_open
+
+    - id: 1.8.8
+      title: Ensure GDM autorun-never is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - dconf_gnome_disable_autorun
+
+    - id: 1.8.9
+      title: Ensure GDM autorun-never is not overridden (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - dconf_gnome_disable_autorun
+
+    - id: 1.8.10
+      title: Ensure XDMCP is not enabled (Automated)
+      notes: |-
+          This was inherited from the RHEL 9 profile.
+          However, it was reported that XDMCP is no
+          longer in RHEL 10.
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      related_rules:
+          - gnome_gdm_disable_xdmcp
+
+    - id: 2.1.1
+      title: Ensure autofs services are not in use (Automated)
+      levels:
+          - l1_server
+          - l2_workstation
+      status: automated
+      rules:
+          - service_autofs_disabled
+
+    - id: 2.1.2
+      title: Ensure avahi daemon services are not in use (Automated)
+      levels:
+          - l1_server
+          - l2_workstation
+      status: automated
+      rules:
+          - service_avahi-daemon_disabled
+      related_rules:
+          - package_avahi_removed
+
+    - id: 2.1.3
+      title: Ensure dhcp server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_kea_removed
+      related_rules:
+          - service_dhcpd_disabled
+
+    - id: 2.1.4
+      title: Ensure dns server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_bind_removed
+      related_rules:
+          - service_named_disabled
+
+    - id: 2.1.5
+      title: Ensure dnsmasq services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_dnsmasq_removed
+
+    - id: 2.1.6
+      title: Ensure samba file server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_samba_removed
+      related_rules:
+          - service_smb_disabled
+
+    - id: 2.1.7
+      title: Ensure ftp server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_vsftpd_removed
+      related_rules:
+          - service_vsftpd_disabled
+
+    - id: 2.1.8
+      title: Ensure message access server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_dovecot_removed
+          - package_cyrus-imapd_removed
+      related_rules:
+          - service_dovecot_disabled
     # new rule would be nice to disable cyrus-imapd service
 
-  - id: 2.1.9
-    title: Ensure network file system services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      Many of the libvirt packages used by Enterprise Linux virtualization are dependent on the
-      nfs-utils package.
-    rules:
-      - service_nfs_disabled
-    related_rules:
-      - package_nfs-utils_removed
+    - id: 2.1.9
+      title: Ensure network file system services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          Many of the libvirt packages used by Enterprise Linux virtualization are dependent on the
+          nfs-utils package.
+      rules:
+          - service_nfs_disabled
+      related_rules:
+          - package_nfs-utils_removed
 
-  - id: 2.1.10
-    title: Ensure nis server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    related_rules:
-      - service_ypserv_disabled
-      - package_ypserv_removed
+    - id: 2.1.10
+      title: Ensure nis server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      related_rules:
+          - service_ypserv_disabled
+          - package_ypserv_removed
 
-  - id: 2.1.11
-    title: Ensure print server services are not in use (Automated)
-    levels:
-      - l1_server
-    status: automated
-    rules:
-      - service_cups_disabled
-    related_rules:
-      - package_cups_removed
+    - id: 2.1.11
+      title: Ensure print server services are not in use (Automated)
+      levels:
+          - l1_server
+      status: automated
+      rules:
+          - service_cups_disabled
+      related_rules:
+          - package_cups_removed
 
-  - id: 2.1.12
-    title: Ensure rpcbind services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      Many of the libvirt packages used by Enterprise Linux virtualization, and the nfs-utils
-      package used for The Network File System (NFS), are dependent on the rpcbind package.
-    rules:
-      - service_rpcbind_disabled
-    related_rules:
-      - package_rpcbind_removed
+    - id: 2.1.12
+      title: Ensure rpcbind services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          Many of the libvirt packages used by Enterprise Linux virtualization, and the nfs-utils
+          package used for The Network File System (NFS), are dependent on the rpcbind package.
+      rules:
+          - service_rpcbind_disabled
+      related_rules:
+          - package_rpcbind_removed
 
-  - id: 2.1.13
-    title: Ensure rsync services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_rsync_removed
-    related_rules:
-      - service_rsyncd_disabled
+    - id: 2.1.13
+      title: Ensure rsync services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_rsync_removed
+      related_rules:
+          - service_rsyncd_disabled
 
-  - id: 2.1.14
-    title: Ensure snmp services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_net-snmp_removed
-    related_rules:
-      - service_snmpd_disabled
+    - id: 2.1.14
+      title: Ensure snmp services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_net-snmp_removed
+      related_rules:
+          - service_snmpd_disabled
 
-  - id: 2.1.15
-    title: Ensure telnet server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_telnet-server_removed
-    related_rules:
-      - service_telnet_disabled
+    - id: 2.1.15
+      title: Ensure telnet server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_telnet-server_removed
+      related_rules:
+          - service_telnet_disabled
 
-  - id: 2.1.16
-    title: Ensure tftp server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_tftp-server_removed
-    related_rules:
-      - service_tftp_disabled
+    - id: 2.1.16
+      title: Ensure tftp server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_tftp-server_removed
+      related_rules:
+          - service_tftp_disabled
 
-  - id: 2.1.17
-    title: Ensure web proxy server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_squid_removed
-    related_rules:
-      - service_squid_disabled
+    - id: 2.1.17
+      title: Ensure web proxy server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_squid_removed
+      related_rules:
+          - service_squid_disabled
 
-  - id: 2.1.18
-    title: Ensure web server services are not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_httpd_removed
-      - package_nginx_removed
-    related_rules:
-      - service_httpd_disabled
+    - id: 2.1.18
+      title: Ensure web server services are not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_httpd_removed
+          - package_nginx_removed
+      related_rules:
+          - service_httpd_disabled
     # rule would be nice to disable nginx service
 
-  - id: 2.1.20
-    title: Ensure X window server services are not in use (Automated)
-    levels:
-      - l2_server
-    status: automated
-    notes: |-
-      Review the availability of xorg-x11-server-common package when the product is out.
-      The rule also configures correct run level to prevent unbootable system.
-    rules:
-      - package_gdm_removed
-      - xwindows_runlevel_target
-
-  - id: 2.1.21
-    title: Ensure mail transfer agents are configured for local-only mode (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: partial
-    notes:  |-
-      The rule has_nonlocal_mta currently checks for services listening only on port 25,
-      but the policy checks also for ports 465 and 587
-    rules:
-      - postfix_network_listening_disabled
-      - var_postfix_inet_interfaces=loopback-only
-      - has_nonlocal_mta
-
-  - id: 2.1.22
-    title: Ensure only approved services are listening on a network interface (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 2.2.1
-    title: Ensure ftp client is not installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_ftp_removed
-
-  - id: 2.2.2
-    title: Ensure ldap client is not installed (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - package_openldap-clients_removed
-
-  - id: 2.2.3
-    title: Ensure nis client is not installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    related_rules:
-      - package_ypbind_removed
-
-  - id: 2.2.4
-    title: Ensure telnet client is not installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_telnet_removed
-
-  - id: 2.2.5
-    title: Ensure tftp client is not installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_tftp_removed
-
-  - id: 2.3.1
-    title: Ensure time synchronization is in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    related_rules:
-      - package_chrony_installed
-
-  - id: 2.3.2
-    title: Ensure chrony is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - chronyd_specify_remote_server
-      - var_multiple_time_servers=rhel
-
-  - id: 2.3.3
-    title: Ensure chrony is not run as the root user (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - chronyd_run_as_chrony_user
-
-  - id: 2.4.1.1
-    title: Ensure cron daemon is enabled and active (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_cron_installed
-      - service_crond_enabled
-
-  - id: 2.4.1.2
-    title: Ensure permissions on /etc/crontab are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_crontab
-      - file_owner_crontab
-      - file_permissions_crontab
-
-  - id: 2.4.1.3
-    title: Ensure permissions on /etc/cron.hourly are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_cron_hourly
-      - file_owner_cron_hourly
-      - file_permissions_cron_hourly
-
-  - id: 2.4.1.4
-    title: Ensure permissions on /etc/cron.daily are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_cron_daily
-      - file_owner_cron_daily
-      - file_permissions_cron_daily
-
-  - id: 2.4.1.5
-    title: Ensure permissions on /etc/cron.weekly are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_cron_weekly
-      - file_owner_cron_weekly
-      - file_permissions_cron_weekly
-
-  - id: 2.4.1.6
-    title: Ensure permissions on /etc/cron.monthly are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_cron_monthly
-      - file_owner_cron_monthly
-      - file_permissions_cron_monthly
-
-  - id: 2.4.1.7
-    title: Ensure permissions on /etc/cron.d are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_cron_d
-      - file_owner_cron_d
-      - file_permissions_cron_d
-
-  - id: 2.4.1.8
-    title: Ensure crontab is restricted to authorized users (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_cron_deny_not_exist
-      - file_cron_allow_exists
-      - file_groupowner_cron_allow
-      - file_owner_cron_allow
-      - file_permissions_cron_allow
-
-  - id: 2.4.2.1
-    title: Ensure at is restricted to authorized users (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: partial
-    notes: |-
-      It is necessary to create a rule to ensure the existence of at.allow.
-      file_cron_allow_exists can be used as reference for a new templated rule.
-    rules:
-      - file_at_deny_not_exist
-      - file_groupowner_at_allow
-      - file_owner_at_allow
-      - file_permissions_at_allow
-
-  - id: 3.1.1
-    title: Ensure IPv6 status is identified (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 3.1.2
-    title: Ensure wireless interfaces are disabled (Automated)
-    levels:
-      - l1_server
-    status: automated
-    rules:
-      - wireless_disable_interfaces
-
-  - id: 3.1.3
-    title: Ensure bluetooth services are not in use (Automated)
-    levels:
-      - l1_server
-      - l2_workstation
-    status: automated
-    rules:
-      - service_bluetooth_disabled
-
-  - id: 3.2.2
-    title: Ensure tipc kernel module is not available (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - kernel_module_tipc_disabled
-
-  - id: 3.2.4
-    title: Ensure sctp kernel module is not available (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - kernel_module_sctp_disabled
-
-  - id: 3.3.1
-    title: Ensure IP forwarding is disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_ip_forward
-      - sysctl_net_ipv6_conf_all_forwarding
-      - sysctl_net_ipv6_conf_all_forwarding_value=disabled
-
-  - id: 3.3.2
-    title: Ensure packet redirect sending is disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_conf_all_send_redirects
-      - sysctl_net_ipv4_conf_default_send_redirects
-
-  - id: 3.3.3
-    title: Ensure bogus icmp responses are ignored (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
-      - sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value=enabled
-
-  - id: 3.3.4
-    title: Ensure broadcast icmp requests are ignored (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
-      - sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value=enabled
-
-  - id: 3.3.5
-    title: Ensure icmp redirects are not accepted (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_conf_all_accept_redirects
-      - sysctl_net_ipv4_conf_all_accept_redirects_value=disabled
-      - sysctl_net_ipv4_conf_default_accept_redirects
-      - sysctl_net_ipv4_conf_default_accept_redirects_value=disabled
-      - sysctl_net_ipv6_conf_all_accept_redirects
-      - sysctl_net_ipv6_conf_all_accept_redirects_value=disabled
-      - sysctl_net_ipv6_conf_default_accept_redirects
-      - sysctl_net_ipv6_conf_default_accept_redirects_value=disabled
-
-  - id: 3.3.6
-    title: Ensure secure icmp redirects are not accepted (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_conf_all_secure_redirects
-      - sysctl_net_ipv4_conf_all_secure_redirects_value=disabled
-      - sysctl_net_ipv4_conf_default_secure_redirects
-      - sysctl_net_ipv4_conf_default_secure_redirects_value=disabled
-
-  - id: 3.3.7
-    title: Ensure reverse path filtering is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_conf_all_rp_filter
-      - sysctl_net_ipv4_conf_all_rp_filter_value=enabled
-      - sysctl_net_ipv4_conf_default_rp_filter
-      - sysctl_net_ipv4_conf_default_rp_filter_value=enabled
-
-  - id: 3.3.8
-    title: Ensure source routed packets are not accepted (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_conf_all_accept_source_route
-      - sysctl_net_ipv4_conf_all_accept_source_route_value=disabled
-      - sysctl_net_ipv4_conf_default_accept_source_route
-      - sysctl_net_ipv4_conf_default_accept_source_route_value=disabled
-      - sysctl_net_ipv6_conf_all_accept_source_route
-      - sysctl_net_ipv6_conf_all_accept_source_route_value=disabled
-      - sysctl_net_ipv6_conf_default_accept_source_route
-      - sysctl_net_ipv6_conf_default_accept_source_route_value=disabled
-
-  - id: 3.3.9
-    title: Ensure suspicious packets are logged (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_conf_all_log_martians
-      - sysctl_net_ipv4_conf_all_log_martians_value=enabled
-      - sysctl_net_ipv4_conf_default_log_martians
-      - sysctl_net_ipv4_conf_default_log_martians_value=enabled
-
-  - id: 3.3.10
-    title: Ensure tcp syn cookies is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv4_tcp_syncookies
-      - sysctl_net_ipv4_tcp_syncookies_value=enabled
-
-  - id: 3.3.11
-    title: Ensure IPv6 router advertisements are not accepted (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sysctl_net_ipv6_conf_all_accept_ra
-      - sysctl_net_ipv6_conf_all_accept_ra_value=disabled
-      - sysctl_net_ipv6_conf_default_accept_ra
-      - sysctl_net_ipv6_conf_default_accept_ra_value=disabled
-
-  - id: 4.1.1
-    title: Ensure nftables is installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_nftables_installed
-
-  - id: 4.1.2
-    title: Ensure a single firewall configuration utility is in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - service_firewalld_enabled
-      - package_firewalld_installed
-      - service_nftables_disabled
-
-  - id: 4.2.1
-    title: Ensure firewalld drops unnecessary services and ports (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-    related_rules:
-      - configure_firewalld_ports
-
-  - id: 4.2.2
-    title: Ensure firewalld loopback traffic is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - firewalld_loopback_traffic_trusted
-      - firewalld_loopback_traffic_restricted
-
-  - id: 4.3.1
-    title: Ensure nftables base chains exist (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: supported
-    notes: |-
-      RHEL systems use firewalld for firewall management. Although nftables is the default
-      back-end for firewalld, it is not recommended to use nftables directly when firewalld
-      is in use. When using firewalld the base chains are installed by default.
-    related_rules:
-      - set_nftables_base_chain
-      - var_nftables_table=firewalld
-      - var_nftables_family=inet
-      - var_nftables_base_chain_names=chain_names
-      - var_nftables_base_chain_types=chain_types
-      - var_nftables_base_chain_hooks=chain_hooks
-      - var_nftables_base_chain_priorities=chain_priorities
-      - var_nftables_base_chain_policies=chain_policies
-
-  - id: 4.3.2
-    title: Ensure nftables established connections are configured (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 4.3.3
-    title: Ensure nftables default deny firewall policy (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: supported
-    notes: |-
-      RHEL systems use firewalld for firewall management. Although nftables is the default
-      back-end for firewalld, it is not recommended to use nftables directly when firewalld
-      is in use.
-    related_rules:
-      - nftables_ensure_default_deny_policy
-
-  - id: 4.3.4
-    title: Ensure nftables loopback traffic is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: supported
-    notes: |-
-      RHEL systems use firewalld for firewall management. Although nftables is the default
-      back-end for firewalld, it is not recommended to use nftables directly when firewalld
-      is in use.
-    related_rules:
-      - set_nftables_loopback_traffic
-
-  - id: 5.1.1
-    title: Ensure permissions on /etc/ssh/sshd_config are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_sshd_config
-      - file_owner_sshd_config
-      - file_permissions_sshd_config
-
-  - id: 5.1.2
-    title: Ensure permissions on SSH private host key files are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_permissions_sshd_private_key
-      - file_ownership_sshd_private_key
-      - file_groupownership_sshd_private_key
-
-  - id: 5.1.3
-    title: Ensure permissions on SSH public host key files are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_permissions_sshd_pub_key
-      - file_ownership_sshd_pub_key
-      - file_groupownership_sshd_pub_key
-
-  - id: 5.1.4
-    title: Ensure sshd Ciphers are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      The status was automated but we need to double check the approach used in this rule.
-      Therefore I moved it to pending until deeper investigation.
-    related_rules:
-      - sshd_use_approved_ciphers
-      - sshd_approved_ciphers=cis_rhel8
-
-  - id: 5.1.5
-    title: Ensure sshd KexAlgorithms is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      The status was automated but we need to double check the approach used in this rule.
-      Therefore I moved it to pending until deeper investigation.
-    rules:
-      - sshd_use_strong_kex
-      - sshd_strong_kex=cis_rhel8
-
-  - id: 5.1.6
-    title: Ensure sshd MACs are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      The status was automated but we need to double check the approach used in this rule.
-      Therefore I moved it to pending until deeper investigation.
-    rules:
-      - sshd_use_strong_macs
-      - sshd_strong_macs=cis_rhel8
-
-  - id: 5.1.7
-    title: Ensure sshd access is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_limit_user_access
-
-  - id: 5.1.8
-    title: Ensure sshd Banner is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_enable_warning_banner_net
-    related_rules:
-      - sshd_enable_warning_banner
-
-  - id: 5.1.9
-    title: Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      The requirement gives an example of 45 seconds, but is flexible about the values. It is only
-      necessary to ensure there is a timeout configured in alignment to the site policy.
-    rules:
-      - sshd_idle_timeout_value=5_minutes
-      - sshd_set_idle_timeout
-      - sshd_set_keepalive
-      - var_sshd_set_keepalive=1
-
-  - id: 5.1.10
-    title: Ensure sshd DisableForwarding is enabled (Automated)
-    levels:
-      - l2_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      New templated rule is necessary for "disableforwarding" option.
-    related_rules:
-      - sshd_disable_tcp_forwarding
-      - sshd_disable_x11_forwarding
-
-  - id: 5.1.11
-    title: Ensure sshd GSSAPIAuthentication is disabled (Automated)
-    levels:
-      - l2_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_disable_gssapi_auth
-
-  - id: 5.1.12
-    title: Ensure sshd HostbasedAuthentication is disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - disable_host_auth
-
-  - id: 5.1.13
-    title: Ensure sshd IgnoreRhosts is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_disable_rhosts
-
-  - id: 5.1.14
-    title: Ensure sshd LoginGraceTime is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_set_login_grace_time
-      - var_sshd_set_login_grace_time=60
-
-  - id: 5.1.15
-    title: Ensure sshd LogLevel is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      The CIS benchmark is not opinionated about which loglevel is selected here. Here, this
-      profile uses VERBOSE by default, as it allows for the capture of login and logout activity
-      as well as key fingerprints.
-    rules:
-      - sshd_set_loglevel_verbose
-    related_rules:
-      - sshd_set_loglevel_info
-
-  - id: 5.1.16
-    title: Ensure sshd MaxAuthTries is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_max_auth_tries_value=4
-      - sshd_set_max_auth_tries
-
-  - id: 5.1.17
-    title: Ensure sshd MaxStartups is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_set_maxstartups
-      - var_sshd_set_maxstartups=10:30:60
-
-  - id: 5.1.18
-    title: Ensure sshd MaxSessions is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_set_max_sessions
-      - var_sshd_max_sessions=10
-
-  - id: 5.1.19
-    title: Ensure sshd PermitEmptyPasswords is disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_disable_empty_passwords
-
-  - id: 5.1.20
-    title: Ensure sshd PermitRootLogin is disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_disable_root_login
-
-  - id: 5.1.21
-    title: Ensure sshd PermitUserEnvironment is disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_do_not_permit_user_env
-
-  - id: 5.1.22
-    title: Ensure sshd UsePAM is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sshd_enable_pam
-
-  - id: 5.2.1
-    title: Ensure sudo is installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_sudo_installed
-
-  - id: 5.2.2
-    title: Ensure sudo commands use pty (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sudo_add_use_pty
-
-  - id: 5.2.3
-    title: Ensure sudo log file exists (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sudo_custom_logfile
-
-  - id: 5.2.4
-    title: Ensure users must provide password for escalation (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - sudo_require_authentication
-
-  - id: 5.2.5
-    title: Ensure re-authentication for privilege escalation is not disabled globally (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sudo_require_reauthentication
-
-  - id: 5.2.6
-    title: Ensure sudo authentication timeout is configured correctly (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - sudo_require_reauthentication
-
-  - id: 5.2.7
-    title: Ensure access to the su command is restricted (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      Members of "wheel" or GID 0 groups are checked by default if the group option is not set for
-      pam_wheel.so module. The recommendation states the group should be empty to reinforce the
-      use of "sudo" for privileged access. Therefore, members of these groups should be manually
-      checked or a different group should be informed.
-    rules:
-      - var_pam_wheel_group_for_su=cis
-      - use_pam_wheel_group_for_su
-      - ensure_pam_wheel_group_empty
-
-  - id: 5.3.1.1
-    title: Ensure latest version of pam is installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      It is necessary a new rule to ensure PAM package is updated.
-
-  - id: 5.3.1.2
-    title: Ensure latest version of authselect is installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      It is necessary a new rule to ensure authselect package is updated.
-
-  - id: 5.3.1.3
-    title: Ensure latest version of libpwquality is installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      It is necessary a new rule to ensure libpwquality package is updated.
-    rules:
-      - package_pam_pwquality_installed
-
-  - id: 5.3.2.1
-    title: Ensure active authselect profile includes pam modules (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: partial
-    notes: |-
-      This requirement is hard to be automated without any specific requirement. The policy even
-      states that provided commands are examples, other custom settings might be in place and the
-      settings might be different depending on site policies. The other rules will already make
-      sure there is a correct autheselect profile regardless of the existing settings. It is
-      necessary to better discuss with CIS Community.
-    related_rules:
-      - no_empty_passwords
-
-  - id: 5.3.2.2
-    title: Ensure pam_faillock module is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      This requirement is also indirectly satisfied by the requirement 5.3.3.1.
-    rules:
-      - account_password_pam_faillock_password_auth
-      - account_password_pam_faillock_system_auth
-
-  - id: 5.3.2.3
-    title: Ensure pam_pwquality module is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      This requirement is also indirectly satisfied by the requirement 5.3.3.2.
-    related_rules:
-      - package_pam_pwquality_installed
-
-  - id: 5.3.2.4
-    title: Ensure pam_pwhistory module is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      The module is properly enabled by the rules mentioned in related_rules.
-      Requirements in 5.3.3.3 use these rules.
-    related_rules:
-      - accounts_password_pam_pwhistory_remember_password_auth
-      - accounts_password_pam_pwhistory_remember_system_auth
-
-  - id: 5.3.2.5
-    title: Ensure pam_unix module is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: partial
-    notes: |-
-      This module is always present by default. It is necessary to investigate if a new rule to
-      check its existence needs to be created. But so far the rule no_empty_passwords, used in
-      5.3.3.4 can ensure this requirement is attended.
-    related_rules:
-      - no_empty_passwords
-
-  - id: 5.3.3.1.1
-    title: Ensure password failed attempts lockout is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_passwords_pam_faillock_deny
-      - var_accounts_passwords_pam_faillock_deny=5
-
-  - id: 5.3.3.1.2
-    title: Ensure password unlock time is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      The policy also accepts value 0, which means the locked accounts should be manually unlocked
-      by an administrator. However, it also mentions that using value 0 can facilitate a DoS
-      attack to legitimate users.
-    rules:
-      - accounts_passwords_pam_faillock_unlock_time
-      - var_accounts_passwords_pam_faillock_unlock_time=900
-
-  - id: 5.3.3.1.3
-    title: Ensure password failed attempts lockout includes root account (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - accounts_passwords_pam_faillock_deny_root
-
-  - id: 5.3.3.2.1
-    title: Ensure password number of changed characters is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_password_pam_difok
-      - var_password_pam_difok=2
-
-  - id: 5.3.3.2.2
-    title: Ensure password length is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_password_pam_minlen
-      - var_password_pam_minlen=14
-
-  - id: 5.3.3.2.3
-    title: Ensure password complexity is configured (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      This requirement is expected to be manual. However, in previous versions of the policy
-      it was already automated the configuration of "minclass" option. This posture was kept for
-      RHEL 9 in this new version. Rules related to other options are informed in related_rules.
-      In short, minclass=4 alone can achieve the same result achieved by the combination of the
-      other 4 options mentioned in the policy.
-    rules:
-      - accounts_password_pam_minclass
-      - var_password_pam_minclass=4
-    related_rules:
-      - accounts_password_pam_dcredit
-      - accounts_password_pam_lcredit
-      - accounts_password_pam_ocredit
-      - accounts_password_pam_ucredit
-
-  - id: 5.3.3.2.4
-    title: Ensure password same consecutive characters is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_password_pam_maxrepeat
-      - var_password_pam_maxrepeat=3
-
-  - id: 5.3.3.2.5
-    title: Ensure password maximum sequential characters is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: planned
-    notes: |-
-      A new templated rule and variable are necessary for the maxsequence option.
-
-  - id: 5.3.3.2.6
-    title: Ensure password dictionary check is enabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_password_pam_dictcheck
-      - var_password_pam_dictcheck=1
-
-  - id: 5.3.3.2.7
-    title: Ensure password quality is enforced for the root user (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_password_pam_enforce_root
-
-  - id: 5.3.3.3.1
-    title: Ensure password history remember is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      Although mentioned in the section 5.3.3.3, there is no explicit requirement to configure
-      retry option of pam_pwhistory. If come in the future, the rule accounts_password_pam_retry
-      can be used.
-    rules:
-      - accounts_password_pam_pwhistory_remember_password_auth
-      - accounts_password_pam_pwhistory_remember_system_auth
-      - var_password_pam_remember_control_flag=requisite_or_required
-      - var_password_pam_remember=24
-    related_rules:
-      - accounts_password_pam_retry
-
-  - id: 5.3.3.3.2
-    title: Ensure password history is enforced for the root user (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: planned
-    notes: |-
-      A new rule needs to be created to check and remediate the enforce_for_root option in
-      /etc/security/pwhistory.conf. accounts_password_pam_enforce_root can be used as reference.
-
-  - id: 5.3.3.3.3
-    title: Ensure pam_pwhistory includes use_authtok (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: partial
-    notes: |-
-      In RHEL 9 pam_pwhistory is enabled via authselect feature, as required in 5.3.2.4. The
-      feature automatically set "use_authok" option. In any case, we don't have a rule to check
-      this option specifically.
-    related_rules:
-      - accounts_password_pam_pwhistory_remember_password_auth
-      - accounts_password_pam_pwhistory_remember_system_auth
-
-  - id: 5.3.3.4.1
-    title: Ensure pam_unix does not include nullok (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      The rule more specifically used in this requirement also satify the requirement 5.3.2.5.
-    rules:
-      - no_empty_passwords
-
-  - id: 5.3.3.4.2
-    title: Ensure pam_unix does not include remember (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      Usage of pam_unix.so module together with "remember" option is deprecated and is not
-      recommened by this policy. Instead, it should be used remember option of pam_pwhistory
-      module, as required in 5.3.3.3.1. See here for more details about pam_unix.so:
-      https://bugzilla.redhat.com/show_bug.cgi?id=1778929
-      A new rule needs to be created to remove the remember option from pam_unix module.
-
-  - id: 5.3.3.4.3
-    title: Ensure pam_unix includes a strong password hashing algorithm (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      Changes in logindefs mentioned in this requirement are more specifically covered by 5.4.1.4
-    rules:
-      - set_password_hashing_algorithm_systemauth
-      - set_password_hashing_algorithm_passwordauth
-      - var_password_hashing_algorithm_pam=yescrypt
-
-  - id: 5.3.3.4.4
-    title: Ensure pam_unix includes use_authtok (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: partial
-    notes: |-
-      In RHEL 9 pam_unix is enabled by default in all authselect profiles already with the
-      use_authtok option set. In any case, we don't have a rule to check this option specifically,
-      like in 5.3.3.3.3.
-
-  - id: 5.4.1.1
-    title: Ensure password expiration is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_maximum_age_login_defs
-      - var_accounts_maximum_age_login_defs=365
-      - accounts_password_set_max_life_existing
-
-  - id: 5.4.1.2
-    title: Ensure minimum password days is configured (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - accounts_minimum_age_login_defs
-      - var_accounts_minimum_age_login_defs=1
-      - accounts_password_set_min_life_existing
-
-  - id: 5.4.1.3
-    title: Ensure password expiration warning days is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_password_warn_age_login_defs
-      - var_accounts_password_warn_age_login_defs=7
-      - accounts_password_set_warn_age_existing
-
-  - id: 5.4.1.4
-    title: Ensure strong password hashing algorithm is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      There's a "new" set of options in /etc/login.defs file to define the number of iterations
-      performed during the hashing process.
-    rules:
-      - set_password_hashing_algorithm_libuserconf
-      - set_password_hashing_algorithm_logindefs
-      - var_password_hashing_algorithm=yescrypt
-      - var_password_hashing_algorithm_pam=yescrypt
-
-  - id: 5.4.1.5
-    title: Ensure inactive password lock is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - account_disable_post_pw_expiration
-      - accounts_set_post_pw_existing
-      - var_account_disable_post_pw_expiration=30
-
-  - id: 5.4.1.6
-    title: Ensure all users last password change date is in the past (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_password_last_change_is_in_past
-
-  - id: 5.4.2.1
-    title: Ensure root is the only UID 0 account (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_no_uid_except_zero
-
-  - id: 5.4.2.2
-    title: Ensure root is the only GID 0 account (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: partial
-    notes: |-
-      The rule confirms the primary group for root, but doesn't check if any other user are also
-      using GID 0. New rule is necessary.
-      There is assessment but no automated remediation for this rule and this sounds reasonable.
-    rules:
-      - accounts_root_gid_zero
-
-  - id: 5.4.2.3
-    title: Ensure group root is the only GID 0 group (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      New rule is necessary.
-
-  - id: 5.4.2.4
-    title: Ensure root account access is controlled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - ensure_root_password_configured
-
-  - id: 5.4.2.5
-    title: Ensure root path integrity (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_root_path_dirs_no_write
-      - root_path_no_dot
-
-  - id: 5.4.2.6
-    title: Ensure root user umask is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      There is no rule to ensure umask in /root/.bash_profile and /root/.bashrc. A new rule have
-      to be created. It can be based on accounts_umask_interactive_users.
-
-  - id: 5.4.2.7
-    title: Ensure system accounts do not have a valid login shell (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - no_password_auth_for_systemaccounts
-      - no_shelllogin_for_systemaccounts
-
-  - id: 5.4.2.8
-    title: Ensure accounts without a valid login shell are locked (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      New rule is necessary.
-
-  - id: 5.4.3.1
-    title: Ensure nologin is not listed in /etc/shells (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: pending
-    notes: |-
-      It is necessary to create a new rule to check and remove nologin from /etc/shells.
-      The no_tmux_in_shells rule can be used as referece.
-
-  - id: 5.4.3.2
-    title: Ensure default user shell timeout is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_tmout
-      - var_accounts_tmout=15_min
-
-  - id: 5.4.3.3
-    title: Ensure default user umask is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_umask_etc_bashrc
-      - accounts_umask_etc_login_defs
-      - accounts_umask_etc_profile
-      - var_accounts_user_umask=027
-
-  - id: 6.1.1
-    title: Ensure AIDE is installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_aide_installed
-      - aide_build_database
-
-  - id: 6.1.2
-    title: Ensure filesystem integrity is regularly checked (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - aide_periodic_cron_checking
-
-  - id: 6.1.3
-    title: Ensure cryptographic mechanisms are used to protect the integrity of audit tools (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - aide_check_audit_tools
-    related_rules:
-      - aide_use_fips_hashes
-
-  - id: 6.2.1.1
-    title: Ensure journald service is enabled and active (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - service_systemd-journald_enabled
-
-  - id: 6.2.1.2
-    title: Ensure journald log file access is configured (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 6.2.1.3
-    title: Ensure journald log file rotation is configured (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 6.2.1.4
-    title: Ensure only one logging system is in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      It is necessary to create a new rule to check the status of journald and rsyslog.
-      It would also be necessary a new rule to disable or remove rsyslog.
-
-  - id: 6.2.2.1.1
-    title: Ensure systemd-journal-remote is installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - package_systemd-journal-remote_installed
-
-  - id: 6.2.2.1.2
-    title: Ensure systemd-journal-upload authentication is configured (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 6.2.2.1.3
-    title: Ensure systemd-journal-upload is enabled and active (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      New templated rule is necessary.
-
-  - id: 6.2.2.1.4
-    title: Ensure systemd-journal-remote service is not in use (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - socket_systemd-journal-remote_disabled
-
-  - id: 6.2.2.2
-    title: Ensure journald ForwardToSyslog is disabled (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: pending
-    notes: |-
-      This rule conflicts with 6.2.3.3. More investigation is needed to properly solve this.
-    related_rules:
-      - journald_forward_to_syslog
-
-  - id: 6.2.2.3
-    title: Ensure journald Compress is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - journald_compress
-
-  - id: 6.2.2.4
-    title: Ensure journald Storage is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - journald_storage
-
-  - id: 6.2.3.1
-    title: Ensure rsyslog is installed (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: supported
-    related_rules:
-      - package_rsyslog_installed
-
-  - id: 6.2.3.2
-    title: Ensure rsyslog service is enabled and active (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: supported
-    related_rules:
-      - service_rsyslog_enabled
-
-  - id: 6.2.3.3
-    title: Ensure journald is configured to send logs to rsyslog (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: supported
-    related_rules:
-      - journald_forward_to_syslog
-
-  - id: 6.2.3.4
-    title: Ensure rsyslog log file creation mode is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: supported
-    related_rules:
-      - rsyslog_filecreatemode
-
-  - id: 6.2.3.5
-    title: Ensure rsyslog logging is configured (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-
-  - id: 6.2.3.6
-    title: Ensure rsyslog is configured to send logs to a remote log host (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-    related_rules:
-      - rsyslog_remote_loghost
-
-  - id: 6.2.3.7
-    title: Ensure rsyslog is not configured to receive logs from a remote client (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: supported
-    related_rules:
-      - rsyslog_nolisten
-
-  - id: 6.2.3.8
-    title: Ensure rsyslog logrotate is configured (Manual)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: manual
-    related_rules:
-      - ensure_logrotate_activated
-      - package_logrotate_installed
-      - timer_logrotate_enabled
-
-  - id: 6.2.4.1
-    title: Ensure access to all logfiles has been configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    notes: |-
-      It is not harmful to run these rules even if rsyslog is not installed or active.
-    rules:
-      - rsyslog_files_groupownership
-      - rsyslog_files_ownership
-      - rsyslog_files_permissions
-
-  - id: 6.3.1.1
-    title: Ensure auditd packages are installed (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - package_audit_installed
-      - package_audit-libs_installed
-
-  - id: 6.3.1.2
-    title: Ensure auditing for processes that start prior to auditd is enabled (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - grub2_audit_argument
-
-  - id: 6.3.1.3
-    title: Ensure audit_backlog_limit is sufficient (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - grub2_audit_backlog_limit_argument
-
-  - id: 6.3.1.4
-    title: Ensure auditd service is enabled and active (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - service_auditd_enabled
-
-  - id: 6.3.2.1
-    title: Ensure audit log storage size is configured (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - auditd_data_retention_max_log_file
-      - var_auditd_max_log_file=6
-
-  - id: 6.3.2.2
-    title: Ensure audit logs are not automatically deleted (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - auditd_data_retention_max_log_file_action
-      - var_auditd_max_log_file_action=keep_logs
-
-  - id: 6.3.2.3
-    title: Ensure system is disabled when audit logs are full (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - auditd_data_disk_error_action
-      - auditd_data_disk_full_action
-      - var_auditd_disk_error_action=cis_rhel8
-      - var_auditd_disk_full_action=cis_rhel8
-
-  - id: 6.3.2.4
-    title: Ensure system warns when audit logs are low on space (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - auditd_data_retention_action_mail_acct
-      - auditd_data_retention_admin_space_left_action
-      - auditd_data_retention_space_left_action
-      - var_auditd_action_mail_acct=root
-      - var_auditd_admin_space_left_action=cis_rhel8
-      - var_auditd_space_left_action=cis_rhel8
-
-  - id: 6.3.3.1
-    title: Ensure changes to system administration scope (sudoers) is collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_sysadmin_actions
-
-  - id: 6.3.3.2
-    title: Ensure actions as another user are always logged (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_suid_auid_privilege_function
-
-  - id: 6.3.3.3
-    title: Ensure events that modify the sudo log file are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_sudo_log_events
-
-  - id: 6.3.3.4
-    title: Ensure events that modify date and time information are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_time_adjtimex
-      - audit_rules_time_settimeofday
-      - audit_rules_time_clock_settime
-      - audit_rules_time_watch_localtime
-    related_rules:
-      - audit_rules_time_stime
-
-  - id: 6.3.3.5
-    title: Ensure events that modify the system's network environment are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: partial
-    notes: |-
-      These rules are not covering "/etc/hostname" and "/etc/NetworkManager/".
-    rules:
-      - audit_rules_networkconfig_modification
-      - audit_rules_networkconfig_modification_network_scripts
-
-  - id: 6.3.3.6
-    title: Ensure use of privileged commands are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_privileged_commands
-
-  - id: 6.3.3.7
-    title: Ensure unsuccessful file access attempts are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_unsuccessful_file_modification_creat
-      - audit_rules_unsuccessful_file_modification_ftruncate
-      - audit_rules_unsuccessful_file_modification_open
-      - audit_rules_unsuccessful_file_modification_openat
-      - audit_rules_unsuccessful_file_modification_truncate
-
-  - id: 6.3.3.8
-    title: Ensure events that modify user/group information are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: partial
-    notes: |-
-      Missing rules to check "/etc/nsswitch.conf", "/etc/pam.conf" and "/etc/pam.d"
-    rules:
-      - audit_rules_usergroup_modification_group
-      - audit_rules_usergroup_modification_gshadow
-      - audit_rules_usergroup_modification_opasswd
-      - audit_rules_usergroup_modification_passwd
-      - audit_rules_usergroup_modification_shadow
-
-  - id: 6.3.3.9
-    title: Ensure discretionary access control permission modification events are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_dac_modification_chmod
-      - audit_rules_dac_modification_chown
-      - audit_rules_dac_modification_fchmod
-      - audit_rules_dac_modification_fchmodat
-      - audit_rules_dac_modification_fchmodat2
-      - audit_rules_dac_modification_fchown
-      - audit_rules_dac_modification_fchownat
-      - audit_rules_dac_modification_fremovexattr
-      - audit_rules_dac_modification_fsetxattr
-      - audit_rules_dac_modification_lchown
-      - audit_rules_dac_modification_lremovexattr
-      - audit_rules_dac_modification_lsetxattr
-      - audit_rules_dac_modification_removexattr
-      - audit_rules_dac_modification_setxattr
-
-  - id: 6.3.3.10
-    title: Ensure successful file system mounts are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_media_export
-
-  - id: 6.3.3.11
-    title: Ensure session initiation information is collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_session_events_utmp
-      - audit_rules_session_events_btmp
-      - audit_rules_session_events_wtmp
-
-  - id: 6.3.3.12
-    title: Ensure login and logout events are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_login_events_faillock
-      - audit_rules_login_events_lastlog
-      - var_accounts_passwords_pam_faillock_dir=run
-
-  - id: 6.3.3.13
-    title: Ensure file deletion events by users are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_file_deletion_events_rename
-      - audit_rules_file_deletion_events_renameat
-      - audit_rules_file_deletion_events_renameat2
-      - audit_rules_file_deletion_events_unlink
-      - audit_rules_file_deletion_events_unlinkat
-
-  - id: 6.3.3.14
-    title: Ensure events that modify the system's Mandatory Access Controls are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_mac_modification_etc_selinux
-      - audit_rules_mac_modification_usr_share
-
-  - id: 6.3.3.15
-    title: Ensure successful and unsuccessful attempts to use the chcon command are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_execution_chcon
-
-  - id: 6.3.3.16
-    title: Ensure successful and unsuccessful attempts to use the setfacl command are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_execution_setfacl
-
-  - id: 6.3.3.17
-    title: Ensure successful and unsuccessful attempts to use the chacl command are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_execution_chacl
-
-  - id: 6.3.3.18
-    title: Ensure successful and unsuccessful attempts to use the usermod command are collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_privileged_commands_usermod
-
-  - id: 6.3.3.19
-    title: Ensure kernel module loading unloading and modification is collected (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_kernel_module_loading_delete
-      - audit_rules_kernel_module_loading_finit
-      - audit_rules_kernel_module_loading_init
-      - audit_rules_kernel_module_loading_query
-      - audit_rules_privileged_commands_kmod
-
-  - id: 6.3.3.20
-    title: Ensure the audit configuration is immutable (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - audit_rules_immutable
-
-  - id: 6.3.3.21
-    title: Ensure the running and on disk configuration is the same (Manual)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: manual
-
-  - id: 6.3.4.1
-    title: Ensure the audit log file directory mode is configured (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - directory_permissions_var_log_audit
-
-  - id: 6.3.4.2
-    title: Ensure audit log files mode is configured (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - file_permissions_var_log_audit
-
-  - id: 6.3.4.3
-    title: Ensure audit log files owner is configured (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - file_ownership_var_log_audit_stig
-
-  - id: 6.3.4.4
-    title: Ensure audit log files group owner is configured (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - file_group_ownership_var_log_audit
-
-  - id: 6.3.4.5
-    title: Ensure audit configuration files mode is configured (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - file_permissions_audit_configuration
-
-  - id: 6.3.4.6
-    title: Ensure audit configuration files owner is configured (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - file_ownership_audit_configuration
-
-  - id: 6.3.4.7
-    title: Ensure audit configuration files group owner is configured (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - file_groupownership_audit_configuration
-
-  - id: 6.3.4.8
-    title: Ensure audit tools mode is configured (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - file_permissions_audit_binaries
-
-  - id: 6.3.4.9
-    title: Ensure audit tools owner is configured (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - file_ownership_audit_binaries
-
-  - id: 6.3.4.10
-    title: Ensure audit tools group owner is configured (Automated)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: automated
-    rules:
-      - file_groupownership_audit_binaries
-
-  - id: 7.1.1
-    title: Ensure permissions on /etc/passwd are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_etc_passwd
-      - file_owner_etc_passwd
-      - file_permissions_etc_passwd
-
-  - id: 7.1.2
-    title: Ensure permissions on /etc/passwd- are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_backup_etc_passwd
-      - file_owner_backup_etc_passwd
-      - file_permissions_backup_etc_passwd
-
-  - id: 7.1.3
-    title: Ensure permissions on /etc/group are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_etc_group
-      - file_owner_etc_group
-      - file_permissions_etc_group
-
-  - id: 7.1.4
-    title: Ensure permissions on /etc/group- are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_backup_etc_group
-      - file_owner_backup_etc_group
-      - file_permissions_backup_etc_group
-
-  - id: 7.1.5
-    title: Ensure permissions on /etc/shadow are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_owner_etc_shadow
-      - file_groupowner_etc_shadow
-      - file_permissions_etc_shadow
-
-  - id: 7.1.6
-    title: Ensure permissions on /etc/shadow- are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_backup_etc_shadow
-      - file_owner_backup_etc_shadow
-      - file_permissions_backup_etc_shadow
-
-  - id: 7.1.7
-    title: Ensure permissions on /etc/gshadow are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_etc_gshadow
-      - file_owner_etc_gshadow
-      - file_permissions_etc_gshadow
-
-  - id: 7.1.8
-    title: Ensure permissions on /etc/gshadow- are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_backup_etc_gshadow
-      - file_owner_backup_etc_gshadow
-      - file_permissions_backup_etc_gshadow
-
-  - id: 7.1.9
-    title: Ensure permissions on /etc/shells are configured (Automated)
-    levels:
-    - l1_server
-    - l1_workstation
-    status: automated
-    rules:
-      - file_groupowner_etc_shells
-      - file_owner_etc_shells
-      - file_permissions_etc_shells
-
-  - id: 7.1.10
-    title: Ensure permissions on /etc/security/opasswd are configured (Automated)
-    levels:
-    - l1_server
-    - l1_workstation
-    status: partial
-    rules:
+    - id: 2.1.20
+      title: Ensure X window server services are not in use (Automated)
+      levels:
+          - l2_server
+      status: automated
+      notes: |-
+          Review the availability of xorg-x11-server-common package when the product is out.
+          The rule also configures correct run level to prevent unbootable system.
+      rules:
+          - package_gdm_removed
+          - xwindows_runlevel_target
+
+    - id: 2.1.21
+      title: Ensure mail transfer agents are configured for local-only mode (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: partial
+      notes: |-
+          The rule has_nonlocal_mta currently checks for services listening only on port 25,
+          but the policy checks also for ports 465 and 587
+      rules:
+          - postfix_network_listening_disabled
+          - var_postfix_inet_interfaces=loopback-only
+          - has_nonlocal_mta
+
+    - id: 2.1.22
+      title: Ensure only approved services are listening on a network interface (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 2.2.1
+      title: Ensure ftp client is not installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_ftp_removed
+
+    - id: 2.2.2
+      title: Ensure ldap client is not installed (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - package_openldap-clients_removed
+
+    - id: 2.2.3
+      title: Ensure nis client is not installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      related_rules:
+          - package_ypbind_removed
+
+    - id: 2.2.4
+      title: Ensure telnet client is not installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_telnet_removed
+
+    - id: 2.2.5
+      title: Ensure tftp client is not installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_tftp_removed
+
+    - id: 2.3.1
+      title: Ensure time synchronization is in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      related_rules:
+          - package_chrony_installed
+
+    - id: 2.3.2
+      title: Ensure chrony is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - chronyd_specify_remote_server
+          - var_multiple_time_servers=rhel
+
+    - id: 2.3.3
+      title: Ensure chrony is not run as the root user (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - chronyd_run_as_chrony_user
+
+    - id: 2.4.1.1
+      title: Ensure cron daemon is enabled and active (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_cron_installed
+          - service_crond_enabled
+
+    - id: 2.4.1.2
+      title: Ensure permissions on /etc/crontab are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_crontab
+          - file_owner_crontab
+          - file_permissions_crontab
+
+    - id: 2.4.1.3
+      title: Ensure permissions on /etc/cron.hourly are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_cron_hourly
+          - file_owner_cron_hourly
+          - file_permissions_cron_hourly
+
+    - id: 2.4.1.4
+      title: Ensure permissions on /etc/cron.daily are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_cron_daily
+          - file_owner_cron_daily
+          - file_permissions_cron_daily
+
+    - id: 2.4.1.5
+      title: Ensure permissions on /etc/cron.weekly are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_cron_weekly
+          - file_owner_cron_weekly
+          - file_permissions_cron_weekly
+
+    - id: 2.4.1.6
+      title: Ensure permissions on /etc/cron.monthly are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_cron_monthly
+          - file_owner_cron_monthly
+          - file_permissions_cron_monthly
+
+    - id: 2.4.1.7
+      title: Ensure permissions on /etc/cron.d are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_cron_d
+          - file_owner_cron_d
+          - file_permissions_cron_d
+
+    - id: 2.4.1.8
+      title: Ensure crontab is restricted to authorized users (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_cron_deny_not_exist
+          - file_cron_allow_exists
+          - file_groupowner_cron_allow
+          - file_owner_cron_allow
+          - file_permissions_cron_allow
+
+    - id: 2.4.2.1
+      title: Ensure at is restricted to authorized users (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: partial
+      notes: |-
+          It is necessary to create a rule to ensure the existence of at.allow.
+          file_cron_allow_exists can be used as reference for a new templated rule.
+      rules:
+          - file_at_deny_not_exist
+          - file_groupowner_at_allow
+          - file_owner_at_allow
+          - file_permissions_at_allow
+
+    - id: 3.1.1
+      title: Ensure IPv6 status is identified (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 3.1.2
+      title: Ensure wireless interfaces are disabled (Automated)
+      levels:
+          - l1_server
+      status: automated
+      rules:
+          - wireless_disable_interfaces
+
+    - id: 3.1.3
+      title: Ensure bluetooth services are not in use (Automated)
+      levels:
+          - l1_server
+          - l2_workstation
+      status: automated
+      rules:
+          - service_bluetooth_disabled
+
+    - id: 3.2.2
+      title: Ensure tipc kernel module is not available (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - kernel_module_tipc_disabled
+
+    - id: 3.2.4
+      title: Ensure sctp kernel module is not available (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - kernel_module_sctp_disabled
+
+    - id: 3.3.1
+      title: Ensure IP forwarding is disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_ip_forward
+          - sysctl_net_ipv6_conf_all_forwarding
+          - sysctl_net_ipv6_conf_all_forwarding_value=disabled
+
+    - id: 3.3.2
+      title: Ensure packet redirect sending is disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_conf_all_send_redirects
+          - sysctl_net_ipv4_conf_default_send_redirects
+
+    - id: 3.3.3
+      title: Ensure bogus icmp responses are ignored (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
+          - sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value=enabled
+
+    - id: 3.3.4
+      title: Ensure broadcast icmp requests are ignored (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+          - sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value=enabled
+
+    - id: 3.3.5
+      title: Ensure icmp redirects are not accepted (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_conf_all_accept_redirects
+          - sysctl_net_ipv4_conf_all_accept_redirects_value=disabled
+          - sysctl_net_ipv4_conf_default_accept_redirects
+          - sysctl_net_ipv4_conf_default_accept_redirects_value=disabled
+          - sysctl_net_ipv6_conf_all_accept_redirects
+          - sysctl_net_ipv6_conf_all_accept_redirects_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_redirects
+          - sysctl_net_ipv6_conf_default_accept_redirects_value=disabled
+
+    - id: 3.3.6
+      title: Ensure secure icmp redirects are not accepted (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_conf_all_secure_redirects
+          - sysctl_net_ipv4_conf_all_secure_redirects_value=disabled
+          - sysctl_net_ipv4_conf_default_secure_redirects
+          - sysctl_net_ipv4_conf_default_secure_redirects_value=disabled
+
+    - id: 3.3.7
+      title: Ensure reverse path filtering is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_conf_all_rp_filter
+          - sysctl_net_ipv4_conf_all_rp_filter_value=enabled
+          - sysctl_net_ipv4_conf_default_rp_filter
+          - sysctl_net_ipv4_conf_default_rp_filter_value=enabled
+
+    - id: 3.3.8
+      title: Ensure source routed packets are not accepted (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_conf_all_accept_source_route
+          - sysctl_net_ipv4_conf_all_accept_source_route_value=disabled
+          - sysctl_net_ipv4_conf_default_accept_source_route
+          - sysctl_net_ipv4_conf_default_accept_source_route_value=disabled
+          - sysctl_net_ipv6_conf_all_accept_source_route
+          - sysctl_net_ipv6_conf_all_accept_source_route_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_source_route
+          - sysctl_net_ipv6_conf_default_accept_source_route_value=disabled
+
+    - id: 3.3.9
+      title: Ensure suspicious packets are logged (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_conf_all_log_martians
+          - sysctl_net_ipv4_conf_all_log_martians_value=enabled
+          - sysctl_net_ipv4_conf_default_log_martians
+          - sysctl_net_ipv4_conf_default_log_martians_value=enabled
+
+    - id: 3.3.10
+      title: Ensure tcp syn cookies is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv4_tcp_syncookies
+          - sysctl_net_ipv4_tcp_syncookies_value=enabled
+
+    - id: 3.3.11
+      title: Ensure IPv6 router advertisements are not accepted (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sysctl_net_ipv6_conf_all_accept_ra
+          - sysctl_net_ipv6_conf_all_accept_ra_value=disabled
+          - sysctl_net_ipv6_conf_default_accept_ra
+          - sysctl_net_ipv6_conf_default_accept_ra_value=disabled
+
+    - id: 4.1.1
+      title: Ensure nftables is installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_nftables_installed
+
+    - id: 4.1.2
+      title: Ensure a single firewall configuration utility is in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - service_firewalld_enabled
+          - package_firewalld_installed
+          - service_nftables_disabled
+
+    - id: 4.2.1
+      title: Ensure firewalld drops unnecessary services and ports (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+      related_rules:
+          - configure_firewalld_ports
+
+    - id: 4.2.2
+      title: Ensure firewalld loopback traffic is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - firewalld_loopback_traffic_trusted
+          - firewalld_loopback_traffic_restricted
+
+    - id: 4.3.1
+      title: Ensure nftables base chains exist (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: supported
+      notes: |-
+          RHEL systems use firewalld for firewall management. Although nftables is the default
+          back-end for firewalld, it is not recommended to use nftables directly when firewalld
+          is in use. When using firewalld the base chains are installed by default.
+      related_rules:
+          - set_nftables_base_chain
+          - var_nftables_table=firewalld
+          - var_nftables_family=inet
+          - var_nftables_base_chain_names=chain_names
+          - var_nftables_base_chain_types=chain_types
+          - var_nftables_base_chain_hooks=chain_hooks
+          - var_nftables_base_chain_priorities=chain_priorities
+          - var_nftables_base_chain_policies=chain_policies
+
+    - id: 4.3.2
+      title: Ensure nftables established connections are configured (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 4.3.3
+      title: Ensure nftables default deny firewall policy (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: supported
+      notes: |-
+          RHEL systems use firewalld for firewall management. Although nftables is the default
+          back-end for firewalld, it is not recommended to use nftables directly when firewalld
+          is in use.
+      related_rules:
+          - nftables_ensure_default_deny_policy
+
+    - id: 4.3.4
+      title: Ensure nftables loopback traffic is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: supported
+      notes: |-
+          RHEL systems use firewalld for firewall management. Although nftables is the default
+          back-end for firewalld, it is not recommended to use nftables directly when firewalld
+          is in use.
+      related_rules:
+          - set_nftables_loopback_traffic
+
+    - id: 5.1.1
+      title: Ensure permissions on /etc/ssh/sshd_config are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_sshd_config
+          - file_owner_sshd_config
+          - file_permissions_sshd_config
+
+    - id: 5.1.2
+      title: Ensure permissions on SSH private host key files are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_permissions_sshd_private_key
+          - file_ownership_sshd_private_key
+          - file_groupownership_sshd_private_key
+
+    - id: 5.1.3
+      title: Ensure permissions on SSH public host key files are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_permissions_sshd_pub_key
+          - file_ownership_sshd_pub_key
+          - file_groupownership_sshd_pub_key
+
+    - id: 5.1.4
+      title: Ensure sshd Ciphers are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          The status was automated but we need to double check the approach used in this rule.
+          Therefore I moved it to pending until deeper investigation.
+      related_rules:
+          - sshd_use_approved_ciphers
+          - sshd_approved_ciphers=cis_rhel8
+
+    - id: 5.1.5
+      title: Ensure sshd KexAlgorithms is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          The status was automated but we need to double check the approach used in this rule.
+          Therefore I moved it to pending until deeper investigation.
+      rules:
+          - sshd_use_strong_kex
+          - sshd_strong_kex=cis_rhel8
+
+    - id: 5.1.6
+      title: Ensure sshd MACs are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          The status was automated but we need to double check the approach used in this rule.
+          Therefore I moved it to pending until deeper investigation.
+      rules:
+          - sshd_use_strong_macs
+          - sshd_strong_macs=cis_rhel8
+
+    - id: 5.1.7
+      title: Ensure sshd access is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_limit_user_access
+
+    - id: 5.1.8
+      title: Ensure sshd Banner is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_enable_warning_banner_net
+      related_rules:
+          - sshd_enable_warning_banner
+
+    - id: 5.1.9
+      title: Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          The requirement gives an example of 45 seconds, but is flexible about the values. It is only
+          necessary to ensure there is a timeout configured in alignment to the site policy.
+      rules:
+          - sshd_idle_timeout_value=5_minutes
+          - sshd_set_idle_timeout
+          - sshd_set_keepalive
+          - var_sshd_set_keepalive=1
+
+    - id: 5.1.10
+      title: Ensure sshd DisableForwarding is enabled (Automated)
+      levels:
+          - l2_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          New templated rule is necessary for "disableforwarding" option.
+      related_rules:
+          - sshd_disable_tcp_forwarding
+          - sshd_disable_x11_forwarding
+
+    - id: 5.1.11
+      title: Ensure sshd GSSAPIAuthentication is disabled (Automated)
+      levels:
+          - l2_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_disable_gssapi_auth
+
+    - id: 5.1.12
+      title: Ensure sshd HostbasedAuthentication is disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - disable_host_auth
+
+    - id: 5.1.13
+      title: Ensure sshd IgnoreRhosts is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_disable_rhosts
+
+    - id: 5.1.14
+      title: Ensure sshd LoginGraceTime is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_set_login_grace_time
+          - var_sshd_set_login_grace_time=60
+
+    - id: 5.1.15
+      title: Ensure sshd LogLevel is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          The CIS benchmark is not opinionated about which loglevel is selected here. Here, this
+          profile uses VERBOSE by default, as it allows for the capture of login and logout activity
+          as well as key fingerprints.
+      rules:
+          - sshd_set_loglevel_verbose
+      related_rules:
+          - sshd_set_loglevel_info
+
+    - id: 5.1.16
+      title: Ensure sshd MaxAuthTries is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_max_auth_tries_value=4
+          - sshd_set_max_auth_tries
+
+    - id: 5.1.17
+      title: Ensure sshd MaxStartups is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_set_maxstartups
+          - var_sshd_set_maxstartups=10:30:60
+
+    - id: 5.1.18
+      title: Ensure sshd MaxSessions is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_set_max_sessions
+          - var_sshd_max_sessions=10
+
+    - id: 5.1.19
+      title: Ensure sshd PermitEmptyPasswords is disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_disable_empty_passwords
+
+    - id: 5.1.20
+      title: Ensure sshd PermitRootLogin is disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_disable_root_login
+
+    - id: 5.1.21
+      title: Ensure sshd PermitUserEnvironment is disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_do_not_permit_user_env
+
+    - id: 5.1.22
+      title: Ensure sshd UsePAM is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sshd_enable_pam
+
+    - id: 5.2.1
+      title: Ensure sudo is installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_sudo_installed
+
+    - id: 5.2.2
+      title: Ensure sudo commands use pty (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sudo_add_use_pty
+
+    - id: 5.2.3
+      title: Ensure sudo log file exists (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sudo_custom_logfile
+
+    - id: 5.2.4
+      title: Ensure users must provide password for escalation (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - sudo_require_authentication
+
+    - id: 5.2.5
+      title: Ensure re-authentication for privilege escalation is not disabled globally (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sudo_require_reauthentication
+
+    - id: 5.2.6
+      title: Ensure sudo authentication timeout is configured correctly (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - sudo_require_reauthentication
+
+    - id: 5.2.7
+      title: Ensure access to the su command is restricted (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          Members of "wheel" or GID 0 groups are checked by default if the group option is not set for
+          pam_wheel.so module. The recommendation states the group should be empty to reinforce the
+          use of "sudo" for privileged access. Therefore, members of these groups should be manually
+          checked or a different group should be informed.
+      rules:
+          - var_pam_wheel_group_for_su=cis
+          - use_pam_wheel_group_for_su
+          - ensure_pam_wheel_group_empty
+
+    - id: 5.3.1.1
+      title: Ensure latest version of pam is installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          It is necessary a new rule to ensure PAM package is updated.
+
+    - id: 5.3.1.2
+      title: Ensure latest version of authselect is installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          It is necessary a new rule to ensure authselect package is updated.
+
+    - id: 5.3.1.3
+      title: Ensure latest version of libpwquality is installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          It is necessary a new rule to ensure libpwquality package is updated.
+      rules:
+          - package_pam_pwquality_installed
+
+    - id: 5.3.2.1
+      title: Ensure active authselect profile includes pam modules (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: partial
+      notes: |-
+          This requirement is hard to be automated without any specific requirement. The policy even
+          states that provided commands are examples, other custom settings might be in place and the
+          settings might be different depending on site policies. The other rules will already make
+          sure there is a correct autheselect profile regardless of the existing settings. It is
+          necessary to better discuss with CIS Community.
+      related_rules:
+          - no_empty_passwords
+
+    - id: 5.3.2.2
+      title: Ensure pam_faillock module is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          This requirement is also indirectly satisfied by the requirement 5.3.3.1.
+      rules:
+          - account_password_pam_faillock_password_auth
+          - account_password_pam_faillock_system_auth
+
+    - id: 5.3.2.3
+      title: Ensure pam_pwquality module is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          This requirement is also indirectly satisfied by the requirement 5.3.3.2.
+      related_rules:
+          - package_pam_pwquality_installed
+
+    - id: 5.3.2.4
+      title: Ensure pam_pwhistory module is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          The module is properly enabled by the rules mentioned in related_rules.
+          Requirements in 5.3.3.3 use these rules.
+      related_rules:
+          - accounts_password_pam_pwhistory_remember_password_auth
+          - accounts_password_pam_pwhistory_remember_system_auth
+
+    - id: 5.3.2.5
+      title: Ensure pam_unix module is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: partial
+      notes: |-
+          This module is always present by default. It is necessary to investigate if a new rule to
+          check its existence needs to be created. But so far the rule no_empty_passwords, used in
+          5.3.3.4 can ensure this requirement is attended.
+      related_rules:
+          - no_empty_passwords
+
+    - id: 5.3.3.1.1
+      title: Ensure password failed attempts lockout is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_passwords_pam_faillock_deny
+          - var_accounts_passwords_pam_faillock_deny=5
+
+    - id: 5.3.3.1.2
+      title: Ensure password unlock time is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          The policy also accepts value 0, which means the locked accounts should be manually unlocked
+          by an administrator. However, it also mentions that using value 0 can facilitate a DoS
+          attack to legitimate users.
+      rules:
+          - accounts_passwords_pam_faillock_unlock_time
+          - var_accounts_passwords_pam_faillock_unlock_time=900
+
+    - id: 5.3.3.1.3
+      title: Ensure password failed attempts lockout includes root account (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - accounts_passwords_pam_faillock_deny_root
+
+    - id: 5.3.3.2.1
+      title: Ensure password number of changed characters is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_password_pam_difok
+          - var_password_pam_difok=2
+
+    - id: 5.3.3.2.2
+      title: Ensure password length is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_password_pam_minlen
+          - var_password_pam_minlen=14
+
+    - id: 5.3.3.2.3
+      title: Ensure password complexity is configured (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          This requirement is expected to be manual. However, in previous versions of the policy
+          it was already automated the configuration of "minclass" option. This posture was kept for
+          RHEL 9 in this new version. Rules related to other options are informed in related_rules.
+          In short, minclass=4 alone can achieve the same result achieved by the combination of the
+          other 4 options mentioned in the policy.
+      rules:
+          - accounts_password_pam_minclass
+          - var_password_pam_minclass=4
+      related_rules:
+          - accounts_password_pam_dcredit
+          - accounts_password_pam_lcredit
+          - accounts_password_pam_ocredit
+          - accounts_password_pam_ucredit
+
+    - id: 5.3.3.2.4
+      title: Ensure password same consecutive characters is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_password_pam_maxrepeat
+          - var_password_pam_maxrepeat=3
+
+    - id: 5.3.3.2.5
+      title: Ensure password maximum sequential characters is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: planned
+      notes: |-
+          A new templated rule and variable are necessary for the maxsequence option.
+
+    - id: 5.3.3.2.6
+      title: Ensure password dictionary check is enabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_password_pam_dictcheck
+          - var_password_pam_dictcheck=1
+
+    - id: 5.3.3.2.7
+      title: Ensure password quality is enforced for the root user (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_password_pam_enforce_root
+
+    - id: 5.3.3.3.1
+      title: Ensure password history remember is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          Although mentioned in the section 5.3.3.3, there is no explicit requirement to configure
+          retry option of pam_pwhistory. If come in the future, the rule accounts_password_pam_retry
+          can be used.
+      rules:
+          - accounts_password_pam_pwhistory_remember_password_auth
+          - accounts_password_pam_pwhistory_remember_system_auth
+          - var_password_pam_remember_control_flag=requisite_or_required
+          - var_password_pam_remember=24
+      related_rules:
+          - accounts_password_pam_retry
+
+    - id: 5.3.3.3.2
+      title: Ensure password history is enforced for the root user (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: planned
+      notes: |-
+          A new rule needs to be created to check and remediate the enforce_for_root option in
+          /etc/security/pwhistory.conf. accounts_password_pam_enforce_root can be used as reference.
+
+    - id: 5.3.3.3.3
+      title: Ensure pam_pwhistory includes use_authtok (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: partial
+      notes: |-
+          In RHEL 9 pam_pwhistory is enabled via authselect feature, as required in 5.3.2.4. The
+          feature automatically set "use_authok" option. In any case, we don't have a rule to check
+          this option specifically.
+      related_rules:
+          - accounts_password_pam_pwhistory_remember_password_auth
+          - accounts_password_pam_pwhistory_remember_system_auth
+
+    - id: 5.3.3.4.1
+      title: Ensure pam_unix does not include nullok (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          The rule more specifically used in this requirement also satify the requirement 5.3.2.5.
+      rules:
+          - no_empty_passwords
+
+    - id: 5.3.3.4.2
+      title: Ensure pam_unix does not include remember (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          Usage of pam_unix.so module together with "remember" option is deprecated and is not
+          recommened by this policy. Instead, it should be used remember option of pam_pwhistory
+          module, as required in 5.3.3.3.1. See here for more details about pam_unix.so:
+          https://bugzilla.redhat.com/show_bug.cgi?id=1778929
+          A new rule needs to be created to remove the remember option from pam_unix module.
+
+    - id: 5.3.3.4.3
+      title: Ensure pam_unix includes a strong password hashing algorithm (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          Changes in logindefs mentioned in this requirement are more specifically covered by 5.4.1.4
+      rules:
+          - set_password_hashing_algorithm_systemauth
+          - set_password_hashing_algorithm_passwordauth
+          - var_password_hashing_algorithm_pam=yescrypt
+
+    - id: 5.3.3.4.4
+      title: Ensure pam_unix includes use_authtok (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: partial
+      notes: |-
+          In RHEL 9 pam_unix is enabled by default in all authselect profiles already with the
+          use_authtok option set. In any case, we don't have a rule to check this option specifically,
+          like in 5.3.3.3.3.
+
+    - id: 5.4.1.1
+      title: Ensure password expiration is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_maximum_age_login_defs
+          - var_accounts_maximum_age_login_defs=365
+          - accounts_password_set_max_life_existing
+
+    - id: 5.4.1.2
+      title: Ensure minimum password days is configured (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - accounts_minimum_age_login_defs
+          - var_accounts_minimum_age_login_defs=1
+          - accounts_password_set_min_life_existing
+
+    - id: 5.4.1.3
+      title: Ensure password expiration warning days is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_password_warn_age_login_defs
+          - var_accounts_password_warn_age_login_defs=7
+          - accounts_password_set_warn_age_existing
+
+    - id: 5.4.1.4
+      title: Ensure strong password hashing algorithm is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          There's a "new" set of options in /etc/login.defs file to define the number of iterations
+          performed during the hashing process.
+      rules:
+          - set_password_hashing_algorithm_libuserconf
+          - set_password_hashing_algorithm_logindefs
+          - var_password_hashing_algorithm=yescrypt
+          - var_password_hashing_algorithm_pam=yescrypt
+
+    - id: 5.4.1.5
+      title: Ensure inactive password lock is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - account_disable_post_pw_expiration
+          - accounts_set_post_pw_existing
+          - var_account_disable_post_pw_expiration=30
+
+    - id: 5.4.1.6
+      title: Ensure all users last password change date is in the past (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_password_last_change_is_in_past
+
+    - id: 5.4.2.1
+      title: Ensure root is the only UID 0 account (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_no_uid_except_zero
+
+    - id: 5.4.2.2
+      title: Ensure root is the only GID 0 account (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: partial
+      notes: |-
+          The rule confirms the primary group for root, but doesn't check if any other user are also
+          using GID 0. New rule is necessary.
+          There is assessment but no automated remediation for this rule and this sounds reasonable.
+      rules:
+          - accounts_root_gid_zero
+
+    - id: 5.4.2.3
+      title: Ensure group root is the only GID 0 group (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          New rule is necessary.
+
+    - id: 5.4.2.4
+      title: Ensure root account access is controlled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - ensure_root_password_configured
+
+    - id: 5.4.2.5
+      title: Ensure root path integrity (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_root_path_dirs_no_write
+          - root_path_no_dot
+
+    - id: 5.4.2.6
+      title: Ensure root user umask is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          There is no rule to ensure umask in /root/.bash_profile and /root/.bashrc. A new rule have
+          to be created. It can be based on accounts_umask_interactive_users.
+
+    - id: 5.4.2.7
+      title: Ensure system accounts do not have a valid login shell (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - no_password_auth_for_systemaccounts
+          - no_shelllogin_for_systemaccounts
+
+    - id: 5.4.2.8
+      title: Ensure accounts without a valid login shell are locked (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          New rule is necessary.
+
+    - id: 5.4.3.1
+      title: Ensure nologin is not listed in /etc/shells (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: pending
+      notes: |-
+          It is necessary to create a new rule to check and remove nologin from /etc/shells.
+          The no_tmux_in_shells rule can be used as referece.
+
+    - id: 5.4.3.2
+      title: Ensure default user shell timeout is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_tmout
+          - var_accounts_tmout=15_min
+
+    - id: 5.4.3.3
+      title: Ensure default user umask is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_umask_etc_bashrc
+          - accounts_umask_etc_login_defs
+          - accounts_umask_etc_profile
+          - var_accounts_user_umask=027
+
+    - id: 6.1.1
+      title: Ensure AIDE is installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_aide_installed
+          - aide_build_database
+
+    - id: 6.1.2
+      title: Ensure filesystem integrity is regularly checked (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - aide_periodic_cron_checking
+
+    - id: 6.1.3
+      title: Ensure cryptographic mechanisms are used to protect the integrity of audit tools (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - aide_check_audit_tools
+      related_rules:
+          - aide_use_fips_hashes
+
+    - id: 6.2.1.1
+      title: Ensure journald service is enabled and active (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - service_systemd-journald_enabled
+
+    - id: 6.2.1.2
+      title: Ensure journald log file access is configured (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 6.2.1.3
+      title: Ensure journald log file rotation is configured (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 6.2.1.4
+      title: Ensure only one logging system is in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          It is necessary to create a new rule to check the status of journald and rsyslog.
+          It would also be necessary a new rule to disable or remove rsyslog.
+
+    - id: 6.2.2.1.1
+      title: Ensure systemd-journal-remote is installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - package_systemd-journal-remote_installed
+
+    - id: 6.2.2.1.2
+      title: Ensure systemd-journal-upload authentication is configured (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 6.2.2.1.3
+      title: Ensure systemd-journal-upload is enabled and active (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          New templated rule is necessary.
+
+    - id: 6.2.2.1.4
+      title: Ensure systemd-journal-remote service is not in use (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - socket_systemd-journal-remote_disabled
+
+    - id: 6.2.2.2
+      title: Ensure journald ForwardToSyslog is disabled (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: pending
+      notes: |-
+          This rule conflicts with 6.2.3.3. More investigation is needed to properly solve this.
+      related_rules:
+          - journald_forward_to_syslog
+
+    - id: 6.2.2.3
+      title: Ensure journald Compress is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - journald_compress
+
+    - id: 6.2.2.4
+      title: Ensure journald Storage is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - journald_storage
+
+    - id: 6.2.3.1
+      title: Ensure rsyslog is installed (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: supported
+      related_rules:
+          - package_rsyslog_installed
+
+    - id: 6.2.3.2
+      title: Ensure rsyslog service is enabled and active (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: supported
+      related_rules:
+          - service_rsyslog_enabled
+
+    - id: 6.2.3.3
+      title: Ensure journald is configured to send logs to rsyslog (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: supported
+      related_rules:
+          - journald_forward_to_syslog
+
+    - id: 6.2.3.4
+      title: Ensure rsyslog log file creation mode is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: supported
+      related_rules:
+          - rsyslog_filecreatemode
+
+    - id: 6.2.3.5
+      title: Ensure rsyslog logging is configured (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+
+    - id: 6.2.3.6
+      title: Ensure rsyslog is configured to send logs to a remote log host (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+      related_rules:
+          - rsyslog_remote_loghost
+
+    - id: 6.2.3.7
+      title: Ensure rsyslog is not configured to receive logs from a remote client (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: supported
+      related_rules:
+          - rsyslog_nolisten
+
+    - id: 6.2.3.8
+      title: Ensure rsyslog logrotate is configured (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+      related_rules:
+          - ensure_logrotate_activated
+          - package_logrotate_installed
+          - timer_logrotate_enabled
+
+    - id: 6.2.4.1
+      title: Ensure access to all logfiles has been configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      notes: |-
+          It is not harmful to run these rules even if rsyslog is not installed or active.
+      rules:
+          - rsyslog_files_groupownership
+          - rsyslog_files_ownership
+          - rsyslog_files_permissions
+
+    - id: 6.3.1.1
+      title: Ensure auditd packages are installed (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - package_audit_installed
+          - package_audit-libs_installed
+
+    - id: 6.3.1.2
+      title: Ensure auditing for processes that start prior to auditd is enabled (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - grub2_audit_argument
+
+    - id: 6.3.1.3
+      title: Ensure audit_backlog_limit is sufficient (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - grub2_audit_backlog_limit_argument
+
+    - id: 6.3.1.4
+      title: Ensure auditd service is enabled and active (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - service_auditd_enabled
+
+    - id: 6.3.2.1
+      title: Ensure audit log storage size is configured (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - auditd_data_retention_max_log_file
+          - var_auditd_max_log_file=6
+
+    - id: 6.3.2.2
+      title: Ensure audit logs are not automatically deleted (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - auditd_data_retention_max_log_file_action
+          - var_auditd_max_log_file_action=keep_logs
+
+    - id: 6.3.2.3
+      title: Ensure system is disabled when audit logs are full (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - auditd_data_disk_error_action
+          - auditd_data_disk_full_action
+          - var_auditd_disk_error_action=cis_rhel8
+          - var_auditd_disk_full_action=cis_rhel8
+
+    - id: 6.3.2.4
+      title: Ensure system warns when audit logs are low on space (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - auditd_data_retention_action_mail_acct
+          - auditd_data_retention_admin_space_left_action
+          - auditd_data_retention_space_left_action
+          - var_auditd_action_mail_acct=root
+          - var_auditd_admin_space_left_action=cis_rhel8
+          - var_auditd_space_left_action=cis_rhel8
+
+    - id: 6.3.3.1
+      title: Ensure changes to system administration scope (sudoers) is collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_sysadmin_actions
+
+    - id: 6.3.3.2
+      title: Ensure actions as another user are always logged (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_suid_auid_privilege_function
+
+    - id: 6.3.3.3
+      title: Ensure events that modify the sudo log file are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_sudo_log_events
+
+    - id: 6.3.3.4
+      title: Ensure events that modify date and time information are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_time_adjtimex
+          - audit_rules_time_settimeofday
+          - audit_rules_time_clock_settime
+          - audit_rules_time_watch_localtime
+      related_rules:
+          - audit_rules_time_stime
+
+    - id: 6.3.3.5
+      title: Ensure events that modify the system's network environment are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: partial
+      notes: |-
+          These rules are not covering "/etc/hostname" and "/etc/NetworkManager/".
+      rules:
+          - audit_rules_networkconfig_modification
+          - audit_rules_networkconfig_modification_network_scripts
+
+    - id: 6.3.3.6
+      title: Ensure use of privileged commands are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_privileged_commands
+
+    - id: 6.3.3.7
+      title: Ensure unsuccessful file access attempts are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_unsuccessful_file_modification_creat
+          - audit_rules_unsuccessful_file_modification_ftruncate
+          - audit_rules_unsuccessful_file_modification_open
+          - audit_rules_unsuccessful_file_modification_openat
+          - audit_rules_unsuccessful_file_modification_truncate
+
+    - id: 6.3.3.8
+      title: Ensure events that modify user/group information are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: partial
+      notes: |-
+          Missing rules to check "/etc/nsswitch.conf", "/etc/pam.conf" and "/etc/pam.d"
+      rules:
+          - audit_rules_usergroup_modification_group
+          - audit_rules_usergroup_modification_gshadow
+          - audit_rules_usergroup_modification_opasswd
+          - audit_rules_usergroup_modification_passwd
+          - audit_rules_usergroup_modification_shadow
+
+    - id: 6.3.3.9
+      title: Ensure discretionary access control permission modification events are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_dac_modification_chmod
+          - audit_rules_dac_modification_chown
+          - audit_rules_dac_modification_fchmod
+          - audit_rules_dac_modification_fchmodat
+          - audit_rules_dac_modification_fchmodat2
+          - audit_rules_dac_modification_fchown
+          - audit_rules_dac_modification_fchownat
+          - audit_rules_dac_modification_fremovexattr
+          - audit_rules_dac_modification_fsetxattr
+          - audit_rules_dac_modification_lchown
+          - audit_rules_dac_modification_lremovexattr
+          - audit_rules_dac_modification_lsetxattr
+          - audit_rules_dac_modification_removexattr
+          - audit_rules_dac_modification_setxattr
+
+    - id: 6.3.3.10
+      title: Ensure successful file system mounts are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_media_export
+
+    - id: 6.3.3.11
+      title: Ensure session initiation information is collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_session_events_utmp
+          - audit_rules_session_events_btmp
+          - audit_rules_session_events_wtmp
+
+    - id: 6.3.3.12
+      title: Ensure login and logout events are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_login_events_faillock
+          - audit_rules_login_events_lastlog
+          - var_accounts_passwords_pam_faillock_dir=run
+
+    - id: 6.3.3.13
+      title: Ensure file deletion events by users are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_file_deletion_events_rename
+          - audit_rules_file_deletion_events_renameat
+          - audit_rules_file_deletion_events_renameat2
+          - audit_rules_file_deletion_events_unlink
+          - audit_rules_file_deletion_events_unlinkat
+
+    - id: 6.3.3.14
+      title: Ensure events that modify the system's Mandatory Access Controls are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_mac_modification_etc_selinux
+          - audit_rules_mac_modification_usr_share
+
+    - id: 6.3.3.15
+      title: Ensure successful and unsuccessful attempts to use the chcon command are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_execution_chcon
+
+    - id: 6.3.3.16
+      title: Ensure successful and unsuccessful attempts to use the setfacl command are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_execution_setfacl
+
+    - id: 6.3.3.17
+      title: Ensure successful and unsuccessful attempts to use the chacl command are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_execution_chacl
+
+    - id: 6.3.3.18
+      title: Ensure successful and unsuccessful attempts to use the usermod command are collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_privileged_commands_usermod
+
+    - id: 6.3.3.19
+      title: Ensure kernel module loading unloading and modification is collected (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_kernel_module_loading_delete
+          - audit_rules_kernel_module_loading_finit
+          - audit_rules_kernel_module_loading_init
+          - audit_rules_kernel_module_loading_query
+          - audit_rules_privileged_commands_kmod
+
+    - id: 6.3.3.20
+      title: Ensure the audit configuration is immutable (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - audit_rules_immutable
+
+    - id: 6.3.3.21
+      title: Ensure the running and on disk configuration is the same (Manual)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: manual
+
+    - id: 6.3.4.1
+      title: Ensure the audit log file directory mode is configured (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - directory_permissions_var_log_audit
+
+    - id: 6.3.4.2
+      title: Ensure audit log files mode is configured (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - file_permissions_var_log_audit
+
+    - id: 6.3.4.3
+      title: Ensure audit log files owner is configured (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - file_ownership_var_log_audit_stig
+
+    - id: 6.3.4.4
+      title: Ensure audit log files group owner is configured (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - file_group_ownership_var_log_audit
+
+    - id: 6.3.4.5
+      title: Ensure audit configuration files mode is configured (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - file_permissions_audit_configuration
+
+    - id: 6.3.4.6
+      title: Ensure audit configuration files owner is configured (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - file_ownership_audit_configuration
+
+    - id: 6.3.4.7
+      title: Ensure audit configuration files group owner is configured (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - file_groupownership_audit_configuration
+
+    - id: 6.3.4.8
+      title: Ensure audit tools mode is configured (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - file_permissions_audit_binaries
+
+    - id: 6.3.4.9
+      title: Ensure audit tools owner is configured (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - file_ownership_audit_binaries
+
+    - id: 6.3.4.10
+      title: Ensure audit tools group owner is configured (Automated)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: automated
+      rules:
+          - file_groupownership_audit_binaries
+
+    - id: 7.1.1
+      title: Ensure permissions on /etc/passwd are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_etc_passwd
+          - file_owner_etc_passwd
+          - file_permissions_etc_passwd
+
+    - id: 7.1.2
+      title: Ensure permissions on /etc/passwd- are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_backup_etc_passwd
+          - file_owner_backup_etc_passwd
+          - file_permissions_backup_etc_passwd
+
+    - id: 7.1.3
+      title: Ensure permissions on /etc/group are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_etc_group
+          - file_owner_etc_group
+          - file_permissions_etc_group
+
+    - id: 7.1.4
+      title: Ensure permissions on /etc/group- are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_backup_etc_group
+          - file_owner_backup_etc_group
+          - file_permissions_backup_etc_group
+
+    - id: 7.1.5
+      title: Ensure permissions on /etc/shadow are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_owner_etc_shadow
+          - file_groupowner_etc_shadow
+          - file_permissions_etc_shadow
+
+    - id: 7.1.6
+      title: Ensure permissions on /etc/shadow- are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_backup_etc_shadow
+          - file_owner_backup_etc_shadow
+          - file_permissions_backup_etc_shadow
+
+    - id: 7.1.7
+      title: Ensure permissions on /etc/gshadow are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_etc_gshadow
+          - file_owner_etc_gshadow
+          - file_permissions_etc_gshadow
+
+    - id: 7.1.8
+      title: Ensure permissions on /etc/gshadow- are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_backup_etc_gshadow
+          - file_owner_backup_etc_gshadow
+          - file_permissions_backup_etc_gshadow
+
+    - id: 7.1.9
+      title: Ensure permissions on /etc/shells are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_groupowner_etc_shells
+          - file_owner_etc_shells
+          - file_permissions_etc_shells
+
+    - id: 7.1.10
+      title: Ensure permissions on /etc/security/opasswd are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: partial
+      rules:
     # TODO: We need another rule that checks /etc/security/opasswd.old
-    - file_etc_security_opasswd
+          - file_etc_security_opasswd
 
-  - id: 7.1.11
-    title: Ensure world writable files and directories are secured (Automated)
-    levels:
-    - l1_server
-    - l1_workstation
-    status: automated
-    rules:
-    - file_permissions_unauthorized_world_writable
-    - dir_perms_world_writable_sticky_bits
+    - id: 7.1.11
+      title: Ensure world writable files and directories are secured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - file_permissions_unauthorized_world_writable
+          - dir_perms_world_writable_sticky_bits
 
-  - id: 7.1.12
-    title: Ensure no files or directories without an owner and a group exist (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: partial
-    rules:
+    - id: 7.1.12
+      title: Ensure no files or directories without an owner and a group exist (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: partial
+      rules:
     # TODO: add rules for unowned/ungrouped directories
-    - no_files_unowned_by_user
-    - file_permissions_ungroupowned
+          - no_files_unowned_by_user
+          - file_permissions_ungroupowned
 
-  - id: 7.1.13
-    title: Ensure SUID and SGID files are reviewed (Manual)
-    levels:
-    - l1_server
-    - l1_workstation
-    status: manual
-    related_rules:
-      - file_permissions_unauthorized_suid
-      - file_permissions_unauthorized_sgid
+    - id: 7.1.13
+      title: Ensure SUID and SGID files are reviewed (Manual)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: manual
+      related_rules:
+          - file_permissions_unauthorized_suid
+          - file_permissions_unauthorized_sgid
 
-  - id: 7.1.14
-    title: Audit system file permissions (Manual)
-    levels:
-      - l2_server
-      - l2_workstation
-    status: manual
-    related_rules:
-      - rpm_verify_permissions
-      - rpm_verify_ownership
+    - id: 7.1.14
+      title: Audit system file permissions (Manual)
+      levels:
+          - l2_server
+          - l2_workstation
+      status: manual
+      related_rules:
+          - rpm_verify_permissions
+          - rpm_verify_ownership
 
-  - id: 7.2.1
-    title: Ensure accounts in /etc/passwd use shadowed passwords (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_password_all_shadowed
+    - id: 7.2.1
+      title: Ensure accounts in /etc/passwd use shadowed passwords (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_password_all_shadowed
 
-  - id: 7.2.2
-    title: Ensure /etc/shadow password fields are not empty (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - no_empty_passwords_etc_shadow
+    - id: 7.2.2
+      title: Ensure /etc/shadow password fields are not empty (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - no_empty_passwords_etc_shadow
 
-  - id: 7.2.3
-    title: Ensure all groups in /etc/passwd exist in /etc/group (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - gid_passwd_group_same
+    - id: 7.2.3
+      title: Ensure all groups in /etc/passwd exist in /etc/group (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - gid_passwd_group_same
 
-  - id: 7.2.4
-    title: Ensure no duplicate UIDs exist (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - account_unique_id
+    - id: 7.2.4
+      title: Ensure no duplicate UIDs exist (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - account_unique_id
 
-  - id: 7.2.5
-    title: Ensure no duplicate GIDs exist (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - group_unique_id
+    - id: 7.2.5
+      title: Ensure no duplicate GIDs exist (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - group_unique_id
 
-  - id: 7.2.6
-    title: Ensure no duplicate user names exist (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - account_unique_name
+    - id: 7.2.6
+      title: Ensure no duplicate user names exist (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - account_unique_name
 
-  - id: 7.2.7
-    title: Ensure no duplicate group names exist (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - group_unique_name
+    - id: 7.2.7
+      title: Ensure no duplicate group names exist (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - group_unique_name
 
-  - id: 7.2.8
-    title: Ensure local interactive user home directories are configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    status: automated
-    rules:
-      - accounts_user_interactive_home_directory_exists
-      - file_ownership_home_directories
-      - file_permissions_home_directories
-    related_rules:
-      - file_groupownership_home_directories
+    - id: 7.2.8
+      title: Ensure local interactive user home directories are configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      status: automated
+      rules:
+          - accounts_user_interactive_home_directory_exists
+          - file_ownership_home_directories
+          - file_permissions_home_directories
+      related_rules:
+          - file_groupownership_home_directories
 
-  - id: 7.2.9
-    title: Ensure local interactive user dot files access is configured (Automated)
-    levels:
-      - l1_server
-      - l1_workstation
-    notes: |-
-      Missing a rule to check that .bash_history is mode 0600 or more restrictive.
-    status: partial
-    rules:
-      - accounts_user_dot_group_ownership
-      - accounts_user_dot_user_ownership
-      - accounts_user_dot_no_world_writable_programs
-      - file_permission_user_init_files
-      - var_user_initialization_files_regex=all_dotfiles
-      - no_forward_files
-      - no_netrc_files
-    related_rules:
-      - accounts_users_netrc_file_permissions
+    - id: 7.2.9
+      title: Ensure local interactive user dot files access is configured (Automated)
+      levels:
+          - l1_server
+          - l1_workstation
+      notes: |-
+          Missing a rule to check that .bash_history is mode 0600 or more restrictive.
+      status: partial
+      rules:
+          - accounts_user_dot_group_ownership
+          - accounts_user_dot_user_ownership
+          - accounts_user_dot_no_world_writable_programs
+          - file_permission_user_init_files
+          - var_user_initialization_files_regex=all_dotfiles
+          - no_forward_files
+          - no_netrc_files
+      related_rules:
+          - accounts_users_netrc_file_permissions

--- a/controls/ospp.yml
+++ b/controls/ospp.yml
@@ -1,520 +1,523 @@
+---
 id: ospp
 title: 'Protection Profile for General Purpose Operating Systems'
 policy: 'Common Criteria'
 source: 'https://www.niap-ccevs.org/Profile/Info.cfm?PPID=469&id=469'
 version: '4.3'
+
 levels:
-    -   id: base
+    - id: base
+
 controls:
-    -   id: AGD_OPE.1
-        title: 'Operational User Guidance'
-        levels:
-            - base
-        rules:
-            - package_openscap-scanner_installed
-            - package_scap-security-guide_installed
-        status: automated
-    -   id: AGD_PRE.1
-        title: 'Preparative Procedures'
-        levels:
-            - base
-        rules:
-            - package_openscap-scanner_installed
-            - package_scap-security-guide_installed
-        status: automated
-    -   id: FAU_GEN.1
-        title: 'Audit Data Generation (Refined)'
-        levels:
-            - base
-        rules:
-            - auditd_data_retention_flush
-            - auditd_freq
-            - grub2_audit_argument
-            - package_audit_installed
-            - audit_basic_configuration
-            - service_auditd_enabled
-            - var_auditd_flush=incremental_async
-            - sshd_disable_root_login
-            - zipl_audit_argument
-        status: automated
-    -   id: FAU_GEN.1.1
-        title: 'Audit Data Generation - Event Types to be Audited'
-        levels:
-            - base
-        rules:
-            - audit_access_failed
-            - audit_access_failed_aarch64
-            - audit_access_failed_ppc64le
-            - audit_access_success
-            - audit_access_success.role=unscored
-            - audit_access_success.severity=info
-            - audit_access_success_aarch64
-            - audit_access_success_aarch64.role=unscored
-            - audit_access_success_aarch64.severity=info
-            - audit_access_success_ppc64le
-            - audit_access_success_ppc64le.role=unscored
-            - audit_access_success_ppc64le.severity=info
-            - audit_create_failed
-            - audit_create_failed_aarch64
-            - audit_create_failed_ppc64le
-            - audit_create_success
-            - audit_create_success_aarch64
-            - audit_create_success_ppc64le
-            - audit_delete_failed
-            - audit_delete_failed_aarch64
-            - audit_delete_failed_ppc64le
-            - audit_delete_success
-            - audit_delete_success_aarch64
-            - audit_delete_success_ppc64le
-            - audit_modify_failed
-            - audit_modify_failed_aarch64
-            - audit_modify_failed_ppc64le
-            - audit_modify_success
-            - audit_modify_success_aarch64
-            - audit_modify_success_ppc64le
-            - audit_module_load
-            - audit_module_load_ppc64le
-            - audit_ospp_general
-            - audit_ospp_general_aarch64
-            - audit_ospp_general_ppc64le
-            - audit_owner_change_failed
-            - audit_owner_change_failed_aarch64
-            - audit_owner_change_failed_ppc64le
-            - audit_owner_change_success
-            - audit_owner_change_success_aarch64
-            - audit_owner_change_success_ppc64le
-            - audit_perm_change_failed
-            - audit_perm_change_failed_aarch64
-            - audit_perm_change_failed_ppc64le
-            - audit_perm_change_success
-            - audit_perm_change_success_aarch64
-            - audit_perm_change_success_ppc64le
-        status: automated
-    -   id: FAU_GEN.1.2
-        title: 'Audit Data Generation - Audit Event Format'
-        levels:
-            - base
-        rules:
-            - auditd_log_format
-            - auditd_name_format
-            - audit_immutable_login_uids
-            - disable_ctrlaltdel_burstaction
-            - disable_ctrlaltdel_reboot
-        status: automated
-    -   id: FAU_STG.1
-        title: 'Protected audit trail storage'
-        levels:
-            - base
-        rules:
-            - grub2_audit_backlog_limit_argument
-            - zipl_audit_backlog_limit_argument
-        status: automated
-    -   id: FCS_CKM.1
-        title: 'Cryptographic Key Generation'
-        levels:
-            - base
-        rules:
-            - configure_crypto_policy
-            - package_crypto-policies_installed
-            - enable_fips_mode
-            - var_system_crypto_policy=fips_ospp
-            - configure_openssl_crypto_policy
-        status: automated
-    -   id: FCS_CKM.1.1
-        title: 'Cryptographic Key Generation - asymmetric cryptographic'
-        levels:
-            - base
-        rules:
-            - configure_crypto_policy
-            - package_crypto-policies_installed
-            - enable_fips_mode
-            - var_system_crypto_policy=fips_ospp
-            - configure_openssl_crypto_policy
-        status: automated
-    -   id: FCS_CKM.2
-        title: 'Cryptographic Key Establishment'
-        levels:
-            - base
-        rules:
-            - configure_crypto_policy
-            - package_crypto-policies_installed
-            - enable_fips_mode
-            - var_system_crypto_policy=fips_ospp
-            - configure_openssl_crypto_policy
-        status: automated
-    -   id: FCS_COP.1/ENCRYPT
-        title: 'Cryptographic Operation - Encryption/Decryption'
-        levels:
-            - base
-        rules:
-            - configure_crypto_policy
-            - package_crypto-policies_installed
-            - enable_fips_mode
-            - var_system_crypto_policy=fips_ospp
-            - configure_openssl_crypto_policy
-        status: automated
-    -   id: FCS_COP.1/HASH
-        title: 'Cryptographic Operation - Hashing'
-        levels:
-            - base
-        rules:
-            - configure_crypto_policy
-            - package_crypto-policies_installed
-            - enable_fips_mode
-            - var_system_crypto_policy=fips_ospp
-            - configure_openssl_crypto_policy
-        status: automated
+    - id: AGD_OPE.1
+      title: 'Operational User Guidance'
+      levels:
+          - base
+      rules:
+          - package_openscap-scanner_installed
+          - package_scap-security-guide_installed
+      status: automated
+    - id: AGD_PRE.1
+      title: 'Preparative Procedures'
+      levels:
+          - base
+      rules:
+          - package_openscap-scanner_installed
+          - package_scap-security-guide_installed
+      status: automated
+    - id: FAU_GEN.1
+      title: 'Audit Data Generation (Refined)'
+      levels:
+          - base
+      rules:
+          - auditd_data_retention_flush
+          - auditd_freq
+          - grub2_audit_argument
+          - package_audit_installed
+          - audit_basic_configuration
+          - service_auditd_enabled
+          - var_auditd_flush=incremental_async
+          - sshd_disable_root_login
+          - zipl_audit_argument
+      status: automated
+    - id: FAU_GEN.1.1
+      title: 'Audit Data Generation - Event Types to be Audited'
+      levels:
+          - base
+      rules:
+          - audit_access_failed
+          - audit_access_failed_aarch64
+          - audit_access_failed_ppc64le
+          - audit_access_success
+          - audit_access_success.role=unscored
+          - audit_access_success.severity=info
+          - audit_access_success_aarch64
+          - audit_access_success_aarch64.role=unscored
+          - audit_access_success_aarch64.severity=info
+          - audit_access_success_ppc64le
+          - audit_access_success_ppc64le.role=unscored
+          - audit_access_success_ppc64le.severity=info
+          - audit_create_failed
+          - audit_create_failed_aarch64
+          - audit_create_failed_ppc64le
+          - audit_create_success
+          - audit_create_success_aarch64
+          - audit_create_success_ppc64le
+          - audit_delete_failed
+          - audit_delete_failed_aarch64
+          - audit_delete_failed_ppc64le
+          - audit_delete_success
+          - audit_delete_success_aarch64
+          - audit_delete_success_ppc64le
+          - audit_modify_failed
+          - audit_modify_failed_aarch64
+          - audit_modify_failed_ppc64le
+          - audit_modify_success
+          - audit_modify_success_aarch64
+          - audit_modify_success_ppc64le
+          - audit_module_load
+          - audit_module_load_ppc64le
+          - audit_ospp_general
+          - audit_ospp_general_aarch64
+          - audit_ospp_general_ppc64le
+          - audit_owner_change_failed
+          - audit_owner_change_failed_aarch64
+          - audit_owner_change_failed_ppc64le
+          - audit_owner_change_success
+          - audit_owner_change_success_aarch64
+          - audit_owner_change_success_ppc64le
+          - audit_perm_change_failed
+          - audit_perm_change_failed_aarch64
+          - audit_perm_change_failed_ppc64le
+          - audit_perm_change_success
+          - audit_perm_change_success_aarch64
+          - audit_perm_change_success_ppc64le
+      status: automated
+    - id: FAU_GEN.1.2
+      title: 'Audit Data Generation - Audit Event Format'
+      levels:
+          - base
+      rules:
+          - auditd_log_format
+          - auditd_name_format
+          - audit_immutable_login_uids
+          - disable_ctrlaltdel_burstaction
+          - disable_ctrlaltdel_reboot
+      status: automated
+    - id: FAU_STG.1
+      title: 'Protected audit trail storage'
+      levels:
+          - base
+      rules:
+          - grub2_audit_backlog_limit_argument
+          - zipl_audit_backlog_limit_argument
+      status: automated
+    - id: FCS_CKM.1
+      title: 'Cryptographic Key Generation'
+      levels:
+          - base
+      rules:
+          - configure_crypto_policy
+          - package_crypto-policies_installed
+          - enable_fips_mode
+          - var_system_crypto_policy=fips_ospp
+          - configure_openssl_crypto_policy
+      status: automated
+    - id: FCS_CKM.1.1
+      title: 'Cryptographic Key Generation - asymmetric cryptographic'
+      levels:
+          - base
+      rules:
+          - configure_crypto_policy
+          - package_crypto-policies_installed
+          - enable_fips_mode
+          - var_system_crypto_policy=fips_ospp
+          - configure_openssl_crypto_policy
+      status: automated
+    - id: FCS_CKM.2
+      title: 'Cryptographic Key Establishment'
+      levels:
+          - base
+      rules:
+          - configure_crypto_policy
+          - package_crypto-policies_installed
+          - enable_fips_mode
+          - var_system_crypto_policy=fips_ospp
+          - configure_openssl_crypto_policy
+      status: automated
+    - id: FCS_COP.1/ENCRYPT
+      title: 'Cryptographic Operation - Encryption/Decryption'
+      levels:
+          - base
+      rules:
+          - configure_crypto_policy
+          - package_crypto-policies_installed
+          - enable_fips_mode
+          - var_system_crypto_policy=fips_ospp
+          - configure_openssl_crypto_policy
+      status: automated
+    - id: FCS_COP.1/HASH
+      title: 'Cryptographic Operation - Hashing'
+      levels:
+          - base
+      rules:
+          - configure_crypto_policy
+          - package_crypto-policies_installed
+          - enable_fips_mode
+          - var_system_crypto_policy=fips_ospp
+          - configure_openssl_crypto_policy
+      status: automated
 
-    -   id: FCS_COP.1/SIGN
-        title: 'Cryptographic Operation - Signing'
-        levels:
-            - base
-        rules:
-            - configure_crypto_policy
-            - package_crypto-policies_installed
-            - enable_fips_mode
-            - var_system_crypto_policy=fips_ospp
-            - configure_openssl_crypto_policy
-        status: automated
-    -   id: FCS_COP.1/KEYHMAC
-        title: 'Keyed-Hash Message Authentication'
-        levels:
-            - base
-        rules:
-            - configure_crypto_policy
-            - package_crypto-policies_installed
-            - enable_fips_mode
-            - var_system_crypto_policy=fips_ospp
-            - configure_openssl_crypto_policy
-        status: automated
+    - id: FCS_COP.1/SIGN
+      title: 'Cryptographic Operation - Signing'
+      levels:
+          - base
+      rules:
+          - configure_crypto_policy
+          - package_crypto-policies_installed
+          - enable_fips_mode
+          - var_system_crypto_policy=fips_ospp
+          - configure_openssl_crypto_policy
+      status: automated
+    - id: FCS_COP.1/KEYHMAC
+      title: 'Keyed-Hash Message Authentication'
+      levels:
+          - base
+      rules:
+          - configure_crypto_policy
+          - package_crypto-policies_installed
+          - enable_fips_mode
+          - var_system_crypto_policy=fips_ospp
+          - configure_openssl_crypto_policy
+      status: automated
 
-    -   id: FCS_RBG_EXT.1
-        title: 'Random Bit Generation'
-        levels:
-            - base
-        rules:
-            - enable_dracut_fips_module
-            - enable_fips_mode
-            - var_system_crypto_policy=fips_ospp
-        status: automated
-    -   id: FCS_RBG_EXT.1.1
-        title: 'Random Bit Generation - deterministic random bit generation'
-        levels:
-            - base
-        rules:
-            - enable_dracut_fips_module
-            - enable_fips_mode
-            - var_system_crypto_policy=fips_ospp
-        status: automated
+    - id: FCS_RBG_EXT.1
+      title: 'Random Bit Generation'
+      levels:
+          - base
+      rules:
+          - enable_dracut_fips_module
+          - enable_fips_mode
+          - var_system_crypto_policy=fips_ospp
+      status: automated
+    - id: FCS_RBG_EXT.1.1
+      title: 'Random Bit Generation - deterministic random bit generation'
+      levels:
+          - base
+      rules:
+          - enable_dracut_fips_module
+          - enable_fips_mode
+          - var_system_crypto_policy=fips_ospp
+      status: automated
 
-    -   id: FCS_RBG_EXT.1.2
-        title: 'Random Bit Generation - entropy source'
-        levels:
-            - base
-        rules:
-            - enable_dracut_fips_module
-            - enable_fips_mode
-            - var_system_crypto_policy=fips_ospp
-        status: automated
+    - id: FCS_RBG_EXT.1.2
+      title: 'Random Bit Generation - entropy source'
+      levels:
+          - base
+      rules:
+          - enable_dracut_fips_module
+          - enable_fips_mode
+          - var_system_crypto_policy=fips_ospp
+      status: automated
 
-    -   id: FCS_SSHC_EXT.1
-        title: 'SSH Client Protocol'
-        levels:
-            - base
-        rules:
-            - package_openssh-clients_installed
-            - configure_ssh_crypto_policy
-        status: automated
-    -   id: FCS_SSHS_EXT.1
-        title: 'SSH Server Protocol'
-        levels:
-            - base
-        rules:
-            - package_openssh-server_installed
-            - configure_ssh_crypto_policy
-        status: automated
+    - id: FCS_SSHC_EXT.1
+      title: 'SSH Client Protocol'
+      levels:
+          - base
+      rules:
+          - package_openssh-clients_installed
+          - configure_ssh_crypto_policy
+      status: automated
+    - id: FCS_SSHS_EXT.1
+      title: 'SSH Server Protocol'
+      levels:
+          - base
+      rules:
+          - package_openssh-server_installed
+          - configure_ssh_crypto_policy
+      status: automated
 
-    -   id: FCS_SSH_EXT.1
-        title: 'SSH Protocol'
-        levels:
-            - base
-        rules:
-            - package_openssh-clients_installed
-            - package_openssh-server_installed
-            - configure_ssh_crypto_policy
-            - sshd_use_directory_configuration
-        status: automated
+    - id: FCS_SSH_EXT.1
+      title: 'SSH Protocol'
+      levels:
+          - base
+      rules:
+          - package_openssh-clients_installed
+          - package_openssh-server_installed
+          - configure_ssh_crypto_policy
+          - sshd_use_directory_configuration
+      status: automated
 
-    -   id: FCS_SSH_EXT.1.2
-        title: 'SSH Protocol - Authentication Methods'
-        levels:
-            - base
-        rules:
-            - sshd_disable_gssapi_auth
-            - sshd_disable_kerb_auth
-        status: automated
+    - id: FCS_SSH_EXT.1.2
+      title: 'SSH Protocol - Authentication Methods'
+      levels:
+          - base
+      rules:
+          - sshd_disable_gssapi_auth
+          - sshd_disable_kerb_auth
+      status: automated
 
-    -   id: FCS_SSH_EXT.1.8
-        title: 'SSH Protocol - Session'
-        levels:
-            - base
-        rules:
-            - ssh_client_rekey_limit
-            - var_ssh_client_rekey_limit_size=1G
-            - var_ssh_client_rekey_limit_time=1hour
-            - sshd_rekey_limit
-            - var_rekey_limit_size=1G
-            - var_rekey_limit_time=1hour
-        status: automated
+    - id: FCS_SSH_EXT.1.8
+      title: 'SSH Protocol - Session'
+      levels:
+          - base
+      rules:
+          - ssh_client_rekey_limit
+          - var_ssh_client_rekey_limit_size=1G
+          - var_ssh_client_rekey_limit_time=1hour
+          - sshd_rekey_limit
+          - var_rekey_limit_size=1G
+          - var_rekey_limit_time=1hour
+      status: automated
 
-    -   id: FCS_TLSC_EXT.1
-        title: 'TLS Client Protocol'
-        levels:
-            - base
-        rules:
-            - configure_crypto_policy
-            - package_crypto-policies_installed
-            - enable_fips_mode
-            - configure_openssl_crypto_policy
-        status: automated
+    - id: FCS_TLSC_EXT.1
+      title: 'TLS Client Protocol'
+      levels:
+          - base
+      rules:
+          - configure_crypto_policy
+          - package_crypto-policies_installed
+          - enable_fips_mode
+          - configure_openssl_crypto_policy
+      status: automated
 
-    -   id: FCS_TLSC_EXT.1.1
-        title: 'Allowed Cipher Suites'
-        levels:
-            - base
-        rules:
-            - configure_crypto_policy
-            - package_crypto-policies_installed
-            - enable_fips_mode
-            - configure_openssl_crypto_policy
-        status: automated
-    -   id: FIA_AFL.1
-        title: 'Authentication failure handling'
-        levels:
-            - base
-        rules:
-            - accounts_passwords_pam_faillock_deny
-            - var_accounts_passwords_pam_faillock_deny=3
-            - accounts_passwords_pam_faillock_interval
-            - var_accounts_passwords_pam_faillock_fail_interval=900
-            - accounts_passwords_pam_faillock_unlock_time
-            - var_accounts_passwords_pam_faillock_unlock_time=never
-        status: automated
+    - id: FCS_TLSC_EXT.1.1
+      title: 'Allowed Cipher Suites'
+      levels:
+          - base
+      rules:
+          - configure_crypto_policy
+          - package_crypto-policies_installed
+          - enable_fips_mode
+          - configure_openssl_crypto_policy
+      status: automated
+    - id: FIA_AFL.1
+      title: 'Authentication failure handling'
+      levels:
+          - base
+      rules:
+          - accounts_passwords_pam_faillock_deny
+          - var_accounts_passwords_pam_faillock_deny=3
+          - accounts_passwords_pam_faillock_interval
+          - var_accounts_passwords_pam_faillock_fail_interval=900
+          - accounts_passwords_pam_faillock_unlock_time
+          - var_accounts_passwords_pam_faillock_unlock_time=never
+      status: automated
 
-    -   id: FIA_UAU.1
-        title: 'Timing of authentication'
-        levels:
-            - base
-        rules:
-            - disable_host_auth
-            - sshd_disable_empty_passwords
-            - require_singleuser_auth
-            - service_debug-shell_disabled
-            - no_empty_passwords
-            - grub2_disable_recovery
-            - grub2_systemd_debug-shell_argument_absent
-            - grub2_password
-            - zipl_systemd_debug-shell_argument_absent
-        status: automated
+    - id: FIA_UAU.1
+      title: 'Timing of authentication'
+      levels:
+          - base
+      rules:
+          - disable_host_auth
+          - sshd_disable_empty_passwords
+          - require_singleuser_auth
+          - service_debug-shell_disabled
+          - no_empty_passwords
+          - grub2_disable_recovery
+          - grub2_systemd_debug-shell_argument_absent
+          - grub2_password
+          - zipl_systemd_debug-shell_argument_absent
+      status: automated
 
-    -   id: FIA_UAU.5
-        title: 'Multiple Authentication Mechanisms'
-        levels:
-            - base
-        rules:
-            - package_openssh-clients_installed
-            - package_openssh-server_installed
-        status: automated
+    - id: FIA_UAU.5
+      title: 'Multiple Authentication Mechanisms'
+      levels:
+          - base
+      rules:
+          - package_openssh-clients_installed
+          - package_openssh-server_installed
+      status: automated
 
-    -   id: FIA_X509_EXT.1
-        title: 'X.509 Certificate Validation'
-        levels:
-            - base
-        rules:
-            - package_gnutls-utils_installed
-        status: automated
+    - id: FIA_X509_EXT.1
+      title: 'X.509 Certificate Validation'
+      levels:
+          - base
+      rules:
+          - package_gnutls-utils_installed
+      status: automated
 
-    -   id: FIA_X509_EXT.1.1
-        title: 'X.509 Certificate Validation - Valid Certificates'
-        levels:
-            - base
-        rules:
-            - package_gnutls-utils_installed
-        status: automated
+    - id: FIA_X509_EXT.1.1
+      title: 'X.509 Certificate Validation - Valid Certificates'
+      levels:
+          - base
+      rules:
+          - package_gnutls-utils_installed
+      status: automated
 
-    -   id: FIA_X509_EXT.2
-        title: 'X.509 Certificate Validation - basicConstraints'
-        levels:
-            - base
-        rules:
-            - package_gnutls-utils_installed
-        status: automated
+    - id: FIA_X509_EXT.2
+      title: 'X.509 Certificate Validation - basicConstraints'
+      levels:
+          - base
+      rules:
+          - package_gnutls-utils_installed
+      status: automated
 
-    -   id: FMT_MOF_EXT.1
-        title: 'Management of security functions behavior'
-        levels:
-            - base
-        rules:
-            - package_sudo_installed
-            - logind_session_timeout
-            - var_logind_session_timeout=30_minutes
-            - selinux_policytype # SELinux doesn't have a SFR associated, this one seems the least controversial
-            - selinux_state
-            - var_selinux_state=enforcing
-            - var_selinux_policy_name=targeted
-        status: automated
+    - id: FMT_MOF_EXT.1
+      title: 'Management of security functions behavior'
+      levels:
+          - base
+      rules:
+          - package_sudo_installed
+          - logind_session_timeout
+          - var_logind_session_timeout=30_minutes
+          - selinux_policytype  # SELinux doesn't have a SFR associated, this one seems the least controversial
+          - selinux_state
+          - var_selinux_state=enforcing
+          - var_selinux_policy_name=targeted
+      status: automated
 
-    -   id: FMT_SMF_EXT.1
-        title: 'Specification of Management Functions'
-        levels:
-            - base
-        rules:
-            - package_fapolicyd_installed
-            - service_fapolicyd_enabled
-            - chronyd_client_only
-            - package_chrony_installed
-            - configure_usbguard_auditbackend
-            - package_usbguard_installed
-            - service_usbguard_enabled
-            - usbguard_allow_hid_and_hub
-            - accounts_password_pam_dcredit
-            - accounts_password_pam_lcredit
-            - accounts_password_pam_minlen
-            - accounts_password_pam_ocredit
-            - accounts_password_pam_ucredit
-            - var_password_pam_minlen=12
-            - var_password_pam_ocredit=1
-            - var_password_pam_dcredit=1
-            - var_password_pam_ucredit=1
-            - var_password_pam_lcredit=1
-            - package_firewalld_installed
-            - service_firewalld_enabled
-            - kernel_module_can_disabled
-            - kernel_module_tipc_disabled
-            - kernel_module_bluetooth_disabled
-            - kernel_module_sctp_disabled
-            - service_systemd-coredump_disabled
-            - sysctl_kernel_core_pattern_empty_string
-            - sysctl_kernel_core_uses_pid
-            - sysctl_kernel_perf_event_paranoid
-            - sysctl_kernel_unprivileged_bpf_disabled_accept_default
-            - sysctl_kernel_unprivileged_bpf_disabled_value=2
-            - sysctl_kernel_dmesg_restrict
-            - sysctl_kernel_kptr_restrict
-            - sysctl_kernel_kexec_load_disabled
-            - sysctl_kernel_yama_ptrace_scope
-            - sysctl_user_max_user_namespaces
-            - partition_for_var_log_audit
-            - mount_option_var_log_audit_nodev
-            - mount_option_var_log_audit_nosuid
-            - mount_option_var_log_audit_noexec
-            - dnf-automatic_apply_updates
-            - timer_dnf-automatic_enabled
-            - logind_session_timeout
-            - var_logind_session_timeout=30_minutes
-        status: automated
+    - id: FMT_SMF_EXT.1
+      title: 'Specification of Management Functions'
+      levels:
+          - base
+      rules:
+          - package_fapolicyd_installed
+          - service_fapolicyd_enabled
+          - chronyd_client_only
+          - package_chrony_installed
+          - configure_usbguard_auditbackend
+          - package_usbguard_installed
+          - service_usbguard_enabled
+          - usbguard_allow_hid_and_hub
+          - accounts_password_pam_dcredit
+          - accounts_password_pam_lcredit
+          - accounts_password_pam_minlen
+          - accounts_password_pam_ocredit
+          - accounts_password_pam_ucredit
+          - var_password_pam_minlen=12
+          - var_password_pam_ocredit=1
+          - var_password_pam_dcredit=1
+          - var_password_pam_ucredit=1
+          - var_password_pam_lcredit=1
+          - package_firewalld_installed
+          - service_firewalld_enabled
+          - kernel_module_can_disabled
+          - kernel_module_tipc_disabled
+          - kernel_module_bluetooth_disabled
+          - kernel_module_sctp_disabled
+          - service_systemd-coredump_disabled
+          - sysctl_kernel_core_pattern_empty_string
+          - sysctl_kernel_core_uses_pid
+          - sysctl_kernel_perf_event_paranoid
+          - sysctl_kernel_unprivileged_bpf_disabled_accept_default
+          - sysctl_kernel_unprivileged_bpf_disabled_value=2
+          - sysctl_kernel_dmesg_restrict
+          - sysctl_kernel_kptr_restrict
+          - sysctl_kernel_kexec_load_disabled
+          - sysctl_kernel_yama_ptrace_scope
+          - sysctl_user_max_user_namespaces
+          - partition_for_var_log_audit
+          - mount_option_var_log_audit_nodev
+          - mount_option_var_log_audit_nosuid
+          - mount_option_var_log_audit_noexec
+          - dnf-automatic_apply_updates
+          - timer_dnf-automatic_enabled
+          - logind_session_timeout
+          - var_logind_session_timeout=30_minutes
+      status: automated
 
-    -   id: FMT_SMF_EXT.1.1
-        title: 'Management of security functions behavior - Restrict Administrator Functions'
-        levels:
-            - base
-        rules:
-            - service_kdump_disabled
-            - logind_session_timeout
-            - use_pam_wheel_for_su
-        status: automated
+    - id: FMT_SMF_EXT.1.1
+      title: 'Management of security functions behavior - Restrict Administrator Functions'
+      levels:
+          - base
+      rules:
+          - service_kdump_disabled
+          - logind_session_timeout
+          - use_pam_wheel_for_su
+      status: automated
 
-    -   id: FPT_ASLR_EXT.1
-        title: 'Address Space Layout Randomization'
-        levels:
-            - base
-        rules:
-            - grub2_vsyscall_argument
-        status: automated
+    - id: FPT_ASLR_EXT.1
+      title: 'Address Space Layout Randomization'
+      levels:
+          - base
+      rules:
+          - grub2_vsyscall_argument
+      status: automated
 
-    -   id: FPT_TUD_EXT.1
-        title: 'Trusted Update'
-        levels:
-            - base
-        rules:
-            - package_dnf-plugin-subscription-manager_installed
-            - package_dnf-automatic_installed
-            - package_subscription-manager_installed
-            - ensure_gpgcheck_globally_activated
-            - ensure_gpgcheck_local_packages
-            - ensure_gpgcheck_never_disabled
-            - ensure_redhat_gpgkey_installed
-        status: automated
+    - id: FPT_TUD_EXT.1
+      title: 'Trusted Update'
+      levels:
+          - base
+      rules:
+          - package_dnf-plugin-subscription-manager_installed
+          - package_dnf-automatic_installed
+          - package_subscription-manager_installed
+          - ensure_gpgcheck_globally_activated
+          - ensure_gpgcheck_local_packages
+          - ensure_gpgcheck_never_disabled
+          - ensure_redhat_gpgkey_installed
+      status: automated
 
-    -   id: FPT_TUD_EXT.2
-        title: 'Trusted Update for Application Software'
-        levels:
-            - base
-        rules:
-            - package_dnf-plugin-subscription-manager_installed
-            - package_dnf-automatic_installed
-            - package_subscription-manager_installed
-            - ensure_gpgcheck_globally_activated
-            - ensure_gpgcheck_local_packages
-            - ensure_gpgcheck_never_disabled
-            - ensure_redhat_gpgkey_installed
-        status: automated
+    - id: FPT_TUD_EXT.2
+      title: 'Trusted Update for Application Software'
+      levels:
+          - base
+      rules:
+          - package_dnf-plugin-subscription-manager_installed
+          - package_dnf-automatic_installed
+          - package_subscription-manager_installed
+          - ensure_gpgcheck_globally_activated
+          - ensure_gpgcheck_local_packages
+          - ensure_gpgcheck_never_disabled
+          - ensure_redhat_gpgkey_installed
+      status: automated
 
-    -   id: FPT_TST_EXT.1
-        title: Boot Integrity
-        levels:
-            - base
-        rules:
-            - zipl_bls_entries_only
-            - zipl_bootmap_is_up_to_date
-        status: automated
+    - id: FPT_TST_EXT.1
+      title: Boot Integrity
+      levels:
+          - base
+      rules:
+          - zipl_bls_entries_only
+          - zipl_bootmap_is_up_to_date
+      status: automated
 
-    -   id: FTA_SSL.1
-        title: 'TSF-initiated session locking'
-        levels:
-            - base
-        rules:
-            - logind_session_timeout
-            - var_logind_session_timeout=30_minutes
-        status: automated
+    - id: FTA_SSL.1
+      title: 'TSF-initiated session locking'
+      levels:
+          - base
+      rules:
+          - logind_session_timeout
+          - var_logind_session_timeout=30_minutes
+      status: automated
 
-    -   id: FTA_TAB.1
-        title: 'Default TOE access banners'
-        levels:
-            - base
-        rules:
-            - sshd_enable_warning_banner
-        status: automated
+    - id: FTA_TAB.1
+      title: 'Default TOE access banners'
+      levels:
+          - base
+      rules:
+          - sshd_enable_warning_banner
+      status: automated
 
-    -   id: FTP_ITC_EXT.1
-        title: 'Trusted channel communication'
-        levels:
-            - base
-        rules:
-            - package_openssh-clients_installed
-            - package_openssh-server_installed
-            - sshd_disable_gssapi_auth
-            - sshd_disable_kerb_auth
-        status: automated
+    - id: FTP_ITC_EXT.1
+      title: 'Trusted channel communication'
+      levels:
+          - base
+      rules:
+          - package_openssh-clients_installed
+          - package_openssh-server_installed
+          - sshd_disable_gssapi_auth
+          - sshd_disable_kerb_auth
+      status: automated
 
-    -   id: FTP_ITC_EXT.1.1
-        title: 'Trusted channel communication - TLS'
-        levels:
-            - base
-        rules:
-            - package_openssh-clients_installed
-            - package_openssh-server_installed
-            - sshd_disable_gssapi_auth
-            - sshd_disable_kerb_auth
-        status: automated
+    - id: FTP_ITC_EXT.1.1
+      title: 'Trusted channel communication - TLS'
+      levels:
+          - base
+      rules:
+          - package_openssh-clients_installed
+          - package_openssh-server_installed
+          - sshd_disable_gssapi_auth
+          - sshd_disable_kerb_auth
+      status: automated
 
-    -   id: AVA_VAN.1
-        title: 'Vulnerability Assessment'
-        levels:
-            - base
-        rules:
-            - grub2_init_on_alloc_argument
-            - grub2_page_alloc_shuffle_argument
-            - zipl_init_on_alloc_argument
-            - zipl_page_alloc_shuffle_argument
-        status: automated
+    - id: AVA_VAN.1
+      title: 'Vulnerability Assessment'
+      levels:
+          - base
+      rules:
+          - grub2_init_on_alloc_argument
+          - grub2_page_alloc_shuffle_argument
+          - zipl_init_on_alloc_argument
+          - zipl_page_alloc_shuffle_argument
+      status: automated

--- a/controls/srg_gpos.yml
+++ b/controls/srg_gpos.yml
@@ -1,27 +1,30 @@
+---
 policy: Security Requirements Guide - General Purpose Operating System
 title: Security Requirements Guide - General Purpose Operating System
 id: srg_gpos
 version: 'v3r1'
 source: https://public.cyber.mil/stigs/downloads/
 controls_dir: srg_gpos
+
 levels:
-- id: high
-- id: medium
-- id: low
+    - id: high
+    - id: medium
+    - id: low
+
 controls:
-    -   id: Variables
-        levels:
-            - high
-            - medium
-            - low
-        title: Variables
-        rules:
-            - var_sshd_disable_compression=no
-            - var_password_hashing_algorithm=SHA512
-            - var_password_pam_dictcheck=1
-            - sshd_idle_timeout_value=10_minutes
-            - var_accounts_authorized_local_users_regex=rhel9
-            - var_account_disable_post_pw_expiration=35
-            - login_banner_text=dod_banners
-            - var_authselect_profile=sssd
-            - var_auditd_name_format=stig
+    - id: Variables
+      levels:
+          - high
+          - medium
+          - low
+      title: Variables
+      rules:
+          - var_sshd_disable_compression=no
+          - var_password_hashing_algorithm=SHA512
+          - var_password_pam_dictcheck=1
+          - sshd_idle_timeout_value=10_minutes
+          - var_accounts_authorized_local_users_regex=rhel9
+          - var_account_disable_post_pw_expiration=35
+          - login_banner_text=dod_banners
+          - var_authselect_profile=sssd
+          - var_auditd_name_format=stig

--- a/products/rhel10/profiles/anssi_bp28_enhanced.profile
+++ b/products/rhel10/profiles/anssi_bp28_enhanced.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel10/profiles/anssi_bp28_high.profile
+++ b/products/rhel10/profiles/anssi_bp28_high.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel10/profiles/anssi_bp28_intermediary.profile
+++ b/products/rhel10/profiles/anssi_bp28_intermediary.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel10/profiles/anssi_bp28_minimal.profile
+++ b/products/rhel10/profiles/anssi_bp28_minimal.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel10/profiles/cis.profile
+++ b/products/rhel10/profiles/cis.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel10/profiles/cis_server_l1.profile
+++ b/products/rhel10/profiles/cis_server_l1.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:
@@ -16,4 +17,3 @@ description: |-
 selections:
     - cis_rhel10:all:l1_server
     - var_authselect_profile=local
-

--- a/products/rhel10/profiles/cis_workstation_l1.profile
+++ b/products/rhel10/profiles/cis_workstation_l1.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:
@@ -16,4 +17,3 @@ description: |-
 selections:
     - cis_rhel10:all:l1_workstation
     - var_authselect_profile=local
-

--- a/products/rhel10/profiles/cis_workstation_l2.profile
+++ b/products/rhel10/profiles/cis_workstation_l2.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel10/profiles/default.profile
+++ b/products/rhel10/profiles/default.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 hidden: true
@@ -5,32 +6,31 @@ hidden: true
 title: Default Profile for Red Hat Enterprise Linux 10
 
 description: |-
-  This profile contains all the rules that once belonged to the rhel10
-  product. This profile won't be rendered into an XCCDF Profile entity,
-  nor it will select any of these rules by default. The only purpose of
-  this profile is to keep a rule in the product's XCCDF Benchmark.
+    This profile contains all the rules that once belonged to the rhel10
+    product. This profile won't be rendered into an XCCDF Profile entity,
+    nor it will select any of these rules by default. The only purpose of
+    this profile is to keep a rule in the product's XCCDF Benchmark.
 
 selections:
-  - grub2_nousb_argument
-  - audit_rules_kernel_module_loading_create
-  - grub2_uefi_admin_username
-  - grub2_uefi_password
-  - no_tmux_in_shells
-  - package_tmux_installed
-  - configure_tmux_lock_after_time
-  - configure_tmux_lock_command
-  - configure_tmux_lock_keybinding
-  - audit_rules_session_events
-  - enable_authselect
-  - audit_rules_login_events
-  - audit_rules_unsuccessful_file_modification
-  - configure_openssl_tls_crypto_policy
-  - audit_rules_privileged_commands_pt_chown
-  - package_iprutils_removed
-  - service_rlogin_disabled
-  - service_rsh_disabled
-  - service_rexec_disabled
-  - package_scap-security-guide_installed
-  - set_password_hashing_yescrypt_cost_factor_logindefs
-  - var_authselect_profile=local
-
+    - grub2_nousb_argument
+    - audit_rules_kernel_module_loading_create
+    - grub2_uefi_admin_username
+    - grub2_uefi_password
+    - no_tmux_in_shells
+    - package_tmux_installed
+    - configure_tmux_lock_after_time
+    - configure_tmux_lock_command
+    - configure_tmux_lock_keybinding
+    - audit_rules_session_events
+    - enable_authselect
+    - audit_rules_login_events
+    - audit_rules_unsuccessful_file_modification
+    - configure_openssl_tls_crypto_policy
+    - audit_rules_privileged_commands_pt_chown
+    - package_iprutils_removed
+    - service_rlogin_disabled
+    - service_rsh_disabled
+    - service_rexec_disabled
+    - package_scap-security-guide_installed
+    - set_password_hashing_yescrypt_cost_factor_logindefs
+    - var_authselect_profile=local

--- a/products/rhel10/profiles/e8.profile
+++ b/products/rhel10/profiles/e8.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel10/profiles/hipaa.profile
+++ b/products/rhel10/profiles/hipaa.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel10/profiles/ism_o.profile
+++ b/products/rhel10/profiles/ism_o.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel10/profiles/ism_o_secret.profile
+++ b/products/rhel10/profiles/ism_o_secret.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel10/profiles/ism_o_top_secret.profile
+++ b/products/rhel10/profiles/ism_o_top_secret.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel10/profiles/ospp.profile
+++ b/products/rhel10/profiles/ospp.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:
@@ -13,7 +14,6 @@ title: 'DRAFT - Protection Profile for General Purpose Operating Systems'
 description: |-
     This is draft profile is based on the Red Hat Enterprise Linux 9 Common Criteria Guidance as
     guidance for Red Hat Enterprise Linux 10 was not available at the time of release.
-
 
     Where appropriate, CNSSI 1253 or DoD-specific values are used for
     configuration, based on Configuration Annex to the OSPP.

--- a/products/rhel10/profiles/pci-dss.profile
+++ b/products/rhel10/profiles/pci-dss.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 metadata:

--- a/products/rhel10/profiles/stig.profile
+++ b/products/rhel10/profiles/stig.profile
@@ -1,9 +1,9 @@
+---
 documentation_complete: true
 
 metadata:
     SMEs:
         - mab879
-
 
 reference: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
 

--- a/products/rhel10/profiles/stig_gui.profile
+++ b/products/rhel10/profiles/stig_gui.profile
@@ -1,9 +1,9 @@
+---
 documentation_complete: true
 
 metadata:
     SMEs:
         - mab879
-
 
 reference: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
 


### PR DESCRIPTION
Description:

Format rhel10 related yaml file using yamlfix command, yamlfix.toml as config file.

Rationale:

The reason to format yaml file is to unify all yaml file format. So that external library change can be minimal, real change can be easily spotted instead of seeing a lots of format change.

Currently, when update cac content yaml file content, i found the yaml file format is chaotic. It will cause irrelevant format changes and let reviewer hard to focus what's really changed. We need to unify cac content yaml file format, update style guide of yaml.

Review Hints:

Format rhel9 related yaml file using yamlfix command, [yamlfix.toml](https://github.com/ComplianceAsCode/content/blob/master/yamlfix.toml) as config file.

```shell
yamlfix -c yamlfix.toml file_path
```