### PR TITLE
Update account_password_* behavior for OL to support only new releases

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/ansible/shared.yml
@@ -10,8 +10,10 @@
   register: faillock_output
   with_items:
     - /etc/security/faillock.conf
+    {{% if 'ol' not in families %}}
     - /etc/pam.d/system-auth
     - /etc/pam.d/password-auth
+    {{% endif %}}
 
 - name: {{{ rule_title }}} - Create a list directories from faillock
   ansible.builtin.set_fact:

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/bash/shared.sh
@@ -1,6 +1,10 @@
 # platform = multi_platform_all
 
+{{% if 'ol' in families %}}
+FAILLOCK_CONF_FILES="/etc/security/faillock.conf"
+{{% else %}}
 FAILLOCK_CONF_FILES="/etc/security/faillock.conf /etc/pam.d/system-auth /etc/pam.d/password-auth"
+{{% endif %}}
 faillock_dirs=$(grep -oP "^\s*(?:auth.*pam_faillock.so.*)?dir\s*=\s*(\S+)" $FAILLOCK_CONF_FILES \
                | sed -r 's/.*=\s*(\S+)/\1/')
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/oval/shared.xml
@@ -1,6 +1,10 @@
+{{% if 'ol' in families %}}
+{{% set faillock_files = ["/etc/security/faillock.conf"] %}}
+{{% else %}}
 {{% set faillock_files = ["/etc/pam.d/password-auth",
                           "/etc/pam.d/system-auth",
                           "/etc/security/faillock.conf"] %}}
+{{% endif %}}
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
   {{{ oval_metadata("An SELinux Context must be configured for the Faillock directory.", rule_title=rule_title) }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/rule.yml
@@ -21,7 +21,7 @@ identifiers:
 references:
     nist: AC-7 (a)
     srg: SRG-OS-000021-GPOS-00005
-    stigid@ol8: OL08-00-020027,OL08-00-020028
+    stigid@ol8: OL08-00-020027
 
 {{% if product == "ol8" %}}
 platform: os_linux[ol]>=8.2 and system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/rule.yml
@@ -23,7 +23,11 @@ references:
     srg: SRG-OS-000021-GPOS-00005
     stigid@ol8: OL08-00-020027,OL08-00-020028
 
+{{% if product == "ol8" %}}
+platform: os_linux[ol]>=8.2 and system_with_kernel
+{{% else %}}
 platform: system_with_kernel
+{{% endif %}}
 
 ocil_clause: 'the security context type of the non-default tally directory is not "faillog_t"'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/oval/shared.xml
@@ -10,6 +10,7 @@
             that if faillock.conf is available, authselect tool only manage parameters on it -->
         <criteria operator="OR"
         comment="Check expected value for pam_faillock.so audit parameter">
+            {{% if 'ol' not in families %}}
             <criteria operator="AND"
             comment="Check expected pam_faillock.so audit parameter in pam files">
                 <criterion
@@ -22,6 +23,7 @@
                 test_ref="test_pam_faillock_audit_parameter_no_faillock_conf"
                 comment="Ensure /etc/security/faillock.conf is not used together with pam files"/>
             </criteria>
+            {{% endif %}}
             <criteria operator="AND"
             comment="Check expected pam_faillock.so audit parameter in faillock.conf">
                 <criterion

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/rule.yml
@@ -21,7 +21,11 @@ references:
     stigid@ol8: OL08-00-020020,OL08-00-020021
 
 {{% if product == "rhel8" %}}
-platform: os_linux[rhel]>=8.2
+platform: os_linux[rhel]>=8.2 and package[pam]
+{{% elif product == "ol8" %}}
+platform: os_linux[ol]>=8.2 and package[pam]
+{{% else %}}
+platform: package[pam]
 {{% endif %}}
 
 ocil_clause: 'the "audit" option is not set, is missing or commented out'
@@ -42,4 +46,3 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} must log user name information when unsuccessful logon attempts occur.'
 
-platform: package[pam]

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/rule.yml
@@ -18,7 +18,7 @@ identifiers:
 references:
     nist: AC-7 (a)
     srg: SRG-OS-000021-GPOS-00005
-    stigid@ol8: OL08-00-020020,OL08-00-020021
+    stigid@ol8: OL08-00-020021
 
 {{% if product == "rhel8" %}}
 platform: os_linux[rhel]>=8.2 and package[pam]

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/expected_pam_files.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_audit/tests/expected_pam_files.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect,pam
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle,multi_platform_almalinux
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhv,multi_platform_sle,multi_platform_almalinux
 
 source common.sh
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
@@ -46,7 +46,7 @@ references:
     pcidss: Req-8.1.6
     srg: SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005
     stigid@ol7: OL07-00-010320
-    stigid@ol8: OL08-00-020010,OL08-00-020011
+    stigid@ol8: OL08-00-020011
 
 {{% if product == "ol8" %}}
 platform: os_linux[ol]>=8.2 and package[pam]

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
@@ -48,7 +48,11 @@ references:
     stigid@ol7: OL07-00-010320
     stigid@ol8: OL08-00-020010,OL08-00-020011
 
+{{% if product == "ol8" %}}
+platform: os_linux[ol]>=8.2 and package[pam]
+{{% else %}}
 platform: package[pam]
+{{% endif %}}
 
 ocil_clause: |-
     the "deny" option is not set to "{{{ xccdf_value("var_accounts_passwords_pam_faillock_deny") }}}"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/oval/shared.xml
@@ -21,6 +21,7 @@
              versions, in /etc/security/faillock.conf. The last is the recommended option when
              available. Also, is the option used by auselect tool. However, regardless the
              approach, a minimal declaration is common in pam files. -->
+        {{% if 'ol' not in families %}}
         <criteria operator="AND" comment="Check common definition of pam_faillock.so">
           <criterion
               test_ref="test_accounts_passwords_pam_faillock_deny_root_system_pam_faillock_auth"
@@ -35,6 +36,7 @@
               test_ref="test_accounts_passwords_pam_faillock_deny_root_password_pam_faillock_account"
               comment="pam_faillock.so is properly defined in account section of password-auth"/>
         </criteria>
+        {{% endif %}}
       </criteria>
 
       <!-- pam_faillock.so parameters should be defined in /etc/security/faillock.conf whenever
@@ -44,6 +46,7 @@
            that if faillock.conf is available, authselect tool only manage parameters on it -->
       <criteria operator="OR"
                 comment="Check expected value for pam_faillock.so even_deny_root parameter">
+        {{% if 'ol' not in families %}}
         <criteria operator="AND"
                   comment="Check expected pam_faillock.so even_deny_root parameter in pam files">
           <criterion
@@ -56,6 +59,7 @@
               test_ref="test_accounts_passwords_pam_faillock_deny_root_parameter_no_faillock_conf"
               comment="Ensure /etc/security/faillock.conf is not used together with pam files"/>
         </criteria>
+        {{% endif %}}
         <criteria operator="AND"
               comment="Check expected pam_faillock.so even_deny_root parameter in faillock.conf">
           <criterion

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/rule.yml
@@ -40,7 +40,11 @@ references:
     stigid@ol8: OL08-00-020022,OL08-00-020023
 
 {{% if product == "rhel8" %}}
-platform: os_linux[rhel]>=8.2
+platform: os_linux[rhel]>=8.2 and package[pam]
+{{% elif product == "ol8" %}}
+platform: os_linux[ol]>=8.2 and package[pam]
+{{% else %}}
+platform: package[pam]
 {{% endif %}}
 
 ocil_clause: 'the "even_deny_root" option is not set, is missing or commented out'
@@ -63,8 +67,6 @@ fixtext: |-
     add or uncomment the following line:
     <pre>even_deny_root</pre>
 
-
-platform: package[pam]
 
 warnings:
     - general: |-

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/rule.yml
@@ -37,7 +37,7 @@ references:
     nist-csf: PR.AC-7
     srg: SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005
     stigid@ol7: OL07-00-010330
-    stigid@ol8: OL08-00-020022,OL08-00-020023
+    stigid@ol8: OL08-00-020023
 
 {{% if product == "rhel8" %}}
 platform: os_linux[rhel]>=8.2 and package[pam]

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/oval/shared.xml
@@ -9,6 +9,7 @@
                   that if faillock.conf is available, authselect tool only manage parameters on it -->
             <criteria operator="OR"
             comment="Check expected value for pam_faillock.so dir parameter">
+                  {{%- if 'ol' not in families -%}}
                   <criteria operator="AND"
                   comment="Check expected pam_faillock.so dir parameter in pam files">
                         <criterion
@@ -21,6 +22,7 @@
                         test_ref="test_pam_faillock_dir_parameter_no_faillock_conf"
                         comment="Ensure /etc/security/faillock.conf is not used together with pam files"/>
                   </criteria>
+                  {{%- endif -%}}
                   <criteria operator="AND"
                   comment="Check expected pam_faillock.so dir parameter in faillock.conf">
                         <criterion

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/rule.yml
@@ -53,7 +53,11 @@ fixtext: |-
     add, uncomment or edit the following line:
     <pre>dir = {{{ xccdf_value("var_accounts_passwords_pam_faillock_dir") }}}</pre>
 
+{{% if product == "ol8" %}}
+platform: os_linux[ol]>=8.2 and package[pam]
+{{% else %}}
 platform: package[pam]
+{{% endif %}}
 
 srg_requirement: '{{{ full_name }}} must ensure account lockouts persist.'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/rule.yml
@@ -35,7 +35,7 @@ identifiers:
 references:
     nist: AC-7(b),AC-7(a),AC-7.1(ii)
     srg: SRG-OS-000021-GPOS-00005,SRG-OS-000329-GPOS-00128
-    stigid@ol8: OL08-00-020016,OL08-00-020017
+    stigid@ol8: OL08-00-020017
 
 ocil_clause: 'the "dir" option is not set to a non-default documented tally log directory, is missing or commented out'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/tests/expected_pam_files.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/tests/expected_pam_files.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect,pam
-# platform = multi_platform_fedora,Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 source common.sh
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
@@ -44,7 +44,11 @@ references:
     stigid@ol7: OL07-00-010320
     stigid@ol8: OL08-00-020012,OL08-00-020013
 
+{{% if product == "ol8" %}}
+platform: os_linux[ol]>=8.2 and package[pam]
+{{% else %}}
 platform: package[pam]
+{{% endif %}}
 
 ocil_clause: |-
     the "fail_interval" option is not set to "{{{ xccdf_value("var_accounts_passwords_pam_faillock_fail_interval") }}}"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
@@ -42,7 +42,7 @@ references:
     ospp: FIA_AFL.1
     srg: SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005
     stigid@ol7: OL07-00-010320
-    stigid@ol8: OL08-00-020012,OL08-00-020013
+    stigid@ol8: OL08-00-020013
 
 {{% if product == "ol8" %}}
 platform: os_linux[ol]>=8.2 and package[pam]

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/oval/shared.xml
@@ -10,6 +10,7 @@
             that if faillock.conf is available, authselect tool only manage parameters on it -->
         <criteria operator="OR"
         comment="Check expected value for pam_faillock.so silent parameter">
+            {{% if 'ol' not in families %}}
             <criteria operator="AND"
             comment="Check expected pam_faillock.so silent parameter in pam files">
                 <criterion
@@ -22,6 +23,7 @@
                 test_ref="test_pam_faillock_silent_parameter_no_faillock_conf"
                 comment="Ensure /etc/security/faillock.conf is not used together with pam files"/>
             </criteria>
+            {{% endif %}}
             <criteria operator="AND"
             comment="Check expected pam_faillock.so silent parameter in faillock.conf">
                 <criterion

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/rule.yml
@@ -48,7 +48,11 @@ fixtext: |-
     add or uncomment the following line:
     <pre>silent</pre>
 
+{{% if product == "ol8" %}}
+platform: os_linux[ol]>=8.2 and package[pam]
+{{% else %}}
 platform: package[pam]
+{{% endif %}}
 
 warnings:
     - general: |-

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/rule.yml
@@ -27,7 +27,7 @@ identifiers:
 
 references:
     srg: SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005
-    stigid@ol8: OL08-00-020018,OL08-00-020019
+    stigid@ol8: OL08-00-020019
 
 ocil_clause: 'the system shows messages when three unsuccessful logon attempts occur'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/common.sh
@@ -11,5 +11,6 @@ done
 authselect select --force custom/testingProfile
 {{{ bash_pam_faillock_enable() }}}
 
-
+{{% if 'ol' not in families %}}
 rm -f /etc/security/faillock.conf
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/expected_pam_files.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/tests/expected_pam_files.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle,multi_platform_almalinux
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhv,multi_platform_sle,multi_platform_almalinux
 
 source common.sh
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
@@ -47,7 +47,7 @@ references:
     pcidss: Req-8.1.7
     srg: SRG-OS-000329-GPOS-00128,SRG-OS-000021-GPOS-00005
     stigid@ol7: OL07-00-010320
-    stigid@ol8: OL08-00-020014,OL08-00-020015
+    stigid@ol8: OL08-00-020015
 
 {{% if product == "ol8" %}}
 platform: os_linux[ol]>=8.2 and package[pam]

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
@@ -49,7 +49,11 @@ references:
     stigid@ol7: OL07-00-010320
     stigid@ol8: OL08-00-020014,OL08-00-020015
 
+{{% if product == "ol8" %}}
+platform: os_linux[ol]>=8.2 and package[pam]
+{{% else %}}
 platform: package[pam]
+{{% endif %}}
 
 ocil_clause: |-
     the "unlock_time" option is not set to "{{{ xccdf_value("var_accounts_passwords_pam_faillock_unlock_time") }}}",

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -489,26 +489,26 @@ selections:
     # OL08-00-020000, OL08-00-020270
     - account_temp_expire_date
 
-    # OL08-00-020010, OL08-00-020011
+    # OL08-00-020011
     - accounts_passwords_pam_faillock_deny
 
-    # OL08-00-020012, OL08-00-020013
+    # OL08-00-020013
     - accounts_passwords_pam_faillock_interval
 
 
-    # OL08-00-020014, OL08-00-020015
+    # OL08-00-020015
     - accounts_passwords_pam_faillock_unlock_time
 
-    # OL08-00-020016, OL08-00-020017
+    # OL08-00-020017
     - accounts_passwords_pam_faillock_dir
 
-    # OL08-00-020018, OL08-00-020019
+    # OL08-00-020019
     - accounts_passwords_pam_faillock_silent
 
-    # OL08-00-020020, OL08-00-020021
+    # OL08-00-020021
     - accounts_passwords_pam_faillock_audit
 
-    # OL08-00-020022, OL08-00-020023
+    # OL08-00-020023
     - accounts_passwords_pam_faillock_deny_root
 
     # OL08-00-020024
@@ -520,7 +520,7 @@ selections:
     # OL08-00-020026
     - account_password_pam_faillock_password_auth
 
-    # OL08-00-020027, OL08-00-020028
+    # OL08-00-020027
     - account_password_selinux_faillock_dir
 
     # OL08-00-020030, OL08-00-020082

--- a/shared/templates/pam_account_password_faillock/oval.template
+++ b/shared/templates/pam_account_password_faillock/oval.template
@@ -53,6 +53,7 @@
 	  <criterion test_ref="test_accounts_passwords_pam_faillock_{{{ PRM_NAME }}}_password_pam_unix_auth"
                      comment="pam_unix.so appears only once in auth section of password-auth"/>
 	</criteria>
+        {{% if 'ol' not in families %}}
 	
         <!-- pam_faillock.so parameters can be defined directly in pam files or, in newer
              versions, in /etc/security/faillock.conf. The last is the recommended option when
@@ -72,6 +73,7 @@
 	      test_ref="test_accounts_passwords_pam_faillock_{{{ PRM_NAME }}}_password_pam_faillock_account"
 	      comment="pam_faillock.so is properly defined in account section of password-auth"/>
         </criteria>
+        {{% endif %}}
       </criteria>
 
       <!-- pam_faillock.so parameters should be defined in /etc/security/faillock.conf whenever
@@ -80,6 +82,7 @@
            may confuse the assessment. The following tests ensure only one option is used. Note
            that if faillock.conf is available, authselect tool only manage parameters on it -->
       <criteria operator="OR" comment="Check expected value for pam_faillock.so {{{ PRM_NAME }}} parameter">
+        {{% if 'ol' not in families %}}
         <criteria operator="AND"
                   comment="Check expected pam_faillock.so {{{ PRM_NAME }}} parameter in pam files">
           <criterion
@@ -92,6 +95,7 @@
               test_ref="test_accounts_passwords_pam_faillock_{{{ PRM_NAME }}}_parameter_no_faillock_conf"
               comment="Ensure the {{{ PRM_NAME }}} parameter is not present in /etc/security/faillock.conf"/>
         </criteria>
+        {{% endif %}}
         <criteria operator="AND"
                   comment="Check expected pam_faillock.so {{{ PRM_NAME }}} parameter in faillock.conf">
           <criterion


### PR DESCRIPTION
#### Description:

Update for only support newer releases for OL

- pam_account_password_faillock template
- accounts_passwords_pam_faillock_interval
- accounts_passwords_pam_faillock_unlock_time
- accounts_passwords_pam_faillock_dir
- accounts_passwords_pam_faillock_audit
- accounts_passwords_pam_faillock_deny_root
- accounts_passwords_pam_faillock_deny
- accounts_passwords_pam_faillock_silent

#### Rationale:

This change update the approach from OL8 STIG requirements to only support newer OL versions