### PR TITLE
[Ubuntu] Define firewall varriable for Ubuntu 2404 STIG 

### DIFF
--- a/controls/stig_ubuntu2404.yml
+++ b/controls/stig_ubuntu2404.yml
@@ -98,6 +98,7 @@ controls:
       levels:
           - medium
       rules:
+          - var_network_filtering_service=ufw
           - package_ufw_installed
       status: automated
 


### PR DESCRIPTION
#### Description:

- Define firewall varriable for Ubuntu 2404 STIG 

#### Rationale:

The rule package_ufw_installed use the template package_installed_guard_var but without defining the necessary var

podman test result:
```
ADDITIONAL_TEST_OPTIONS="--debug --duplicate-templates --remove-fips-certified" tests/test_rule_in_container.sh --no-make-applicable-in-containers --dontclean --logdir logs_bash --remediate-using bash --name ssg_ubuntu2404 --datastream build/ssg-ubuntu2404-ds.xml package_ufw_installed
Setting console output to log level INFO
INFO - The base image option has been specified, choosing Podman-based test environment.
INFO - Logging into logs_bash/test_suite.log
INFO - xccdf_org.ssgproject.content_rule_package_ufw_installed
INFO - Script package-installed.pass.sh using profile (all) OK
INFO - Script package-removed.fail.sh using profile (all) OK
INFO - Script package-installed-removed.fail.sh using profile (all) OK
INFO - Script package-removed-wrong-var.pass.sh using profile (all) OK
```

The generated fix `oscap xccdf generate fix --profile stig --out fix.sh ssg-ubuntu2404-ds.xml` :
```
###############################################################################
# BEGIN fix (79 / 231) for 'xccdf_org.ssgproject.content_rule_package_ufw_installed'
###############################################################################
(>&2 echo "Remediating rule 79/231: 'xccdf_org.ssgproject.content_rule_package_ufw_installed'"); (

var_network_filtering_service='ufw'



  if [[ "ufw" =~ $var_network_filtering_service ]]; then
    DEBIAN_FRONTEND=noninteractive apt-get install -y "ufw"
  fi

) # END fix for 'xccdf_org.ssgproject.content_rule_package_ufw_installed'
```