### PR TITLE
Support banner with single quote

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/bash/shared.sh
@@ -1,6 +1,6 @@
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle,multi_platform_slmicro,multi_platform_ubuntu,multi_platform_almalinux
 
-{{{ bash_instantiate_variables("login_banner_text") }}}
+login_banner_text="(bash-populate login_banner_text)"
 
 # Multiple regexes transform the banner regex into a usable banner
 # 0 - Remove anchors around the banner text

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/tests/banner_etc_issue_disa_dod_short.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/tests/banner_etc_issue_disa_dod_short.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# variables = login_banner_text=^I've[\s\n]+read[\s\n]+\&amp;[\s\n]+consent[\s\n]+to[\s\n]+terms[\s\n]+in[\s\n]+IS[\s\n]+user[\s\n]+agreem't\.$
+
+# dod_short banner
+echo "Hello, how are you" > /etc/issue

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1398,7 +1398,7 @@ EOF
 
 {{# Strips newline or newline escape sequence regex #}}
 {{% macro bash_deregexify_banner_newline(banner_var_name, newline) -%}}
-{{{ banner_var_name }}}=$(echo "${{{ banner_var_name }}}" | sed 's/(?:\[\\n\]+|(?:\\\\n)+)/{{{ newline }}}/g')
+{{{ banner_var_name }}}=$(echo "${{{ banner_var_name }}}" | sed 's/(?:\[\\n\]+|(?:\\n)+)/{{{ newline }}}/g')
 {{%- endmacro %}}
 
 


### PR DESCRIPTION
The value of `dod_short` selector in variable login_banner_text contains single quotes but the bash remediation uses single quotes for the variable which conflicts with the single quote inside the value and leads to incomplete bash remediation. To change single quotes to double quotes for the variable, we need to use a different construction than using the bash_instantiate_variables Jinja macro.

The commit also adds a test scenario that covers this situation.

Resolves: https://issues.redhat.com/browse/OPENSCAP-5403

