### PR TITLE
Set ipsec package name for sle15 platform

### DIFF
--- a/shared/applicability/package.yml
+++ b/shared/applicability/package.yml
@@ -53,7 +53,11 @@ args:
     pkgname: libpwquality
     {{% endif %}}
   libreswan:
+    {{% if product == "sle15" %}}
+    pkgname: strongswan-ipsec
+    {{% else %}}
     pkgname: libreswan
+    {{% endif %}}
   libuser:
     pkgname: libuser
   logrotate:


### PR DESCRIPTION
#### Description:

- Set ipsec package name for sle15 platform

#### Rationale:

- Set correct package name that is relevant for SLE15 platform