### PR TITLE
Add RHEL 9, RHEL 10, and Fedora Reformats to git blame ignore list

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,12 +1,20 @@
-# This file ignores the specificed commits from git blame.
+# This file ignores the specified commits from git blame.
 # This used to ignore commit that only affect formatting of files to make git blame more useful.
-# This file is used by running:
+# This file is used by running the command below in the root of the project:
 # git config blame.ignoreRevsFile .git-blame-ignore-revs
 # GitHub and GitLab use this file by default.
 
 # There should be commit above the commit explainly it why it was added to this list.
 
-# Refomrating RHEL 8 controls and profiles - https://github.com/ComplianceAsCode/content/pull/13621
+# Reformatting RHEL 8 controls and profiles - https://github.com/ComplianceAsCode/content/pull/13621
 e705b83c8f388772fc1a34a566ead2bfb0b4a409
 # Reformatting Fedora CUSP - https://github.com/ComplianceAsCode/content/pull/13623
 cdb12a649604b946dcb56d2354ff05ea03bd748b
+# Reformatting RHEL 9 - https://github.com/ComplianceAsCode/content/pull/13630
+658f2b133357dea85a2e7bcb92b7ad740dc6e281
+# Reformatting RHEL 10 - https://github.com/ComplianceAsCode/content/pull/13631
+71f391d42f283eb1ffad4c18b3229064982b171f
+# Reformatting Fedora - https://github.com/ComplianceAsCode/content/pull/13637
+79c4ac79682f79d8aef5f0a20fef30c071723d3c
+# Reformatting OCP4 - https://github.com/ComplianceAsCode/content/pull/13632
+d4c044fa558d4eb0a37d863a4ec49235017043d7


### PR DESCRIPTION
#### Description:
Add RHEL 9 and 10 to git blame ignore list

#### Rationale:

Make git blame easier to use
