### PR TITLE
Remove configure_crypto_policy

### DIFF
--- a/controls/stig_rhel9.yml
+++ b/controls/stig_rhel9.yml
@@ -3807,7 +3807,6 @@ controls:
           - enable_fips_mode
           - sysctl_crypto_fips_enabled
           - var_system_crypto_policy=fips
-          - configure_crypto_policy
           - enable_dracut_fips_module
       status: automated
 


### PR DESCRIPTION
Remove rule configure_crypto_policy from control RHEL-09-671010 in RHEL 9 STIG. But, the rule remains part of the profile because it's part of other controls.

The control is about FIPS mode and FIPS mode should be achieved by setting the kernel flag fips=1 before installation.

This change prevents reporting misalignments if disa-alignment contest test uses a VM that doesn't run in FIPS mode for running the test.

Resolves: https://github.com/ComplianceAsCode/content/issues/13108


