### PR TITLE
Make SPO and CLO rules not applicable on ARM64

### DIFF
--- a/applications/openshift/api-server/audit_log_forwarding_enabled/rule.yml
+++ b/applications/openshift/api-server/audit_log_forwarding_enabled/rule.yml
@@ -26,7 +26,7 @@ references:
   pcidss: Req-2.2,Req-10.5.3,Req-10.5.4
   srg: SRG-APP-000092-CTR-000165,SRG-APP-000111-CTR-000220,SRG-APP-000358-CTR-000805
 
-platform: not ocp4-on-hypershift and not ocp4-on-hypershift-hosted
+platform: not ocp4-on-hypershift and not ocp4-on-hypershift-hosted and not aarch64_arch
 
 
 ocil_clause: 'Logs are not forwarded outside the cluster'

--- a/applications/openshift/confinement/security_profiles_operator_exists/rule.yml
+++ b/applications/openshift/confinement/security_profiles_operator_exists/rule.yml
@@ -25,6 +25,8 @@ ocil: |-
 
 severity: medium
 
+platform: not aarch64_arch
+
 warnings:
 - general: |-
     {{{ openshift_cluster_setting("/apis/operators.coreos.com/v1alpha1/namespaces/openshift-security-profiles/subscriptions/security-profiles-operator") | indent(4) }}}


### PR DESCRIPTION

#### Description:

- Make these rules result in NOT-APPLICABLE when run on ARM64.

#### Rationale:

- Cluster Logging Operator and Security Profiles Operator are not available on ARM64.
