### PR TITLE
CMP-3230: Update assertions for PCI-DSS testing on ARM

### DIFF
--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.12.yml
@@ -127,7 +127,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-pci-dss-4-0-audit-log-forwarding-enabled:
     default_result: FAIL
-    result_after_remediation: PASS
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-audit-log-forwarding-webhook:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
@@ -343,7 +343,7 @@ rule_results:
     result_after_remediation: MANUAL
   e2e-pci-dss-4-0-security-profiles-operator-exists:
     default_result: FAIL
-    result_after_remediation: PASS
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-storageclass-encryption-enabled:
     default_result: PASS
     result_after_remediation: PASS
@@ -358,4 +358,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-pci-dss-4-0-api-server-tls-security-profile-not-old:
     default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-4-0-ingress-controller-tls-cipher-suites:
+    default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.13.yml
@@ -127,7 +127,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-pci-dss-4-0-audit-log-forwarding-enabled:
     default_result: FAIL
-    result_after_remediation: PASS
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-audit-log-forwarding-webhook:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
@@ -343,7 +343,7 @@ rule_results:
     result_after_remediation: MANUAL
   e2e-pci-dss-4-0-security-profiles-operator-exists:
     default_result: FAIL
-    result_after_remediation: PASS
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-storageclass-encryption-enabled:
     default_result: PASS
     result_after_remediation: PASS
@@ -358,4 +358,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-pci-dss-4-0-api-server-tls-security-profile-not-old:
     default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-4-0-ingress-controller-tls-cipher-suites:
+    default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.14.yml
@@ -127,7 +127,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-pci-dss-4-0-audit-log-forwarding-enabled:
     default_result: FAIL
-    result_after_remediation: PASS
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-audit-log-forwarding-webhook:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
@@ -343,7 +343,7 @@ rule_results:
     result_after_remediation: MANUAL
   e2e-pci-dss-4-0-security-profiles-operator-exists:
     default_result: FAIL
-    result_after_remediation: PASS
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-storageclass-encryption-enabled:
     default_result: PASS
     result_after_remediation: PASS
@@ -358,4 +358,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-pci-dss-4-0-api-server-tls-security-profile-not-old:
     default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-4-0-ingress-controller-tls-cipher-suites:
+    default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.15.yml
@@ -127,7 +127,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-pci-dss-4-0-audit-log-forwarding-enabled:
     default_result: FAIL
-    result_after_remediation: PASS
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-audit-log-forwarding-webhook:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
@@ -343,7 +343,7 @@ rule_results:
     result_after_remediation: MANUAL
   e2e-pci-dss-4-0-security-profiles-operator-exists:
     default_result: FAIL
-    result_after_remediation: PASS
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-storageclass-encryption-enabled:
     default_result: PASS
     result_after_remediation: PASS
@@ -358,4 +358,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-pci-dss-4-0-api-server-tls-security-profile-not-old:
     default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-4-0-ingress-controller-tls-cipher-suites:
+    default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.16.yml
@@ -127,7 +127,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-pci-dss-4-0-audit-log-forwarding-enabled:
     default_result: FAIL
-    result_after_remediation: PASS
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-audit-log-forwarding-webhook:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
@@ -343,7 +343,7 @@ rule_results:
     result_after_remediation: MANUAL
   e2e-pci-dss-4-0-security-profiles-operator-exists:
     default_result: FAIL
-    result_after_remediation: PASS
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-storageclass-encryption-enabled:
     default_result: PASS
     result_after_remediation: PASS
@@ -358,4 +358,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-pci-dss-4-0-api-server-tls-security-profile-not-old:
     default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-4-0-ingress-controller-tls-cipher-suites:
+    default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.17.yml
@@ -127,7 +127,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-pci-dss-4-0-audit-log-forwarding-enabled:
     default_result: FAIL
-    result_after_remediation: PASS
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-audit-log-forwarding-webhook:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
@@ -343,7 +343,7 @@ rule_results:
     result_after_remediation: MANUAL
   e2e-pci-dss-4-0-security-profiles-operator-exists:
     default_result: FAIL
-    result_after_remediation: PASS
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-storageclass-encryption-enabled:
     default_result: PASS
     result_after_remediation: PASS
@@ -358,4 +358,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-pci-dss-4-0-api-server-tls-security-profile-not-old:
     default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-4-0-ingress-controller-tls-cipher-suites:
+    default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.18.yml
@@ -127,7 +127,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-pci-dss-4-0-audit-log-forwarding-enabled:
     default_result: FAIL
-    result_after_remediation: PASS
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-audit-log-forwarding-webhook:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
@@ -343,7 +343,7 @@ rule_results:
     result_after_remediation: MANUAL
   e2e-pci-dss-4-0-security-profiles-operator-exists:
     default_result: FAIL
-    result_after_remediation: PASS
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-4-0-storageclass-encryption-enabled:
     default_result: PASS
     result_after_remediation: PASS
@@ -358,4 +358,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-pci-dss-4-0-api-server-tls-security-profile-not-old:
     default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-4-0-ingress-controller-tls-cipher-suites:
+    default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.12.yml
@@ -121,7 +121,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-pci-dss-audit-log-forwarding-enabled:
     default_result: FAIL
-    result_after_remediation: PASS
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-audit-log-forwarding-webhook:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
@@ -367,10 +367,13 @@ rule_results:
     result_after_remediation: PASS
   e2e-pci-dss-security-profiles-operator-exists:
     default_result: FAIL
-    result_after_remediation: PASS
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-api-server-tls-security-profile-custom-min-tls-version:
     default_result: PASS
     result_after_remediation: PASS
   e2e-pci-dss-api-server-tls-security-profile-not-old:
     default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-ingress-controller-tls-cipher-suites:
+    default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.13.yml
@@ -121,7 +121,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-pci-dss-audit-log-forwarding-enabled:
     default_result: FAIL
-    result_after_remediation: PASS
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-audit-log-forwarding-webhook:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
@@ -366,10 +366,13 @@ rule_results:
     result_after_remediation: PASS
   e2e-pci-dss-security-profiles-operator-exists:
     default_result: FAIL
-    result_after_remediation: PASS
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-api-server-tls-security-profile-custom-min-tls-version:
     default_result: PASS
     result_after_remediation: PASS
   e2e-pci-dss-api-server-tls-security-profile-not-old:
     default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-ingress-controller-tls-cipher-suites:
+    default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.14.yml
@@ -121,7 +121,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-pci-dss-audit-log-forwarding-enabled:
     default_result: FAIL
-    result_after_remediation: PASS
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-audit-log-forwarding-webhook:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
@@ -366,10 +366,13 @@ rule_results:
     result_after_remediation: PASS
   e2e-pci-dss-security-profiles-operator-exists:
     default_result: FAIL
-    result_after_remediation: PASS
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-api-server-tls-security-profile-custom-min-tls-version:
     default_result: PASS
     result_after_remediation: PASS
   e2e-pci-dss-api-server-tls-security-profile-not-old:
     default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-ingress-controller-tls-cipher-suites:
+    default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.15.yml
@@ -121,7 +121,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-pci-dss-audit-log-forwarding-enabled:
     default_result: FAIL
-    result_after_remediation: PASS
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-audit-log-forwarding-webhook:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
@@ -366,10 +366,13 @@ rule_results:
     result_after_remediation: PASS
   e2e-pci-dss-security-profiles-operator-exists:
     default_result: FAIL
-    result_after_remediation: PASS
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-api-server-tls-security-profile-custom-min-tls-version:
     default_result: PASS
     result_after_remediation: PASS
   e2e-pci-dss-api-server-tls-security-profile-not-old:
     default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-ingress-controller-tls-cipher-suites:
+    default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.16.yml
@@ -121,7 +121,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-pci-dss-audit-log-forwarding-enabled:
     default_result: FAIL
-    result_after_remediation: PASS
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-audit-log-forwarding-webhook:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
@@ -366,10 +366,13 @@ rule_results:
     result_after_remediation: PASS
   e2e-pci-dss-security-profiles-operator-exists:
     default_result: FAIL
-    result_after_remediation: PASS
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-api-server-tls-security-profile-custom-min-tls-version:
     default_result: PASS
     result_after_remediation: PASS
   e2e-pci-dss-api-server-tls-security-profile-not-old:
     default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-ingress-controller-tls-cipher-suites:
+    default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.17.yml
@@ -121,7 +121,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-pci-dss-audit-log-forwarding-enabled:
     default_result: FAIL
-    result_after_remediation: PASS
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-audit-log-forwarding-webhook:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
@@ -367,10 +367,13 @@ rule_results:
     result_after_remediation: PASS
   e2e-pci-dss-security-profiles-operator-exists:
     default_result: FAIL
-    result_after_remediation: PASS
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-api-server-tls-security-profile-custom-min-tls-version:
     default_result: PASS
     result_after_remediation: PASS
   e2e-pci-dss-api-server-tls-security-profile-not-old:
     default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-ingress-controller-tls-cipher-suites:
+    default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.18.yml
@@ -121,7 +121,7 @@ rule_results:
     result_after_remediation: PASS
   e2e-pci-dss-audit-log-forwarding-enabled:
     default_result: FAIL
-    result_after_remediation: PASS
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-audit-log-forwarding-webhook:
     default_result: NOT-APPLICABLE
     result_after_remediation: NOT-APPLICABLE
@@ -367,10 +367,13 @@ rule_results:
     result_after_remediation: PASS
   e2e-pci-dss-security-profiles-operator-exists:
     default_result: FAIL
-    result_after_remediation: PASS
+    result_after_remediation: PASS or NOT-APPLICABLE
   e2e-pci-dss-api-server-tls-security-profile-custom-min-tls-version:
     default_result: PASS
     result_after_remediation: PASS
   e2e-pci-dss-api-server-tls-security-profile-not-old:
     default_result: PASS
+    result_after_remediation: PASS
+  e2e-pci-dss-ingress-controller-tls-cipher-suites:
+    default_result: FAIL
     result_after_remediation: PASS


### PR DESCRIPTION
Some rules don't behave on arm64 like they do for amd64. This commit
updates those so the tests pass. The is primarily due to some operators
not being supported on ARM64 yet, so they don't install.
