### PR TITLE
Expand internal function to pass yaml dict

### DIFF
--- a/ssg/profiles.py
+++ b/ssg/profiles.py
@@ -289,7 +289,7 @@ def _process_profile(profile: ProfileSelections, profile_yaml: dict, profiles_fi
     return profile
 
 
-def _load_controls_manager(controls_dir: str) -> object:
+def _load_controls_manager(controls_dir: str, product_yaml: dict) -> object:
     """
     Loads and initializes a ControlsManager instance.
 
@@ -299,7 +299,7 @@ def _load_controls_manager(controls_dir: str) -> object:
     Returns:
         object: An instance of ControlsManager with loaded controls.
     """
-    control_mgr = ControlsManager(controls_dir)
+    control_mgr = ControlsManager(controls_dir, product_yaml)
     control_mgr.load()
     return control_mgr
 
@@ -340,7 +340,7 @@ def get_profiles_from_products(content_dir: str, products: list,
         product_yaml = _load_product_yaml(content_dir, product)
         product_title = product_yaml.get("full_name")
         profiles_files = get_profile_files_from_root(product_yaml, product_yaml)
-        controls_manager = _load_controls_manager(controls_dir)
+        controls_manager = _load_controls_manager(controls_dir, product_yaml)
         for file in profiles_files:
             profile_id = os.path.basename(file).split('.profile')[0]
             profile_yaml = _load_yaml_profile_file(file)


### PR DESCRIPTION
#### Description:

Although the main control files are no longer using Jinja2 macros, when processing the controls in `srg_ctr` directory a yaml dict is necessary to avoid errors when loading policies.

#### Rationale:

- https://issues.redhat.com/browse/CPLYTM-916

#### Review Hints:

The following script can be used to more easily test:
```
import os
from ssg.profiles import get_profiles_from_products
from ssg.jinja import load_macros_from_content_dir
from pprint import pprint


def _get_root_content_dir() -> str:
    # Update the path according to your environment
    home_dir = os.path.expanduser("~")
    content_root_dir = os.path.join(home_dir, "CaC", "Forks", "content")
    return content_root_dir


def main():
    rhel_products = ['rhel10']
    content_root_dir = _get_root_content_dir()
    load_macros_from_content_dir(content_root_dir)
    
    # Get all profiles for the specified products.
    profiles = get_profiles_from_products(content_root_dir, rhel_products, sorted=True)
    for profile in profiles:
        if profile.profile_id in ['anssi_bp28_high']:
            print(f'Rules for {profile.product_id} in profile {profile.profile_id}:')
            pprint(profile.rules)


if __name__ == "__main__":
    main()
```
Use `source .pyenv.sh` before executing the script.