### PR TITLE
[Ubuntu] Only allow password set for root on Ubuntu 2204

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_root_access_controlled/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_root_access_controlled/oval/shared.xml
@@ -13,7 +13,11 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_root_access_controlled_etc_shadow" version="1">
     <ind:filepath>/etc/shadow</ind:filepath>
+    {{% if product == "ubuntu2204" %}}
+    <ind:pattern operation="pattern match">^root:(\$(y|[0-9].+)\$).*$</ind:pattern>
+    {{% else %}}
     <ind:pattern operation="pattern match">^root:(\$(y|[0-9].+)\$|!.*|\*.*).*$</ind:pattern>
+    {{% endif %}}
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_root_access_controlled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_root_access_controlled/rule.yml
@@ -4,8 +4,8 @@ documentation_complete: true
 title: 'Ensure root account access is controlled'
 
 description: |-
-    There are a number of methods to access the root account directly. 
-    Without a password set any user would be able to gain access and 
+    There are a number of methods to access the root account directly.
+    Without a password set any user would be able to gain access and
     thus control over the entire system.
 
 rationale: |-
@@ -14,22 +14,35 @@ rationale: |-
 severity: medium
 
 platform: system_with_kernel
-
+{{%- if product != "ubuntu2204" %}}
 ocil_clause: 'root password is not set or is not locked'
 
 ocil: |-
     Run the following command to verify that either the root user's
     password is set or the root user's account is locked:
     <pre># passwd -S root | awk '$2 ~ /^(P|L)/ {print "User: \"" $1 "\" Password is status: " $2}'</pre>
-    Verify the output is either: 
+    Verify the output is either:
     User: "root" Password is status: P
     - OR -
     User: "root" Password is status: L
     Note:
     - P - Password is set
     - L - Password is locked
-    
 
 warnings:
   - general: This rule doesn't come with a remediation, as the exact requirement allows root to either have a password or be locked.
-  
+{{%- else %}}
+ocil_clause: 'root password is not set'
+
+ocil: |-
+    Run the following command to verify that the password is set for root:
+    <pre># passwd -S root | awk '$2 ~ /^P/ {print "User: \"" $1 "\" Password is status: " $2}'</pre>
+    Verify the output is: User: "root" Password is status: P
+    Note:
+    - P - Password is set
+
+warnings:
+  - general: This rule doesn't come with a remediation, as the exact requirement allows root to have a password.
+{{% endif %}}
+
+

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_root_access_controlled/tests/empty.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_root_access_controlled/tests/empty.fail.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # packages = passwd
+{{% if product == 'ubuntu2204' %}}
+# platform = Not Applicable
+{{% else %}}
 # platform = multi_platform_all
+{{% endif %}}
 # remediation = none
 
 passwd -d root


### PR DESCRIPTION
#### Description:

- Only allow password set for root on Ubuntu 2204

#### Rationale:

- Align with cis v2 jammy 5.4.2.4