### PR TITLE
Improve OVAL checks for nss-altfiles

### DIFF
--- a/linux_os/guide/services/ntp/file_groupowner_etc_chrony_keys/oval/shared.xml
+++ b/linux_os/guide/services/ntp/file_groupowner_etc_chrony_keys/oval/shared.xml
@@ -4,14 +4,22 @@
     {{{ oval_metadata("/etc/chrony.keys should be owned by chrony group", rule_title=rule_title) }}}
     <criteria operator="OR">
       <criteria operator="AND">
-        <criterion test_ref="test_file_groupowner_etc_chrony_keys_nsswitch_uses_altfiles" negate="true"
-          comment="The /etc/nsswitch.conf does not use nss-altfiles"/>
+        <criteria operator="AND" negate="true">
+          <criterion test_ref="test_file_groupowner_etc_chrony_keys_nsswitch_uses_altfiles"
+            comment="The /etc/nsswitch.conf uses nss-altfiles"/>
+          <criterion test_ref="test_file_groupowner_etc_chrony_keys_package_nss-altfiles_installed"
+            comment="Check if nss-altfiles package is installed"/>
+        </criteria>
         <criterion test_ref="test_file_groupowner_etc_chrony_keys"
           comment="Check group ownership of /etc/chrony.keys"/>
       </criteria>
       <criteria operator="AND">
-        <criterion test_ref="test_file_groupowner_etc_chrony_keys_nsswitch_uses_altfiles"
-          comment="The /etc/nsswitch.conf uses nss-altfiles"/>
+        <criteria operator="AND">
+          <criterion test_ref="test_file_groupowner_etc_chrony_keys_nsswitch_uses_altfiles"
+            comment="The /etc/nsswitch.conf uses nss-altfiles"/>
+          <criterion test_ref="test_file_groupowner_etc_chrony_keys_package_nss-altfiles_installed"
+            comment="Check if nss-altfiles package is installed"/>
+        </criteria>
         <criterion test_ref="test_file_groupowner_etc_chrony_keys_with_usrlib"
           comment="Check group ownership of /etc/chrony.keys"/>
       </criteria>
@@ -19,6 +27,7 @@
   </definition>
 
 {{{ oval_test_nsswitch_uses_altfiles(rule_id=rule_id) }}}
+{{{ oval_test_package_installed("nss-altfiles", test_id="test_file_groupowner_etc_chrony_keys_package_nss-altfiles_installed") }}}
 
   <unix:file_test id="test_file_groupowner_etc_chrony_keys" version="1" check="all" comment="Testing group ownership of /etc/chrony.keys" check_existence="none_exist" state_operator="AND">
     <unix:object object_ref="object_file_groupowner_etc_chrony_keys" />

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/oval/shared.xml
@@ -4,14 +4,22 @@
     {{{ oval_metadata("All files should be owned by a group", rule_title=rule_title) }}}
     <criteria operator="OR">
       <criteria operator="AND">
-        <criterion test_ref="test_file_permissions_ungroupowned_nsswitch_uses_altfiles" negate="true"
-          comment="The /etc/nsswitch.conf does not use nss-altfiles"/>
+        <criteria operator="AND" negate="true">
+          <criterion test_ref="test_file_permissions_ungroupowned_nsswitch_uses_altfiles"
+            comment="The /etc/nsswitch.conf uses nss-altfiles"/>
+          <criterion test_ref="test_file_permissions_ungroupowned_package_nss-altfiles_installed"
+            comment="Check if nss-altfiles package is installed"/>
+        </criteria>
         <criterion test_ref="test_file_permissions_ungroupowned"
           comment="Check all local files and make sure they are owned by a group"/>
       </criteria>
       <criteria operator="AND">
-        <criterion test_ref="test_file_permissions_ungroupowned_nsswitch_uses_altfiles"
-          comment="The /etc/nsswitch.conf uses nss-altfiles"/>
+        <criteria operator="AND">
+          <criterion test_ref="test_file_permissions_ungroupowned_nsswitch_uses_altfiles"
+            comment="The /etc/nsswitch.conf uses nss-altfiles"/>
+          <criterion test_ref="test_file_permissions_ungroupowned_package_nss-altfiles_installed"
+            comment="Check if nss-altfiles package is installed"/>
+        </criteria>
         <criterion test_ref="test_file_permissions_ungroupowned_with_usrlib"
           comment="Check all local files and make sure they are owned by a group"/>
       </criteria>
@@ -94,6 +102,7 @@
   </unix:file_object>
 
 {{{ oval_test_nsswitch_uses_altfiles(rule_id=rule_id) }}}
+{{{ oval_test_package_installed("nss-altfiles", test_id="test_file_permissions_ungroupowned_package_nss-altfiles_installed") }}}
 
   <unix:file_test id="test_file_permissions_ungroupowned" version="1"
     check="all" check_existence="none_exist"

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/tests/group_in_usr_lib.pass.sh
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/tests/group_in_usr_lib.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+# packages = nss-altfiles
 {{% if 'ubuntu' in product %}}
 # platform = Not Applicable
 {{% endif %}}


### PR DESCRIPTION
To source group data from /usr/lib/group it isn't sufficient to configure altfiles in /etc/nsswitch.conf but it's also needed to install the nss-altfiles package. This means that the OVAL check in rules file_groupowner_etc_chrony_keys need to be extended so that both /etc/nsswitch.conf contents and nss-altfiles package will be checked.

