### PR TITLE
OCPBUGS-60415: Add insights-runtime-extractor-scc to default regex list of variable

### DIFF
--- a/applications/openshift/scc/var_sccs_with_allowed_capabilities_regex.var
+++ b/applications/openshift/scc/var_sccs_with_allowed_capabilities_regex.var
@@ -11,4 +11,4 @@ operator: equals
 interactive: false
 
 options:
-  default: "^privileged$|^hostnetwork-v2$|^restricted-v2$|^nonroot-v2$"
+  default: "^privileged$|^hostnetwork-v2$|^restricted-v2$|^nonroot-v2$|^insights-runtime-extractor-scc$"


### PR DESCRIPTION
#### Description:

Adding  SCC `insights-runtime-extractor-scc` into the default regex list of the SCCs that are permitted to set the allowedCapabilities attribute. 

#### Rationale:

Rule `scc-limit-container-allowed-capabilities` was failing on OCP 4.19 and 4.20 clusters, because the SCC `insights-runtime-extractor-scc` is present on the cluster. This SCC is a required part of [Insights Runtime Extractor](https://github.com/openshift/insights-runtime-extractor) feature that enhances [OpenShift Insights Operator](https://github.com/openshift/insights-operator/tree/master) that monitors the cluster, reports to Red Hat Insights and is a part of the Openshift cluster by default. 

- Fixes this Jira Issue, hopefully: https://issues.redhat.com/browse/OCPBUGS-60415

#### Review Hints:

