### PR TITLE
Adapt chronyd_specify_remote_server for Ubuntu 24.04 STIG

### DIFF
--- a/controls/stig_ubuntu2404.yml
+++ b/controls/stig_ubuntu2404.yml
@@ -1008,7 +1008,7 @@ controls:
     rules:
       - var_time_service_set_maxpoll=18_hours
       - var_multiple_time_servers=stig
-      - chronyd_configure_pool_and_server
+      - chronyd_specify_remote_server
       - chronyd_or_ntpd_set_maxpoll
       - chronyd_server_directive
     status: automated

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/oval/ubuntu.xml
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/oval/ubuntu.xml
@@ -1,0 +1,46 @@
+<def-group>
+  <definition class="compliance" id="chronyd_specify_remote_server" version="1">
+    {{{ oval_metadata("A remote NTP Server for time synchronization should be
+      specified (and dependencies are met)", rule_title=rule_title) }}}
+    <criteria comment="chrony.conf conditions are met">
+      <criterion test_ref="test_chronyd_remote_server" />
+    </criteria>
+  </definition>
+
+  <ind:variable_test check="all" check_existence="at_least_one_exists"
+  comment="tests the server hostnames in the chronyd configuration"
+  id="test_chronyd_remote_server" version="1">
+    <ind:object object_ref="obj_chronyd_config_servers_var" />
+    <ind:state state_ref="ste_chronyd_allowed_servers" />
+  </ind:variable_test>
+
+
+  <ind:variable_object id="obj_chronyd_config_servers_var" version="1">
+    <ind:var_ref>var_chronyd_config_servers</ind:var_ref>
+  </ind:variable_object>
+
+  <local_variable id="var_chronyd_config_servers" datatype="string" version="1" comment="Chronyd server hostnames">
+    <object_component item_field="subexpression" object_ref="obj_chronyd_config_servers" />
+  </local_variable>
+
+  <ind:textfilecontent54_object comment="Grep all server hostnames from chrony configs"
+  id="obj_chronyd_config_servers" version="1">
+    <ind:filepath operation="pattern match">^({{{ chrony_conf_path }}}|{{{ chrony_d_path }}}.+\.conf)$</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*server\s+(\S+)\b.*$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int" >1</ind:instance>
+  </ind:textfilecontent54_object>
+
+
+  <ind:variable_state comment="allowed chronyd server hostnames" id="ste_chronyd_allowed_servers" version="1">
+    <ind:value operation="equals" datatype="string" var_ref="var_chronyd_allowed_servers" var_check="at least one" />
+  </ind:variable_state>
+
+  <local_variable id="var_chronyd_allowed_servers" datatype="string" version="1" comment="Allowed time servers split on comma">
+    <split delimiter=",">
+      <variable_component var_ref="var_multiple_time_servers" />
+    </split>
+  </local_variable>
+
+  <external_variable comment="Allowed time servers" datatype="string" id="var_multiple_time_servers" version="1" />
+
+</def-group>

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/correct.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/correct.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # packages = chrony
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux,multi_platform_ubuntu
 
 echo "server 0.pool.ntp.org" > {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/file_empty.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/file_empty.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # packages = chrony
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux,multi_platform_ubuntu
 
 echo "" > {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/file_missing.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/file_missing.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # packages = chrony
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux,multi_platform_ubuntu
+# variables = var_multiple_time_servers=0.pool.ntp.org,1.pool.ntp.org
 
 rm -f {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/line_missing.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/line_missing.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = chrony
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux,multi_platform_ubuntu
 
 echo "some line" > {{{ chrony_conf_path }}}
 echo "another line" >> {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/multiple_incorrect.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/multiple_incorrect.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = chrony
+# platform = multi_platform_ubuntu
+# remediation = None
+
+echo "server 0.pool.ntp.org" > {{{ chrony_conf_path }}}
+echo "server 0.ubuntu.pool.ntp.org" >> {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/multiple_servers.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/multiple_servers.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = chrony
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_almalinux,multi_platform_ubuntu
 
 echo "server 0.pool.ntp.org" > {{{ chrony_conf_path }}}
 echo "server 1.pool.ntp.org" >> {{{ chrony_conf_path }}}


### PR DESCRIPTION

#### Description:

- Adapt chronyd_specify_remote_server for Ubuntu 24.04 STIG
- The new ubuntu OVAL checks that all the chronyd server hostnames match those defined in XCCDF variable var_multiple_time_servers which is also more aligned with the existing remediation.

#### Rationale:

- Satisfies UBTU-24-600160
