### PR TITLE
Switch to warning to pass more workflow tests

### DIFF
--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -456,7 +456,7 @@ class RuleChecker(oscap.Checker):
         if not self.rule_spec:
             source = self.template_spec
         if not rules_to_test:
-            logging.error("No tests found matching the {0}(s) '{1}'".format(
+            logging.warning("No tests found matching the {0}(s) '{1}'".format(
                 self.target_type,
                 ", ".join(source)))
             return


### PR DESCRIPTION
#### Description:

- Switch to warning if there is not tests for a rule

#### Rationale:

- No tests can be ok, and throwing a warning will make workflow pass more