### PR TITLE
Remove remaining dependencies on installed_OS_is_FIPS_certified

### DIFF
--- a/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/oval/shared.xml
@@ -2,7 +2,6 @@
   <definition class="compliance" id="grub2_enable_fips_mode" version="1">
     {{{ oval_metadata("Ensure fips=1 is configured in the kernel line in /etc/default/grub.", rule_title=rule_title) }}}
     <criteria operator="AND">
-      <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
       <extend_definition comment="prelink disabled" definition_ref="disable_prelink" />
       <extend_definition comment="package dracut-fips installed" definition_ref="package_dracut-fips_installed" />
       <extend_definition comment="package dracut-fips-aesni installed" definition_ref="package_dracut-fips-aesni_installed" />

--- a/linux_os/guide/system/software/integrity/fips/package_dracut-fips-aesni_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/package_dracut-fips-aesni_installed/oval/shared.xml
@@ -9,7 +9,6 @@
     <criteria operator="OR">
       <criterion comment="System does not support AES instruction set" test_ref="test_processor_aes_instruction" />
       <criteria operator="AND">
-        <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
         <criterion comment="package dracut-fips-aesni is installed"
         test_ref="test_package_dracut-fips-aesni_installed" />
       </criteria>

--- a/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/oval/shared.xml
@@ -7,7 +7,6 @@
   version="1">
     {{{ oval_metadata("The RPM package dracut-fips should be installed.", rule_title=rule_title) }}}
     <criteria>
-      <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
       <criterion comment="package dracut-fips is installed"
       test_ref="test_package_dracut-fips_installed" />
     </criteria>

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_use_fips_hashes/oval/shared.xml
@@ -3,7 +3,6 @@
     {{{ oval_metadata("AIDE should be configured to use the FIPS 140-2 
       cryptographic hashes.", rule_title=rule_title) }}}
     <criteria operator="AND">
-      <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
       <extend_definition comment="Aide is installed" definition_ref="package_aide_installed" />
       <criterion comment="non-FIPS hashes are not configured" test_ref="test_aide_non_fips_hashes" />
       <criterion comment="FIPS hashes are configured" test_ref="test_aide_use_fips_hashes" />


### PR DESCRIPTION
This commit will remove remaining references in extend_definition to rule installed_OS_is_FIPS_certified.  This is a follow up on the removal that has been done in
https://github.com/ComplianceAsCode/content/pull/13594.

Affected rules are failing
because of installed_OS_is_FIPS_certified was evaluated as false. The problem is that the rule installed_OS_is_FIPS_certified doesn't make sense because OS can't be ceritified by FIPS, instead specific cryptography modules are FIPS certified. The modules need to be of a specific version of the cryptography library, so the check shouldn't be tied to a OS major version For information about FIPS certified cryptography modules in Red Hat products, see: https://access.redhat.com/compliance/fips

For checking FIPS compliance status we have a different rule enable_fips_mode, if this rule is included in the profile we don't need to inject any checks to other rules.

Another factor is that the rule installed_OS_is_FIPS_certified fails on RHEL 9 and 10 because the list hasn't been updated which means the dependent rules always failed on these systems.

This change affects rules:
- grub2_enable_fips_mode
- package_dracut-fips-aesni_installed
- package_dracut-fips_installed
- aide_use_fips_hashes

Resolves: https://issues.redhat.com/browse/RHEL-81743

