### PR TITLE
Fix architecture dependent path

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/bash/ubuntu.sh
@@ -6,4 +6,5 @@ if [ ! -f /etc/pam_pkcs11/pam_pkcs11.conf ]; then
     cp /usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example /etc/pam_pkcs11/pam_pkcs11.conf
 fi
 
-sed -i -e 's/debug = true/debug = false/g' -e 's|module = /usr/lib/opensc-pkcs11|module = /usr/lib/x86_64-linux-gnu/pkcs11/opensc-pkcs11|' /etc/pam_pkcs11/pam_pkcs11.conf
+sed -i -e 's/debug = true/debug = false/g' \
+    -e 's|module = /usr/lib/opensc-pkcs11|module = /usr/lib/'"$(uname -m)"'-linux-gnu/pkcs11/opensc-pkcs11|' /etc/pam_pkcs11/pam_pkcs11.conf


### PR DESCRIPTION
#### Description:

- Fix path for architecture-dependent smartcard library

#### Rationale:

- Failed on aarch64 with `ERROR:pam_pkcs11.c:329: load_pkcs11_module() failed loading /usr/lib/x86_64-linux-gnu/pkcs11/opensc-pkcs11.so: stat() failed: No such file or directory`