### PR TITLE
[Ubuntu] Pass rule if IPv6 is disabled on kernel

### DIFF
--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/ip6tables_rules_for_open_ports/sce/shared.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/ip6tables_rules_for_open_ports/sce/shared.sh
@@ -4,6 +4,11 @@
 
 result=$XCCDF_RESULT_PASS
 
+# Pass rule if IPv6 is disabled on kernel
+if [ ! -e /proc/sys/net/ipv6/conf/all/disable_ipv6 ] || [ "$(cat /proc/sys/net/ipv6/conf/all/disable_ipv6)" -eq 1 ]; then
+    exit "$XCCDF_RESULT_PASS"
+fi
+
 iptables_status="$(ip6tables -S INPUT -v)"
 while read -r proto port;
 do


### PR DESCRIPTION
#### Description:

- Pass rule if IPv6 is disabled on kernel or by sysctl

#### Rationale:

- CIS benchmark and current implementation of other ipv6 rules has such condition check
- https://github.com/ComplianceAsCode/content/blob/9c94c324375d6363589841f093d042d534e7aa0e/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/sce/shared.sh#L4-L6