### PR TITLE
Enable check_root_user on Ubuntu 24.04

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fremovexattr/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fremovexattr/rule.yml
@@ -98,6 +98,7 @@ template:
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
         check_root_user@ubuntu2204: "true"
+        check_root_user@ubuntu2404: "true"
         syscall_grouping:
           - fremovexattr
           - lremovexattr

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fsetxattr/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fsetxattr/rule.yml
@@ -93,6 +93,7 @@ template:
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
         check_root_user@ubuntu2204: "true"
+        check_root_user@ubuntu2404: "true"
         syscall_grouping:
           - fremovexattr
           - lremovexattr

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lremovexattr/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lremovexattr/rule.yml
@@ -98,6 +98,7 @@ template:
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
         check_root_user@ubuntu2204: "true"
+        check_root_user@ubuntu2404: "true"
         syscall_grouping:
           - fremovexattr
           - lremovexattr

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lsetxattr/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lsetxattr/rule.yml
@@ -93,6 +93,7 @@ template:
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
         check_root_user@ubuntu2204: "true"
+        check_root_user@ubuntu2404: "true"
         syscall_grouping:
           - fremovexattr
           - lremovexattr

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_removexattr/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_removexattr/rule.yml
@@ -97,6 +97,7 @@ template:
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
         check_root_user@ubuntu2204: "true"
+        check_root_user@ubuntu2404: "true"
         syscall_grouping:
           - fremovexattr
           - lremovexattr

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_setxattr/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_setxattr/rule.yml
@@ -93,6 +93,7 @@ template:
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
         check_root_user@ubuntu2204: "true"
+        check_root_user@ubuntu2404: "true"
         syscall_grouping:
           - fremovexattr
           - lremovexattr


### PR DESCRIPTION
#### Description:

- Enable check_root_user in audit_rules_dac_modification_* rules on Ubuntu 24.04

#### Rationale:

- Aligns content with UBTU-24-900130
