### PR TITLE
Fix rule auditd_freq

### DIFF
--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -28,6 +28,9 @@
     -   **value** - the value of configuration item specified by
         parameter
 
+    - **xccdf_variable** - specifies an XCCDF variable to use as a value for the specified **parameter**.
+        This parameter conflicts with the **value** parameter.
+
     -   **missing_parameter_pass** - effective only in OVAL checks, if
         set to `"false"` and the parameter is not present in the
         configuration file, the OVAL check will return false (default value: `"false"`).

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_freq/rule.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_freq/rule.yml
@@ -46,4 +46,4 @@ template:
         missing_parameter_pass: 'false'
         parameter: freq
         rule_id: auditd_freq
-        value: '50'
+        xccdf_variable: var_auditd_freq

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_freq/tests/correct_exact_stig.pass.sh
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_freq/tests/correct_exact_stig.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = audit
+# variables = var_auditd_freq=100
+# This TS is a regression test for https://issues.redhat.com/browse/RHEL-64013
+echo "freq = 100" > "/etc/audit/auditd.conf"

--- a/shared/macros/10-oval.jinja
+++ b/shared/macros/10-oval.jinja
@@ -669,6 +669,8 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
 :type parameter: str
 :param value: The value to be checked. This can also be a regular expression (e.g: value1|value2 can match both values).
 :type value: str
+:param xccdf_variable: the name of an XCCDF variable carrying the value, this conflicts with the value parameter
+:type xccdf_variable: str
 :param missing_parameter_pass: If set, the check will also pass if the parameter is not present in the configuration file (default is applied).
 :type missing_parameter_pass: bool
 :param multi_value: If set, it means that the parameter can accept multiple values and the expected value must be present in the current list of values.
@@ -677,8 +679,8 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
 :type missing_config_file_fail: bool
 
 #}}
-{{%- macro oval_auditd_config(parameter='', value='', missing_parameter_pass=false, multi_value=false, missing_config_file_fail=false, rule_id=None, rule_title=None) %}}
-{{{ oval_check_config_file("/etc/audit/auditd.conf", prefix_regex="^[ \\t]*(?i)", parameter=parameter, separator_regex='(?-i)[ \\t]*=[ \\t]*', value="(?i)"+value+"(?-i)", missing_parameter_pass=missing_parameter_pass, application="auditd", multi_value=multi_value, missing_config_file_fail=missing_config_file_fail, rule_id=rule_id, rule_title=rule_title) }}}
+{{%- macro oval_auditd_config(parameter='', value='', xccdf_variable='', missing_parameter_pass=false, multi_value=false, missing_config_file_fail=false, rule_id=None, rule_title=None) %}}
+{{{ oval_check_config_file("/etc/audit/auditd.conf", prefix_regex="^[ \\t]*(?i)", parameter=parameter, separator_regex='(?-i)[ \\t]*=[ \\t]*', value="(?i)"+value+"(?-i)", xccdf_variable=xccdf_variable, missing_parameter_pass=missing_parameter_pass, application="auditd", multi_value=multi_value, missing_config_file_fail=missing_config_file_fail, rule_id=rule_id, rule_title=rule_title) }}}
 {{%- endmacro %}}
 
 

--- a/shared/templates/auditd_lineinfile/ansible.template
+++ b/shared/templates/auditd_lineinfile/ansible.template
@@ -3,8 +3,15 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+
+{{% if XCCDF_VARIABLE %}}
+{{{ ansible_instantiate_variables(XCCDF_VARIABLE) }}}
+{{% set value = "{{ " + XCCDF_VARIABLE + " }}" %}}
+{{% else %}}
+{{% set value = VALUE %}}
+{{% endif %}}
 {{{
     ansible_auditd_set(
         parameter=PARAMETER,
-        value=VALUE, rule_title=rule_title)
+        value=value, rule_title=rule_title)
 }}}

--- a/shared/templates/auditd_lineinfile/bash.template
+++ b/shared/templates/auditd_lineinfile/bash.template
@@ -3,4 +3,10 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-{{{ bash_auditd_config_set(parameter=PARAMETER, value=VALUE, rule_id=rule_id) }}}
+{{% if XCCDF_VARIABLE %}}
+{{{ bash_instantiate_variables(XCCDF_VARIABLE) }}}
+{{% set value = "$" ~ XCCDF_VARIABLE %}}
+{{% else %}}
+{{% set value = VALUE %}}
+{{% endif %}}
+{{{ bash_auditd_config_set(parameter=PARAMETER, value=value, rule_id=rule_id) }}}

--- a/shared/templates/auditd_lineinfile/oval.template
+++ b/shared/templates/auditd_lineinfile/oval.template
@@ -1,6 +1,15 @@
+{{%- if XCCDF_VARIABLE -%}}
+{{{
+oval_auditd_config(
+	parameter=PARAMETER,
+	xccdf_variable=XCCDF_VARIABLE,
+	missing_parameter_pass=MISSING_PARAMETER_PASS, rule_id=rule_id, rule_title=rule_title)
+}}}
+{{%- else -%}}
 {{{
 oval_auditd_config(
 	parameter=PARAMETER,
 	value=VALUE,
 	missing_parameter_pass=MISSING_PARAMETER_PASS, rule_id=rule_id, rule_title=rule_title)
 }}}
+{{%- endif -%}}

--- a/shared/templates/auditd_lineinfile/template.py
+++ b/shared/templates/auditd_lineinfile/template.py
@@ -4,7 +4,7 @@ from ssg.utils import parse_template_boolean_value
 def preprocess(data, lang):
     if data.get("value") is not None and data.get("xccdf_variable") is not None:
         errmsg = (
-            f"The template definition of {data["_rule_id"]} specifies both "
+            f"The template definition of {data['_rule_id']} specifies both "
             f"value and xccdf_variable. This is forbidden."
         )
         raise ValueError(errmsg)

--- a/shared/templates/auditd_lineinfile/template.py
+++ b/shared/templates/auditd_lineinfile/template.py
@@ -2,5 +2,23 @@ from ssg.utils import parse_template_boolean_value
 
 
 def preprocess(data, lang):
-    data["missing_parameter_pass"] = parse_template_boolean_value(data, parameter="missing_parameter_pass", default_value=False)
+    if data.get("value") is not None and data.get("xccdf_variable") is not None:
+        errmsg = (
+            f"The template definition of {data["_rule_id"]} specifies both "
+            f"value and xccdf_variable. This is forbidden."
+        )
+        raise ValueError(errmsg)
+    data["missing_parameter_pass"] = parse_template_boolean_value(
+        data, parameter="missing_parameter_pass", default_value=False)
+    return set_variables_for_test_scenarios(data)
+
+
+def set_variables_for_test_scenarios(data):
+    if not data.get("value"):
+        # this implies XCCDF variable is used
+        data["wrong_value"] = "wrong_value"
+        data["correct_value"] = "correct_value"
+    else:
+        data["wrong_value"] = "wrong_value"
+        data["correct_value"] = str(data["value"])
     return data

--- a/shared/templates/auditd_lineinfile/tests/commented.fail.sh
+++ b/shared/templates/auditd_lineinfile/tests/commented.fail.sh
@@ -3,4 +3,7 @@
 # platform = Not Applicable
 {{% endif%}}
 # packages = audit
-echo "#{{{ PARAMETER }}} = {{{ VALUE }}}" > "/etc/audit/auditd.conf"
+{{% if XCCDF_VARIABLE %}}
+# variables = {{{ XCCDF_VARIABLE }}}={{{ CORRECT_VALUE }}}
+{{% endif %}}
+echo "#{{{ PARAMETER }}} = {{{ CORRECT_VALUE }}}" > "/etc/audit/auditd.conf"

--- a/shared/templates/auditd_lineinfile/tests/correct_value.pass.sh
+++ b/shared/templates/auditd_lineinfile/tests/correct_value.pass.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 # packages = audit
-echo "{{{ PARAMETER }}} = {{{ VALUE }}}" > "/etc/audit/auditd.conf"
+{{% if XCCDF_VARIABLE %}}
+# variables = {{{ XCCDF_VARIABLE }}}={{{ CORRECT_VALUE }}}
+{{% endif %}}
+echo "{{{ PARAMETER }}} = {{{ CORRECT_VALUE }}}" > "/etc/audit/auditd.conf"

--- a/shared/templates/auditd_lineinfile/tests/correct_value_capital.pass.sh
+++ b/shared/templates/auditd_lineinfile/tests/correct_value_capital.pass.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 # packages = audit
+{{% if XCCDF_VARIABLE %}}
+# platform = Not Applicable
+{{% endif %}}
 echo "{{{ PARAMETER | upper }}} = {{{ VALUE | upper }}}" > "/etc/audit/auditd.conf"

--- a/shared/templates/auditd_lineinfile/tests/double_assignment.fail.sh
+++ b/shared/templates/auditd_lineinfile/tests/double_assignment.fail.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 # packages = audit
-echo "{{{ PARAMETER }}} = {{{ VALUE }}}" >> "/etc/audit/auditd.conf"
+{{% if XCCDF_VARIABLE %}}
+# variables = {{{ XCCDF_VARIABLE }}}={{{ CORRECT_VALUE }}}
+{{% endif %}}
+echo "{{{ PARAMETER }}} = {{{ CORRECT_VALUE }}}" >> "/etc/audit/auditd.conf"
 echo "{{{ PARAMETER }}} = wrong_value" >> "/etc/audit/auditd.conf"

--- a/shared/templates/auditd_lineinfile/tests/wrong_value.fail.sh
+++ b/shared/templates/auditd_lineinfile/tests/wrong_value.fail.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 # packages = audit
-echo "{{{ PARAMETER }}} = wrong_value" > "/etc/audit/auditd.conf"
+{{% if XCCDF_VARIABLE %}}
+# variables = {{{ XCCDF_VARIABLE }}}={{{ CORRECT_VALUE }}}
+{{% endif %}}
+echo "{{{ PARAMETER }}} = {{{ WRONG_VALUE | upper }}}" > "/etc/audit/auditd.conf"

--- a/shared/templates/auditd_lineinfile/tests/wrong_value_capital.fail.sh
+++ b/shared/templates/auditd_lineinfile/tests/wrong_value_capital.fail.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 # packages = audit
-echo "{{{ PARAMETER | upper }}} = WRONG_VALUE" > "/etc/audit/auditd.conf"
+{{% if XCCDF_VARIABLE %}}
+# variables = {{{ XCCDF_VARIABLE }}}={{{ CORRECT_VALUE }}}
+{{% endif %}}
+echo "{{{ PARAMETER | upper }}} = {{{ WRONG_VALUE | upper }}}" > "/etc/audit/auditd.conf"


### PR DESCRIPTION
The rule `auditd_freq` is parametrized by `var_auditd_freq` variable but the value of the variable wasn't honored by checks and remediations and is hardcoded to 50 instead. The reason was `auditd_lineinfile` template didn't support parametrizing by variables. In this commit, we will enhance the `auditd_lineinfile` template to support variables.  Then, we will use the enhanced template to pass in the variable in rule `auditd_freq`.

Resolves: https://issues.redhat.com/browse/RHEL-64013

