### PR TITLE
Change applicability of some rules in containers and in Image Mode

### DIFF
--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_servers/use_kerberos_security_all_exports/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_servers/use_kerberos_security_all_exports/rule.yml
@@ -40,3 +40,5 @@ ocil: |-
     <pre>$ grep "sec=" /etc/exports</pre>
     All configured NFS exports should show the <tt>sec=krb5:krb5i:krb5p</tt> setting in parentheses.
     This is not applicable if NFS is not implemented.
+
+platform: system_with_kernel

--- a/linux_os/guide/services/ssh/directory_groupowner_sshd_config_d/rule.yml
+++ b/linux_os/guide/services/ssh/directory_groupowner_sshd_config_d/rule.yml
@@ -42,3 +42,5 @@ template:
     vars:
         filepath: '/etc/ssh/sshd_config.d/'
         gid_or_name: '0'
+
+platform: system_with_kernel

--- a/linux_os/guide/services/ssh/directory_owner_sshd_config_d/rule.yml
+++ b/linux_os/guide/services/ssh/directory_owner_sshd_config_d/rule.yml
@@ -42,3 +42,5 @@ template:
     vars:
         filepath: '/etc/ssh/sshd_config.d/'
         uid_or_name: '0'
+
+platform: system_with_kernel

--- a/linux_os/guide/services/ssh/directory_permissions_sshd_config_d/rule.yml
+++ b/linux_os/guide/services/ssh/directory_permissions_sshd_config_d/rule.yml
@@ -42,3 +42,5 @@ template:
     vars:
         filepath: /etc/ssh/sshd_config.d/
         filemode: '0700'
+
+platform: system_with_kernel

--- a/linux_os/guide/services/ssh/file_groupowner_sshd_config/rule.yml
+++ b/linux_os/guide/services/ssh/file_groupowner_sshd_config/rule.yml
@@ -49,3 +49,5 @@ template:
     vars:
         filepath: /etc/ssh/sshd_config
         gid_or_name: '0'
+
+platform: system_with_kernel

--- a/linux_os/guide/services/ssh/file_groupowner_sshd_drop_in_config/rule.yml
+++ b/linux_os/guide/services/ssh/file_groupowner_sshd_drop_in_config/rule.yml
@@ -43,3 +43,5 @@ template:
         filepath: '/etc/ssh/sshd_config.d/'
         file_regex: '^.*$'
         gid_or_name: '0'
+
+platform: system_with_kernel

--- a/linux_os/guide/services/ssh/file_groupownership_sshd_private_key/rule.yml
+++ b/linux_os/guide/services/ssh/file_groupownership_sshd_private_key/rule.yml
@@ -36,3 +36,5 @@ warnings:
     - general: |-
         Remediation is not possible at bootable container build time because SSH host
         keys are generated post-deployment.
+
+platform: system_with_kernel

--- a/linux_os/guide/services/ssh/file_groupownership_sshd_pub_key/rule.yml
+++ b/linux_os/guide/services/ssh/file_groupownership_sshd_pub_key/rule.yml
@@ -35,3 +35,5 @@ warnings:
     - general: |-
         Remediation is not possible at bootable container build time because SSH host
         keys are generated post-deployment.
+
+platform: system_with_kernel

--- a/linux_os/guide/services/ssh/file_owner_sshd_config/rule.yml
+++ b/linux_os/guide/services/ssh/file_owner_sshd_config/rule.yml
@@ -49,3 +49,5 @@ template:
     vars:
         filepath: /etc/ssh/sshd_config
         uid_or_name: '0'
+
+platform: system_with_kernel

--- a/linux_os/guide/services/ssh/file_owner_sshd_drop_in_config/rule.yml
+++ b/linux_os/guide/services/ssh/file_owner_sshd_drop_in_config/rule.yml
@@ -44,3 +44,5 @@ template:
         filepath: '/etc/ssh/sshd_config.d/'
         file_regex: '^.*$'
         uid_or_name: '0'
+
+platform: system_with_kernel

--- a/linux_os/guide/services/ssh/file_ownership_sshd_private_key/rule.yml
+++ b/linux_os/guide/services/ssh/file_ownership_sshd_private_key/rule.yml
@@ -34,3 +34,5 @@ warnings:
     - general: |-
         Remediation is not possible at bootable container build time because SSH host
         keys are generated post-deployment.
+
+platform: system_with_kernel

--- a/linux_os/guide/services/ssh/file_ownership_sshd_pub_key/rule.yml
+++ b/linux_os/guide/services/ssh/file_ownership_sshd_pub_key/rule.yml
@@ -35,3 +35,5 @@ warnings:
     - general: |-
         Remediation is not possible at bootable container build time because SSH host
         keys are generated post-deployment.
+
+platform: system_with_kernel

--- a/linux_os/guide/services/ssh/file_permissions_sshd_config/rule.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_config/rule.yml
@@ -50,3 +50,5 @@ template:
         filepath:
             - /etc/ssh/sshd_config
         filemode: '0600'
+
+platform: system_with_kernel

--- a/linux_os/guide/services/ssh/file_permissions_sshd_drop_in_config/rule.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_drop_in_config/rule.yml
@@ -43,3 +43,5 @@ template:
         filepath: '/etc/ssh/sshd_config.d/'
         file_regex: '^.*$'
         filemode: '0600'
+
+platform: system_with_kernel

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/rule.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/rule.yml
@@ -67,3 +67,5 @@ warnings:
     - general: |-
         Remediation is not possible at bootable container build time because SSH host
         keys are generated post-deployment.
+
+platform: system_with_kernel

--- a/linux_os/guide/services/ssh/file_permissions_sshd_pub_key/rule.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_pub_key/rule.yml
@@ -58,3 +58,5 @@ warnings:
     - general: |-
         Remediation is not possible at bootable container build time because SSH host
         keys are generated post-deployment.
+
+platform: system_with_kernel

--- a/linux_os/guide/services/ssh/file_sshd_50_redhat_exists/rule.yml
+++ b/linux_os/guide/services/ssh/file_sshd_50_redhat_exists/rule.yml
@@ -34,3 +34,5 @@ template:
     backends:
         ansible: off
         bash: off
+
+platform: system_with_kernel

--- a/linux_os/guide/services/ssh/firewalld_sshd_disabled/rule.yml
+++ b/linux_os/guide/services/ssh/firewalld_sshd_disabled/rule.yml
@@ -18,3 +18,5 @@ severity: unknown
 
 references:
     cui: 3.1.12
+
+platform: system_with_kernel

--- a/linux_os/guide/services/ssh/group.yml
+++ b/linux_os/guide/services/ssh/group.yml
@@ -12,5 +12,3 @@ description: |-
     {{{ weblink(link="https://www.openssh.com") }}}.
     Its server program is called <tt>sshd</tt> and provided by the RPM package
     <tt>openssh-server</tt>.
-
-platform: system_with_kernel

--- a/linux_os/guide/services/ssh/iptables_sshd_disabled/rule.yml
+++ b/linux_os/guide/services/ssh/iptables_sshd_disabled/rule.yml
@@ -19,3 +19,5 @@ rationale: |-
     port will avoid possible exploitation of the port by an attacker.
 
 severity: unknown
+
+platform: system_with_kernel

--- a/linux_os/guide/services/ssh/package_openssh-server_installed/rule.yml
+++ b/linux_os/guide/services/ssh/package_openssh-server_installed/rule.yml
@@ -45,3 +45,5 @@ fixtext: |-
     {{{ describe_package_install(package="openssh-server") }}}
 
 srg_requirement: '{{{ srg_requirement_package_installed("openssh-server") }}}'
+
+platform: system_with_kernel

--- a/linux_os/guide/services/ssh/service_sshd_disabled/rule.yml
+++ b/linux_os/guide/services/ssh/service_sshd_disabled/rule.yml
@@ -47,3 +47,5 @@ template:
         packagename@opensuse: openssh
         packagename@sle12: openssh
         daemonname@debian11: ssh
+
+platform: system_with_kernel

--- a/linux_os/guide/services/ssh/service_sshd_enabled/rule.yml
+++ b/linux_os/guide/services/ssh/service_sshd_enabled/rule.yml
@@ -63,3 +63,5 @@ fixtext: |-
     {{{ fixtext_service_enabled("sshd") }}}
 
 srg_requirement: '{{{ srg_requirement_service_enabled("sshd") }}}'
+
+platform: system_with_kernel

--- a/linux_os/guide/services/ssh/ssh_server/group.yml
+++ b/linux_os/guide/services/ssh/ssh_server/group.yml
@@ -8,3 +8,5 @@ description: |-
     file <tt>/etc/ssh/sshd_config</tt>. The following recommendations can be
     applied to this file. See the <tt>sshd_config(5)</tt> man page for more
     detailed information.
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/rule.yml
@@ -49,4 +49,4 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} must not be configured to bypass password requirements for privilege escalation.'
 
-platform: package[pam]
+platform: package[pam] and system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/rule.yml
@@ -62,7 +62,7 @@ references:
     stigid@sle12: SLES-12-010390
     stigid@sle15: SLES-15-020080
 
-platform: package[pam]
+platform: package[pam] and system_with_kernel
 
 ocil_clause: '"{{{ pam_lastlog }}}" is not properly configured in "{{{ pam_lastlog_path }}}" file'
 

--- a/linux_os/guide/system/accounts/accounts-pam/enable_pam_namespace/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/enable_pam_namespace/rule.yml
@@ -33,4 +33,4 @@ ocil: |-
   The output should return the following uncommented:
   <pre>session    required     pam_namespace.so</pre>
 
-platform: package[pam]
+platform: package[pam] and system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/group.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/group.yml
@@ -16,3 +16,5 @@ warnings:
         must weigh whether the risk of such a
         denial-of-service attack outweighs the benefits of thwarting
         password guessing attacks.
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/group.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/group.yml
@@ -15,3 +15,5 @@ description: |-
     The man pages <tt>pam_pwquality(8)</tt>
     provide information on the capabilities and configuration of
     each.
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/group.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/group.yml
@@ -6,3 +6,5 @@ description: |-
     The system's default algorithm for storing password hashes in
     <tt>/etc/shadow</tt> is SHA-512. This can be configured in several
     locations.
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/group.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/group.yml
@@ -20,3 +20,5 @@ description: |-
 
 warnings:
    - general: 'This will only apply to newly created accounts'
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-restrictions/accounts_authorized_local_users/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/accounts_authorized_local_users/rule.yml
@@ -65,3 +65,5 @@ fixtext: |-
     Document all authorized accounts on the system.
 
 srg_requirement: '{{{ full_name }}} must not have unnecessary accounts.'
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-restrictions/group_unique_id/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/group_unique_id/rule.yml
@@ -43,3 +43,5 @@ srg_requirement:
 warnings:
     - general: |-
           Automatic remediation of this control is not available due to the unique requirements of each system.
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-restrictions/group_unique_name/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/group_unique_name/rule.yml
@@ -36,3 +36,5 @@ ocil: |-
 warnings:
     - general: |-
           Automatic remediation of this control is not available due to the unique requirements of each system.
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/group.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/group.yml
@@ -30,3 +30,5 @@ description: |-
     could be adjusted to a 180 day maximum password age, 7 day minimum password
     age, and 7 day warning period with the following command:
     <pre>$ sudo chage -M 180 -m 7 -W 7 USER</pre>
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/rule.yml
@@ -55,7 +55,7 @@ ocil: |-
     <pre>password sufficient pam_unix.so sha512 rounds={{{ xccdf_value("var_password_pam_unix_rounds") }}}</pre>
     {{% endif %}}
 
-platform: package[pam]
+platform: package[pam] and system_with_kernel
 
 fixtext: |-
     Configure {{{ full_name }}} to use {{{ xccdf_value("var_password_pam_unix_rounds") }}} hashing rounds for hashing passwords.

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/rule.yml
@@ -40,7 +40,7 @@ ocil: |-
     The output should show the following match:
     <pre>password sufficient pam_unix.so sha512 rounds={{{ xccdf_value("var_password_pam_unix_rounds") }}}</pre>
 
-platform: package[pam]
+platform: package[pam] and system_with_kernel
 
 fixtext: |-
     Configure {{{ full_name }}} to use {{{ xccdf_value("var_password_pam_unix_rounds") }}} hashing rounds for hashing passwords.

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_forward_files/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_forward_files/rule.yml
@@ -32,3 +32,5 @@ ocil: |-
     To check the system for the existence of any <tt>.forward</tt> files,
     run the following command:
     <pre>$ sudo find /home -xdev -name .forward</pre>
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_netrc_files/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_netrc_files/rule.yml
@@ -42,3 +42,5 @@ ocil: |-
     To check the system for the existence of any <tt>.netrc</tt> files,
     run the following command:
     <pre>$ sudo find /home -xdev -name .netrc</pre>
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/rule.yml
@@ -67,3 +67,5 @@ fixtext: |-
     assign a UID of greater than "{{{ uid_min }}}" that has not already been assigned.
 
 srg_requirement: 'The root account must be the only account having unrestricted access to the {{{ full_name }}} system.'
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_root_gid_zero/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_root_gid_zero/rule.yml
@@ -34,3 +34,5 @@ ocil: |-
     <pre>
     0
     </pre>
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/rule.yml
@@ -51,3 +51,5 @@ warnings:
         Note that this rule just ensures the group exists and has no members. This rule does not
         configure <tt>pam_wheel.so</tt> module. The <tt>pam_wheel.so</tt> module configuration is
         accomplished by <tt>use_pam_wheel_group_for_su</tt> rule.
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_password_auth_for_systemaccounts/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_password_auth_for_systemaccounts/rule.yml
@@ -40,3 +40,5 @@ ocil: |-
             awk -v user="$account" -F: '$1~account { print $1 ":" $2 }' /etc/shadow
         done</pre>
     Verify if all accounts are locked.
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/rule.yml
@@ -66,3 +66,5 @@ warnings:
     - functionality: |-
         Do not perform the steps in this section on the root account. Doing so might cause the
         system to become inaccessible.
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/restrict_serial_port_logins/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/restrict_serial_port_logins/rule.yml
@@ -40,3 +40,5 @@ ocil: |-
     run the following command:
     <pre>$ sudo grep ^ttyS/[0-9] /etc/securetty</pre>
     If any output is returned, then root login over serial ports is permitted.
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/securetty_root_login_console_only/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/securetty_root_login_console_only/rule.yml
@@ -47,3 +47,5 @@ ocil: |-
     following command:
     <pre>$ sudo grep ^vc/[0-9] /etc/securetty</pre>
     If any output is returned, then root logins over virtual console devices is permitted.
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/rule.yml
@@ -48,4 +48,4 @@ fixtext: |-
 
 srg_requirement: "All {{{ full_name }}} local interactive user accounts must be assigned a home directory upon creation."
 
-platform: package[shadow-utils]
+platform: package[shadow-utils] and system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/rule.yml
@@ -42,7 +42,7 @@ ocil: |-
     <pre>$ sudo grep -i "FAIL_DELAY" {{{ login_defs_path }}}
     FAIL_DELAY {{{ xccdf_value("var_accounts_fail_delay") }}}</pre>
 
-platform: package[shadow-utils]
+platform: package[shadow-utils] and system_with_kernel
 
 fixtext: |-
     Configure the {{{ full_name }}} to enforce a delay of at least {{{ xccdf_value("var_accounts_fail_delay") }}} seconds between logon prompts following a failed console logon attempt.

--- a/linux_os/guide/system/accounts/accounts-session/accounts_max_concurrent_login_sessions/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_max_concurrent_login_sessions/rule.yml
@@ -67,4 +67,4 @@ fixtext: |-
 
 srg_requirement: '{{{ full_name }}} must limit the number of concurrent sessions to ten for all accounts and/or account types.'
 
-platform: package[pam]
+platform: package[pam] and system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_tmp/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_tmp/rule.yml
@@ -31,3 +31,5 @@ ocil: |-
   <pre>$ sudo grep /tmp /etc/security/namespace.conf</pre>
   The output should return the following:
   <pre>/tmp     /tmp/tmp-inst/            level      root,adm</pre>
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_var_tmp/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_var_tmp/rule.yml
@@ -31,3 +31,5 @@ ocil: |-
   <pre>$ sudo grep /var/tmp /etc/security/namespace.conf</pre>
   The output should return the following:
   <pre>/var/tmp /var/tmp/tmp-inst/    level      root,adm</pre>
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/rule.yml
@@ -46,3 +46,5 @@ warnings:
        Due to OVAL limitation, this rule can report a false negative in a
        specific situation where two interactive users swap the group-ownership
        of their respective initialization files.
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/rule.yml
@@ -51,3 +51,5 @@ fixtext: |-
 
 srg_requirement: |-
     Local {{{ full_name }}} initialization files must not execute world-writable programs.
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/rule.yml
@@ -44,3 +44,5 @@ warnings:
        Due to OVAL limitation, this rule can report a false negative in a
        specific situation where two interactive users swap the ownership of
        their respective initialization files.
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_home_paths_only/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_home_paths_only/rule.yml
@@ -52,3 +52,5 @@ fixtext: |-
     If a local interactive user requires path variables to reference a directory owned by the application, it must be documented with the ISSO.
 
 srg_requirement: 'Executable search paths within the initialization files of all local interactive {{{ full_name }}} users must only contain paths that resolve to the system default or the users home directory.'
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/rule.yml
@@ -46,3 +46,5 @@ fixtext: |-
     Assign home directories to all local interactive users on {{{ full_name }}} that currently do not have a home directory assigned.
 
 srg_requirement: 'All {{{ full_name }}} local interactive users must have a home directory assigned in the /etc/passwd file.'
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/rule.yml
@@ -58,3 +58,5 @@ fixtext: |-
     $ sudo chmod 0750 /home/smithj
 
 srg_requirement: 'All {{{ full_name }}} local interactive user home directories defined in the /etc/passwd file must exist.'
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/rule.yml
@@ -45,3 +45,5 @@ warnings:
        Due to OVAL limitation, this rule can report a false negative in a
        specific situation where two interactive users swap the group-ownership
        of folders or files in their respective home directories.
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/rule.yml
@@ -45,3 +45,5 @@ warnings:
        Due to OVAL limitation, this rule can report a false negative in a
        specific situation where two interactive users swap the ownership of
        folders or files in their respective home directories.
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_permissions/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_permissions/rule.yml
@@ -37,3 +37,5 @@ ocil: |-
     directory, excluding local initialization files, have a mode of <tt>0750</tt>,
     run the following command:
     <pre>$ sudo ls -lLR /home/<i>USER</i></pre>
+
+platform: system_with_kernel

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/group.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/group.yml
@@ -18,3 +18,5 @@ description: |-
     easy to intentionally share files with groups of which the user is
     a member.
     <br /><br />
+
+platform: system_with_kernel

--- a/linux_os/guide/system/network/network-ipsec/libreswan_approved_tunnels/rule.yml
+++ b/linux_os/guide/system/network/network-ipsec/libreswan_approved_tunnels/rule.yml
@@ -65,3 +65,5 @@ warnings:
     - general: |-
         Automatic remediation of this control is not available due to the unique
         requirements of each system.
+
+platform: system_with_kernel

--- a/linux_os/guide/system/network/network-ipsec/package_libreswan_installed/rule.yml
+++ b/linux_os/guide/system/network/network-ipsec/package_libreswan_installed/rule.yml
@@ -48,3 +48,5 @@ template:
     name: package_installed
     vars:
         pkgname: libreswan
+
+platform: system_with_kernel

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_static_address/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_static_address/rule.yml
@@ -22,3 +22,5 @@ identifiers:
 
 references:
     ism: 1315,1319
+
+platform: system_with_kernel

--- a/linux_os/guide/system/permissions/files/file_groupowner_etc_crypttab/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_groupowner_etc_crypttab/rule.yml
@@ -32,3 +32,5 @@ template:
     vars:
         filepath: /etc/crypttab
         gid_or_name: root
+
+platform: system_with_kernel

--- a/linux_os/guide/system/permissions/files/file_groupowner_systemmap/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_groupowner_systemmap/rule.yml
@@ -32,3 +32,5 @@ template:
         filepath: /boot/
         file_regex: ^.*System\.map.*$
         gid_or_name: root
+
+platform: system_with_kernel

--- a/linux_os/guide/system/permissions/files/file_owner_etc_crypttab/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_owner_etc_crypttab/rule.yml
@@ -32,3 +32,5 @@ template:
     vars:
         filepath: /etc/crypttab
         uid_or_name: '0'
+
+platform: system_with_kernel

--- a/linux_os/guide/system/permissions/files/file_owner_systemmap/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_owner_systemmap/rule.yml
@@ -32,3 +32,5 @@ template:
         filepath: /boot/
         file_regex: ^.*System\.map.*$
         uid_or_name: '0'
+
+platform: system_with_kernel

--- a/linux_os/guide/system/permissions/files/file_permissions_etc_crypttab/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_etc_crypttab/rule.yml
@@ -32,3 +32,5 @@ template:
     vars:
         filepath: /etc/crypttab
         filemode: '0600'
+
+platform: system_with_kernel

--- a/linux_os/guide/system/permissions/files/file_permissions_systemmap/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_systemmap/rule.yml
@@ -33,3 +33,5 @@ template:
         file_regex: ^.*System\.map.*$
         filemode: '0600'
         allow_stricter_permissions: 'true'
+
+platform: system_with_kernel

--- a/linux_os/guide/system/permissions/restrictions/coredumps/group.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/group.yml
@@ -21,3 +21,5 @@ description: |-
     <tt>sysctl</tt> variable <tt>fs.suid_dumpable</tt> controls whether
     the kernel allows core dumps from these programs at all. The default
     value of 0 is recommended.
+
+platform: system_with_kernel

--- a/linux_os/guide/system/permissions/restrictions/enable_nx/bios_enable_execution_restrictions/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_nx/bios_enable_execution_restrictions/rule.yml
@@ -65,3 +65,5 @@ fixtext: |-
     The NX bit execute protection must be enabled in the system BIOS.
 
 srg_requirement: '{{{ full_name }}} must implement non-executable data to protect its memory from unauthorized code execution.'
+
+platform: machine

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/rule.yml
@@ -66,3 +66,5 @@ fixtext: |-
     include /etc/crypto-policies/back-ends/libreswan.config
 
 srg_requirement: '{{{ full_name }}} must implement NIST FIPS-validated cryptography for the following: to provision digital signatures, to generate cryptographic hashes, and to protect data requiring data-at-rest protections in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, and standards.'
+
+platform: system_with_kernel

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/rule.yml
@@ -53,3 +53,5 @@ fixtext: |-
 
 srg_requirement: |-
     {{{ full_name }}} must implement approved encryption in the OpenSSH package.
+
+platform: system_with_kernel

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/rule.yml
@@ -60,3 +60,5 @@ warnings:
         party review by an accredited lab. While open source software is
         capable of meeting this, it does not meet FIPS-140 unless the vendor
         submits to this process.
+
+platform: system_with_kernel

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/rule.yml
@@ -58,3 +58,5 @@ warnings:
         party review by an accredited lab. While open source software is
         capable of meeting this, it does not meet FIPS-140 unless the vendor
         submits to this process.
+
+platform: system_with_kernel

--- a/linux_os/guide/system/software/system-tools/package_cryptsetup-luks_installed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_cryptsetup-luks_installed/rule.yml
@@ -28,3 +28,5 @@ template:
     name: package_installed
     vars:
         pkgname: cryptsetup
+
+platform: system_with_kernel

--- a/linux_os/guide/system/software/updating/clean_components_post_updating/rule.yml
+++ b/linux_os/guide/system/software/updating/clean_components_post_updating/rule.yml
@@ -91,5 +91,5 @@ srg_requirement: |-
     {{{ full_name }}} must remove all software components after updated versions have been installed.
 
 {{% if 'ubuntu' not in product %}}
-platform: package[{{{ pkg_manager }}}]
+platform: package[{{{ pkg_manager }}}] and not bootc
 {{% endif %}}

--- a/linux_os/guide/system/software/updating/dnf-automatic_apply_updates/rule.yml
+++ b/linux_os/guide/system/software/updating/dnf-automatic_apply_updates/rule.yml
@@ -30,7 +30,7 @@ references:
     ospp: FMT_SMF_EXT.1
     srg: SRG-OS-000805-GPOS-00260
 
-platform: not bootc
+platform: not bootc and not container
 
 ocil_clause: 'apply_updates is not set to yes'
 

--- a/linux_os/guide/system/software/updating/dnf-automatic_security_updates_only/rule.yml
+++ b/linux_os/guide/system/software/updating/dnf-automatic_security_updates_only/rule.yml
@@ -26,7 +26,7 @@ references:
     nist: SI-2(5),CM-6(a),SI-2(c)
     srg: SRG-OS-000191-GPOS-00080
 
-platform: not bootc
+platform: not bootc and not container
 
 ocil_clause: 'the upgrade_type is not set to security'
 

--- a/linux_os/guide/system/software/updating/package_dnf-automatic_installed/rule.yml
+++ b/linux_os/guide/system/software/updating/package_dnf-automatic_installed/rule.yml
@@ -27,7 +27,7 @@ ocil_clause: 'the package is not installed'
 
 ocil: '{{{ ocil_package(package="dnf-automatic") }}}'
 
-platform: not bootc
+platform: not bootc and not container
 
 template:
     name: package_installed

--- a/linux_os/guide/system/software/updating/timer_dnf-automatic_enabled/rule.yml
+++ b/linux_os/guide/system/software/updating/timer_dnf-automatic_enabled/rule.yml
@@ -28,7 +28,7 @@ ocil_clause: 'the dnf-automatic.timer is not enabled'
 
 ocil: "{{{ ocil_timer_enabled(timer='dnf-automatic') }}}"
 
-platform: not bootc
+platform: not bootc and not container
 
 template:
     name: timer_enabled


### PR DESCRIPTION
#### Description:

This PR changes `platform` key in multiple rules in order to change rule applicability in Image Mode and/or Container environment or both.

The most common changes:
- mark rules related to systemd services as notapplicable in containers because containers typically don't run systemd and can't run services, they usually run a single process or single application
- mark rules that depend on CPU or other hardware features as notapplicable in containers because containers don't have direct hardware access
- mark rules related to log in or password management as notapplicable in containers because you typically don't login to containers

#### Rationale:

This change is based on our applicability analysis which we did for all rules used in any RHEL 10 profiles.
The goal is more consistent applicability results in different environments.

#### Review Hints:

I have run these contest tests on RHEL 10 using this PR as a custom pipeline and all of them passed:

- /hardening/container/anaconda-ostree/
-  /hardening/container/bootc-image-builder
- /hardening/container/old-new
- /scanning/container-rules-applicability
