### PR TITLE
shared: macros: oval: Fix evr datatype for dpkg-based distros

### DIFF
--- a/shared/macros/10-oval.jinja
+++ b/shared/macros/10-oval.jinja
@@ -846,7 +846,7 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
   </linux:dpkginfo_object>
   {{% if evr %}}
     <linux:dpkginfo_state id="ste_{{{ test_id }}}" version="1">
-      <linux:evr datatype="evr_string" operation="{{{ evr_op }}}">{{{ evr }}}</linux:evr>
+      <linux:evr datatype="debian_evr_string" operation="{{{ evr_op }}}">{{{ evr }}}</linux:evr>
     </linux:dpkginfo_state>
   {{% endif %}}
 {{% endif %}}


### PR DESCRIPTION
Fixes #13879