### PR TITLE
Improvements of accounts_umask_root remediation and test scenarios

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/bash/shared.sh
@@ -1,3 +1,7 @@
 # platform = multi_platform_all
 
-sed -i -E -e "s/^([^#]*\bumask)[[:space:]]+[[:digit:]]+/\1 0027/g" /root/.bashrc /root/.profile
+for file in /root/.bashrc /root/.profile; do
+    if [ -f "$file" ]; then
+        sed -i -E -e "s/^([^#]*\bumask)[[:space:]]+[[:digit:]]+/\1 0027/g" "$file"
+    fi
+done

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/rule.yml
@@ -5,7 +5,7 @@ title: 'Ensure the Root Bash Umask is Set Correctly'
 description: |-
     To ensure the root user's umask of the Bash shell is set properly,
     add or correct the <tt>umask</tt> setting in <tt>/root/.bashrc</tt>
-    or <tt>/root/.bashrc</tt> to read as follows:
+    or <tt>/root/.profile</tt> to read as follows:
     <pre>umask 0027</pre>
 
 rationale: |-

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/commented.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/commented.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-sed '/umask/d' -i /root/.bashrc /root/.profile
+sed '/umask/d' -i /root/.bashrc /root/.profile || true
 echo "# umask 0022" >> /root/.bashrc
 

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/correct_bashrc.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/correct_bashrc.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-sed '/umask/d' -i /root/.bashrc /root/.profile
+sed '/umask/d' -i /root/.bashrc /root/.profile || true
 echo "umask 0027" >> /root/.bashrc

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/correct_profile.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/correct_profile.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-sed '/umask/d' -i /root/.bashrc /root/.profile
+sed '/umask/d' -i /root/.bashrc /root/.profile || true
 echo "umask 0027" >> /root/.profile

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/lenient.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/lenient.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-sed '/umask/d' -i /root/.bashrc /root/.profile
+sed '/umask/d' -i /root/.bashrc /root/.profile || true
 echo "umask 0022" >> /root/.profile

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/lenient2.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/lenient2.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-sed '/umask/d' -i /root/.bashrc /root/.profile
+sed '/umask/d' -i /root/.bashrc /root/.profile || true
 echo "umask 0017" >> /root/.profile

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/lenient_bashrc_correct_profile.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/lenient_bashrc_correct_profile.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-sed '/umask/d' -i /root/.bashrc /root/.profile
+sed '/umask/d' -i /root/.bashrc /root/.profile || true
 echo "umask 0000" >> /root/.bashrc
 echo "umask 0027" >> /root/.profile

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/lenient_threedigit.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/lenient_threedigit.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-sed '/umask/d' -i /root/.bashrc /root/.profile
+sed '/umask/d' -i /root/.bashrc /root/.profile || true
 echo "umask 022" >> /root/.profile

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/missing.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/missing.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-sed '/umask/d' -i /root/.bashrc /root/.profile
-
+sed '/umask/d' -i /root/.bashrc /root/.profile || true

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/strict.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_root/tests/strict.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-sed '/umask/d' -i /root/.bashrc /root/.profile
+sed '/umask/d' -i /root/.bashrc /root/.profile || true
 echo "umask 0777" >> /root/.profile


### PR DESCRIPTION
Improve remediation and test scenarios of the rule `accounts_umask_root` to handle cases where one (or both) of the files passed to `sed` command (`/root/.bashrc` or `/root/.profile`) do not exist.

Before:
```
$ ./automatus.py rule --duplicate-templates --libvirt qemu:///session ssgts_10 --datastream ../build/ssg-rhel10-ds.xml --remediate-using bash accounts_umask_root
INFO - xccdf_org.ssgproject.content_rule_accounts_umask_root
INFO - Script commented.pass.sh using profile (all) OK
INFO - Script correct_bashrc.pass.sh using profile (all) OK
INFO - Script correct_profile.pass.sh using profile (all) OK
INFO - Script lenient.fail.sh using profile (all) OK
INFO - Script lenient2.fail.sh using profile (all) OK
INFO - Script lenient_bashrc_correct_profile.fail.sh using profile (all) OK
INFO - Script lenient_threedigit.fail.sh using profile (all) OK
ERROR - Rule 'accounts_umask_root' test setup script 'missing.pass.sh' failed with exit code 2
ERROR - Environment failed to prepare, skipping test
INFO - Script strict.pass.sh using profile (all) OK

$ cat logs/.../accounts_umask_root.prescripts.log
##### accounts_umask_root / missing.pass.sh #####
...
+ sed /umask/d -i /root/.bashrc /root/.profile
sed: can't read /root/.profile: No such file or directory
```

After the changes from this PR:
```
$ ./automatus.py rule --duplicate-templates --libvirt qemu:///session ssgts_10 --datastream ../build/ssg-rhel10-ds.xml --remediate-using bash accounts_umask_root
INFO - xccdf_org.ssgproject.content_rule_accounts_umask_root
INFO - Script commented.pass.sh using profile (all) OK
INFO - Script correct_bashrc.pass.sh using profile (all) OK
INFO - Script correct_profile.pass.sh using profile (all) OK
INFO - Script lenient.fail.sh using profile (all) OK
INFO - Script lenient2.fail.sh using profile (all) OK
INFO - Script lenient_bashrc_correct_profile.fail.sh using profile (all) OK
INFO - Script lenient_threedigit.fail.sh using profile (all) OK
INFO - Script missing.pass.sh using profile (all) OK
INFO - Script strict.pass.sh using profile (all) OK
```