### PR TITLE
Disable value of zero in dconf_gnome_screensaver_idle_delay

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/oval/shared.xml
@@ -35,6 +35,8 @@
   id="test_screensaver_idle_delay_setting" version="1">
     <ind:object object_ref="obj_screensaver_idle_delay_setting" />
     <ind:state state_ref="state_screensaver_idle_delay_setting" />
+    <!-- Value of zero disables this functionality -->
+    <ind:state state_ref="state_screensaver_idle_delay_setting_not_zero" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_screensaver_idle_delay_setting"
   version="1"> 
@@ -47,9 +49,11 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_state id="state_screensaver_idle_delay_setting" version="1" operator="AND">
+  <ind:textfilecontent54_state id="state_screensaver_idle_delay_setting" version="1">
     <ind:subexpression datatype="int" operation="less than or equal" var_check="all" var_ref="inactivity_timeout_value" />
-    <!-- Value of zero disables this functionality -->
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_state id="state_screensaver_idle_delay_setting_not_zero" version="1">
     <ind:subexpression datatype="int" operation="not equal">0</ind:subexpression>
   </ind:textfilecontent54_state>
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/oval/shared.xml
@@ -47,8 +47,10 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_state id="state_screensaver_idle_delay_setting" version="1">
+  <ind:textfilecontent54_state id="state_screensaver_idle_delay_setting" version="1" operator="AND">
     <ind:subexpression datatype="int" operation="less than or equal" var_check="all" var_ref="inactivity_timeout_value" />
+    <!-- Value of zero disables this functionality -->
+    <ind:subexpression datatype="int" operation="not equal">0<ind:subexpression />
   </ind:textfilecontent54_state>
 
   <external_variable comment="inactivity timeout variable" datatype="int"

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/oval/shared.xml
@@ -50,7 +50,7 @@
   <ind:textfilecontent54_state id="state_screensaver_idle_delay_setting" version="1" operator="AND">
     <ind:subexpression datatype="int" operation="less than or equal" var_check="all" var_ref="inactivity_timeout_value" />
     <!-- Value of zero disables this functionality -->
-    <ind:subexpression datatype="int" operation="not equal">0<ind:subexpression />
+    <ind:subexpression datatype="int" operation="not equal">0</ind:subexpression>
   </ind:textfilecontent54_state>
 
   <external_variable comment="inactivity timeout variable" datatype="int"

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/tests/zero_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/tests/zero_value.fail.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# packages = dconf,gdm
+# variables = inactivity_timeout_value=900
+
+. $SHARED/dconf_test_functions.sh
+
+clean_dconf_settings
+add_dconf_profiles
+add_dconf_setting "org/gnome/desktop/session" "idle-delay" "uint32 0" "local.d" "00-security-settings"
+
+{{% if 'ubuntu' in product %}}
+add_dconf_lock "org/gnome/desktop/session" "idle-delay" "local.d" "00-security-settings"
+{{% endif %}}


### PR DESCRIPTION
#### Description:

- Disable value of zero in `dconf_gnome_screensaver_idle_delay`

#### Rationale:

- The value of zero disables this functionality, so it shouldn't be allowed

#### Review Hints:

- The new automatus test should be enough to cover this new behavior