### PR TITLE
Move from public.cyber.mil to www.cyber.mil

### DIFF
--- a/controls/srg_ctr.yml
+++ b/controls/srg_ctr.yml
@@ -2,7 +2,7 @@
 policy: Container Platform Security Requirements Guide
 title: Container Platform Security Requirements Guide
 id: srg_ctr
-source: https://public.cyber.mil/stigs/downloads/
+source: https://www.cyber.mil/stigs/downloads/
 
 levels:
     - id: high

--- a/controls/srg_gpos.yml
+++ b/controls/srg_gpos.yml
@@ -3,7 +3,7 @@ policy: Security Requirements Guide - General Purpose Operating System
 title: Security Requirements Guide - General Purpose Operating System
 id: srg_gpos
 version: 'v3r1'
-source: https://public.cyber.mil/stigs/downloads/
+source: https://www.cyber.mil/stigs/downloads/
 controls_dir: srg_gpos
 
 levels:

--- a/controls/stig_ocp4.yml
+++ b/controls/stig_ocp4.yml
@@ -3,7 +3,7 @@ policy: Red Hat OpenShift Container Platform 4.12 Security Technical Implementat
 title: Red Hat OpenShift Container Platform 4.12 Security Technical Implementation Guide
 id: stig_ocp4
 version: V2R1
-source: https://public.cyber.mil/stigs/downloads/
+source: https://www.cyber.mil/stigs/downloads/
 reference_type: stigid
 
 product:

--- a/controls/stig_ol9.yml
+++ b/controls/stig_ol9.yml
@@ -2,7 +2,7 @@
 policy: 'Oracle Linux 9 Security Technical Implementation Guide'
 title: 'Oracle Linux 9 Security Technical Implementation Guide'
 id: stig_ol9
-source: https://public.cyber.mil/stigs/downloads/
+source: https://www.cyber.mil/stigs/downloads/
 version: V1R1
 reference_type: stigid
 product: ol9

--- a/controls/stig_rhel9.yml
+++ b/controls/stig_rhel9.yml
@@ -2,7 +2,7 @@
 policy: 'Red Hat Enterprise Linux 9 Security Technical Implementation Guide'
 title: 'Red Hat Enterprise Linux 9 Security Technical Implementation Guide'
 id: stig_rhel9
-source: https://public.cyber.mil/stigs/downloads/
+source: https://www.cyber.mil/stigs/downloads/
 version: V2R4
 reference_type: stigid
 product: rhel9

--- a/controls/stig_slmicro5.yml
+++ b/controls/stig_slmicro5.yml
@@ -2,7 +2,7 @@
 policy: SUSE Linux Enterprise Micro (SLEM) 5 Security Technical Implementation Guide
 title: SUSE Linux Enterprise Micro (SLEM) 5 Security Technical Implementation Guide
 id: stig_slmicro5
-source: https://public.cyber.mil/stigs/downloads/
+source: https://www.cyber.mil/stigs/downloads/
 version: V1R1
 reference_type: stigid
 product: slmicro5

--- a/controls/stig_ubuntu2404.yml
+++ b/controls/stig_ubuntu2404.yml
@@ -3,7 +3,7 @@ policy: Canonical Ubuntu 24.04 LTS Security Technical Implementation Guide (STIG
 title: Canonical Ubuntu 24.04 LTS Security Technical Implementation Guide (STIG)
 id: stig_ubuntu2404
 version: V1R1
-source: https://public.cyber.mil/stigs/downloads/
+source: https://www.cyber.mil/stigs/downloads/
 
 levels:
     - id: high

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/install_hids/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/install_hids/rule.yml
@@ -47,7 +47,7 @@ warnings:
         existing infrastructure. Per DISA guidance, when these supplemental tools interfere
         with proper functioning of SELinux, SELinux takes precedence. Should further
         clarification be required, DISA contact information is published publicly at
-        https://public.cyber.mil/stigs/
+        https://www.cyber.mil/stigs/
 
 platform: system_with_kernel
 

--- a/products/ocp4/product.yml
+++ b/products/ocp4/product.yml
@@ -13,7 +13,7 @@ init_system: "systemd"
 
 reference_uris:
   cis: 'https://www.cisecurity.org/benchmark/kubernetes/'
-  stigid: 'https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform'
+  stigid: 'https://www.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform'
 
 cpes_root: "../../shared/applicability"
 cpes:

--- a/products/rhcos4/product.yml
+++ b/products/rhcos4/product.yml
@@ -12,7 +12,7 @@ pkg_manager: "dnf"
 init_system: "systemd"
 
 reference_uris:
-  stigid: 'https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform'
+  stigid: 'https://www.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform'
 
 groups:
   dedicated_ssh_keyowner:

--- a/tests/data/product_stability/ocp4.yml
+++ b/tests/data/product_stability/ocp4.yml
@@ -156,7 +156,7 @@ reference_uris:
   ospp: https://www.niap-ccevs.org/Profile/PP.cfm
   pcidss: https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-2-1.pdf
   pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
-  stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
+  stigid: https://www.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   stigref: https://public.cyber.mil/stigs/srg-stig-tools/
 rsyslog_cafile: /etc/pki/tls/cert.pem
 sshd_distributed_config: 'false'

--- a/tests/data/product_stability/rhcos4.yml
+++ b/tests/data/product_stability/rhcos4.yml
@@ -77,7 +77,7 @@ reference_uris:
   ospp: https://www.niap-ccevs.org/Profile/PP.cfm
   pcidss: https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-2-1.pdf
   pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
-  stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
+  stigid: https://www.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
   stigref: https://public.cyber.mil/stigs/srg-stig-tools/
 release_key_fingerprint: 567E347AD0044ADE55BA8A5F199E2F91FD431D51
 rsyslog_cafile: /etc/pki/tls/cert.pem


### PR DESCRIPTION
#### Description:
Move from public.cyber.mil to www.cyber.mil

#### Rationale:
Due to the new Cyber Exchange we need to update our URLs. 
 https://www.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform
While the filtered urls (e.g. ` https://www.cyber.mil/stigs/downloads/?_dl_facet_stigs=container-platform`) no longer work we need to keep them so the OpenSCAP keeps the references straight.