### PR TITLE
file_groupownership_system_commands_dirs fix test scenario

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/symlink.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/symlink.pass.sh
@@ -4,6 +4,8 @@
 useradd crontab
 {{% endif %}}
 
+groupadd group_test
+
 {{% if 'ubuntu' in product %}}
 for SYSLIBDIRS in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin
 {{% else %}}
@@ -14,4 +16,4 @@ do
 done
 
 ln -s $(mktemp -p /tmp) /usr/bin/test.log.symlink
-chgrp -h nogroup /usr/bin/test.log.symlink
+chgrp -h group_test /usr/bin/test.log.symlink


### PR DESCRIPTION
#### Description:

-in the symlink.pass.sh test scenario, create a fake group for test scenario purposes

#### Rationale:

- originally, the "nogroup" was used, but never created



#### Review Hints:

Run automatus tests.