### PR TITLE
[test suite] Stop test and return if initial scan result is non applicable

### DIFF
--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -159,6 +159,7 @@ class RuleChecker(oscap.Checker):
                 return False
             if initial_scan_res == 2:
                 # notapplicable
+                self.initial_scan_result = 2
                 return True
 
             supported_and_available_remediations = self._get_available_remediations(scenario)
@@ -495,6 +496,8 @@ class RuleChecker(oscap.Checker):
         self._current_result.scenario = common.Scenario_run(rule_id, scenario.script)
         self._current_result.when = self.test_timestamp_str
 
+        if hasattr(self, 'initial_scan_result') and self.initial_scan_result == 2:
+            return
         with self.copy_of_datastream():
             self._check_rule_scenario(scenario, remote_rule_dir, rule_id, remediation_available)
         self.results.append(self._current_result.save_to_dict())


### PR DESCRIPTION
#### Description:

- Stop test and return if initial scan result is non applicable

#### Rationale:

- Tests will be applied no matter how the applicability is set in rule.yml. If the tests failed under non-applicable, the return code will still be stored and cause error.
- Should fix [failed workflow](https://github.com/ComplianceAsCode/content/actions/runs/15906115104/job/44861538120?pr=13634) of pr #13634
- https://github.com/ComplianceAsCode/content/issues/12511