### PR TITLE
Removing duplicated words in /shared/applicability/

### DIFF
--- a/shared/applicability/oval/installed_app_is_eks.xml
+++ b/shared/applicability/oval/installed_app_is_eks.xml
@@ -8,7 +8,7 @@
         <platform>multi_platform_ocp</platform>
       </affected>
       <reference ref_id="cpe:/a:amazon:elastic_kubernetes_service:1" source="CPE" />
-      <description>The application installed installed on the system is EKS.</description>
+      <description>The application installed on the system is EKS.</description>
     </metadata>
     <criteria operator="AND">
       <criterion comment="cluster is EKS" test_ref="test_eks" />
@@ -53,7 +53,7 @@
         <platform>Amazon Elastic Kubernetes Service 1.{{{ minorversion }}}</platform>
       </affected>
       <reference ref_id="cpe:/a:amazon:elastic_kubernetes_service:1.{{{ minorversion }}}" source="CPE" />
-      <description>The application installed installed on the system is Amazon Elastic Kubernetes Service 1.{{{ minorversion }}}.</description>
+      <description>The application installed on the system is Amazon Elastic Kubernetes Service 1.{{{ minorversion }}}.</description>
     </metadata>
     <criteria operator="AND">
       <criterion comment="cluster is EKS 1.{{{ minorversion }}}" test_ref="test_eks_1_{{{ minorversion }}}" />

--- a/shared/applicability/oval/installed_app_is_eks_node.xml
+++ b/shared/applicability/oval/installed_app_is_eks_node.xml
@@ -7,7 +7,7 @@
         <platform>multi_platform_ocp</platform>
       </affected>
       <reference ref_id="cpe:/o:amazon:elastic_kubernetes_service_node:1" source="CPE" />
-      <description>The application installed installed on the system is EKS 4.</description>
+      <description>The application installed on the system is EKS 4.</description>
     </metadata>
     <criteria>
       <criterion comment="Kubelet is installed" test_ref="test_kubelet_kubeconfig_exists" />

--- a/shared/applicability/oval/installed_app_is_ocp4.xml
+++ b/shared/applicability/oval/installed_app_is_ocp4.xml
@@ -8,7 +8,7 @@
         <platform>multi_platform_ocp</platform>
       </affected>
       <reference ref_id="cpe:/a:redhat:openshift_container_platform:4.1" source="CPE" />
-      <description>The application installed installed on the system is OpenShift 4.</description>
+      <description>The application installed on the system is OpenShift 4.</description>
     </metadata>
     <criteria operator="AND">
       <criterion comment="cluster is OpenShift 4" test_ref="test_ocp4" />
@@ -110,7 +110,7 @@
         <platform>Red Hat OpenShift Container Platform 4.{{{ minorversion }}}</platform>
       </affected>
       <reference ref_id="cpe:/a:redhat:openshift_container_platform:4.{{{ minorversion }}}" source="CPE" />
-      <description>The application installed installed on the system is OpenShift version 4.{{{ minorversion }}}.</description>
+      <description>The application installed on the system is OpenShift version 4.{{{ minorversion }}}.</description>
     </metadata>
     <criteria operator="OR">
       <criteria operator="AND">
@@ -172,7 +172,7 @@
         <platform>Red Hat OpenShift Container Platform 4 on {{{ platform }}}</platform>
       </affected>
       <reference ref_id="cpe:/a:redhat:openshift_container_platform_on_{{{ platform|lower }}}:4" source="CPE" />
-      <description>The application installed installed on the system is OpenShift version 4 on {{{ platform }}}.</description>
+      <description>The application installed on the system is OpenShift version 4 on {{{ platform }}}.</description>
     </metadata>
     <criteria operator="AND">
       <criterion comment="cluster is OpenShift 4 on {{{ platform }}}" test_ref="test_ocp4_on_{{{ platform|lower }}}" />
@@ -220,7 +220,7 @@
         <platform>Red Hat OpenShift Container network 4 on {{{ network }}}</platform>
       </affected>
       <reference ref_id="cpe:/a:redhat:openshift_container_network_on_{{{ network|lower }}}:4" source="CPE" />
-      <description>The application installed installed on the system is OpenShift version 4 on {{{ network }}}.</description>
+      <description>The application installed on the system is OpenShift version 4 on {{{ network }}}.</description>
     </metadata>
     <criteria operator="AND">
       <criterion comment="cluster is OpenShift 4 on {{{ network }}}" test_ref="test_ocp4_on_{{{ network|lower }}}" />
@@ -252,7 +252,7 @@
         <platform>Red Hat OpenShift Container Platform 4 on HyperShift</platform>
       </affected>
       <reference ref_id="cpe:/a:redhat:openshift_container_platform_on_hypershift:4" source="CPE" />
-      <description>The application installed installed on the system is OpenShift 4 on HyperShift Management Cluster.</description>
+      <description>The application installed on the system is OpenShift 4 on HyperShift Management Cluster.</description>
     </metadata>
     <criteria operator="AND">
       <criterion comment="Make sure there is version for HyperShift HostedCluster" test_ref="test_hypershift_version"/>
@@ -267,7 +267,7 @@
         <platform>Red Hat OpenShift Container Platform 4 on HyperShift</platform>
       </affected>
       <reference ref_id="cpe:/a:redhat:openshift_container_platform_on_hypershift_hosted:4" source="CPE" />
-      <description>The application installed installed on the system is OpenShift 4 on HyperShift Hosted Cluster.</description>
+      <description>The application installed on the system is OpenShift 4 on HyperShift Hosted Cluster.</description>
     </metadata>
     <criteria operator="AND">
       <criterion comment="Make sure there is HyperShift in the Compliance Operator Command flag" test_ref="test_hypershift_hosted"/>

--- a/shared/applicability/oval/installed_app_is_ocp4_node.xml
+++ b/shared/applicability/oval/installed_app_is_ocp4_node.xml
@@ -7,7 +7,7 @@
         <platform>multi_platform_ocp</platform>
       </affected>
       <reference ref_id="cpe:/o:redhat:openshift_container_platform_node:4" source="CPE" />
-      <description>The application installed installed on the system is OpenShift 4.</description>
+      <description>The application installed on the system is OpenShift 4.</description>
     </metadata>
     <criteria>
       <criterion comment="Kubelet is installed" test_ref="test_kubelet_conf_exists" />
@@ -49,7 +49,7 @@
         <platform>Red Hat OpenShift Container network 4 on {{{ network }}}</platform>
       </affected>
       <reference ref_id="cpe:/a:redhat:openshift_container_node_network_on_{{{ network|lower }}}:4" source="CPE" />
-      <description>The application installed installed on the system is OpenShift version 4 on {{{ network }}}.</description>
+      <description>The application installed on the system is OpenShift version 4 on {{{ network }}}.</description>
     </metadata>
     <criteria operator="AND">
       <criterion comment="cluster is OpenShift 4 on {{{ network }}}" test_ref="test_ocp4_on_{{{ network|lower }}}" />

--- a/shared/applicability/oval/installed_app_is_rhv4.xml
+++ b/shared/applicability/oval/installed_app_is_rhv4.xml
@@ -8,7 +8,7 @@
       </affected>
       <reference ref_id="cpe:/a:redhat:virtualization:4"
       source="CPE" />
-      <description>The application installed installed on the system is
+      <description>The application installed on the system is
       Red Hat Virtualization 4.</description>
     </metadata>
     <criteria>


### PR DESCRIPTION
#### Description:

- Clean up duplicate wording in /shared/applicability/ XML files.

#### Rationale:

- Some of these files contained the word “installed,” which was repeated several times.
