### PR TITLE
Workaround OpenSCAP issue for Image Mode

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/bash/shared.sh
@@ -4,15 +4,18 @@ FAILLOCK_CONF_FILES="/etc/security/faillock.conf /etc/pam.d/system-auth /etc/pam
 faillock_dirs=$(grep -oP "^\s*(?:auth.*pam_faillock.so.*)?dir\s*=\s*(\S+)" $FAILLOCK_CONF_FILES \
                | sed -r 's/.*=\s*(\S+)/\1/')
 
+# Workaround for https://github.com/OpenSCAP/openscap/issues/2242: Use full
+# path to semanage and restorecon commands to avoid the issue with the command
+# not being found.
 if [ -n "$faillock_dirs" ]; then
     for dir in $faillock_dirs; do
-        if ! semanage fcontext -a -t faillog_t "$dir(/.*)?"; then
-            semanage fcontext -m -t faillog_t "$dir(/.*)?"
+        if ! /usr/sbin/semanage fcontext -a -t faillog_t "$dir(/.*)?"; then
+            /usr/sbin/semanage fcontext -m -t faillog_t "$dir(/.*)?"
         fi
         if [ ! -e $dir ]; then
             mkdir -p $dir
         fi
-        restorecon -R -v $dir
+        /usr/sbin/restorecon -R -v $dir
     done
 else
 echo "

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/bash/shared.sh
@@ -14,5 +14,8 @@
 {{{ bash_package_install("policycoreutils-python-utils") }}}
 
 mkdir -p "$var_accounts_passwords_pam_faillock_dir"
-semanage fcontext -a -t faillog_t "$var_accounts_passwords_pam_faillock_dir(/.*)?"
-restorecon -R -v "$var_accounts_passwords_pam_faillock_dir"
+# Workaround for https://github.com/OpenSCAP/openscap/issues/2242: Use full
+# path to semanage and restorecon commands to avoid the issue with the command
+# not being found.
+/usr/sbin/semanage fcontext -a -t faillog_t "$var_accounts_passwords_pam_faillock_dir(/.*)?"
+/usr/sbin/restorecon -R -v "$var_accounts_passwords_pam_faillock_dir"

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/bash/shared.sh
@@ -2,8 +2,10 @@
 
 {{{ bash_instantiate_variables("var_pam_wheel_group_for_su") }}}
 
+# Workaround for https://github.com/OpenSCAP/openscap/issues/2242: Use full
+# path to groupadd command to avoid the issue with the command not being found.
 if ! grep -q "^${var_pam_wheel_group_for_su}:[^:]*:[^:]*:[^:]*" /etc/group; then
-    groupadd ${var_pam_wheel_group_for_su}
+    /usr/sbin/groupadd ${var_pam_wheel_group_for_su}
 fi
 
 # group must be empty

--- a/shared/templates/sebool/bash.template
+++ b/shared/templates/sebool/bash.template
@@ -16,9 +16,12 @@
 {{{ bash_package_install("libsemanage-python") }}}
 {{% endif %}}
 
+# Workaround for https://github.com/OpenSCAP/openscap/issues/2242: Use full
+# path to setsebool command to avoid the issue with the command not being
+# found.
 {{% if SEBOOL_BOOL %}}
-    setsebool -P {{{ SEBOOLID }}} {{{ SEBOOL_BOOL }}}
+    /usr/sbin/setsebool -P {{{ SEBOOLID }}} {{{ SEBOOL_BOOL }}}
 {{% else %}}
     {{{ bash_instantiate_variables("var_" + SEBOOLID) }}}
-    setsebool -P {{{ SEBOOLID }}} $var_{{{ SEBOOLID }}}
+    /usr/sbin/setsebool -P {{{ SEBOOLID }}} $var_{{{ SEBOOLID }}}
 {{% endif %}}


### PR DESCRIPTION
Use full path for some commands in /usr/sbin in Bash remediations.

This is a workaround for OpenSCAP issue:
https://github.com/OpenSCAP/openscap/issues/2242
A proper fix would be in OpenSCAP, but it's less likely to update OpenSCAP in downstream than to update the content.

Effectively, this change will fix some rules that fail when building a hardened bootable container image:
https://github.com/ComplianceAsCode/content/issues/13550 https://github.com/ComplianceAsCode/content/issues/13551 https://github.com/ComplianceAsCode/content/issues/13552

In future, this problem will be smaller, because starting from Fedora 42, /usr/sbin is a symlink to /usr/bin, see: https://fedoraproject.org/wiki/Changes/Unify_bin_and_sbin
