### PR TITLE
Fix ssg get_profiles_from_products function exception

### DIFF
--- a/ssg/profiles.py
+++ b/ssg/profiles.py
@@ -338,6 +338,7 @@ def get_profiles_from_products(content_dir: str, products: list,
 
     for product in products:
         product_yaml = _load_product_yaml(content_dir, product)
+        product_yaml = product_yaml._data_as_dict
         product_title = product_yaml.get("full_name")
         profiles_files = get_profile_files_from_root(product_yaml, product_yaml)
         controls_manager = _load_controls_manager(controls_dir, product_yaml)


### PR DESCRIPTION


#### Description:

- Fix ssg `get_profiles_from_products` function exception

#### Rationale:

- Invoking ssg get_profiles_from_products function will raise exception.
```shell
Traceback (most recent call last):
  File "/Users/axuan/fork/content/ssg_test.py", line 5, in <module>
    profiles = get_profiles_from_products("/Users/axuan/content", ["rhel10"])
  File "/Users/axuan/fork/content/ssg/profiles.py", line 344, in get_profiles_from_products
    controls_manager = _load_controls_manager(controls_dir, product_yaml)
  File "/Users/axuan/fork/content/ssg/profiles.py", line 303, in _load_controls_manager
    control_mgr.load()
  File "/Users/axuan/fork/content/ssg/controls.py", line 836, in load
    self._load("yml")
  File "/Users/axuan/fork/content/ssg/controls.py", line 819, in _load
    policy.load()
  File "/Users/axuan/fork/content/ssg/controls.py", line 636, in load
    yaml_contents = ssg.yaml.open_and_expand(self.filepath, self.env_yaml)
  File "/Users/axuan/fork/content/ssg/yaml.py", line 190, in open_and_expand
    expanded_template = process_file(yaml_file, substitutions_dict)
  File "/Users/axuan/fork/content/ssg/jinja.py", line 211, in process_file
    template = _get_jinja_environment(substitutions_dict).get_template(filepath)
  File "/Users/axuan/fork/content/ssg/jinja.py", line 150, in _get_jinja_environment
    add_python_functions(substitutions_dict)
  File "/Users/axuan/fork/content/ssg/jinja.py", line 230, in add_python_functions
    substitutions_dict['product_to_name'] = product_to_name
TypeError: 'Product' object does not support item assignment
```
This is because when calling `add_python_functions` function, parameter `substitutions_dict` is a `Product` object, not dict. 

- Fixes CPLYTM-916 

#### Review Hints:

- Using this code snippet to test if `get_profiles_from_products` works as expected.
```python
from ssg.profiles import get_profiles_from_products

profiles = get_profiles_from_products("content_root", ["rhel10"])
print(profiles)
```
