### PR TITLE
Enable all_apparmor_profiles_enforced for SLE platforms

### DIFF
--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/sce/shared.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/sce/shared.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_ubuntu,multi_platform_debian
+# platform = multi_platform_debian,multi_platform_sle,multi_platform_ubuntu
 # check-import = stdout
 
 # If apparmor or apparmor-utils are not installed, then this test fails.


### PR DESCRIPTION
#### Description:

- Enable all_apparmor_profiles_enforced for SLE platforms

#### Rationale:

- Be able to run the all_apparmor_profiles_enforced rule on SLE
