### PR TITLE
Update OCP STIG version

### DIFF
--- a/controls/stig_ocp4.yml
+++ b/controls/stig_ocp4.yml
@@ -2,7 +2,7 @@
 policy: Red Hat OpenShift Container Platform 4.12 Security Technical Implementation Guide
 title: Red Hat OpenShift Container Platform 4.12 Security Technical Implementation Guide
 id: stig_ocp4
-version: V2R1
+version: V2R2
 source: https://www.cyber.mil/stigs/downloads/
 reference_type: stigid
 


### PR DESCRIPTION
The STIG version was bumped in 898477dc07b, but we forgot this version
string.

This updates it so that it's using the latest support STIG version,
which is V2R2.
