### PR TITLE
[Ubuntu] Reorder 2.4.1.2 for cis_ubuntu2404

### DIFF
--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -1029,7 +1029,6 @@ controls:
           - l1_server
           - l1_workstation
       rules:
-          - file_cron_allow_exists
           - file_groupowner_crontab
           - file_owner_crontab
           - file_permissions_crontab
@@ -1096,6 +1095,7 @@ controls:
           - l1_server
           - l1_workstation
       rules:
+          - file_cron_allow_exists
           - file_cron_deny_not_exist
           - file_groupowner_cron_allow
           - file_owner_cron_allow


### PR DESCRIPTION
#### Description:

- Reorder 2.4.1.2 for cis_ubuntu2404

#### Rationale:

- It's rule 2.4.1.8 check the existence of /etc/cron.allow
