### PR TITLE
Correct invalid multiline string indicator in yaml file

### DIFF
--- a/controls/cis_almalinux9.yml
+++ b/controls/cis_almalinux9.yml
@@ -24,7 +24,8 @@ controls:
       levels:
           - l1_server
           - l1_workstation
-      notes: <- This is a helper rule to reload Dconf database correctly.
+      notes: |-
+          This is a helper rule to reload Dconf database correctly.
       status: automated
       rules:
           - dconf_db_up_to_date
@@ -34,7 +35,8 @@ controls:
       levels:
           - l1_server
           - l1_workstation
-      notes: <- We need this in all CIS versions, but the policy doesn't have any section where this
+      notes: |-
+          We need this in all CIS versions, but the policy doesn't have any section where this
           would fit better.
       status: automated
       rules:

--- a/controls/cis_rhel10.yml
+++ b/controls/cis_rhel10.yml
@@ -24,7 +24,8 @@ controls:
       levels:
           - l1_server
           - l1_workstation
-      notes: <- This is a helper rule to reload Dconf database correctly.
+      notes: |-
+          This is a helper rule to reload Dconf database correctly.
       status: automated
       rules:
           - dconf_db_up_to_date

--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -24,7 +24,8 @@ controls:
       levels:
           - l1_server
           - l1_workstation
-      notes: <- This is a helper rule to reload Dconf database correctly.
+      notes: |-
+          This is a helper rule to reload Dconf database correctly.
       status: automated
       rules:
           - dconf_db_up_to_date
@@ -34,7 +35,8 @@ controls:
       levels:
           - l1_server
           - l1_workstation
-      notes: <- We need this in all CIS versions, but the policy doesn't have any section where this
+      notes: |-
+          We need this in all CIS versions, but the policy doesn't have any section where this
           would fit better.
       status: automated
       rules:

--- a/controls/cis_rhel9.yml
+++ b/controls/cis_rhel9.yml
@@ -24,7 +24,8 @@ controls:
       levels:
           - l1_server
           - l1_workstation
-      notes: <- This is a helper rule to reload Dconf database correctly.
+      notes: |-
+          This is a helper rule to reload Dconf database correctly.
       status: automated
       rules:
           - dconf_db_up_to_date
@@ -34,7 +35,8 @@ controls:
       levels:
           - l1_server
           - l1_workstation
-      notes: <- We need this in all CIS versions, but the policy doesn't have any section where this
+      notes: |-
+          We need this in all CIS versions, but the policy doesn't have any section where this
           would fit better.
       status: automated
       rules:
@@ -474,7 +476,8 @@ controls:
           - l1_server
           - l1_workstation
       status: automated
-      notes: <- RHEL9 unified the paths for grub2 files.
+      notes: |-
+          RHEL9 unified the paths for grub2 files.
       rules:
           - grub2_password
       related_rules:
@@ -486,7 +489,8 @@ controls:
           - l1_server
           - l1_workstation
       status: pending
-      notes: <- RHEL9 unified the paths for grub2 files. This requirement demands a deeper review of
+      notes: |-
+          RHEL9 unified the paths for grub2 files. This requirement demands a deeper review of
           the rules.
       rules:
           - file_groupowner_grub2_cfg

--- a/controls/cis_sle12.yml
+++ b/controls/cis_sle12.yml
@@ -23,7 +23,8 @@ controls:
           - l1_workstation
           - l2_server
           - l2_workstation
-      notes: <- This is a helper rule to reload Dconf database correctly.
+      notes: |-
+          This is a helper rule to reload Dconf database correctly.
       status: automated
       rules:
           - dconf_db_up_to_date
@@ -1138,7 +1139,8 @@ controls:
           - l2_server
           - l2_workstation
       status: automated
-      notes: <- Note that currently the value is hardcoded to 8192
+      notes: |-
+          Note that currently the value is hardcoded to 8192
       rules:
           - grub2_audit_backlog_limit_argument
 

--- a/controls/cis_sle15.yml
+++ b/controls/cis_sle15.yml
@@ -23,7 +23,8 @@ controls:
           - l1_workstation
           - l2_server
           - l2_workstation
-      notes: <- This is a helper rule to reload Dconf database correctly.
+      notes: |-
+          This is a helper rule to reload Dconf database correctly.
       status: automated
       rules:
           - dconf_db_up_to_date


### PR DESCRIPTION
#### Description:

- Correct invalid multiline string indicator in yaml file

#### Rationale:

- <- does not have standard or inherent meaning in the YAML specification. Align multiline string indicator with other notes field.

#### Review Hints:

- This should not be a problem, except will cause this field value not as expected, for example, when we read this [field](https://github.com/ComplianceAsCode/content/blob/master/controls/cis_rhel8.yml#L37), we will get `"<- We need this in all CIS versions, but the policy doesn't have any section where this would fit better."` . <-  added as part of this field's value.
