### PR TITLE
Remove 2 functions

### DIFF
--- a/build-scripts/build_tests.py
+++ b/build-scripts/build_tests.py
@@ -67,7 +67,7 @@ def _get_deny_templated_scenarios(test_config_path: pathlib.Path) -> Set[str]:
 
 def _process_shared_file(env_yaml: dict, file: pathlib.Path, shared_output_path: pathlib.Path) \
         -> None:
-    file_contents = ssg.jinja.process_file_with_macros(str(file.absolute()), env_yaml)
+    file_contents = ssg.jinja.process_file(str(file.absolute()), env_yaml)
     shared_script_path = shared_output_path / file.name
     _write_path(file_contents, shared_script_path)
 
@@ -109,15 +109,15 @@ def _process_local_tests(product: str, env_yaml: dict, rule_output_path: pathlib
                            rule_output_path.name)
             continue
         if not _is_test_file(test.name):
-            file_contents = ssg.jinja.process_file_with_macros(str(test.absolute()),
-                                                               env_yaml)
+            file_contents = ssg.jinja.process_file(str(test.absolute()),
+                                                   env_yaml)
             output_file = rule_output_path / test.name
             rule_output_path.mkdir(parents=True, exist_ok=True)
             _write_path(file_contents, output_file)
         file_contents = test.read_text()
         platform = _get_platform_from_file_contents(file_contents)
         if ssg.utils.is_applicable_for_product(platform, product):
-            content = ssg.jinja.process_file_with_macros(str(test.absolute()), env_yaml)
+            content = ssg.jinja.process_file(str(test.absolute()), env_yaml)
             rule_output_path.mkdir(parents=True, exist_ok=True)
             _write_path(content, rule_output_path / test.name)
 
@@ -163,7 +163,7 @@ def _process_templated_tests(env_yaml: Dict, rendered_rule_obj: Dict, templates_
         template_parameters = template.preprocess(rendered_rule_obj["template"]["vars"], "test")
         env_yaml = env_yaml.copy()
         jinja_dict = ssg.utils.merge_dicts(env_yaml, template_parameters)
-        file_contents = ssg.jinja.process_file_with_macros(str(test.absolute()), jinja_dict)
+        file_contents = ssg.jinja.process_file(str(test.absolute()), jinja_dict)
         platform = _get_platform_from_file_contents(file_contents)
         if ssg.utils.is_applicable_for_product(platform, product):
             rule_output_path.mkdir(parents=True, exist_ok=True)

--- a/ssg/build_ovals.py
+++ b/ssg/build_ovals.py
@@ -5,7 +5,7 @@ from . import utils, products
 from .rules import get_rule_dir_ovals, find_rule_dirs_in_paths
 from .oval_object_model import OVALDocument
 from .build_yaml import Rule, DocumentationNotComplete
-from .jinja import process_file_with_macros
+from .jinja import process_file
 from .id_translate import IDTranslator
 from .xml import ElementTree
 
@@ -16,7 +16,7 @@ def expand_shorthand(shorthand_path, oval_path, env_yaml):
     oval_document.product_name = "test"
     oval_document.schema_version = env_yaml.get("target_oval_version_str", "5.11")
 
-    shorthand_file_content = process_file_with_macros(shorthand_path, env_yaml)
+    shorthand_file_content = process_file(shorthand_path, env_yaml)
     oval_document.load_shorthand(shorthand_file_content)
 
     root = oval_document.get_xml_element()
@@ -157,7 +157,7 @@ class OVALBuilder:
             logging.critical("File name '{}' doesn't end with '.xml'.".format(file_path))
 
         if from_benchmark or "checks_from_templates" not in file_path:
-            return process_file_with_macros(file_path, context)
+            return process_file(file_path, context)
 
         with open(file_path, "r") as f:
             return f.read()

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -9,11 +9,11 @@ from collections import defaultdict, namedtuple, OrderedDict
 
 import ssg.yaml
 import ssg.build_yaml
+import ssg.jinja
 from . import rules
 from . import utils
 
 from . import constants
-from .jinja import process_file_with_macros as jinja_process_file
 
 from .xml import ElementTree
 from .constants import XCCDF12_NS
@@ -91,7 +91,7 @@ def parse_from_file_with_jinja(file_path, env_yaml):
     update ssg.fixes.parse_platform(...).
     """
 
-    fix_file = jinja_process_file(file_path, env_yaml)
+    fix_file = ssg.jinja.process_file(file_path, env_yaml)
     return split_remediation_content_and_metadata(fix_file)
 
 

--- a/ssg/build_sce.py
+++ b/ssg/build_sce.py
@@ -10,7 +10,7 @@ from .constants import (
     MULTI_PLATFORM_LIST, OSCAP_VALUE, datastream_namespace,
     xlink_namespace, XCCDF12_NS, SCE_SYSTEM
 )
-from .jinja import process_file_with_macros
+from .jinja import process_file
 from .rules import get_rule_dir_id, get_rule_dir_sces, find_rule_dirs_in_paths
 from . import utils, products
 
@@ -30,7 +30,7 @@ def load_sce_and_metadata(file_path, local_env_yaml):
     Returns (audit_content, metadata).
     """
 
-    raw_content = process_file_with_macros(file_path, local_env_yaml)
+    raw_content = process_file(file_path, local_env_yaml)
     return load_sce_and_metadata_parsed(raw_content)
 
 

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -45,7 +45,7 @@ from .constants import (XCCDF12_NS,
 from .rules import get_rule_dir_yaml, is_rule_dir
 
 from .cce import is_cce_format_valid, is_cce_value_valid
-from .yaml import DocumentationNotComplete, open_and_macro_expand
+from .yaml import DocumentationNotComplete, open_and_expand
 from .utils import required_key, mkdir_p
 
 from .xml import ElementTree as ET, register_namespaces, parse_file
@@ -1945,7 +1945,7 @@ class Rule(XCCDFEntity, Templatable):
         Returns:
             dict: The processed YAML data from the content file.
         """
-        yaml_data = open_and_macro_expand(filename, env_yaml)
+        yaml_data = open_and_expand(filename, env_yaml)
         return yaml_data
 
     def read_policy_specific_content(self, env_yaml, files):

--- a/ssg/entities/common.py
+++ b/ssg/entities/common.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 from ssg.yaml import yaml_Dumper
 
 from ..xml import ElementTree as ET, add_xhtml_namespace
-from ..yaml import DocumentationNotComplete, open_and_macro_expand
+from ..yaml import DocumentationNotComplete, open_and_expand
 from ..shims import unicode_func
 
 from ..constants import (
@@ -247,7 +247,7 @@ class XCCDFEntity(object):
 
         if env_yaml:
             env_yaml[cls.ID_LABEL] = entity_id
-        yaml_data = open_and_macro_expand(yaml_file, env_yaml)
+        yaml_data = open_and_expand(yaml_file, env_yaml)
 
         try:
             processed_data = cls.process_input_dict(yaml_data, env_yaml, product_cpes)

--- a/ssg/jinja.py
+++ b/ssg/jinja.py
@@ -206,9 +206,6 @@ def process_file(filepath, substitutions_dict):
 
     Returns:
         str: The rendered template as a string.
-
-    Note:
-        This function does not load the project macros. Use `process_file_with_macros(...)` for that.
     """
     filepath = os.path.abspath(filepath)
     template = _get_jinja_environment(substitutions_dict).get_template(filepath)
@@ -322,32 +319,6 @@ def load_macros_from_content_dir(content_dir, substitutions_dict=None):
     """
     jinja_macros_directory = os.path.join(content_dir, 'shared', 'macros')
     return _load_macros(jinja_macros_directory, substitutions_dict)
-
-
-def process_file_with_macros(filepath, substitutions_dict):
-    """
-    Process a file with Jinja macros.
-
-    This function processes the file located at the given `filepath` using Jinja macros and the
-    specified `substitutions_dict`. The `substitutions_dict` is first processed to load any
-    macros, and then it is used to substitute values in the file. The function ensures that the
-    key 'indent' is not present in the `substitutions_dict`.
-
-    Args:
-        filepath (str): The path to the file to be processed.
-        substitutions_dict (dict): A dictionary containing the substitutions to be applied to the file.
-
-    Returns:
-        str: The processed file content as a string.
-
-    Raises:
-        AssertionError: If the key 'indent' is present in `substitutions_dict`.
-
-    See also:
-        process_file: A function that processes a file with the given substitutions.
-    """
-    assert 'indent' not in substitutions_dict
-    return process_file(filepath, substitutions_dict)
 
 
 def url_encode(source):

--- a/ssg/oval.py
+++ b/ssg/oval.py
@@ -13,7 +13,7 @@ from .constants import oval_namespace as ovalns
 from .xml import ElementTree as ET
 from .xml import oval_generated_header
 
-from .jinja import process_file_with_macros
+from .jinja import process_file
 from .products import _get_implied_properties
 
 
@@ -66,7 +66,7 @@ def applicable_platforms(oval_file, oval_version_string=None):
     subst_dict = _get_implied_properties(subst_dict)
     subst_dict['target_oval_version'] = [999, 999.999]
 
-    body = process_file_with_macros(oval_file, subst_dict)
+    body = process_file(oval_file, subst_dict)
 
     try:
         oval_tree = ET.fromstring(header + body + footer)

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -363,7 +363,7 @@ class Builder(object):
         env_yaml = self.env_yaml.copy()
         env_yaml.update(local_env_yaml)
         jinja_dict = ssg.utils.merge_dicts(env_yaml, template_parameters)
-        return ssg.jinja.process_file_with_macros(template_file_path, jinja_dict)
+        return ssg.jinja.process_file(template_file_path, jinja_dict)
 
     def get_lang_contents_for_templatable(self, templatable, language):
         """

--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -200,29 +200,10 @@ def open_and_expand(yaml_file, substitutions_dict=None):
     return yaml_contents
 
 
-def open_and_macro_expand(yaml_file, substitutions_dict=None):
-    """
-    Opens a YAML file and expands macros within it using the provided substitutions dictionary.
-
-    This function loads definitions of macros and uses them to expand the template within the YAML
-    file. It is similar to open_and_expand, but load definitions of macros
-
-    Args:
-        yaml_file (str): The path to the YAML file to be opened and expanded.
-        substitutions_dict (dict, optional): A dictionary containing macro definitions and their
-                                             corresponding values. If not provided, an empty
-                                             dictionary is used.
-
-    Returns:
-        dict: The expanded content of the YAML file with macros substituted.
-    """
-    return open_and_expand(yaml_file, substitutions_dict)
-
-
 def open_and_macro_expand_from_dir(yaml_file, content_dir, substitutions_dict=None):
     """
     Opens a YAML file and expands macros from a specified directory. It is similar to
-    open_and_macro_expand but loads macro definitions from a specified directory instead of the
+    open_and_expand but loads macro definitions from a specified directory instead of the
     default directory defined in constants. This is useful in cases where the SSG library is
     consumed by an external project.
 

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -17,7 +17,7 @@ from ssg.build_yaml import Rule as RuleYAML
 from ssg.constants import MULTI_PLATFORM_MAPPING
 from ssg.constants import FULL_NAME_TO_PRODUCT_MAPPING
 from ssg.constants import OSCAP_RULE
-from ssg.jinja import process_file_with_macros
+from ssg.jinja import process_file
 from ssg.products import product_yaml_path, load_product_yaml
 from ssg.rules import get_rule_dir_yaml
 from ssg.utils import mkdir_p, select_templated_tests
@@ -288,7 +288,7 @@ def write_rule_test_content_to_dir(rule_dir, test_content):
         with open(file_path, "w") as f:
             f.write(file_content)
             # Ensure newline at the end of the file because
-            # process_file_with_macros strips it off
+            # process_file strips it off
             f.write("\n")
 
 
@@ -447,7 +447,7 @@ def load_test(absolute_path, rule_template, local_env_yaml):
                          "which doesn't exist in '{}".format(template_name, _SHARED_TEMPLATES))
 
     jinja_dict = ssg.utils.merge_dicts(local_env_yaml, template_parameters)
-    filled_template = ssg.jinja.process_file_with_macros(
+    filled_template = ssg.jinja.process_file(
         absolute_path, jinja_dict)
     return filled_template
 
@@ -476,7 +476,7 @@ def fetch_local_tests_paths(tests_dir):
 def load_local_tests(local_tests_paths, local_env_yaml):
     local_tests = dict()
     for path in local_tests_paths:
-        test = process_file_with_macros(path, local_env_yaml)
+        test = process_file(path, local_env_yaml)
         basename = os.path.basename(path)
         local_tests[basename] = test
     return local_tests

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -15,7 +15,7 @@ import tempfile
 
 import ssg.utils
 from ssg.constants import OSCAP_PROFILE, OSCAP_PROFILE_ALL_ID, OSCAP_RULE
-from ssg.jinja import process_file_with_macros
+from ssg.jinja import process_file
 from ssg.rules import is_rule_dir
 
 from tests.ssg_test_suite import oscap
@@ -432,7 +432,7 @@ class RuleChecker(oscap.Checker):
                 file_path = os.path.join(dirpath, file_name)
                 rel_path = os.path.relpath(file_path, common._SHARED_DIR)
                 try:
-                    file_content = process_file_with_macros(file_path, product_yaml)
+                    file_content = process_file(file_path, product_yaml)
                 except Exception as e:
                     logging.error("Error processing file {0}: {1}".format(file_path, str(e)))
                     continue

--- a/utils/build_control_from_reference.py
+++ b/utils/build_control_from_reference.py
@@ -64,7 +64,7 @@ def _get_id_mapping(env_yaml, reference, json_path: str) -> Dict:
     id_mapping: Dict[str, list[str]] = defaultdict(list) # type: ignore [misc] # For old mypy
     for rule_id, rule_obj in rule_dir_json.items():
         rule_yaml = os.path.join(rule_obj["dir"], "rule.yml")
-        rule = ssg.yaml.open_and_macro_expand(rule_yaml, env_yaml)
+        rule = ssg.yaml.open_and_expand(rule_yaml, env_yaml)
         if "references" not in rule:
             continue
         ref_id = rule["references"].get(reference)

--- a/utils/fix_rules.py
+++ b/utils/fix_rules.py
@@ -45,7 +45,7 @@ def has_empty_identifier(rule_path, rule, rule_lines):
 
 
 def has_no_cce(yaml_file, product_yaml=None):
-    rule = yaml.open_and_macro_expand(yaml_file, product_yaml)
+    rule = yaml.open_and_expand(yaml_file, product_yaml)
     product = product_yaml["product"]
     if 'identifiers' in rule and rule['identifiers'] is None:
         return True
@@ -158,7 +158,7 @@ def rule_data_generator(args):
 
         rule_path = ssg.rules.get_rule_dir_yaml(rule_obj['dir'])
         try:
-            rule = yaml.open_and_macro_expand(rule_path, local_env_yaml)
+            rule = yaml.open_and_expand(rule_path, local_env_yaml)
             rule_lines = read_file_list(rule_path)
             yield rule_path, rule, rule_lines, product_path, local_env_yaml
         except jinja2.exceptions.UndefinedError as ue:
@@ -484,7 +484,7 @@ def _fixed_file_contents(path, file_contents, product_yaml, func):
         file_contents = file_contents[:-1]
 
     subst_dict = product_yaml
-    yaml_contents = yaml.open_and_macro_expand(path, subst_dict)
+    yaml_contents = yaml.open_and_expand(path, subst_dict)
 
     try:
         new_file_contents = func(file_contents, yaml_contents)


### PR DESCRIPTION
#### Description:
1. Replace `open_and_macro_expand` by `open_and_expand`

The function `open_and_macro_expand` only calls function `open_and_expand` and it doesn't do anything in addition.
We will remove it and replace all occurences of it by the latter.

2. Replace `process_file_with_macros` by `process_file`

The function `process_file_with_macros` basically calls function `process_file` and in addition it contains a questionable assert that probably can be removed. Without the assert the functions are identical. We will remove `process_file_with_macros` and replace it by `process_file` everywhere.

