### PR TITLE
Fix bootc platform CPE OVAL check

### DIFF
--- a/shared/applicability/oval/bootc.xml
+++ b/shared/applicability/oval/bootc.xml
@@ -13,7 +13,7 @@
 {{% else %}}
 {{% set kernel_package = "kernel" %}}
 {{% endif %}}
-{{{ oval_test_package_installed(package="{{{ kernel_package }}}", test_id="bootc_platform_test_kernel_installed") }}}
+{{{ oval_test_package_installed(package=kernel_package, test_id="bootc_platform_test_kernel_installed") }}}
 {{{ oval_test_package_installed(package="rpm-ostree", test_id="bootc_platform_test_rpm_ostree_installed") }}}
 {{{ oval_test_package_installed(package="bootc", test_id="bootc_platform_test_bootc_installed") }}}
 {{{ oval_test_package_removed(package="openshift-kubelet", test_id="bootc_platform_test_openshift_kubelet_removed") }}}

--- a/shared/checks/oval/bootc.xml
+++ b/shared/checks/oval/bootc.xml
@@ -8,7 +8,12 @@
       <criterion comment="openshift-kubelet is not installed" test_ref="bootc_platform_test_openshift_kubelet_removed" />
     </criteria>
   </definition>
-{{{ oval_test_package_installed(package="kernel", test_id="bootc_platform_test_kernel_installed") }}}
+{{% if product == "fedora" or "rhel" in product %}}
+{{% set kernel_package = "kernel-core" %}}
+{{% else %}}
+{{% set kernel_package = "kernel" %}}
+{{% endif %}}
+{{{ oval_test_package_installed(package=kernel_package, test_id="bootc_platform_test_kernel_installed") }}}
 {{{ oval_test_package_installed(package="rpm-ostree", test_id="bootc_platform_test_rpm_ostree_installed") }}}
 {{{ oval_test_package_installed(package="bootc", test_id="bootc_platform_test_bootc_installed") }}}
 {{{ oval_test_package_removed(package="openshift-kubelet", test_id="bootc_platform_test_openshift_kubelet_removed") }}}


### PR DESCRIPTION
Curly braces aren't allowed inside curly braces. This caused that multiple rules (eg. dnf-automatic_apply_updates, mount_option_boot_noexec) were evaluated as applicable in Image Mode environments where these rules should be evaluated as notapplicable. We will fix the CPE OVAL definition and also we will synchronize the similar OVAL with the CPE OVAL.

