### PR TITLE
Fix ruff error in tests/test_product_stability.py

### DIFF
--- a/tests/test_product_stability.py
+++ b/tests/test_product_stability.py
@@ -95,7 +95,7 @@ def inform_and_append_fix_based_on_reference_compiled_product(ref, build_root):
     compiled_product = ssg.products.Product(compiled_path)
     difference = get_reference_vs_built_difference(ref_product, compiled_product)
     all_ok = difference.empty
-    if all_ok == False:
+    if not all_ok:
         print(describe_change(difference, product_id), file=sys.stderr)
     return all_ok
 


### PR DESCRIPTION

#### Description:

Changed all_ok == False to not all_ok


#### Rationale:
Keep ruff clean to that we don't ignore it.