### PR TITLE
docs: Define how to handle ADR PRs

### DIFF
--- a/docs/manual/developer/11_governance.md
+++ b/docs/manual/developer/11_governance.md
@@ -86,7 +86,12 @@ All issues and pull requests for product removal must use the [product-removal](
 #### Architectural Decision Records
 - We use [Architectural Decision Records](#introduction-of-architecture-decisions-records)
 - The first ADR defines the context and guidelines for new ADRs.
-
+- All PRs that support or justify a proposed ADR should be linked to that ADR in the description, labeled with the ADR label and should remain in the draft
+  state until ADR is accepted.
+  In case a PR of such nature is not linked to an ADR, not in the draft state or not labeled with the ADR label, reviewers should inform the author and assist
+  in bringing it to the correct state.
+  In case a PR linked to an ADR is found to be valuable to the project in isolation from the ADR, reviewers may decide to unlink the PR from ADR, switch it
+  to the ready state and proceed with the PR via the normal review process.
 
 ### Shared Resources
 


### PR DESCRIPTION
#### Description:

- We should keep the changes related to a proposed ADR at bay until the ADR is accepted.

#### Rationale:

- It'd allow us to protect the project from proposal creep-in.

#### Review Hints:

Alternative for #13614.