### PR TITLE
Fix typos in the linux_os and docs folder

### DIFF
--- a/docs/manual/developer/03_creating_content.md
+++ b/docs/manual/developer/03_creating_content.md
@@ -1085,7 +1085,7 @@ The `references` key in `rule.yml` maps the rule to a requirement of an external
 If a control file is used to map the policy requirements, then the references don't need to be specified in `rule.yml`.
 Instead, the build system is able to assign the references to rules automatically at the build time.
 This feature of the build system saves time and avoids data duplication, because the references are centralized in the control file, and they are not specified in `rule.yml` files.
-To use the automated reference assignement, the `reference_type` key must be added to the control file.
+To use the automated reference assignment, the `reference_type` key must be added to the control file.
 The value of this key represents the type of reference that will be assigned.
 
 For example, to instruct the build system to use the control file to automatically assign `anssi` references to all rules listed in the control file, add the following line to the control file:

--- a/docs/manual/developer/05_tools_and_utilities.md
+++ b/docs/manual/developer/05_tools_and_utilities.md
@@ -770,7 +770,7 @@ $ ./utils/ansible_playbook_to_role.py --dry-run output
 ### `utils/find_unused_rules.py` &ndash; List Rules That Are Not Used In Any Data stream
 
 This script will output rules are not in any data streams.
-To prevent false positives the script will not run if the number of build datas treams less than the total number of products in the project.
+To prevent false positives the script will not run if the number of build data treams less than the total number of products in the project.
 The script assumes that `./build_project --derivatives` was executed before the script is used.
 This script does require that `./utils/rule_dir_json.py` was executed before this script is used as well.
 

--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -1269,7 +1269,7 @@ We don't support using the release component (eg. `-1` or `-1.el8`) in the versi
 For example, upstream package `foo` version `1.2.3` can be packaged in RHEL 8 as `foo-1.2.3-1.el8`.
 Imagine that you create a rule for a feature that has been introduced in upstream version `1.2.4` of this software.
 You would like to make the rule applicable if the `1.2.4` version or newer is installed.
-You would expect tha the rule will not be applicable if `foo-1.2.3-1.el8` (or older) is installed.
+You would expect that the rule will not be applicable if `foo-1.2.3-1.el8` (or older) is installed.
 However, in this example, the expression `package[foo]>1.2.3` will be evaluated as *true* because `1.2.3-1.el8` is greater than `1.2.3` using the `rpmvercmp` algorithm that is used by OVAL.
 That means that a correct expression in this example is `package[foo]>=1.2.4`.
 In general, find the first version where the feature you want is present and use the `>=` operator.
@@ -1279,7 +1279,7 @@ On contrary, if you want to make some rule not applicable starting some version,
 But, in general, we recommend to derive rule applicability from operating system release version instead of basing that on a version of a specific package.
 The reason for this recommendation is that packages in Linux distributions might be patched, bug fixes and features sometimes get backported to older stable versions, so the behavior of the software might differ from upstream release behavior.
 If the check would be based on operating system version, you can track what packages are distributed there and what patches they contain.
-Examine the actual contents and changelog of the rpm/deb pakcage in the specific product.
+Examine the actual contents and changelog of the rpm/deb package in the specific product.
 Then, use the `os_linux` platform instead of `package` platform.
 For example, use `os_linux[rhel]>=8.6` instead of `package[foo]>=1.2.4`, if you know that an up-to-date RHEL 8.6 and later comes with `foo` that contains the feature that you are interested in.
 

--- a/docs/manual/developer/08_content_tests.md
+++ b/docs/manual/developer/08_content_tests.md
@@ -89,13 +89,13 @@ This script uses `tests/stig_srg_mapping.py` to run the test.
 This test ensures no rules are removed from the data stream.
 This test requires a built version of the "old" content to compare.
 In CI we use the last upstream release.
-Curently, this is only enabled for RHEL products.
+Currently, this is only enabled for RHEL products.
 To run this test on your own machine follow the example below.
 You should replace `0.1.76` with the latest release of the project.
 
 1. `wget https://github.com/ComplianceAsCode/content/releases/download/v0.1.76/scap-security-guide-0.1.76.zip`
 1. `unzip scap-security-guide-0.1.76.zip`
-1. `export ADDITIONAL_CMAKE_OPTIONS="-DENABLE_CHECK_RULE_REMOVAL:BOOL=ON -DOLD_RELEASE_DIR=full/path/to/unziped/scap-security-guide-0.1.76"`
+1. `export ADDITIONAL_CMAKE_OPTIONS="-DENABLE_CHECK_RULE_REMOVAL:BOOL=ON -DOLD_RELEASE_DIR=full/path/to/unzipped/scap-security-guide-0.1.76"`
 1. `./build_product rhel10 rhel8 rhel9`
 1. `cd build`
 1. `ctest -R  rule-removal --output-on-failure`

--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -959,7 +959,7 @@ The selected value can be changed in the profile (consult the actual variable fo
     -   **missing_parameter_pass** - if set to `true` the check will pass if the
         setting for the given **sysctlvar** is not present in sysctl
         configuration files. In other words, the check will pass if the system
-        default isn't overriden by configuration. Default value: `false`.
+        default isn't overridden by configuration. Default value: `false`.
 
     -   **operation** - operation used for comparison of collected object
         with **sysctlval**. Default value: `equals`.
@@ -1012,7 +1012,7 @@ The selected value can be changed in the profile (consult the actual variable fo
     - **remediation_xccdf_variable** - if specified, then the given XCCDF
         variable is used during remediation instead of hardcoded value. The
         variable is NOT used during checking. But you can specify multiple values
-        separated by | as a `value` parameter and they wil be used during
+        separated by | as a `value` parameter and they will be used during
         checking.
 
 -   Languages: Ansible, Bash, OVAL

--- a/docs/workshop/data/ospp-fedora.profile
+++ b/docs/workshop/data/ospp-fedora.profile
@@ -18,7 +18,7 @@ selections:
     ## FCS_CKM.1 Cryptographic Key Generation
 
     ### FCS_CKM.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FCS_CKM.1.1
-    ### The OS shall generate asymetric cryptographic
+    ### The OS shall generate asymmetric cryptographic
     ### keys in accordance with a specified cryptographic key
     ### generation algorithm.
 
@@ -154,7 +154,7 @@ selections:
     # 5.1.2 User Data Protection (FDP)
 
     #######################################################
-    ## FDP_ACF_EXT.1 Access Controlls for Protecting User Data
+    ## FDP_ACF_EXT.1 Access Controls for Protecting User Data
 
     ### FDP_ACF_EXT.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FDP_ACF_EXT.1.1
     ### The OS shall implement access controls which can prohibit
@@ -401,7 +401,7 @@ selections:
     #### USER ENABLE (Success/Failure)
 
 
-    #### GROUP/ROLE ADD (Succes/Failure)
+    #### GROUP/ROLE ADD (Success/Failure)
     - audit_rules_privileged_commands_newgidmap
     - audit_rules_privileged_commands_newgrp
     - audit_rules_privileged_commands_newuidmap
@@ -488,7 +488,7 @@ selections:
     ### FPT_ASLR_EXT.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FPT_ASLR_EXT.1.1
     ### The OS shall always randomize address space memory locations
     ### with [selection: 8, [assignment: number greater than 8]] bits of
-    ### entropy except for [assignment: list of explicity exceptions]
+    ### entropy except for [assignment: list of explicitly exceptions]
 
     #######################################################
     ## FPT_SBOP_EXT.1 Stack Buffer Overflow Protection
@@ -510,7 +510,7 @@ selections:
     ###
     ### ] prior to its execution through the use of [selection:
     ###     - a digital signature using a hardware-protected
-    ###       asymetric key,
+    ###       asymmetric key,
     ###     - a hardware-protected hash]
 
     #######################################################
@@ -570,7 +570,7 @@ selections:
     ## FIA_AFL.1 Authentication failure handling (Refined)
 
     ### FIA_AFL.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FIA_AFL.1.1
-    ### The OS shall detet when [selection:
+    ### The OS shall detect when [selection:
     ###     - [assignment: positive integer number],
     ###     - an administrator configurable positive integer within
     ###       [assignment: range of acceptable values]
@@ -583,7 +583,7 @@ selections:
     ### ]
 
     ### FIA_AFL.1.2: https://www.niap-ccevs.org/MMO/PP/-424-/#FIA_AFL.1.2
-    ### When the defined number of unsuccesful authentication attempts
+    ### When the defined number of unsuccessful authentication attempts
     ### for an account has been met, the OS shall: [selection:
     ### Account Lockout, Account Disablement, Mandatory Credential Reset,
     ### [assignment: list of actions]].
@@ -615,7 +615,7 @@ selections:
     ### in accordance with the following rules:
     ###     - RFC 5280 certificate validation and certificate path validation
     ###     - The certificate path must terminate with a trusted CA certificate
-    ###     - The OS shall validate a certificate path by ensuring the presense
+    ###     - The OS shall validate a certificate path by ensuring the presence
     ###       of the basicConstraints extension and that the CA flag is set to
     ###       TRUE for all CA certificates
     ###     - The OS shall validate the revocation status of the certificate

--- a/docs/workshop/data/ospp-rhel8.profile
+++ b/docs/workshop/data/ospp-rhel8.profile
@@ -18,7 +18,7 @@ selections:
     ## FCS_CKM.1 Cryptographic Key Generation
 
     ### FCS_CKM.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FCS_CKM.1.1
-    ### The OS shall generate asymetric cryptographic
+    ### The OS shall generate asymmetric cryptographic
     ### keys in accordance with a specified cryptographic key
     ### generation algorithm.
 
@@ -154,7 +154,7 @@ selections:
     # 5.1.2 User Data Protection (FDP)
 
     #######################################################
-    ## FDP_ACF_EXT.1 Access Controlls for Protecting User Data
+    ## FDP_ACF_EXT.1 Access Controls for Protecting User Data
 
     ### FDP_ACF_EXT.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FDP_ACF_EXT.1.1
     ### The OS shall implement access controls which can prohibit
@@ -400,7 +400,7 @@ selections:
     #### USER ENABLE (Success/Failure)
 
 
-    #### GROUP/ROLE ADD (Succes/Failure)
+    #### GROUP/ROLE ADD (Success/Failure)
     - audit_rules_privileged_commands_newgidmap
     - audit_rules_privileged_commands_newgrp
     - audit_rules_privileged_commands_newuidmap
@@ -487,7 +487,7 @@ selections:
     ### FPT_ASLR_EXT.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FPT_ASLR_EXT.1.1
     ### The OS shall always randomize address space memory locations
     ### with [selection: 8, [assignment: number greater than 8]] bits of
-    ### entropy except for [assignment: list of explicity exceptions]
+    ### entropy except for [assignment: list of explicit exceptions]
 
     #######################################################
     ## FPT_SBOP_EXT.1 Stack Buffer Overflow Protection
@@ -509,7 +509,7 @@ selections:
     ###
     ### ] prior to its execution through the use of [selection:
     ###     - a digital signature using a hardware-protected
-    ###       asymetric key,
+    ###       asymmetric key,
     ###     - a hardware-protected hash]
 
     #######################################################
@@ -569,7 +569,7 @@ selections:
     ## FIA_AFL.1 Authentication failure handling (Refined)
 
     ### FIA_AFL.1.1: https://www.niap-ccevs.org/MMO/PP/-424-/#FIA_AFL.1.1
-    ### The OS shall detet when [selection:
+    ### The OS shall detect when [selection:
     ###     - [assignment: positive integer number],
     ###     - an administrator configurable positive integer within
     ###       [assignment: range of acceptable values]
@@ -582,7 +582,7 @@ selections:
     ### ]
 
     ### FIA_AFL.1.2: https://www.niap-ccevs.org/MMO/PP/-424-/#FIA_AFL.1.2
-    ### When the defined number of unsuccesful authentication attempts
+    ### When the defined number of unsuccessful authentication attempts
     ### for an account has been met, the OS shall: [selection:
     ### Account Lockout, Account Disablement, Mandatory Credential Reset,
     ### [assignment: list of actions]].
@@ -614,7 +614,7 @@ selections:
     ### in accordance with the following rules:
     ###     - RFC 5280 certificate validation and certificate path validation
     ###     - The certificate path must terminate with a trusted CA certificate
-    ###     - The OS shall validate a certificate path by ensuring the presense
+    ###     - The OS shall validate a certificate path by ensuring the presence
     ###       of the basicConstraints extension and that the CA flag is set to
     ###       TRUE for all CA certificates
     ###     - The OS shall validate the revocation status of the certificate

--- a/docs/workshop/lab3_profiles.adoc
+++ b/docs/workshop/lab3_profiles.adoc
@@ -633,7 +633,7 @@ For more information about the templating system, including the list of currentl
 
 In the final section, you use the new profile that you just created to scan your machine using OpenSCAP.
 
-You have examined only the HTML guide so far, but for automated scanning, you use a datas tream instead.
+You have examined only the HTML guide so far, but for automated scanning, you use a data tream instead.
 A data stream is an XML file that contains all of the data (rules, checks, remediations, and metadata) in a single file.
 The data stream that contains your new profile was also built during the content build.
 It is called `ssg-rhel8-ds.xml` and is located in the `build` directory.

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_creat/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_creat/rule.yml
@@ -9,7 +9,7 @@ description: |-
     all users and root. The <tt>open_by_handle_at</tt> syscall can be used to create new files
     when O_CREAT flag is specified.
 
-    The following auidt rules will asure that unsuccessful attempts to create a
+    The following auidt rules will assure that unsuccessful attempts to create a
     file via <tt>open_by_handle_at</tt> syscall are collected.
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>augenrules</tt>

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_trunc_write/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_trunc_write/rule.yml
@@ -8,7 +8,7 @@ description: |-
     all users and root. The <tt>open_by_handle_at</tt> syscall can be used to modify files
     if called for write operation of with O_TRUNC_WRITE flag.
 
-    The following auidt rules will asure that unsuccessful attempts to modify a
+    The following auidt rules will assure that unsuccessful attempts to modify a
     file via <tt>open_by_handle_at</tt> syscall are collected.
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>augenrules</tt>

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/rule.yml
@@ -9,7 +9,7 @@ description: |-
     all users and root. The <tt>open</tt> syscall can be used to create new files
     when O_CREAT flag is specified.
 
-    The following auidt rules will asure that unsuccessful attempts to create a
+    The following auidt rules will assure that unsuccessful attempts to create a
     file via <tt>open</tt> syscall are collected.
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>augenrules</tt>

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/rule.yml
@@ -7,7 +7,7 @@ description: |-
     The audit system should collect detailed unauthorized file accesses for
     all users and root. The <tt>open</tt> syscall can be used to modify files
     if called for write operation of with O_TRUNC_WRITE flag.
-    The following auidt rules will asure that unsuccessful attempts to modify a
+    The following auidt rules will assure that unsuccessful attempts to modify a
     file via <tt>open</tt> syscall are collected.
     If the <tt>auditd</tt> daemon is configured to use the <tt>augenrules</tt>
     program to read audit rules during daemon startup (the default), add the

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/tests/unordered.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/tests/unordered.fail.sh
@@ -4,7 +4,7 @@
 # remediation = none
 
 # The rule without filter is less specific, and thus, catches more events than the more specific rules (with O_CREAT and O_TRUNC filters)
-# If they rule withou filter is first, it will catch everything and rules below it will never trigger
+# If they rule without filter is first, it will catch everything and rules below it will never trigger
 grep -h 'arch=b32.*EACCES' $SHARED/audit_open.rules $SHARED/audit_open_o_creat.rules $SHARED/audit_open_o_trunc_write.rules > /etc/audit/rules.d/unordered.rules
 grep -h 'arch=b32.*EPERM' $SHARED/audit_open.rules $SHARED/audit_open_o_creat.rules $SHARED/audit_open_o_trunc_write.rules >> /etc/audit/rules.d/unordered.rules
 grep -h 'arch=b64.*EACCES' $SHARED/audit_open.rules $SHARED/audit_open_o_creat.rules $SHARED/audit_open_o_trunc_write.rules >> /etc/audit/rules.d/unordered.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/rule.yml
@@ -9,7 +9,7 @@ description: |-
     all users and root. The <tt>openat</tt> syscall can be used to create new files
     when O_CREAT flag is specified.
 
-    The following auidt rules will asure that unsuccessful attempts to create a
+    The following auidt rules will assure that unsuccessful attempts to create a
     file via <tt>openat</tt> syscall are collected.
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>augenrules</tt>

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/rule.yml
@@ -8,7 +8,7 @@ description: |-
     all users and root. The <tt>openat</tt> syscall can be used to modify files
     if called for write operation of with O_TRUNC_WRITE flag.
 
-    The following auidt rules will asure that unsuccessful attempts to modify a
+    The following auidt rules will assure that unsuccessful attempts to modify a
     file via <tt>openat</tt> syscall are collected.
 
     If the <tt>auditd</tt> daemon is configured to use the <tt>augenrules</tt>

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_rule_order/tests/unordered.fail.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_rule_order/tests/unordered.fail.sh
@@ -4,7 +4,7 @@
 # remediation = none
 
 # The rule without filter is less specific, and thus, catches more events than the more specific rules (with O_CREAT and O_TRUNC filters)
-# If they rule withou filter is first, it will catch everything and rules below it will never trigger
+# If they rule without filter is first, it will catch everything and rules below it will never trigger
 grep -h 'arch=b32.*EACCES' $SHARED/audit_open.rules $SHARED/audit_openat_o_creat.rules $SHARED/audit_openat_o_trunc_write.rules > /etc/audit/rules.d/unordered.rules
 grep -h 'arch=b32.*EPERM' $SHARED/audit_open.rules $SHARED/audit_openat_o_creat.rules $SHARED/audit_openat_o_trunc_write.rules >> /etc/audit/rules.d/unordered.rules
 grep -h 'arch=b64.*EACCES' $SHARED/audit_open.rules $SHARED/audit_openat_o_creat.rules $SHARED/audit_openat_o_trunc_write.rules >> /etc/audit/rules.d/unordered.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
@@ -66,7 +66,7 @@
        Here all mount points are collected and filtered to include only devices under /dev in
        order to ignore special file systems. Then, the mount options are checked to exclude
        file systems mounted with nosuid or noexec. The privileged commands can't execute on these
-       file systems, so there is no reason to proble these file systems. -->
+       file systems, so there is no reason to probe these file systems. -->
   <linux:partition_object id="object_audit_rules_privileged_commands_exec_partitions" version="1">
     <linux:mount_point operation="pattern match">^(?!/proc(/.*|$)).*$</linux:mount_point>
     <filter action="include">state_audit_rules_privileged_commands_dev_partitons</filter>

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured_mixed_keys.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured_mixed_keys.pass.sh
@@ -4,5 +4,5 @@
 
 ./generate_privileged_commands_rule.sh {{{ uid_min }}} privileged /etc/audit/rules.d/privileged.rules
 # change key of rules for binaries in /usr/sbin
-# A mixed conbination of -k and -F key= should be accepted
+# A mixed combination of -k and -F key= should be accepted
 sed -i '/sbin/s/-k /-F key=/g' /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/auditing/auditd_configure_rules/file_permissions_var_log_audit/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_permissions_var_log_audit/rule.yml
@@ -77,7 +77,7 @@ fixtext: |-
     $ sudo chmod 0600 $log_file
     $ sudo chmod 0400 $log_file.*
 
-    Otherwise, configure the permisssions the following way:
+    Otherwise, configure the permissions the following way:
 
     $ sudo chmod 0640 $log_file
     $ sudo chmod 0440 $log_file.*

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/policy/stig/shared.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/policy/stig/shared.yml
@@ -15,7 +15,7 @@ checktext: |-
 
     action_mail_acct = root
 
-    If the value of the "action_mail_acct" keyword is not set to "root" and/or other accounts for security personnel, the "action_mail_acct" keyword is missing, or the retuned line is commented out, ask the system administrator to indicate how they and the ISSO are notified of an audit process failure.  If there is no evidence of the proper personnel being notified of an audit processing failure, this is a finding.
+    If the value of the "action_mail_acct" keyword is not set to "root" and/or other accounts for security personnel, the "action_mail_acct" keyword is missing, or the returned line is commented out, ask the system administrator to indicate how they and the ISSO are notified of an audit process failure.  If there is no evidence of the proper personnel being notified of an audit processing failure, this is a finding.
 
 fixtext: |-
     Configure "auditd" service to notify the SA and ISSO in the event of an audit processing failure.

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/rule.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/rule.yml
@@ -47,7 +47,7 @@ references:
     stigid@sle12: SLES-12-020040
     stigid@sle15: SLES-15-030570
 
-ocil_clause: 'the value of the "action_mail_acct" keyword is not set to "{{{ xccdf_value("var_auditd_action_mail_acct") }}}" and/or other accounts for security personnel, the "action_mail_acct" keyword is missing, or the retuned line is commented out, ask the system administrator to indicate how they and the ISSO are notified of an audit process failure. If there is no evidence of the proper personnel being notified of an audit processing failure'
+ocil_clause: 'the value of the "action_mail_acct" keyword is not set to "{{{ xccdf_value("var_auditd_action_mail_acct") }}}" and/or other accounts for security personnel, the "action_mail_acct" keyword is missing, or the returned line is commented out, ask the system administrator to indicate how they and the ISSO are notified of an audit process failure. If there is no evidence of the proper personnel being notified of an audit processing failure'
 
 ocil: |-
     Verify that {{{ full_name }}} is configured to notify the SA and/or ISSO (at a minimum) in the event of an audit processing failure with the following command:

--- a/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/rule.yml
+++ b/linux_os/guide/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/rule.yml
@@ -40,7 +40,7 @@ references:
     stigid@sle12: SLES-12-020030
     stigid@sle15: SLES-15-030700
 
-ocil_clause: 'the system is not configured a specfic size in MB to notify administrators of an issue'
+ocil_clause: 'the system is not configured a specific size in MB to notify administrators of an issue'
 
 ocil: |-
     Inspect <tt>/etc/audit/auditd.conf</tt> and locate the following line to

--- a/linux_os/guide/auditing/coreos_audit_option/rule.yml
+++ b/linux_os/guide/auditing/coreos_audit_option/rule.yml
@@ -41,7 +41,7 @@ ocil: |-
     Inspect the form of BLS (Boot Loader Specification) options lines for the Linux operating system
     in <tt>/boot/loader/entries/*.conf</tt>. If they include <tt>audit=1</tt>, then auditing
     is enabled at boot time.
-    <pre># grep 'options.*audit=1.*' /boot/loader/entires/*.conf</pre>
+    <pre># grep 'options.*audit=1.*' /boot/loader/entries/*.conf</pre>
     <br />
 
 template:

--- a/linux_os/guide/auditing/policy_rules/audit_access_failed/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_access_failed/rule.yml
@@ -19,7 +19,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Unsuccessful attempts to access a file might be signs of malicious activity happening within the system. Auditing of such activities helps in their monitoring and investigation.

--- a/linux_os/guide/auditing/policy_rules/audit_access_failed_aarch64/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_access_failed_aarch64/rule.yml
@@ -19,7 +19,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Unsuccessful attempts to access a file might be signs of malicious activity happening within the system. Auditing of such activities helps in their monitoring and investigation.

--- a/linux_os/guide/auditing/policy_rules/audit_access_failed_ppc64le/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_access_failed_ppc64le/rule.yml
@@ -17,7 +17,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Unsuccessful attempts to access a file might be signs of malicious activity happening within the system. Auditing of such activities helps in their monitoring and investigation.

--- a/linux_os/guide/auditing/policy_rules/audit_access_success/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_access_success/rule.yml
@@ -18,7 +18,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Auditing of successful attempts to access a file helps in investigation of activities performed on the system.

--- a/linux_os/guide/auditing/policy_rules/audit_access_success_aarch64/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_access_success_aarch64/rule.yml
@@ -18,7 +18,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Auditing of successful attempts to access a file helps in investigation of activities performed on the system.

--- a/linux_os/guide/auditing/policy_rules/audit_access_success_ppc64le/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_access_success_ppc64le/rule.yml
@@ -17,7 +17,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Auditing of successful attempts to access a file helps in investigation of activities performed on the system.

--- a/linux_os/guide/auditing/policy_rules/audit_create_failed/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_create_failed/rule.yml
@@ -27,7 +27,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Unsuccessful file creations might be a sign of a malicious action being performed on the system. Keeping log of such events helps in monitoring and investigation of such actions.

--- a/linux_os/guide/auditing/policy_rules/audit_create_failed_aarch64/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_create_failed_aarch64/rule.yml
@@ -23,7 +23,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Unsuccessful file creations might be a sign of a malicious action being performed on the system. Keeping log of such events helps in monitoring and investigation of such actions.

--- a/linux_os/guide/auditing/policy_rules/audit_create_failed_ppc64le/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_create_failed_ppc64le/rule.yml
@@ -21,7 +21,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Unsuccessful file creations might be a sign of a malicious action being performed on the system. Keeping log of such events helps in monitoring and investigation of such actions.

--- a/linux_os/guide/auditing/policy_rules/audit_create_success/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_create_success/rule.yml
@@ -21,7 +21,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Auditing of successful attempts to create a file helps in investigation of actions which happened on the system.

--- a/linux_os/guide/auditing/policy_rules/audit_create_success_aarch64/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_create_success_aarch64/rule.yml
@@ -19,7 +19,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Auditing of successful attempts to create a file helps in investigation of actions which happened on the system.

--- a/linux_os/guide/auditing/policy_rules/audit_create_success_ppc64le/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_create_success_ppc64le/rule.yml
@@ -18,7 +18,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Auditing of successful attempts to create a file helps in investigation of actions which happened on the system.

--- a/linux_os/guide/auditing/policy_rules/audit_delete_failed/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_delete_failed/rule.yml
@@ -19,7 +19,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Unsuccessful attempts to delete a file might be signs of malicious activities. Auditing of such events help in monitoring and investigating of such activities.

--- a/linux_os/guide/auditing/policy_rules/audit_delete_failed_aarch64/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_delete_failed_aarch64/rule.yml
@@ -19,7 +19,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Unsuccessful attempts to delete a file might be signs of malicious activities. Auditing of such events help in monitoring and investigating of such activities.

--- a/linux_os/guide/auditing/policy_rules/audit_delete_failed_ppc64le/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_delete_failed_ppc64le/rule.yml
@@ -17,7 +17,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Unsuccessful attempts to delete a file might be signs of malicious activities. Auditing of such events help in monitoring and investigating of such activities.

--- a/linux_os/guide/auditing/policy_rules/audit_delete_success/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_delete_success/rule.yml
@@ -17,7 +17,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Auditing of successful attempts to delete a file may help in monitoring and investigation of activities performed on the system.

--- a/linux_os/guide/auditing/policy_rules/audit_delete_success_aarch64/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_delete_success_aarch64/rule.yml
@@ -17,7 +17,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Auditing of successful attempts to delete a file may help in monitoring and investigation of activities performed on the system.

--- a/linux_os/guide/auditing/policy_rules/audit_delete_success_ppc64le/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_delete_success_ppc64le/rule.yml
@@ -16,7 +16,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Auditing of successful attempts to delete a file may help in monitoring and investigation of activities performed on the system.

--- a/linux_os/guide/auditing/policy_rules/audit_modify_failed/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_modify_failed/rule.yml
@@ -27,7 +27,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Unsuccessful file modifications might be a sign of a malicious action being performed on the system. Auditing of such events helps in detection and investigation of such actions.

--- a/linux_os/guide/auditing/policy_rules/audit_modify_failed_aarch64/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_modify_failed_aarch64/rule.yml
@@ -25,7 +25,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Unsuccessful file modifications might be a sign of a malicious action being performed on the system. Auditing of such events helps in detection and investigation of such actions.

--- a/linux_os/guide/auditing/policy_rules/audit_modify_failed_ppc64le/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_modify_failed_ppc64le/rule.yml
@@ -21,7 +21,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Unsuccessful file modifications might be a sign of a malicious action being performed on the system. Auditing of such events helps in detection and investigation of such actions.

--- a/linux_os/guide/auditing/policy_rules/audit_modify_success/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_modify_success/rule.yml
@@ -21,7 +21,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 
 rationale: |-

--- a/linux_os/guide/auditing/policy_rules/audit_modify_success_aarch64/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_modify_success_aarch64/rule.yml
@@ -20,7 +20,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 
 rationale: |-

--- a/linux_os/guide/auditing/policy_rules/audit_modify_success_ppc64le/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_modify_success_ppc64le/rule.yml
@@ -18,7 +18,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 
 rationale: |-

--- a/linux_os/guide/auditing/policy_rules/audit_ospp_general/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_ospp_general/rule.yml
@@ -140,7 +140,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Auditing of events listed in the description provides data for monitoring and investigation of potentially malicious events e.g. tampering with <tt>Audit</tt> logs, malicious access to files storing information about system users and groups etc.

--- a/linux_os/guide/auditing/policy_rules/audit_ospp_general_aarch64/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_ospp_general_aarch64/rule.yml
@@ -137,7 +137,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Auditing of events listed in the description provides data for monitoring and investigation of potentially malicious events e.g. tampering with <tt>Audit</tt> logs, malicious access to files storing information about system users and groups etc.

--- a/linux_os/guide/auditing/policy_rules/audit_ospp_general_ppc64le/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_ospp_general_ppc64le/rule.yml
@@ -108,7 +108,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Auditing of events listed in the description provides data for monitoring and investigation of potentially malicious events e.g. tampering with <tt>Audit</tt> logs, malicious access to files storing information about system users and groups etc.

--- a/linux_os/guide/auditing/policy_rules/audit_owner_change_failed/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_owner_change_failed/rule.yml
@@ -19,7 +19,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Unsuccessful attempts to change an ownership of files or directories might be signs of a malicious activity. Having such events audited helps in monitoring and investigation of such activities.

--- a/linux_os/guide/auditing/policy_rules/audit_owner_change_failed_aarch64/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_owner_change_failed_aarch64/rule.yml
@@ -19,7 +19,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Unsuccessful attempts to change an ownership of files or directories might be signs of a malicious activity. Having such events audited helps in monitoring and investigation of such activities.

--- a/linux_os/guide/auditing/policy_rules/audit_owner_change_failed_ppc64le/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_owner_change_failed_ppc64le/rule.yml
@@ -17,7 +17,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Unsuccessful attempts to change an ownership of files or directories might be signs of a malicious activity. Having such events audited helps in monitoring and investigation of such activities.

--- a/linux_os/guide/auditing/policy_rules/audit_owner_change_success/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_owner_change_success/rule.yml
@@ -17,10 +17,10 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
-    Auditing of successful ownership changes of files or directories helps in monitoring or investingating of activities performed on the system.
+    Auditing of successful ownership changes of files or directories helps in monitoring or investigating of activities performed on the system.
 
 severity: medium
 

--- a/linux_os/guide/auditing/policy_rules/audit_owner_change_success_aarch64/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_owner_change_success_aarch64/rule.yml
@@ -17,10 +17,10 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
-    Auditing of successful ownership changes of files or directories helps in monitoring or investingating of activities performed on the system.
+    Auditing of successful ownership changes of files or directories helps in monitoring or investigating of activities performed on the system.
 
 severity: medium
 

--- a/linux_os/guide/auditing/policy_rules/audit_owner_change_success_ppc64le/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_owner_change_success_ppc64le/rule.yml
@@ -16,10 +16,10 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
-    Auditing of successful ownership changes of files or directories helps in monitoring or investingating of activities performed on the system.
+    Auditing of successful ownership changes of files or directories helps in monitoring or investigating of activities performed on the system.
 
 severity: medium
 

--- a/linux_os/guide/auditing/policy_rules/audit_perm_change_failed/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_perm_change_failed/rule.yml
@@ -19,7 +19,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Unsuccessful attempts to change permissions of files or directories might be signs of malicious activity. Having such events audited helps in monitoring and investigation of such activities.

--- a/linux_os/guide/auditing/policy_rules/audit_perm_change_failed_aarch64/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_perm_change_failed_aarch64/rule.yml
@@ -19,7 +19,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Unsuccessful attempts to change permissions of files or directories might be signs of malicious activity. Having such events audited helps in monitoring and investigation of such activities.

--- a/linux_os/guide/auditing/policy_rules/audit_perm_change_failed_ppc64le/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_perm_change_failed_ppc64le/rule.yml
@@ -17,7 +17,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Unsuccessful attempts to change permissions of files or directories might be signs of malicious activity. Having such events audited helps in monitoring and investigation of such activities.

--- a/linux_os/guide/auditing/policy_rules/audit_perm_change_success/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_perm_change_success/rule.yml
@@ -17,7 +17,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Auditing successful file or directory permission changes helps in monitoring and investigating of activities performed on the system.

--- a/linux_os/guide/auditing/policy_rules/audit_perm_change_success_aarch64/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_perm_change_success_aarch64/rule.yml
@@ -17,7 +17,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Auditing successful file or directory permission changes helps in monitoring and investigating of activities performed on the system.

--- a/linux_os/guide/auditing/policy_rules/audit_perm_change_success_ppc64le/rule.yml
+++ b/linux_os/guide/auditing/policy_rules/audit_perm_change_success_ppc64le/rule.yml
@@ -16,7 +16,7 @@ description: |-
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
-    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are alligned with your needs.
+    Note: This rule uses a special set of Audit rules to comply with OSPP 4.2.1. You may reuse this rule in different profiles. If you decide to do so, it is recommended that you inspect contents of the file closely and make sure that they are aligned with your needs.
 
 rationale: |-
     Auditing successful file or directory permission changes helps in monitoring and investigating of activities performed on the system.

--- a/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/rule.yml
+++ b/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/rule.yml
@@ -5,9 +5,9 @@ title: 'Disable unauthenticated repositories in APT configuration'
 description: 'Unauthenticated repositories should not be used for updates.'
 
 rationale: |-
-    Repositories hosts all packages that will be intsalled on the system during update.
+    Repositories hosts all packages that will be installed on the system during update.
         If a repository is not authenticated, the associated packages can't be trusted,
-        and then should not be installed localy.
+        and then should not be installed locally.
 
 severity: unknown
 

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_cron_deny_not_exist/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_cron_deny_not_exist/rule.yml
@@ -29,7 +29,7 @@ ocil_clause: 'the file /etc/cron.deny exists'
 
 ocil: |-
     The file <tt>/etc/cron.deny</tt> should not exist.
-    This can be checked by runnig the following
+    This can be checked by running the following
     <pre>
     stat /etc/cron.deny
     </pre>

--- a/linux_os/guide/services/deprecated/package_ntpdate_removed/rule.yml
+++ b/linux_os/guide/services/deprecated/package_ntpdate_removed/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 title: 'Uninstall the ntpdate package'
 
-description: 'ntpdate is a historical ntp synchronization client for unixes. It sould be uninstalled.'
+description: 'ntpdate is a historical ntp synchronization client for unixes. It should be uninstalled.'
 
 rationale: 'ntpdate is an old not security-compliant ntp client. It should be replaced by modern ntp clients such as ntpd, able to use cryptographic mechanisms integrated in NTP.'
 

--- a/linux_os/guide/services/docker/docker_selinux_enabled/rule.yml
+++ b/linux_os/guide/services/docker/docker_selinux_enabled/rule.yml
@@ -11,7 +11,7 @@ description: |-
     <pre>OPTIONS='--selinux-enabled'</pre>
 
 rationale: |-
-    If SELinux is not explicitely enabled in the Docker daemon configuration,
+    If SELinux is not explicitly enabled in the Docker daemon configuration,
     Docker does not use SELinux which means Docker runs unconfined,
     and SELinux will not provide security separation for Docker container
     processes. However enabling SELinux for the Docker service prevents
@@ -20,6 +20,6 @@ rationale: |-
 
 severity: high
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
+platform: machine  # The check uses service_... extended definition, which doesn't support offline mode
 
 platform: machine

--- a/linux_os/guide/services/docker/docker_storage_configured/rule.yml
+++ b/linux_os/guide/services/docker/docker_storage_configured/rule.yml
@@ -17,6 +17,6 @@ rationale: |-
 
 severity: low
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
+platform: machine  # The check uses service_... extended definition, which doesn't support offline mode
 
 platform: machine

--- a/linux_os/guide/services/http/securing_httpd/httpd_nipr_accredited_dmz/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_nipr_accredited_dmz/rule.yml
@@ -4,7 +4,7 @@ documentation_complete: true
 title: 'A public web server, if hosted on the NIPRNet, must be isolated in an accredited DoD DMZ extension'
 
 description: |-
-    To minimize exposure of private assets to unnecesarry risk by attackers,
+    To minimize exposure of private assets to unnecessary risk by attackers,
     public web servers must be isolated from internal systems.
 
     Logically relocate public web servers to be isolated from internal
@@ -14,7 +14,7 @@ description: |-
     that are a part of the same system as the web server.
 
 rationale: |-
-    Public web servers are by nature more vulnerabile to attack from publically
+    Public web servers are by nature more vulnerabile to attack from publicly
     based sources, such as the public Internet. Once compromised, a public
     server might be used as a base for further attack on private resources,
     unless additional layers of protection are implemented. Public web servers

--- a/linux_os/guide/services/http/securing_httpd/httpd_no_compilers_in_prod/rule.yml
+++ b/linux_os/guide/services/http/securing_httpd/httpd_no_compilers_in_prod/rule.yml
@@ -16,7 +16,7 @@ severity: medium
 
 
 ocil_clause: |-
-    the web server is part of an application suite and a comiler is needed
+    the web server is part of an application suite and a compiler is needed
     for installation, patching, and upgrading of the suite or if the compiler
     is embedded and can't be removed without breaking the suite, document the
     installation of the compiler with the ISSO/ISSM and verify that the compiler

--- a/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/oval/shared.xml
@@ -10,13 +10,13 @@
     {{{ oval_metadata("Ensure that no other user than chrony is configured to run the chrony service", rule_title=rule_title) }}}
 
       <criteria comment="chronyd enabled and multiple remote servers specified" operator="AND">
-        <criterion comment="The default chrony user hasn't been overriden" test_ref="test_no_user_override" />
+        <criterion comment="The default chrony user hasn't been overridden" test_ref="test_no_user_override" />
       </criteria>
 
   </definition>
 
   <ind:textfilecontent54_test id="test_no_user_override"
-    comment="The default chrony user hasn't been overriden"
+    comment="The default chrony user hasn't been overridden"
     check_existence="none_exist" check="all" version="1">
     <ind:object object_ref="obj_user_override" />
   </ind:textfilecontent54_test>

--- a/linux_os/guide/services/ntp/chronyd_server_directive/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_server_directive/oval/shared.xml
@@ -26,7 +26,7 @@
   version="1">
     <ind:object object_ref="object_chronyd_no_pool_directive" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object comment="Matches pool entires in Chrony conf files"
+  <ind:textfilecontent54_object comment="Matches pool entries in Chrony conf files"
   id="object_chronyd_no_pool_directive" version="1">
     <ind:filepath operation="pattern match">{{{ filepath_regex }}}</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]+pool.*$</ind:pattern>

--- a/linux_os/guide/services/ntp/group.yml
+++ b/linux_os/guide/services/ntp/group.yml
@@ -32,7 +32,7 @@ description: |-
     packages respectively.
     <br /><br />
     The default <tt>chronyd</tt> daemon can work well when external time references
-    are only intermittently accesible, can perform well even when the network is
+    are only intermittently accessible, can perform well even when the network is
     congested for longer periods of time, can usually synchronize the clock faster
     and with better time accuracy, and quickly adapts to sudden changes in the rate
     of the clock, for example, due to changes in the temperature of the crystal

--- a/linux_os/guide/services/ntp/package_ntp_installed/rule.yml
+++ b/linux_os/guide/services/ntp/package_ntp_installed/rule.yml
@@ -4,7 +4,7 @@ title: 'Install the ntp service'
 
 description: 'The ntpd service should be installed.'
 
-rationale: 'Time synchronization (using NTP) is required by almost all network and administrative tasks (syslog, cryptographic based services (authentication, etc.), etc.). Ntpd is regulary maintained and updated, supporting security features such as RFC 5906.'
+rationale: 'Time synchronization (using NTP) is required by almost all network and administrative tasks (syslog, cryptographic based services (authentication, etc.), etc.). Ntpd is regularly maintained and updated, supporting security features such as RFC 5906.'
 
 severity: high
 

--- a/linux_os/guide/services/obsolete/inetd_and_xinetd/package_tcp_wrappers_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/inetd_and_xinetd/package_tcp_wrappers_removed/rule.yml
@@ -10,7 +10,7 @@ rationale: |-
     Administrators can use TCP wrapper library and daemon for host
     control over network services. In these implementations,
     <tt>xinetd</tt> runs <tt>tcpd</tt> program, which first looks
-    at the incomming connection as well as the access control lists
+    at the incoming connection as well as the access control lists
     in the /etc/hosts.allow and /etc/hosts.deny files.
     Removing the <tt>xinetd</tt> package decreases the risk of the
     xinetd service's accidental (or intentional) activation. The

--- a/linux_os/guide/services/obsolete/telnet/package_telnet-server_removed/policy/stig/shared.yml
+++ b/linux_os/guide/services/obsolete/telnet/package_telnet-server_removed/policy/stig/shared.yml
@@ -2,7 +2,7 @@ srg_requirement: |-
     {{{ full_name }}} must not have the telnet-server package installed.
 
 vuldiscussion: |-
-    It is detrimental for operating systems to provide, or install by default, functionality exceeding requirements or mission objectives. These unnecessary capabilities are often overlooked and therefore, may remain unsecure. They increase the risk to the platform by providing additional attack vectors.
+    It is detrimental for operating systems to provide, or install by default, functionality exceeding requirements or mission objectives. These unnecessary capabilities are often overlooked and therefore, may remain insecure. They increase the risk to the platform by providing additional attack vectors.
 
     The telnet service provides an unencrypted remote access service, which does not provide for the confidentiality and integrity of user passwords or the remote session. If a privileged user were to login using this service, the privileged user password could be compromised.
 

--- a/linux_os/guide/services/obsolete/telnet/package_telnet-server_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/telnet/package_telnet-server_removed/rule.yml
@@ -10,7 +10,7 @@ rationale: |-
     It is detrimental for operating systems to provide, or install by default,
     functionality exceeding requirements or mission objectives. These
     unnecessary capabilities are often overlooked and therefore may remain
-    unsecure. They increase the risk to the platform by providing additional
+    insecure. They increase the risk to the platform by providing additional
     attack vectors.
     <br />
     The telnet service provides an unencrypted remote access service which does

--- a/linux_os/guide/services/obsolete/tftp/package_tftp-server_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/tftp/package_tftp-server_removed/rule.yml
@@ -16,7 +16,7 @@ rationale: |-
     <br /><br />
     If TFTP is required for operational support (such as transmission of router
     configurations), its use must be documented with the Information Systems
-    Securty Manager (ISSM), restricted to only authorized personnel, and have
+    Security Manager (ISSM), restricted to only authorized personnel, and have
     access control rules established.
 
 severity: high

--- a/linux_os/guide/services/obsolete/tftp/package_tftp_removed/policy/stig/shared.yml
+++ b/linux_os/guide/services/obsolete/tftp/package_tftp_removed/policy/stig/shared.yml
@@ -2,7 +2,7 @@ srg_requirement: |-
     {{{ full_name }}} must not have the tftp package installed.
 
 vuldiscussion: |-
-    It is detrimental for operating systems to provide, or install by default, functionality exceeding requirements or mission objectives. These unnecessary capabilities are often overlooked and therefore, may remain unsecure. They increase the risk to the platform by providing additional attack vectors.
+    It is detrimental for operating systems to provide, or install by default, functionality exceeding requirements or mission objectives. These unnecessary capabilities are often overlooked and therefore, may remain insecure. They increase the risk to the platform by providing additional attack vectors.
 
     If TFTP is required for operational support (such as transmission of router configurations), its use must be documented with the information systems security manager (ISSM), restricted to only authorized personnel, and have access control rules established.
 

--- a/linux_os/guide/services/obsolete/tftp/tftp_uses_secure_mode_systemd/rule.yml
+++ b/linux_os/guide/services/obsolete/tftp/tftp_uses_secure_mode_systemd/rule.yml
@@ -21,7 +21,7 @@ rationale: |-
 severity: medium
 
 ocil: |-
-    Use <tt>udo systemctl show tftp</tt> to verify that tftp service is using secure mode.
+    Use <tt>sudo systemctl show tftp</tt> to verify that tftp service is using secure mode.
     <pre>$ sudo systemctl show tftp | grep ExecStart=
     ExecStart={ path=/usr/sbin/in.tftpd ; argv[]=/usr/sbin/in.tftpd -s /var/lib/tftpboot ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=(null) ; status=0/0 }e
     </pre>

--- a/linux_os/guide/services/ssh/ssh_client/ssh_client_rekey_limit/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_client/ssh_client_rekey_limit/ansible/shared.yml
@@ -14,7 +14,7 @@
     patterns: "*.config"
   register: ssh_config_include_files
 
-- name: Remove all occurences of RekeyLimit configuration from include config files of ssh client
+- name: Remove all occurrences of RekeyLimit configuration from include config files of ssh client
   ansible.builtin.lineinfile:
     path: "{{ item }}"
     regexp: '^[\s]*RekeyLimit.*$'

--- a/linux_os/guide/services/ssh/ssh_client/ssh_client_use_approved_ciphers_ordered_stig/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_client/ssh_client_use_approved_ciphers_ordered_stig/oval/shared.xml
@@ -9,7 +9,7 @@
         test_ref="test_{{{ rule_id }}}" />
       <criterion comment="Check the ciphers in /etc/ssh/ssh_config.d if any"
         test_ref="test_{{{ rule_id }}}_config_dir" />
-      <criterion comment="the configuraton exists" test_ref="test_ciphers_present_{{{ rule_id }}}" />
+      <criterion comment="the configuration exists" test_ref="test_ciphers_present_{{{ rule_id }}}" />
     </criteria>
   </definition>
 

--- a/linux_os/guide/services/ssh/ssh_client/ssh_use_approved_macs_ordered_stig/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_client/ssh_use_approved_macs_ordered_stig/oval/shared.xml
@@ -8,7 +8,7 @@
         <criterion comment="Check the MACs in /etc/ssh/ssh_config.d if any"
           test_ref="test_{{{ rule_id }}}_config_dir" />
       </criteria>
-      <criterion comment="the configuraton exists" test_ref="test_MACs_present_{{{ rule_id }}}" />
+      <criterion comment="the configuration exists" test_ref="test_MACs_present_{{{ rule_id }}}" />
     </criteria>
   </definition>
 

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/bash/shared.sh
@@ -34,7 +34,7 @@ else
     if {{{ in_chrooted_environment() }}}; then
         # TODO: NM (nmcli) now has --offline mode support, and it could operate without NM service.
         # See: https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/merge_requests/1183
-        # The feature is not quite straighforward (and probably incomplete), though.
+        # The feature is not quite straightforward (and probably incomplete), though.
         echo "Not applicable in offline mode. Remediation aborted!"
     else
         if systemctl is-active NetworkManager && systemctl is-active firewalld; then

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/oval/shared.xml
@@ -69,7 +69,7 @@
          least one NIC assigned to it. Since it was possible to easily have the list of active
          zones, it was cumbersome to use that list in other OVAL objects without introduce a high
          level of complexity to ensure proper assessment in environments where multiple NICs and
-         multiple zones are in use. So, in favor of simplicity and readbility it was decided to
+         multiple zones are in use. So, in favor of simplicity and readability it was decided to
          work with a static list. It means that, in the future, it is possible this list needs to
          be updated. -->
     <local_variable id="var_firewalld_sshd_port_enabled_default_zones" version="1"
@@ -149,7 +149,7 @@
          properly configured by the administrator. -->
     <ind:xmlfilecontent_test id="test_firewalld_sshd_port_enabled_ssh_service_usr"
         check="all" check_existence="all_exist" version="1"
-        comment="SSH service is interger in the /usr/lib/firewalld/services dir">
+        comment="SSH service is integer in the /usr/lib/firewalld/services dir">
       <ind:object object_ref="object_firewalld_sshd_port_enabled_ssh_service_file_usr"/>
     </ind:xmlfilecontent_test>
 

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/customized_zone_configured.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/customized_zone_configured.pass.sh
@@ -25,7 +25,7 @@ systemctl restart NetworkManager
 # Active zones are zones with at least one interface assigned to it.
 readarray -t firewalld_active_zones < <(firewall-cmd --get-active-zones | grep -v interfaces)
 
-# It is possible that traffic is comming by any active interface and consequently any
+# It is possible that traffic is coming by any active interface and consequently any
 # active zone. So, this make sure all active zones are permanently allowing SSH service.
 # Most of the zones already allow ssh, so it is also allowed http to ensure a custom file is
 # created in /etc/firewalld/zones.

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/customized_zone_without_ssh.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/customized_zone_without_ssh.fail.sh
@@ -25,7 +25,7 @@ systemctl restart NetworkManager
 # Active zones are zones with at least one interface assigned to it.
 readarray -t firewalld_active_zones < <(firewall-cmd --get-active-zones | grep -v interfaces)
 
-# It is possible that traffic is comming by any active interface and consequently any
+# It is possible that traffic is coming by any active interface and consequently any
 # active zone. So, this make sure all active zones are permanently allowing SSH service.
 # It is to ensure a custom file is created in /etc/firewalld/zones.
 for zone in $firewalld_active_zones; do

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/new_zone_configured.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/new_zone_configured.pass.sh
@@ -27,7 +27,7 @@ systemctl restart NetworkManager
 # Active zones are zones with at least one interface assigned to it.
 readarray -t firewalld_active_zones < <(firewall-cmd --get-active-zones | grep -v interfaces)
 
-# It is possible that traffic is comming by any active interface and consequently any
+# It is possible that traffic is coming by any active interface and consequently any
 # active zone. So, this make sure all active zones are permanently allowing SSH service.
 for zone in $firewalld_active_zones "$custom_zone_name"; do
     firewall-cmd --permanent --zone="$zone" --add-service=ssh

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/new_zone_without_ssh.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/new_zone_without_ssh.fail.sh
@@ -27,7 +27,7 @@ systemctl restart NetworkManager
 # Active zones are zones with at least one interface assigned to it.
 readarray -t firewalld_active_zones < <(firewall-cmd --get-active-zones | grep -v interfaces)
 
-# It is possible that traffic is comming by any active interface and consequently any
+# It is possible that traffic is coming by any active interface and consequently any
 # active zone. So, this make sure all active zones are permanently allowing SSH service.
 for zone in $firewalld_active_zones "$custom_zone_name"; do
     firewall-cmd --permanent --zone="$zone" --remove-service=ssh

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/only_nics_configured.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/only_nics_configured.fail.sh
@@ -25,7 +25,7 @@ systemctl restart NetworkManager
 # Active zones are zones with at least one interface assigned to it.
 readarray -t firewalld_active_zones < <(firewall-cmd --get-active-zones | grep -v interfaces)
 
-# It is possible that traffic is comming by any active interface and consequently any
+# It is possible that traffic is coming by any active interface and consequently any
 # active zone. So, this make sure all active zones are permanently allowing SSH service.
 for zone in $firewalld_active_zones; do
     firewall-cmd --permanent --zone="$zone" --remove-service=ssh

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/only_zones_configured.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/only_zones_configured.pass.sh
@@ -26,6 +26,6 @@ for zone in $firewalld_all_zones; do
     firewall-cmd --permanent --zone="$zone" --add-service=ssh
 done
 
-# It is not a problem to reload the settings since all interfaces without an explicit assgined zone
+# It is not a problem to reload the settings since all interfaces without an explicit assigned zone
 # will be automatically assigned to the default zone.
 firewall-cmd --reload

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/zones_and_nics_configured.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/zones_and_nics_configured.pass.sh
@@ -25,7 +25,7 @@ systemctl restart NetworkManager
 # Active zones are zones with at least one interface assigned to it.
 readarray -t firewalld_active_zones < <(firewall-cmd --get-active-zones | grep -v interfaces)
 
-# It is possible that traffic is comming by any active interface and consequently any
+# It is possible that traffic is coming by any active interface and consequently any
 # active zone. So, this make sure all active zones are permanently allowing SSH service.
 for zone in $firewalld_active_zones; do
     firewall-cmd --permanent --zone="$zone" --add-service=ssh

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/zones_and_nics_ok_no_custom_files.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/zones_and_nics_ok_no_custom_files.pass.sh
@@ -25,7 +25,7 @@ systemctl restart NetworkManager
 # Active zones are zones with at least one interface assigned to it.
 readarray -t firewalld_active_zones < <(firewall-cmd --get-active-zones | grep -v interfaces)
 
-# It is possible that traffic is comming by any active interface and consequently any
+# It is possible that traffic is coming by any active interface and consequently any
 # active zone. So, this make sure all active zones are permanently allowing SSH service.
 for zone in $firewalld_active_zones; do
     firewall-cmd --permanent --zone="$zone" --add-service=ssh

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/zones_and_nics_ok_port_changed.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/tests/zones_and_nics_ok_port_changed.pass.sh
@@ -25,7 +25,7 @@ systemctl restart NetworkManager
 # Active zones are zones with at least one interface assigned to it.
 readarray -t firewalld_active_zones < <(firewall-cmd --get-active-zones | grep -v interfaces)
 
-# It is possible that traffic is comming by any active interface and consequently any
+# It is possible that traffic is coming by any active interface and consequently any
 # active zone. So, this make sure all active zones are permanently allowing SSH service.
 for zone in $firewalld_active_zones; do
     firewall-cmd --permanent --zone="$zone" --add-service=ssh

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_gssapi_auth/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_gssapi_auth/rule.yml
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'Enable GSSAPI Authentication'
 
 description: |-
-    Sites setup to use Kerberos or other GSSAPI Authenticaion require setting
+    Sites setup to use Kerberos or other GSSAPI Authentication require setting
     sshd to accept this authentication.
     To enable GSSAPI authentication, add or correct the following line in
     {{{ sshd_config_file() }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_loglevel_info/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_loglevel_info/rule.yml
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'Set LogLevel to INFO'
 
 description: |-
-    The INFO parameter specifices that record login and logout activity will be logged.
+    The INFO parameter specifies that record login and logout activity will be logged.
     <br/>
     The default SSH configuration sets the log level to INFO. The appropriate
     configuration is used if no value is set for <tt>LogLevel</tt>.

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/oval/shared.xml
@@ -14,7 +14,7 @@
         definition_ref="sshd_required_or_unset" />
         <extend_definition comment="rpm package openssh-server installed"
         definition_ref="package_openssh-server_installed" />
-        <criterion comment="Check the Cipers list in /etc/ssh/sshd_config"
+        <criterion comment="Check the Ciphers list in /etc/ssh/sshd_config"
         test_ref="test_sshd_use_approved_ciphers" />
       </criteria>
     </criteria>
@@ -41,13 +41,13 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <local_variable id="var_sshd_config_ciphers" datatype="string" version="1" comment="Ciphers values splitted on comma">
+  <local_variable id="var_sshd_config_ciphers" datatype="string" version="1" comment="Ciphers values split on comma">
     <split delimiter=",">
       <object_component item_field="subexpression" object_ref="obj_sshd_config_ciphers" />
     </split>
   </local_variable>
 
-  <local_variable id="var_sshd_approved_ciphers" datatype="string" version="1" comment="approved ciphers values splitted on comma">
+  <local_variable id="var_sshd_approved_ciphers" datatype="string" version="1" comment="approved ciphers values split on comma">
     <split delimiter=",">
       <variable_component var_ref="sshd_approved_ciphers" />
     </split>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/oval/shared.xml
@@ -14,7 +14,7 @@
         definition_ref="sshd_required_or_unset" />
         <extend_definition comment="rpm package openssh-server installed"
         definition_ref="package_openssh-server_installed" />
-        <criterion comment="Check the Cipers list in /etc/ssh/sshd_config"
+        <criterion comment="Check the Ciphers list in /etc/ssh/sshd_config"
         test_ref="test_sshd_use_approved_ciphers_ordered_stig" />
       </criteria>
     </criteria>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/oval/ubuntu.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/oval/ubuntu.xml
@@ -28,7 +28,7 @@
             <criterion comment="Check the ciphers in /etc/ssh/sshd_config.d if any"
               test_ref="test_{{{ rule_id }}}_config_dir" />
           </criteria>
-          <criterion comment="the configuraton exists" test_ref="test_ciphers_present_{{{ rule_id }}}" />
+          <criterion comment="the configuration exists" test_ref="test_ciphers_present_{{{ rule_id }}}" />
         </criteria>
       </criteria>
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/oval/ubuntu.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/oval/ubuntu.xml
@@ -26,7 +26,7 @@
             <criterion comment="Check the KexAlgorithms in /etc/ssh/sshd_config.d if any"
               test_ref="test_{{{ rule_id }}}_config_dir" />
           </criteria>
-          <criterion comment="the configuraton exists" test_ref="test_KexAlgorithms_present_{{{ rule_id }}}" />
+          <criterion comment="the configuration exists" test_ref="test_KexAlgorithms_present_{{{ rule_id }}}" />
         </criteria>
       </criteria>
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/oval/shared.xml
@@ -51,13 +51,13 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <local_variable id="var_sshd_config_macs" datatype="string" version="1" comment="MACs values splitted on comma">
+  <local_variable id="var_sshd_config_macs" datatype="string" version="1" comment="MACs values split on comma">
     <split delimiter=",">
       <object_component item_field="subexpression" object_ref="obj_sshd_config_macs" />
     </split>
   </local_variable>
 
-  <local_variable id="var_sshd_approved_macs" datatype="string" version="1" comment="approved MACs values splitted on comma">
+  <local_variable id="var_sshd_approved_macs" datatype="string" version="1" comment="approved MACs values split on comma">
     <split delimiter=",">
       <variable_component var_ref="sshd_approved_macs" />
     </split>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/oval/ubuntu.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/oval/ubuntu.xml
@@ -28,7 +28,7 @@
               <criterion comment="Check the MACs in /etc/ssh/sshd_config.d if any"
                 test_ref="test_{{{ rule_id }}}_config_dir" />
             </criteria>
-            <criterion comment="the configuraton exists" test_ref="test_MACs_present_{{{ rule_id }}}" />
+            <criterion comment="the configuration exists" test_ref="test_MACs_present_{{{ rule_id }}}" />
           </criteria>
         </criteria>
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/oval/shared.xml
@@ -57,7 +57,7 @@
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <local_variable id="var_sshd_config_kex" datatype="string" version="1" comment="KEXs values splitted on comma">
+  <local_variable id="var_sshd_config_kex" datatype="string" version="1" comment="KEXs values split on comma">
     <split delimiter=",">
       <object_component item_field="subexpression" object_ref="obj_sshd_config_kex" />
     </split>
@@ -86,7 +86,7 @@
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <local_variable id="var_sshd_config_kex_config_dir" datatype="string" version="1" comment="KEXs values splitted on comma">
+  <local_variable id="var_sshd_config_kex_config_dir" datatype="string" version="1" comment="KEXs values split on comma">
     <split delimiter=",">
       <object_component item_field="subexpression" object_ref="obj_sshd_config_kex_config_dir" />
     </split>
@@ -108,7 +108,7 @@
   </ind:textfilecontent54_object>
 
 
-  <local_variable id="var_sshd_strong_kex" datatype="string" version="1" comment="approved strong KEX values splitted on comma">
+  <local_variable id="var_sshd_strong_kex" datatype="string" version="1" comment="approved strong KEX values split on comma">
     <split delimiter=",">
       <variable_component var_ref="sshd_strong_kex" />
     </split>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/oval/shared.xml
@@ -84,20 +84,20 @@
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <local_variable id="var_sshd_config_macs_config_dir" datatype="string" version="1" comment="MACs values splitted on comma">
+  <local_variable id="var_sshd_config_macs_config_dir" datatype="string" version="1" comment="MACs values split on comma">
     <split delimiter=",">
       <object_component item_field="subexpression" object_ref="obj_sshd_config_macs_config_dir" />
     </split>
   </local_variable>
   {{%- endif %}}
 
-  <local_variable id="var_sshd_config_strong_macs" datatype="string" version="1" comment="MACs values splitted on comma">
+  <local_variable id="var_sshd_config_strong_macs" datatype="string" version="1" comment="MACs values split on comma">
     <split delimiter=",">
       <object_component item_field="subexpression" object_ref="obj_sshd_config_strong_macs" />
     </split>
   </local_variable>
 
-  <local_variable id="var_sshd_strong_macs" datatype="string" version="1" comment="strong MACs values splitted on comma">
+  <local_variable id="var_sshd_strong_macs" datatype="string" version="1" comment="strong MACs values split on comma">
     <split delimiter=",">
       <variable_component var_ref="sshd_strong_macs" />
     </split>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_rng/policy/stig/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_rng/policy/stig/shared.yml
@@ -4,7 +4,7 @@ srg_requirement: |-
 vuldiscussion: |-
     SSH implementation in {{{ full_name }}} uses the openssl library, which doesn't use high-entropy sources by default.
     Randomness is needed to generate data-encryption keys, and as plaintext padding and initialization vectors
-    in encryption algorithms, and high-quality entropy elliminates the possibility that the output of
+    in encryption algorithms, and high-quality entropy eliminates the possibility that the output of
     the random number generator used by SSH would be known to potential attackers.
 
 checktext: |-

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_rng/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_rng/rule.yml
@@ -15,7 +15,7 @@ rationale: |-
     SSH implementation in {{{ full_name }}} uses the openssl library, which doesn't use
     high-entropy sources by default. Randomness is needed to generate data-encryption keys, and as
     plaintext padding and initialization vectors in encryption algorithms, and high-quality
-    entropy elliminates the possibility that the output of the random number generator used by SSH
+    entropy eliminates the possibility that the output of the random number generator used by SSH
     would be known to potential attackers.
 
 severity: low

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/bash/shared.sh
@@ -12,7 +12,7 @@ login_banner_text="(bash-populate login_banner_text)"
 {{{ bash_deregexify_banner_space("login_banner_text") }}}
 # 3 - Adds newlines. (Transforms "(?:\[\\n\]+|(?:\\n)+)" into "\n")
 {{{ bash_deregexify_banner_newline("login_banner_text", "\\n") }}}
-# 4 - Remove any leftover backslash. (From any parethesis in the banner, for example).
+# 4 - Remove any leftover backslash. (From any parenthesis in the banner, for example).
 {{{ bash_deregexify_banner_backslash("login_banner_text") }}}
 formatted=$(echo "$login_banner_text" | fold -sw 80)
 

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/tests/banner_etc_issue_cis_mingetty.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/tests/banner_etc_issue_cis_mingetty.fail.sh
@@ -2,4 +2,4 @@
 # profiles = xccdf_org.ssgproject.content_profile_cis, xccdf_org.ssgproject.content_profile_cis_server_l1, xccdf_org.ssgproject.content_profile_cis_workstation_l1, xccdf_org.ssgproject.content_profile_cis_workstation_l2
 
 # CIS doesn't have an explicit content required, but doesn't expect technical information about the OS.
-echo "Sytem name \s version \s " > /etc/issue
+echo "System name \s version \s " > /etc/issue

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/bash/shared.sh
@@ -12,7 +12,7 @@
 {{{ bash_deregexify_banner_space("remote_login_banner_text") }}}
 # 3 - Adds newlines. (Transforms "(?:\[\\n\]+|(?:\\n)+)" into "\n")
 {{{ bash_deregexify_banner_newline("remote_login_banner_text", "\\n") }}}
-# 4 - Remove any leftover backslash. (From any parethesis in the banner, for example).
+# 4 - Remove any leftover backslash. (From any parenthesis in the banner, for example).
 {{{ bash_deregexify_banner_backslash("remote_login_banner_text") }}}
 formatted=$(echo "$remote_login_banner_text" | fold -sw 80)
 

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/tests/banner_etc_issue_net_cis_mingetty.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/tests/banner_etc_issue_net_cis_mingetty.fail.sh
@@ -2,4 +2,4 @@
 # profiles = xccdf_org.ssgproject.content_profile_cis
 
 # CIS doesn't have an explicit content required, but doesn't expect technical information about the OS.
-echo "Sytem name \s version \s " > /etc/issue.net
+echo "System name \s version \s " > /etc/issue.net

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/bash/shared.sh
@@ -12,7 +12,7 @@
 {{{ bash_deregexify_banner_space("motd_banner_text") }}}
 # 3 - Adds newlines. (Transforms "(?:\[\\n\]+|(?:\\n)+)" into "\n")
 {{{ bash_deregexify_banner_newline("motd_banner_text", "\\n") }}}
-# 4 - Remove any leftover backslash. (From any parethesis in the banner, for example).
+# 4 - Remove any leftover backslash. (From any parenthesis in the banner, for example).
 {{{ bash_deregexify_banner_backslash("motd_banner_text") }}}
 formatted=$(echo "$motd_banner_text" | fold -sw 80)
 

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/tests/banner_etc_motd_cis_mingetty.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/tests/banner_etc_motd_cis_mingetty.fail.sh
@@ -2,4 +2,4 @@
 # profiles = xccdf_org.ssgproject.content_profile_cis, xccdf_org.ssgproject.content_profile_cis_server_l1, xccdf_org.ssgproject.content_profile_cis_workstation_l1, xccdf_org.ssgproject.content_profile_cis_workstation_l2
 
 # CIS doesn't have an explicit content required, but doesn't expect technical information about the OS.
-echo "Sytem name \s version \s " > /etc/motd
+echo "System name \s version \s " > /etc/motd

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_profiled_ssh_confirm/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_profiled_ssh_confirm/bash/shared.sh
@@ -9,7 +9,7 @@
 {{{ bash_deregexify_banner_space("var_ssh_confirm_text") }}}
 # 2 - Adds newlines. (Transforms "(?:\[\n\]+|(?:\n)+)" into "\n")
 {{{ bash_deregexify_banner_newline("var_ssh_confirm_text", "\\n") }}}
-# 3 - Remove any leftover backslash. (From any parethesis in the banner, for example).
+# 3 - Remove any leftover backslash. (From any parenthesis in the banner, for example).
 {{{ bash_deregexify_banner_backslash("var_ssh_confirm_text") }}}
 formatted=$(echo "$var_ssh_confirm_text")
 

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/banner_etc_gdm_banner/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/banner_etc_gdm_banner/bash/shared.sh
@@ -12,7 +12,7 @@
 {{{ bash_deregexify_banner_space("login_banner_text") }}}
 # 3 - Adds newlines. (Transforms "(?:\[\\n\]+|(?:\\n)+)" into "\n")
 {{{ bash_deregexify_banner_newline("login_banner_text", "\\n") }}}
-# 4 - Remove any leftover backslash. (From any parethesis in the banner, for example).
+# 4 - Remove any leftover backslash. (From any parenthesis in the banner, for example).
 {{{ bash_deregexify_banner_backslash("login_banner_text") }}}
 formatted=$(echo "$login_banner_text" | fold -sw 80)
 

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/bash/shared.sh
@@ -12,7 +12,7 @@ login_banner_text="(bash-populate login_banner_text)"
 {{{ bash_deregexify_banner_space("login_banner_text") }}}
 # 3 - Adds newline "tokens". (Transforms "(?:\[\\n\]+|(?:\\n)+)" into "(n)*")
 {{{ bash_deregexify_banner_newline("login_banner_text", "(n)*") }}}
-# 4 - Remove any leftover backslash. (From any parethesis in the banner, for example).
+# 4 - Remove any leftover backslash. (From any parenthesis in the banner, for example).
 {{{ bash_deregexify_banner_backslash("login_banner_text") }}}
 # 5 - Removes the newline "token." (Transforms them into newline escape sequences "\n").
 #    ( Needs to be done after 4, otherwise the escapce sequence will become just "n".

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/bash/ubuntu.sh
@@ -12,7 +12,7 @@
 {{{ bash_deregexify_banner_space("login_banner_text") }}}
 # 3 - Adds newline "tokens". (Transforms "(?:\[\\n\]+|(?:\\n)+)" into "(n)*")
 {{{ bash_deregexify_banner_newline("login_banner_text", "(n)*") }}}
-# 4 - Remove any leftover backslash. (From any parethesis in the banner, for example).
+# 4 - Remove any leftover backslash. (From any parenthesis in the banner, for example).
 {{{ bash_deregexify_banner_backslash("login_banner_text") }}}
 # 5 - Removes the newline "token." (Transforms them into newline escape sequences "\n").
 #    ( Needs to be done after 4, otherwise the escapce sequence will become just "n".

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enforce_root/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_enforce_root/rule.yml
@@ -11,7 +11,7 @@ description: |-
     In the file <tt>/etc/pam.d/common-password</tt>, make sure the parameters
     <tt>enforce_for_root</tt> is present.
 
-rationale: 'Preventing re-use of previous passwords helps ensure that a compromised password is not re-used by a user.'
+rationale: 'Preventing reuse of previous passwords helps ensure that a compromised password is not reused by a user.'
 
 severity: medium
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/rule.yml
@@ -14,7 +14,7 @@ description: |-
     <pre>password requisite pam_pwhistory.so <i>...existing_options...</i> remember={{{ xccdf_value("var_password_pam_remember") }}} use_authtok</pre>
     The profile requirement is {{{ xccdf_value("var_password_pam_remember") }}} passwords.
 
-rationale: 'Preventing re-use of previous passwords helps ensure that a compromised password is not re-used by a user.'
+rationale: 'Preventing reuse of previous passwords helps ensure that a compromised password is not reused by a user.'
 
 severity: medium
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/oval/shared.xml
@@ -136,13 +136,13 @@
   <!-- variables used to collect the remember parameter value -->
   <local_variable id="var_accounts_password_pam_pwhistory_remember_password_auth_pam_param_regex"
     datatype="string" version="1"
-    comment="The regex is to collect the pam_pwhistory.so remember paramerter from PAM files">
+    comment="The regex is to collect the pam_pwhistory.so remember parameter from PAM files">
     <literal_component>^\s*password\b.*\bpam_pwhistory\.so\b.*\bremember=([0-9]*).*$</literal_component>
   </local_variable>
 
   <local_variable id="var_accounts_password_pam_pwhistory_remember_password_auth_conf_param_regex"
     datatype="string" version="1"
-    comment="The regex is to collect the pam_pwhistory.so remember paramerter in pwhistory.conf">
+    comment="The regex is to collect the pam_pwhistory.so remember parameter in pwhistory.conf">
     <literal_component>^\s*remember\s*=\s*([0-9]+)</literal_component>
   </local_variable>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/rule.yml
@@ -30,8 +30,8 @@ description: |-
     {{% endif %}}
 
 rationale: |-
-    Preventing re-use of previous passwords helps ensure that a compromised password is not
-    re-used by a user.
+    Preventing reuse of previous passwords helps ensure that a compromised password is not
+    reused by a user.
 
 severity: medium
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/oval/shared.xml
@@ -136,13 +136,13 @@
   <!-- variables used to collect the remember parameter value -->
   <local_variable id="var_accounts_password_pam_pwhistory_remember_system_auth_pam_param_regex"
     datatype="string" version="1"
-    comment="The regex is to collect the pam_pwhistory.so remember paramerter from PAM files">
+    comment="The regex is to collect the pam_pwhistory.so remember parameter from PAM files">
     <literal_component>^\s*password\b.*\bpam_pwhistory\.so\b.*\bremember=([0-9]*).*$</literal_component>
   </local_variable>
 
   <local_variable id="var_accounts_password_pam_pwhistory_remember_system_auth_conf_param_regex"
     datatype="string" version="1"
-    comment="The regex is to collect the pam_pwhistory.so remember paramerter in pwhistory.conf">
+    comment="The regex is to collect the pam_pwhistory.so remember parameter in pwhistory.conf">
     <literal_component>^\s*remember\s*=\s*([0-9]+)</literal_component>
   </local_variable>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/rule.yml
@@ -30,8 +30,8 @@ description: |-
     {{% endif %}}
 
 rationale: |-
-    Preventing re-use of previous passwords helps ensure that a compromised password is not
-    re-used by a user.
+    Preventing reuse of previous passwords helps ensure that a compromised password is not
+    reused by a user.
 
 severity: medium
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/oval/shared.xml
@@ -135,13 +135,13 @@
   <!-- variables used to collect the remember parameter value -->
   <local_variable id="var_accounts_password_pam_unix_remember_pam_param_regex"
 		  datatype="string" version="1"
-		  comment="The regex is to collect the pam_pwhistory.so remember paramerter from PAM files">
+		  comment="The regex is to collect the pam_pwhistory.so remember parameter from PAM files">
     <literal_component>^\s*password\b.*\bpam_pwhistory\.so\b.*\bremember=([0-9]*).*$</literal_component>
   </local_variable>
 
   <local_variable id="var_accounts_password_pam_unix_remember_conf_param_regex"
 		  datatype="string" version="1"
-		  comment="The regex is to collect the pam_pwhistory.so remember paramerter in pwhistory.conf">
+		  comment="The regex is to collect the pam_pwhistory.so remember parameter in pwhistory.conf">
     <literal_component>^\s*remember\s*=\s*([0-9]+)</literal_component>
   </local_variable>
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/rule.yml
@@ -14,8 +14,8 @@ description: |-
     <tt>remember</tt> option for the <tt>pam_unix</tt> or <tt>pam_pwhistory</tt> PAM modules.
 
 rationale: |-
-    Preventing re-use of previous passwords helps ensure that a compromised password is not
-    re-used by a user.
+    Preventing reuse of previous passwords helps ensure that a compromised password is not
+    reused by a user.
 
 severity: medium
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faildelay_delay/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faildelay_delay/rule.yml
@@ -31,7 +31,7 @@ references:
 ocil_clause: 'the value of delay is not set properly or the line is commented or missing'
 
 ocil: |-
-    Verify that the {{{ full_name }}} operating system enforces a minimum delay betweeen
+    Verify that the {{{ full_name }}} operating system enforces a minimum delay between
     logon prompts following a failed logon attempt.
 
     <pre># grep pam_faildelay /etc/pam.d/common-auth

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/oval/debian.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/oval/debian.xml
@@ -107,7 +107,7 @@
   <ind:filepath operation="pattern match">^/etc/pam.d/common-auth$</ind:filepath>
   <ind:pattern operation="pattern match"
                var_ref="var_accounts_passwords_pam_faillock_deny_root_pam_unix_regex"/>
-  <!-- only one occurence of pam_unix.so is expected -->
+  <!-- only one occurrence of pam_unix.so is expected -->
 <ind:instance datatype="int" operation="equals">1</ind:instance>
 </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/oval/sle15.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/oval/sle15.xml
@@ -107,7 +107,7 @@
   <ind:filepath operation="pattern match">^/etc/pam.d/common-auth$</ind:filepath>
   <ind:pattern operation="pattern match"
                var_ref="var_accounts_passwords_pam_faillock_deny_root_pam_unix_regex"/>
-  <!-- only one occurence of pam_unix.so is expected -->
+  <!-- only one occurrence of pam_unix.so is expected -->
 <ind:instance datatype="int" operation="equals">1</ind:instance>
 </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/rule.yml
@@ -7,7 +7,7 @@ description: |-
     This rule ensures that the system lock out accounts using <tt>pam_faillock.so</tt> persist
     after system reboot. From "pam_faillock" man pages:
     <pre>Note that the default directory that "pam_faillock" uses is usually cleared on system
-    boot so the access will be reenabled after system reboot. If that is undesirable, a different
+    boot so the access will be re-enabled after system reboot. If that is undesirable, a different
     tally directory must be set with the "dir" option.</pre>
 
     pam_faillock.so module requires multiple entries in pam files. These entries must be carefully

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_enabled/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_enabled/oval/shared.xml
@@ -51,7 +51,7 @@
   </constant_variable>
 
   {{% macro generate_test_faillock_enabled(file_stem) %}}
-  <!-- Check occurences of pam_unix.so in auth section of {{{ file_stem }}}-auth file -->
+  <!-- Check occurrences of pam_unix.so in auth section of {{{ file_stem }}}-auth file -->
   <ind:textfilecontent54_test
       check="all" check_existence="none_exist" version="2"
       id="test_accounts_passwords_pam_faillock_{{{ file_stem }}}_pam_unix_auth"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/oval/shared.xml
@@ -3,14 +3,14 @@
     {{{ oval_metadata("The number of allowed failed logins should be set correctly.", rule_title=rule_title) }}}
     <criteria operator="AND" comment="Checks common to both scenarios">
       <criterion test_ref="test_accounts_passwords_pam_tally2_deny_auth"
-      comment="Verify deny configuation of pam_tally2 in common-auth" />
+      comment="Verify deny configuration of pam_tally2 in common-auth" />
       <criterion test_ref="test_accounts_passwords_pam_tally2_deny_account"
-      comment="Verify deny configuation of pam_tally2 in common-account" />
+      comment="Verify deny configuration of pam_tally2 in common-account" />
     </criteria>
   </definition>
   <ind:textfilecontent54_test id="test_accounts_passwords_pam_tally2_deny_auth"
   check="all" check_existence="all_exist"
-  comment="Verify deny configuation of pam_tally2" version="1">
+  comment="Verify deny configuration of pam_tally2" version="1">
     <ind:object object_ref="object_accounts_passwords_pam_tally2_deny_auth" />
     <ind:state state_ref="state_var_accounts_passwords_pam_tally2_deny_value_upper_bound" />
     <ind:state state_ref="state_var_accounts_passwords_pam_tally2_deny_value_lower_bound" />
@@ -41,7 +41,7 @@
 
   <ind:textfilecontent54_test id="test_accounts_passwords_pam_tally2_deny_account"
   check="all" check_existence="all_exist"
-  comment="Verify deny configuation of pam_tally2_account" version="1">
+  comment="Verify deny configuration of pam_tally2_account" version="1">
     <ind:object object_ref="object_accounts_passwords_pam_tally2_deny_account" />
   </ind:textfilecontent54_test>
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_deny_root/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_deny_root/oval/shared.xml
@@ -4,17 +4,17 @@
     defined failed attempts has been reached.", rule_title=rule_title) }}}
     <criteria operator="AND" comment="Checks common to both scenarios">
       <criterion test_ref="test_accounts_passwords_pam_tally2_even_deny_root"
-      comment="Verify deny root configuation of pam_tally2 in common-auth" />
+      comment="Verify deny root configuration of pam_tally2 in common-auth" />
       <criterion test_ref="test_accounts_passwords_pam_tally2_deny_number"
-      comment="Verify deny number configuation of pam_tally2 in common-auth" />
+      comment="Verify deny number configuration of pam_tally2 in common-auth" />
       <criterion test_ref="test_accounts_passwords_pam_tally2_even_deny_root_account"
-      comment="Verify deny configuation of pam_tally2 in common-account" />
+      comment="Verify deny configuration of pam_tally2 in common-account" />
     </criteria>
   </definition>
 
   <ind:textfilecontent54_test id="test_accounts_passwords_pam_tally2_even_deny_root"
   check="all" check_existence="all_exist"
-  comment="Verify even_deny_root configuation of pam_tally2" version="1">
+  comment="Verify even_deny_root configuration of pam_tally2" version="1">
     <ind:object object_ref="object_accounts_passwords_pam_tally2_even_deny_root" />
   </ind:textfilecontent54_test>
 
@@ -26,7 +26,7 @@
 
   <ind:textfilecontent54_test id="test_accounts_passwords_pam_tally2_deny_number"
   check="all" check_existence="all_exist"
-  comment="Verify deny number configuation of pam_tally2" version="1">
+  comment="Verify deny number configuration of pam_tally2" version="1">
     <ind:object object_ref="object_accounts_passwords_pam_tally2_deny_number" />
   </ind:textfilecontent54_test>
 
@@ -38,7 +38,7 @@
 
   <ind:textfilecontent54_test id="test_accounts_passwords_pam_tally2_even_deny_root_account"
   check="all" check_existence="all_exist"
-  comment="Verify deny configuation of pam_tally2_account" version="1">
+  comment="Verify deny configuration of pam_tally2_account" version="1">
     <ind:object object_ref="object_accounts_passwords_pam_tally2_even_deny_root_account" />
   </ind:textfilecontent54_test>
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_unlock_time/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_unlock_time/oval/shared.xml
@@ -3,15 +3,15 @@
     {{{ oval_metadata("The unlock time after number of failed logins should be set correctly.", rule_title=rule_title) }}}
     <criteria operator="AND" comment="Checks common to both scenarios">
       <criterion test_ref="test_accounts_passwords_pam_tally2_unlock_time"
-      comment="Verify unlock time configuation of pam_tally2 in common-auth" />
+      comment="Verify unlock time configuration of pam_tally2 in common-auth" />
       <criterion test_ref="test_accounts_passwords_pam_tally2_unlock_time_account"
-      comment="Verify unlock time configuation of pam_tally2 in common-account" />
+      comment="Verify unlock time configuration of pam_tally2 in common-account" />
     </criteria>
   </definition>
 
   <ind:textfilecontent54_test id="test_accounts_passwords_pam_tally2_unlock_time"
   check="all" check_existence="all_exist"
-  comment="Verify unlock_time configuation of pam_tally2" version="1">
+  comment="Verify unlock_time configuration of pam_tally2" version="1">
     <ind:object object_ref="object_accounts_passwords_pam_tally2_unlock_time" />
     <ind:state state_ref="state_accounts_passwords_pam_tally2_unlock_time" />
   </ind:textfilecontent54_test>
@@ -32,7 +32,7 @@
 
   <ind:textfilecontent54_test id="test_accounts_passwords_pam_tally2_unlock_time_account"
   check="all" check_existence="all_exist"
-  comment="Verify  configuation of pam_tally2_account" version="1">
+  comment="Verify  configuration of pam_tally2_account" version="1">
     <ind:object object_ref="object_accounts_passwords_pam_tally2_unlock_time_account" />
   </ind:textfilecontent54_test>
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/var_password_pam_remember.var
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/var_password_pam_remember.var
@@ -2,7 +2,7 @@ documentation_complete: true
 
 title: pwhistory_remember
 
-description: 'Prevent password re-use using password history lookup'
+description: 'Prevent password reuse using password history lookup'
 
 type: number
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_lcredit/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_lcredit/policy/stig/shared.yml
@@ -9,7 +9,7 @@ vuldiscussion: |-
 
     Password complexity is one factor of several that determines how long it takes
     to crack a password. The more complex the password, the greater the number of
-    possble combinations that need to be tested before the password is compromised.
+    possible combinations that need to be tested before the password is compromised.
     Requiring a minimum number of lowercase characters makes password guessing attacks
     more difficult by ensuring a larger search space.
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_lcredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_lcredit/rule.yml
@@ -18,7 +18,7 @@ rationale: |-
     <br />
     Password complexity is one factor of several that determines how long it takes
     to crack a password. The more complex the password, the greater the number of
-    possble combinations that need to be tested before the password is compromised.
+    possible combinations that need to be tested before the password is compromised.
     Requiring a minimum number of lowercase characters makes password guessing attacks
     more difficult by ensuring a larger search space.
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ucredit/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ucredit/policy/stig/shared.yml
@@ -9,7 +9,7 @@ vuldiscussion: |-
 
     Password complexity is one factor of several that determines how long it takes
     to crack a password. The more complex the password, the greater the number of
-    possble combinations that need to be tested before the password is compromised.
+    possible combinations that need to be tested before the password is compromised.
     Requiring a minimum number of lowercase characters makes password guessing attacks
     more difficult by ensuring a larger search space.
 

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/rule.yml
@@ -35,7 +35,7 @@ description: |-
     </pre>
     <p>
     This will add the relevant configuration to <tt>/etc/systemd/system.conf.d/</tt>,
-    thus configuring Systemd apropriately.
+    thus configuring Systemd appropriately.
     </p>
     {{{ machineconfig_description_footer() | indent(4) }}}
     {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/rule.yml
@@ -31,7 +31,7 @@ platform: package[tmux]
 ocil_clause: 'the "lock-session" is not bound to a specific key'
 
 ocil: |-
-    Verify {{{ full_name }}} enables the user to initiate a session lock trhough key bindings with the following commands:
+    Verify {{{ full_name }}} enables the user to initiate a session lock through key bindings with the following commands:
 
     <pre>$ grep "lock-session" /etc/tmux.conf</pre>
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_ca/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_ca/rule.yml
@@ -40,7 +40,7 @@ ocil: |-
     To verify the operating system implements certificate status checking for PKI
     authentication, run the following command:
     <pre>$ sudo grep -i cert_policy /etc/pam_pkcs11/pam_pkcs11.conf</pre>
-    The output should return multiple lines similiar to the following:
+    The output should return multiple lines similar to the following:
     <pre>cert_policy = ca, ocsp_on, signature;
     cert_policy = ca, ocsp_on, signature;
     cert_policy = ca, ocsp_on, signature;</pre>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/rule.yml
@@ -44,7 +44,7 @@ ocil: |-
     To verify the operating system implements certificate status checking for PKI
     authentication, run the following command:
     <pre>$ sudo grep -i cert_policy /etc/pam_pkcs11/pam_pkcs11.conf</pre>
-    The output should return multiple lines similiar to the following:
+    The output should return multiple lines similar to the following:
     <pre>cert_policy = ca, ocsp_on, signature;
     cert_policy = ca, ocsp_on, signature;
     cert_policy = ca, ocsp_on, signature;</pre>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/rule.yml
@@ -50,7 +50,7 @@ ocil: |-
     <pre>$ sudo grep rounds {{{ pam_passwd_file_path }}}</pre>
     The output should show the following match:
     {{% if product in ["debian12", "debian13", 'ubuntu2404'] %}}
-    <pre>password [sucess=1 default=ignore] pam_unix.so sha512 rounds={{{ xccdf_value("var_password_pam_unix_rounds") }}}</pre>
+    <pre>password [success=1 default=ignore] pam_unix.so sha512 rounds={{{ xccdf_value("var_password_pam_unix_rounds") }}}</pre>
     {{% else %}}
     <pre>password sufficient pam_unix.so sha512 rounds={{{ xccdf_value("var_password_pam_unix_rounds") }}}</pre>
     {{% endif %}}
@@ -63,7 +63,7 @@ fixtext: |-
     Add or modify the following line in "{{{ pam_passwd_file_path }}}" and set "rounds" to {{{ xccdf_value("var_password_pam_unix_rounds") }}}.
     For example:
     {{% if product in ["debian12", "debian13", 'ubuntu2404'] %}}
-    password [sucess=1 default=ignore] pam_unix.so sha512 rounds=5000
+    password [success=1 default=ignore] pam_unix.so sha512 rounds=5000
     {{% else %}}
     password sufficient pam_unix.so sha512 rounds=5000
     {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_invalid_shell_accounts_unlocked/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_invalid_shell_accounts_unlocked/oval/shared.xml
@@ -66,7 +66,7 @@
     <ind:subexpression datatype="string" operation="equals" var_check="at least one" var_ref="var_{{{ rule_id }}}_locked_accounts" ></ind:subexpression>
   </ind:textfilecontent54_state>
 
-  <local_variable id="var_{{{ rule_id }}}_locked_accounts" datatype="string" version="1" comment="Account name of locked acounts">
+  <local_variable id="var_{{{ rule_id }}}_locked_accounts" datatype="string" version="1" comment="Account name of locked accounts">
       <object_component item_field="subexpression" object_ref="obj_{{{ rule_id }}}_locked_accounts" />
   </local_variable>
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/var_accounts_authorized_local_users_regex.var
+++ b/linux_os/guide/system/accounts/accounts-restrictions/var_accounts_authorized_local_users_regex.var
@@ -5,7 +5,7 @@ title: 'Accounts Authorized Local Users on the Operating System'
 
 description: |-
     List the user accounts that are authorized locally on the operating system. This list
-    includes both users requried by the operating system and by the installed applications.
+    includes both users required by the operating system and by the installed applications.
     Depending on the Operating System distribution, version, software groups and applications,
     the user list is different and can be customized with scap-workbench.
     OVAL regular expression is used for the user list.

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
@@ -7,7 +7,7 @@
 
 {{{ bash_instantiate_variables("var_accounts_tmout") }}}
 
-# if 0, no occurence of tmout found, if 1, occurence found
+# if 0, no occurrence of tmout found, if 1, occurrence found
 tmout_found=0
 
 {{% if system_configuration_using_etc_bashrc_expected %}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/ubuntu.sh
@@ -2,7 +2,7 @@
 
 {{{ bash_instantiate_variables("var_accounts_tmout") }}}
 
-# if 0, no occurence of tmout found, if 1, occurence found
+# if 0, no occurrence of tmout found, if 1, occurrence found
 tmout_found=0
 
 for f in /etc/bash.bashrc /etc/profile /etc/profile.d/*.sh; do

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_permissions/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_permissions/oval/shared.xml
@@ -5,7 +5,7 @@
       <criterion test_ref="test_accounts_users_home_files_permissions_files"
                  comment="All files under interactive user's Home Directories must have proper permissions"/>
       <criterion test_ref="test_accounts_users_home_files_permissions_dirs"
-                 comment="All direcories under home directories must have proper permissions"/>
+                 comment="All directories under home directories must have proper permissions"/>
     </criteria>
   </definition>
 

--- a/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/oval/shared.xml
@@ -37,7 +37,7 @@
   </unix:file_state>
 
   <!-- #### creation of test #### -->
-  <!-- #### creatin of test_file_groupownership_home_directories #### -->
+  <!-- #### creation of test_file_groupownership_home_directories #### -->
   <unix:file_test id="test_file_groupownership_home_directories" check="all" check_existence="any_exist"
                   version="1" comment="All home directories are group-owned by a local interactive group">
     <unix:object object_ref="object_file_groupownership_home_directories_dirs"/>

--- a/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/oval/shared.xml
@@ -48,7 +48,7 @@
 
   <!--
     #### creation of state ####
-    We have the relevant uids, but we need a "file_state" object to use in our intendend test.
+    We have the relevant uids, but we need a "file_state" object to use in our intended test.
     So, we create this file_state based on content from the previous local variable.
   -->
   <unix:file_state id="state_file_ownership_home_directories_uids" version="1">

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_all_dirs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_all_dirs/rule.yml
@@ -9,7 +9,7 @@ description: |-
 
 rationale: |-
     Locations in root's path that are not directories could cause unexpected behavior,
-    such as executing scrips from unintended locations. Ensuring that all locations in
+    such as executing scripts from unintended locations. Ensuring that all locations in
     root's path are directories helps maintain a secure environment for root.
 
 severity: medium

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/rule.yml
@@ -7,7 +7,7 @@ description: |-
     add or correct the <tt>umask</tt> setting in <tt>/etc/profile</tt> to read as follows:
     <pre>umask {{{ xccdf_value("var_accounts_user_umask") }}}</pre>
 
-    Note that <tt>/etc/profile</tt> also reads scrips within <tt>/etc/profile.d</tt> directory.
+    Note that <tt>/etc/profile</tt> also reads scripts within <tt>/etc/profile.d</tt> directory.
     These scripts are also valid files to set umask value. Therefore, they should also be
     considered during the check and properly remediated, if necessary.
 

--- a/linux_os/guide/system/bootloader-grub2/grub2_nosmap_argument_absent/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_nosmap_argument_absent/rule.yml
@@ -8,7 +8,7 @@ description: |-
     But it could be disabled through kernel boot parameters.
 
     Ensure that Supervisor Mode Access Prevention (SMAP) is not disabled by
-    the <tt>nosmap</tt> boot paramenter option.
+    the <tt>nosmap</tt> boot parameter option.
 
     {{{ describe_grub2_argument_absent("nosmap") | indent(4) }}}
 

--- a/linux_os/guide/system/bootloader-grub2/grub2_nosmep_argument_absent/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_nosmep_argument_absent/rule.yml
@@ -8,7 +8,7 @@ description: |-
     kernel boot parameters.
 
     Ensure that Supervisor Mode Execution Prevention (SMEP) is not disabled by
-    the <tt>nosmep</tt> boot paramenter option.
+    the <tt>nosmep</tt> boot parameter option.
 
     {{{ describe_grub2_argument_absent("nosmep") | indent(4) }}}
 

--- a/linux_os/guide/system/bootloader-grub2/grub2_spec_store_bypass_disable_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_spec_store_bypass_disable_argument/rule.yml
@@ -20,7 +20,7 @@ description: |-
     {{{ describe_grub2_argument("spec_store_bypass_disable=" + xccdf_value("var_spec_store_bypass_disable_options")) | indent(4) }}}
 
 rationale: |-
-    In vulnerable processsors, the speculatively forwarded store can be used in a cache side channel
+    In vulnerable processors, the speculatively forwarded store can be used in a cache side channel
     attack. An example of this is reading memory to which the attacker does not directly have access,
     for example inside the sandboxed code.
 

--- a/linux_os/guide/system/bootloader-grub2/grub2_systemd_debug-shell_argument_absent/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_systemd_debug-shell_argument_absent/rule.yml
@@ -32,7 +32,7 @@ identifiers:
 references:
     ospp: FIA_UAU.1
 
-ocil_clause: 'the comand returns a line'
+ocil_clause: 'the command returns a line'
 
 ocil: |-
     Ensure that debug-shell service is not enabled with the following command:

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_no_removeable_media/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_no_removeable_media/rule.yml
@@ -1,12 +1,12 @@
 documentation_complete: true
 
 
-title: 'Boot Loader Is Not Installed On Removeable Media'
+title: 'Boot Loader Is Not Installed On Removable Media'
 
 description: |-
     The system must not allow removable media to be used as the boot loader.
     Remove alternate methods of booting the system from removable media.
-    <tt>usb0</tt>, <tt>cd</tt>, <tt>fd0</tt>, etc. are some examples of removeable
+    <tt>usb0</tt>, <tt>cd</tt>, <tt>fd0</tt>, etc. are some examples of removable
     media which should not exist in the lines:
     <pre>set root='hd0,msdos1'</pre>
 
@@ -33,7 +33,7 @@ ocil: |-
     <pre>$ sudo grep "set root='hd0" {{{ grub2_boot_path }}}/grub.cfg</pre>
     The output should return something similar to:
     <pre>set root='hd0,msdos1'</pre>
-    <tt>usb0</tt>, <tt>cd</tt>, <tt>fd0</tt>, etc. are some examples of removeable
+    <tt>usb0</tt>, <tt>cd</tt>, <tt>fd0</tt>, etc. are some examples of removable
     media which should not exist in the lines:
     <pre>set root='hd0,msdos1'</pre>
 

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/oval/shared.xml
@@ -7,7 +7,7 @@
       <criterion comment="make sure a password is defined in {{{ grub2_boot_path }}}/user.cfg" test_ref="test_grub2_password_usercfg" />
       {{% else %}}
       <criteria operator="AND">
-        <criteria comment="check both files to account for procedure change in documenation" operator="OR">
+        <criteria comment="check both files to account for procedure change in documentation" operator="OR">
           <criterion comment="make sure a password is defined in {{{ grub2_boot_path }}}/user.cfg" test_ref="test_grub2_password_usercfg" />
           <criterion comment="make sure a password is defined in {{{ grub2_boot_path }}}/grub.cfg" test_ref="test_grub2_password_grubcfg" />
         </criteria>

--- a/linux_os/guide/system/bootloader-grub2/uefi/uefi_no_removeable_media/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/uefi_no_removeable_media/rule.yml
@@ -1,12 +1,12 @@
 documentation_complete: true
 
 
-title: 'UEFI Boot Loader Is Not Installed On Removeable Media'
+title: 'UEFI Boot Loader Is Not Installed On Removable Media'
 
 description: |-
     The system must not allow removable media to be used as the boot loader.
     Remove alternate methods of booting the system from removable media.
-    <tt>usb0</tt>, <tt>cd</tt>, <tt>fd0</tt>, etc. are some examples of removeable
+    <tt>usb0</tt>, <tt>cd</tt>, <tt>fd0</tt>, etc. are some examples of removable
     media which should not exist in the lines:
     <pre>set root='hd0,msdos1'</pre>
 
@@ -33,7 +33,7 @@ ocil: |-
     <pre>$ sudo grep "set root='hd0" {{{ grub2_uefi_boot_path }}}/grub.cfg</pre>
     The output should return something similar to:
     <pre>set root='hd0,msdos1'</pre>
-    <tt>usb0</tt>, <tt>cd</tt>, <tt>fd0</tt>, etc. are some examples of removeable
+    <tt>usb0</tt>, <tt>cd</tt>, <tt>fd0</tt>, etc. are some examples of removable
     media which should not exist in the lines:
     <pre>set root='hd0,msdos1'</pre>
 

--- a/linux_os/guide/system/bootloader-zipl/zipl_bls_entries_only/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_bls_entries_only/rule.yml
@@ -8,7 +8,7 @@ description: |-
     by checking that <tt>/etc/zipl.conf</tt> doesn't contain <tt>image = </tt>.
 
 rationale: |-
-    {{{ full_name }}} adheres to Boot Loader Specification (BLS) and is the prefered method of
+    {{{ full_name }}} adheres to Boot Loader Specification (BLS) and is the preferred method of
     configuration.
 
 severity: medium

--- a/linux_os/guide/system/bootloader-zipl/zipl_systemd_debug-shell_argument_absent/rule.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_systemd_debug-shell_argument_absent/rule.yml
@@ -14,7 +14,7 @@ description: |-
     By default, the <tt>debug-shell</tt> systemd service is already disabled.
 
     Ensure the debug-shell is not enabled by the <tt>systemd.debug-shel=1</tt>
-    boot paramenter option.
+    boot parameter option.
 
     Check that not boot entries in <tt>/boot/loader/entries/*.conf</tt> have
     <tt>systemd.debug-shell=1</tt> included in its options.<br />
@@ -35,7 +35,7 @@ identifiers:
 references:
     ospp: FIA_UAU.1
 
-ocil_clause: 'the comand returns a line'
+ocil_clause: 'the command returns a line'
 
 ocil: |-
     Ensure that debug-shell service is not enabled with the following command:

--- a/linux_os/guide/system/kernel_build_config/kernel_config_arm64_sw_ttbr0_pan/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_arm64_sw_ttbr0_pan/rule.yml
@@ -14,7 +14,7 @@ description: |-
 
 rationale: |-
     The Privileged Access Never (PAN) is the ARM equivalent of the x86 Supervisor Mode Access
-    Prevention (SMAP), and it prevents privileged acccess to user data unless explicitly enabled.
+    Prevention (SMAP), and it prevents privileged access to user data unless explicitly enabled.
 
 platform: aarch64_arch
 

--- a/linux_os/guide/system/kernel_build_config/kernel_config_compat_vdso/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_compat_vdso/rule.yml
@@ -6,7 +6,7 @@ description: |-
     Certain buggy versions of glibc (2.3.3) will crash if they are presented with a 32-bit vDSO
     that is not mapped at the address indicated in its segment table.
     Setting <tt>CONFIG_COMPAT_VDSO</tt> to <tt>y</tt> turns off the 32-bit VDSO and works
-    aroud the glibc bug.
+    around the glibc bug.
 
     {{{ describe_kernel_build_config("CONFIG_COMPAT_VDSO", "n") | indent(4) }}}
 

--- a/linux_os/guide/system/kernel_build_config/kernel_config_debug_list/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_debug_list/rule.yml
@@ -9,7 +9,7 @@ description: |-
 
 rationale: |-
     This add sanity checks to manipulation of linked lists structures in the kernel and may
-    prevent exploits such as CVE-2017-1661, where a race condition and simultaneos operations
+    prevent exploits such as CVE-2017-1661, where a race condition and simultaneous operations
     caused a list to corrupt.
 
 warnings:

--- a/linux_os/guide/system/kernel_build_config/kernel_config_stackprotector/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_stackprotector/rule.yml
@@ -1,7 +1,7 @@
 documentation_complete: true
 
 
-title: 'Stack Protector buffer overlow detection'
+title: 'Stack Protector buffer overflow detection'
 
 description: |-
     This feature puts, at the beginning of functions, a canary value on the stack just before the

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdrivermode/rule.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdrivermode/rule.yml
@@ -9,7 +9,7 @@ description: |-
   library implementing the SSL, TLS and DTLS protocols), and you have a method to securely
   encrypt and off-load auditing.
 
-  When using <tt>rsyslogd</tt> to off-load logs off a encrpytion system must be used.
+  When using <tt>rsyslogd</tt> to off-load logs off a encryption system must be used.
 
   Set the following configuration option in /etc/rsyslog.conf or in a file in /etc/rsyslog.d (using legacy syntax):
   <pre>$ActionSendStreamDriverMode 1</pre>

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_logging_configured/tests/rsyslog_file_with_everything_logged_to_messages.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_logging_configured/tests/rsyslog_file_with_everything_logged_to_messages.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # platform = multi_platform_sle
 
-# Check rsyslog.conf with no includes and all loggging facility/priority configured to go to /var/log/messages
+# Check rsyslog.conf with no includes and all logging facility/priority configured to go to /var/log/messages
 
 source $SHARED/rsyslog_log_utils.sh
 cat << EOF > ${RSYSLOG_CONF}

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_logging_configured/tests/rsyslog_file_with_no_logging.fail.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_logging_configured/tests/rsyslog_file_with_no_logging.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # platform = multi_platform_sle
 
-# Check rsyslog.conf with no includes and no loggging facility/priority configured
+# Check rsyslog.conf with no includes and no logging facility/priority configured
 
 source $SHARED/rsyslog_log_utils.sh
 cat << EOF > ${RSYSLOG_CONF}

--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/ansible/shared.yml
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/ansible/shared.yml
@@ -11,7 +11,7 @@
     regexp: "^daily$"
     line: "daily"
 
-- name: Make sure daily log rotation setting is not overriden in /etc/logrotate.conf
+- name: Make sure daily log rotation setting is not overridden in /etc/logrotate.conf
   ansible.builtin.lineinfile:
     create: no
     dest: "/etc/logrotate.conf"

--- a/linux_os/guide/system/network/network-firewalld/firewalld-backend/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld-backend/rule.yml
@@ -7,7 +7,7 @@ description: |-
     Firewalld can be configured with many backends, such as nftables.
 
 rationale: |-
-    Nftables is modern kernel module for controling network connections coming into a system.
+    Nftables is modern kernel module for controlling network connections coming into a system.
     Utilizing the limit statement in "nftables" can help to mitigate DoS attacks.
 
 severity: medium

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_forwarding/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_forwarding/rule.yml
@@ -25,7 +25,7 @@ references:
     stigid@sle12: SLES-12-030365
     stigid@sle15: SLES-15-040382
 
-ocil_clause: 'IPv6 Forwading is not disabled'
+ocil_clause: 'IPv6 Forwarding is not disabled'
 
 ocil: |-
     {{{ ocil_sysctl_option_value(sysctl="net.ipv6.conf.default.forwarding", value="0") }}}

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_drop_gratuitous_arp/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_drop_gratuitous_arp/rule.yml
@@ -1,7 +1,7 @@
 documentation_complete: true
 
 
-title: 'Drop Gratuitious ARP frames on All IPv4 Interfaces'
+title: 'Drop Gratuitous ARP frames on All IPv4 Interfaces'
 
 description: '{{{ describe_sysctl_option_value(sysctl="net.ipv4.conf.all.drop_gratuitous_arp", value="1") }}}'
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_log_martians/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_log_martians/rule.yml
@@ -1,7 +1,7 @@
 documentation_complete: true
 
 
-title: 'Enable Kernel Paremeter to Log Martian Packets on all IPv4 Interfaces by Default'
+title: 'Enable Kernel Parameter to Log Martian Packets on all IPv4 Interfaces by Default'
 
 description: '{{{ describe_sysctl_option_value(sysctl="net.ipv4.conf.default.log_martians", value="1") }}}'
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_echo_ignore_broadcasts/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_echo_ignore_broadcasts/policy/stig/shared.yml
@@ -15,7 +15,7 @@ checktext: |-
 
     net.ipv4.icmp_echo_ignore_broadcasts = 1
 
-    If the returned line does not have a value of "1", a line is not returned, or the retuned line is commented out, this is a finding.
+    If the returned line does not have a value of "1", a line is not returned, or the returned line is commented out, this is a finding.
 
     Check that the configuration files are present to enable this network parameter.
 

--- a/linux_os/guide/system/network/network-nftables/set_nftables_base_chain/bash/shared.sh
+++ b/linux_os/guide/system/network/network-nftables/set_nftables_base_chain/bash/shared.sh
@@ -6,7 +6,7 @@
 
 #Name of the table
 {{{ bash_instantiate_variables("var_nftables_table") }}}
-#Familiy of the table 
+#Family of the table 
 {{{ bash_instantiate_variables("var_nftables_family") }}}
 #Name(s) of base chain
 {{{ bash_instantiate_variables("var_nftables_base_chain_names") }}}

--- a/linux_os/guide/system/network/network-nftables/set_nftables_base_chain/tests/set_base_chain.pass.sh
+++ b/linux_os/guide/system/network/network-nftables/set_nftables_base_chain/tests/set_base_chain.pass.sh
@@ -3,7 +3,7 @@
 #Set name of the table
 var_nftables_table='filter'
 
-#Set familiy of the table 
+#Set family of the table 
 var_nftables_family='inet'
 
 #Set name(s) of base chain

--- a/linux_os/guide/system/network/network_nmcli_permissions/oval/shared.xml
+++ b/linux_os/guide/system/network/network_nmcli_permissions/oval/shared.xml
@@ -7,7 +7,7 @@
   </definition>
 
   <ind:textfilecontent54_test id="test_network_nmcli_permissions"
-  comment="polkit is properly configured to prevent non-privilged users from changing networking settings"
+  comment="polkit is properly configured to prevent non-privileged users from changing networking settings"
   check="all" check_existence="all_exist" version="1">
     <ind:object object_ref="object_network_nmcli_permissions" />
     <ind:state state_ref="state_network_nmcli_permissions" />

--- a/linux_os/guide/system/permissions/files/rootfiles/rootfiles_configured/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/rootfiles/rootfiles_configured/ansible/shared.yml
@@ -10,7 +10,7 @@
     {{% set dest_path = "/root/." ~  file -%}}
     {{% set source_path = "/usr/share/rootfiles/." ~ file -%}}
     {{% set new_line = "C " ~ dest_path ~ " 600 root root - "  ~ source_path  %}}
-- name: "{{{ rule_title }}} - Find configation files"
+- name: "{{{ rule_title }}} - Find configuration files"
   ansible.builtin.find:
     paths: /etc/tmpfiles.d/
     file_type: file

--- a/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_udf_disabled/rule.yml
@@ -10,7 +10,7 @@ description: |-
     The <tt>udf</tt> filesystem type is the universal disk format
     used to implement the ISO/IEC 13346 and ECMA-167 specifications.
     This is an open vendor filesystem type for data storage on a broad
-    range of media. This filesystem type is neccessary to support
+    range of media. This filesystem type is necessary to support
     writing DVDs and newer optical disc formats.
 
 rationale: |-

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/oval/shared.xml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/oval/shared.xml
@@ -23,7 +23,7 @@
     <!--
       Look at all partitions except / (root), /boot and /efi. The / is
       excluded because nodev is allowed on / by the rule text. The /boot and
-      /efi are excluded because they are special paritions that are
+      /efi are excluded because they are special partitions that are
       usually handled by a systemd mount which causes troubles if the rule is
       used in operating system installation.
       -->

--- a/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/rule.yml
@@ -8,7 +8,7 @@ description: |-
     and set-group-identifier (SGID) permissions from taking effect. These permissions
     allow users to execute binaries with the same permissions as the owner and group
     of the file respectively. Users should not be allowed to introduce SUID and SGID
-    files into the system via partitions mounted from removeable media.
+    files into the system via partitions mounted from removable media.
     {{{ describe_mount(option="nosuid", part="any removable media partitions") }}}
 
 rationale: |-

--- a/linux_os/guide/system/permissions/permissions_local/file_permissions_local_var_log_messages/rule.yml
+++ b/linux_os/guide/system/permissions/permissions_local/file_permissions_local_var_log_messages/rule.yml
@@ -4,7 +4,7 @@ documentation_complete: true
 title: 'Verify that local /var/log/messages is not world-readable'
 
 description: |-
-    Files containing sensitive informations should be protected by restrictive
+    Files containing sensitive information should be protected by restrictive
     permissions. Most of the time, there is no need that these files need to be read by any non-root user
     {{{ describe_file_permissions(file="/var/log/messages", perms="0640") }}}
 

--- a/linux_os/guide/system/permissions/permissions_local/permissions_local_var_log_audit/rule.yml
+++ b/linux_os/guide/system/permissions/permissions_local/permissions_local_var_log_audit/rule.yml
@@ -4,7 +4,7 @@ documentation_complete: true
 title: 'Verify that Local Logs of the audit Daemon are not World-Readable'
 
 description: |-
-    Files containing sensitive informations should be protected by restrictive
+    Files containing sensitive information should be protected by restrictive
     permissions. Most of the time, there is no need that these files need to be
     read by any non-root user.
 

--- a/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_backtraces/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_backtraces/rule.yml
@@ -17,7 +17,7 @@ rationale: |-
 
     Enabling core dumps on production systems is not recommended,
     however there may be overriding operational requirements to enable advanced
-    debuging. Permitting temporary enablement of core dumps during such situations
+    debugging. Permitting temporary enablement of core dumps during such situations
     should be reviewed through local needs and policy.
 
 severity: medium

--- a/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_storage/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_storage/rule.yml
@@ -14,7 +14,7 @@ rationale: |-
     and is generally useful only for developers or system operators trying to
     debug problems. Enabling core dumps on production systems is not recommended,
     however there may be overriding operational requirements to enable advanced
-    debuging. Permitting temporary enablement of core dumps during such situations
+    debugging. Permitting temporary enablement of core dumps during such situations
     should be reviewed through local needs and policy.
 
 severity: medium

--- a/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/oval/shared.xml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/oval/shared.xml
@@ -42,7 +42,7 @@
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_test check="all"
-  comment="Tests for existance of the ^[\s]*\*[\s]+(hard|-)[\s]+core setting in the /etc/security/limits.d directory"
+  comment="Tests for existence of the ^[\s]*\*[\s]+(hard|-)[\s]+core setting in the /etc/security/limits.d directory"
   id="test_core_dumps_limits_d_exists" version="1">
     <ind:object object_ref="object_core_dumps_limits_d_exists" />
   </ind:textfilecontent54_test>

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_cpu_time_max_percent/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_cpu_time_max_percent/rule.yml
@@ -6,7 +6,7 @@ title: 'Limit CPU consumption of the Perf system'
 description: '{{{ describe_sysctl_option_value(sysctl="kernel.perf_cpu_time_max_percent", value="1") }}}'
 
 rationale: |-
-    The <tt>kernel.perf_cpu_time_max_percent</tt> configures a treshold of
+    The <tt>kernel.perf_cpu_time_max_percent</tt> configures a threshold of
     maximum percentile of CPU that can be used by Perf system. Restricting usage
     of <tt>Perf</tt> system decreases risk of potential availability problems.
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_builtin_scripting/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_httpd_builtin_scripting/rule.yml
@@ -6,7 +6,7 @@ title: 'Configure the httpd_builtin_scripting SELinux Boolean'
 description: |-
     By default, the SELinux boolean <tt>httpd_builtin_scripting</tt> is enabled.
     This setting should be disabled if <tt>httpd</tt> is not running <tt>php</tt>
-    or some similary scripting language.
+    or some similarly scripting language.
     {{{ describe_sebool_disable(sebool="httpd_builtin_scripting") }}}
 
 rationale: ""

--- a/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_notification/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_notification/rule.yml
@@ -7,7 +7,7 @@ description: |-
     By default, <tt>GNOME</tt> disables WIFI notification. This should be permanently set
     so that users do not connect to a wireless network when the system finds one.
     While useful for mobile devices, this setting should be disabled for all other systems.
-    To configure the system to disable the WIFI notication, add or set
+    To configure the system to disable the WIFI notification, add or set
     <tt>suppress-wireless-networks-available</tt> to <tt>true</tt> in
     <tt>/etc/dconf/db/local.d/00-security-settings</tt>. For example:
     <pre>[org/gnome/nm-applet]

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/rule.yml
@@ -13,7 +13,7 @@ description: |-
 
 rationale: |-
     A session lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity
-    of the information system but does not want to logout because of the temporary nature of the absense.
+    of the information system but does not want to logout because of the temporary nature of the absence.
 
 severity: medium
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/rule.yml
@@ -14,7 +14,7 @@ description: |-
 
 rationale: |-
     A session lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity
-    of the information system but does not want to logout because of the temporary nature of the absense.
+    of the information system but does not want to logout because of the temporary nature of the absence.
 
 severity: medium
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/rule.yml
@@ -26,7 +26,7 @@ description: |-
 
 rationale: |-
     A session lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity
-    of the information system but does not want to logout because of the temporary nature of the absense.
+    of the information system but does not want to logout because of the temporary nature of the absence.
 
 severity: medium
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/rule.yml
@@ -13,7 +13,7 @@ description: |-
 
 rationale: |-
     A session lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity
-    of the information system but does not want to logout because of the temporary nature of the absense.
+    of the information system but does not want to logout because of the temporary nature of the absence.
 
 severity: medium
 

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/group.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/group.yml
@@ -4,8 +4,8 @@ title: 'GNOME System Settings'
 
 description: |-
     GNOME provides configuration and functionality to a graphical desktop environment
-    that changes grahical configurations or allow a user to perform
+    that changes graphical configurations or allow a user to perform
     actions that users normally would not be able to do in non-graphical mode such as
     remote access configuration, power policies, Geo-location, etc.
-    Configuring such settings in GNOME will prevent accidential graphical configuration
+    Configuring such settings in GNOME will prevent accidental graphical configuration
     changes by users from taking place.

--- a/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_kerberos_crypto_policy/rule.yml
@@ -35,7 +35,7 @@ ocil_clause: 'the symlink does not exist or points to a different target'
 ocil: |-
     Check that the symlink exists and target the correct Kerberos crypto policy, with the following command:
     <pre>file /etc/krb5.conf.d/crypto-policies</pre>
-    If command ouput shows the following line, Kerberos is configured to use the system-wide crypto policy.
+    If command output shows the following line, Kerberos is configured to use the system-wide crypto policy.
     <pre>/etc/krb5.conf.d/crypto-policies: symbolic link to /etc/crypto-policies/back-ends/krb5.config</pre>
 
 fixtext: |-

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_crypto_policy/bash/shared.sh
@@ -3,7 +3,7 @@
 cp="CRYPTO_POLICY='-oCiphers=aes256-ctr,aes128-ctr,aes256-cbc,aes128-cbc -oMACs=hmac-sha2-512,hmac-sha2-256 -oGSSAPIKeyExchange=no -oKexAlgorithms=ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group14-sha1 -oHostKeyAlgorithms=ssh-rsa,ecdsa-sha2-nistp384,ecdsa-sha2-nistp256 -oPubkeyAcceptedKeyTypes=rsa-sha2-512,rsa-sha2-256,ssh-rsa,ecdsa-sha2-nistp384,ecdsa-sha2-nistp256'"
 file=/etc/crypto-policies/local.d/opensshserver-ospp.config
 
-#blank line at the begining to ease later readibility
+#blank line at the beginning to ease later readability
 echo '' > "$file"
 echo "$cp" >> "$file"
 update-crypto-policies

--- a/linux_os/guide/system/software/integrity/crypto/var_ssh_client_rekey_limit_time.var
+++ b/linux_os/guide/system/software/integrity/crypto/var_ssh_client_rekey_limit_time.var
@@ -6,7 +6,7 @@ description: |-
     Specify the time component of the rekey limit. The session key is
     renegotiated after the defined amount of time passes. The number is followed
     by units such as H or M for hours or minutes. Note that the RekeyLimit can
-    be also configured according to amount of transfered data.
+    be also configured according to amount of transferred data.
 
 interactive: true
 

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_antivirus_definitions_updated/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_antivirus_definitions_updated/oval/shared.xml
@@ -34,7 +34,7 @@ id="object_mcafee_definitions_modified_time" version="1">
     var_ref="var_mcafee_antivirus_definition_expire" />
   </ind:variable_state>
 
-  <external_variable comment="defintions age" datatype="int"
+  <external_variable comment="definitions age" datatype="int"
   id="var_mcafee_antivirus_definition_expire" version="1" />
 
 </def-group>

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/var_mcafee_antivirus_definition_expire.var
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/var_mcafee_antivirus_definition_expire.var
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'The age of McAfee defintion file before requiring updating'
+title: 'The age of McAfee definition file before requiring updating'
 
 description: |-
     Specify the amount of time (in seconds) before McAfee definition files need to be

--- a/linux_os/guide/system/software/integrity/fips/fips_crypto_policy_symlinks/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/fips_crypto_policy_symlinks/oval/shared.xml
@@ -20,7 +20,7 @@
 <def-group>
     <definition class="compliance" id="{{{ rule_id }}}" version="1">
         {{{ oval_metadata("All system wide cryptopolicy symblinks should point to FIPS policy", rule_title=rule_title) }}}
-        <criteria operator="AND" comment="All crypto-policies symlinks should poin to FIPS">
+        <criteria operator="AND" comment="All crypto-policies symlinks should point to FIPS">
             {{% for symlink in expected_symlinks_src_files %}}
             <criterion comment="Symlink from {{{ expected_symlinks_src_dir ~ symlink }}}"
                 test_ref="test_symlink_from_{{{ symlink | escape_id }}}" />

--- a/linux_os/guide/system/software/integrity/fips/fips_crypto_policy_symlinks/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/fips_crypto_policy_symlinks/rule.yml
@@ -36,7 +36,7 @@ references:
 ocil_clause: Any file shows a different output
 
 ocil: |-
-    Validate all files are symlinks to ponting to /usr/share/crypto-policies/FIPS/ except for
+    Validate all files are symlinks to pointing to /usr/share/crypto-policies/FIPS/ except for
     nss.config:
     <pre>
     $ stat -c%N /etc/crypto-policies/back-ends/*

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/default.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/default.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # packages = aide
 
-# default instalation
+# default installation
 true

--- a/linux_os/guide/system/software/prefer_64bit_os/rule.yml
+++ b/linux_os/guide/system/software/prefer_64bit_os/rule.yml
@@ -22,7 +22,7 @@ identifiers:
   cce@sle12: CCE-91504-1
   cce@sle15: CCE-91195-8
 
-ocil_clause: the installed operating sytem is 32-bit but the CPU supports operation in 64-bit
+ocil_clause: the installed operating system is 32-bit but the CPU supports operation in 64-bit
 
 ocil: |-
   To check if the installed Operating System is 64-bit, run the following command:

--- a/linux_os/guide/system/software/sap_host/accounts_authorized_local_users_sidadm_orasid/oval/shared.xml
+++ b/linux_os/guide/system/software/sap_host/accounts_authorized_local_users_sidadm_orasid/oval/shared.xml
@@ -66,7 +66,7 @@
   </ind:textfilecontent54_state>
 
   <ind:textfilecontent54_state id="state_accounts_authorized_local_users_sidadm_orasid"
-  version="1" comment="query if user accounts from /etc/passwd are authrorized" >
+  version="1" comment="query if user accounts from /etc/passwd are authorized" >
     <ind:subexpression operation="pattern match"
     var_ref="var_accounts_authorized_local_users_regex"/>
   </ind:textfilecontent54_state>

--- a/linux_os/guide/system/software/sudo/sudo_add_env_reset/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_add_env_reset/rule.yml
@@ -15,7 +15,7 @@ description: |-
 
 rationale: |-
     Forcing sudo to reset the environment ensures that environment variables are not passed on to the
-    command accidentaly, preventing leak of potentially sensitive information.
+    command accidentally, preventing leak of potentially sensitive information.
 
 severity: medium
 

--- a/linux_os/guide/system/software/sudo/sudoers_default_includedir/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudoers_default_includedir/rule.yml
@@ -16,8 +16,8 @@ description: |-
     Note that the '#' character doesn't denote a comment in the configuration file.
 
 rationale: |-
-   Some <tt>sudo</tt> configurtion options allow users to run programs without re-authenticating.
-   Use of these configuration options makes it easier for one compromised accound to be used to
+   Some <tt>sudo</tt> configuration options allow users to run programs without re-authenticating.
+   Use of these configuration options makes it easier for one compromised account to be used to
    compromise other accounts.
 
 severity: medium

--- a/linux_os/guide/system/software/sudo/sudoers_explicit_command_args/tests/false_positive.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_explicit_command_args/tests/false_positive.fail.sh
@@ -4,7 +4,7 @@
 # packages = sudo
 
 # The val1\,val2 is the first argument of the /bin/dog command that contains a comma.
-# Our check tends to interpret the comma as commad delimiter, so the dog arg is val1\
+# Our check tends to interpret the comma as command delimiter, so the dog arg is val1\
 # and val2 is another command in the user spec.
 echo 'nobody ALL=/bin/ls "", (!bob,alice) /bin/dog val1\,val2, /bin/cat ""' > /etc/sudoers
 

--- a/linux_os/guide/system/software/sudo/sudoers_validate_passwd/ansible/shared.yml
+++ b/linux_os/guide/system/software/sudo/sudoers_validate_passwd/ansible/shared.yml
@@ -21,7 +21,7 @@
 {{%- endmacro %}}
 
 {{%- macro delete_line_in_sudoers_file(line) %}}
-- name: "Remove any ocurrences of {{{ line }}} in /etc/sudoers"
+- name: "Remove any occurrences of {{{ line }}} in /etc/sudoers"
   ansible.builtin.lineinfile:
     path: "/etc/sudoers"
     regexp: "^{{{ line }}}$"

--- a/linux_os/guide/system/software/system-tools/package_scap-security-guide_installed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_scap-security-guide_installed/rule.yml
@@ -15,7 +15,7 @@ rationale: |-
     A system administrator can use the <tt>oscap</tt> CLI tool from the <tt>openscap-scanner</tt>
     package, or the SCAP Workbench GUI tool from the <tt>scap-workbench</tt> package, to verify
     that the system conforms to provided guidelines. Refer to the scap-security-guide(8) manual
-    page for futher information.
+    page for further information.
 
 severity: medium
 

--- a/linux_os/guide/system/software/updating/ensure_amazon_gpgkey_installed/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_amazon_gpgkey_installed/bash/shared.sh
@@ -1,5 +1,5 @@
 # platform = multi_platform_al
-# The fingerprint below are retrieved from the offical amazon linux 2023 machine
+# The fingerprint below are retrieved from the official amazon linux 2023 machine
 readonly AMAZON_RELEASE_FINGERPRINT="{{{ release_key_fingerprint }}}"
 
 # Location of the key we would like to import (once it's integrity verified)

--- a/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/rule.yml
@@ -7,7 +7,7 @@ description: |-
     To ensure the system can cryptographically verify base software
     packages come from Fedora (and to connect to the Fedora Network to
     receive them), the Fedora GPG key must properly be installed.
-    To install the Fedora GPG key, run one of the commands below, depending on your Fedora vesion:
+    To install the Fedora GPG key, run one of the commands below, depending on your Fedora version:
     <pre>$ sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-{{{ latest_version }}}-primary</pre>"
     <pre>$ sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-{{{ previous_version }}}-primary</pre>"
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -363,7 +363,7 @@ StrictHostKeyChecking no
 UserKnownHostsFile /dev/null
 ```
 
-All test logs are stored in `logs` directory. The specific diretory is shown at the beginning of each test run.
+All test logs are stored in `logs` directory. The specific directory is shown at the beginning of each test run.
 
 If you want more verbose logs, pass the `--dontclean` argument that preserves result files, reports and verbose scanner output
 even in cases when the test result went according to the expectations.
@@ -508,7 +508,7 @@ scenario will be executed using the tested profile. If there is the `profiles`
 key but it doesn't contain the tested profile the test scenario will be skipped
 and won't be executed. Most of the test scenarios do not have `profiles` key,
 therefore using the virtual `(all)` profile is the most frequent behavior.
-This way we can re-use test scenarios when testing any profile.
+This way we can reuse test scenarios when testing any profile.
 
 If you want to have a specific regression test only for a certain profile(s)
 which relies on a specific value being selected by some variable in this profile
@@ -535,7 +535,7 @@ If you would like to test all profile's rules against their test scenarios:
 
 In this mode you can test all rules that use a template.
 This is very useful when one fixes a bug or makes improvements to the template.
-Each rule may use the template in a specfic way and this provides a way to easily
+Each rule may use the template in a specific way and this provides a way to easily
 run the test scenarios for all rules based on their template.
 
 The test scenarios executed are based on the template and the rule that uses it.


### PR DESCRIPTION
#### Description:

- Fix typos in the linux_os and docs folder

#### Rationale:

- No typos, meaning better quality.
- I've used `codespell` to find and fix the typos, of course some of them are intentional or are not really a typo, so I had to manually remove some of the occurrences. The PR should not affect any coding aspect of the project. If that is the case then we need to ignore it.
- Some other directories can be fixed as well

Here is the command I ran in `linux_os` and `docs` folder:

`codespell . --skip=".git,node_modules,build,logs" --ignore-regex "chage|fpr|alse|notin|FPT" -w`

`-w` will write the suggestions whenever there is only one suggestion.

I don't plan to do any thorough analysis of typos in the project, this was just an experiment but it yielded okay results.
