### PR TITLE
Add OL9 in oval to directory_permissions_var_log_audit rule

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/directory_permissions_var_log_audit/oval/shared.xml
+++ b/linux_os/guide/auditing/auditd_configure_rules/directory_permissions_var_log_audit/oval/shared.xml
@@ -2,7 +2,7 @@
   <definition class="compliance" id="directory_permissions_var_log_audit" version="1">
     {{{ oval_metadata("Checks for correct permissions for audit logs.", rule_title=rule_title) }}}
     <criteria operator="OR">
-      {{% if product not in ["ol8"] and 'rhel' not in product %}}
+      {{% if 'ol' not in families and 'rhel' not in product %}}
       <criteria operator="AND" comment="log_file set">
         <extend_definition comment="log_file set in auditd.conf" definition_ref="auditd_conf_log_file_not_set" negate="true" />
         <criteria operator="AND" comment="log_group in auditd.conf is not root">


### PR DESCRIPTION
#### Description:

Add OL9 to oval conditional in directory_permissions_var_log_audit rule

#### Rationale:

Incorrect behavior for OL9 
