### PR TITLE
Ensure tmout.sh and ssh_confirm.sh have correct permissions on creation

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_profiled_ssh_confirm/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_profiled_ssh_confirm/bash/shared.sh
@@ -13,8 +13,11 @@
 {{{ bash_deregexify_banner_backslash("var_ssh_confirm_text") }}}
 formatted=$(echo "$var_ssh_confirm_text")
 
+OLD_UMASK=$(umask)
+umask u=rw,go=r
+
 cat <<EOF >/etc/profile.d/ssh_confirm.sh
 $formatted
 EOF
 
-chmod a+x /etc/profile.d/ssh_confirm.sh
+umask $OLD_UMASK

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/ubuntu.sh
@@ -18,9 +18,12 @@ for f in /etc/bash.bashrc /etc/profile /etc/profile.d/*.sh; do
     fi
 done
 
+OLD_UMASK=$(umask)
+umask u=rw,go=r
 if [ $tmout_found -eq 0 ]; then
         echo -e "\n# Set TMOUT to $var_accounts_tmout per security requirements" >> /etc/profile.d/tmout.sh
         echo "TMOUT=$var_accounts_tmout" >> /etc/profile.d/tmout.sh
         echo "readonly TMOUT" >> /etc/profile.d/tmout.sh
         echo "export TMOUT" >> /etc/profile.d/tmout.sh
 fi
+umask $OLD_UMASK


### PR DESCRIPTION
#### Description:

- Set correct umask when creating scripts in /etc/profile.d/
 
#### Rationale:

- /etc/profile.d/ scripts need to be readable by all users otherwise they are ignored
- Fixes Ubuntu 24.04 STIG rules UBTU-24-200060 and UBTU-24-200680