### PR TITLE
add kickstart file for bsi profile in rhel9

### DIFF
--- a/products/rhel9/kickstart/ssg-rhel9-bsi-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-bsi-ks.cfg
@@ -1,0 +1,150 @@
+# SCAP Security Guide BSI profile (SYS.1.1 and SYS.1.3) kickstart for Red Hat Enterprise Linux 9 Server
+# Version: 0.0.1
+# Date: 2025-07-28
+#
+# Based on:
+# https://pykickstart.readthedocs.io/en/latest/
+# For more information see the following documentation:
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/scanning-the-system-for-configuration-compliance-and-vulnerabilities_security-hardening#deploying-baseline-compliant-rhel-systems-using-kickstart_deploying-systems-that-are-compliant-with-a-security-profile-immediately-after-an-installation
+
+# Specify installation method to use for installation
+# To use a different one comment out the 'url' one below, update
+# the selected choice with proper options & un-comment it
+#
+# Install from an installation tree on a remote server via FTP or HTTP:
+# --url		the URL to install from
+#
+# Example:
+#
+# url --url=http://192.168.122.1/image
+#
+# Modify concrete URL in the above example appropriately to reflect the actual
+# environment machine is to be installed in
+#
+# Other possible / supported installation methods:
+# * install from the first CD-ROM/DVD drive on the system:
+#
+# cdrom
+#
+# * install from a directory of ISO images on a local drive:
+#
+# harddrive --partition=hdb2 --dir=/tmp/install-tree
+#
+# * install from provided NFS server:
+#
+# nfs --server=<hostname> --dir=<directory> [--opts=<nfs options>]
+#
+
+# Set language to use during installation and the default language to use on the installed system (required)
+lang en_US.UTF-8
+
+# Set system keyboard type / layout (required)
+keyboard --vckeymap us
+
+# Configure network information for target system and activate network devices in the installer environment (optional)
+# --onboot	enable device at a boot time
+# --device	device to be activated and / or configured with the network command
+# --bootproto	method to obtain networking configuration for device (default dhcp)
+network --onboot yes --device eth0 --bootproto dhcp
+
+# Set the system's root password (required)
+# Plaintext password is: server
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
+# encrypted password form for different plaintext password
+rootpw --iscrypted $6$/0RYeeRdK70ynvYz$jH2ZN/80HM6DjndHMxfUF9KIibwipitvizzXDH1zW.fTjyD3RD3tkNdNUaND18B/XqfAUW3vy1uebkBybCuIm0
+
+# The selected profile will restrict root login
+# Add a user that can login and escalate privileges
+# Plaintext password is: admin123
+user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUafQM9jyHCY9BiE5/ahXLNWUMiVQnFGblu0WWGZ1e6icTaCGO4GNgZNtspp1Let/qpM7FMVB0 --iscrypted
+
+# Configure firewall settings for the system (optional)
+# --enabled	reject incoming connections that are not in response to outbound requests
+# --ssh		allow sshd service through the firewall
+firewall --enabled --ssh
+
+# State of SELinux on the installed system (optional)
+# Defaults to enforcing
+selinux --enforcing
+
+# Set the system time zone (required)
+# since BSI is a local profile, we assume German Timezone
+timezone --utc Europe/Berlin
+
+# Specify how the bootloader should be installed (required)
+# Plaintext password is: password
+# Refer to e.g. grub2-mkpasswd-pbkdf2 to see how to create
+# encrypted password form for different plaintext password
+bootloader --password=grub.pbkdf2.sha512.10000.45912D32B964BA58B91EAF9847F3CCE6F4C962638922543AFFAEE4D29951757F4336C181E6FC9030E07B7D9874DAD696A1B18978D995B1D7F27AF9C38159FDF3.99F65F3896012A0A3D571A99D6E6C695F3C51BE5343A01C1B6907E1C3E1373CB7F250C2BC66C44BB876961E9071F40205006A05189E51C2C14770C70C723F3FD --iscrypted
+
+# Initialize (format) all disks (optional)
+zerombr
+
+# The following partition layout scheme assumes disk of size 20GB or larger
+# Modify size of partitions appropriately to reflect actual machine's hardware
+#
+# Remove Linux partitions from the system prior to creating new ones (optional)
+# --linux	erase all Linux partitions
+# --initlabel	initialize the disk label to the default based on the underlying architecture
+clearpart --linux --initlabel
+
+# Create primary system partitions (required for installs)
+part /boot --fstype=xfs --size=512
+part pv.01 --grow --size=1
+
+# Create a Logical Volume Management (LVM) group (optional)
+volgroup VolGroup pv.01
+
+# Create particular logical volumes (optional)
+logvol / --fstype=xfs --name=root --vgname=VolGroup --size=4272
+# Ensure /usr Located On Separate Partition
+# partition_for_usr
+logvol /usr --fstype=xfs --name=usr --vgname=VolGroup --size=5000 --fsoptions="nodev"
+# Ensure /opt Located On Separate Partition
+# partition_for_opt
+logvol /opt --fstype=xfs --name=opt --vgname=VolGroup --size=1024
+# Ensure /home Located On Separate Partition
+# partition_for_home
+logvol /home --fstype=xfs --name=home --vgname=VolGroup --size=1024 --fsoptions="nodev"
+# Ensure /tmp Located On Separate Partition
+# partition_for_tmp
+logvol /tmp --fstype=xfs --name=tmp --vgname=VolGroup --size=1024 --fsoptions="nodev,noexec,nosuid"
+# Ensure /var/tmp Located On Separate Partition
+# partition_for_var_tmp
+logvol /var/tmp --fstype=xfs --name=vartmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var Located On Separate Partition
+# partition_for_var
+logvol /var --fstype=xfs --name=var --vgname=VolGroup --size=3072
+# Ensure /var/log Located On Separate Partition
+# partition_for_var_log
+logvol /var/log --fstype=xfs --name=varlog --vgname=VolGroup --size=1024
+logvol swap --name=swap --vgname=VolGroup --size=2016
+
+
+# The OpenSCAP installer add-on is used to apply SCAP (Security Content Automation Protocol)
+# content - security policies - on the installed system.This add-on has been enabled by default
+# since Red Hat Enterprise Linux 7.2. When enabled, the packages necessary to provide this
+# functionality will automatically be installed. However, by default, no policies are enforced,
+# meaning that no checks are performed during or after installation unless specifically configured.
+#
+#  Important
+#   Applying a security policy is not necessary on all systems. This screen should only be used
+#   when a specific policy is mandated by your organization rules or government regulations.
+#   Unlike most other commands, this add-on does not accept regular options, but uses key-value
+#   pairs in the body of the %addon definition instead. These pairs are whitespace-agnostic.
+#   Values can be optionally enclosed in single quotes (') or double quotes (").
+#
+# For more details and configuration options see
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/performing_an_advanced_rhel_9_installation/index#addon-com_redhat_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
+%addon com_redhat_oscap
+        content-type = scap-security-guide
+	profile = xccdf_org.ssgproject.content_profile_bsi
+%end
+
+# Packages selection (%packages section is required)
+%packages
+%end
+
+# Reboot after the installation is complete (optional)
+# --eject	attempt to eject CD or DVD media before rebooting
+reboot --eject


### PR DESCRIPTION
#### Description:

This PR adds a Kickstart file for the RHEL9 BSI Profile

#### Rationale:

a kickstart file simplifies the unattended deployment of linux systems. Furthermore some of the controls in the BSI Basic Protection Profile require corrections at deployment time (i.e. partitioning)

#### Review Hints:

- This .ks is based on the cis ks
- I modified only what seemed to be no requirements or clever to do
- removed the ipv6 disabling as BSI does not demand it
- set timezone to europe/berlin, as a german standard this might be the main TZ this will be deployed
- modified the partitioning
- switched the oscap profile called to the bsi one (without versioning)