### PR TITLE
Improve CI sync-cac-oscal when rule/var description/options change

### DIFF
--- a/.github/workflows/sync-cac-oscal.yml
+++ b/.github/workflows/sync-cac-oscal.yml
@@ -62,16 +62,48 @@ jobs:
         if: ${{ env.SKIP == 'false' }}
         id: changed-files
         run: |
-          repo=${{ github.repository }}
+          OWNER="ComplianceAsCode"
+          REPO="content"
           # Fetch all pages of the files for the pull request
-          url="repos/$repo/pulls/${{ env.PR_NUMBER }}/files"
+          url="repos/$OWNER/$REPO/pulls/${{ env.PR_NUMBER }}/files"
           response=$(gh api "$url" --paginate)
           echo "$response" | jq -r '.[].filename' > filenames.txt
           echo "CHANGE_FOUND=false" >> $GITHUB_ENV
-          if grep -E "controls/|.profile|rule.yml|.var" filenames.txt ; then
+          cd cac-content
+          has_change() {
+            local file="$1"
+            local key="$2"
+            ! python compare_rule_var.py \
+              --owner "$OWNER" \
+              --repo "$REPO" \
+              "${{ env.PR_NUMBER }}" \
+              "$file" \
+              "$key"
+          }
+          while IFS= read -r line; do
+            case "$line" in
+              *controls/*|*.profile*)
+                echo "$line" >> updated_filenames.txt
+                ;;
+              *rule.yml)
+                if has_change "$line" "description"; then
+                  echo "Change detected: The description in '$line' was updated."
+                  echo "$line" >> updated_filenames.txt
+                fi
+                ;;
+              *.var)
+                if has_change "$line" "description" || has_change "$line" "options"; then
+                  echo "Change detected: The description or options in '$line' were updated."
+                  echo "$line" >> updated_filenames.txt
+                fi
+              ;;
+            esac
+          done < ../filenames.txt
+          if [[ -f valid_files.txt ]]; then
+            echo "Shows valid_files:"
+            cat valid_files.txt
             echo "CHANGE_FOUND=true" >> $GITHUB_ENV
           fi
-          cat filenames.txt
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
       # Step 6: Setup the complyscribe environment
@@ -130,8 +162,7 @@ jobs:
       - name: Handle the detected updates
         if: ${{ env.CHANGE_FOUND == 'true' }}
         run: |
-          cat filenames.txt
-          python cac-content/utils/handle_detected_updates.py 'filenames.txt' > updates 2>&1
+          python cac-content/utils/handle_detected_updates.py 'cac-content/valid_files.txt' > updates 2>&1
           cd complyscribe && source venv/bin/activate
           RH_PRODUCTS=${{ env.RH_PRODUCTS }}
           i=0
@@ -325,7 +356,7 @@ jobs:
           commit=$(git log -1 --format=%H)
           PR_BODY="This is an auto-generated commit $commit from CAC PR [${{ env.PR_NUMBER }}]("$CAC_PR_URL")"
           if [[ "$(git branch --show-current)" == "${{ env.BRANCH_NAME }}" ]]; then
-            if [ "${{ env.SQUASH_COUNT }} -eq 0" ]; then
+            if [ "${{ env.SQUASH_COUNT }}" -eq 0 ]; then
               echo "No commits from the CAC PR ${{ env.PR_NUMBER }}. Skipping PR creation."
             else
               # Check if the PR exists

--- a/utils/compare_rule_var.py
+++ b/utils/compare_rule_var.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+import sys
+import subprocess
+import json
+import base64
+import argparse
+from typing import Optional, Tuple, NoReturn
+
+from ssg.rule_yaml import find_section_lines
+
+
+def run_command(command: list[str]) -> tuple[int, str, str]:
+    """Runs a shell command and returns its exit code, stdout, and stderr."""
+    res = subprocess.run(command, capture_output=True, text=True, check=False)
+    return res.returncode, res.stdout, res.stderr
+
+
+def get_file_content_from_pr(owner: str, repo: str, sha: str, file_path: str) -> str:
+    """Fetches file content for a given commit SHA using the GitHub API.
+    The base64 encoding and decoding step is necessary because of how the
+    GitHub API is designed to transmit file content.
+    """
+    api_path = f"/repos/{owner}/{repo}/contents/{file_path}?ref={sha}"
+    print(f"-> Fetching file content for '{file_path}' from commit {sha[:7]}...")
+    returncode, stdout, stderr = run_command(["gh", "api", api_path])
+
+    if returncode != 0:
+        print(f"Exception: Could not fetch file. It may be new or deleted. "
+              f"(stderr: {stderr.strip()})")
+        return ""
+
+    try:
+        content_json = json.loads(stdout)
+        encoded_content = content_json.get('content', '')
+        if not encoded_content:
+            return ""
+
+        return base64.b64decode(encoded_content).decode('utf-8')
+    except (json.JSONDecodeError, KeyError, TypeError) as e:
+        print(f"Exception: Could not parse or decode content. Error: {e}", file=sys.stderr)
+        return ""
+
+
+def get_section_from_content(content: str, section: str) -> Optional[str]:
+    """
+    Extracts a section's value from a string containing the file content.
+    """
+    if not content:
+        return None
+
+    lines = content.splitlines()
+    found_ranges = find_section_lines(lines, section)
+
+    if found_ranges:
+        start, end = found_ranges[0]
+        section_content = lines[start: end + 1]
+        return '\n'.join(section_content)
+
+    return None
+
+
+def get_pr_shas(owner: str, repo: str, pr_number: int) -> Tuple[str, str]:
+    """
+    Fetches the base and head commit SHAs for a PR.
+    """
+    gh_pr_command = [
+        "gh", "pr", "view", str(pr_number),
+        "--repo", f"{owner}/{repo}",
+        "--json", "baseRefOid,headRefOid"
+    ]
+    returncode, stdout, stderr = run_command(gh_pr_command)
+
+    if returncode != 0:
+        raise RuntimeError(f"Failed to get PR details. GitHub CLI stderr: {stderr.strip()}")
+
+    try:
+        shas = json.loads(stdout)
+        base_sha = shas['baseRefOid']
+        head_sha = shas['headRefOid']
+        return base_sha, head_sha
+    except (json.JSONDecodeError, KeyError) as e:
+        raise ValueError(f"Could not parse commit SHAs from API response. Error: {e}") from e
+
+
+def get_value_from_commit(
+    owner: str,
+    repo: str,
+    file_path: str,
+    key: str,
+    sha: str
+) -> Optional[str]:
+    """
+    Fetches a file from a specific commit and extracts the value of a given key.
+
+    Args:
+        owner: The repository owner.
+        repo: The repository name.
+        file_path: The path to the file within the repository.
+        key: The section to extract from the file's content.
+        sha: The commit SHA from which to retrieve the file.
+
+    Returns:
+        The extracted value as a string, or None if the file or key is not found.
+    """
+    # 1. Fetch the file's content for the given commit SHA.
+    content = get_file_content_from_pr(owner, repo, sha, file_path)
+
+    # 2. Parse the content to get the desired value.
+    value = get_section_from_content(content, key)
+
+    return value
+
+
+def compare_value(
+    owner: str,
+    repo: str,
+    pr_number: int,
+    file_path: str,
+    key: str
+) -> NoReturn:
+    """
+    This function handles the entire process:
+    1. Fetches the base and head commit SHAs for the PR.
+    2. Retrieves the value of the specified key from the file at both commits.
+    3. Compares the two values, prints a report, and exits with a status code.
+    """
+    # 1. Get the base and head commit SHAs.
+    base_sha, head_sha = get_pr_shas(owner, repo, pr_number)
+
+    # 2. Fetch and parse the values from the commits.
+    before_value = get_value_from_commit(owner, repo, file_path, key, base_sha)
+    after_value = get_value_from_commit(owner, repo, file_path, key, head_sha)
+
+    # 3. Compare the results and print the final output.
+    print("\n--- Comparison Result ---")
+    print(f"Value in base branch:\n---\n{before_value or 'Not found'}\n---")
+    print(f"Value in PR branch:\n---\n{after_value or 'Not found'}\n---")
+
+    if before_value == after_value:
+        print("\nNo changes detected for the specified keys.")
+        sys.exit(0)
+    else:
+        print("\nChange detected for one of the specified keys!")
+        print("\nCHANGE_FOUND=true")
+        sys.exit(1)
+
+
+def parse_args() -> argparse.Namespace:
+    """
+    Parses command-line arguments for the script.
+
+    Returns:
+        An object containing the parsed command-line arguments.
+    """
+    parser = argparse.ArgumentParser(
+        description="Compare specific keys in a YAML file between a PR's base and head branches."
+    )
+    # Required arguments
+    parser.add_argument("--owner", required=True, help="The owner of the repository.")
+    parser.add_argument("--repo", required=True, help="The name of the repository.")
+    parser.add_argument("pr_number", type=int, help="The Pull Request number.")
+    parser.add_argument("file_path", type=str, help="The file path within the repository.")
+    parser.add_argument("key", type=str, help="The key to be checked in the file.")
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    compare_value(
+        args.owner,
+        args.repo,
+        args.pr_number,
+        args.file_path,
+        args.key
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
#### Description:

The CI sync-cac-oscal will be triggered when it detects any updates to `controls/profiles/rule/var`.
Actually, for the `rule` and `var` files, only the `rule.description`, `var.description`, and `var.options` could impact the `component-definition`. This PR aims to compare the value of rule/var description/options, then do the sync.


#### Review Hints:

- How to test the script:
Var.options was updated in PR:[13820](https://github.com/ComplianceAsCode/content/pull/13820) 
- `python utils/compare_rule_var.py --owner ComplianceAsCode --repo content 13820 linux_os/guide/services/ntp/var_multiple_time_pools.var options`
No updates of rule.description in PR:[13150](https://github.com/ComplianceAsCode/content/pull/13150)
- `python utils/compare_rule_var.py --owner ComplianceAsCode --repo content 13150 applications/openshift/logging/audit_log_forwarding_uses_tls/rule.yml description `

