### PR TITLE
Clarification in describe_module_disable macro

### DIFF
--- a/shared/macros/01-general.jinja
+++ b/shared/macros/01-general.jinja
@@ -351,7 +351,7 @@ Describe allowing access to a service in firewalld.
     To configure the system to prevent the <code>{{{ module }}}</code>
     kernel module from being loaded, add the following line to the file <code>/etc/modprobe.d/{{{ module }}}.conf</code>:
     <pre>install {{{ module }}} /bin/false</pre>
-    This entry will cause cause a non-zero return value during a <code>{{{ module }}}</code> module installation
+    This entry will cause a non-zero return value during a <code>{{{ module }}}</code> module installation
     and additionally convey the meaning of the entry to the user in form of an error message. 
     If you would like to omit a non-zero return value and an error message, you may want to add a different line instead
     (both <code>/bin/true</code> and <code>/bin/false</code> are allowed by OVAL and will be accepted by the scan):

--- a/shared/macros/01-general.jinja
+++ b/shared/macros/01-general.jinja
@@ -351,6 +351,11 @@ Describe allowing access to a service in firewalld.
     To configure the system to prevent the <code>{{{ module }}}</code>
     kernel module from being loaded, add the following line to the file <code>/etc/modprobe.d/{{{ module }}}.conf</code>:
     <pre>install {{{ module }}} /bin/false</pre>
+    This entry will cause cause a non-zero return value during a <code>{{{ module }}}</code> module installation
+    and additionally convey the meaning of the entry to the user in form of an error message. 
+    If you would like to omit a non-zero return value and an error message, you may want to add a different line instead
+    (both <code>/bin/true</code> and <code>/bin/false</code> are allowed by OVAL and will be accepted by the scan):
+    <pre>install {{{ module }}} /bin/true</pre>
     {{% if "ol" in product or product in ["rhel8"] %}}
     To configure the system to prevent the <code>{{{ module }}}</code> from being used,
     add the following line to file <code>/etc/modprobe.d/{{{ module }}}.conf</code>:


### PR DESCRIPTION
#### Description:

Adding some clarifications about using `install {module} /bin/false` and `install {module} /bin/true` in remediation scripts for disabling kernel modules. 

#### Rationale:

Changes were made in response to a [RHEL-106814](https://issues.redhat.com/browse/RHEL-106814) ticket on Jira.

#### Review Hints:

- Shared macro `describe_module_disable` in `/shared/macros/01-general.jinja` file was modified. These changes will affect all of the rules that are using `kernel_module_disabled` template
