### PR TITLE
Update profile to variable in banner_etc_issue_disa_dod_short test

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/tests/banner_etc_issue_disa_dod_short.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/tests/banner_etc_issue_disa_dod_short.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_stig
+# variables = login_banner_text=^I've[\s\n]+read[\s\n]+\&amp;[\s\n]+consent[\s\n]+to[\s\n]+terms[\s\n]+in[\s\n]+IS[\s\n]+user[\s\n]+agreem't\.$
 
 # dod_short banner
 echo "I've read & consent to terms in IS user agreem't." > /etc/issue


### PR DESCRIPTION
#### Description:

Update profile to variable in banner_etc_issue_disa_dod_short test

#### Rationale:

Use the variable instead the profile to avoid errors when the profile don't get the short agreement.
