### PR TITLE
Update library files rules to check .so files for OL8

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/rule.yml
@@ -64,7 +64,11 @@ template:
             - /usr/lib/
             - /usr/lib64/
         recursive: 'true'
+{{% if 'ol8' in product %}}
+        file_regex: ^.*\.so.*$
+{{% else %}}
         file_regex: ^.*$
+{{% endif %}}
         uid_or_name: '0'
 
 fixtext: |-

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/tests/incorrect_owner.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/tests/incorrect_owner.fail.sh
@@ -2,7 +2,11 @@
 # platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu,multi_platform_almalinux
 
 useradd user_test
+{{% if 'ol8' in product %}}
+for TESTFILE in /lib/test_me.so /lib64/test_me.so /usr/lib/test_me.so /usr/lib64/test_me.so
+{{% else %}}
 for TESTFILE in /lib/test_me /lib64/test_me /usr/lib/test_me /usr/lib64/test_me
+{{% endif %}}
 do
    if [[ ! -f $TESTFILE ]]
    then

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/tests/incorrect_owner_within_dir.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/tests/incorrect_owner_within_dir.fail.sh
@@ -6,5 +6,10 @@ useradd user_test
 TESTDIR="/usr/lib/dir/"
 
 mkdir -p "${TESTDIR}"
+{{% if 'ol8' in product %}}
+touch "${TESTDIR}"/test_me.so
+chown user_test "${TESTDIR}"/test_me.so
+{{% else %}}
 touch "${TESTDIR}"/test_me
 chown user_test "${TESTDIR}"/test_me
+{{% endif %}}

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/rule.yml
@@ -64,7 +64,11 @@ template:
             - /usr/lib/
             - /usr/lib64/
         recursive: 'true'
+{{% if 'ol8' in product %}}
+        file_regex: ^.*\.so.*$
+{{% else %}}
         file_regex: ^.*$
+{{% endif %}}
         filemode: '7755'
 
 fixtext: |-

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/tests/lenient_permissions.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/tests/lenient_permissions.fail.sh
@@ -4,5 +4,9 @@ DIRS="/lib /lib64 /usr/lib /usr/lib64"
 for dirPath in $DIRS; do
     # Limit the test changes to a subset of file in the directory
     # Remediation the whole library dirs is very time consuming
+{{% if 'ol8' in product %}}
+    find "$dirPath" -type f -regex ".*\.so" -exec chmod go+w '{}' \;
+{{% else %}}
     find "$dirPath" -type f -regex ".*\.txt" -exec chmod go+w '{}' \;
+{{% endif %}}
 done

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/rule.yml
@@ -66,7 +66,11 @@ template:
             - /lib64/
             - /usr/lib/
             - /usr/lib64/
+{{% if 'ol8' in product %}}
+        file_regex: ^.*\.so.*$
+{{% else %}}
         file_regex: ^.*$
+{{% endif %}}
         recursive: 'true'
         gid_or_name: '0'
 {{% endif %}}

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/tests/correct_groupowner.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/tests/correct_groupowner.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_sle,multi_platform_rhel,multi_platform_fedora,multi_platform_ubuntu
+# platform = multi_platform_sle,multi_platform_rhel,multi_platform_fedora,multi_platform_ubuntu,multi_platform_ol
 
 for SYSLIBDIRS in /lib /lib64 /usr/lib /usr/lib64
 do

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/tests/incorrect_groupowner.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/tests/incorrect_groupowner.fail.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
-# platform = multi_platform_sle,multi_platform_rhel,multi_platform_fedora,multi_platform_ubuntu
+# platform = multi_platform_sle,multi_platform_rhel,multi_platform_fedora,multi_platform_ubuntu,multi_platform_ol
 
 groupadd group_test
+{{% if 'ol8' in product %}}
+for TESTFILE in /lib/test_me.so /lib64/test_me.so /usr/lib/test_me.so /usr/lib64/test_me.so
+{{% else %}}
 for TESTFILE in /lib/test_me /lib64/test_me /usr/lib/test_me /usr/lib64/test_me
+{{% endif %}}
 do
    if [[ ! -f $TESTFILE ]]
    then


### PR DESCRIPTION
#### Description:

Update current regex file to match .so files in the following rules
- OL08-00-010330 - file_permissions_library_dirs
- OL08-00-010350 - root_permissions_syslibrary_files
- OL08-00-010340 - file_ownership_library_dirs


#### Rationale:

To be aligned with OL8 V2R5 STIG
