### PR TITLE
stop using fixfiles relabel in remediations

### DIFF
--- a/linux_os/guide/system/selinux/selinux_not_disabled/ansible/shared.yml
+++ b/linux_os/guide/system/selinux/selinux_not_disabled/ansible/shared.yml
@@ -5,3 +5,8 @@
 # disruption = low
 
 {{{ ansible_selinux_config_set(parameter="SELINUX", value="permissive", rule_title=rule_title) }}}
+
+- name: "{{{ RULE_TITLE }}} - Mark system to relabel SELinux on next boot"
+  ansible.builtin.file:
+    path: /.autorelabel
+    state: touch

--- a/linux_os/guide/system/selinux/selinux_not_disabled/bash/shared.sh
+++ b/linux_os/guide/system/selinux/selinux_not_disabled/bash/shared.sh
@@ -7,4 +7,3 @@
 {{{ bash_selinux_config_set(parameter="SELINUX", value="permissive", rule_id=rule_id) }}}
 
 fixfiles onboot
-fixfiles -f relabel

--- a/linux_os/guide/system/selinux/selinux_not_disabled/rule.yml
+++ b/linux_os/guide/system/selinux/selinux_not_disabled/rule.yml
@@ -9,6 +9,9 @@ description: |-
     <pre>SELINUX=enforcing</pre>
     OR
     <pre>SELINUX=permissive</pre>
+    Ensure that all files have correct SELinux labels by running:
+    <pre>fixfiles onboot</pre>
+    Then reboot the system.
 
 rationale: |-
     Running SELinux in disabled mode is strongly discouraged. It prevents enforcing the SELinux

--- a/linux_os/guide/system/selinux/selinux_state/ansible/shared.yml
+++ b/linux_os/guide/system/selinux/selinux_state/ansible/shared.yml
@@ -6,3 +6,8 @@
 {{{ ansible_instantiate_variables("var_selinux_state") }}}
 
 {{{ ansible_selinux_config_set(parameter="SELINUX", value="{{ var_selinux_state }}", rule_title=rule_title) }}}
+
+- name: "{{{ RULE_TITLE }}} - Mark system to relabel SELinux on next boot"
+  ansible.builtin.file:
+    path: /.autorelabel
+    state: touch

--- a/linux_os/guide/system/selinux/selinux_state/bash/shared.sh
+++ b/linux_os/guide/system/selinux/selinux_state/bash/shared.sh
@@ -9,4 +9,3 @@
 {{{ bash_selinux_config_set(parameter="SELINUX", value="$var_selinux_state", rule_id=rule_id) }}}
 
 fixfiles onboot
-fixfiles -f relabel

--- a/linux_os/guide/system/selinux/selinux_state/rule.yml
+++ b/linux_os/guide/system/selinux/selinux_state/rule.yml
@@ -10,6 +10,9 @@ description: |-
     system boot time.  In the file <tt>/etc/selinux/config</tt>, add or correct the
     following line to configure the system to boot into enforcing mode:
     <pre>SELINUX={{{ xccdf_value("var_selinux_state") }}}</pre>
+    Ensure that all files have correct SELinux labels by running:
+    <pre>fixfiles onboot</pre>
+    Then reboot the system.
 
 rationale: |-
     Setting the SELinux state to enforcing ensures SELinux is able to confine


### PR DESCRIPTION
#### Description:

- make following modifications to selinux_state and selinux_not_disabled rules:
    - stop using fixfiles -F relabel
    - enhance the description to inform that fixfiles onboot should be used and the system should be rebooted
    - add Ansible task which basically does the same thing as if fixfiles onboot would be run

#### Rationale:

- there is no policy which mandates fixfiles relabel to be actually used, fixfiles onboot should be enough
- Moreover, the current implementation is inconsistent - Bash remediation is not the same as Ansible.
- Also the current Bash remediation clears the /tmp directory and that is not expected.

- Fixes https://issues.redhat.com/browse/RHEL-99311

#### Review Hints:

Run Automatus tests.