### PR TITLE
Debian 12 CIS: Fix expected PAM version

### DIFF
--- a/controls/cis_debian12.yml
+++ b/controls/cis_debian12.yml
@@ -1828,7 +1828,7 @@ controls:
           - package_pam_runtime_installed
       status: automated
       notes: |
-          The CIS control checks that version >= 1.5.3-5 and not that
+          The CIS control checks that version >= 1.5.2-6 and not that
           it is the latest version as the title suggests.
 
     - id: 5.3.1.2

--- a/linux_os/guide/system/accounts/accounts-pam/package_pam_modules_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/package_pam_modules_installed/rule.yml
@@ -19,3 +19,4 @@ template:
         pkgname: libpam-modules
         evr@ubuntu2204: 0:1.4.0-11
         evr@ubuntu2404: 0:1.5.3-5
+        evr@debian12: 0:1.5.2-6

--- a/linux_os/guide/system/accounts/accounts-pam/package_pam_runtime_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/package_pam_runtime_installed/rule.yml
@@ -17,3 +17,4 @@ template:
         pkgname: libpam-runtime
         evr@ubuntu2204: 0:1.4.0-11
         evr@ubuntu2404: 0:1.5.3-5
+        evr@debian12: 0:1.5.2-6


### PR DESCRIPTION
#### Description:

- When testing the CIS level 2 (server) benchmark on Debian 12, failures are reported for rules `xccdf_org.ssgproject.content_rule_package_pam_runtime_installed` and `xccdf_org.ssgproject.content_rule_package_pam_modules_installed`.
These failures stem from looking for the wrong package version; specifically, we inherit the Ubuntu version number, and we're searching for `evr: 0:1.5.3-5`.
However, version `1.5.2-6+deb12u1` is the latest available package version for Debian 12, for both `libpam-modules` and `libpam-runtime`. Moreover, the CIS benchmark itself mandates the usage of "_version 1.5.2-6 or later_".
- This PR specify the expected version for Debian 12 for both rules

#### Rationale:

- If we don't fix it, there can never be a Pass result for those rules in Debian 12
- Addresses the Debian-related portion of #13879
  - (not the `oscap-docker` part of it)

#### Review Hints:

- To test this, it is sufficient to build the Debian 12 policy, then in a Debian 12 VM or container:
  - `# setup`
  - `apt-get update && apt-get -y install docker.io openscap-scanner openscap-utils unzip wget curl`
  - `# audit`
  - `oscap xccdf eval --profile xccdf_org.ssgproject.content_profile_cis_level2_server --report debian12_cis_L2.html --results debian12_cis_L2.xml --oval-results --fetch-remote-resources /path/to/ssg-debian12-ds.xml`
- With the modified policy, you should see a `pass` for both `xccdf_org.ssgproject.content_rule_package_pam_runtime_installed` and `xccdf_org.ssgproject.content_rule_package_pam_modules_installed`:

<img width="654" height="214" alt="image" src="https://github.com/user-attachments/assets/1d6de929-4a91-4bd7-8a78-962595dc0f2e" />

  Whereas, if you try with the original policy, both would end in `fail`.