### PR TITLE
kernel_module_vfat_disabled: limit to non-uefi

### DIFF
--- a/linux_os/guide/system/permissions/mounting/kernel_module_vfat_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_vfat_disabled/rule.yml
@@ -18,7 +18,7 @@ rationale: |-
 
 severity: low
 
-platform: system_with_kernel
+platform: system_with_kernel and non-uefi
 
 identifiers:
     cce@rhcos4: CCE-82720-4


### PR DESCRIPTION
Currently kernel_module_vfat_disabled is low or failed on systems with
a kernel. However, on UEFI platforms VFAT is required to access ESP
and is typically built-in. Blocking modprobe of it is a no-op, and
VFAT usage is required on such systems.

Thus limit the platform of this rule to non-uefi systems, as only on
those platforms one can realistically run without VFAT support.

Another option is to remove this rule entirely. Many distributions
make VFAT built-in even on those architectures / platforms that do not
use VFAT for booting.
