### PR TITLE
[Ubuntu] Extra tests for #13668

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/bash/shared.sh
@@ -1,6 +1,3 @@
 # platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_slmicro,multi_platform_almalinux
 
-for SYSCMDFILES in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin
-do
-   find -P $SYSCMDFILES \! -group root -type f -exec chgrp root '{}' \;
-done
+find -P /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin \! -group root -type f -exec chgrp root '{}' \; || true

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/bash/ubuntu.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/bash/ubuntu.sh
@@ -1,11 +1,7 @@
 # platform = multi_platform_ubuntu
 
 {{% if product in ["ubuntu2404"] %}}
-find -P /bin/ /sbin/ /usr/bin/ /usr/sbin/ /usr/local/bin/ /usr/local/sbin/ -maxdepth 1 -type f  \! -gid -{{{ gid_min }}} -regextype posix-extended -regex '.*' -exec chgrp --no-dereference root {} \;
-
+find -P /bin/ /sbin/ /usr/bin/ /usr/sbin/ /usr/local/bin/ /usr/local/sbin/ -maxdepth 1 -type f  \! -gid -{{{ gid_min }}} -regextype posix-extended -regex '.*' -exec chgrp --no-dereference root {} \; || true
 {{% else %}}
-for SYSCMDFILES in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin
-do
-   find -P $SYSCMDFILES \! -gid -{{{ gid_min }}} -type f ! -perm /2000 -exec chgrp root '{}' \;
-done
+find -P /bin/ /sbin/ /usr/bin/ /usr/sbin/ /usr/local/bin/ /usr/local/sbin/ \! -gid -{{{ gid_min }}} -type f ! -perm /2000 -exec chgrp root '{}' \; || true
 {{% endif %}}

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/bash/ubuntu.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/bash/ubuntu.sh
@@ -1,7 +1,7 @@
 # platform = multi_platform_ubuntu
 
 {{% if product in ["ubuntu2404"] %}}
-find -P /bin/ /sbin/ /usr/bin/ /usr/sbin/ /usr/local/bin/ /usr/local/sbin/ -maxdepth 1 -type f  \! -gid -{{{ gid_min }}} -regextype posix-extended -regex '.*' -exec chgrp -P root {} \;
+find -P /bin/ /sbin/ /usr/bin/ /usr/sbin/ /usr/local/bin/ /usr/local/sbin/ -maxdepth 1 -type f  \! -gid -{{{ gid_min }}} -regextype posix-extended -regex '.*' -exec chgrp --no-dereference root {} \;
 
 {{% else %}}
 for SYSCMDFILES in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/oval/ubuntu.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/oval/ubuntu.xml
@@ -25,6 +25,7 @@
   <unix:file_state id="state_groupowner_system_commands_dirs_not_system_group_not_sgid" version="1">
     <unix:group_id datatype="int" operation="greater than or equal">{{{ gid_min }}}</unix:group_id>
     <unix:sgid datatype="boolean">false</unix:sgid>
+    <unix:uexec datatype="boolean">true</unix:uexec>
   </unix:file_state>
 
   <unix:file_state comment="symbolic link" id="state_groupowner_system_commands_dirs_symlink" version="1">

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/oval/ubuntu.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/oval/ubuntu.xml
@@ -25,7 +25,9 @@
   <unix:file_state id="state_groupowner_system_commands_dirs_not_system_group_not_sgid" version="1">
     <unix:group_id datatype="int" operation="greater than or equal">{{{ gid_min }}}</unix:group_id>
     <unix:sgid datatype="boolean">false</unix:sgid>
+    {{% if product in ['ubuntu2404'] %}}
     <unix:uexec datatype="boolean">true</unix:uexec>
+    {{% endif %}}
   </unix:file_state>
 
   <unix:file_state comment="symbolic link" id="state_groupowner_system_commands_dirs_symlink" version="1">

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_groupowner.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_groupowner.pass.sh
@@ -6,5 +6,5 @@ for SYSLIBDIRS in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin
 for SYSLIBDIRS in /bin /sbin /usr/bin /usr/sbin /usr/local/bin
 {{% endif %}}
 do
-  find -L  $SYSLIBDIRS \! -group root -type f -exec chgrp root '{}' \;
+  find -P $SYSLIBDIRS \! -group root -type f -exec chgrp -P root '{}' \;
 done

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_groupowner.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_groupowner.pass.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-{{% if product in ["ubuntu2404"] %}}
-useradd crontab
-{{% endif %}}
-
 {{% if 'ubuntu' in product %}}
 for SYSLIBDIRS in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin
 {{% else %}}

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_groupowner.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_groupowner.pass.sh
@@ -6,5 +6,5 @@ for SYSLIBDIRS in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin
 for SYSLIBDIRS in /bin /sbin /usr/bin /usr/sbin /usr/local/bin
 {{% endif %}}
 do
-  find -P $SYSLIBDIRS \! -group root -type f -exec chgrp -P root '{}' \;
+  find -P $SYSLIBDIRS \! -group root -type f -exec chgrp --no-dereference root '{}' \;
 done

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_groupowner.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_groupowner.pass.sh
@@ -1,10 +1,3 @@
 #!/bin/bash
 
-{{% if 'ubuntu' in product %}}
-for SYSLIBDIRS in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin
-{{% else %}}
-for SYSLIBDIRS in /bin /sbin /usr/bin /usr/sbin /usr/local/bin
-{{% endif %}}
-do
-  find -P $SYSLIBDIRS \! -group root -type f -exec chgrp --no-dereference root '{}' \;
-done
+find -P /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin \! -group root -type f -exec chgrp --no-dereference root '{}' \; || true

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_groupowner_no_sgid.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_groupowner_no_sgid.fail.sh
@@ -1,14 +1,7 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 
-{{% if 'ubuntu' in product %}}
-for SYSLIBDIRS in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin
-{{% else %}}
-for SYSLIBDIRS in /bin /sbin /usr/bin /usr/sbin /usr/local/bin
-{{% endif %}}
-do
-  find -L  $SYSLIBDIRS \! -group root -type f -exec chgrp root '{}' \;
-done
+find -P /bin/ /sbin/ /usr/bin/ /usr/sbin/ /usr/local/bin/ /usr/local/sbin/ -type f -exec chgrp -P root {} \;
 
 groupadd group_test
 
@@ -23,5 +16,5 @@ do
     touch $TESTFILE
   fi
   chgrp group_test $TESTFILE
-  chmod g-s $TESTFILE
+  chmod u+x,g-s $TESTFILE
 done

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_groupowner_no_sgid.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_groupowner_no_sgid.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 
-find -P /bin/ /sbin/ /usr/bin/ /usr/sbin/ /usr/local/bin/ /usr/local/sbin/ -type f -exec chgrp -P root {} \;
+find -P /bin/ /sbin/ /usr/bin/ /usr/sbin/ /usr/local/bin/ /usr/local/sbin/ -type f -exec chgrp --no-dereference root {} \;
 
 groupadd group_test
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_groupowner_sgid.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_groupowner_sgid.fail.sh
@@ -2,7 +2,6 @@
 # platform = multi_platform_ubuntu
 
 {{% if 'ubuntu' in product %}}
-useradd crontab
 for SYSLIBDIRS in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin
 {{% else %}}
 for SYSLIBDIRS in /bin /sbin /usr/bin /usr/sbin /usr/local/bin

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_groupowner_sgid.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_groupowner_sgid.pass.sh
@@ -1,14 +1,7 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 
-{{% if 'ubuntu' in product %}}
-for SYSLIBDIRS in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin
-{{% else %}}
-for SYSLIBDIRS in /bin /sbin /usr/bin /usr/sbin /usr/local/bin
-{{% endif %}}
-do
-  find -L  $SYSLIBDIRS \! -group root -type f -exec chgrp root '{}' \;
-done
+find -P /bin/ /sbin/ /usr/bin/ /usr/sbin/ /usr/local/bin/ /usr/local/sbin/ -type f -exec chgrp -P root {} \;
 
 {{% if 'ubuntu' in product %}}
 for TESTFILE in /bin/test_me /sbin/test_me /usr/bin/test_me /usr/sbin/test_me /usr/local/bin/test_me /usr/local/sbin/test_me

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_groupowner_sgid.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_groupowner_sgid.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 
-find -P /bin/ /sbin/ /usr/bin/ /usr/sbin/ /usr/local/bin/ /usr/local/sbin/ -type f -exec chgrp -P root {} \;
+find -P /bin/ /sbin/ /usr/bin/ /usr/sbin/ /usr/local/bin/ /usr/local/sbin/ -type f -exec chgrp --no-dereference root {} \;
 
 {{% if 'ubuntu' in product %}}
 for TESTFILE in /bin/test_me /sbin/test_me /usr/bin/test_me /usr/sbin/test_me /usr/local/bin/test_me /usr/local/sbin/test_me

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_groupowner_sgid.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_groupowner_sgid.pass.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 
-{{% if product in ["ubuntu2404"] %}}
-useradd crontab
-{{% endif %}}
-
-
 {{% if 'ubuntu' in product %}}
 for SYSLIBDIRS in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin
 {{% else %}}

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_groupowner_sgid.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_groupowner_sgid.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 
-find -P /bin/ /sbin/ /usr/bin/ /usr/sbin/ /usr/local/bin/ /usr/local/sbin/ -type f -exec chgrp --no-dereference root {} \;
+find -P /bin/ /sbin/ /usr/bin/ /usr/sbin/ /usr/local/bin/ /usr/local/sbin/ -type f -exec chgrp --no-dereference root {} \; || true
 
 {{% if 'ubuntu' in product %}}
 for TESTFILE in /bin/test_me /sbin/test_me /usr/bin/test_me /usr/sbin/test_me /usr/local/bin/test_me /usr/local/sbin/test_me

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_large_gid_groupownership.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_large_gid_groupownership.pass.sh
@@ -5,5 +5,5 @@ groupadd -r sys_group_test
 
 for SYSLIBDIRS in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin
 do
-  find -P $SYSLIBDIRS \! -group root -type f -exec chgrp -P sys_group_test '{}' \;
+  find -P $SYSLIBDIRS \! -group root -type f -exec chgrp --no-dereference sys_group_test '{}' \;
 done

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_large_gid_groupownership.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_large_gid_groupownership.pass.sh
@@ -5,5 +5,5 @@ groupadd -r sys_group_test
 
 for SYSLIBDIRS in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin
 do
-  find -P $SYSLIBDIRS \! -group root -type f -exec chgrp sys_group_test '{}' \;
+  find -P $SYSLIBDIRS \! -group root -type f -exec chgrp -P sys_group_test '{}' \;
 done

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_large_gid_groupownership.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_large_gid_groupownership.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+groupadd -r sys_group_test
+
+for SYSLIBDIRS in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin
+do
+  find -P $SYSLIBDIRS \! -group root -type f -exec chgrp sys_group_test '{}' \;
+done

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_large_gid_groupownership.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/correct_large_gid_groupownership.pass.sh
@@ -3,7 +3,4 @@
 
 groupadd -r sys_group_test
 
-for SYSLIBDIRS in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin
-do
-  find -P $SYSLIBDIRS \! -group root -type f -exec chgrp --no-dereference sys_group_test '{}' \;
-done
+find -P /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin \! -group root -type f -exec chgrp --no-dereference sys_group_test '{}' \; || true

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/incorrect_groupownership.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/incorrect_groupownership.fail.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-{{% if product in ["ubuntu2404"] %}}
-useradd crontab
-{{% endif %}}
-
 groupadd group_test
 
 {{% if 'ubuntu' in product %}}

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/incorrect_groupownership.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/incorrect_groupownership.fail.sh
@@ -2,7 +2,7 @@
 
 groupadd group_test
 
-find -P /bin/ /sbin/ /usr/bin/ /usr/sbin/ /usr/local/bin/ /usr/local/sbin/ -type f -exec chgrp --no-dereference root {} \;
+find -P /bin/ /sbin/ /usr/bin/ /usr/sbin/ /usr/local/bin/ /usr/local/sbin/ -type f -exec chgrp --no-dereference root {} \; || true
 
 {{% if 'ubuntu' in product %}}
 for TESTFILE in /bin/test_me /sbin/test_me /usr/bin/test_me /usr/sbin/test_me /usr/local/bin/test_me /usr/local/sbin/test_me

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/incorrect_groupownership.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/incorrect_groupownership.fail.sh
@@ -2,7 +2,7 @@
 
 groupadd group_test
 
-find -P /bin/ /sbin/ /usr/bin/ /usr/sbin/ /usr/local/bin/ /usr/local/sbin/ -type f -exec chgrp -P root {} \;
+find -P /bin/ /sbin/ /usr/bin/ /usr/sbin/ /usr/local/bin/ /usr/local/sbin/ -type f -exec chgrp --no-dereference root {} \;
 
 {{% if 'ubuntu' in product %}}
 for TESTFILE in /bin/test_me /sbin/test_me /usr/bin/test_me /usr/sbin/test_me /usr/local/bin/test_me /usr/local/sbin/test_me

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/incorrect_groupownership.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/incorrect_groupownership.fail.sh
@@ -2,6 +2,8 @@
 
 groupadd group_test
 
+find -P /bin/ /sbin/ /usr/bin/ /usr/sbin/ /usr/local/bin/ /usr/local/sbin/ -type f -exec chgrp -P root {} \;
+
 {{% if 'ubuntu' in product %}}
 for TESTFILE in /bin/test_me /sbin/test_me /usr/bin/test_me /usr/sbin/test_me /usr/local/bin/test_me /usr/local/sbin/test_me
 {{% else %}}
@@ -12,5 +14,6 @@ do
   then
     touch $TESTFILE
   fi
+  chmod u+x $TESTFILE
   chgrp group_test $TESTFILE
 done

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/non_exec_groupowner.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/non_exec_groupowner.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_ubuntu
+# platform = Ubuntu 24.04
 
 groupadd group_test
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/non_exec_groupowner.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/non_exec_groupowner.pass.sh
@@ -3,7 +3,7 @@
 
 groupadd group_test
 
-find -P /bin/ /sbin/ /usr/bin/ /usr/sbin/ /usr/local/bin/ /usr/local/sbin/ \! -group root -type f -exec chgrp -P root {} \;
+find -P /bin/ /sbin/ /usr/bin/ /usr/sbin/ /usr/local/bin/ /usr/local/sbin/ \! -group root -type f -exec chgrp --no-dereference root {} \;
 
 for TESTFILE in /bin/test_me /sbin/test_me /usr/bin/test_me /usr/sbin/test_me /usr/local/bin/test_me /usr/local/sbin/test_me
 do

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/non_exec_groupowner.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/non_exec_groupowner.pass.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+groupadd group_test
+
+find -P /bin/ /sbin/ /usr/bin/ /usr/sbin/ /usr/local/bin/ /usr/local/sbin/ \! -group root -type f -exec chgrp -P root {} \;
+
+for TESTFILE in /bin/test_me /sbin/test_me /usr/bin/test_me /usr/sbin/test_me /usr/local/bin/test_me /usr/local/sbin/test_me
+do
+  if [[ ! -f $TESTFILE ]]
+  then
+    touch $TESTFILE
+  fi
+  chgrp group_test $TESTFILE
+  chmod u-x $TESTFILE
+done

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/non_exec_groupowner.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/non_exec_groupowner.pass.sh
@@ -3,7 +3,7 @@
 
 groupadd group_test
 
-find -P /bin/ /sbin/ /usr/bin/ /usr/sbin/ /usr/local/bin/ /usr/local/sbin/ \! -group root -type f -exec chgrp --no-dereference root {} \;
+find -P /bin/ /sbin/ /usr/bin/ /usr/sbin/ /usr/local/bin/ /usr/local/sbin/ \! -group root -type f -exec chgrp --no-dereference root {} \; || true
 
 for TESTFILE in /bin/test_me /sbin/test_me /usr/bin/test_me /usr/sbin/test_me /usr/local/bin/test_me /usr/local/sbin/test_me
 do

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/symlink.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/symlink.pass.sh
@@ -2,14 +2,7 @@
 
 groupadd group_test
 
-{{% if 'ubuntu' in product %}}
-for SYSLIBDIRS in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin
-{{% else %}}
-for SYSLIBDIRS in /bin /sbin /usr/bin /usr/sbin /usr/local/bin
-{{% endif %}}
-do
-  find -L  $SYSLIBDIRS \! -group root -type f -exec chgrp root '{}' \;
-done
+find -P /bin/ /sbin/ /usr/bin/ /usr/sbin/ /usr/local/bin/ /usr/local/sbin/ \! -group root -type f -exec chgrp -P root {} \;
 
 ln -s $(mktemp -p /tmp) /usr/bin/test.log.symlink
 chgrp -h group_test /usr/bin/test.log.symlink

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/symlink.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/symlink.pass.sh
@@ -2,7 +2,7 @@
 
 groupadd group_test
 
-find -P /bin/ /sbin/ /usr/bin/ /usr/sbin/ /usr/local/bin/ /usr/local/sbin/ \! -group root -type f -exec chgrp -P root {} \;
+find -P /bin/ /sbin/ /usr/bin/ /usr/sbin/ /usr/local/bin/ /usr/local/sbin/ \! -group root -type f -exec chgrp --no-dereference root {} \;
 
 ln -s $(mktemp -p /tmp) /usr/bin/test.log.symlink
 chgrp -h group_test /usr/bin/test.log.symlink

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/symlink.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/symlink.pass.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-{{% if product in ["ubuntu2404"] %}}
-useradd crontab
-{{% endif %}}
-
 groupadd group_test
 
 {{% if 'ubuntu' in product %}}

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/symlink.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/symlink.pass.sh
@@ -2,7 +2,7 @@
 
 groupadd group_test
 
-find -P /bin/ /sbin/ /usr/bin/ /usr/sbin/ /usr/local/bin/ /usr/local/sbin/ \! -group root -type f -exec chgrp --no-dereference root {} \;
+find -P /bin/ /sbin/ /usr/bin/ /usr/sbin/ /usr/local/bin/ /usr/local/sbin/ \! -group root -type f -exec chgrp --no-dereference root {} \; || true
 
 ln -s $(mktemp -p /tmp) /usr/bin/test.log.symlink
 chgrp -h group_test /usr/bin/test.log.symlink

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/system_account_groupownership.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/system_account_groupownership.pass.sh
@@ -11,5 +11,5 @@ do
   then
     touch $TESTFILE
   fi
-  chgrp "$test_group" $TESTFILE
+  chgrp -P "$test_group" $TESTFILE
 done

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/system_account_groupownership.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/system_account_groupownership.pass.sh
@@ -11,5 +11,5 @@ do
   then
     touch $TESTFILE
   fi
-  chgrp -P "$test_group" $TESTFILE
+  chgrp --no-dereference "$test_group" $TESTFILE
 done


### PR DESCRIPTION
#### Description:

- Add tests for gid < 1000 
- Only checks files with user execution permission
- Remove unnecessary useradd
- Never follow symbolic in tests
- Execute `find` in any "possible" directory
- Enable user execute perm which won't affect non-Ubuntu platforms tests but will invalidate tests if on Ubuntu platform

#### Rationale:

- The check content of STIG rule UBTU-24-300013 is: `$ ﬁnd /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin \-type f -perm -u=x -exec stat --format="%n %G" {} + | \awk '$2 != "root" && $2 != "daemon" && $2 != "adm" && $2 != "shadow" && $2 != "mail" && $2 != "crontab" && $2 != "_ssh"'` which only include `-perm -u=x`
- Only STIG Ubuntu 24.04 in Ubuntu use this rule, so it's safe to add this stig-only `-perm -u=x` change to ubuntu.xml
- Complete #13668