### PR TITLE
Update STIG for RHEL 9 to allow for FIPS:STIG

### DIFF
--- a/controls/stig_rhel9.yml
+++ b/controls/stig_rhel9.yml
@@ -3814,7 +3814,7 @@ controls:
       rules:
           - enable_fips_mode
           - sysctl_crypto_fips_enabled
-          - var_system_crypto_policy=fips
+          - var_system_crypto_policy=fips_stig
           - enable_dracut_fips_module
       status: automated
 

--- a/linux_os/guide/system/software/integrity/crypto/var_system_crypto_policy.var
+++ b/linux_os/guide/system/software/integrity/crypto/var_system_crypto_policy.var
@@ -17,6 +17,7 @@ options:
     default_nosha1: "DEFAULT:NO-SHA1"
     fips: FIPS
     fips_ospp: "FIPS:OSPP"
+    fips_stig: "FIPS:STIG"
     legacy: LEGACY
     future: FUTURE
     next: NEXT

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/oval/shared.xml
@@ -119,12 +119,12 @@
   <ind:variable_state id="ste_system_crypto_policy_value" version="2"
     comment="variable value is set to 'FIPS' or 'FIPS:modifier', where the modifier corresponds
 to a crypto policy module that further restricts the modified crypto policy.">
-  {{% if product in ["ol9","rhel9"] -%}}
-    <ind:value operation="pattern match" datatype="string">^FIPS(:OSPP)?$</ind:value>
+  {{% if product in ["ol9","rhel9","rhel10","fedora"] -%}}
+    <ind:value operation="pattern match" datatype="string">^FIPS(:(OSPP|STIG))?$</ind:value>
   {{%- else %}}
   {{# Legacy and more relaxed list of crypto policies that were historically considered
       FIPS-compatible. More recent products should use the more restricted list of options #}}
-    <ind:value operation="pattern match" datatype="string">^FIPS(:(OSPP|NO-SHA1|NO-CAMELLIA))?$</ind:value>
+    <ind:value operation="pattern match" datatype="string">^FIPS(:(OSPP|NO-SHA1|NO-CAMELLIA|STIG))?$</ind:value>
   {{%- endif %}}
   </ind:variable_state>
 

--- a/tests/data/profile_stability/rhel9/stig.profile
+++ b/tests/data/profile_stability/rhel9/stig.profile
@@ -540,7 +540,7 @@ var_sshd_disable_compression=no
 var_sshd_set_keepalive=1
 var_sssd_certificate_verification_digest_function=sha512
 var_sudo_timestamp_timeout=always_prompt
-var_system_crypto_policy=fips
+var_system_crypto_policy=fips_stig
 var_time_service_set_maxpoll=18_hours
 var_user_initialization_files_regex=all_dotfiles
 wireless_disable_interfaces

--- a/tests/data/profile_stability/rhel9/stig_gui.profile
+++ b/tests/data/profile_stability/rhel9/stig_gui.profile
@@ -538,7 +538,7 @@ var_sshd_disable_compression=no
 var_sshd_set_keepalive=1
 var_sssd_certificate_verification_digest_function=sha512
 var_sudo_timestamp_timeout=always_prompt
-var_system_crypto_policy=fips
+var_system_crypto_policy=fips_stig
 var_time_service_set_maxpoll=18_hours
 var_user_initialization_files_regex=all_dotfiles
 wireless_disable_interfaces


### PR DESCRIPTION


#### Description:

Update STIG for RHEL 9 to allow for FIPS:STIG

#### Rationale:

Fixes #13812
Fixes #13813
#### Review Hints:
Run contest
* `/hardening/image-builder/stig`
* /hardening/anaconda/stig`
