### PR TITLE
CI: fedora gating - collapse the multiline command

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -137,7 +137,7 @@ jobs:
           run: pip install -r requirements-base.txt -r test-requirements.txt
       -   name: Build
           run: |-
-            ./build_product al2023  alinux2  alinux3 anolis23 anolis8 chromium fedora firefox ocp4  rhcos4 rhel8 rhel9 rhel10
+            ./build_product al2023 alinux2 alinux3 anolis23 anolis8 chromium fedora firefox ocp4 rhcos4 rhel8 rhel9 rhel10
           env:
             ADDITIONAL_CMAKE_OPTIONS: "-DSSG_OVAL_SCHEMATRON_VALIDATION_ENABLED=OFF"
       -   name: Test

--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -137,20 +137,7 @@ jobs:
           run: pip install -r requirements-base.txt -r test-requirements.txt
       -   name: Build
           run: |-
-            ./build_product \
-                al2023 \
-                alinux2 \
-                alinux3 \
-                anolis23 \
-                anolis8 \
-                chromium \
-                fedora \
-                firefox \
-                ocp4 \
-                rhcos4 \
-                rhel8 \
-                rhel9 \
-                rhel10 \
+            ./build_product al2023  alinux2  alinux3 anolis23 anolis8 chromium fedora firefox ocp4  rhcos4 rhel8 rhel9 rhel10
           env:
             ADDITIONAL_CMAKE_OPTIONS: "-DSSG_OVAL_SCHEMATRON_VALIDATION_ENABLED=OFF"
       -   name: Test


### PR DESCRIPTION
#### Description:

- collapse the multiline command into one line

#### Rationale:

- it seems that when breaking the line with backslash, it fails to run gating on Fedora RAwhide


#### Review Hints:

Check the CI.

- _Use this optional section to give any relevant information which could help the reviewer to more quickly and assertively understand and test the changes._

- _Good examples are useful commands, if it is better to review all commits together or in a suggested sequence, any relevant discussion in other PRs or issues, etc._
