### PR TITLE
Update Install VM Script

### DIFF
--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -24,7 +24,7 @@ UNRELEASED_DISTROS_AND_OSINFO = {
 
 DISTRO_URL = {
     "fedora":
-        "https://download.fedoraproject.org/pub/fedora/linux/releases/41/Everything/x86_64/os",
+        "https://download.fedoraproject.org/pub/fedora/linux/releases/42/Everything/x86_64/os",
     "centos8": "http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/",
     "centos9": "http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/",
 }

--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -208,11 +208,14 @@ def handle_ssh_pubkey(data):
     data.ssh_pubkey_used = bool(data.ssh_pubkey)
     if not data.ssh_pubkey:
         home_dir = os.path.expanduser('~')
-        user_default_key = f'{home_dir}/.ssh/id_rsa.pub'
-        if os.path.isfile(user_default_key):
-            data.ssh_pubkey = user_default_key
-            with open(data.ssh_pubkey) as f:
-                data.pub_key_content = f.readline().rstrip()
+        key_types = ['ed25519', 'rsa',]
+        for key_type in key_types:
+            user_default_key = f'{home_dir}/.ssh/id_{key_type}.pub'
+            if os.path.isfile(user_default_key):
+                data.ssh_pubkey = user_default_key
+                with open(data.ssh_pubkey) as f:
+                    data.pub_key_content = f.readline().rstrip()
+                    return
         else:
             err('SSH public key was not found or informed by "--ssh-pubkey" option.')
 

--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -256,8 +256,8 @@ def handle_kickstart(data):
 
         if data.uefi:
             content = content.replace(
-                "part /boot --fstype=xfs --size=512",
-                "part /boot --fstype=xfs --size=312\npart /boot/efi --fstype=efi --size=200",
+                "part /boot --fstype=xfs --size=1152",
+                "part /boot --fstype=xfs --size=640\npart /boot/efi --fstype=efi --size=512",
             ).replace(
                 "part biosboot ",
                 "# part biosboot ",

--- a/tests/kickstarts/test_suite.cfg
+++ b/tests/kickstarts/test_suite.cfg
@@ -69,22 +69,22 @@ clearpart --linux --initlabel
 
 # Create primary system partitions (required for installs)
 part biosboot --fstype biosboot --size=1
-part /boot --fstype=xfs --size=512 --fsoptions="nosuid,noexec"
+part /boot --fstype=xfs --size=1152 --fsoptions="nosuid,noexec"
 part pv.01 --grow --size=1
 
 # Create a Logical Volume Management (LVM) group (optional)
 volgroup VolGroup --pesize=4096 pv.01
 
 # Create particular logical volumes (optional)
-logvol / --fstype=xfs --name=LogVol06 --vgname=VolGroup --size=3192 --grow
+logvol / --fstype=xfs --name=LogVol06 --vgname=VolGroup --size=2936 --grow
 # Ensure /usr Located On Separate Partition
-logvol /usr --fstype=xfs --name=LogVol08 --vgname=VolGroup --size=5512 --fsoptions="nodev"
+logvol /usr --fstype=xfs --name=LogVol08 --vgname=VolGroup --size=5384 --fsoptions="nodev"
 # Ensure /opt Located On Separate Partition
 logvol /opt --fstype=xfs --name=LogVol09 --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid"
 # Ensure /srv Located On Separate Partition
 logvol /srv --fstype=xfs --name=LogVol10 --vgname=VolGroup --size=512 --fsoptions="nodev,nosuid"
 # Ensure /home Located On Separate Partition
-logvol /home --fstype=xfs --name=home --vgname=VolGroup --size=1024 --fsoptions="nodev"
+logvol /home --fstype=xfs --name=home --vgname=VolGroup --size=768 --fsoptions="nodev"
 # Ensure /tmp Located On Separate Partition
 logvol /tmp --fstype=xfs --name=tmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
 # Ensure /var/tmp Located On Separate Partition


### PR DESCRIPTION
#### Description:
* Move to Fedora 42
* Allow ed25519 keys by default as they are default now.
* Increase /boot to 1024. See this [Red Hat Solution](https://access.redhat.com/solutions/7008336) for more details.
#### Rationale:

* keep Fedora references up to date.
* Keep up with default SSH keys
* Allow RHEL 10 and Fedora to install with a gui.

#### Review Hints:
Install a Fedora VM with the script.