### PR TITLE
CMP-3591: Suppress warnings about file-permissions-proxy-kubeconfig

### DIFF
--- a/applications/openshift/worker/file_permissions_proxy_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_permissions_proxy_kubeconfig/rule.yml
@@ -53,7 +53,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/apis/apps/v1/namespaces/openshift-sdn/daemonsets/sdn") | indent(4) }}}
+    {{{ openshift_cluster_setting("/apis/apps/v1/namespaces/openshift-sdn/daemonsets/sdn", true) | indent(4) }}}
 
 template:
   name: yamlfile_value


### PR DESCRIPTION
This rule fetches an openshift-sdn daemon set, but if the user isn't
using that netowrking provider the operator will emit a warning about it
not being present, which is obvious and noisy.

Let's suppress it.
