### PR TITLE
Allow spaces around equal sign

### DIFF
--- a/shared/templates/systemd_dropin_configuration/oval.template
+++ b/shared/templates/systemd_dropin_configuration/oval.template
@@ -8,5 +8,6 @@ oval_check_dropin_file(
 	application=APPLICATION,
 	no_quotes=NO_QUOTES,
 	missing_parameter_pass=MISSING_PARAMETER_PASS,
+	separator_regex='\h*=\h*',
 	missing_config_file_fail=MISSING_CONFIG_FILE_FAIL, rule_id=rule_id, rule_title=rule_title)
 }}}

--- a/shared/templates/systemd_dropin_configuration/tests/correct_dir_spaces.pass.sh
+++ b/shared/templates/systemd_dropin_configuration/tests/correct_dir_spaces.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# This scenario is a regression test for https://issues.redhat.com/browse/RHEL-93659
+SECTION="{{{ SECTION }}}"
+PARAM="{{{ PARAM }}}"
+VALUE="{{{ VALUE }}}"
+DROPIN_DIR="{{{ DROPIN_DIR }}}"
+[ -d $DROPIN_DIR ] || mkdir -p $DROPIN_DIR
+{{% if NO_QUOTES %}}
+echo -e "[$SECTION]\n$PARAM = $VALUE" > "$DROPIN_DIR/ssg.conf"
+{{% else %}}
+echo -e "[$SECTION]\n$PARAM = \"$VALUE\"" > "$DROPIN_DIR/ssg.conf"
+{{% endif %}}

--- a/shared/templates/systemd_dropin_configuration/tests/wrong_dir_spaces.fail.sh
+++ b/shared/templates/systemd_dropin_configuration/tests/wrong_dir_spaces.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# This scenario is a regression test for https://issues.redhat.com/browse/RHEL-93659
+SECTION="{{{ SECTION }}}"
+PARAM="{{{ PARAM }}}"
+DROPIN_DIR="{{{ DROPIN_DIR }}}"
+[ -d $DROPIN_DIR ] || mkdir -p $DROPIN_DIR
+{{% if NO_QUOTES %}}
+echo -e "[$SECTION]\n$PARAM = badval" > "$DROPIN_DIR/ssg.conf"
+{{% else %}}
+echo -e "[$SECTION]\n$PARAM = \"badval\"" > "$DROPIN_DIR/ssg.conf"
+{{% endif %}}


### PR DESCRIPTION
Allow spaces around equal sign in systemd configuration files. In systemd configuation files, whitespace around equal sign is allowed and doesn't affect the configuration. See `man systemd.syntax`.

Resolves: https://issues.redhat.com/browse/RHEL-93659


