### PR TITLE
[Ubuntu] Additional fix for rule ensure_root_access_controlled

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_root_access_controlled/tests/empty.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_root_access_controlled/tests/empty.fail.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 # packages = passwd
-{{% if product == 'ubuntu2204' %}}
-# platform = Not Applicable
-{{% else %}}
 # platform = multi_platform_all
-{{% endif %}}
 # remediation = none
 
 passwd -d root

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_root_access_controlled/tests/locked.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_root_access_controlled/tests/locked.pass.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # packages = passwd
+{{% if product == 'ubuntu2204' %}}
+# platform = Not Applicable
+{{% else %}}
 # platform = multi_platform_all
+{{% endif %}}
 
 passwd -l root


### PR DESCRIPTION
#### Description:

- Only allow password set for root on Ubuntu 2204 in tests

#### Rationale:

- Empty should fail in both cases (Ubuntu 22.04 cis requires password set, 24 cis requires locker or password set)
- Locked should pass in Ubuntu 24 not in 22
- Fix pr #13823