### PR TITLE
OCPBUGS-60143: Add stigref file for RHCOS4

### DIFF
--- a/shared/references/disa-stig-rhcos4-v2r2-xccdf-manual.xml
+++ b/shared/references/disa-stig-rhcos4-v2r2-xccdf-manual.xml
@@ -1,0 +1,1 @@
+./disa-stig-ocp4-v2r2-xccdf-manual.xml


### PR DESCRIPTION


#### Description:

- The build system relies on a specific file path to find the stigref for a product.
  Since the STIG for OCP4 should be the same for RHCOS4, I added a symlink so that the build system can find it and add the references for us.

#### Rationale:

- RHCOS4 DS wasn't being built with `stigref` references like:
  ` <xccdf-1.2:reference href="https://public.cyber.mil/stigs/srg-stig-tools/">SV-257527r960930_rule</xccdf-1.2:reference>`
- Fixes part of RHEL-102158

#### Review Hints:

- Check that before this patch, the RHCOS4 DS doesn't have any `stigref`, and after this patch it does.
- This is the place where STIG reference files are searched for:
  https://github.com/ComplianceAsCode/content/blob/65c1adcc489952cd3cf087d028a62c216cff9441/cmake/SSGCommon.cmake#L109