### PR TITLE
Fix some ansible remediation jinja substitution and remove obsolete code from `ensure_redhat_gpgkey_installed`

### DIFF
--- a/linux_os/guide/system/permissions/files/dir_system_commands_group_root_owned/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/dir_system_commands_group_root_owned/ansible/shared.yml
@@ -4,7 +4,7 @@
 # complexity = medium
 # disruption = medium
 
--  name: "{{{ RULE_TITLE }}} - Set group ownership of directories that contain system commands to root"
+-  name: "{{{ rule_title }}} - Set group ownership of directories that contain system commands to root"
    ansible.builtin.file: 
      path: "{{ item }}"
      group: "root"

--- a/linux_os/guide/system/permissions/files/dir_system_commands_root_owned/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/dir_system_commands_root_owned/ansible/shared.yml
@@ -4,7 +4,7 @@
 # complexity = medium
 # disruption = medium
 
--  name: "{{{ RULE_TITLE }}} - Set ownership of directories that contain system commands to root"
+-  name: "{{{ rule_title }}} - Set ownership of directories that contain system commands to root"
    ansible.builtin.file: 
      path: "{{ item }}"
      owner: "root"

--- a/linux_os/guide/system/selinux/selinux_not_disabled/ansible/shared.yml
+++ b/linux_os/guide/system/selinux/selinux_not_disabled/ansible/shared.yml
@@ -6,7 +6,7 @@
 
 {{{ ansible_selinux_config_set(parameter="SELINUX", value="permissive", rule_title=rule_title) }}}
 
-- name: "{{{ RULE_TITLE }}} - Mark system to relabel SELinux on next boot"
+- name: "{{{ rule_title }}} - Mark system to relabel SELinux on next boot"
   ansible.builtin.file:
     path: /.autorelabel
     state: touch

--- a/linux_os/guide/system/selinux/selinux_state/ansible/shared.yml
+++ b/linux_os/guide/system/selinux/selinux_state/ansible/shared.yml
@@ -7,7 +7,7 @@
 
 {{{ ansible_selinux_config_set(parameter="SELINUX", value="{{ var_selinux_state }}", rule_title=rule_title) }}}
 
-- name: "{{{ RULE_TITLE }}} - Mark system to relabel SELinux on next boot"
+- name: "{{{ rule_title }}} - Mark system to relabel SELinux on next boot"
   ansible.builtin.file:
     path: /.autorelabel
     state: touch

--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/ansible/shared.yml
@@ -13,11 +13,7 @@
 
 - name: Read signatures in GPG key
   # According to /usr/share/doc/gnupg2/DETAILS fingerprints are in "fpr" record in field 10
-  {{% if product in ['rhel8', 'rhel9'] -%}}
   ansible.builtin.command: gpg --show-keys --with-fingerprint --with-colons "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
-  {{%- else -%}}
-  ansible.builtin.command: gpg --with-fingerprint --with-colons "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
-  {{%- endif %}}
   changed_when: False
   register: gpg_fingerprints
   failed_when: False

--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/bash/shared.sh
@@ -13,11 +13,7 @@ if [ "${RPM_GPG_DIR_PERMS}" -le "755" ]
 then
   # If they are safe, try to obtain fingerprints from the key file
   # (to ensure there won't be e.g. CRC error).
-{{% if product in ["rhel8", "rhel9", "rhv4"] %}}
   readarray -t GPG_OUT < <(gpg --show-keys --with-fingerprint --with-colons "$REDHAT_RELEASE_KEY" | grep -A1 "^pub" | grep "^fpr" | cut -d ":" -f 10)
-{{% else %}}
-  readarray -t GPG_OUT < <(gpg --with-fingerprint --with-colons "$REDHAT_RELEASE_KEY" | grep "^fpr" | cut -d ":" -f 10)
-{{% endif %}}
   GPG_RESULT=$?
   # No CRC error, safe to proceed
   if [ "${GPG_RESULT}" -eq "0" ]


### PR DESCRIPTION
#### Description:

- This PR fixes a case where the ansible remediation was using a wrong property for the rule_title attribute, it needs to be lower case, otherwise it renders an empty string
- It also removes some obsolete remediation code for the rule `ensure_redhat_gpgkey_installed`.
- See individual commit messages for more details.
