### PR TITLE
Make CLO install channel change resilient

### DIFF
--- a/applications/openshift/api-server/audit_log_forwarding_enabled_logging_api/tests/ocp4/e2e-remediation.sh
+++ b/applications/openshift/api-server/audit_log_forwarding_enabled_logging_api/tests/ocp4/e2e-remediation.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 set -xe
 
-echo "installing cluster-logging-operator"
-oc apply -f ${ROOT_DIR}/ocp-resources/e2e/cluster-logging-install.yaml
+export CLO_CHANNEL=$(oc get packagemanifest -o jsonpath='{range .status.channels[*]}{.name}{"\n"}{end}' -n openshift-marketplace cluster-logging | sort | tail -1)
+
+echo "installing cluster-logging-operator from channel ${CLO_CHANNEL}"
+envsusbst < <(cat ${ROOT_DIR}/ocp-resources/e2e/cluster-logging-install.yaml) | oc apply -f
 
 sleep 30
 

--- a/ocp-resources/e2e/cluster-logging-install-observability.yaml
+++ b/ocp-resources/e2e/cluster-logging-install-observability.yaml
@@ -50,7 +50,7 @@ metadata:
   name: cluster-logging
   namespace: openshift-logging
 spec:
-  channel: stable-6.1
+  channel: ${CLO_CHANNEL}
   name: cluster-logging
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/ocp-resources/e2e/cluster-logging-install.yaml
+++ b/ocp-resources/e2e/cluster-logging-install.yaml
@@ -50,7 +50,7 @@ metadata:
   name: cluster-logging
   namespace: openshift-logging
 spec:
-  channel: stable
+  channel: ${CLO_CHANNEL}
   name: cluster-logging
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION




#### Description:

- This patch probes the operator manifest to grab the latest available channel and use that to install CLO.

#### Rationale:

- Cluster Logging Operator keeps changing the list of available channels.
  On OCP version 4.19 stable-6.1 is not available anymore, while on 4.16 stable-6.3 is not available.

#### Review Hints:

- Check that manual remediation work across supported OCP versions.
