### PR TITLE
Update accounts_password_pam_pwquality_retry for OL STIG

### DIFF
--- a/controls/stig_ol9.yml
+++ b/controls/stig_ol9.yml
@@ -2593,7 +2593,7 @@ controls:
       title: OL 9 must ensure the password complexity module in the system-auth file is configured for
           three retries or less.
       rules:
-          - accounts_password_pam_retry
+          - accounts_password_pam_pwquality_retry
           - var_password_pam_retry=3
       status: automated
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_retry/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_retry/rule.yml
@@ -25,6 +25,10 @@ identifiers:
 references:
     srg: SRG-OS-000069-GPOS-00037
 
+{{% if product == "ol8" %}}
+platform: os_linux[ol]>8.3
+{{% endif %}}
+
 ocil_clause: 'the value of "retry" is set to "0" or greater than "{{{ xccdf_value("var_password_pam_retry") }}}", or is missing'
 
 ocil: |-

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/ansible/shared.yml
@@ -5,7 +5,7 @@
 # disruption = medium
 {{% if 'ubuntu' in product %}}
 {{% set configuration_files = ["common-password"] %}}
-{{% elif product in ['ol8', 'ol9'] or 'rhel' in product or 'almalinux' in product %}}
+{{% elif 'ol' in families or 'rhel' in product or 'almalinux' in product %}}
 {{% set configuration_files = ["password-auth","system-auth"] %}}
 {{% else %}}
 {{% set configuration_files = ["system-auth"] %}}
@@ -13,7 +13,7 @@
 
 {{{ ansible_instantiate_variables("var_password_pam_retry") }}}
 
-{{% if product in ['ol8', 'ol9', 'rhel8', 'rhel9', 'almalinux'] -%}}
+{{% if product in ['rhel8', 'rhel9', 'almalinux'] -%}}
 - name: Ensure PAM variable retry is set accordingly
   ansible.builtin.lineinfile:
     create: yes

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/bash/shared.sh
@@ -1,6 +1,6 @@
 # platform = multi_platform_all
 
-{{% if product in ['ol8', 'ol9'] or 'rhel' in product %}}
+{{% if 'ol' in families or 'rhel' in product %}}
 {{% set configuration_files = ["password-auth","system-auth"] %}}
 {{% else %}}
 {{% set configuration_files = ["system-auth"] %}}
@@ -9,7 +9,7 @@
 
 {{{ bash_instantiate_variables("var_password_pam_retry") }}}
 
-{{% if product in ['ol8', 'ol9'] or 'rhel' in product -%}}
+{{% if 'rhel' in product -%}}
 	{{{ bash_replace_or_append('/etc/security/pwquality.conf',
 							   '^retry',
 							   '$var_password_pam_retry',

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
@@ -19,6 +19,7 @@
           test_ref="test_password_pam_pwquality_retry_{{{ file | escape_id }}}" />
           {{% endfor %}}
         </criteria>
+        {{% if 'ol' not in families%}}
         <criteria operator="AND" comment="Conditions for retry in pwquality.conf file are satisfied">
           {{% for file in configuration_files %}}
           <criterion
@@ -28,6 +29,7 @@
           <criterion comment="check retry parameter in pwquality.conf"
           test_ref="test_password_pam_pwquality_retry_pwquality_conf"/>
         </criteria>
+        {{% endif %}}
       </criteria>
     </criteria>
   </definition>
@@ -64,9 +66,11 @@
   {{{ object_pwquality_retry( path="/etc/pam.d/" ~ file ,
                             test_ref="password_pam_pwquality_retry_" ~ (file | escape_id)) }}}
 
+  {{% if 'ol' not in families %}}
   {{{ test_pwquality_notset(file,
                             "password_pam_pwquality_retry_" ~ (file | escape_id) ~"_not_set",
                             "password_pam_pwquality_retry_" ~ (file | escape_id)) }}}
+  {{% endif %}}
   {{% endfor %}}
 
   <ind:textfilecontent54_state id="state_password_pam_retry_upper_bound" version="1"
@@ -82,7 +86,7 @@
 
   <external_variable datatype="int" id="var_password_pam_retry" version="1"
                      comment="External variable for pam_pwquality retry"/>
-
+  {{% if 'ol' not in families %}}
   <ind:textfilecontent54_test check="all" version="1"
                               id="test_password_pam_pwquality_retry_pwquality_conf"
                               comment="check the configuration of /etc/security/pwquality.conf">
@@ -96,4 +100,5 @@
     <ind:pattern operation="pattern match">^[\s]*retry[\s]*=[\s]*(\d+)(?:[\s]|$)</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
+  {{% endif %}}
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/rule.yml
@@ -64,7 +64,11 @@ ocil: |-
     <pre>password requisite pam_pwquality.so retry={{{ xccdf_value("var_password_pam_retry") }}}</pre>
     {{% endif %}}
 
+{{% if product == "ol8" %}}
+platform: os_linux[ol]<8.4 and package[libpwquality]
+{{% else %}}
 platform: package[libpwquality]
+{{% endif %}}
 
 fixtext: |-
     Configure {{{ full_name }}} to limit the "pwquality" retry option to {{{ xccdf_value("var_password_pam_retry") }}}.

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/argument_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/argument_missing.fail.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 # platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_ubuntu,multi_platform_almalinux
 # variables = var_password_pam_retry=3
+{{% if 'ol' in families %}}
+# packages = authselect
+{{% endif %}}
 
 source common.sh

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/common.sh
@@ -1,13 +1,13 @@
 {{% if 'ubuntu' in product %}}
 configuration_files=("common-password")
-{{% elif product in ['ol8', 'ol9'] or 'rhel' in product %}}
+{{% elif 'ol' in families or 'rhel' in product %}}
 configuration_files=("password-auth" "system-auth")
 {{% else %}}
 configuration_files=("system-auth")
 {{% endif %}}
 
 
-{{% if product in ['ol8', 'ol9'] or 'rhel' in product %}}
+{{% if 'ol' in families or 'rhel' in product %}}
 authselect create-profile testingProfile --base-on sssd
 
 for file in ${configuration_files[@]}; do

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/correct_value.pass.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
-# platform = Oracle Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ubuntu
+# platform = multi_platform_ol,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ubuntu
 # variables = var_password_pam_retry=3
+{{% if 'ol' in families %}}
+# packages = authselect
+{{% endif %}}
 
 source common.sh
 
@@ -16,6 +19,16 @@ Password:
 EOF
 
 DEBIAN_FRONTEND=noninteractive pam-auth-update
+{{% elif 'ol' in families %}}
+for cfile in ${configuration_files[@]}; do
+{{{ bash_ensure_pam_module_configuration('/etc/pam.d/$cfile',
+										  'password',
+										  'required',
+										  'pam_pwquality.so',
+										  'retry',
+										  "3",
+										  '^\s*account') }}}
+done
 {{% else %}}
 for file in ${configuration_files[@]}; do
 {{{ bash_ensure_pam_module_option('/etc/pam.d/$file',

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_commented.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel
+# platform = multi_platform_rhel
 # variables = var_password_pam_retry=3
 
 source common.sh

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_conflicting_values.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_conflicting_values.fail.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# packages = authselect
+# platform = multi_platform_rhel
 # variables = var_password_pam_retry=3
 
 source common.sh

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_correct.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel
+# platform = multi_platform_rhel
 # variables = var_password_pam_retry=3
 
 source common.sh

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_correct_with_space.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_correct_with_space.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel
+# platform = multi_platform_rhel
 # variables = var_password_pam_retry=3
 
 source common.sh

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_duplicate_values.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_duplicate_values.pass.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# packages = authselect
+# platform = multi_platform_rhel
 # variables = var_password_pam_retry=3
 
 source common.sh

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_overriden.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_overriden.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel
+# platform = multi_platform_rhel
 # variables = var_password_pam_retry=3
 
 source common.sh

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_wrong.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_wrong.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Oracle Linux 8,Oracle Linux 9,multi_platform_rhel
+# platform = multi_platform_rhel
 # variables = var_password_pam_retry=3
 
 source common.sh

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/wrong_value.fail.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
-# platform = Oracle Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ubuntu
+# platform = multi_platform_ol,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ubuntu
 # variables = var_password_pam_retry=3
+{{% if 'ol' in families %}}
+# packages = authselect
+{{% endif %}}
 
 source common.sh
 
@@ -16,6 +19,16 @@ Password:
 EOF
 
 DEBIAN_FRONTEND=noninteractive pam-auth-update
+{{% elif 'ol' in families %}}
+for cfile in ${configuration_files[@]}; do
+{{{ bash_ensure_pam_module_configuration('/etc/pam.d/$cfile',
+										  'password',
+										  'required',
+										  'pam_pwquality.so',
+										  'retry',
+										  "7",
+										  '^\s*account') }}}
+done
 {{% else %}}
 for file in ${configuration_files[@]}; do
 {{{ bash_ensure_pam_module_option('/etc/pam.d/$file',

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -561,8 +561,11 @@ selections:
     # OL08-00-020101
     - accounts_password_pam_pwquality_system_auth
 
-    # OL08-00-020102, OL08-00-020103, OL08-00-020104
+    # OL08-00-020102, OL08-00-020103
     - accounts_password_pam_retry
+
+    # OL08-00-020104
+    - accounts_password_pam_pwquality_retry
 
     # OL08-00-020110
     - accounts_password_pam_ucredit

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -529,7 +529,7 @@ selections:
     # OL08-00-020031
     - dconf_gnome_screensaver_lock_delay
     - var_screensaver_lock_delay=5_seconds
-    
+
     # OL08-00-020032
     - dconf_gnome_disable_user_list
 

--- a/shared/templates/accounts_password/ansible.template
+++ b/shared/templates/accounts_password/ansible.template
@@ -5,7 +5,7 @@
 # disruption = low
 - (xccdf-var var_password_pam_{{{ VARIABLE }}})
 
-{{% if product in ["ol8","ol9"] or 'rhel' in product %}}
+{{% if 'ol' in families or 'rhel' in product %}}
 - name: {{{ rule_title }}} - Find pwquality.conf.d files
   ansible.builtin.find:
     paths: /etc/security/pwquality.conf.d/
@@ -20,8 +20,14 @@
   with_items: "{{ pwquality_conf_d_files.files }}"
 {{% endif %}}
 
-{{% if "ol" in product %}}
+{{% if "ol" in families %}}
 {{{ ansible_remove_pam_module_option_configuration('/etc/pam.d/system-auth',
+                                  'password',
+                                  '',
+                                  'pam_pwquality.so',
+                                  VARIABLE, rule_title=rule_title)
+}}}
+{{{ ansible_remove_pam_module_option_configuration('/etc/pam.d/password-auth',
                                   'password',
                                   '',
                                   'pam_pwquality.so',

--- a/shared/templates/accounts_password/bash.template
+++ b/shared/templates/accounts_password/bash.template
@@ -6,14 +6,20 @@
 
 {{{ bash_instantiate_variables("var_password_pam_" ~ VARIABLE) }}}
 
-{{% if product in ["ol8","ol9"] or 'rhel' in product %}}
+{{% if 'ol' in families or 'rhel' in product %}}
 if grep -sq {{{ VARIABLE }}} /etc/security/pwquality.conf.d/*.conf ; then
     sed -i "/{{{ VARIABLE }}}/d" /etc/security/pwquality.conf.d/*.conf
 fi
 {{% endif %}}
 
-{{% if "ol" in product %}}
+{{% if "ol" in families %}}
 {{{ bash_remove_pam_module_option_configuration('/etc/pam.d/system-auth',
+                                  'password',
+                                  '',
+                                  'pam_pwquality.so',
+                                  VARIABLE)
+}}}
+{{{ bash_remove_pam_module_option_configuration('/etc/pam.d/password-auth',
                                   'password',
                                   '',
                                   'pam_pwquality.so',

--- a/shared/templates/accounts_password/oval.template
+++ b/shared/templates/accounts_password/oval.template
@@ -1,4 +1,4 @@
-{{% if product in ["ol8","ol9"] or 'rhel' in product %}}
+{{% if 'ol' in families or 'rhel' in product %}}
 {{% set filepath_regex="^/etc/security/pwquality\.conf(\.d/[^/]+\.conf)?$" %}}
 {{% else %}}
 {{% set filepath_regex="^/etc/security/pwquality\.conf$" %}}
@@ -11,14 +11,16 @@
       <criteria operator="OR">
         <criterion comment="pwquality.conf" test_ref="test_password_pam_pwquality_{{{ VARIABLE }}}" />
       </criteria>
-      {{% if "ol" in product %}}
+      {{% if "ol" in families %}}
       <criterion comment="{{{ VARIABLE }}} is not overwritten in system-auth"
         test_ref="test_password_pam_pwquality_{{{ VARIABLE }}}_not_overwritten"/>
+      <criterion comment="{{{ VARIABLE }}} is not overwritten in password-auth"
+        test_ref="test_password_pam_pwquality_{{{ VARIABLE }}}_not_overwritten_password-auth"/>
       {{% endif %}}
     </criteria>
   </definition>
 
-  {{% if "ol" in product %}}
+  {{% if "ol" in families %}}
   <ind:textfilecontent54_test check="all" check_existence="none_exist"
     comment="check the configuration of /etc/pam.d/system-auth doens't override pwquality.conf"
     id="test_password_pam_pwquality_{{{ VARIABLE }}}_not_overwritten" version="1">
@@ -28,6 +30,20 @@
   <ind:textfilecontent54_object id="obj_password_pam_pwquality_{{{ VARIABLE }}}_not_overwritten"
   version="1">
     <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
+    <ind:pattern
+    operation="pattern match">^\s*password.*pam_pwquality\.so.*\b{{{ VARIABLE }}}\b</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="none_exist"
+    comment="check the configuration of /etc/pam.d/password-auth doens't override pwquality.conf"
+    id="test_password_pam_pwquality_{{{ VARIABLE }}}_not_overwritten_password-auth" version="1">
+    <ind:object object_ref="obj_password_pam_pwquality_{{{ VARIABLE }}}_not_overwritten_password-auth" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_password_pam_pwquality_{{{ VARIABLE }}}_not_overwritten_password-auth"
+  version="1">
+    <ind:filepath>/etc/pam.d/password-auth</ind:filepath>
     <ind:pattern
     operation="pattern match">^\s*password.*pam_pwquality\.so.*\b{{{ VARIABLE }}}\b</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>

--- a/shared/templates/accounts_password/tests/correct_value.pass.sh
+++ b/shared/templates/accounts_password/tests/correct_value.pass.sh
@@ -4,6 +4,20 @@
 {{% if product == "ubuntu2404" %}}
 {{{ bash_pam_pwquality_enable() }}}
 {{% endif %}}
+{{% if "ol" in families %}}
+{{{ bash_remove_pam_module_option_configuration('/etc/pam.d/system-auth',
+                                  'password',
+                                  '',
+                                  'pam_pwquality.so',
+                                  VARIABLE)
+}}}
+{{{ bash_remove_pam_module_option_configuration('/etc/pam.d/password-auth',
+                                  'password',
+                                  '',
+                                  'pam_pwquality.so',
+                                  VARIABLE)
+}}}
+{{% endif %}}
 
 truncate -s 0 /etc/security/pwquality.conf
 

--- a/shared/templates/accounts_password/tests/correct_value_directory.pass.sh
+++ b/shared/templates/accounts_password/tests/correct_value_directory.pass.sh
@@ -9,6 +9,20 @@
 {{% if product == "ubuntu2404" %}}
 {{{ bash_pam_pwquality_enable() }}}
 {{% endif %}}
+{{% if "ol" in families %}}
+{{{ bash_remove_pam_module_option_configuration('/etc/pam.d/system-auth',
+                                  'password',
+                                  '',
+                                  'pam_pwquality.so',
+                                  VARIABLE)
+}}}
+{{{ bash_remove_pam_module_option_configuration('/etc/pam.d/password-auth',
+                                  'password',
+                                  '',
+                                  'pam_pwquality.so',
+                                  VARIABLE)
+}}}
+{{% endif %}}
 
 truncate -s 0 /etc/security/pwquality.conf
 

--- a/shared/templates/accounts_password/tests/duplicated_values.pass.sh
+++ b/shared/templates/accounts_password/tests/duplicated_values.pass.sh
@@ -4,6 +4,20 @@
 {{% if product == "ubuntu2404" %}}
 {{{ bash_pam_pwquality_enable() }}}
 {{% endif %}}
+{{% if "ol" in families %}}
+{{{ bash_remove_pam_module_option_configuration('/etc/pam.d/system-auth',
+                                  'password',
+                                  '',
+                                  'pam_pwquality.so',
+                                  VARIABLE)
+}}}
+{{{ bash_remove_pam_module_option_configuration('/etc/pam.d/password-auth',
+                                  'password',
+                                  '',
+                                  'pam_pwquality.so',
+                                  VARIABLE)
+}}}
+{{% endif %}}
 
 truncate -s 0 /etc/security/pwquality.conf
 

--- a/shared/templates/accounts_password/tests/multiple_correct_value.pass.sh
+++ b/shared/templates/accounts_password/tests/multiple_correct_value.pass.sh
@@ -6,6 +6,20 @@
 {{% if product == "ubuntu2404" %}}
 {{{ bash_pam_pwquality_enable() }}}
 {{% endif %}}
+{{% if "ol" in families %}}
+{{{ bash_remove_pam_module_option_configuration('/etc/pam.d/system-auth',
+                                  'password',
+                                  '',
+                                  'pam_pwquality.so',
+                                  VARIABLE)
+}}}
+{{{ bash_remove_pam_module_option_configuration('/etc/pam.d/password-auth',
+                                  'password',
+                                  '',
+                                  'pam_pwquality.so',
+                                  VARIABLE)
+}}}
+{{% endif %}}
 
 truncate -s 0 /etc/security/pwquality.conf
 

--- a/shared/templates/accounts_password/tests/password_auth_overwritten.fail.sh
+++ b/shared/templates/accounts_password/tests/password_auth_overwritten.fail.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# This test only applies to platforms that check password-auth to not override
+# the value in pwquality.conf
+# platform = multi_platform_ol
+# variables = var_password_pam_{{{ VARIABLE }}}={{{ TEST_VAR_VALUE }}}
+
+truncate -s 0 /etc/security/pwquality.conf
+
+echo "{{{ VARIABLE }}} = {{{ TEST_CORRECT_VALUE }}}" >> /etc/security/pwquality.conf
+
+{{{
+    bash_ensure_pam_module_configuration('/etc/pam.d/password-auth',
+                                  'password',
+                                  'required',
+                                  'pam_pwquality.so',
+                                  VARIABLE,
+                                  TEST_CORRECT_VALUE)
+}}}


### PR DESCRIPTION
#### Description:

- Update accounts_password_pam_pwquality_retry rule to validate configurations in /etc/pam.d/password-auth for OL, corresponding OVAL, remediation, and test files were updated, and a new test was added specifically to check this file.
- Update accounts_password_pam_retry rule to skip checks on /etc/security/pwquality.conf for OL. Its OVAL, remediation, and test files were also updated accordingly.
- Update accounts_password_pam_pwquality_retry rule in OL9 STIG control.
- Add accounts_password_pam_pwquality_retry rule to OL8 STIG profile.

#### Rationale:

This change splits the approach from OL8 STIG requirements into two separate rules to better handle different OL versions:
- OL08-00-020104 accounts_password_pam_pwquality_retry: Addresses the issue for OL8.4 and later.
- OL08-00-020102 & OL08-00-020103 accounts_password_pam_retry: Covers the requirements for OL8.3 and earlier.
