### PR TITLE
grub2_*_admin_username: make regex less strict

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_admin_username/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_admin_username/oval/shared.xml
@@ -36,7 +36,7 @@
   <ind:textfilecontent54_object id="object_bootloader_unique_superuser" version="1">
     <ind:filepath>{{{ grub2_boot_path }}}/grub.cfg</ind:filepath>
     <ind:pattern operation="pattern match"
-          >^[\s]*set[\s]+superusers="(?i)\b(?!(?:root|admin|administrator)\b)(\w+)".*\nexport superusers$</ind:pattern>
+          >^[\s]*set[\s]+superusers="(?i)\b(?!(?:root|admin|administrator)\b)(\w+)".*\n[\s]*export[\s]+superusers[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_admin_username/tests/unique_username_but_export_indented.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_admin_username/tests/unique_username_but_export_indented.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# remediation = none
+
+. $SHARED/grub2.sh
+
+set_superusers_indented_export "koskic"

--- a/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_admin_username/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_admin_username/oval/shared.xml
@@ -36,7 +36,7 @@
   <ind:textfilecontent54_object id="object_bootloader_uefi_unique_superuser" version="1">
     <ind:filepath>{{{ grub2_uefi_boot_path }}}/grub.cfg</ind:filepath>
     <ind:pattern operation="pattern match"
-          >^[\s]*set[\s]+superusers="(?i)\b(?!(?:root|admin|administrator)\b)(\w+)".*\nexport superusers$</ind:pattern>
+          >^[\s]*set[\s]+superusers="(?i)\b(?!(?:root|admin|administrator)\b)(\w+)".*\n[\s]*export[\s]+superusers[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_admin_username/tests/unique_username_but_export_indented.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_admin_username/tests/unique_username_but_export_indented.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# remediation = none
+
+. $SHARED/grub2.sh
+
+set_grub_uefi_root
+
+set_superusers_indented_export "koskic"

--- a/tests/shared/grub2.sh
+++ b/tests/shared/grub2.sh
@@ -48,3 +48,8 @@ function set_root_unquoted {
 function set_superusers_no_export {
 	set_superusers_unquoted "\"$1\""
 }
+
+function set_superusers_indented_export {
+	set_superusers_unquoted "\"$1\""
+	echo "    export superusers" >> "$GRUB_CFG_ROOT/grub.cfg"
+}


### PR DESCRIPTION
#### Description:

- allow indentation and more spaces in the regex which checks for configuration of Grub2 admin users

#### Rationale:



- Fixes https://issues.redhat.com/browse/RHEL-104969

#### Review Hints:

Run automatus tests on grub2_admin_username and grub2_uefi_admin_username