### PR TITLE
Enable multi_platform_sle platforms for encrypt_partition oval check

### DIFF
--- a/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/oval/shared.xml
+++ b/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/oval/shared.xml
@@ -1,7 +1,8 @@
 <def-group>
     <definition class="compliance" id="{{{ rule_id }}}" version="1">
         {{{ oval_metadata("Verify all partitions are encrypted except /boot /boot/efi",
-                            affected_platforms=["multi_platform_ol", "multi_platform_ubuntu"], rule_title=rule_title) }}}
+                            affected_platforms=["multi_platform_ol", "multi_platform_ubuntu", "multi_platform_sle"],
+                            rule_title=rule_title) }}}
         <criteria>
             <criterion test_ref="test_encrypted_partitions" comment="Check all partitions are encrypted" />
             <!-- Needed to collect the obj_crypttab_partitions object -->


### PR DESCRIPTION
#### Description:

- Enable encrypt_partition oval check for SLE platforms 

#### Rationale:

- Can run the oval on SLE