### PR TITLE
CMP-3539: Configure sast-snyk-check to upload reports to our org

### DIFF
--- a/.tekton/compliance-operator-content-dev-pull-request.yaml
+++ b/.tekton/compliance-operator-content-dev-pull-request.yaml
@@ -401,6 +401,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ARGS
+        value: "--project-name=openshift/compliance-operator --report --org=86a5b6bf-8aad-4842-ab41-e5c7358c202e"
       runAfter:
       - build-image-index
       taskRef:

--- a/.tekton/compliance-operator-content-dev-push.yaml
+++ b/.tekton/compliance-operator-content-dev-push.yaml
@@ -399,6 +399,8 @@ spec:
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ARGS
+        value: "--project-name=openshift/compliance-operator --report --org=86a5b6bf-8aad-4842-ab41-e5c7358c202e"
       runAfter:
       - build-image-index
       taskRef:


### PR DESCRIPTION
#### Description:

- Configure `sast-snyk-check` to upload reports to our Snyk Dashboard

#### Rationale:

- Helps us keep track of Snyk findings

- Fixes https://issues.redhat.com/browse/CMP-3539

#### Review Hints:

- Login to Snyk Dashboard
- Check that reports are uploaded