### PR TITLE
Add distributed config support for sshd_use_strong_macs

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/ansible/shared.yml
@@ -5,4 +5,4 @@
 # disruption = low
 {{{ ansible_instantiate_variables("sshd_strong_macs") }}}
 
-{{{ ansible_sshd_set(parameter="MACs", value="{{ sshd_strong_macs }}", rule_title=rule_title) }}}
+{{{ ansible_sshd_set(parameter="MACs", value="{{ sshd_strong_macs }}", config_is_distributed=sshd_distributed_config, rule_title=rule_title) }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/bash/shared.sh
@@ -2,5 +2,4 @@
 
 {{{ bash_instantiate_variables("sshd_strong_macs") }}}
 
-{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^MACs', "$sshd_strong_macs", '%s %s', cce_identifiers=cce_identifiers) }}}
-
+{{{ bash_sshd_remediation(parameter="MACs", value="$sshd_strong_macs", config_is_distributed=sshd_distributed_config, rule_id=rule_id) }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/oval/shared.xml
@@ -1,3 +1,5 @@
+{{%- set sshd_config_dir = "/etc/ssh/sshd_config.d" -%}}
+{{%- set case_insensitivity_kwargs = dict(prefix_regex="^[ \\t]*(?i)", separator_regex = "(?-i)[ \\t]+") -%}}
 <def-group>
   <definition class="compliance" id="sshd_use_strong_macs" version="1">
     {{{ oval_metadata("Ensure only strong MAC algorithms are used", rule_title=rule_title) }}}
@@ -27,12 +29,18 @@
           {{% endif %}}
           <criterion comment="Check MACs in /etc/ssh/sshd_config"
           test_ref="test_sshd_use_strong_macs" />
+          {{%- if sshd_distributed_config == "true" %}}
+          <criterion comment="Check MACs in /etc/ssh/sshd_config.d/"
+            test_ref="test_sshd_use_strong_macs_config_dir" />
+          {{%- endif %}}
+          <criterion comment="the configuration exists"
+            test_ref="test_sshd_macs_exists" />
         </criteria>
       </criteria>
     </criteria>
   </definition>
 
-  <ind:variable_test check="at least one"
+  <ind:variable_test check="all" check_existence="any_exist"
   comment="tests the value of MACs setting in the /etc/ssh/sshd_config file"
   id="test_sshd_use_strong_macs" version="1">
     <ind:object object_ref="obj_sshd_use_strong_macs" />
@@ -50,8 +58,38 @@
   <ind:textfilecontent54_object id="obj_sshd_config_strong_macs" version="1">
     <ind:filepath>/etc/ssh/sshd_config</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*(?i)MACs(?-i)[\s]+([\w,-@]+)+[\s]*(?:#.*)?$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  {{%- if sshd_distributed_config == "true" %}}
+  <ind:variable_test check="all" check_existence="any_exist"
+  comment="tests the value of MACs setting in the /etc/ssh/sshd_config.d dir"
+  id="test_sshd_use_strong_macs_config_dir" version="1">
+    <ind:object object_ref="obj_sshd_use_strong_macs_config_dir" />
+    <ind:state state_ref="ste_sshd_use_strong_macs_config_dir" />
+  </ind:variable_test>
+
+  <ind:variable_object id="obj_sshd_use_strong_macs_config_dir" version="1">
+    <ind:var_ref>var_sshd_config_macs_config_dir</ind:var_ref>
+  </ind:variable_object>
+
+  <ind:variable_state comment="approved strong macs" id="ste_sshd_use_strong_macs_config_dir" version="1">
+    <ind:value operation="equals" datatype="string" var_ref="var_sshd_strong_macs" var_check="at least one" />
+  </ind:variable_state>
+
+  <ind:textfilecontent54_object id="obj_sshd_config_macs_config_dir" version="1">
+    <ind:path>/etc/ssh/sshd_config.d</ind:path>
+    <ind:filename operation="pattern match">.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^[\s]*(?i)MACs(?-i)[\s]+([\w,-@]+)+[\s]*(?:#.*)?$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <local_variable id="var_sshd_config_macs_config_dir" datatype="string" version="1" comment="MACs values splitted on comma">
+    <split delimiter=",">
+      <object_component item_field="subexpression" object_ref="obj_sshd_config_macs_config_dir" />
+    </split>
+  </local_variable>
+  {{%- endif %}}
 
   <local_variable id="var_sshd_config_strong_macs" datatype="string" version="1" comment="MACs values splitted on comma">
     <split delimiter=",">
@@ -65,6 +103,19 @@
     </split>
   </local_variable>
   <external_variable comment="SSH MAC algorithms considered strong" datatype="string" id="sshd_strong_macs" version="1" />
+
+  <ind:textfilecontent54_test id="test_sshd_macs_exists" version="1" check="all" check_existence="at_least_one_exists"
+    comment="Verify that the value of MACs is present">
+    <ind:object object_ref="obj_sshd_macs_all_configs" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object comment="All confs collection" id="obj_sshd_macs_all_configs" version="1">
+    <set>
+      <object_reference>obj_sshd_config_strong_macs</object_reference>
+      {{% if sshd_distributed_config == "true" %}}
+      <object_reference>obj_sshd_config_macs_config_dir</object_reference>
+      {{% endif %}}
+    </set>
+  </ind:textfilecontent54_object>
+
 </def-group>
-
-

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/commented.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/commented.fail.sh
@@ -2,4 +2,5 @@
 # platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_ubuntu,multi_platform_almalinux
 # variables = sshd_strong_macs=hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512
 
-sed -i 's/^\s*MACs\s/# &/i' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* || true
+sed -i '/^\s*MACs\s/Id' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* || true
+echo "#MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512" >> /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/conflicting.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/conflicting.fail.sh
@@ -3,6 +3,6 @@
 # variables = sshd_strong_macs=hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512
 
 sed -i '/^\s*MACs\s/Id' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* || true
-echo "#MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512" >> /etc/ssh/sshd_config
+echo "MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512" >> /etc/ssh/sshd_config
 
 echo "MACs hmac-sha1" >> /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/conflicting.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/conflicting.fail.sh
@@ -2,4 +2,7 @@
 # platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_ubuntu,multi_platform_almalinux
 # variables = sshd_strong_macs=hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512
 
-sed -i 's/^\s*MACs\s/# &/i' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* || true
+sed -i '/^\s*MACs\s/Id' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* || true
+echo "#MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512" >> /etc/ssh/sshd_config
+
+echo "MACs hmac-sha1" >> /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/conflicting_dir.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/conflicting_dir.fail.sh
@@ -6,5 +6,7 @@
 {{% endif %}}
 # variables = sshd_strong_macs=hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512
 
-sed -i 's/^\s*MACs\s.*//i' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* || true
-echo "MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512" >> /etc/ssh/sshd_config
+sed -i '/^\s*MACs\s/Id' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* || true
+echo "#MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512" >> /etc/ssh/sshd_config
+
+echo "MACs hmac-sha1" >> /etc/ssh/sshd_config.d/00-test.conf

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/conflicting_dir.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/conflicting_dir.fail.sh
@@ -7,6 +7,6 @@
 # variables = sshd_strong_macs=hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512
 
 sed -i '/^\s*MACs\s/Id' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* || true
-echo "#MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512" >> /etc/ssh/sshd_config
+echo "MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512" >> /etc/ssh/sshd_config
 
 echo "MACs hmac-sha1" >> /etc/ssh/sshd_config.d/00-test.conf

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/correct_dir.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/correct_dir.pass.sh
@@ -7,4 +7,4 @@
 # variables = sshd_strong_macs=hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512
 
 sed -i 's/^\s*MACs\s.*//i' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* || true
-echo "MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512" >> /etc/ssh/sshd_config
+echo "MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512" >> /etc/ssh/sshd_config.d/00-test.conf

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/correct_mixed.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/correct_mixed.pass.sh
@@ -7,4 +7,4 @@
 # variables = sshd_strong_macs=hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512
 
 sed -i 's/^\s*MACs\s.*//i' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* || true
-echo "MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512" >> /etc/ssh/sshd_config
+echo "MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha2-256-etm@openssh.com" >> /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/correct_mixed.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/correct_mixed.pass.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-{{% if sshd_distributed_config == "false" %}}
-# platform = Not Applicable
-{{% else %}}
 # platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_ubuntu,multi_platform_almalinux
-{{% endif %}}
 # variables = sshd_strong_macs=hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512
 
 sed -i 's/^\s*MACs\s.*//i' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* || true

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/correct_subset.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/correct_subset.pass.sh
@@ -7,4 +7,4 @@
 # variables = sshd_strong_macs=hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512
 
 sed -i 's/^\s*MACs\s.*//i' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* || true
-echo "MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512" >> /etc/ssh/sshd_config
+echo "MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256" >> /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/correct_subset.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/correct_subset.pass.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-{{% if sshd_distributed_config == "false" %}}
-# platform = Not Applicable
-{{% else %}}
 # platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_ubuntu,multi_platform_almalinux
-{{% endif %}}
 # variables = sshd_strong_macs=hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512
 
 sed -i 's/^\s*MACs\s.*//i' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* || true

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/good_mac.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/tests/good_mac.pass.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-{{% if sshd_distributed_config == "false" %}}
-# platform = Not Applicable
-{{% else %}}
 # platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_ubuntu,multi_platform_almalinux
-{{% endif %}}
 # variables = sshd_strong_macs=hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512
 
 sed -i 's/^\s*MACs\s.*//i' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* || true


### PR DESCRIPTION
#### Description:

- Add distributed config support for sshd_use_strong_macs
- Add test cases for distributed config

#### Rationale:

- Ubuntu support sshd distributed config
- Use bash_sshd_remediation to replace the bash_replace_or_append macro to be more consistent.