### PR TITLE
OPENSCAP-5940: Fix SCAPVal fail

### DIFF
--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -606,6 +606,8 @@ When the remediation is applied duplicate occurrences of `key` are removed.
 
     - **xccdf_variable** - use value stored in an XCCDF variable instead of hardcoded value
 
+    - **variable_datatype** - data type of the XCCDF variable specified by the xccdf_variable parameter, optional, default is string
+
     - **app** - optional. If not set the check will use the default text `The respective application or service`.
       If set, the `app` is used within sentences like: "`application` is configured correctly and configuration file exists"
 

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_yescrypt_cost_factor_logindefs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_yescrypt_cost_factor_logindefs/rule.yml
@@ -51,6 +51,7 @@ template:
         path: {{{ login_defs_path }}}
         key: "YESCRYPT_COST_FACTOR"
         xccdf_variable: "var_password_yescrypt_cost_factor_login_defs"
+        variable_datatype: int
         sep: " "
         sep_regex: "\\s*"
         app: 'login.defs'

--- a/shared/macros/10-oval.jinja
+++ b/shared/macros/10-oval.jinja
@@ -45,9 +45,11 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
 :type quotes: str
 :param xccdf_variable: the name of an XCCDF variable carrying the value, this conflicts with the value parameter
 :type xccdf_variable: str
+:param variable_datatype: data type of the XCCDF variable specified by the xccdf_variable parameter, optional, default is string
+:type variable_datatype: str
 
 #}}
-{{%- macro oval_check_config_file(path='', prefix_regex='^[ \\t]*', parameter='', separator_regex='[ \\t]+', value='', missing_parameter_pass=false, application='', multi_value=false, missing_config_file_fail=false, section='', quotes='', xccdf_variable="", rule_id=None, rule_title=None) -%}}
+{{%- macro oval_check_config_file(path='', prefix_regex='^[ \\t]*', parameter='', separator_regex='[ \\t]+', value='', missing_parameter_pass=false, application='', multi_value=false, missing_config_file_fail=false, section='', quotes='', xccdf_variable="", variable_datatype="string", rule_id=None, rule_title=None) -%}}
 {{%- if application == '' -%}}
 	{{%- set application = "The respective application or service" -%}}
 {{%- endif -%}}
@@ -77,13 +79,13 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
   </definition>
 
   {{% if xccdf_variable %}}
-  {{{ oval_line_in_file_define_variable(xccdf_variable, datatype="string") }}}
+  {{{ oval_line_in_file_define_variable(xccdf_variable, datatype=variable_datatype) }}}
   {{% endif %}}
 
   {{{ oval_line_in_file_test(path, parameter, rule_id=rule_id) }}}
   {{{ oval_line_in_file_object(path, section, prefix_regex, parameter, separator_regex, false, multi_value, rule_id=rule_id) }}}
   {{%- if xccdf_variable -%}}
-  {{{ oval_line_in_file_state_xccdf_variable(xccdf_variable, datatype="string", rule_id=rule_id) }}}
+  {{{ oval_line_in_file_state_xccdf_variable(xccdf_variable, datatype=variable_datatype, rule_id=rule_id) }}}
   {{%- else -%}}
   {{{ oval_line_in_file_state(value, multi_value, quotes, rule_id=rule_id) }}}
   {{%- endif -%}}

--- a/shared/templates/key_value_pair_in_file/oval.template
+++ b/shared/templates/key_value_pair_in_file/oval.template
@@ -1,5 +1,5 @@
 {{%- if XCCDF_VARIABLE -%}}
-{{{ oval_check_config_file(PATH, prefix_regex=PREFIX_REGEX, parameter=KEY, separator_regex=SEP_REGEX, xccdf_variable=XCCDF_VARIABLE, application=APP, missing_config_file_fail=true, rule_id=rule_id, rule_title=rule_title) }}}
+{{{ oval_check_config_file(PATH, prefix_regex=PREFIX_REGEX, parameter=KEY, separator_regex=SEP_REGEX, xccdf_variable=XCCDF_VARIABLE, variable_datatype=VARIABLE_DATATYPE, application=APP, missing_config_file_fail=true, rule_id=rule_id, rule_title=rule_title) }}}
 {{%- else -%}}
 {{{ oval_check_config_file(PATH, prefix_regex=PREFIX_REGEX, parameter=KEY, separator_regex=SEP_REGEX, value=VALUE, application=APP, missing_config_file_fail=true, rule_id=rule_id, rule_title=rule_title) }}}
 {{%- endif -%}}

--- a/shared/templates/key_value_pair_in_file/template.py
+++ b/shared/templates/key_value_pair_in_file/template.py
@@ -28,5 +28,9 @@ def preprocess(data, lang):
 
     if "app" not in data:
         data["app"] = ""
+
+    if "variable_datatype" not in data:
+        data["variable_datatype"] = "string"
+
     data = set_variables_for_test_scenarios(data)
     return data


### PR DESCRIPTION
Rule `set_password_hashing_yescrypt_cost_factor_logindefs` references XCCDF Value `var_password_yescrypt_cost_factor_login_defs` which holds a number but the OVAL check references to the variable as a string. This caused error SRC-38-1 in SCAPVal Validation Report.

We will fix this problem by extending the template `key_value_pair_in_file`. We will add a new optional parameter `variable_datatype` which allows us to specify a data type other than string. By default, this will be a string but in the affected rule we explicitly define it to be an integer.

Fixes: https://github.com/ComplianceAsCode/content/issues/13545

#### Review Hints:

```
java -Djava.protocol.handler.pkgs=sun.net.www.protocol  -jar ~/work/scapval/scapval-1.3.6.jar -file build/ssg-rhel10-ds.xml -scapversion 1.3
```
