### PR TITLE
Assign value to var_accounts_maximum_age_login_defs

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/commented_standard_fedora.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/commented_standard_fedora.fail.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_standard
 # platform = multi_platform_fedora
+# variables = var_accounts_maximum_age_login_defs=90
 
 rm -f {{{ login_defs_path }}}
 echo '#PASS_MAX_DAYS 90' > {{{ login_defs_path }}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/commented_stig.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/commented_stig.fail.sh
@@ -4,6 +4,7 @@
 {{% else %}}
 # profiles = xccdf_org.ssgproject.content_profile_stig
 {{% endif %}}
+# variables = var_accounts_maximum_age_login_defs=60
 
 
 rm -f {{{ login_defs_path }}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/correct_cis.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/correct_cis.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_cis
+# variables = var_accounts_maximum_age_login_defs=365
 
 rm -f {{{ login_defs_path }}}
 echo "PASS_MAX_DAYS        365" > {{{ login_defs_path }}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/correct_standard_fedora.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/correct_standard_fedora.pass.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_standard
 # platform = multi_platform_fedora
+# variables = var_accounts_maximum_age_login_defs=90
 
 rm -f {{{ login_defs_path }}}
 echo "PASS_MAX_DAYS    90" > {{{ login_defs_path }}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/correct_stig.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/correct_stig.pass.sh
@@ -4,6 +4,7 @@
 {{% else %}}
 # profiles = xccdf_org.ssgproject.content_profile_stig
 {{% endif %}}
+# variables = var_accounts_maximum_age_login_defs=60
 
 rm -f {{{ login_defs_path }}}
 echo "PASS_MAX_DAYS        60" > {{{ login_defs_path }}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/correct_stig_double.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/correct_stig_double.pass.sh
@@ -4,6 +4,7 @@
 {{% else %}}
 # profiles = xccdf_org.ssgproject.content_profile_stig
 {{% endif %}}
+# variables = var_accounts_maximum_age_login_defs=60
 
 
 rm -f {{{ login_defs_path }}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/incorrect_cis.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/incorrect_cis.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_cis
+# variables = var_accounts_maximum_age_login_defs=365
 
 rm -f {{{ login_defs_path }}}
 echo "PASS_MAX_DAYS        375" > {{{ login_defs_path }}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/incorrect_standard_fedora.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/incorrect_standard_fedora.fail.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_standard
 # platform = multi_platform_fedora
+# variables = var_accounts_maximum_age_login_defs=90
 
 rm -f {{{ login_defs_path }}}
 echo "PASS_MAX_DAYS 120" > {{{ login_defs_path }}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/incorrect_stig.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/incorrect_stig.fail.sh
@@ -4,6 +4,7 @@
 {{% else %}}
 # profiles = xccdf_org.ssgproject.content_profile_stig
 {{% endif %}}
+# variables = var_accounts_maximum_age_login_defs=60
 
 
 rm -f {{{ login_defs_path }}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/incorrect_stig_double.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/tests/incorrect_stig_double.fail.sh
@@ -4,6 +4,7 @@
 {{% else %}}
 # profiles = xccdf_org.ssgproject.content_profile_stig
 {{% endif %}}
+# variables = var_accounts_maximum_age_login_defs=60
 
 
 rm -f {{{ login_defs_path }}}


### PR DESCRIPTION
#### Description:

- Assign value to var_accounts_maximum_age_login_defs

#### Rationale:

- If run automatus.py rule test with profile (all), test script's value of var_accounts_maximum_age_login_defs is default one