### PR TITLE
Fix ssg get incorrect profile variable value error

### DIFF
--- a/ssg/profiles.py
+++ b/ssg/profiles.py
@@ -154,8 +154,7 @@ def _process_selected_variable(profile: ProfileSelections, variable: str) -> Non
         ValueError: If the variable is not in the correct format.
     """
     variable_name, variable_value = variable.split('=', 1)
-    if variable_name not in profile.variables:
-        profile.variables[variable_name] = variable_value
+    profile.variables[variable_name] = variable_value
 
 
 def _process_selected_rule(profile: ProfileSelections, rule: str) -> None:
@@ -176,7 +175,7 @@ def _process_selected_rule(profile: ProfileSelections, rule: str) -> None:
 def _process_control(profile: ProfileSelections, control: object) -> None:
     """
     Processes a control by iterating through its rules and applying the appropriate processing
-    function. Not that at this level rules list in control can include both variables and rules.
+    function. Note that at this level rules list in control can include both variables and rules.
     The function distinguishes between variable and rules based on the presence of an '='
     character in the rule.
 


### PR DESCRIPTION
#### Description:

- Fix ssg get incorrect profile variable value error

#### Rationale:

- ssg get_profiles_from_products function get incorrect profile variable value when control file levels have inheritance relationship.

- Fixes CPLYTM-916

#### Review Hints:

- Using this code to test. Using https://github.com/complytime/complyscribe/tree/main/tests/data/content_dir as test content dir. Without this PR, the result is `{'var_password_pam_minlen': {'rhel8': {'example': '1'}}, 'var_sshd_set_keepalive': {'rhel8': {'example': '1'}}, 'var_system_crypto_policy': {'rhel8': {'example': 'default_policy'}}}`. With this PR, result is `{'var_password_pam_minlen': {'rhel8': {'example': '1'}}, 'var_sshd_set_keepalive': {'rhel8': {'example': '1'}}, 'var_system_crypto_policy': {'rhel8': {'example': 'fips'}}}`. Difference is `var_system_crypto_policy`, it's value should be `fips`

```python
from ssg.profiles import get_profiles_from_products
from ssg.variables import (
    get_variables_from_profiles,
)

from typing import Dict, Any


def get_profile_params(root: str, product: str, profile_id: str) -> Dict[str, Any]:
    profiles = get_profiles_from_products(root, [product], sorted=True)
    params = {}
    for profile in profiles:
        if profile.profile_id == profile_id:
            params = get_variables_from_profiles([profile])
            break
    return params


print(get_profile_params("/Users/axuan/complyscribe/tests/data/content_dir", "rhel8", "example"))
```
