### PR TITLE
Fix tests for rule grub2_pti_argument

### DIFF
--- a/shared/templates/grub2_bootloader_argument/tests/arg_not_in_entries.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/arg_not_in_entries.fail.sh
@@ -15,8 +15,8 @@ source common.sh
 # Removes argument from kernel command line in /boot/loader/entries/*.conf
 
 for file in /boot/loader/entries/*.conf ; do
-  if grep -q '^.*{{{ ESCAPED_ARG_NAME }}}=\?.*'  "$file" ; then
-	    sed -i 's/\(^.*\){{{ARG_NAME}}}=\?[^[:space:]]*\(.*\)/\1 \2/'  "$file"
+  if grep -q '^.*\<{{{ ARG_NAME }}}\>=\?.*' "$file" ; then
+	    sed -i 's/\(^.*\)\<{{{ ARG_NAME }}}\>=\?[^[:space:]]*\(.*\)/\1 \2/' "$file"
   fi
 # ensure that grubenv is not referenced
   if grep -q '\$kernelopts' "$file"; then

--- a/shared/templates/grub2_bootloader_argument/tests/arg_not_in_etcdefaultgrub.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/arg_not_in_etcdefaultgrub.fail.sh
@@ -12,6 +12,6 @@ source common.sh
 {{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}
 
 # Removes argument from kernel command line in /etc/default/grub
-if grep -q '^GRUB_CMDLINE_LINUX=.*{{{ARG_NAME}}}=\?.*"'  '/etc/default/grub' ; then
-	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\){{{ARG_NAME}}}=\?[^[:space:]]*\(.*"\)/\1 \2/'  '/etc/default/grub'
+if grep -q '^GRUB_CMDLINE_LINUX=.*\<{{{ ARG_NAME }}}\>=\?.*"'  '/etc/default/grub' ; then
+	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)\<{{{ ARG_NAME }}}\>=\?[^[:space:]]*\(.*"\)/\1 \2/'  '/etc/default/grub'
 fi

--- a/shared/templates/grub2_bootloader_argument/tests/arg_not_in_etcdefaultgrub_recovery_disabled.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/arg_not_in_etcdefaultgrub_recovery_disabled.fail.sh
@@ -11,12 +11,12 @@ source common.sh
 {{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}
 
 # Removes the argument from kernel command line in /etc/default/grub
-if grep -q '^GRUB_CMDLINE_LINUX_DEFAULT=.*{{{ARG_NAME}}}=\?.*"'  '/etc/default/grub' ; then
-	sed -i 's/\(^GRUB_CMDLINE_LINUX_DEFAULT=".*\){{{ARG_NAME}}}=\?[^[:space:]]*\(.*"\)/\1 \2/'  '/etc/default/grub'
+if grep -q '^GRUB_CMDLINE_LINUX_DEFAULT=.*\<{{{ ARG_NAME }}}\>=\?.*"' '/etc/default/grub' ; then
+	sed -i 's/\(^GRUB_CMDLINE_LINUX_DEFAULT=".*\)\<{{{ ARG_NAME }}}\>=\?[^[:space:]]*\(.*"\)/\1 \2/' '/etc/default/grub'
 fi
 
 # removing the parameter from the no recovery kernel parameters as well
-sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\){{{ARG_NAME}}}=\?[^[:space:]]*\(.*"\)/\1 \2/'  '/etc/default/grub'
+sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)\<{{{ ARG_NAME }}}\>=\?[^[:space:]]*\(.*"\)/\1 \2/' '/etc/default/grub'
 
 # disabling recovery
 sed -i 's/\(^.*GRUB_DISABLE_RECOVERY=\).*/\1true/' '/etc/default/grub'

--- a/shared/templates/grub2_bootloader_argument/tests/correct_recovery_disabled.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_recovery_disabled.pass.sh
@@ -16,16 +16,16 @@ source common.sh
 {{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}
 
 # Correct the form of default kernel command line in GRUB /etc/default/grub and applies value through Grubby
-if grep -q '^GRUB_CMDLINE_LINUX_DEFAULT=.*{{{ ARG_NAME }}}=\?.*"'  '/etc/default/grub' ; then
+if grep -q '^GRUB_CMDLINE_LINUX_DEFAULT=.*\<{{{ ARG_NAME }}}\>=\?.*"'  '/etc/default/grub' ; then
 	# modify the GRUB command-line if an arg=value already exists
-	sed -i 's/\(^GRUB_CMDLINE_LINUX_DEFAULT=".*\){{{ ARG_NAME }}}=\?[^[:space:]]*\(.*"\)/\1 {{{ ARG_NAME_VALUE }}} \2/'  '/etc/default/grub'
+	sed -i 's/\(^GRUB_CMDLINE_LINUX_DEFAULT=".*\)\<{{{ ARG_NAME }}}\>=\?[^[:space:]]*\(.*"\)/\1 {{{ ARG_NAME_VALUE }}} \2/'  '/etc/default/grub'
 else
 	# no arg is present, append it
 	sed -i 's/\(^GRUB_CMDLINE_LINUX_DEFAULT=".*\)"/\1 {{{ ARG_NAME_VALUE }}}"/'  '/etc/default/grub'
 fi
 
 # removing the parameter from the no recovery kernel parameters as well
-sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\){{{ ARG_NAME }}}=\?[^[:space:]]*\(.*"\)/\1 \2/'  '/etc/default/grub'
+sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)\<{{{ ARG_NAME }}}\>=\?[^[:space:]]*\(.*"\)/\1 \2/'  '/etc/default/grub'
 
 # disabling recovery
 sed -i 's/\(^.*GRUB_DISABLE_RECOVERY=\).*/\1true/' '/etc/default/grub'

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_grubenv_only.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_grubenv_only.pass.sh
@@ -11,20 +11,20 @@ source common.sh
 
 # adds argument from kernel command line into /etc/default/grub
 file="/etc/default/grub"
-if grep -q '^GRUB_CMDLINE_LINUX=.*{{{ARG_NAME}}}=\?.*"'  "$file"; then
-	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\){{{ARG_NAME}}}=\?[^[:space:]]*\(.*"\)/\1 {{{ARG_NAME_VALUE}}} \2/'  "$file"
+if grep -q '^GRUB_CMDLINE_LINUX=.*\<{{{ ARG_NAME }}}\>=\?.*"'  "$file"; then
+	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)\<{{{ ARG_NAME }}}\>=\?[^[:space:]]*\(.*"\)/\1 {{{ ARG_NAME_VALUE }}} \2/' "$file"
 else
-	sed -i 's/^GRUB_CMDLINE_LINUX=".*/GRUB_CMDLINE_LINUX="{{{ARG_NAME_VALUE}}}"/'  "$file"
+	sed -i 's/^GRUB_CMDLINE_LINUX=".*/GRUB_CMDLINE_LINUX="{{{ ARG_NAME_VALUE }}}"/' "$file"
 fi
 
 # configure the argument in kernel command line in /boot/grub2/grubenv
 file="/boot/grub2/grubenv"
-if grep -q '^.*{{{ARG_NAME}}}=\?.*' "$file"; then
+if grep -q '^.*\<{{{ ARG_NAME }}}\>=\?.*' "$file"; then
 	# modify the GRUB command-line if the arg already exists
-	sed -i 's/\(^.*\){{{ARG_NAME}}}=\?[^[:space:]]*\(.*\)/\1 {{{ARG_NAME_VALUE}}} \2/'  "$file"
+	sed -i 's/\(^.*\)\<{{{ ARG_NAME }}}\>=\?[^[:space:]]*\(.*\)/\1 {{{ ARG_NAME_VALUE }}} \2/' "$file"
 else
 	# no arg is present, append it
-	sed -i 's/\(^.*\(vmlinuz\|kernelopts\).*\)/\1 {{{ARG_NAME_VALUE}}}/'  "$file"
+	sed -i 's/\(^.*\(vmlinuz\|kernelopts\).*\)/\1 {{{ ARG_NAME_VALUE }}}/' "$file"
 fi
 
 

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value_mix_entries_and_grubenv.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value_mix_entries_and_grubenv.pass.sh
@@ -11,20 +11,20 @@ source common.sh
 
 # adds argument from kernel command line into /etc/default/grub
 file="/etc/default/grub"
-if grep -q '^GRUB_CMDLINE_LINUX=.*{{{ARG_NAME}}}=\?.*"'  "$file"; then
-	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\){{{ARG_NAME}}}=\?[^[:space:]]*\(.*"\)/\1 {{{ARG_NAME_VALUE}}} \2/'  "$file"
+if grep -q '^GRUB_CMDLINE_LINUX=.*\<{{{ ARG_NAME }}}\>=\?.*"'  "$file"; then
+	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)\<{{{ ARG_NAME }}}\>=\?[^[:space:]]*\(.*"\)/\1 {{{ ARG_NAME_VALUE }}} \2/' "$file"
 else
-	sed -i 's/^GRUB_CMDLINE_LINUX=".*/GRUB_CMDLINE_LINUX="{{{ARG_NAME_VALUE}}}"/'  "$file"
+	sed -i 's/^GRUB_CMDLINE_LINUX=".*/GRUB_CMDLINE_LINUX="{{{ ARG_NAME_VALUE }}}"/' "$file"
 fi
 
 # configure the argument in kernel command line in /boot/grub2/grubenv
 file="/boot/grub2/grubenv"
-if grep -q '^.*{{{ARG_NAME}}}=\?.*' "$file"; then
+if grep -q '^.*\<{{{ ARG_NAME }}}\>=\?.*' "$file"; then
 	# modify the GRUB command-line if the arg already exists
-	sed -i 's/\(^.*\){{{ARG_NAME}}}=\?[^[:space:]]*\(.*\)/\1 {{{ARG_NAME_VALUE}}} \2/'  "$file"
+	sed -i 's/\(^.*\)\<{{{ ARG_NAME }}}\>=\?[^[:space:]]*\(.*\)/\1 {{{ ARG_NAME_VALUE }}} \2/' "$file"
 else
 	# no arg is present, append it
-	sed -i 's/\(^.*\(vmlinuz\|kernelopts\).*\)/\1 {{{ARG_NAME_VALUE}}}/'  "$file"
+	sed -i 's/\(^.*\(vmlinuz\|kernelopts\).*\)/\1 {{{ ARG_NAME_VALUE }}}/' "$file"
 fi
 
 
@@ -35,7 +35,7 @@ rm -f /boot/loader/entries/*.conf
 		echo 'version 5.0'
 		echo 'linux /vmlinuz'
 		echo 'initrd /initramfs'
-		echo 'options root=UUID=abc-def rhgb ro quiet mock {{{ARG_NAME_VALUE}}}'
+		echo 'options root=UUID=abc-def rhgb ro quiet mock {{{ ARG_NAME_VALUE }}}'
 		echo 'grub_users $grub_users'
 		echo 'grub_arg --unrestricted'
 	} > /boot/loader/entries/mock.conf

--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value_entries.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value_entries.fail.sh
@@ -16,9 +16,9 @@ source common.sh
 
 # Breaks argument from kernel command line in /boot/loader/entries/*.conf
 for file in /boot/loader/entries/*.conf ; do
-  if grep -q '^.*{{{ ESCAPED_ARG_NAME }}}=\?.*'  "$file" ; then
+  if grep -q '^.*\<{{{ ARG_NAME }}}\>=\?.*'  "$file" ; then
       # modify the GRUB command-line if an ={{{ARG_NAME}}} arg already exists
-	    sed -i 's/\(^.*\){{{ ARG_NAME }}}=\?[^[:space:]]*\(.*\)/\1 {{{ ARG_NAME_VALUE_WRONG }}} \2/' "$file"
+	    sed -i 's/\(^.*\)\<{{{ ARG_NAME }}}\>=\?[^[:space:]]*\(.*\)/\1 {{{ ARG_NAME_VALUE_WRONG }}} \2/' "$file"
     else
 	    # no {{{ARG_NAME}}}=arg is present, append it
 	    sed -i 's/\(^.*\(vmlinuz\|kernelopts\).*\)/\1 {{{ ARG_NAME_VALUE_WRONG }}}/'  "$file"

--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value_etcdefaultgrub_recovery_disabled.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value_etcdefaultgrub_recovery_disabled.fail.sh
@@ -15,16 +15,16 @@ source common.sh
 rm -f /etc/default/grub.d/*
 
 # Correct the form of default kernel command line in GRUB /etc/default/grub and applies value through Grubby
-if grep -q '^GRUB_CMDLINE_LINUX_DEFAULT=.*{{{ ESCAPED_ARG_NAME }}}=\?.*"'  '/etc/default/grub' ; then
+if grep -q '^GRUB_CMDLINE_LINUX_DEFAULT=.*\<{{{ ARG_NAME }}}\>=\?.*"'  '/etc/default/grub' ; then
 	# modify the GRUB command-line if an arg=value already exists
-	sed -i 's/\(^GRUB_CMDLINE_LINUX_DEFAULT=".*\){{{ ARG_NAME }}}=\?[^[:space:]]*\(.*"\)/\1{{{ ARG_NAME_VALUE_WRONG }}} \2/'  '/etc/default/grub'
+	sed -i 's/\(^GRUB_CMDLINE_LINUX_DEFAULT=".*\)\<{{{ ARG_NAME }}}\>=\?[^[:space:]]*\(.*"\)/\1{{{ ARG_NAME_VALUE_WRONG }}} \2/'  '/etc/default/grub'
 else
 	# no arg is present, append it
 	sed -i 's/\(^GRUB_CMDLINE_LINUX_DEFAULT=".*\)"/\1{{{ ARG_NAME_VALUE_WRONG }}}"/'  '/etc/default/grub'
 fi
 
 # removing the parameter from the no recovery kernel parameters as well
-sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\){{{ ARG_NAME }}}=\?[^[:space:]]*\(.*"\)/\1 \2/'  '/etc/default/grub'
+sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)\<{{{ ARG_NAME }}}\>=\?[^[:space:]]*\(.*"\)/\1 \2/'  '/etc/default/grub'
 
 # disabling recovery
 sed -i 's/\(^.*GRUB_DISABLE_RECOVERY=\).*/\1true/' '/etc/default/grub'

--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value_grubenv.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value_grubenv.fail.sh
@@ -17,12 +17,12 @@ source common.sh
 
 # Break the argument in kernel command line in /boot/grub2/grubenv
 file="/boot/grub2/grubenv"
-if grep -q '^.*{{{ARG_NAME}}}=\?.*'  "$file" ; then
+if grep -q '^.*\<{{{ ARG_NAME }}}\>=\?.*' "$file" ; then
 	# modify the GRUB command-line if the arg already exists
-	sed -i 's/\(^.*\){{{ ARG_NAME }}}=\?[^[:space:]]*\(.*\)/\1 {{{ ARG_NAME_VALUE_WRONG }}}=wrong \2/'  "$file"
+	sed -i 's/\(^.*\)\<{{{ ARG_NAME }}}\>=\?[^[:space:]]*\(.*\)/\1 {{{ ARG_NAME_VALUE_WRONG }}}=wrong \2/' "$file"
 else
 	# no arg is present, append it
-	sed -i 's/\(^.*\(vmlinuz\|kernelopts\).*\)/\1 {{{ ARG_NAME_VALUE_WRONG }}}=wrong/'  "$file"
+	sed -i 's/\(^.*\(vmlinuz\|kernelopts\).*\)/\1 {{{ ARG_NAME_VALUE_WRONG }}}=wrong/' "$file"
 fi
 
 # Ensure that grubenv is referenced through $kernelopts


### PR DESCRIPTION
Some test scenarios for rule `grub2_pti_argument` are failing.  The reason is that `pti` is a substring of `options`.  This is caused by recent change that make the equal sign `=` optional.  This change has been introduced by
https://github.com/ComplianceAsCode/content/pull/13726. After this change some regular expressions for the `pti` argument started to match `options`. We will prevent that by using word bounds marks (`\<` and `\>`) in regular expressions. Also, as a part of this commit we will fix coding style.



#### Rationale

Fixes: https://github.com/ComplianceAsCode/content/issues/13732


#### Review Hints:

Run automatus for grub2_pti_argument, grub2_audit_argument and grub2_nousb_argument
