### PR TITLE
[Debian] Fix the delimiter of debian time source

### DIFF
--- a/linux_os/guide/services/ntp/var_multiple_time_pools.var
+++ b/linux_os/guide/services/ntp/var_multiple_time_pools.var
@@ -17,4 +17,4 @@ options:
     alinux: "0.ntp.cloud.aliyuncs.com,1.ntp.aliyun.com,2.ntp1.aliyun.com,3.ntp1.cloud.aliyuncs.com"
     amazon: "0.rhel.pool.ntp.org,1.rhel.pool.ntp.org,2.rhel.pool.ntp.org,3.rhel.pool.ntp.org"
     ubuntu: "0.ubuntu.pool.ntp.org,1.ubuntu.pool.ntp.org,2.ubuntu.pool.ntp.org,3.ubuntu.pool.ntp.org"
-    debian: "0.debian.pool.ntp.org 1.debian.pool.ntp.org 2.debian.pool.ntp.org 3.debian.pool.ntp.org"
+    debian: "0.debian.pool.ntp.org,1.debian.pool.ntp.org,2.debian.pool.ntp.org,3.debian.pool.ntp.org"

--- a/linux_os/guide/services/ntp/var_multiple_time_servers.var
+++ b/linux_os/guide/services/ntp/var_multiple_time_servers.var
@@ -20,5 +20,5 @@ options:
     amazon: "0.rhel.pool.ntp.org,1.rhel.pool.ntp.org,2.rhel.pool.ntp.org,3.rhel.pool.ntp.org"
     ubuntu: "0.ubuntu.pool.ntp.org,1.ubuntu.pool.ntp.org,2.ubuntu.pool.ntp.org,3.ubuntu.pool.ntp.org"
     almalinux: "0.almalinux.pool.ntp.org,1.almalinux.pool.ntp.org,2.almalinux.pool.ntp.org,3.almalinux.pool.ntp.org"
-    debian: "0.debian.pool.ntp.org 1.debian.pool.ntp.org 2.debian.pool.ntp.org 3.debian.pool.ntp.org"
+    debian: "0.debian.pool.ntp.org,1.debian.pool.ntp.org,2.debian.pool.ntp.org,3.debian.pool.ntp.org"
     


### PR DESCRIPTION
#### Description:

- Fix the delimiter of debian time server and time pool

#### Rationale:

- The delimiter of oval and bash is "," not space, found out during dev of #13819