### PR TITLE
Prevent fails in check mode

### DIFF
--- a/linux_os/guide/services/fapolicyd/fapolicy_default_deny/ansible/shared.yml
+++ b/linux_os/guide/services/fapolicyd/fapolicy_default_deny/ansible/shared.yml
@@ -4,6 +4,10 @@
 # complexity = low
 # disruption = low
 
+- name: "{{{ rule_title }}} - Gather the package facts"
+  ansible.builtin.package_facts:
+    manager: auto
+
 - name: {{{ rule_title }}} - Ensure a Final Rule Denying Everything
   ansible.builtin.copy:
     content: |
@@ -15,6 +19,8 @@
     owner: root
     group: fapolicyd
     mode: '0644'
+  when:
+    - '"fapolicyd" in ansible_facts.packages'
   register: result_fapolicyd_final_rule
 
 - name: {{{ rule_title }}} - Ensure fapolicyd is Not Permissive
@@ -23,6 +29,8 @@
     regexp: '^(permissive\s*=).*$'
     line: '\1 0'
     backrefs: true
+  when:
+    - '"fapolicyd" in ansible_facts.packages'
   register: result_fapolicyd_enforced
 
 - name: "{{{ rule_title }}} - Restart fapolicyd If Permissive Mode or Final Rule is Changed"
@@ -30,4 +38,5 @@
     name: fapolicyd
     state: restarted
   when:
+    - '"fapolicyd" in ansible_facts.packages'
     - result_fapolicyd_final_rule is changed or result_fapolicyd_enforced is changed

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/ansible/shared.yml
@@ -79,8 +79,8 @@
 - name: '{{{ rule_title }}} - Informative message based on services states'
   ansible.builtin.assert:
     that:
-      - ansible_facts.services['firewalld.service'].state == 'running'
-      - ansible_facts.services['NetworkManager.service'].state == 'running'
+      - ansible_check_mode or ansible_facts.services['firewalld.service'].state == 'running'
+      - ansible_check_mode or ansible_facts.services['NetworkManager.service'].state == 'running'
     fail_msg:
       - firewalld and NetworkManager services are not active. Remediation aborted!
       - This remediation could not be applied because it depends on firewalld and NetworkManager services running.

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/ansible/shared.yml
@@ -18,13 +18,19 @@
   block:
     {{{ ansible_ensure_pam_facts_and_authselect_profile(pam_file, rule_title=rule_title) | indent(4) }}}
 
-    - name: '{{{ rule_title }}} - Ensure That Only the Correct Hashing Algorithm Option For pam_unix.so Is Used in {{{ pam_file }}}'
+    - name: '{{{ rule_title }}} - Check if "{{ pam_file_path }}" File is Present'
+      ansible.builtin.stat:
+        path: "{{ pam_file_path }}"
+      register: pam_file_path_present
+
+    - name: '{{{ rule_title }}} - Ensure That Only the Correct Hashing Algorithm Option For pam_unix.so Is Used in {{ pam_file_path }}'
       ansible.builtin.replace:
         dest: "{{ pam_file_path }}"
         regexp: (^\s*password.*pam_unix\.so.*)\b{{ item }}\b\s*(.*)
         replace: '\1\2'
       when:
-        item != var_password_hashing_algorithm_pam
+        - item != var_password_hashing_algorithm_pam
+        - pam_file_path_present.stat.exists
       loop:
         - 'sha512'
         - 'yescrypt'

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/ansible/shared.yml
@@ -24,13 +24,19 @@
   block:
     {{{ ansible_ensure_pam_facts_and_authselect_profile(pam_file, rule_title=rule_title) | indent(4) }}}
 
-    - name: '{{{ rule_title }}} - Ensure That Only the Correct Hashing Algorithm Option For pam_unix.so Is Used in {{{ pam_file }}}'
+    - name: '{{{ rule_title }}} - Check if "{{ pam_file_path }}" File is Present'
+      ansible.builtin.stat:
+        path: "{{ pam_file_path }}"
+      register: pam_file_path_present
+
+    - name: '{{{ rule_title }}} - Ensure That Only the Correct Hashing Algorithm Option For pam_unix.so Is Used in {{ pam_file_path }}'
       ansible.builtin.replace:
         dest: "{{ pam_file_path }}"
         regexp: (^\s*password.*pam_unix\.so.*)\b{{ item }}\b\s*(.*)
         replace: '\1\2'
       when:
-        item != var_password_hashing_algorithm_pam
+        - item != var_password_hashing_algorithm_pam
+        - pam_file_path_present.stat.exists
       loop:
         - 'sha512'
         - 'yescrypt'

--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/ansible/shared.yml
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/ansible/shared.yml
@@ -39,4 +39,5 @@
         path: "/etc/cron.daily/logrotate"
         line: '/usr/sbin/logrotate /etc/logrotate.conf'
         regexp: '^[\s]*/usr/sbin/logrotate[\s\S]*/etc/logrotate.conf$'
+        create: yes
 {{% endif %}}

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_restricted/ansible/shared.yml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_restricted/ansible/shared.yml
@@ -43,7 +43,7 @@
 - name: '{{{ rule_title }}} - Informative Message Based on Service State'
   ansible.builtin.assert:
     that:
-      - ansible_facts.services['firewalld.service'].state == 'running'
+      - ansible_check_mode or ansible_facts.services['firewalld.service'].state == 'running'
     fail_msg:
       - firewalld service is not active. Remediation aborted!
       - This remediation could not be applied because it depends on firewalld service running.

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_trusted/ansible/shared.yml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_trusted/ansible/shared.yml
@@ -36,7 +36,7 @@
 - name: '{{{ rule_title }}} - Informative Message Based on Service State'
   ansible.builtin.assert:
     that:
-      - ansible_facts.services['firewalld.service'].state == 'running'
+      - ansible_check_mode or ansible_facts.services['firewalld.service'].state == 'running'
     fail_msg:
       - firewalld service is not active. Remediation aborted!
       - This remediation could not be applied because it depends on firewalld service running.

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/ansible/shared.yml
@@ -17,6 +17,9 @@
   with_items:
     - aide
 
+- name: "{{{ rule_title }}} - Gather the package facts"
+  ansible.builtin.package_facts:
+    manager: auto
 
 - name: Set audit_tools fact
   set_fact:
@@ -41,7 +44,8 @@
     line: "{{ item }} {{{ aide_string() }}}"
     create: true
   with_items: "{{ audit_tools }}"
-
+  when:
+    - '"aide" in ansible_facts.packages'
 
 - name: Configure AIDE to properly protect audit tools
   lineinfile:
@@ -49,3 +53,5 @@
     line: "{{ item }} {{{ aide_string() }}}"
     create: true
   with_items: "{{ audit_tools }}"
+  when:
+    - '"aide" in ansible_facts.packages'

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/ansible/shared.yml
@@ -39,6 +39,7 @@
     path: {{{ aide_conf_path }}}
     regexp: ^{{ item }}\s
     line: "{{ item }} {{{ aide_string() }}}"
+    create: true
   with_items: "{{ audit_tools }}"
 
 
@@ -46,4 +47,5 @@
   lineinfile:
     path: {{{ aide_conf_path }}}
     line: "{{ item }} {{{ aide_string() }}}"
+    create: true
   with_items: "{{ audit_tools }}"

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/ansible/shared.yml
@@ -22,11 +22,17 @@
             - gost
             - crc32
 
+- name: "{{{ rule_title }}} - Gather the package facts"
+  ansible.builtin.package_facts:
+    manager: auto
+
 -   name: "{{{ rule_title }}} - Remove forbidden hashes"
     ansible.builtin.replace:
         path: "{{ aide_conf }}"
         regexp: '(^\s*[A-Z][A-Za-z_]*\s*=.*?)({{ item }}\+|\+?{{ item }})(.*)'
         replace: '\1\3'
+    when:
+        - '"aide" in ansible_facts.packages'
     loop: "{{ forbidden_hashes }}"
 
 -   name: "{{{ rule_title }}} - Set sha512"
@@ -34,3 +40,5 @@
         path: "{{ aide_conf }}"
         regexp: '(^\s*[A-Z][A-Za-z_]*\s*=)((?:(?!\+?sha512).)*)\s*$'
         replace: '\1\2+sha512'
+    when:
+        - '"aide" in ansible_facts.packages'

--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/ansible/shared.yml
@@ -20,6 +20,7 @@
   {{%- endif %}}
   changed_when: False
   register: gpg_fingerprints
+  failed_when: False
   check_mode: no
 
 - name: Set Fact - Installed GPG Fingerprints

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -221,6 +221,7 @@ value: :code:`Setting={{ varname1 }}`
   ansible.builtin.file:
     path: {{{ config_file }}}
     mode: '0600'
+    state: touch
 {{%- else %}}
 {{{ ansible_set_config_file(msg, "/etc/ssh/sshd_config", parameter, value=value, create="yes", prefix_regex='(?i)^\s*', validate="/usr/sbin/sshd -t -f %s", insert_before="BOF", rule_title=rule_title) }}}
 {{%- endif %}}

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -855,12 +855,13 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
     cmd: authselect check
   register: result_authselect_check_cmd
   changed_when: false
+  check_mode: false
   failed_when: false
 
 - name: '{{{ rule_title }}} - Informative message based on the authselect integrity check result'
   ansible.builtin.assert:
     that:
-      - result_authselect_check_cmd.rc == 0
+      - ansible_check_mode or result_authselect_check_cmd.rc == 0
     fail_msg:
       - authselect integrity check failed. Remediation aborted!
       - This remediation could not be applied because an authselect profile was not selected or the selected profile is not intact.

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1781,6 +1781,11 @@ Part of the grub2_bootloader_argument_absent template.
   ansible.builtin.set_fact:
     pam_module_control: '{{{ control }}}'
 
+- name: '{{{ rule_title }}} - Check if {{{ pam_file }}} file is present'
+  ansible.builtin.stat:
+    path: "{{{ pam_file }}}"
+  register: result_pam_file_present
+
 - name: '{{{ rule_title }}} - Ensure the "{{{ option }}}" option from "{{{ module }}}" is not present in {{{ pam_file }}}'
   ansible.builtin.replace:
     dest: "{{{ pam_file }}}"
@@ -1791,6 +1796,7 @@ Part of the grub2_bootloader_argument_absent template.
     {{%- endif %}}
     replace: '\1\2'
   register: result_pam_option_removal
+  when: result_pam_file_present.stat.exists
 {{%- endmacro -%}}
 
 

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -927,6 +927,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
     cmd: authselect current | tail -n+3 | awk '{ print $2 }'
   register: result_authselect_features
   changed_when: false
+  check_mode: false
   when:
     - result_authselect_check_cmd is success
 
@@ -958,6 +959,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
     cmd: authselect current | tail -n+3 | awk '{ print $2 }'
   register: result_authselect_features
   changed_when: false
+  check_mode: false
   when:
     - result_authselect_check_cmd is success
 
@@ -1024,6 +1026,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
     cmd: authselect list-features sssd
   register: result_authselect_available_features
   changed_when: false
+  check_mode: false
   when:
     - result_authselect_present.stat.exists
 
@@ -1066,6 +1069,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
     cmd: authselect list-features sssd
   register: result_authselect_available_features
   changed_when: false
+  check_mode: false
   when:
     - result_authselect_present.stat.exists
 
@@ -1107,6 +1111,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
     cmd: authselect list-features sssd
   register: result_authselect_available_features
   changed_when: false
+  check_mode: false
   when:
     - result_authselect_present.stat.exists
 
@@ -1479,12 +1484,14 @@ Part of the grub2_bootloader_argument template.
 {{%- macro ansible_grub2_bootloader_argument(arg_name, arg_name_value) -%}}
 {{% if 'ubuntu' in product or 'debian' in product or product in ['ol7', 'sle12', 'sle15', 'slmicro5'] %}}
 - name: Check {{{ arg_name }}} argument exists
-  command: grep '^\s*GRUB_CMDLINE_LINUX=.*{{{ arg_name }}}=' /etc/default/grub
+  ansible.builtin.command: grep '^\s*GRUB_CMDLINE_LINUX=.*{{{ arg_name }}}=' /etc/default/grub
+  check_mode: False
   failed_when: False
   register: argcheck
 
 - name: Check {{{ arg_name }}} argument exists
-  command: grep '^\s*GRUB_CMDLINE_LINUX=' /etc/default/grub
+  ansible.builtin.command: grep '^\s*GRUB_CMDLINE_LINUX=' /etc/default/grub
+  check_mode: False
   failed_when: False
   register: linecheck
 
@@ -1537,7 +1544,8 @@ Part of the grub2_bootloader_argument_absent template.
 {{%- macro ansible_grub2_bootloader_argument_absent(arg_name) -%}}
 {{% if 'ubuntu' in product or 'debian' in product or product in ['ol7', 'sle12', 'sle15'] %}}
 - name: Check {{{ arg_name }}} argument exists
-  command: grep '^GRUB_CMDLINE_LINUX=.*{{{ arg_name }}}=.*"' /etc/default/grub
+  ansible.builtin.command: grep '^GRUB_CMDLINE_LINUX=.*{{{ arg_name }}}=.*"' /etc/default/grub
+  check_mode: False
   failed_when: False
   register: argcheck
 
@@ -1825,6 +1833,7 @@ Part of the grub2_bootloader_argument_absent template.
     cmd: authselect current | tail -n+3 | awk '{ print $2 }'
   register: result_authselect_features
   changed_when: false
+  check_mode: false
   when:
     - result_authselect_profile is not skipped
     - authselect_current_profile is not match("custom/")

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1744,6 +1744,7 @@ Part of the grub2_bootloader_argument_absent template.
     state: present
   register: result_pam_{{{ rule_id }}}_add
   when:
+    - result_pam_module_{{{ rule_id }}}_option_present.found is defined
     - result_pam_module_{{{ rule_id }}}_option_present.found == 0
 
 {{%- if value != '' %}}
@@ -1922,6 +1923,8 @@ Part of the grub2_bootloader_argument_absent template.
     - name: '{{{ rule_title }}} - Change the PAM file to be edited according to the custom authselect profile'
       ansible.builtin.set_fact:
         pam_file_path: "/etc/authselect/{{ authselect_custom_profile }}/{{ pam_file_path | basename }}"
+      when:
+        - authselect_custom_profile is defined
   when:
     - result_authselect_present.stat.exists
 {{%- endmacro -%}}

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1851,12 +1851,14 @@ Part of the grub2_bootloader_argument_absent template.
   register: result_authselect_custom_profile_present
   changed_when: false
   when:
+    - result_authselect_profile is not skipped
     - authselect_current_profile is not match("custom/")
 
 - name: '{{{ rule_title }}} - Create an authselect custom profile based on the current profile'
   ansible.builtin.command:
     cmd: authselect create-profile hardening -b {{ authselect_current_profile }}
   when:
+    - result_authselect_profile is not skipped
     - result_authselect_check_cmd is success
     - authselect_current_profile is not match("^(custom/|local)")
     - not result_authselect_custom_profile_present.stat.exists
@@ -1865,6 +1867,7 @@ Part of the grub2_bootloader_argument_absent template.
   ansible.builtin.command:
     cmd: authselect create-profile hardening -b sssd
   when:
+    - result_authselect_profile is not skipped
     - result_authselect_check_cmd is success
     - authselect_current_profile is match("local")
     - not result_authselect_custom_profile_present.stat.exists

--- a/shared/templates/audit_file_contents/ansible.template
+++ b/shared/templates/audit_file_contents/ansible.template
@@ -14,3 +14,4 @@
   ansible.builtin.file:
     path: {{{ FILEPATH }}}
     mode: g-rwx,o-rwx
+    state: touch


### PR DESCRIPTION
#### Description:
This PR changes some Ansible Tasks to work in check mode. The objective is to prevent premature terminations of Ansible Playbooks for our profiles.

The most frequent change is that some Ansible tasks that use the command or shell module will run also in check mode. This isn't done for all tasks using these modules but only for some of them that are read only and they check some status or read some files, usually the grep command.

For more details, please read commit messages of each commit.

#### Rationale:

Resolves: https://issues.redhat.com/browse/OPENSCAP-5480

#### Review Hints:
Run the contest test that will be introduced by PR https://github.com/RHSecurityCompliance/contest/pull/424.
