### PR TITLE
[Stabilization]: broaden applicability of rules wrt FIPS cryptopolicy

### DIFF
--- a/linux_os/guide/system/software/integrity/fips/enable_dracut_fips_module/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/enable_dracut_fips_module/rule.yml
@@ -47,7 +47,7 @@ ocil: |-
     The output should look like this:
     <tt>add_dracutmodules+=" fips "</tt>
 
-platform: not bootc
+platform: not bootc and system_with_kernel and not osbuild
 
 warnings:
     - general: |-

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/rule.yml
@@ -83,3 +83,5 @@ fixtext: |-
     The installer for the system must be booted with kernel parameter <tt>fips=1</tt>.
 
 srg_requirement: '{{{ full_name }}} must implement NIST FIPS-validated cryptography for the following: to provision digital signatures, to generate cryptographic hashes, and to protect data requiring data-at-rest protections in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, and standards.'
+
+platform: system_with_kernel and not osbuild

--- a/linux_os/guide/system/software/integrity/fips/etc_system_fips_exists/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/etc_system_fips_exists/rule.yml
@@ -69,3 +69,5 @@ warnings:
         party review by an accredited lab. While open source software is
         capable of meeting this, it does not meet FIPS-140 unless the vendor
         submits to this process.
+
+platform: system_with_kernel and not osbuild

--- a/linux_os/guide/system/software/integrity/fips/fips_crypto_policy_symlinks/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/fips_crypto_policy_symlinks/rule.yml
@@ -54,3 +54,5 @@ ocil: |-
     '/etc/crypto-policies/back-ends/openssl.config' -> '/usr/share/crypto-policies/FIPS/openssl.txt'
     '/etc/crypto-policies/back-ends/openssl_fips.config' -> '/usr/share/crypto-policies/FIPS/openssl_fips.txt'
     </pre>
+
+platform: system_with_kernel and not osbuild

--- a/linux_os/guide/system/software/integrity/fips/group.yml
+++ b/linux_os/guide/system/software/integrity/fips/group.yml
@@ -15,4 +15,3 @@ description: |-
     <br /><br />
     See <b>{{{ weblink(link="http://csrc.nist.gov/publications/PubsFIPS.html") }}}</b> for more information.
 
-platform: system_with_kernel and not osbuild

--- a/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/rule.yml
@@ -43,8 +43,7 @@ rationale: |-
 
 severity: high
 
-platforms:
-    - grub2
+platform: grub2 and system_with_kernel and not osbuild
 
 identifiers:
     cce@rhel10: CCE-86191-4

--- a/linux_os/guide/system/software/integrity/fips/is_fips_mode_enabled/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/is_fips_mode_enabled/rule.yml
@@ -58,3 +58,5 @@ warnings:
         party review by an accredited lab. While open source software is
         capable of meeting this, it does not meet FIPS-140 unless the vendor
         submits to this process.
+
+platform: system_with_kernel and not osbuild

--- a/linux_os/guide/system/software/integrity/fips/package_dracut-fips-aesni_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/package_dracut-fips-aesni_installed/rule.yml
@@ -54,3 +54,5 @@ warnings:
         party review by an accredited lab. While open source software is
         capable of meeting this, it does not meet FIPS-140 unless the vendor
         submits to this process.
+
+platform: system_with_kernel and not osbuild

--- a/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/rule.yml
@@ -58,3 +58,5 @@ template:
         pkgname: dracut-fips
     backends:
         oval: "off"
+
+platform: system_with_kernel and not osbuild

--- a/linux_os/guide/system/software/integrity/fips/sysctl_crypto_fips_enabled/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/sysctl_crypto_fips_enabled/rule.yml
@@ -86,3 +86,5 @@ checktext: |-
     $ sudo fips-mode-setup --check
     FIPS mode is enabled.
     If FIPS mode is not enabled, this is a finding.
+
+platform: system_with_kernel and not osbuild

--- a/linux_os/guide/system/software/integrity/fips/system_booted_in_fips_mode/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/system_booted_in_fips_mode/rule.yml
@@ -57,3 +57,5 @@ warnings:
         party review by an accredited lab. While open source software is
         capable of meeting this, it does not meet FIPS-140 unless the vendor
         submits to this process.
+
+platform: system_with_kernel and not osbuild


### PR DESCRIPTION
#### Description:

- in fips group, take the platform from group.yml and apply it to every rule except for fips_custom_stig_sub_policy and fips_crypto_subpolicy

#### Rationale:

- the reason is that two rules, especially fips_crypto_subpolicy and fips_custom_stig_sub_policy make sense even on systems without kernel. Actually I think they should be located in the crypto group instead, but having them in this group somehow makes them having precedence before crypto rules are applied. And this is needed because the rule fips_custom_stig_sub_policy creates a new subpolicy. If the order is reversed, it currently causes trouble.

The alternative approach would be to move these rules into the crypto group and modify the code so that they have precedence before the configure_crypto_policy rule. It can be fixed in this way in the future.

- Fixes #13813 

#### Review Hints:

When using Contest test suite, utilize the test /hardening/image-builder/stig.

Try it with the content before this PR and with this PR included.