### PR TITLE
Use platform specific audit binaries

### DIFF
--- a/linux_os/guide/auditing/file_permissions_auditd/file_groupownership_audit_binaries/rule.yml
+++ b/linux_os/guide/auditing/file_permissions_auditd/file_groupownership_audit_binaries/rule.yml
@@ -8,18 +8,10 @@ description: |-
     ownership configured to protected against unauthorized access.
 
     Verify it by running the following command:
-    <pre>$ stat -c "%n %G" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace /sbin/auditd /sbin/audispd /sbin/augenrules
-
-    /sbin/auditctl root
-    /sbin/aureport root
-    /sbin/ausearch root
-    {{% if product not in ["rhel10"] %}}/sbin/autrace root{{% endif %}}
-    /sbin/auditd root
-    {{% if 'rhel' not in product %}}/sbin/audispd root{{% endif %}}
-    /sbin/augenrules root
-    {{%- if 'rhel' in product %}}
-    /sbin/audisp-syslog root
-    {{%- endif %}}
+    <pre>$ stat -c "%n %G" {{{ audit_binaries | join(" ")}}}
+    {{% for binary in audit_binaries %}}
+    {{{ binary }}} root
+    {{% endfor %}}
     </pre>
 
     Audit tools needed to successfully view and manipulate audit information
@@ -49,16 +41,10 @@ references:
 
 ocil: |-
     Verify it by running the following command:
-    <pre>$ stat -c "%n %G" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace /sbin/auditd /sbin/audispd /sbin/augenrules /sbin/audisp-syslog
-
-    /sbin/auditctl root
-    /sbin/aureport root
-    /sbin/ausearch root
-    {{% if product not in ["rhel10"] %}}/sbin/autrace root{{% endif %}}
-    /sbin/auditd root
-    {{% if 'rhel' not in product %}}/sbin/audispd root{{% endif %}}
-    /sbin/augenrules root
-    {{% if 'rhel' in product %}}/sbin/audisp-syslog root{{% endif %}}
+    <pre>$ stat -c "%n %G" {{{ audit_binaries | join(" ")}}}
+    {{% for binary in audit_binaries %}}
+    {{{ binary }}} root
+    {{% endfor %}}
     </pre>
 
     If the command does not return all the above lines, the missing ones
@@ -73,13 +59,5 @@ ocil: |-
 template:
     name: file_groupowner
     vars:
-        filepath:
-            - /sbin/auditctl
-            - /sbin/aureport
-            - /sbin/ausearch
-            {{% if product not in ["rhel10"] %}}- /sbin/autrace{{% endif %}}
-            - /sbin/auditd
-            {{% if 'rhel' not in product and 'ubuntu' not in product %}}- /sbin/audispd{{% endif %}}
-            - /sbin/augenrules
-            {{% if 'rhel' in product %}}- /sbin/audisp-syslog{{% endif %}}
+        filepath: {{{ audit_binaries }}}
         gid_or_name: '0'

--- a/linux_os/guide/auditing/file_permissions_auditd/file_ownership_audit_binaries/rule.yml
+++ b/linux_os/guide/auditing/file_permissions_auditd/file_ownership_audit_binaries/rule.yml
@@ -8,16 +8,10 @@ description: |-
     ownership configured to protected against unauthorized access.
 
     Verify it by running the following command:
-    <pre>$ stat -c "%n %U" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace /sbin/auditd /sbin/audispd /sbin/augenrules /sbin/audisp-syslog
-
-    /sbin/auditctl root
-    /sbin/aureport root
-    /sbin/ausearch root
-    {{% if product not in ["rhel10"] %}}/sbin/autrace root{{% endif %}}
-    /sbin/auditd root
-    {{% if 'rhel' not in product %}}/sbin/audispd root{{% endif %}}
-    /sbin/augenrules root
-    {{% if 'rhel' in product %}}/sbin/audisp-syslog root{{% endif %}}
+    <pre>$ stat -c "%n %U" {{{ audit_binaries | join(" ")}}}
+    {{% for binary in audit_binaries %}}
+    {{{ binary }}} root
+    {{% endfor %}}
     </pre>
 
     Audit tools needed to successfully view and manipulate audit information
@@ -48,17 +42,11 @@ references:
 
 ocil: |-
     Verify it by running the following command:
-    <pre>$ stat -c "%n %U" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace /sbin/auditd /sbin/audispd /sbin/augenrules
-
-    /sbin/auditctl root
-    /sbin/aureport root
-    /sbin/ausearch root
-    {{% if product not in ["rhel10"] %}}/sbin/autrace root{{% endif %}}
-    /sbin/auditd root
-    {{% if 'rhel' not in product %}}/sbin/audispd root{{% endif %}}
-    /sbin/augenrules root
+    <pre>$ stat -c "%n %U" {{{ audit_binaries | join(" ")}}}
+    {{% for binary in audit_binaries %}}
+    {{{ binary }}} root
+    {{% endfor %}}
     </pre>
-
     If the command does not return all the above lines, the missing ones
     need to be added.
 
@@ -71,13 +59,5 @@ ocil: |-
 template:
     name: file_owner
     vars:
-        filepath:
-            - /sbin/auditctl
-            - /sbin/aureport
-            - /sbin/ausearch
-            {{% if product not in ["rhel10"] %}}- /sbin/autrace{{% endif %}}
-            - /sbin/auditd
-            {{% if 'rhel' not in product %}}- /sbin/audispd{{% endif %}}
-            - /sbin/augenrules
-            {{% if 'rhel' in product %}}- /sbin/audisp-syslog{{% endif %}}
+        filepath: {{{ audit_binaries }}}
         uid_or_name: '0'

--- a/linux_os/guide/auditing/file_permissions_auditd/file_permissions_audit_binaries/rule.yml
+++ b/linux_os/guide/auditing/file_permissions_auditd/file_permissions_audit_binaries/rule.yml
@@ -8,22 +8,10 @@ description: |-
     permissions configured to protected against unauthorized access.
 
     Verify it by running the following command:
-    <pre>$ stat -c "%n %a" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace /sbin/auditd /sbin/audispd /sbin/augenrules
-
-    /sbin/auditctl 755
-    /sbin/aureport 755
-    /sbin/ausearch 755
-    {{%- if product not in ["rhel10"] %}}
-    /sbin/autrace 755
-    {{%- endif %}}
-    /sbin/auditd 755
-    {{%- if 'rhel' not in product %}}
-    /sbin/audispd 755
-    {{%- endif %}}
-    /sbin/augenrules 755
-    {{%- if 'rhel' in product %}}
-    /sbin/audisp-syslog 755
-    {{%- endif %}}
+    <pre>$ stat -c "%n %a" {{{ audit_binaries | join(" ")}}}
+    {{% for binary in audit_binaries %}}
+    {{{ binary }}} 755
+    {{% endfor %}}
     </pre>
 
     Audit tools needed to successfully view and manipulate audit information
@@ -54,17 +42,11 @@ references:
 
 ocil: |-
     Verify it by running the following command:
-    <pre>$ stat -c "%n %a" /sbin/auditctl /sbin/aureport /sbin/ausearch /sbin/autrace /sbin/auditd /sbin/audispd /sbin/augenrules
-
-    /sbin/auditctl 755
-    /sbin/aureport 755
-    /sbin/ausearch 755
-    {{% if product not in ["rhel10"] %}}/sbin/autrace 755{{% endif %}}
-    /sbin/auditd 755
-    {{% if 'rhel' not in product %}}/sbin/audispd 755{{% endif %}}
-    /sbin/augenrules 755
+    <pre>$ stat -c "%n %a" {{{ audit_binaries | join(" ")}}}
+    {{% for binary in audit_binaries %}}
+    {{{ binary }}} 755
+    {{% endfor %}}
     </pre>
-
     If the command does not return all the above lines, the missing ones
     need to be added.
 
@@ -78,13 +60,5 @@ ocil: |-
 template:
     name: file_permissions
     vars:
-        filepath:
-            - /sbin/auditctl
-            - /sbin/aureport
-            - /sbin/ausearch
-            {{% if product not in ["rhel10"] %}}- /sbin/autrace{{% endif %}}
-            - /sbin/auditd
-            {{% if 'rhel' not in product %}}- /sbin/audispd{{% endif %}}
-            - /sbin/augenrules
-            {{% if 'rhel' in product %}}- /sbin/audisp-syslog{{% endif %}}
+        filepath: {{{ audit_binaries }}}
         filemode: '0755'

--- a/product_properties/10-audit-binaries.yml
+++ b/product_properties/10-audit-binaries.yml
@@ -1,0 +1,21 @@
+default:
+  audit_binaries:
+    - /sbin/auditctl
+    - /sbin/aureport
+    - /sbin/ausearch
+    {{% if product not in ["rhel10"] %}}- /sbin/autrace{{% endif %}}
+    - /sbin/auditd
+    {{% if 'rhel' not in product %}}- /sbin/audispd{{% endif %}}
+    - /sbin/augenrules
+    {{% if 'rhel' in product %}}- /sbin/audisp-syslog{{% endif %}}
+overrides:
+{{% if product == 'sle15' %}}
+  audit_binaries:
+    - /usr/sbin/auditctl
+    - /usr/sbin/aureport
+    - /usr/sbin/ausearch
+    - /usr/sbin/autrace
+    - /usr/sbin/auditd
+    - /usr/sbin/augenrules
+    - /usr/sbin/audisp-syslog
+{{% endif %}}


### PR DESCRIPTION
#### Description:

- Use platform specific audit binaries path definitions

#### Rationale:

- Define platform specifc paths for audit binaries

- The oval checks in file_permissions_auditd rule so oval checks pass for sle15 platform. Instead of using symlinks to those binaries because oval checks fail when using symlinks
