### PR TITLE
SLE fixes for gid-related rules 

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/ansible/shared.yml
@@ -7,4 +7,8 @@
 - name: Ensure interactive local users are the group-owners of their respective initialization files
   ansible.builtin.shell:
     cmd: |
+{{% if product in ["sle12", "sle15", "slmicro5"] %}}
+      awk -F: '{if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) print $4":"$6}' /etc/passwd | while IFS=: read -r gid home; do find -P "$home" -maxdepth 1 -type f -name "\.[^.]*" -exec chgrp -f --no-dereference -- $gid "{}" \;; done
+{{% else %}}
       awk -F: '{if ($4 >= {{{ gid_min }}} && $4 != {{{ nobody_gid }}}) print $4":"$6}' /etc/passwd | while IFS=: read -r gid home; do find -P "$home" -maxdepth 1 -type f -name "\.[^.]*" -exec chgrp -f --no-dereference -- $gid "{}" \;; done
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/bash/shared.sh
@@ -4,4 +4,8 @@
 # complexity = low
 # disruption = low
 
+{{% if product in ["sle12", "sle15", "slmicro5"] %}}
+awk -F: '{if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) print $4":"$6}' /etc/passwd | while IFS=: read -r gid home; do find -P "$home" -maxdepth 1 -type f -name "\.[^.]*" -exec chgrp -f --no-dereference -- $gid "{}" \;; done
+{{% else %}}
 awk -F: '{if ($4 >= {{{ gid_min }}} && $4 != {{{ nobody_gid }}}) print $4":"$6}' /etc/passwd | while IFS=: read -r gid home; do find -P "$home" -maxdepth 1 -type f -name "\.[^.]*" -exec chgrp -f --no-dereference -- $gid "{}" \;; done
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/oval/shared.xml
@@ -20,8 +20,10 @@
 
   <local_variable id="var_accounts_user_dot_group_ownership_gids" datatype="int" version="1"
                   comment="List of interactive users gids">
+    <unique>
     <object_component item_field="subexpression"
                       object_ref="{{{ interactive_users_gids_object }}}"/>
+    </unique>
   </local_variable>
 
   <!-- #### creation of object #### -->

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/expected_groupowner.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/expected_groupowner.pass.sh
@@ -3,4 +3,5 @@
 USER="cac_user"
 useradd -m $USER
 touch /home/$USER/.bashrc
-chgrp $USER /home/$USER/.bashrc
+GROUP=$(id $USER -g)
+chgrp -f $GROUP /home/$USER/.bashrc

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/home_dirs_one_absent_group_ok.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/home_dirs_one_absent_group_ok.pass.sh
@@ -7,4 +7,5 @@ useradd -m $USER1
 useradd -M $USER2
 
 touch /home/$USER1/.bashrc
-chgrp $USER1 /home/$USER1/.bashrc
+GROUP=$(id $USER -g)
+chgrp -f $GROUP /home/$USER/.bashrc

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/home_dirs_one_absent_group_ok.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/home_dirs_one_absent_group_ok.pass.sh
@@ -7,5 +7,5 @@ useradd -m $USER1
 useradd -M $USER2
 
 touch /home/$USER1/.bashrc
-GROUP=$(id $USER -g)
-chgrp -f $GROUP /home/$USER/.bashrc
+GROUP=$(id $USER1 -g)
+chgrp -f $GROUP /home/$USER1/.bashrc

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/warning_swapped_groupowners.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/warning_swapped_groupowners.pass.sh
@@ -11,5 +11,8 @@ touch /home/$USER2/.bashrc
 # Swap the ownership of files in two home directories
 # WARNING: This test scenario will report a false negative, as explained in the
 # warning section of this rule.
-chgrp -f $USER2 /home/$USER1/.bashrc
-chgrp -f $USER1 /home/$USER2/.bashrc
+GROUP1=$(id $USER1 -g)
+GROUP2=$(id $USER2 -g)
+chgrp -f $GROUP2 /home/$USER1/.bashrc
+chgrp -f $GROUP1 /home/$USER2/.bashrc
+

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/ansible/shared.yml
@@ -19,5 +19,5 @@
     create_home: yes
   loop: '{{ local_users }}'
   when:
-    - item.value[2]|int >= {{{ uid_min }}}
-    - item.value[2]|int != {{{ nobody_uid }}}
+    - item.value[1]|int >= {{{ uid_min }}}
+    - item.value[1]|int != {{{ nobody_uid }}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/oval/shared.xml
@@ -20,8 +20,10 @@
 
   <local_variable id="var_accounts_users_home_files_groupownership_gids" datatype="int" version="1"
                   comment="List of interactive users gids">
+    <unique>
     <object_component item_field="subexpression"
                       object_ref="{{{ interactive_users_gids_object }}}"/>
+    </unique>
   </local_variable>
 
   <!-- #### creation of object #### -->

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/tests/expected_groupowner.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/tests/expected_groupowner.pass.sh
@@ -3,4 +3,6 @@
 USER="cac_user"
 useradd -m $USER
 echo "$USER" > /home/$USER/$USER.txt
-chgrp -f $USER /home/$USER/$USER.txt
+GROUP=$(id $USER -g)
+chgrp -f $GROUP /home/$USER/$USER.txt
+

--- a/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/oval/shared.xml
@@ -20,7 +20,9 @@
 
   <local_variable id="var_file_groupownership_home_directories_gids" datatype="int" version="1"
                   comment="Variable including all gids from primary interactive group">
+    <unique>
     <object_component item_field="subexpression" object_ref="{{{ interactive_users_gids_object }}}"/>
+    </unique>
   </local_variable>
 
   <!-- #### creation of object #### -->

--- a/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/tests/expected_groupowner.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/tests/expected_groupowner.pass.sh
@@ -2,4 +2,6 @@
 
 USER="cac_user"
 useradd -m $USER
-chgrp $USER /home/$USER
+GROUP=$(id $USER -g)
+chgrp $GROUP /home/$USER
+

--- a/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/tests/home_dirs_with_same_groupowner.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/tests/home_dirs_with_same_groupowner.pass.sh
@@ -6,5 +6,6 @@ USER2="cac_user2"
 useradd -m $USER1
 useradd -m $USER2
 # Define the same owner for two home directories
-chgrp $USER1 /home/$USER1
-chgrp $USER1 /home/$USER2
+GROUP1=$(id $USER1 -g)
+chgrp $GROUP1 /home/$USER1
+chgrp $GROUP1 /home/$USER2

--- a/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/tests/warning_home_dirs_swapped_groupowner.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/tests/warning_home_dirs_swapped_groupowner.pass.sh
@@ -8,5 +8,8 @@ useradd -m $USER2
 # Swap the group-ownership of two home directories
 # WARNING: This test scenario will report a false negative, as explained in the
 # warning section of this rule.
-chgrp $USER2 /home/$USER1
-chgrp $USER1 /home/$USER2
+GROUP1=$(id $USER1 -g)
+GROUP2=$(id $USER2 -g)
+chgrp $GROUP2 /home/$USER1
+chgrp $GROUP1 /home/$USER2
+

--- a/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_permission_user_bash_history/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_ubuntu
+# platform = multi_platform_sle,multi_platform_ubuntu
 # reboot = false
 # strategy = restrict
 # complexity = low
@@ -13,8 +13,7 @@ USERS_IGNORED_REGEX='nobody|nfsnobody'
 for (( i=0; i<"${#interactive_users[@]}"; i++ )); do
     if ! grep -qP "$USERS_IGNORED_REGEX" <<< "${interactive_users[$i]}" && \
         [ "${interactive_users_shell[$i]}" != "/sbin/nologin" ]; then
-        
+
         chmod u-sx,go= "${interactive_users_home[$i]}/.bash_history"
     fi
 done
-


### PR DESCRIPTION
#### Description:

- Use unique parameter for oval varaiable list so in case list of gids

#### Rationale:

-In case we have gids duplicateing entry that will mislead the oval check for only one match for group ownership
- For SLE platforms we do not have separate gid for new user

