### PR TITLE
Build reference tables in RHEL9 and RHEL10 and include CCE

### DIFF
--- a/products/rhel10/CMakeLists.txt
+++ b/products/rhel10/CMakeLists.txt
@@ -7,6 +7,8 @@ set(PRODUCT "rhel10")
 
 ssg_build_product(${PRODUCT})
 
+ssg_build_html_ref_tables("${PRODUCT}" "table-${PRODUCT}-{ref_id}refs" "anssi;cis;cui;nist;pcidss")
+
 ssg_build_html_cce_table(${PRODUCT})
 
 ssg_build_html_srgmap_tables(${PRODUCT})

--- a/products/rhel9/CMakeLists.txt
+++ b/products/rhel9/CMakeLists.txt
@@ -7,6 +7,8 @@ set(PRODUCT "rhel9")
 
 ssg_build_product(${PRODUCT})
 
+ssg_build_html_ref_tables("${PRODUCT}" "table-${PRODUCT}-{ref_id}refs" "anssi;cis;cui;nist;pcidss")
+
 ssg_build_html_cce_table(${PRODUCT})
 
 ssg_build_html_srgmap_tables(${PRODUCT})

--- a/utils/tables/reference_tables_template.html
+++ b/utils/tables/reference_tables_template.html
@@ -6,6 +6,7 @@
 <table>
   <thead>
     <th>Mapping</th>
+    <th>CCE</th>
     <th>Rule Title</th>
     <th>Description</th>
     <th>Rationale</th>
@@ -16,6 +17,9 @@
     {{% for rule in rules -%}}
     <tr>
       <td>{{{ "<br/>".join(rule.relevant_refs) }}}</td>
+      <td xml:lang="en-US">
+        {{{ rule.identifiers["cce"] }}}
+      </td>
       <td>{{{ rule.title }}}</td>
       <td xml:lang="en-US">
         {{{ rule.description }}}


### PR DESCRIPTION
#### Description:

- Build reference tables in RHEL9 and RHEL10 and include CCE

#### Rationale:

- These tables are a good source of information for people mapping things. The CCE is a unique identifier for rules and should help people managing content.
- Tables are published at: https://complianceascode.github.io/content-pages/tables and can be easily accessed by people.
- Note: These tables will be built into the final package and are seen as a change in the content of the rpm package for example. They will trigger a change and this change needs to be acknowledged.

- Build the content and inspect files at build/tables


Rendered table
<img width="2050" height="514" alt="Screenshot From 2025-09-12 15-07-22" src="https://github.com/user-attachments/assets/f3ba4f7d-d419-4935-888d-cd2273f906ce" />


