### PR TITLE
Set var_screensaver_lock_delay for OL9

### DIFF
--- a/controls/stig_ol9.yml
+++ b/controls/stig_ol9.yml
@@ -2066,6 +2066,7 @@ controls:
           activated.
       rules:
           - dconf_gnome_screensaver_lock_delay
+          - var_screensaver_lock_delay=5_seconds
       status: automated
 
     - id: OL09-00-002125


### PR DESCRIPTION
#### Description:

- Set `var_screensaver_lock_delay` for OL9 in STIG profile to 5 seconds

#### Rationale:

- Align with DISA STIG requirement

