### PR TITLE
Import ssg for CI sync-cac-oscal

### DIFF
--- a/.github/workflows/sync-cac-oscal.yml
+++ b/.github/workflows/sync-cac-oscal.yml
@@ -57,7 +57,20 @@ jobs:
           repositories: |
             content
             oscal-content
-      # Step 5: Detect the updates of CAC content
+      # Step 5: Checkout complyscribe and setup the environment
+      - name: Checkout complyscribe repo
+        if: ${{ env.SKIP == 'false' }}
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: complytime/complyscribe
+          path: complyscribe
+      - name: Setup complyscribe
+        if: ${{ env.SKIP == 'false' }}
+        run: |
+          cd complyscribe && python3 -m venv venv && source venv/bin/activate
+          python3 -m pip install --no-cache-dir "poetry==1.7.1"
+          poetry install
+      # Step 6: Detect the updates of CAC content
       - name: Detect files changed by PR
         if: ${{ env.SKIP == 'false' }}
         id: changed-files
@@ -69,6 +82,7 @@ jobs:
           response=$(gh api "$url" --paginate)
           echo "$response" | jq -r '.[].filename' > filenames.txt
           echo "CHANGE_FOUND=false" >> $GITHUB_ENV
+          source complyscribe/venv/bin/activate
           cd cac-content
           has_change() {
             local file="$1"
@@ -110,7 +124,6 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-      # Step 6: Setup the complyscribe environment
       - name: Checkout OSCAL content repo
         if: ${{ env.CHANGE_FOUND == 'true' }}
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -119,18 +132,6 @@ jobs:
           path: oscal-content
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
-      - name: Checkout complyscribe repo
-        if: ${{ env.CHANGE_FOUND == 'true' }}
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          repository: complytime/complyscribe
-          path: complyscribe
-      - name: Setup complyscribe
-        if: ${{ env.CHANGE_FOUND == 'true' }}
-        run: |
-          cd complyscribe && python3 -m venv venv && source venv/bin/activate
-          python3 -m pip install --no-cache-dir "poetry==1.7.1"
-          poetry install
       - name: Set RH_PRODUCTS
         if: ${{ env.CHANGE_FOUND == 'true' }}
         run: |


### PR DESCRIPTION
In CI sync-cac-oscal, it will call `utils/compare_rule_var.py`, which requires the SSG module. The step `setup complyscribe` also requires the SSG module. In this PR, the order of the steps has been changed to share the imported SSG module.
