### PR TITLE
SLE kernel package may be called kernel-default-base

### DIFF
--- a/shared/applicability/oval/system_with_kernel.xml
+++ b/shared/applicability/oval/system_with_kernel.xml
@@ -6,12 +6,16 @@
       {{% if "ol" in families %}}
       <criterion comment="kernel-uek is installed" test_ref="inventory_test_kernel_uek_installed" />
       {{% endif %}}
+      {{% if 'sle' in product or 'slmicro' in product %}}
+      <criterion comment="kernel-default-base is installed" test_ref="inventory_test_kernel_default_base_installed" />
+      {{% endif %}}
     </criteria>
   </definition>
 {{% if 'debian' in product or 'ubuntu' in product %}}
 {{{ oval_test_package_installed(package="linux-base", test_id="inventory_test_kernel_installed") }}}
 {{% elif 'sle' in product or 'slmicro' in product %}}
 {{{ oval_test_package_installed(package="kernel-default", test_id="inventory_test_kernel_installed") }}}
+{{{ oval_test_package_installed(package="kernel-default-base", test_id="inventory_test_kernel_default_base_installed") }}}
 {{% else %}}
 {{{ oval_test_package_installed(package="kernel", test_id="inventory_test_kernel_installed") }}}
 {{% endif %}}

--- a/shared/applicability/system_with_kernel.yml
+++ b/shared/applicability/system_with_kernel.yml
@@ -17,7 +17,7 @@ title: Bare-metal systems, virtual machines, bootc container images, running boo
 check_id: system_with_kernel
 {{% if pkg_system == "rpm" %}}
 {{% if "sle" in product or "slmicro" in product %}}
-bash_conditional: "rpm --quiet -q kernel-default"
+bash_conditional: "rpm --quiet -q kernel-default || rpm --quiet -q kernel-default-base"
 {{% elif "ol" in families %}}
 bash_conditional: "rpm --quiet -q kernel || rpm --quiet -q kernel-uek"
 {{% else %}}
@@ -33,7 +33,7 @@ bash_conditional: "dpkg-query --show --showformat='${db:Status-Status}' 'kernel'
 {{% if "debian" in product or "ubuntu" in product %}}
 ansible_conditional: '"linux-base" in ansible_facts.packages'
 {{% elif "sle" in product or "slmicro" in product %}}
-ansible_conditional: '"kernel-default" in ansible_facts.packages'
+ansible_conditional: '("kernel-default" in ansible_facts.packages or "kernel-default-base" in ansible_facts.packages)'
 {{% elif "ol" in families %}}
 ansible_conditional: '("kernel" in ansible_facts.packages or "kernel-uek" in ansible_facts.packages)'
 {{% else %}}


### PR DESCRIPTION
#### Description:

- Latest SLE15 and SLMicro platforms  kernel package may be called kernel-default-base

#### Rationale:

- Make sure check for system with kernel does not fail wrongly due to inconsistency/changes of package naming 