### PR TITLE
[Ubuntu2404] Fix root_unlock_time value

### DIFF
--- a/controls/cis_debian12.yml
+++ b/controls/cis_debian12.yml
@@ -1911,7 +1911,7 @@ controls:
           - l2_server
           - l2_workstation
       rules:
-          - var_accounts_passwords_pam_faillock_unlock_time=900
+          - var_accounts_passwords_pam_faillock_root_unlock_time=900
           - accounts_passwords_pam_faillock_root_unlock_time
       status: automated
 

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -1932,7 +1932,7 @@ controls:
           - l2_server
           - l2_workstation
       rules:
-          - var_accounts_passwords_pam_faillock_unlock_time=60
+          - var_accounts_passwords_pam_faillock_root_unlock_time=60
           - accounts_passwords_pam_faillock_root_unlock_time
       status: automated
 

--- a/controls/cis_ubuntu2404.yml
+++ b/controls/cis_ubuntu2404.yml
@@ -1932,7 +1932,7 @@ controls:
           - l2_server
           - l2_workstation
       rules:
-          - var_accounts_passwords_pam_faillock_unlock_time=900
+          - var_accounts_passwords_pam_faillock_unlock_time=60
           - accounts_passwords_pam_faillock_root_unlock_time
       status: automated
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_root_unlock_time/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_root_unlock_time/rule.yml
@@ -9,7 +9,7 @@ description: |-
 
     Ensure that the file <tt>/etc/security/faillock.conf</tt> contains the following entry:
     <tt>root_unlock_time=&lt;interval-in-seconds&gt;</tt> where
-    <tt>interval-in-seconds</tt> is <tt>{{{xccdf_value("var_accounts_passwords_pam_faillock_unlock_time") }}}</tt> or greater.
+    <tt>interval-in-seconds</tt> is <tt>{{{xccdf_value("var_accounts_passwords_pam_faillock_root_unlock_time") }}}</tt> or greater.
 
     If <tt>root_unlock_time</tt> is set to <tt>0</tt>, it may enable attacker to
     apply denial of service to legitimate users.

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_root_unlock_time/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_root_unlock_time/rule.yml
@@ -29,6 +29,6 @@ template:
     prm_name: root_unlock_time
     prm_regex_conf: ^[\s]*root_unlock_time[\s]*=[\s]*([0-9]+)
     prm_regex_pamd: ^[\s]*auth[\s]+.+[\s]+pam_faillock.so[\s]+[^\n]*root_unlock_time=([0-9]+)
-    ext_variable: var_accounts_passwords_pam_faillock_unlock_time
+    ext_variable: var_accounts_passwords_pam_faillock_root_unlock_time
     description: The unlock time after number of failed logins should be set correctly.
     variable_lower_bound: use_ext_variable

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/var_accounts_passwords_pam_faillock_root_unlock_time.var
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/var_accounts_passwords_pam_faillock_root_unlock_time.var
@@ -1,0 +1,23 @@
+documentation_complete: true
+
+title: fail_root_unlock_time
+
+description: 'Seconds before automatic unlocking or permanently locking after excessive failed logins to root'
+
+type: number
+
+operator: equals
+
+interactive: false
+
+options:
+    60: 60
+    1800: 1800
+    3600: 3600
+    600: 600
+    604800: 604800
+    86400: 86400
+    900: 900
+    300: 300
+    default: 0
+    never: 0

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/var_accounts_passwords_pam_faillock_unlock_time.var
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/var_accounts_passwords_pam_faillock_unlock_time.var
@@ -11,7 +11,6 @@ operator: equals
 interactive: false
 
 options:
-    60: 60
     1800: 1800
     3600: 3600
     600: 600

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/var_accounts_passwords_pam_faillock_unlock_time.var
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/var_accounts_passwords_pam_faillock_unlock_time.var
@@ -11,6 +11,7 @@ operator: equals
 interactive: false
 
 options:
+    60: 60
     1800: 1800
     3600: 3600
     600: 600


### PR DESCRIPTION
#### Description:

- Fix root_unlock_time value to cis benchmark designated value

#### Rationale: