### PR TITLE
Make Ansible Tasks in GRUB rules idempotent

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/ansible/shared.yml
@@ -4,26 +4,29 @@
 # complexity = low
 # disruption = low
 
-- name: Verify GRUB_DISABLE_RECOVERY=true
+- name: {{{ rule_title }}} - Verify GRUB_DISABLE_RECOVERY=true
   ansible.builtin.lineinfile:
     path: /etc/default/grub
     regexp: '^GRUB_DISABLE_RECOVERY=.*'
     line: 'GRUB_DISABLE_RECOVERY=true'
     state: present
+  register: grub_disable_recovery_changed
 
-- name: Verify that Interactive Boot is Disabled in /etc/default/grub
+- name: {{{ rule_title }}} - Verify that Interactive Boot is Disabled in /etc/default/grub
   ansible.builtin.replace:
     dest: /etc/default/grub
     regexp: systemd.confirm_spawn(=(1|yes|true|on)|\b)
     replace: systemd.confirm_spawn=no
+  register: grub_confirm_spawn_changed
 
+- name: {{{ rule_title }}} - Verify that Interactive Boot is Disabled (runtime)
 {{% if 'sle' in product %}}
-- name: Verify that Interactive Boot is Disabled (runtime)
   ansible.builtin.command: /usr/bin/grub2-editenv - unset systemd.confirm_spawn
 {{% else %}}
-- name: Verify that Interactive Boot is Disabled (runtime)
   ansible.builtin.command: /sbin/grubby --update-kernel=ALL --remove-args="systemd.confirm_spawn"
 {{% endif %}}
+  when: grub_confirm_spawn_changed is changed
 
-- name: Regen grub.cfg handle updated GRUB_DISABLE_RECOVERY and confirm_spawn
+- name: {{{ rule_title }}} - Regen grub.cfg handle updated GRUB_DISABLE_RECOVERY and confirm_spawn
   ansible.builtin.command: grub2-mkconfig -o  {{{ grub2_boot_path }}}/grub.cfg
+  when: grub_disable_recovery_changed is changed or grub_confirm_spawn_changed is changed

--- a/linux_os/guide/system/bootloader-grub2/grub2_disable_recovery/ansible/shared.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_disable_recovery/ansible/shared.yml
@@ -4,17 +4,19 @@
 # complexity = low
 # disruption = low
 
-- name: Verify GRUB_DISABLE_RECOVERY=true
+- name: {{{ rule_title }}} - Verify GRUB_DISABLE_RECOVERY=true
   ansible.builtin.lineinfile:
     path: /etc/default/grub
     regexp: '^GRUB_DISABLE_RECOVERY=.*'
     line: 'GRUB_DISABLE_RECOVERY=true'
     state: present
+  register: grub_config_changed
 
 {{% if product in ['sle12', 'sle15'] %}}
-- name: Update grub defaults and the bootloader menu
+- name: {{{ rule_title }}} - Update grub defaults and the bootloader menu
   ansible.builtin.command: /usr/sbin/grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg
 {{% else %}}
-- name: Update grub defaults and the bootloader menu
+- name: {{{ rule_title }}} - Update grub defaults and the bootloader menu
   ansible.builtin.command: /sbin/grubby --update-kernel=ALL
+  when: grub_config_changed is changed
 {{% endif -%}}


### PR DESCRIPTION
This commit will make Ansible remediations for rule grub2_disable_interactive_boot and grub2_disable_recovery idempotent. Specifically, the tasks that execute the bootloader regenerations (execute grubby or grub2mkconfig) will be guarded by condition that will cause these tasks will be executed only if the configuration files were changed by the previous lineinfile task in the remediation.

Resolves: https://issues.redhat.com/browse/OPENSCAP-6242



#### Review Hints:

-  `./build_product --playbook-per-rule rhel9`
- manually replace hosts by `hosts: all` in build/rhel9/playbooks/ospp/grub2_disable_recovery.yml and  build/rhel9/playbooks/stig/grub2_disable_interactive_boot.yml
- run `ansible-playbook -u root -i 192.168.124.51, build/rhel9/playbooks/ospp/grub2_disable_recovery.yml` at least twice and compare the output of the first run with the second run and so on, verify that the second and next runs don't change anything and that the output contains only "ok" or "skipping"
- dtto with the second playbook
