### PR TITLE
replace instances of grub-mkconfig with correct grub2-mkconfig

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_admin_username/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_admin_username/rule.yml
@@ -23,7 +23,7 @@ description: |-
     update the
     <tt>grub.cfg</tt> file by running:
     {{%- if "rhel" in product %}}
-    <pre>grub-mkconfig -o /boot/grub2/grub.cfg</pre>
+    <pre>grub2-mkconfig -o /boot/grub2/grub.cfg</pre>
     {{%- else %}}
     <pre>{{{ grub_command("update") }}}</pre>
     {{%- endif %}}
@@ -85,7 +85,7 @@ fixtext: |-
     Once the superuser account has been added, update the grub.cfg file by running:
 
     {{%- if "rhel" in product %}}
-    <pre>grub-mkconfig -o /boot/grub2/grub.cfg</pre>
+    <pre>grub2-mkconfig -o /boot/grub2/grub.cfg</pre>
     {{%- else %}}
     <pre>{{{ grub_command("update") }}}</pre>
     {{%- endif %}}

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/rule.yml
@@ -28,7 +28,7 @@ description: |-
     update the
     <tt>grub.cfg</tt> file by running:
     {{%- if "rhel" in product %}}
-    <pre>grub-mkconfig -o /boot/grub2/grub.cfg</pre>
+    <pre>grub2-mkconfig -o /boot/grub2/grub.cfg</pre>
     {{%- else %}}
     <pre>{{{ grub_command("update") }}}</pre>
     {{%- endif %}}
@@ -111,7 +111,7 @@ fixtext: |-
     Once the superuser account has been added, update the grub.cfg file by running:
 
     {{%- if "rhel" in product %}}
-    <pre>grub-mkconfig -o /boot/grub2/grub.cfg</pre>
+    <pre>grub2-mkconfig -o /boot/grub2/grub.cfg</pre>
     {{%- else %}}
     <pre>{{{ grub_command("update") }}}</pre>
     {{%- endif %}}

--- a/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_admin_username/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_admin_username/rule.yml
@@ -23,7 +23,7 @@ description: |-
     update the
     <tt>grub.cfg</tt> file by running:
     {{%- if "rhel" in product %}}
-    <pre>grub-mkconfig -o /boot/grub2/grub.cfg</pre>
+    <pre>grub2-mkconfig -o /boot/grub2/grub.cfg</pre>
     {{%- else %}}
     <pre>{{{ grub_command("update") }}}</pre>
     {{%- endif %}}
@@ -89,7 +89,7 @@ fixtext: |-
     Once the superuser account has been added, update the grub.cfg file by running:
 
     {{%- if "rhel" in product %}}
-    <pre>grub-mkconfig -o /boot/grub2/grub.cfg</pre>
+    <pre>grub2-mkconfig -o /boot/grub2/grub.cfg</pre>
     {{%- else %}}
     <pre>{{{ grub_command("update") }}}</pre>
     {{%- endif %}}

--- a/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/rule.yml
@@ -28,7 +28,7 @@ description: |-
     update the
     <tt>grub.cfg</tt> file by running:
     {{%- if "rhel" in product %}}
-    <pre>grub-mkconfig -o /boot/grub2/grub.cfg</pre>
+    <pre>grub2-mkconfig -o /boot/grub2/grub.cfg</pre>
     {{%- else %}}
     <pre>{{{ grub_command("update") }}}</pre>
     {{%- endif %}}
@@ -109,7 +109,7 @@ fixtext: |-
     Then, update the grub.cfg file by running:
 
     {{%- if "rhel" in product %}}
-    <pre>grub-mkconfig -o /boot/grub2/grub.cfg</pre>
+    <pre>grub2-mkconfig -o /boot/grub2/grub.cfg</pre>
     {{%- else %}}
     <pre>{{{ grub_command("update") }}}</pre>
     {{%- endif %}}


### PR DESCRIPTION
#### Description:

- replace instances of grub-mkconfig with the correct version of grub2-mkconfig
- scope - rule.yaml files within the linux_os/guide directory

#### Rationale:

- fix invalid command


#### Review Hints:

- grep the data stream for instances of grub-mkconfig