### PR TITLE
SLE15 iptables service rules related fixes

### DIFF
--- a/linux_os/guide/system/network/network-iptables/iptables_activation/service_iptables_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/service_iptables_enabled/rule.yml
@@ -39,8 +39,8 @@ ocil: |-
 template:
     name: service_enabled_guard_var
     vars:
-        packagename: ip6tables
-        servicename: iptables-ipv6
+        packagename: iptables
+        servicename: iptables
         variable: var_network_filtering_service
         value: iptables
 {{%- else %}}

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/bash/shared.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/bash/shared.sh
@@ -1,4 +1,4 @@
-{{% if 'ubuntu' in product %}}
+{{% if 'ubuntu' in product or 'sle15' in product %}}
 # platform = Not Applicable
 {{% else %}}
 # platform = multi_platform_all

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/rule.yml
@@ -55,7 +55,7 @@ ocil: |-
     the default policy for the INPUT chain. It should be set to DROP:
     <pre>$ sudo grep ":INPUT" /etc/sysconfig/ip6tables</pre>
 
-{{% if 'ubuntu' in product %}}
+{{% if 'ubuntu' in product or 'sle15' in product %}}
 warnings:
     - general: |-
         Automated remediation for this rule is disabled.

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_ipv6_loopback_traffic/sce/shared.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_ipv6_loopback_traffic/sce/shared.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_ubuntu
+# platform = multi_platform_sle,multi_platform_ubuntu
 # check-import = stdout
 
 # Pass rule if IPv6 is disabled on kernel

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_loopback_traffic/sce/shared.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_loopback_traffic/sce/shared.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_ubuntu
+# platform = multi_platform_sle,multi_platform_ubuntu
 # check-import = stdout
 
 regex="\s+[0-9]+\s+[0-9]+\s+ACCEPT\s+all\s+--\s+lo\s+\*\s+0\.0\.0\.0\/0\s+0\.0\.0\.0\/0[[:space:]]+[0-9]+\s+[0-9]+\s+DROP\s+all\s+--\s+\*\s+\*\s+127\.0\.0\.0\/8\s+0\.0\.0\.0\/0"

--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/set_iptables_default_rule/bash/shared.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/set_iptables_default_rule/bash/shared.sh
@@ -1,4 +1,4 @@
-{{% if 'ubuntu' in product %}}
+{{% if 'ubuntu' in product or 'sle15' in product %}}
 # platform = Not Applicable
 {{% else %}}
 # platform = multi_platform_all

--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/set_iptables_default_rule/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/set_iptables_default_rule/rule.yml
@@ -49,7 +49,7 @@ ocil: |-
     the default policy for the INPUT chain. It should be set to DROP:
     <pre>$ sudo grep ":INPUT" /etc/sysconfig/iptables</pre>
 
-{{% if 'ubuntu' in product %}}
+{{% if 'ubuntu' in product or 'sle15' in product %}}
 warnings:
     - general: |-
         Automated remediation for this rule is disabled.

--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/set_iptables_default_rule/sce/shared.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/set_iptables_default_rule/sce/shared.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_ubuntu
+# platform = multi_platform_sle,multi_platform_ubuntu
 # check-import = stdout
 
 output="$(iptables -L | grep Chain)"


### PR DESCRIPTION
#### Description:

- SLE platform related fixes for rules about iptables service functionality

#### Rationale:

- Enable SCE checks, where possible, for iptables rules in SLE platforms
- Make sure correct iptables package is used in SLE15 not ip6tables one.
- Make use of important warning about lack of automatic remediation for iptables rules
- Drop attempt for automatic remediation for iptables rules in SLE15