### PR TITLE
[Ubuntu] Allow sys uid and empty user group

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupownerships_var_log/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupownerships_var_log/oval/shared.xml
@@ -21,6 +21,9 @@
     <unix:object object_ref="object_group_ownership_var_log" />
     <unix:state state_ref="state_group_ownership_adm_var_log_auth_log"/>
     <unix:state state_ref="state_group_ownership_root_var_log_auth_log"/>
+    {{%- if product == "ubuntu2204" %}}
+    <unix:state state_ref="{{{ rule_id }}}_group_only_has_sys_uids"/>
+    {{%- endif %}}
   </unix:file_test>
   <unix:file_object comment="/var/log/*" id="object_group_ownership_var_log" version="1">
     <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="all" />
@@ -93,4 +96,47 @@
   <unix:file_state id="{{{ rule_id }}}_exclude_files_waagent" version="1">
     <unix:filename operation="pattern match">^waagent\.log.*$</unix:filename>
   </unix:file_state>
+  {{%- if product == "ubuntu2204" %}}
+  <unix:file_state id="{{{ rule_id }}}_group_only_has_sys_uids" version="1">
+    <unix:group_id datatype="int" var_ref="empty_group_ids" var_check="at least one"/>
+  </unix:file_state>
+
+  <local_variable id="empty_group_ids" comment="Group IDs with no members" datatype="int" version="1">
+    <object_component item_field="subexpression" object_ref="empty_members_in_etc_group"/>
+  </local_variable>
+
+  <ind:textfilecontent54_object comment="Groups with no members" id="empty_members_in_etc_group" version="1">
+    <ind:filepath>/etc/group</ind:filepath>
+     <ind:pattern operation="pattern match" var_ref="variable_{{{ rule_id }}}_group_regex" var_check="at least one"/>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <local_variable id="variable_{{{ rule_id }}}_group_regex" datatype="string" version="1" comment="gid rows retrieved from /etc/passwd">
+    <concat>
+      <literal_component>^[^:]+:[^:]*:(</literal_component>
+      <object_component item_field="subexpression" object_ref="obj_{{{ rule_id }}}_gids_with_only_sys_uids" />
+      <literal_component>):$</literal_component>
+    </concat>
+  </local_variable>
+
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}_gids_with_only_sys_uids" version="1">
+    <ind:filepath>/etc/passwd</ind:filepath>
+    <ind:pattern operation="pattern match" var_ref="variable_{{{ rule_id }}}_regex" var_check="at least one"/>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <local_variable id="variable_{{{ rule_id }}}_regex" datatype="string" version="1" comment="uid rows retrieved from /etc/passwd">
+    <concat>
+      <literal_component>^[^:]*:[^:]*:</literal_component>
+        <object_component item_field="subexpression" object_ref="obj_{{{ rule_id }}}_sys_uid" />
+      <literal_component>:(\d+):.*$</literal_component>
+    </concat>
+  </local_variable>
+
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}_sys_uid" version="1">
+    <ind:filepath>/etc/passwd</ind:filepath>
+    <ind:pattern operation="pattern match">^[^:]+:[^:]*:(\d\d?\d?):.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+  {{%- endif %}}
 </def-group>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupownerships_var_log/tests/owned_by_non_sys_acc_grp.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupownerships_var_log/tests/owned_by_non_sys_acc_grp.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# platform = Ubuntu 22.04
+# packages = rsyslog
+
+chown root -R /var/log/*
+
+groupadd testgroup
+useradd testUser
+usermod -g testgroup testUser
+
+touch /var/log/test.log
+chgrp testgroup /var/log/test.log

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupownerships_var_log/tests/owned_by_sys_acc_grp.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupownerships_var_log/tests/owned_by_sys_acc_grp.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# platform = Ubuntu 22.04
+# packages = rsyslog
+
+chown root -R /var/log/*
+
+groupadd testgroup
+useradd -r testUser
+usermod -g testgroup testUser
+
+touch /var/log/test.log
+chgrp testgroup /var/log/test.log

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_ownerships_var_log/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_ownerships_var_log/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Ubuntu 24.04
+# platform = multi_platform_ubuntu
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_ownerships_var_log/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_ownerships_var_log/oval/shared.xml
@@ -6,22 +6,23 @@
     </criteria>
   </definition>
 
-  <unix:password_object id="object_syslog_uid" version="1">
-    {{% if 'debian' in product %}}
-    <unix:username operation="pattern match">root</unix:username>
-    {{% else %}}
-    <unix:username operation="pattern match">syslog</unix:username>
-    {{% endif %}}
-  </unix:password_object>
-  <local_variable id="var_syslog_uid" comment="Retrieve the uid of syslog" datatype="int" version="1">
-    <object_component item_field="user_id" object_ref="object_syslog_uid" />
+  <ind:textfilecontent54_object id="{{{ rule_id }}}_object_syslog_uid" version="1" comment="uid of the dedicated syslog group">
+    <ind:filepath>/etc/passwd</ind:filepath>
+    <ind:pattern operation="pattern match">^syslog:[^:]+:([0-9]+):</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <local_variable id="{{{ rule_id }}}_var_syslog_uid" comment="Retrieve the uid of syslog" datatype="int" version="1">
+    <object_component item_field="subexpression" object_ref="{{{ rule_id }}}_object_syslog_uid" />
   </local_variable>
 
-  <unix:file_test check="all" comment="/var/log/* owner is root|syslog"
+  <unix:file_test check_existence="any_exist" check="all" comment="/var/log/* owner is root|syslog"
       id="test_file_ownership_var_log" state_operator="OR" version="1">
     <unix:object object_ref="object_file_ownership_var_log" />
     <unix:state state_ref="state_file_ownership_syslog_var_log_auth_log"/>
     <unix:state state_ref="state_file_ownership_root_var_log_auth_log"/>
+    {{%- if product == "ubuntu2204" %}}
+    <unix:state state_ref="{{{ rule_id }}}_system_files_with_empty_group"/>
+    {{%- endif %}}
   </unix:file_test>
   <unix:file_object comment="/var/log/*" id="object_file_ownership_var_log" version="1">
     <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="all" />
@@ -47,12 +48,15 @@
     <filter action="exclude">{{{ rule_id }}}_exclude_files_aide</filter>
     <filter action="exclude">{{{ rule_id }}}_exclude_files_exim</filter>
     {{% endif %}}
+    <!-- {{%- if product == "ubuntu2204" %}}
+    <filter action="exclude">{{{ rule_id }}}_system_files_with_empty_group</filter>
+    {{% endif %}} -->
   </unix:file_object>
   <unix:file_state id="{{{ rule_id }}}_exclude_symlinks" version="1">
     <unix:type operation="equals">symbolic link</unix:type>
   </unix:file_state>
   <unix:file_state id="state_file_ownership_syslog_var_log_auth_log" version="1">
-    <unix:user_id datatype="int" operation="equals" var_ref="var_syslog_uid"/>
+    <unix:user_id datatype="int" operation="equals" var_ref="{{{ rule_id }}}_var_syslog_uid"/>
   </unix:file_state>
   <unix:file_state id="state_file_ownership_root_var_log_auth_log" version="1">
     <unix:user_id datatype="int" operation="equals">0</unix:user_id>
@@ -107,4 +111,21 @@
     <unix:filepath operation="pattern match">^/var/log/exim4/.*$</unix:filepath>
   </unix:file_state>
   {{% endif %}}
+  {{%- if product == "ubuntu2204" %}}
+  <unix:file_state id="{{{ rule_id }}}_system_files_with_empty_group" version="3">
+    <!-- <unix:group_id datatype="int" var_ref="empty_group_ids" var_check="at least one"/> -->
+    <unix:user_id datatype="int" operation="less than">{{{ uid_min }}}</unix:user_id>
+  </unix:file_state>
+
+  <!-- <local_variable id="empty_group_ids" comment="Group IDs with no members" datatype="int" version="3">
+    <object_component item_field="subexpression" object_ref="empty_members_in_etc_group"/>
+  </local_variable>
+
+  <ind:textfilecontent54_object comment="Groups with no members" id="empty_members_in_etc_group" version="3">
+    <ind:filepath>/etc/group</ind:filepath>
+    <ind:pattern operation="pattern match">^[^:]+:[^:]*:([0-9]+):$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object> -->
+
+  {{%- endif %}}
 </def-group>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_ownerships_var_log/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_ownerships_var_log/oval/shared.xml
@@ -48,9 +48,6 @@
     <filter action="exclude">{{{ rule_id }}}_exclude_files_aide</filter>
     <filter action="exclude">{{{ rule_id }}}_exclude_files_exim</filter>
     {{% endif %}}
-    <!-- {{%- if product == "ubuntu2204" %}}
-    <filter action="exclude">{{{ rule_id }}}_system_files_with_empty_group</filter>
-    {{% endif %}} -->
   </unix:file_object>
   <unix:file_state id="{{{ rule_id }}}_exclude_symlinks" version="1">
     <unix:type operation="equals">symbolic link</unix:type>
@@ -113,19 +110,7 @@
   {{% endif %}}
   {{%- if product == "ubuntu2204" %}}
   <unix:file_state id="{{{ rule_id }}}_system_files_with_empty_group" version="3">
-    <!-- <unix:group_id datatype="int" var_ref="empty_group_ids" var_check="at least one"/> -->
     <unix:user_id datatype="int" operation="less than">{{{ uid_min }}}</unix:user_id>
   </unix:file_state>
-
-  <!-- <local_variable id="empty_group_ids" comment="Group IDs with no members" datatype="int" version="3">
-    <object_component item_field="subexpression" object_ref="empty_members_in_etc_group"/>
-  </local_variable>
-
-  <ind:textfilecontent54_object comment="Groups with no members" id="empty_members_in_etc_group" version="3">
-    <ind:filepath>/etc/group</ind:filepath>
-    <ind:pattern operation="pattern match">^[^:]+:[^:]*:([0-9]+):$</ind:pattern>
-    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
-  </ind:textfilecontent54_object> -->
-
   {{%- endif %}}
 </def-group>

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_ownerships_var_log/tests/excluded_files.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_ownerships_var_log/tests/excluded_files.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Ubuntu 24.04
+# platform = multi_platform_ubuntu
 # packages = rsyslog
 
 chown root -R /var/log/*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_ownerships_var_log/tests/owned_by_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_ownerships_var_log/tests/owned_by_root.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Ubuntu 24.04
+# platform = multi_platform_ubuntu
 # packages = rsyslog
 
 chown root -R /var/log/*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_ownerships_var_log/tests/owned_by_sysacc.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_ownerships_var_log/tests/owned_by_sysacc.pass.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
-# platform = multi_platform_ubuntu
+# platform = Ubuntu 22.04
 # packages = rsyslog
 
 chown root -R /var/log/*
 
+useradd -r testUser
+
 touch /var/log/test.log
-chown nobody /var/log/test.log
+chown testUser /var/log/test.log

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_ownerships_var_log/tests/owned_by_syslog.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_ownerships_var_log/tests/owned_by_syslog.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Ubuntu 24.04
+# platform = multi_platform_ubuntu
 # packages = rsyslog
 
 chown root -R /var/log/*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_ownerships_var_log/tests/symlink.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_ownerships_var_log/tests/symlink.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Ubuntu 24.04
+# platform = multi_platform_ubuntu
 
 chown root -R /var/log/*
 


### PR DESCRIPTION
#### Description:


ownership (check if any of the following satisfy):

- owned by root or syslog
- UID of file must be < UID_MIN

group-ownership (check if any of the following satisfy):

- group-owned by root or adm
- group of files must not have extra users
- all uids whose primary group == group must be < UID_MIN


#### Rationale:

- Align with cis v2 jammy benchmark complex bash audit script
