### PR TITLE
Reduce gathering facts in profile Ansible Playbooks

### DIFF
--- a/build-scripts/generate_profile_remediations.py
+++ b/build-scripts/generate_profile_remediations.py
@@ -168,63 +168,6 @@ def ansible_tasks_to_string(tasks):
     return tasks_str
 
 
-facts_task = collections.OrderedDict([
-    ('name', 'Gather the package facts'),
-    ('ansible.builtin.package_facts', {'manager': 'auto'})
-])
-
-
-def task_is(task, names):
-    """
-    Check if the task is one of the given names.
-    """
-    for name in names:
-        if name in task:
-            return True
-    return False
-
-
-class AnsibleSnippetsProcessor:
-    def __init__(self, all_snippets):
-        self.all_snippets = all_snippets
-        self.package_tasks = []
-        self.other_tasks = []
-
-    def _process_task(self, task):
-        if task_is(task, ["block"]):
-            # Process block tasks recursively
-            new_block = []
-            for subtask in task["block"]:
-                if self._process_task(subtask) is not None:
-                    new_block.append(subtask)
-            task["block"] = new_block
-            return task if new_block else None
-        if task_is(task, ["ansible.builtin.package_facts", "package_facts"]):
-            # Skip package_facts tasks because they will be replaced by
-            # a single package_facts task that will be added later
-            return None
-        if task_is(task, ["ansible.builtin.package", "package"]):
-            # Collect package tasks to be processed later
-            self.package_tasks.append(task)
-            return None
-        return task
-
-    def _process_snippet(self, snippet):
-        tasks = ssg.yaml.ordered_load(snippet)
-        for task in tasks:
-            if self._process_task(task) is not None:
-                self.other_tasks.append(task)
-
-    def process_snippets(self):
-        for snippet in self.all_snippets:
-            self._process_snippet(snippet)
-
-    def get_ansible_tasks(self):
-        self.package_tasks.insert(0, facts_task)
-        self.package_tasks.append(facts_task)
-        return self.package_tasks + self.other_tasks
-
-
 class ScriptGenerator:
     def __init__(self, language, product_id, ds_file_path, output_dir):
         self.language = language
@@ -280,7 +223,7 @@ class ScriptGenerator:
     def create_output_ansible(self, profile_el):
         ansible_vars, ansible_snippets = self.collect_ansible_vars_and_tasks(
             profile_el)
-        sp = AnsibleSnippetsProcessor(ansible_snippets)
+        sp = ssg.ansible.AnsibleSnippetsProcessor(ansible_snippets)
         sp.process_snippets()
         ansible_tasks = sp.get_ansible_tasks()
         profile_id = profile_el.get("id")

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/ansible/shared.yml
@@ -16,7 +16,6 @@
 
 - name: '{{{ rule_title }}} - Collect facts about system services'
   ansible.builtin.service_facts:
-  register: result_services_states
 
 - name: '{{{ rule_title }}} - Remediation is applicable if firewalld and NetworkManager services are running'
   block:

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_trusted/ansible/shared.yml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/firewalld_loopback_traffic_trusted/ansible/shared.yml
@@ -13,7 +13,6 @@
 
 - name: '{{{ rule_title }}} - Collect Facts About System Services'
   ansible.builtin.service_facts:
-  register: result_services_states
 
 - name: '{{{ rule_title }}} - Remediation is Applicable if firewalld Service is Running'
   block:

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/ansible/shared.yml
@@ -5,24 +5,16 @@
 # disruption = low
 - name: "Ensure AIDE is installed"
   package:
-    name: "{{ item }}"
+    name: aide
     state: present
-  with_items:
-    - aide
-
-- name: Set cron package name - RedHat
-  set_fact:
-    cron_pkg_name: cronie
-  when: ansible_os_family == "RedHat" or ansible_os_family == "Suse"
-
-- name: Set cron package name - Debian
-  set_fact:
-    cron_pkg_name: cron
-  when: ansible_os_family == "Debian"
 
 - name: Install cron
   package:
-    name: "{{ cron_pkg_name }}"
+{{% if "ubuntu" in product or "debian" in product %}}
+    name: cron
+{{% else %}}
+    name: cronie
+{{% endif %}}
     state: present
 
 {{% if product != 'ubuntu2404' %}}

--- a/shared/templates/service_disabled/ansible.template
+++ b/shared/templates/service_disabled/ansible.template
@@ -6,35 +6,39 @@
 
 {{%- if init_system == "systemd" %}}
 
-- name: "{{{ rule_title }}} - Collect systemd Services Present in the System"
-  ansible.builtin.command: systemctl -q list-unit-files --type service
-  register: service_exists
-  changed_when: false
-  failed_when: service_exists.rc not in [0, 1]
-  check_mode: false
+- name: "{{{ rule_title }}} - Disable service {{{ SERVICENAME }}}"
+  block:
+  - name: "{{{ rule_title }}} - Collect systemd Services Present in the System"
+    ansible.builtin.command: systemctl -q list-unit-files --type service
+    register: service_exists
+    changed_when: false
+    failed_when: service_exists.rc not in [0, 1]
+    check_mode: false
 
-- name: "{{{ rule_title }}} - Ensure {{{ DAEMONNAME }}}.service is Masked"
-  ansible.builtin.systemd:
-    name: "{{{ DAEMONNAME }}}.service"
-    state: "stopped"
-    enabled: false
-    masked: true
-  when: 'service_exists.stdout_lines is search("{{{ SERVICENAME }}}.service", multiline=True)'
+  - name: "{{{ rule_title }}} - Ensure {{{ DAEMONNAME }}}.service is Masked"
+    ansible.builtin.systemd:
+      name: "{{{ DAEMONNAME }}}.service"
+      state: "stopped"
+      enabled: false
+      masked: true
+    when: 'service_exists.stdout_lines is search("{{{ SERVICENAME }}}.service", multiline=True)'
 
-- name: "Unit Socket Exists - {{{ DAEMONNAME }}}.socket"
-  ansible.builtin.command: systemctl -q list-unit-files {{{ DAEMONNAME }}}.socket
-  register: socket_file_exists
-  changed_when: false
-  failed_when: socket_file_exists.rc not in [0, 1]
-  check_mode: false
+  - name: "Unit Socket Exists - {{{ DAEMONNAME }}}.socket"
+    ansible.builtin.command: systemctl -q list-unit-files {{{ DAEMONNAME }}}.socket
+    register: socket_file_exists
+    changed_when: false
+    failed_when: socket_file_exists.rc not in [0, 1]
+    check_mode: false
 
-- name: "{{{ rule_title }}} - Disable Socket {{{ SERVICENAME }}}"
-  ansible.builtin.systemd:
-    name: "{{{ DAEMONNAME }}}.socket"
-    enabled: false
-    state: "stopped"
-    masked: true
-  when: 'socket_file_exists.stdout_lines is search("{{{ DAEMONNAME }}}.socket", multiline=True)'
+  - name: "{{{ rule_title }}} - Disable Socket {{{ SERVICENAME }}}"
+    ansible.builtin.systemd:
+      name: "{{{ DAEMONNAME }}}.socket"
+      enabled: false
+      state: "stopped"
+      masked: true
+    when: 'socket_file_exists.stdout_lines is search("{{{ DAEMONNAME }}}.socket", multiline=True)'
 {{%- else %}}
 JINJA TEMPLATE ERROR: Unknown init system '{{{ init_system }}}'
 {{%- endif %}}
+  tags:
+  - special_service_block

--- a/shared/templates/service_enabled/ansible.template
+++ b/shared/templates/service_enabled/ansible.template
@@ -21,3 +21,5 @@
 {{%- else %}}
 JINJA TEMPLATE ERROR: Unknown init system '{{{ init_system }}}'
 {{%- endif %}}
+  tags:
+  - special_service_block

--- a/ssg/ansible.py
+++ b/ssg/ansible.py
@@ -85,9 +85,14 @@ def remove_trailing_whitespace(ansible_src):
     return re.sub(r'[ \t]+$', '', ansible_src, 0, flags=re.M)
 
 
-facts_task = collections.OrderedDict([
+package_facts_task = collections.OrderedDict([
     ('name', 'Gather the package facts'),
     ('ansible.builtin.package_facts', {'manager': 'auto'}),
+    ('tags', ['always'])
+])
+service_facts_task = collections.OrderedDict([
+    ('name', 'Gather the service facts'),
+    ('ansible.builtin.service_facts', None),
     ('tags', ['always'])
 ])
 
@@ -153,6 +158,10 @@ class AnsibleSnippetsProcessor:
             # Skip package_facts tasks because they will be replaced by
             # a single package_facts task that will be added later
             return None
+        if task_is(task, ["ansible.builtin.service_facts", "service_facts"]):
+            # Skip service_facts tasks because they will be replaced by
+            # a single service_facts task that will be added later
+            return None
         if task_is(task, ["ansible.builtin.package", "package"]):
             # Collect package tasks to be processed later
             self.package_tasks.append(task)
@@ -188,4 +197,4 @@ class AnsibleSnippetsProcessor:
         Returns:
             list: Combined list of all processed tasks.
         """
-        return [facts_task, *self.package_tasks, copy.deepcopy(facts_task), *self.other_tasks]
+        return [package_facts_task, *self.package_tasks, copy.deepcopy(package_facts_task), service_facts_task, *self.other_tasks]

--- a/ssg/ansible.py
+++ b/ssg/ansible.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import collections
+import copy
 import re
 
 from .constants import ansible_version_requirement_pre_task_name
@@ -186,6 +187,4 @@ class AnsibleSnippetsProcessor:
         Returns:
             list: Combined list of all processed tasks.
         """
-        self.package_tasks.insert(0, facts_task)
-        self.package_tasks.append(facts_task)
-        return self.package_tasks + self.other_tasks
+        return [facts_task, *self.package_tasks, copy.deepcopy(facts_task), *self.other_tasks]

--- a/ssg/ansible.py
+++ b/ssg/ansible.py
@@ -87,7 +87,8 @@ def remove_trailing_whitespace(ansible_src):
 
 facts_task = collections.OrderedDict([
     ('name', 'Gather the package facts'),
-    ('ansible.builtin.package_facts', {'manager': 'auto'})
+    ('ansible.builtin.package_facts', {'manager': 'auto'}),
+    ('tags', ['always'])
 ])
 
 

--- a/tests/unit/ssg-module/test_ansible.py
+++ b/tests/unit/ssg-module/test_ansible.py
@@ -299,3 +299,19 @@ class TestAnsibleSnippetsProcessor:
         # This should raise SystemExit when trying to parse invalid YAML
         with pytest.raises(SystemExit):
             processor.process_snippets()
+
+    def test_process_task_special_service_block(self):
+      """Test processing of special service block tasks."""
+      processor = ssg.ansible.AnsibleSnippetsProcessor([])
+
+      service_task = {
+        "name": "Enable service sshd",
+        "block": [{"name":"Gather package facts", "ansible.builtin.package_facts": {"manager": "auto"}}, {"name": "Enable service sshd", "ansible.builtin.systemd": {"name": "sshd"}}],
+        "tags": ["special_service_block"]
+      }
+      result = processor._process_task(service_task)
+
+      assert result is None  # Service tasks should be skipped
+      assert len(processor.service_tasks) == 1
+      assert processor.service_tasks[0] == service_task
+      assert "ansible.builtin.package_facts" not in processor.service_tasks[0]["block"][0]


### PR DESCRIPTION
#### Description:

This PR introduces additional logic to builder that builds profile oriented Ansible Playbooks. The goal is to reduce amount of `ansible.builtin.package_facts` and  `ansible.builtin.service_facts` in the built Ansible Playbook.

The builder changes order of Ansible Tasks in the Ansible Playbook.

It moves all Ansible Tasks that install or remove packages to the beginning of the Playbook. The outcome of moving these Ansible Tasks is that just two instances of  `ansible.builtin.package_facts`  Ansible Tasks are needed in the Ansible Playbook - first at the beginning of the Ansible Playbook and second after the package installation or removal part.

Similarly, tasks that enable or disable systemd services are moved to beginning, right after installing packages, to prevent need for having multiple `ansible.builtin.service_facts` in the Ansible Playbook.

We can't merge the package installation or removal Ansible Tasks to only 2 Ansible Tasks (one for installation and one for removal) because that would break the use case of skipping or selecting specific rules by using tags.

#### Rationale:

Our Ansible Playbooks take a long time to run. This change will decrease the time they need to complete. Experiments suggest that the change brings about 15 % speed up of a CIS playbook.

Resolves: https://issues.redhat.com/browse/OPENSCAP-6045

#### Review Hints:
Contest tests `/hardening/ansible`
