### PR TITLE
New time rule

### DIFF
--- a/components/chrony.yml
+++ b/components/chrony.yml
@@ -3,6 +3,7 @@ packages:
 - chrony
 rules:
 - chronyd_configure_pool_and_server
+- chronyd_configure_server
 - chronyd_or_ntpd_specify_remote_server
 - chronyd_run_as_chrony_user
 - chronyd_server_directive

--- a/components/ntp.yml
+++ b/components/ntp.yml
@@ -6,6 +6,7 @@ packages:
 rules:
 - chronyd_client_only
 - chronyd_configure_pool_and_server
+- chronyd_configure_server
 - chronyd_no_chronyc_network
 - chronyd_or_ntpd_set_maxpoll
 - chronyd_or_ntpd_specify_multiple_servers

--- a/controls/stig_ubuntu2404.yml
+++ b/controls/stig_ubuntu2404.yml
@@ -1008,7 +1008,7 @@ controls:
     rules:
       - var_time_service_set_maxpoll=18_hours
       - var_multiple_time_servers=stig
-      - chronyd_configure_pool_and_server
+      - chronyd_configure_server
       - chronyd_or_ntpd_set_maxpoll
       - chronyd_server_directive
     status: automated

--- a/linux_os/guide/services/ntp/chronyd_configure_server/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_configure_server/rule.yml
@@ -1,0 +1,29 @@
+documentation_complete: true
+
+
+title: 'Chrony Configure Server'
+
+description: |-
+    <tt>Chrony</tt> is a daemon which implements the Network Time Protocol (NTP). It is designed to
+    synchronize system clocks across a variety of systems and use a source that is highly
+    accurate. More information on <tt>chrony</tt> can be found at
+    {{{ weblink(link="https://chrony-project.org/") }}}.
+    <tt>Chrony</tt> can be configured to be a client and/or a server.
+    Add or edit server lines to <tt>{{{ chrony_conf_path }}}</tt> as appropriate:
+    <pre>server &lt;remote-server&gt;</pre>
+    Multiple servers may be configured.
+    Contact organization's IT support for approved time servers.
+
+rationale: |-
+    If <tt>chrony</tt> is in use on the system proper configuration is vital to ensuring time
+    synchronization is working properly.
+
+severity: medium
+
+platform: package[chrony]
+
+ocil_clause: 'a remote time server is not configured'
+
+ocil: |-
+    Run the following command and verify remote servers are configured properly:
+    <pre># grep -E "^server" {{{ chrony_conf_path }}}</pre>


### PR DESCRIPTION
#### Description:

- Add new rule chronyd_configure_server
- Replace rule chronyd_configure_pool_and_server with chronyd_configure_server

#### Rationale:

- STIG require time source to be authoritative while hasn't provided one, so check and remediation is no possible.  