### PR TITLE
Add a warning for aide_build_database

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/rule.yml
@@ -33,6 +33,17 @@ rationale: |-
     For AIDE to be effective, an initial database of "known-good" information about files
     must be captured and it should be able to be verified against the installed files.
 
+warnings:
+    - general: |-
+        In RHEL Image Mode (bootc) systems, the AIDE database must be regenerated after each system update.
+        Image Mode systems receive updates through new container images that may include modified files.
+        After applying system updates, run the following commands to regenerate the AIDE database:
+        <pre>$ sudo {{{ aide_bin_path }}} --init</pre>
+        Then replace the existing database:
+        <pre>$ sudo cp /var/lib/aide/aide.db.new.gz /var/lib/aide/aide.db.gz</pre>
+        Failure to regenerate the AIDE database after updates will result in false positive alerts
+        for legitimate system changes introduced by the update process.
+
 severity: medium
 
 identifiers:


### PR DESCRIPTION
In Image Mode systems, it's required to regenerate the AIDE database after the system update.
