### PR TITLE
Update CLO install channel

### DIFF
--- a/ocp-resources/e2e/cluster-logging-install-observability.yaml
+++ b/ocp-resources/e2e/cluster-logging-install-observability.yaml
@@ -50,7 +50,7 @@ metadata:
   name: cluster-logging
   namespace: openshift-logging
 spec:
-  channel: stable-6.1
+  channel: stable-6.3
   name: cluster-logging
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Using stable-6.1 apparently hangs. Using 6.3 installs the latest CLO.
Without this change the remediations hang in the ocp4e2e testing because
CLO never installs.
