### PR TITLE
fix conditional check bash_bootc_build

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
@@ -65,6 +65,10 @@ references:
     pcidss: Req-10.2.2
     srg: SRG-OS-000327-GPOS-00127
 
+{{% if pkg_system == "dpkg" %}}
+platform: not container
+{{% endif %}}
+
 ocil_clause: "any setuid or setgid programs doesn't have a line in the audit rules"
 
 ocil: |-

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/rule.yml
@@ -79,8 +79,11 @@ references:
     stigid@sle15: SLES-15-040060
     stigid@ubuntu2204: UBTU-22-211015
 
-ocil_clause: 'the system is configured to reboot when Ctrl-Alt-Del is pressed'
+{{% if pkg_system == "dpkg" %}}
+platform: not container
+{{% endif %}}
 
+ocil_clause: 'the system is configured to reboot when Ctrl-Alt-Del is pressed'
 
 ocil: |-
     To ensure the system is configured to mask the Ctrl-Alt-Del sequence, Check

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -2701,7 +2701,11 @@ This macro defines a conditional expression that is evaluated as true
 if the remediation is performed during a build of a bootable container image.
 #}}
 {{%- macro bash_bootc_build() -%}}
+{{%- if pkg_system == "rpm" -%}}
 { rpm --quiet -q kernel rpm-ostree bootc && ! rpm --quiet -q openshift-kubelet && { [ -f "/run/.containerenv" ] || [ -f "/.containerenv" ]; }; }
+{{%- else -%}}
+/bin/false
+{{%- endif -%}}
 {{%- endmacro -%}}
 
 {{#


### PR DESCRIPTION
#### Description:

- fix conditional check bash_bootc_build

#### Rationale:

- Current implementation only works for rpm-based distro