### PR TITLE
On RHEL for library dirs rules only check *.so files

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/rule.yml
@@ -64,7 +64,7 @@ template:
             - /usr/lib/
             - /usr/lib64/
         recursive: 'true'
-{{% if 'ol8' in product %}}
+{{% if 'ol8' in product or 'rhel' in product %}}
         file_regex: ^.*\.so.*$
 {{% else %}}
         file_regex: ^.*$

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/tests/incorrect_owner.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/tests/incorrect_owner.fail.sh
@@ -2,7 +2,7 @@
 # platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu,multi_platform_almalinux
 
 useradd user_test
-{{% if 'ol8' in product %}}
+{{% if 'ol8' in product or 'rhel' in product %}}
 for TESTFILE in /lib/test_me.so /lib64/test_me.so /usr/lib/test_me.so /usr/lib64/test_me.so
 {{% else %}}
 for TESTFILE in /lib/test_me /lib64/test_me /usr/lib/test_me /usr/lib64/test_me

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/tests/incorrect_owner_within_dir.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/tests/incorrect_owner_within_dir.fail.sh
@@ -6,7 +6,7 @@ useradd user_test
 TESTDIR="/usr/lib/dir/"
 
 mkdir -p "${TESTDIR}"
-{{% if 'ol8' in product %}}
+{{% if 'ol8' in product or 'rhel' in product %}}
 touch "${TESTDIR}"/test_me.so
 chown user_test "${TESTDIR}"/test_me.so
 {{% else %}}

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/rule.yml
@@ -64,7 +64,7 @@ template:
             - /usr/lib/
             - /usr/lib64/
         recursive: 'true'
-{{% if 'ol8' in product %}}
+{{% if 'ol8' in product or 'rhel' in product %}}
         file_regex: ^.*\.so.*$
 {{% else %}}
         file_regex: ^.*$

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/tests/lenient_permissions.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/tests/lenient_permissions.fail.sh
@@ -4,7 +4,7 @@ DIRS="/lib /lib64 /usr/lib /usr/lib64"
 for dirPath in $DIRS; do
     # Limit the test changes to a subset of file in the directory
     # Remediation the whole library dirs is very time consuming
-{{% if 'ol8' in product %}}
+{{% if 'ol8' in product or 'rhel' in product %}}
     find "$dirPath" -type f -regex ".*\.so" -exec chmod go+w '{}' \;
 {{% else %}}
     find "$dirPath" -type f -regex ".*\.txt" -exec chmod go+w '{}' \;

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/rule.yml
@@ -66,7 +66,7 @@ template:
             - /lib64/
             - /usr/lib/
             - /usr/lib64/
-{{% if 'ol8' in product %}}
+{{% if 'ol8' in product or 'rhel' in product %}}
         file_regex: ^.*\.so.*$
 {{% else %}}
         file_regex: ^.*$

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/tests/incorrect_groupowner.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/tests/incorrect_groupowner.fail.sh
@@ -2,7 +2,7 @@
 # platform = multi_platform_sle,multi_platform_rhel,multi_platform_fedora,multi_platform_ubuntu,multi_platform_ol
 
 groupadd group_test
-{{% if 'ol8' in product %}}
+{{% if 'ol8' in product or 'rhel' in product %}}
 for TESTFILE in /lib/test_me.so /lib64/test_me.so /usr/lib/test_me.so /usr/lib64/test_me.so
 {{% else %}}
 for TESTFILE in /lib/test_me /lib64/test_me /usr/lib/test_me /usr/lib64/test_me


### PR DESCRIPTION
#### Description:

On RHEL for library dirs rules only check *.so files

#### Rationale:

This reflects changes in the latest STIG.

For an example see: https://stigaview.com/products/rhel9/v2r5/RHEL-09-232200

