### PR TITLE
make service_rngd_enabled applicable in case FIPS mode is not enabled

### DIFF
--- a/linux_os/guide/services/rng/service_rngd_enabled/rule.yml
+++ b/linux_os/guide/services/rng/service_rngd_enabled/rule.yml
@@ -37,7 +37,7 @@ fixtext: '{{{ fixtext_service_disabled("rngd") }}}'
 srg_requirement: '{{{ srg_requirement_service_disabled("rngd") }}}'
 
 {{% if product == "rhel8" %}}
-platform: os_linux[rhel]<=8.3
+platform: os_linux[rhel]<=8.3 or (os_linux[rhel]>=8.4 and not runtime_kernel_fips_enabled)
 warnings:
   - general: |-
       For RHEL versions 8.4 and above running with kernel FIPS mode enabled this rule is not applicable.


### PR DESCRIPTION
#### Description:

- change the applicability platform of the rule service_rngd_enabled so that it matches the one for ol8.

#### Rationale:

- The rule should be usable in RHEL >= 8.4 in case kernel is not in FIPS mode.


#### Review Hints:

1. Start RHEL 8 machine where RHEL >= 8.4.
2. Scan for the rule service_rngd_enabled before applying this PR. The result should be not applicable.
3. Apply this PR and scan for the rule, the result should be probably "fail", or maybe "pass".
4. Convert system to FIPS mode.
5. Both before / after application of this PR, rule should report "not applicable".