### PR TITLE
Update ansible for auditd_data_retention_action_mail_acct

### DIFF
--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/ansible/shared.yml
@@ -5,7 +5,7 @@
 # disruption = low
 {{{ ansible_instantiate_variables("var_auditd_action_mail_acct") }}}
 
--   name: Configure auditd mail_acct Action on Low Disk Space
+-   name: {{{ rule_title }}} - Configure auditd mail_acct Action on Low Disk Space
     ansible.builtin.lineinfile:
         dest: /etc/audit/auditd.conf
         regexp: "^action_mail_acct"

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/ansible/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/ansible/shared.yml
@@ -5,10 +5,10 @@
 # disruption = low
 {{{ ansible_instantiate_variables("var_auditd_action_mail_acct") }}}
 
-- name: Configure auditd mail_acct Action on Low Disk Space
-  lineinfile:
-    dest: /etc/audit/auditd.conf
-    line: "action_mail_acct = {{ var_auditd_action_mail_acct }}"
-    state: present
-    create: yes
-  #notify: reload auditd
+-   name: Configure auditd mail_acct Action on Low Disk Space
+    ansible.builtin.lineinfile:
+        dest: /etc/audit/auditd.conf
+        regexp: "^action_mail_acct"
+        line: "action_mail_acct = {{ var_auditd_action_mail_acct }}"
+        state: present
+        create: yes

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/oval/shared.xml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/oval/shared.xml
@@ -16,7 +16,7 @@
     <!-- Allow only space (exactly) as delimiter: https://fedorahosted.org/audit/browser/trunk/src/auditd-config.c#L426 -->
     <!-- Require at least one space before and after the equal sign -->
     <ind:pattern operation="pattern match">^[ ]*action_mail_acct[ ]+=[ ]+(\S+)[ ]*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_auditd_data_retention_action_mail_acct" version="1">

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/tests/action_mail_acct_alias.fail.sh
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/tests/action_mail_acct_alias.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = audit
 #
-# remediation = bash
 
 . $SHARED/auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/tests/action_mail_acct_email.fail.sh
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/tests/action_mail_acct_email.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = audit
 #
-# remediation = bash
 
 . $SHARED/auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/tests/action_mail_acct_not_there.fail.sh
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/tests/action_mail_acct_not_there.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = audit
 #
-# remediation = bash
 
 . $SHARED/auditd_utils.sh
 prepare_auditd_test_enviroment


### PR DESCRIPTION
#### Description:

- Add regex for the lineinfile module so if the configuration is already there it fixes it instead of adding a new line

#### Rationale:

- Improve ansible remediation

#### Review Hints:

- Now automatus tests pass remediating with ansible
