### PR TITLE
Fix the mapping between rule.title and rule.description for CI

### DIFF
--- a/.github/workflows/sync-cac-oscal.yml
+++ b/.github/workflows/sync-cac-oscal.yml
@@ -86,8 +86,8 @@ jobs:
                 echo "$line" >> updated_filenames.txt
                 ;;
               *rule.yml)
-                if has_change "$line" "description"; then
-                  echo "Change detected: The description in '$line' was updated."
+                if has_change "$line" "title"; then
+                  echo "Change detected: The title in '$line' was updated."
                   echo "$line" >> updated_filenames.txt
                 fi
                 ;;


### PR DESCRIPTION
#### Description:

- Fix the error in CI sync-cac-oscal. The mapping should be `rule.title` in content is `rule.description` in oscal-content  component-definition. That's different from the params.
- https://github.com/complytime/complyscribe/blob/main/complyscribe/transformers/cac_transformer.py#L308
