### PR TITLE
Format fedora related yaml file

### DIFF
--- a/controls/cusp_fedora.yml
+++ b/controls/cusp_fedora.yml
@@ -3,7 +3,8 @@ policy: 'Fedora Common User Security Policy'
 title: 'Fedora Common User Security Policy'
 id: cusp_fedora
 version: '1.0.0'
-source: "jodehnal's bachelor thesis on creating a SCAP profile for common users of Fedora workstation - link will be added after publication"
+source: "jodehnal's bachelor thesis on creating a SCAP profile for common users of Fedora workstation\
+    \ - link will be added after publication"
 
 controls:
     ###

--- a/products/fedora/profiles/cusp_fedora.profile
+++ b/products/fedora/profiles/cusp_fedora.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 title: 'CUSP - Common User Security Profile for Fedora Workstation'
@@ -6,4 +7,4 @@ description: |-
     This profile contains rules to harden Fedora Linux according to the Common User Security Guide for Fedora Workstation.
 
 selections:
-  - cusp_fedora:all
+    - cusp_fedora:all

--- a/products/fedora/profiles/default.profile
+++ b/products/fedora/profiles/default.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 hidden: true

--- a/products/fedora/profiles/ospp.profile
+++ b/products/fedora/profiles/ospp.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 title: 'OSPP - Protection Profile for General Purpose Operating Systems'

--- a/products/fedora/profiles/pci-dss.profile
+++ b/products/fedora/profiles/pci-dss.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 title: 'PCI-DSS v3.2.1 Control Baseline for Fedora'

--- a/products/fedora/profiles/standard.profile
+++ b/products/fedora/profiles/standard.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: true
 
 title: 'Standard System Security Profile for Fedora'

--- a/products/fedora/profiles/test.profile
+++ b/products/fedora/profiles/test.profile
@@ -1,3 +1,4 @@
+---
 documentation_complete: false
 
 metadata:
@@ -6,7 +7,6 @@ metadata:
         - mab879
 
 title: 'Automatus Testing Profile'
-
 
 description: |-
     This profile contains a few rules used to test Automatus in profile and combined modes.


### PR DESCRIPTION
Description:

- Format fedora related yaml file using yamlfix command, yamlfix.toml as config file.

Rationale:

- The reason to format yaml file is to unify all yaml file format. So that external library change can be minimal, real change can be easily spotted instead of seeing a lots of format change.

- Currently, when update cac content yaml file content, i found the yaml file format is chaotic. It will cause irrelevant format changes and let reviewer hard to focus what's really changed. We need to unify cac content yaml file format, update style guide of yaml.

Review Hints:

- Format fedora related yaml file using yamlfix command, [yamlfix.toml](https://github.com/ComplianceAsCode/content/blob/master/yamlfix.toml) as config file.

```shell
yamlfix -c yamlfix.toml file_path
```