### PR TITLE
Add support for file_group_ownership_var_log_audit in SLE platform

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_ubuntu
+# platform = multi_platform_sle,multi_platform_ubuntu
 # reboot = false
 # strategy = restrict
 # complexity = low
@@ -23,12 +23,46 @@
       log_file: "{{ log_file_line }}"
   when: (log_file_line is defined) and (log_file_line | length > 0)
 
-- name: "{{{ rule_title }}} - List All Log File Backups"
+- name: "{{{ rule_title }}} - Get All Log File Backups"
   ansible.builtin.find:
       path: "{{ log_file | dirname }}"
       patterns: "{{ log_file | basename }}.*"
   register: backup_files
 
+{{% if product == "sle15" %}}
+- name: "{{{ rule_title }}} - Get Audit Log Group"
+  ansible.builtin.command: grep -iw ^log_group /etc/audit/auditd.conf
+  failed_when: false
+  register: log_group_exists
+
+- name: "{{{ rule_title }}} - Set Log Group Facts"
+  ansible.builtin.set_fact:
+      log_group_line: "{{ log_group_exists.stdout | split(' ') | last }}"
+
+- name: "{{{ rule_title }}} - Set Default log_group if Not Set"
+  ansible.builtin.set_fact:
+      log_group: "root"
+  when: (log_group_exists is undefined) or (log_group_exists.stdout | length == 0)
+
+- name: "{{{ rule_title }}} - Set log_group From log_group_line if Not Set Already"
+  ansible.builtin.set_fact:
+      log_group: "{{ log_group_line }}"
+  when: (log_group_line is defined) and (log_group_line | length > 0)
+
+- name: "{{{ rule_title }}} - Apply Mode to All Backup Log Files"
+  ansible.builtin.file:
+      path: "{{ item }}"
+      group: "{{ log_group }}"
+  failed_when: false
+  loop: "{{ backup_files.files| map(attribute='path') | list }}"
+
+- name: "{{{ rule_title }}} - Apply Mode to Log File"
+  ansible.builtin.file:
+      path: "{{ log_file }}"
+      group: "{{ log_group }}"
+  failed_when: false
+
+{{% else %}}
 - name: "{{{ rule_title }}} - Apply Mode to All Backup Log Files"
   ansible.builtin.file:
       path: "{{ item }}"
@@ -41,3 +75,4 @@
       path: "{{ log_file }}"
       group: root
   failed_when: false
+{{% endif %}}

--- a/linux_os/guide/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/oval/sle15.xml
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/oval/sle15.xml
@@ -1,0 +1,116 @@
+<def-group>
+  <definition class="compliance" id="file_group_ownership_var_log_audit" version="1">
+    {{{ oval_metadata("Checks that all audit log files are group owned by the root user.", rule_title=rule_title) }}}
+    <criteria operator="OR">
+      <criteria operator="AND" comment="log_file set">
+        <extend_definition comment="log file set in auditd.conf" definition_ref="auditd_conf_log_file_not_set" negate="true" />
+
+        <criteria operator="OR">
+          <criteria operator="AND" comment="log_file set and log_group set to not root">
+            <criterion comment="log_group in auditd.conf is set" test_ref="test_auditd_conf_log_group_not_set" negate="true"/>
+            <criterion comment="default log_file and log_group set" test_ref="test_group_ownership_audit_log_files_not_root"/>
+          </criteria>
+          <criteria operator="AND" comment="log_file set and log_group root">
+            <criterion comment="log_group in auditd.conf is not set" test_ref="test_auditd_conf_log_group_not_set"/>
+            <criterion comment="default log_file and log_group root" test_ref="test_group_ownership_audit_log_files_root"/>
+          </criteria>
+        </criteria>
+
+      </criteria>
+      <criteria operator="AND" comment="log_file not set">
+        <extend_definition comment="log file not set in auditd.conf" definition_ref="auditd_conf_log_file_not_set" />
+
+        <criteria operator="OR">
+          <criteria operator="AND" comment="default log_file and log_group set to not root">
+            <criterion comment="log_group in auditd.conf is set" test_ref="test_auditd_conf_log_group_not_set" negate="true"/>
+            <criterion comment="default log_file and log_group set" test_ref="test_group_ownership_default_audit_log_files_not_root"/>
+          </criteria>
+          <criteria operator="AND" comment="default log_file and log_group root">
+            <criterion comment="log_group in auditd.conf is not set" test_ref="test_auditd_conf_log_group_not_set"/>
+            <criterion comment="default log_file and log_group root" test_ref="test_group_ownership_default_audit_log_files_root"/>
+          </criteria>
+        </criteria>
+
+      </criteria>
+    </criteria>
+  </definition>
+
+
+  <ind:textfilecontent54_test id="test_auditd_conf_log_group_not_set" check="all" check_existence="none_exist" comment="log_group not set" version="1">
+    <ind:object object_ref="object_auditd_conf_log_group_configured" />
+  </ind:textfilecontent54_test>
+
+
+  <!-- default file and default state -->
+  <unix:file_object comment="/var/log/audit files" id="object_default_audit_log_file" version="1">
+    <unix:filepath operation="equals">/var/log/audit/audit.log</unix:filepath>
+  </unix:file_object>
+  <unix:file_state id="state_default_group_root" version="1">
+    <unix:group_id datatype="int" operation="equals">0</unix:group_id>
+  </unix:file_state>
+
+  <unix:file_test check="all" check_existence="all_exist" comment="/var/log/audit/audit.log file is owned by root" id="test_group_ownership_default_audit_log_files_root" version="1">
+    <unix:object object_ref="object_default_audit_log_file" />
+    <unix:state state_ref="state_default_group_root" />
+  </unix:file_test>
+
+
+  <!-- default file and non default state -->
+  <ind:textfilecontent54_object id="object_auditd_conf_log_group_configured" comment="log_group is set" version="1">
+    <ind:filepath operation="equals">/etc/audit/auditd.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^[ ]*log_group[ ]+=[ ](\w+)$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <local_variable id="var_auditd_conf_log_group" version="1" datatype="string" comment="audit log_group">
+    <object_component item_field="subexpression" object_ref="object_auditd_conf_log_group_configured" />
+  </local_variable>
+
+  <local_variable id="var_auditd_conf_log_group_regex" datatype="string" version="1"
+    comment="a local variable regex to auditd configured log_group">
+      <concat>
+          <literal_component>^</literal_component>
+          <variable_component var_ref="var_auditd_conf_log_group"/>
+          <literal_component>:\w+:(\w+):.*</literal_component>
+      </concat>
+  </local_variable>
+
+  <ind:textfilecontent54_object id="object_auditd_log_group_etc_group_id" version="1" comment="gid of the audit log_group (from /etc/group)">
+    <ind:filepath>/etc/group</ind:filepath>
+    <ind:pattern operation="pattern match" var_ref="var_auditd_conf_log_group_regex"/>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <local_variable id="var_file_groupowner_audit_log_group_gid" datatype="int" version="1" comment="Retrieve the gid audit log_group">
+    <object_component item_field="subexpression" object_ref="object_auditd_log_group_etc_group_id"/>
+  </local_variable>
+
+  <unix:file_state id="state_group_owner_log_group_var_log_audit" version="1">
+    <unix:group_id datatype="int" operation="equals" var_ref="var_file_groupowner_audit_log_group_gid"></unix:group_id>
+  </unix:file_state>
+
+  <unix:file_test check="all" check_existence="all_exist" comment="/var/log/audit/audit.log file is owned by log_group" id="test_group_ownership_default_audit_log_files_not_root" version="1">
+    <unix:object object_ref="object_default_audit_log_file"/>
+    <unix:state state_ref="state_group_owner_log_group_var_log_audit"/>
+  </unix:file_test>
+
+
+  <!-- non default file default state -->
+  <unix:file_object comment="audit log file" id="object_non_default_audit_log_file" version="1">
+    <unix:filepath operation="equals" var_ref="audit_log_file_path"/>
+  </unix:file_object>
+
+  <unix:file_test check="all" check_existence="all_exist" comment="log_file file is owned by root" id="test_group_ownership_audit_log_files_root" version="1">
+    <unix:object object_ref="object_non_default_audit_log_file"/>
+    <unix:state state_ref="state_default_group_root"/>
+  </unix:file_test>
+
+
+  <!-- non default file non default state -->
+
+  <unix:file_test check="all" check_existence="all_exist" comment="log_file file is owned by log_group" id="test_group_ownership_audit_log_files_not_root" version="1">
+    <unix:object object_ref="object_non_default_audit_log_file"/>
+    <unix:state state_ref="state_group_owner_log_group_var_log_audit"/>
+  </unix:file_test>
+
+</def-group>

--- a/linux_os/guide/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/tests/correct_value_non-root_group.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/tests/correct_value_non-root_group.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel,multi_platform_sle
 
 if grep -iwq "log_file" /etc/audit/auditd.conf; then
     FILE=$(awk -F "=" '/^log_file/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')

--- a/linux_os/guide/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/tests/wrong_value_non-root_group.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/tests/wrong_value_non-root_group.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel,multi_platform_sle
 
 if grep -iwq "log_file" /etc/audit/auditd.conf; then
     FILE=$(awk -F "=" '/^log_file/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')

--- a/products/sle15/profiles/standard.profile
+++ b/products/sle15/profiles/standard.profile
@@ -45,6 +45,7 @@ selections:
     - file_groupowner_etc_passwd
     - file_permissions_etc_group
     - file_owner_etc_group
+    - file_group_ownership_var_log_audit
     - file_groupowner_etc_group
     - sysctl_fs_protected_symlinks
     - sysctl_fs_protected_hardlinks


### PR DESCRIPTION
#### Description:

- Ass support in SLE platforms for file_group_ownership_var_log_audit rule

#### Rationale:

- Implement platform specific OVAL to simplify the logic and make sure the group is retrieved, when log group is not root
- Adapt the tests for the rule

