### PR TITLE
[Ubuntu] Fix rule account_disable_post_pw_expiration

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -2135,6 +2135,7 @@ controls:
     rules:
       - var_account_disable_post_pw_expiration=45
       - account_disable_post_pw_expiration
+      - accounts_set_post_pw_existing
     status: automated
     notes: CIS setting now 45 days.
 


### PR DESCRIPTION
#### Description:


- Include rule accounts_set_post_pw_existing for cis Ubnutu 

#### Rationale:

- cis ubuntu (20 22 24) requires inactive setting also in /etc/shadow
- Restrict INACTIVE in /etc/shadow