### PR TITLE
Update rules applicability in containers

### DIFF
--- a/linux_os/guide/services/http/securing_httpd/httpd_secure_content/partition_for_web_content/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_secure_content/partition_for_web_content/rule.yml
@@ -28,3 +28,9 @@ ocil: |-
     <pre>$ grep `grep -i documentroot /etc/httpd/conf/httpd.conf | awk -F'"' '{print $2}'` /etc/fstab</pre>
     Each of the corresponding <tt>DocumentRoot</tt> entries should have a
     corresponding entry in <tt>/etc/fstab</tt>.
+
+{{% if 'ubuntu' in product %}}
+platform: not container
+{{% else %}}
+platform: not container and not bootc
+{{% endif %}}

--- a/linux_os/guide/system/software/sudo/group.yml
+++ b/linux_os/guide/system/software/sudo/group.yml
@@ -10,3 +10,5 @@ description: |-
     <br /><br />
     For more information on <tt>Sudo</tt> and addition <tt>Sudo</tt> configuration options, see
     <b>{{{ weblink(link="https://www.sudo.ws") }}}</b>.
+
+platform: system_with_kernel

--- a/linux_os/guide/system/software/sudo/package_sudo_installed/rule.yml
+++ b/linux_os/guide/system/software/sudo/package_sudo_installed/rule.yml
@@ -45,5 +45,3 @@ template:
     name: package_installed
     vars:
         pkgname: sudo
-
-platform: system_with_kernel


### PR DESCRIPTION
Partitioning rules are not applicable in containers, therefore update the `partition_for_web_content` rule platform based on platform of the other partitioning rules as defined in
`linux_os/guide/system/software/disk_partitioning/group.yml`.

All rules related to `sudo` component shouldn't be evaluated in containers so the `platform: system_with_kernel` is added into `linux_os/guide/system/software/sudo/group.yml`.