### PR TITLE
Use UBI minimal instead of UBI micro

### DIFF
--- a/Dockerfiles/compliance-operator-content-konflux.Containerfile
+++ b/Dockerfiles/compliance-operator-content-konflux.Containerfile
@@ -78,7 +78,7 @@ RUN if [ "$(uname -m)" = "x86_64" ] || [ "$(uname -m)" = "ppc64le" ]; then \
         else ./build_product ocp4 --datastream-only; \
         fi
 
-FROM registry.redhat.io/ubi9/ubi-micro:latest
+FROM registry.redhat.io/ubi9/ubi-minimal:latest
 
 LABEL \
         io.k8s.display-name="Compliance Content" \


### PR DESCRIPTION
The micro image is a subset of the minimal image, and doesn't have
openssl packages. This means check-payload will fail on images built
from the micro image.

Let's use the minimal image at the expense of a larger image so that
we're including the necessary openssl packages to pass the check-payload
verification for release.
