### PR TITLE
Fix the conflicts of "Auto-generated PRs" in oscal-content

### DIFF
--- a/.github/workflows/sync-cac-oscal.yml
+++ b/.github/workflows/sync-cac-oscal.yml
@@ -160,25 +160,43 @@ jobs:
                 done
               fi
           done < "$GITHUB_WORKSPACE"/updates
-      # Step 10: Check if the OSCAL content branch exists
+      # Step 10: Check if there is any existing open PR
+      - name: Check if there is any existing open PR
+        run: |
+          # Use the GitHub CLI to search for an open PR.
+          # The 'jq' query filters for PRs where the branch name contains "sync_cac_pr".
+          # We take the first result found.
+          PR_BRANCH=$(gh pr list --state open --json headRefName --jq '.[] | select(.headRefName | contains("sync_cac_pr")) | .headRefName' | head -n 1)
+          if [[ -n "$PR_BRANCH" ]]; then
+            echo "Found matching PR branch: $PR_BRANCH"
+            # Set the branch name as the PR_BRANCH.
+            echo "BRANCH_NAME=$PR_BRANCH" >> $GITHUB_ENV
+          else
+            echo "No open PR found with 'sync_cac_pr' in the branch name."
+            BRANCH_NAME="sync_cac_pr${{ env.PR_NUMBER }}"
+            echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+          fi
+      # Step 11: Check if the OSCAL content branch exists
       - name: Check if the OSCAL content branch exists
         if: ${{ env.CHANGE_FOUND == 'true' }}
         run: |
-          BRANCH_NAME="sync_cac_pr${{ env.PR_NUMBER }}"
           cd oscal-content
           git fetch --all
-          if git show-ref --verify --quiet refs/remotes/origin/"$BRANCH_NAME"; then
-            git checkout -b "sync_cac_pr${{ env.PR_NUMBER }}" origin/sync_cac_pr${{ env.PR_NUMBER }}
+          if git show-ref --verify --quiet refs/remotes/origin/"${{ env.BRANCH_NAME }}"; then
+            git checkout -b "${{ env.BRANCH_NAME }}" origin/${{ env.BRANCH_NAME }}
           else
             echo "OSCAL content branch $BRANCH_NAME doesn't exist"
           fi
-      # Step 11: Sync updated controls to OSCAL content
+          # Get the base commit HASH
+          base_commit=$(git log -1 --format=%H)
+          echo "base_commit=$base_commit" >> $GITHUB_ENV
+
+      # Step 12: Sync updated controls to OSCAL content
       - name: Sync updated controls to OSCAL content
         if: ${{ env.CHANGE_FOUND == 'true' }}
         run: |
           cd complyscribe && source venv/bin/activate
           RH_PRODUCTS=${{ env.RH_PRODUCTS }}
-          pr_number="${{ env.PR_NUMBER }}"
           # 1.1 Get the updated controls to array
           file="updated_controls"
           if [ -f "$file" ] && [ -s "$file" ]; then
@@ -194,17 +212,17 @@ jobs:
               for pc in "${available_controls[@]}"; do
                 if [[ "$pc" == "$policy_id" ]]; then
                   # 1.2.1 Sync the updated controls to OSCAL catalog
-                  poetry run complyscribe sync-cac-content catalog  --repo-path ../oscal-content --committer-email "openscap-ci@gmail.com" --committer-name "openscap-ci" --branch "sync_cac_pr$pr_number" --cac-content-root "$GITHUB_WORKSPACE/cac-content" --cac-policy-id "$policy_id" --oscal-catalog "$policy_id"
+                  poetry run complyscribe sync-cac-content catalog  --repo-path ../oscal-content --committer-email "openscap-ci@gmail.com" --committer-name "openscap-ci" --branch "${{ env.BRANCH_NAME }}" --cac-content-root "$GITHUB_WORKSPACE/cac-content" --cac-policy-id "$policy_id" --oscal-catalog "$policy_id"
                   # 1.2.2 Sync the updated controls to OSCAL profile
-                  poetry run complyscribe sync-cac-content profile  --repo-path ../oscal-content --committer-email "openscap-ci@gmail.com" --committer-name "openscap-ci" --branch "sync_cac_pr$pr_number" --cac-content-root "$GITHUB_WORKSPACE/cac-content" --product "$product" --cac-policy-id "$policy_id" --oscal-catalog "$policy_id"
+                  poetry run complyscribe sync-cac-content profile  --repo-path ../oscal-content --committer-email "openscap-ci@gmail.com" --committer-name "openscap-ci" --branch "${{ env.BRANCH_NAME }}" --cac-content-root "$GITHUB_WORKSPACE/cac-content" --product "$product" --cac-policy-id "$policy_id" --oscal-catalog "$policy_id"
                 fi
               done
               # 1.2.3 Sync the updated controls to OSCAL component-definition
               # This sync depends on the control assoicated profile and levels
-              sh ../cac-content/utils/complyscribe-cli-compd.sh true $policy_id $product $pr_number $GITHUB_WORKSPACE $product"_map.json"
+              sh ../cac-content/utils/complyscribe-cli-compd.sh true $policy_id $product ${{ env.BRANCH_NAME }} $GITHUB_WORKSPACE $product"_map.json"
             done
           done
-      # Step 12: Sync updated profiles to OSCAL content
+      # Step 13: Sync updated profiles to OSCAL content
       - name: Sync updated profiles to OSCAL content
         if: ${{ env.CHANGE_FOUND == 'true' }}
         run: |
@@ -225,15 +243,15 @@ jobs:
                   policy_id=$(echo "$map" | jq -r '.policy_id')
                   profile_name=$(echo "$map" | jq -r '.profile_name')
                   if [[ "$profile" == "$profile_name" ]]; then
-                    poetry run complyscribe sync-cac-content profile  --repo-path ../oscal-content --committer-email "openscap-ci@gmail.com" --committer-name "openscap-ci" --branch "sync_cac_pr$pr_number" --cac-content-root "$GITHUB_WORKSPACE/cac-content" --product "$product" --cac-policy-id "$policy_id" --oscal-catalog "$policy_id"
+                    poetry run complyscribe sync-cac-content profile  --repo-path ../oscal-content --committer-email "openscap-ci@gmail.com" --committer-name "openscap-ci" --branch "${{ env.BRANCH_NAME }}" --cac-content-root "$GITHUB_WORKSPACE/cac-content" --product "$product" --cac-policy-id "$policy_id" --oscal-catalog "$policy_id"
                   fi
                 done < $product"_map.json"
                 # 2.2 Sync CaC profile to OSCAL component-definition
-                sh ../cac-content/utils/complyscribe-cli-compd.sh false $profile $product $pr_number $GITHUB_WORKSPACE $product"_map.json"
+                sh ../cac-content/utils/complyscribe-cli-compd.sh false $profile $product ${{ env.BRANCH_NAME }} $GITHUB_WORKSPACE $product"_map.json"
               done
             fi
           done
-      # Step 13: Sync rule updates to OSCAL component-definition
+      # Step 14: Sync rule updates to OSCAL component-definition
       - name: Sync rule updates to OSCAL component-definition
         if: ${{ env.CHANGE_FOUND == 'true' }}
         run: |
@@ -249,7 +267,7 @@ jobs:
             for product in "${RH_PRODUCTS[@]}"; do
               # Sync CAC controls' updates to OSCAL content
               for policy_id in "${rule_impacted_controls[@]}"; do
-                sh ../cac-content/utils/complyscribe-cli-compd.sh true $policy_id $product $pr_number $GITHUB_WORKSPACE $product"_map.json"
+                sh ../cac-content/utils/complyscribe-cli-compd.sh true $policy_id $product ${{ env.BRANCH_NAME }} $GITHUB_WORKSPACE $product"_map.json"
               done
             done
           fi
@@ -261,23 +279,23 @@ jobs:
               echo "The rule impacted profiles for $product: ${rule_impacted_profiles[@]}"
               # 4. Sync the rule impacted profiles to OSCAL component-definition
               for profile in "${rule_impacted_profiles[@]}"; do
-                sh ../cac-content/utils/complyscribe-cli-compd.sh false $profile $product $pr_number $GITHUB_WORKSPACE $product"_map.json"
+                sh ../cac-content/utils/complyscribe-cli-compd.sh false $profile $product ${{ env.BRANCH_NAME }} $GITHUB_WORKSPACE $product"_map.json"
               done
             fi
           done
-      # Step 14: Squash multiple commits
+      # Step 15: Squash multiple commits for each run
       - name: Squash multiple commits
         if: ${{ env.CHANGE_FOUND == 'true' }}
         run: |
           cd oscal-content
-          BRANCH_NAME="sync_cac_pr${{ env.PR_NUMBER }}"
           git config user.name "openscap-ci"
           git config user.email "openscap-ci@gmail.com"
           echo "PR_SKIP=false" >> $GITHUB_ENV
-          if [ "$(git branch --show-current)" == "$BRANCH_NAME" ]; then
-            SQUASH_COUNT=$(git rev-list --count main..HEAD)
+          if [ "$(git branch --show-current)" == "${{ env.BRANCH_NAME }}" ]; then
+            SQUASH_COUNT=$(git rev-list --count ${{ env.base_commit }}..HEAD)
+            echo "SQUASH_COUNT=$SQUASH_COUNT" >> $GITHUB_ENV
             if [[ "$SQUASH_COUNT" -eq 0 ]]; then
-              echo "No commit of the branch."
+              echo "No commit from the CAC PR ${{ env.PR_NUMBER }}."
               echo "PR_SKIP=true" >> $GITHUB_ENV
             elif [[ "$SQUASH_COUNT" -eq 1 ]]; then
               echo "::notice::Branch has 1 commit. No squashing needed."
@@ -287,44 +305,44 @@ jobs:
             fi
           else
             echo "PR_SKIP=true" >> $GITHUB_ENV
-            echo "No branch $BRANCH_NAME. Skipping squash and create PR."
+            echo "No branch ${{ env.BRANCH_NAME }}. Skipping squash and create PR."
           fi
         shell: bash
         env:
           GH_TOKEN: ${{ env.INSTALLATION_TOKEN }}
-      # Step 15: Create PR in OSCAL content
+      # Step 16: Create PR or update PR in OSCAL content
       - name: Create a Pull Request in OSCAL content
         if: ${{ env.PR_SKIP == 'false' }}
         run: |
           cd oscal-content
-          BRANCH_NAME="sync_cac_pr${{ env.PR_NUMBER }}"
           OWNER="ComplianceAsCode" 
           REPO="oscal-content"
           CAC_PR_URL="https://github.com/$OWNER/content/pull/${{ env.PR_NUMBER }}"
-          if [[ "$(git branch --show-current)" == "$BRANCH_NAME" ]]; then
-            # Check if the PR exists
-            PR_EXISTS=$(gh pr list --repo $OWNER/$REPO \
-              --head $BRANCH_NAME --state open --json id \
-              | jq length)
-            # Get commits between main and branch
-            commits=$(git log main..$BRANCH_NAME --oneline)
-            # If the PR does not exist and there are commits in the branch,
-            # then create a PR for this branch.
-            if [ "$PR_EXISTS" -gt 0 ]; then
-              echo "PR $BRANCH_NAME already exists. Skipping PR creation."
-            elif [ -z "$commits" ]; then
-              echo "No commits between main and $BRANCH_NAME. Skipping PR creation."
+          commit=$(git log -1 --format=%H)
+          PR_BODY="This is an auto-generated commit $commit from CAC PR [${{ env.PR_NUMBER }}]("$CAC_PR_URL")"
+          if [[ "$(git branch --show-current)" == "${{ env.BRANCH_NAME }}" ]]; then
+            if [ "${{ env.SQUASH_COUNT }} -eq 0" ]; then
+              echo "No commits from the CAC PR ${{ env.PR_NUMBER }}. Skipping PR creation."
             else
-              echo "Creating PR for new branch: $BRANCH_NAME"
-              PR_BODY="This is an auto-generated PR from CAC PR [${{ env.PR_NUMBER }}]("$CAC_PR_URL")"
-              gh pr create --repo $OWNER/$REPO \
-                --title "Auto-generated PR from CAC ${{ env.PR_NUMBER }}" \
-                --head "$BRANCH_NAME" \
-                --base "main" \
-                --body "${PR_BODY}"
+              # Check if the PR exists
+              PR_EXISTS=$(gh pr list --repo $OWNER/$REPO \
+                --head $BRANCH_NAME --state open --json id \
+                | jq length)
+              if [ "$PR_EXISTS" -gt 0 ]; then
+                echo "PR ${{ env.BRANCH_NAME }} already exists. Skipping PR creation.
+                echo "Add a comment for the CAC PR ${{ env.PR_NUMBER }}."
+                gh pr comment ${{ env.BRANCH_NAME }} --body "${PR_BODY}"
+              else
+                echo "Creating PR for new branch: ${{ env.BRANCH_NAME }}"
+                gh pr create --repo $OWNER/$REPO \
+                  --title "Auto-generated PR from CAC ${{ env.PR_NUMBER }}" \
+                  --head "${{ env.BRANCH_NAME }}" \
+                  --base "main" \
+                  --body "${PR_BODY}"
+              fi
             fi
           else
-            echo "No branch $BRANCH_NAME. Skipping PR creation."
+            echo "No branch ${{ env.BRANCH_NAME }}. Skipping PR creation."
           fi
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/utils/complyscribe-cli-compd.sh
+++ b/utils/complyscribe-cli-compd.sh
@@ -7,19 +7,19 @@
 # 1. The flag, "true" means the second requirement is policy_id.
 # 2. The related policy_id or profile id of the CaC updates.
 # 3. The product.
-# 4. The CaC content PR number.
+# 4. The oscal-content branch name.
 # 5. The GitHub workspace path.
 # 6. The mapping file for the specific product.
 
 # Usage:
-# sh utils/complyscribe-cli-compd.sh false anssi_bp28_minimal rhel10 4 "/User/huiwang" rhel10_map.json
-# sh utils/complyscribe-cli-compd.sh true anssi rhel10 4 "/User/huiwang" rhel10_map.json
+# sh utils/complyscribe-cli-compd.sh false anssi_bp28_minimal rhel10 branch_name "/User/huiwang" rhel10_map.json
+# sh utils/complyscribe-cli-compd.sh true anssi rhel10 branch_name "/User/huiwang" rhel10_map.json
 
 # Get the arguments
 flag=$1
 policy_or_profile=$2
 product=$3
-pr_number=$4
+branch_name=$4
 workspace_path=$5
 product_mapping_file=$6
 
@@ -47,9 +47,9 @@ while IFS= read -r line; do
         type="software"
       fi
       sed -i "/href/s|\(trestle://\)[^ ]*\(catalogs\)|\1\2|g" "../oscal-content/profiles/$oscal_profile/profile.json"
-      poetry run complyscribe sync-cac-content component-definition --repo-path ../oscal-content --committer-email "openscap-ci@gmail.com" --committer-name "openscap-ci" --branch "sync_cac_pr$pr_number" --cac-content-root "$workspace_path/cac-content" --product "$product" --component-definition-type "$type" --cac-profile "$profile" --oscal-profile "$oscal_profile"
+      poetry run complyscribe sync-cac-content component-definition --repo-path ../oscal-content --committer-email "openscap-ci@gmail.com" --committer-name "openscap-ci" --branch "$branch_name" --cac-content-root "$workspace_path/cac-content" --product "$product" --component-definition-type "$type" --cac-profile "$profile" --oscal-profile "$oscal_profile"
       type="validation"
-      poetry run complyscribe sync-cac-content component-definition --repo-path ../oscal-content --committer-email "openscap-ci@gmail.com" --committer-name "openscap-ci" --branch "sync_cac_pr$pr_number" --cac-content-root "$workspace_path/cac-content" --product "$product" --component-definition-type "$type" --cac-profile "$profile" --oscal-profile "$oscal_profile"
+      poetry run complyscribe sync-cac-content component-definition --repo-path ../oscal-content --committer-email "openscap-ci@gmail.com" --committer-name "openscap-ci" --branch "$branch_name" --cac-content-root "$workspace_path/cac-content" --product "$product" --component-definition-type "$type" --cac-profile "$profile" --oscal-profile "$oscal_profile"
     done < levels
   fi
 done < "$product_mapping_file"


### PR DESCRIPTION
#### Description:

This PR aims to fix the conflicts between different PRs of oscal-content.
The CI sync-cac-oscal will "Auto-generate" PRs according to the content updates. Sometimes, the content updates in different PRs could update the same oscal-content file. The conflicts can't be fixed by rebasing completely. 

#### Review Hints:
The resolution explanation: 

- Check if there is an open PR: If there is an open PR, get the branch_name
- Set the oscal-content branch as workspace: If there is an open PR, set the branch_name is the PR branch_name, else set the branch_name as the sync_cac_pr${{ env.PR_NUMBER }}
- Sync the content based on the branch_name that was set up in last step
- Squash the commits based on the commits from each CAC PR, not for a oscal-content PR
   - That means one CAC PR matches one commit after squash
   - It’s easy to see that each CAC PR impacts what the oscal-content changes are
- Create or update oscal-content PR,
   - No commits, no need to do anything
   - Has commits, if the PR exists, add a comment to the PR with the related CAC PR info
   - Has commits; if the PR does not exist, create a new PR

