### PR TITLE
[Ubuntu] Enable applicability check for rsyslog service

### DIFF
--- a/linux_os/guide/system/logging/journald/journald_compress/rule.yml
+++ b/linux_os/guide/system/logging/journald/journald_compress/rule.yml
@@ -62,6 +62,6 @@ template:
         no_quotes: 'true'
 {{% endif -%}}
 
-{{% if product in ['ubuntu2404'] %}}
+{{% if 'ubuntu' in product %}}
 platform: service_disabled[rsyslog]
 {{% endif %}}

--- a/linux_os/guide/system/logging/journald/journald_storage/rule.yml
+++ b/linux_os/guide/system/logging/journald/journald_storage/rule.yml
@@ -62,6 +62,6 @@ template:
         no_quotes: 'true'
 {{% endif -%}}
 
-{{% if product in ['ubuntu2404'] %}}
+{{% if 'ubuntu' in product %}}
 platform: service_disabled[rsyslog]
 {{% endif %}}

--- a/linux_os/guide/system/logging/journald/package_systemd-journal-remote_installed/rule.yml
+++ b/linux_os/guide/system/logging/journald/package_systemd-journal-remote_installed/rule.yml
@@ -35,7 +35,7 @@ template:
     vars:
         pkgname: systemd-journal-remote
 
-{{% if product in ['ubuntu2404'] %}}
+{{% if 'ubuntu' in product %}}
 platform: service_disabled[rsyslog]
 {{% endif %}}
 

--- a/linux_os/guide/system/logging/journald/systemd_journal_upload_server_tls/rule.yml
+++ b/linux_os/guide/system/logging/journald/systemd_journal_upload_server_tls/rule.yml
@@ -37,6 +37,6 @@ fixtext: |-
     Configure systemd-journal-upload ServerCertificateFile to {{{ xccdf_value("var_journal_upload_server_certificate_file") }}}
     Configure systemd-journal-upload TrustedCertificateFile to {{{ xccdf_value("var_journal_upload_server_trusted_certificate_file") }}}
 
-{{% if product in ['ubuntu2404'] %}}
+{{% if 'ubuntu' in product %}}
 platform: service_disabled[rsyslog]
 {{% endif %}}

--- a/linux_os/guide/system/logging/journald/systemd_journal_upload_url/rule.yml
+++ b/linux_os/guide/system/logging/journald/systemd_journal_upload_url/rule.yml
@@ -32,6 +32,6 @@ ocil: |-
 fixtext: |-
    Configure systemd-journal-upload URL to {{{ xccdf_value("var_journal_upload_url") }}}
 
-{{% if product in ['ubuntu2404'] %}}
+{{% if 'ubuntu' in product %}}
 platform: service_disabled[rsyslog]
 {{% endif %}}


### PR DESCRIPTION
#### Description:

- Enable applicability check for rsyslog service for Ubuntu 22.04

#### Rationale:

- cis jammy v2 benchmark drop entire section about rsyslog and leaves a comment:
> If your organization makes use of another logging system such as rsyslog or an
> enterprise wide logging system completely outside of journald, then the
> following recommendations do not directly apply. 