### PR TITLE
Update kernel package name for better applicability with VMs

### DIFF
--- a/shared/applicability/oval/system_with_kernel.xml
+++ b/shared/applicability/oval/system_with_kernel.xml
@@ -17,7 +17,7 @@
 {{{ oval_test_package_installed(package="kernel-default", test_id="inventory_test_kernel_installed") }}}
 {{{ oval_test_package_installed(package="kernel-default-base", test_id="inventory_test_kernel_default_base_installed") }}}
 {{% else %}}
-{{{ oval_test_package_installed(package="kernel", test_id="inventory_test_kernel_installed") }}}
+{{{ oval_test_package_installed(package="kernel-core", test_id="inventory_test_kernel_installed") }}}
 {{% endif %}}
 {{% if "ol" in families %}}
 {{{ oval_test_package_installed(package="kernel-uek", test_id="inventory_test_kernel_uek_installed") }}}


### PR DESCRIPTION
#### Description:

This PR updates the kernel package name in https://github.com/ComplianceAsCode/content/blob/master/shared/applicability/oval/system_with_kernel.xml#L20 to use `kernel-core` instead of only `kernel` since the last is not always present in VMs.

#### Rationale:

- Fixes #13734

#### Review Hints:

Details in #13734 could be used to test the change.