### PR TITLE
doc: default_ingress_ca_replaced link to docs.openshift.com is out-of-date

### DIFF
--- a/applications/openshift/networking/default_ingress_ca_replaced/rule.yml
+++ b/applications/openshift/networking/default_ingress_ca_replaced/rule.yml
@@ -17,7 +17,7 @@ rationale: |-
   to be replaced since a certificate coming from a trusted provider is
   needed.
 
-  {{{ weblink(link="https://docs.openshift.com/container-platform/latest/security/certificates/replacing-default-ingress-certificate.html") }}}
+  {{{ weblink(link="https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/security_and_compliance/configuring-certificates#replacing-default-ingress") }}}
 
 severity: medium
 


### PR DESCRIPTION
#### Description:
Doc pointed to docs.openshift.com versus the preferred docs.redhat.com, I've provided the updated link.

#### Rationale:
Doc for the rule was out of date

#### Review Hints:
n/a
