### PR TITLE
Set OVAL version to 5.11.3 and add option for still building 5.11, 5.11.1 and 5.11.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ set(SSG_PATCH_VERSION 79)
 set(SSG_VERSION "${SSG_MAJOR_VERSION}.${SSG_MINOR_VERSION}.${SSG_PATCH_VERSION}")
 
 set(SSG_TARGET_OVAL_MAJOR_VERSION "5" CACHE STRING "Which major version of OVAL are we targetting. Only 5 is supported at the moment.")
-set(SSG_TARGET_OVAL_MINOR_VERSION "11" CACHE STRING "Which minor version of OVAL are we targetting. Only 11 is supported at the moment.")
+set(SSG_TARGET_OVAL_MINOR_VERSION "11" CACHE STRING "Which minor version of OVAL are we targetting. Only 11, up to 11.3, is supported at the moment.")
 set(SSG_TARGET_OVAL_VERSION "${SSG_TARGET_OVAL_MAJOR_VERSION}.${SSG_TARGET_OVAL_MINOR_VERSION}")
 set(SSG_VENDOR "ssgproject" CACHE STRING "Specify the XCCDF 1.2 vendor string.")
 
@@ -191,8 +191,8 @@ find_python_module(prometheus_client)
 find_python_module(requests)
 find_python_module(trestle)
 
-if(NOT SSG_TARGET_OVAL_VERSION VERSION_EQUAL "5.11")
-    message(WARNING "You are targeting OVAL version ${SSG_TARGET_OVAL_VERSION}. In SSG we support/test 5.11 only!")
+if(NOT (SSG_TARGET_OVAL_VERSION VERSION_GREATER_EQUAL "5.11" AND SSG_TARGET_OVAL_VERSION VERSION_LESS_EQUAL "5.11.3"))
+    message(WARNING "You are targeting OVAL version ${SSG_TARGET_OVAL_VERSION}. In SSG we support/test up to 5.11.3 only!")
 endif()
 
 # OCP4 requires non-standard extensions. Vanilla OpenSCAP 1.2 doesn't support it.

--- a/build_product
+++ b/build_product
@@ -14,7 +14,7 @@
 # ARG_USE_ENV([ADDITIONAL_CMAKE_OPTIONS],[],[Whitespace-separated string of arguments to pass to CMake])
 # ARG_POSITIONAL_INF([product],[Products to build, ALL means all products],[0],[ALL])
 # ARG_DEFAULTS_POS([])
-# ARG_TYPE_GROUP_SET([oval_ver],[VERSION],[oval],[5.11,auto])
+# ARG_TYPE_GROUP_SET([oval_ver],[VERSION],[oval],[5.11,5.11.1,5.11.2,5.11.3,auto])
 # ARG_TYPE_GROUP_SET([builder_type],[BUILDER],[builder],[make,ninja,auto])
 # ARG_HELP([Wipes out contents of the 'build' directory and builds only and only the given products.])
 # ARGBASH_GO()
@@ -38,12 +38,12 @@ die()
 
 oval_ver()
 {
-	local _allowed=("5.11" "auto") _seeking="$1"
+	local _allowed=("5.11" "5.11.1" "5.11.2" "5.11.3" "auto") _seeking="$1"
 	for element in "${_allowed[@]}"
 	do
 		test "$element" = "$_seeking" && echo "$element" && return 0
 	done
-	die "Value '$_seeking' (of argument '$2') doesn't match the list of allowed values: '5.11' and 'auto'" 4
+	die "Value '$_seeking' (of argument '$2') doesn't match the list of allowed values: '5.11', '5.11.1' '5.11.2' '5.11.3' and 'auto'" 4
 }
 
 
@@ -89,7 +89,7 @@ print_help()
 	printf '%s\n' "Wipes out contents of the 'build' directory and builds only and only the given products."
 	printf 'Usage: %s [-o|--oval <VERSION>] [-b|--builder <BUILDER>] [-j|--jobs <arg>] [--(no-)debug] [--(no-)derivatives] [--(no-)ansible-playbooks] [--(no-)bash-scripts] [-d|--(no-)datastream-only] [-p|--(no-)profiling] [-h|--help] [<product-1>] ... [<product-n>] ...\n' "$0"
 	printf '\t%s\n' "<product>: Products to build, ALL means all products (defaults for <product>: 'ALL')"
-	printf '\t%s\n' "-o, --oval: OVAL version. Can be one of: '5.11' or 'auto' (default: 'auto')"
+	printf '\t%s\n' "-o, --oval: OVAL version. Can be one of: '5.11', '5.11.1', '5.11.2' '5.11.3' or 'auto' (default: 'auto')"
 	printf '\t%s\n' "-b, --builder: Builder engine. Can be one of: 'make', 'ninja' and 'auto' (default: 'auto')"
 	printf '\t%s\n' "-j, --jobs: Count of simultaneous jobs (default: 'auto')"
 	printf '\t%s\n' "--debug, --no-debug: Make a debug build with draft profiles (off by default)"
@@ -391,7 +391,7 @@ all_cmake_products=(
 )
 
 DEFAULT_OVAL_MAJOR_VERSION=5
-DEFAULT_OVAL_MINOR_VERSION=11
+DEFAULT_OVAL_MINOR_VERSION=11.3
 
 build_type_option="-DCMAKE_BUILD_TYPE=Release"
 


### PR DESCRIPTION
#### Description:

- This is a second attempt on bumping the OVAL version (first was #11903). Differently from the first, I tried to also allow for builds on 5.11, 5.11.1 and 5.11.2. Also the discussions from the first attempt were mainly considering the output of `oscap --version`  and as I mentioned on #13900 it seems that openscap never reflected the updates on OVAL version: https://github.com/OpenSCAP/openscap/blob/main/src/OVAL/oval_agent_api_impl.h#L38

#### Rationale:

- Add support for newer versions of OVAL which contain relevant data formats and will help with OVAL checks writing.

- This is also needed for #13900.
