### PR TITLE
Fix sshd_rekey_limit test scenarios

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/bad_size_directory.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/bad_size_directory.fail.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Oracle Linux 9,Red Hat Enterprise Linux 9
+{{% if sshd_distributed_config == "false" %}}
+# platform = Not Applicable
+{{% else %}}
+# platform = multi_platform_all
+{{% endif %}}
 # variables = var_rekey_limit_time=1h
 
 mkdir -p /etc/ssh/sshd_config.d

--- a/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/bad_time_directory.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/bad_time_directory.fail.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Oracle Linux 9,Red Hat Enterprise Linux 9
+{{% if sshd_distributed_config == "false" %}}
+# platform = Not Applicable
+{{% else %}}
+# platform = multi_platform_all
+{{% endif %}}
 # variables = var_rekey_limit_size=512M
 
 mkdir -p /etc/ssh/sshd_config.d

--- a/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/correct_main_file_wrong_directory.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/correct_main_file_wrong_directory.fail.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
-
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 9,Oracle Linux 9
+{{% if sshd_distributed_config == "false" %}}
+# platform = Not Applicable
+{{% else %}}
+# platform = multi_platform_all
+{{% endif %}}
 
 SSHD_PARAM="RekeyLimit"
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/correct_value_directory.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/correct_value_directory.pass.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
+{{% if sshd_distributed_config == "false" %}}
+# platform = Not Applicable
+{{% else %}}
 # platform = multi_platform_all
+{{% endif %}}
 # variables = var_rekey_limit_size=900M,var_rekey_limit_time=3h
 
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/no_line_directory.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/no_line_directory.fail.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Oracle Linux 9,Red Hat Enterprise Linux 9
+{{% if sshd_distributed_config == "false" %}}
+# platform = Not Applicable
+{{% else %}}
+# platform = multi_platform_all
+{{% endif %}}
 
 mkdir -p /etc/ssh/sshd_config.d
 touch /etc/ssh/sshd_config.d/nothing

--- a/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/param_conflict_directory.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/param_conflict_directory.fail.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
-
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 9,Oracle Linux 9
+{{% if sshd_distributed_config == "false" %}}
+# platform = Not Applicable
+{{% else %}}
+# platform = multi_platform_all
+{{% endif %}}
 
 SSHD_PARAM="RekeyLimit"
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/wrong_main_file_correct_directory.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/wrong_main_file_correct_directory.pass.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
-
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 9,Oracle Linux 9
+{{% if sshd_distributed_config == "false" %}}
+# platform = Not Applicable
+{{% else %}}
+# platform = multi_platform_all
+{{% endif %}}
 
 SSHD_PARAM="RekeyLimit"
 


### PR DESCRIPTION
The test /per-rule/oscap/3/sshd_rekey_limit/correct_value_directory.pass fails. The reason of the fail is that we don't support distributed configuration in directory for sshd on RHEL 8.  This is signalized by variable `sshd_distributed_config` which is a property of each product. We will make the test scenario applicability based on this variable which will disable this test scenario on RHEL 8. Also we will do a similar change on other test scenarios in this rule that test the configuration in the directory.

Fixes: https://github.com/ComplianceAsCode/content/issues/13720


