### PR TITLE
Fix level inheritance when processing profiles

### DIFF
--- a/ssg/profiles.py
+++ b/ssg/profiles.py
@@ -205,14 +205,16 @@ def _update_profile_with_policy(profile: ProfileSelections, policy: Policy, leve
     Returns:
         None
     """
-    inherited_levels = getattr(policy.levels_by_id.get(level), "inherits_from", None)
-    if inherited_levels:
-        for inherited_level in inherited_levels:
-            _update_profile_with_policy(profile, policy, inherited_level)
+    inherited_levels = getattr(policy.levels_by_id.get(level), "inherits_from", []) or []
+    for inherited_level in inherited_levels:
+        _update_profile_with_policy(profile, policy, inherited_level)
 
-    for control in policy.controls:
-        if level == 'all' or level in control.levels:
-            _process_control(profile, control)
+    controls = (
+        policy.controls if level == 'all'
+        else [ctrl for ctrl in policy.controls if level in ctrl.levels]
+    )
+    for control in controls:
+        _process_control(profile, control)
 
 
 def _process_controls(profile: ProfileSelections, control_line: str,

--- a/ssg/profiles.py
+++ b/ssg/profiles.py
@@ -199,11 +199,17 @@ def _update_profile_with_policy(profile: ProfileSelections, policy: Policy, leve
         profile (ProfileSelections): The profile to be updated.
         policy (Policy): The policy containing controls to update the profile with.
         level (str): The level of controls to be processed. If 'all', all controls are processed.
-                     Otherwise, only controls matching the specified level are processed.
+                     Otherwise, only controls matching the specified level are processed honoring
+                     inheritance.
 
     Returns:
         None
     """
+    inherited_levels = getattr(policy.levels_by_id.get(level), "inherits_from", None)
+    if inherited_levels:
+        for inherited_level in inherited_levels:
+            _update_profile_with_policy(profile, policy, inherited_level)
+
     for control in policy.controls:
         if level == 'all' or level in control.levels:
             _process_control(profile, control)

--- a/ssg/profiles.py
+++ b/ssg/profiles.py
@@ -289,18 +289,17 @@ def _process_profile(profile: ProfileSelections, profile_yaml: dict, profiles_fi
     return profile
 
 
-def _load_controls_manager(controls_dir: str, product_yaml: dict) -> object:
+def _load_controls_manager(controls_dir: str) -> object:
     """
     Loads and initializes a ControlsManager instance.
 
     Args:
         controls_dir (str): The directory containing control files.
-        product_yaml (dict): The product configuration in YAML format.
 
     Returns:
         object: An instance of ControlsManager with loaded controls.
     """
-    control_mgr = ControlsManager(controls_dir, product_yaml)
+    control_mgr = ControlsManager(controls_dir)
     control_mgr.load()
     return control_mgr
 
@@ -341,7 +340,7 @@ def get_profiles_from_products(content_dir: str, products: list,
         product_yaml = _load_product_yaml(content_dir, product)
         product_title = product_yaml.get("full_name")
         profiles_files = get_profile_files_from_root(product_yaml, product_yaml)
-        controls_manager = _load_controls_manager(controls_dir, product_yaml)
+        controls_manager = _load_controls_manager(controls_dir)
         for file in profiles_files:
             profile_id = os.path.basename(file).split('.profile')[0]
             profile_yaml = _load_yaml_profile_file(file)

--- a/tests/unit/ssg-module/data/content_dir/controls/abcd-levels.yml
+++ b/tests/unit/ssg-module/data/content_dir/controls/abcd-levels.yml
@@ -57,7 +57,7 @@ controls:
     levels:
       - medium
     rules:
-      - configure_crypto_policy
+      - file_groupownership_sshd_private_key
       - var_system_crypto_policy=fips
 
   - id: S7
@@ -65,5 +65,5 @@ controls:
     levels:
       - high
     rules:
-      - configure_crypto_policy
+      - sshd_set_keepalive
       - var_system_crypto_policy=future

--- a/tests/unit/ssg-module/data/content_dir/products/rhel8/profiles/example.profile
+++ b/tests/unit/ssg-module/data/content_dir/products/rhel8/profiles/example.profile
@@ -8,6 +8,5 @@ description: |-
 
 selections:
     - abcd-levels:all:medium
-    - file_groupownership_sshd_private_key
     - sshd_set_keepalive
     - var_sshd_set_keepalive=1

--- a/tests/unit/ssg-module/test_profiles.py
+++ b/tests/unit/ssg-module/test_profiles.py
@@ -22,5 +22,13 @@ def test_get_profiles_from_products():
 
     assert len(profiles) == count_profiles_in_products_dir(products[0])
     assert 'rhel' in profiles[0].product_id
-    assert len(profiles[0].rules) > 0
-    assert len(profiles[0].variables) > 0
+    assert len(profiles[0].rules) == 3
+    assert len(profiles[0].variables) == 3
+
+    # The testing profile uses "abcd-levels:all:medium", which explicitly includes
+    # "file_groupownership_sshd_private_key" as a rule in level "medium". It should also inherit
+    # "configure_crypto_policy" from level "low". Finally, it should include "sshd_set_keepalive"
+    # defined in the profile file.
+    assert 'configure_crypto_policy' in profiles[0].rules   # from level "low"
+    assert 'file_groupownership_sshd_private_key' in profiles[0].rules  # from level "medium"
+    assert 'sshd_set_keepalive' in profiles[0].rules  # from profile file

--- a/tests/unit/ssg-module/test_variables.py
+++ b/tests/unit/ssg-module/test_variables.py
@@ -66,11 +66,11 @@ def test_get_variable_options(tmp_path):
 
 
 def test_get_variables_by_products():
-    products = ["rhel9"]
-    content_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+    products = ["rhel8"]
+    content_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "data/content_dir"))
     result = get_variables_by_products(str(content_dir), products)
-    assert "var_selinux_policy_name" in result
-    assert "rhel9" in result["var_selinux_policy_name"]
+    assert "var_sshd_set_keepalive" in result
+    assert "rhel8" in result["var_sshd_set_keepalive"]
 
 
 def test_get_variable_values(tmp_path):


### PR DESCRIPTION
#### Description:

The `get_profiles_from_products` function was introduced to allow external tools, such as `complyscribe` to process profiles externally.

During tests it was noticed that some rules were not available in profiles levels with inheritance.

#### Rationale:

- Fixes https://issues.redhat.com/browse/CPLYTM-889 

#### Review Hints:

The `get_profiles_from_products`  function is not used internally in the building system.
But this simple script may help to test the changes after using `source .pyenv.sh`:
```
import os
from ssg.profiles import get_profiles_from_products
from ssg.jinja import load_macros_from_content_dir
from pprint import pprint


def _get_root_content_dir() -> str:
    # Update the path according to your environment
    home_dir = os.path.expanduser("~")
    content_root_dir = os.path.join(home_dir, "CaC", "Forks", "content")
    return content_root_dir


def main():
    rhel_products = ['rhel10']
    content_root_dir = _get_root_content_dir()
    load_macros_from_content_dir(content_root_dir)
    
    # Get all profiles for the specified products.
    profiles = get_profiles_from_products(content_root_dir, rhel_products, sorted=True)
    for profile in profiles:
        if profile.profile_id in ['anssi_bp28_high']:
            print(f'Rules for {profile.product_id} in profile {profile.profile_id}:')
            pprint(profile.rules)


if __name__ == "__main__":
    main()
```