### PR TITLE
Fix package name in service_cron_enabled

### DIFF
--- a/linux_os/guide/services/cron_and_at/service_cron_enabled/rule.yml
+++ b/linux_os/guide/services/cron_and_at/service_cron_enabled/rule.yml
@@ -49,4 +49,6 @@ template:
         servicename@rhel9: crond
         servicename@rhel10: crond
         packagename: cron
+        packagename@rhel8: cronie
+        packagename@rhel9: cronie
         packagename@rhel10: cronie


### PR DESCRIPTION
In RHEL 8 and RHEL 9, the `crond` service is provided by the `cronie` package.

Resolves: https://issues.redhat.com/browse/RHEL-89812
