### PR TITLE
Improve ansible remediation of `configure_crypto_policy`

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/ansible/shared.yml
@@ -20,5 +20,11 @@
     line: "{{ var_system_crypto_policy }}"
     create: yes
 
+- name: Check current Crypto Policy (runtime)
+  ansible.builtin.command: /usr/bin/update-crypto-policies --show
+  changed_when: False
+  register: current_crypto_policy
+
 - name: Verify that Crypto Policy is Set (runtime)
   ansible.builtin.command: /usr/bin/update-crypto-policies --set {{ var_system_crypto_policy }}
+  when: current_crypto_policy.stdout.strip() != var_system_crypto_policy


### PR DESCRIPTION
#### Description:

- Modify the ansible remediation to execute `/usr/bin/update-crypto-policies --set` only when the current crypto-policy is different than the expected.
