### PR TITLE
Install package polkit-pkla-compat

### DIFF
--- a/linux_os/guide/system/network/network_nmcli_permissions/ansible/shared.yml
+++ b/linux_os/guide/system/network/network_nmcli_permissions/ansible/shared.yml
@@ -4,7 +4,12 @@
 # complexity = low
 # disruption = low
 
-- name: Ensure non-privileged users do not have access to nmcli
+- name: "{{{ rule_title }}} - Ensure polkit-pkla-compat is installed"
+  package:
+    name: "polkit-pkla-compat"
+    state: present
+
+- name: "{{{ rule_title }}} - Ensure non-privileged users do not have access to nmcli"
   community.general.ini_file:
     path: /etc/polkit-1/localauthority/20-org.d/10-nm-harden-access.pkla
     section: Disable General User Access to NetworkManager

--- a/linux_os/guide/system/network/network_nmcli_permissions/bash/shared.sh
+++ b/linux_os/guide/system/network/network_nmcli_permissions/bash/shared.sh
@@ -4,4 +4,5 @@
 # complexity = low
 # disruption = low
 
+{{{ bash_package_install("polkit-pkla-compat") }}}
 printf "[Disable General User Access to NetworkManager]\nIdentity=default\nAction=org.freedesktop.NetworkManager.*\nResultAny=no\nResultInactive=no\nResultActive=auth_admin\n" > /etc/polkit-1/localauthority/20-org.d/10-nm-harden-access.pkla

--- a/linux_os/guide/system/network/network_nmcli_permissions/tests/missing_compat_package.fail.sh
+++ b/linux_os/guide/system/network/network_nmcli_permissions/tests/missing_compat_package.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = polkit
+# platform = Red Hat Enterprise Linux 9
+# This TS is a regression test for https://issues.redhat.com/browse/RHEL-87606
+dnf remove -y polkit-pkla-compat

--- a/linux_os/guide/system/network/network_nmcli_permissions/tests/missing_compat_package.fail.sh
+++ b/linux_os/guide/system/network/network_nmcli_permissions/tests/missing_compat_package.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # packages = polkit
-# platform = Red Hat Enterprise Linux 9
+# platform = Red Hat Enterprise Linux 9, Red Hat Enterprise Linux 10
 # This TS is a regression test for https://issues.redhat.com/browse/RHEL-87606
-dnf remove -y polkit-pkla-compat
+dnf remove -y --noautoremove polkit-pkla-compat


### PR DESCRIPTION
The package polkit-pkla-compat owns /etc/polkit-1/localauthority which is needed by the remediation.

Resolves: https://issues.redhat.com/browse/RHEL-87606
