### PR TITLE
[stabilization]: auditd_lineinfile: allow specifying data type of XCCDF variable

### DIFF
--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -31,6 +31,17 @@
     - **xccdf_variable** - specifies an XCCDF variable to use as a value for the specified **parameter**.
         This parameter conflicts with the **value** parameter.
 
+    - **variable_datatype** - data type of the XCCDF variable specified by the xccdf_variable parameter, optional, default is string
+
+    - **test_correct_value** - optional. If set, it will be used in test scenarios as a correct value.
+      If not set, the "value" parameter of the template will be used.
+      If XCCDF variable is used and the this option is not set, then a string "corect_value" will be used.
+      This parameter should be used in case the value is defined by an XCCDF variable and the value must be chosen from a strictly defined set of options.
+
+    - **test_wrong_value** - optional. If set, this value will be used test scenarios as a incorrect value.
+      If not set, a string "wrong_value" will be used.
+      This parameter can be used in case that the value has to be chosen from strictly defined set of options.
+
     -   **missing_parameter_pass** - effective only in OVAL checks, if
         set to `"false"` and the parameter is not present in the
         configuration file, the OVAL check will return false (default value: `"false"`).

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_freq/rule.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_freq/rule.yml
@@ -47,3 +47,6 @@ template:
         parameter: freq
         rule_id: auditd_freq
         xccdf_variable: var_auditd_freq
+        variable_datatype: int
+        test_correct_value: 50
+        test_wrong_value: 1

--- a/shared/macros/10-oval.jinja
+++ b/shared/macros/10-oval.jinja
@@ -679,8 +679,8 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
 :type missing_config_file_fail: bool
 
 #}}
-{{%- macro oval_auditd_config(parameter='', value='', xccdf_variable='', missing_parameter_pass=false, multi_value=false, missing_config_file_fail=false, rule_id=None, rule_title=None) %}}
-{{{ oval_check_config_file("/etc/audit/auditd.conf", prefix_regex="^[ \\t]*(?i)", parameter=parameter, separator_regex='(?-i)[ \\t]*=[ \\t]*', value="(?i)"+value+"(?-i)", xccdf_variable=xccdf_variable, missing_parameter_pass=missing_parameter_pass, application="auditd", multi_value=multi_value, missing_config_file_fail=missing_config_file_fail, rule_id=rule_id, rule_title=rule_title) }}}
+{{%- macro oval_auditd_config(parameter='', value='', xccdf_variable='', variable_datatype='string', missing_parameter_pass=false, multi_value=false, missing_config_file_fail=false, rule_id=None, rule_title=None) %}}
+{{{ oval_check_config_file("/etc/audit/auditd.conf", prefix_regex="^[ \\t]*(?i)", parameter=parameter, separator_regex='(?-i)[ \\t]*=[ \\t]*', value="(?i)"+value+"(?-i)", xccdf_variable=xccdf_variable, variable_datatype=variable_datatype, missing_parameter_pass=missing_parameter_pass, application="auditd", multi_value=multi_value, missing_config_file_fail=missing_config_file_fail, rule_id=rule_id, rule_title=rule_title) }}}
 {{%- endmacro %}}
 
 

--- a/shared/templates/auditd_lineinfile/oval.template
+++ b/shared/templates/auditd_lineinfile/oval.template
@@ -3,13 +3,18 @@
 oval_auditd_config(
 	parameter=PARAMETER,
 	xccdf_variable=XCCDF_VARIABLE,
-	missing_parameter_pass=MISSING_PARAMETER_PASS, rule_id=rule_id, rule_title=rule_title)
+	variable_datatype=VARIABLE_DATATYPE,
+	missing_parameter_pass=MISSING_PARAMETER_PASS,
+	rule_id=rule_id,
+	rule_title=rule_title)
 }}}
 {{%- else -%}}
 {{{
 oval_auditd_config(
 	parameter=PARAMETER,
 	value=VALUE,
-	missing_parameter_pass=MISSING_PARAMETER_PASS, rule_id=rule_id, rule_title=rule_title)
+	missing_parameter_pass=MISSING_PARAMETER_PASS,
+	rule_id=rule_id,
+	rule_title=rule_title)
 }}}
 {{%- endif -%}}

--- a/shared/templates/auditd_lineinfile/template.py
+++ b/shared/templates/auditd_lineinfile/template.py
@@ -10,15 +10,20 @@ def preprocess(data, lang):
         raise ValueError(errmsg)
     data["missing_parameter_pass"] = parse_template_boolean_value(
         data, parameter="missing_parameter_pass", default_value=False)
+    if "variable_datatype" not in data:
+        data["variable_datatype"] = "string"
     return set_variables_for_test_scenarios(data)
 
 
 def set_variables_for_test_scenarios(data):
-    if not data.get("value"):
-        # this implies XCCDF variable is used
-        data["wrong_value"] = "wrong_value"
-        data["correct_value"] = "correct_value"
-    else:
-        data["wrong_value"] = "wrong_value"
-        data["correct_value"] = str(data["value"])
+    # if no correct value is specified, we will create one for testing purposes
+    if not data.get("test_correct_value"):
+        if not data.get("value"):
+            # this implies XCCDF variable is used
+            data["test_correct_value"] = "test_correct_value"
+        else:
+            data["test_correct_value"] = str(data["value"])
+    # if no wrong value is provided, we will create one for testing purposes
+    if not data.get("test_wrong_value"):
+        data["test_wrong_value"] = "test_wrong_value"
     return data

--- a/shared/templates/auditd_lineinfile/tests/commented.fail.sh
+++ b/shared/templates/auditd_lineinfile/tests/commented.fail.sh
@@ -4,6 +4,6 @@
 {{% endif%}}
 # packages = audit
 {{% if XCCDF_VARIABLE %}}
-# variables = {{{ XCCDF_VARIABLE }}}={{{ CORRECT_VALUE }}}
+# variables = {{{ XCCDF_VARIABLE }}}={{{ TEST_CORRECT_VALUE }}}
 {{% endif %}}
-echo "#{{{ PARAMETER }}} = {{{ CORRECT_VALUE }}}" > "/etc/audit/auditd.conf"
+echo "#{{{ PARAMETER }}} = {{{ TEST_CORRECT_VALUE }}}" > "/etc/audit/auditd.conf"

--- a/shared/templates/auditd_lineinfile/tests/correct_value.pass.sh
+++ b/shared/templates/auditd_lineinfile/tests/correct_value.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
 {{% if XCCDF_VARIABLE %}}
-# variables = {{{ XCCDF_VARIABLE }}}={{{ CORRECT_VALUE }}}
+# variables = {{{ XCCDF_VARIABLE }}}={{{ TEST_CORRECT_VALUE }}}
 {{% endif %}}
-echo "{{{ PARAMETER }}} = {{{ CORRECT_VALUE }}}" > "/etc/audit/auditd.conf"
+echo "{{{ PARAMETER }}} = {{{ TEST_CORRECT_VALUE }}}" > "/etc/audit/auditd.conf"

--- a/shared/templates/auditd_lineinfile/tests/double_assignment.fail.sh
+++ b/shared/templates/auditd_lineinfile/tests/double_assignment.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = audit
 {{% if XCCDF_VARIABLE %}}
-# variables = {{{ XCCDF_VARIABLE }}}={{{ CORRECT_VALUE }}}
+# variables = {{{ XCCDF_VARIABLE }}}={{{ TEST_CORRECT_VALUE }}}
 {{% endif %}}
-echo "{{{ PARAMETER }}} = {{{ CORRECT_VALUE }}}" >> "/etc/audit/auditd.conf"
-echo "{{{ PARAMETER }}} = wrong_value" >> "/etc/audit/auditd.conf"
+echo "{{{ PARAMETER }}} = {{{ TEST_CORRECT_VALUE }}}" >> "/etc/audit/auditd.conf"
+echo "{{{ PARAMETER }}} = {{{ TEST_WRONG_VALUE }}}" >> "/etc/audit/auditd.conf"

--- a/shared/templates/auditd_lineinfile/tests/wrong_value.fail.sh
+++ b/shared/templates/auditd_lineinfile/tests/wrong_value.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
 {{% if XCCDF_VARIABLE %}}
-# variables = {{{ XCCDF_VARIABLE }}}={{{ CORRECT_VALUE }}}
+# variables = {{{ XCCDF_VARIABLE }}}={{{ TEST_CORRECT_VALUE }}}
 {{% endif %}}
-echo "{{{ PARAMETER }}} = {{{ WRONG_VALUE | upper }}}" > "/etc/audit/auditd.conf"
+echo "{{{ PARAMETER }}} = {{{ TEST_WRONG_VALUE }}}" > "/etc/audit/auditd.conf"

--- a/shared/templates/auditd_lineinfile/tests/wrong_value_capital.fail.sh
+++ b/shared/templates/auditd_lineinfile/tests/wrong_value_capital.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
 {{% if XCCDF_VARIABLE %}}
-# variables = {{{ XCCDF_VARIABLE }}}={{{ CORRECT_VALUE }}}
+# platform = Not Applicable
 {{% endif %}}
 echo "{{{ PARAMETER | upper }}} = {{{ WRONG_VALUE | upper }}}" > "/etc/audit/auditd.conf"


### PR DESCRIPTION
#### Description:

- please see commit messages

#### Rationale:

- values in auditd files are usually strings, but they can be also integers
- in  case they are integers and we do not specify this fact in OVAL, we fail SCAP validation.


#### Review Hints:

Run SCAP validation on for example rhel9 data stream.