### PR TITLE
Fix ssg get invalid jinja macros dir exception when using as third party library

### DIFF
--- a/ssg/jinja.py
+++ b/ssg/jinja.py
@@ -98,10 +98,17 @@ def _preload_macros_from_file(env, macros_file):
 
 
 def preload_macros(env):
-    for filename in sorted(os.listdir(JINJA_MACROS_DIRECTORY)):
+    if "site-packages" in JINJA_MACROS_DIRECTORY and env.globals.get('product_dir'):
+        # use product_dir to find macros directory
+        jinja_macros_directory = os.path.join(
+            os.path.dirname(os.path.dirname(env.globals['product_dir'])), "shared", "macros"
+        )
+    else:
+        jinja_macros_directory = JINJA_MACROS_DIRECTORY
+    for filename in sorted(os.listdir(jinja_macros_directory)):
         if not filename.endswith(".jinja"):
             continue
-        macros_file = os.path.join(JINJA_MACROS_DIRECTORY, filename)
+        macros_file = os.path.join(jinja_macros_directory, filename)
         _preload_macros_from_file(env, macros_file)
 
 


### PR DESCRIPTION
#### Description:

- Fix ssg `preload_macros` function get invalid jinja macros dir exception when using as third party library.

#### Rationale:

- When ssg using as a third party library, if you still use `JINJA_MACROS_DIRECTORY` constant to get jinja macros dir, it will get directory end with `site-packages/shared/macros`.

- Fixes CPLYTM-916

#### Review Hints:

- Using ssg inside content is all fine.
- Using ssg as a third party python library, and when involve `preload_macros` function, will raise an exception. You can test with the following code
```python
from ssg.profiles import get_profiles_from_products

profiles = get_profiles_from_products("content_root_dir", ["rhel10"])

print(profiles)
```
It will raise an exception without this PR, `FileNotFoundError: [Errno 2] No such file or directory: '/home/fedora/.cache/pypoetry/virtualenvs/complyscribe-5ohETF1N-py3.12/lib/python3.12/site-packages/shared/macros'`

