### PR TITLE
RHEL 9 CIS: add ensure_gpgcheck_never_disabled

### DIFF
--- a/controls/cis_rhel9.yml
+++ b/controls/cis_rhel9.yml
@@ -373,6 +373,7 @@ controls:
       status: automated
       rules:
           - ensure_gpgcheck_globally_activated
+          - ensure_gpgcheck_never_disabled
 
     - id: 1.2.1.3
       title: Ensure repo_gpgcheck is globally activated (Manual)

--- a/tests/data/profile_stability/rhel9/cis.profile
+++ b/tests/data/profile_stability/rhel9/cis.profile
@@ -126,6 +126,7 @@ directory_permissions_var_log_audit
 disable_host_auth
 enable_authselect
 ensure_gpgcheck_globally_activated
+ensure_gpgcheck_never_disabled
 ensure_pam_wheel_group_empty
 ensure_root_password_configured
 file_at_deny_not_exist

--- a/tests/data/profile_stability/rhel9/cis_server_l1.profile
+++ b/tests/data/profile_stability/rhel9/cis_server_l1.profile
@@ -59,6 +59,7 @@ dir_perms_world_writable_sticky_bits
 disable_host_auth
 enable_authselect
 ensure_gpgcheck_globally_activated
+ensure_gpgcheck_never_disabled
 ensure_pam_wheel_group_empty
 ensure_root_password_configured
 file_at_deny_not_exist

--- a/tests/data/profile_stability/rhel9/cis_workstation_l1.profile
+++ b/tests/data/profile_stability/rhel9/cis_workstation_l1.profile
@@ -57,6 +57,7 @@ dir_perms_world_writable_sticky_bits
 disable_host_auth
 enable_authselect
 ensure_gpgcheck_globally_activated
+ensure_gpgcheck_never_disabled
 ensure_pam_wheel_group_empty
 ensure_root_password_configured
 file_at_deny_not_exist

--- a/tests/data/profile_stability/rhel9/cis_workstation_l2.profile
+++ b/tests/data/profile_stability/rhel9/cis_workstation_l2.profile
@@ -126,6 +126,7 @@ directory_permissions_var_log_audit
 disable_host_auth
 enable_authselect
 ensure_gpgcheck_globally_activated
+ensure_gpgcheck_never_disabled
 ensure_pam_wheel_group_empty
 ensure_root_password_configured
 file_at_deny_not_exist


### PR DESCRIPTION
#### Description:

- add rule ensure_gpgcheck_never_disabled to the appropriate control

#### Rationale:

- it is aligned with the control

- Fixes https://issues.redhat.com/browse/RHEL-102328

#### Review Hints:

Review the latest CIS RHEL 9 benchmark, in particular 1.2.1.2