### PR TITLE
Only run dconf when there is an actual change in previous tasks for dconf gnome ansible remediations

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/ansible/shared.yml
@@ -11,6 +11,8 @@
     value: "true"
     create: yes
     no_extra_spaces: yes
+  register: result_ini
+  changed_when: result_ini.changed
 
 - name: "Prevent user modification of GNOME banner-message-enabled"
   ansible.builtin.lineinfile:
@@ -18,6 +20,9 @@
     regexp: '^/org/gnome/login-screen/banner-message-enable$'
     line: '/org/gnome/login-screen/banner-message-enable'
     create: yes
+  register: result_lineinfile
+  changed_when: result_lineinfile.changed
 
 - name: Dconf Update
   ansible.builtin.command: dconf update
+  when: result_ini.changed or result_lineinfile.changed

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/ansible/shared.yml
@@ -35,6 +35,8 @@
     value: '{{{ ansible_deregexify_banner_dconf_gnome("login_banner_text") }}}'
     create: yes
     no_extra_spaces: yes
+  register: result_ini
+  changed_when: result_ini.changed
 
 - name: "Prevent user modification of the GNOME3 Login Warning Banner Text"
   ansible.builtin.lineinfile:
@@ -43,6 +45,9 @@
     line: '/org/gnome/login-screen/banner-message-text'
     create: yes
     state: present
+  register: result_lineinfile
+  changed_when: result_lineinfile.changed
 
 - name: Dconf Update
   ansible.builtin.command: dconf update
+  when: result_ini.changed or result_lineinfile.changed

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/ansible/shared.yml
@@ -11,6 +11,8 @@
     value: "true"
     create: yes
     no_extra_spaces: yes
+  register: result_ini
+  changed_when: result_ini.changed
 
 - name: "Prevent user modification of GNOME disablement of Login Restart and Shutdown Buttons"
   ansible.builtin.lineinfile:
@@ -18,6 +20,9 @@
     regexp: '^/org/gnome/login-screen/disable-restart-buttons'
     line: '/org/gnome/login-screen/disable-restart-buttons'
     create: yes
+  register: result_lineinfile
+  changed_when: result_lineinfile.changed
 
 - name: Dconf Update
   ansible.builtin.command: dconf update
+  when: result_ini.changed or result_lineinfile.changed

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/ansible/shared.yml
@@ -11,6 +11,8 @@
     value: "true"
     no_extra_spaces: yes
     create: yes
+  register: result_ini
+  changed_when: result_ini.changed
 
 - name: "Prevent user modification of GNOME3 disablement of Login User List"
   ansible.builtin.lineinfile:
@@ -18,6 +20,9 @@
     regexp: '^/org/gnome/login-screen/disable-user-list$'
     line: '/org/gnome/login-screen/disable-user-list'
     create: yes
+  register: result_lineinfile
+  changed_when: result_lineinfile.changed
 
 - name: Dconf Update
   ansible.builtin.command: dconf update
+  when: result_ini.changed or result_lineinfile.changed

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/ansible/shared.yml
@@ -11,6 +11,8 @@
     value: "true"
     create: yes
     no_extra_spaces: yes
+  register: result_ini
+  changed_when: result_ini.changed
 
 - name: "Prevent user modification of GNOME3 disablement of Smartcard Authentication"
   ansible.builtin.lineinfile:
@@ -18,6 +20,9 @@
     regexp: '^/org/gnome/login-screen/enable-smartcard-authentication$'
     line: '/org/gnome/login-screen/enable-smartcard-authentication'
     create: yes
+  register: result_lineinfile
+  changed_when: result_lineinfile.changed
 
 - name: Dconf Update
   ansible.builtin.command: dconf update
+  when: result_ini.changed or result_lineinfile.changed

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/ansible/shared.yml
@@ -11,6 +11,8 @@
     value: "3"
     create: yes
     no_extra_spaces: yes
+  register: result_ini
+  changed_when: result_ini.changed
 
 - name: "Prevent user modification of GNOME3 Login Number of Failures"
   ansible.builtin.lineinfile:
@@ -18,6 +20,9 @@
     regexp: '^/org/gnome/login-screen/allowed-failures$'
     line: '/org/gnome/login-screen/allowed-failures'
     create: yes
+  register: result_lineinfile
+  changed_when: result_lineinfile.changed
 
 - name: Dconf Update
   ansible.builtin.command: dconf update
+  when: result_ini.changed or result_lineinfile.changed

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount/ansible/shared.yml
@@ -11,6 +11,8 @@
     value: "false"
     create: yes
     no_extra_spaces: yes
+  register: result_ini
+  changed_when: result_ini.changed
 
 - name: "Prevent user modification of GNOME3 Automounting - automount"
   ansible.builtin.lineinfile:
@@ -18,6 +20,9 @@
     regexp: '^/org/gnome/desktop/media-handling/automount$'
     line: '/org/gnome/desktop/media-handling/automount'
     create: yes
+  register: result_lineinfile
+  changed_when: result_lineinfile.changed
 
 - name: Dconf Update
   ansible.builtin.command: dconf update
+  when: result_ini.changed or result_lineinfile.changed

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount_open/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount_open/ansible/shared.yml
@@ -11,6 +11,8 @@
     value: "false"
     create: yes
     no_extra_spaces: yes
+  register: result_ini
+  changed_when: result_ini.changed
 
 - name: "Prevent user modification of GNOME3 Automounting - automount-open"
   ansible.builtin.lineinfile:
@@ -18,6 +20,9 @@
     regexp: '^/org/gnome/desktop/media-handling/automount-open$'
     line: '/org/gnome/desktop/media-handling/automount-open'
     create: yes
+  register: result_lineinfile
+  changed_when: result_lineinfile.changed
 
 - name: Dconf Update
   ansible.builtin.command: dconf update
+  when: result_ini.changed or result_lineinfile.changed

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_autorun/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_autorun/ansible/shared.yml
@@ -11,6 +11,8 @@
     value: "true"
     create: yes
     no_extra_spaces: yes
+  register: result_ini
+  changed_when: result_ini.changed
 
 - name: "Prevent user modification of GNOME3 Automounting - autorun-never"
   ansible.builtin.lineinfile:
@@ -18,6 +20,9 @@
     regexp: '^/org/gnome/desktop/media-handling/autorun-never$'
     line: '/org/gnome/desktop/media-handling/autorun-never'
     create: yes
+  register: result_lineinfile
+  changed_when: result_lineinfile.changed
 
 - name: Dconf Update
   ansible.builtin.command: dconf update
+  when: result_ini.changed or result_lineinfile.changed

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_thumbnailers/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_thumbnailers/ansible/shared.yml
@@ -11,6 +11,8 @@
     value: "true"
     create: yes
     no_extra_spaces: yes
+  register: result_ini
+  changed_when: result_ini.changed
 
 - name: "Prevent user modification of GNOME3 Thumbnailers"
   ansible.builtin.lineinfile:
@@ -18,6 +20,9 @@
     regexp: '^/org/gnome/desktop/thumbnailers/disable-all$'
     line: '/org/gnome/desktop/thumbnailers/disable-all'
     create: yes
+  register: result_lineinfile
+  changed_when: result_lineinfile.changed
 
 - name: Dconf Update
   ansible.builtin.command: dconf update
+  when: result_ini.changed or result_lineinfile.changed

--- a/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_create/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_create/ansible/shared.yml
@@ -11,6 +11,8 @@
     value: "true"
     create: yes
     no_extra_spaces: yes
+  register: result_ini
+  changed_when: result_ini.changed
 
 - name: "Prevent user modification of GNOME3 disablement of WiFi"
   ansible.builtin.lineinfile:
@@ -18,6 +20,9 @@
     regexp: '^/org/gnome/nm-applet/disable-wifi-create$'
     line: '/org/gnome/nm-applet/disable-wifi-create'
     create: yes
+  register: result_lineinfile
+  changed_when: result_lineinfile.changed
 
 - name: Dconf Update
   ansible.builtin.command: dconf update
+  when: result_ini.changed or result_lineinfile.changed

--- a/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_notification/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_notification/ansible/shared.yml
@@ -11,6 +11,8 @@
     value: "true"
     create: yes
     no_extra_spaces: yes
+  register: result_ini
+  changed_when: result_ini.changed
 
 - name: "Prevent user modification of GNOME3 disablement of WiFi"
   ansible.builtin.lineinfile:
@@ -18,6 +20,9 @@
     regexp: '^/org/gnome/nm-applet/suppress-wireless-networks-available$'
     line: '/org/gnome/nm-applet/suppress-wireless-networks-available'
     create: yes
+  register: result_lineinfile
+  changed_when: result_lineinfile.changed
 
 - name: Dconf Update
   ansible.builtin.command: dconf update
+  when: result_ini.changed or result_lineinfile.changed

--- a/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_credential_prompt/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_credential_prompt/ansible/shared.yml
@@ -11,6 +11,8 @@
     value: "['vnc']"
     create: yes
     no_extra_spaces: yes
+  register: result_ini
+  changed_when: result_ini.changed
 
 - name: "Prevent user modification of GNOME3 Credential Prompting for Remote Access"
   ansible.builtin.lineinfile:
@@ -18,6 +20,9 @@
     regexp: '^/org/gnome/Vino/authentication-methods$'
     line: '/org/gnome/Vino/authentication-methods'
     create: yes
+  register: result_lineinfile
+  changed_when: result_lineinfile.changed
 
 - name: Dconf Update
   ansible.builtin.command: dconf update
+  when: result_ini.changed or result_lineinfile.changed

--- a/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_encryption/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_remote_access_settings/dconf_gnome_remote_access_encryption/ansible/shared.yml
@@ -11,6 +11,8 @@
     value: "true"
     create: yes
     no_extra_spaces: yes
+  register: result_ini
+  changed_when: result_ini.changed
 
 - name: "Prevent user modification of GNOME3 Encryption for Remote Access"
   ansible.builtin.lineinfile:
@@ -18,6 +20,9 @@
     regexp: '^/org/gnome/Vino/require-encryption$'
     line: '/org/gnome/Vino/require-encryption'
     create: yes
+  register: result_lineinfile
+  changed_when: result_lineinfile.changed
 
 - name: Dconf Update
   ansible.builtin.command: dconf update
+  when: result_ini.changed or result_lineinfile.changed

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/ansible/shared.yml
@@ -11,6 +11,8 @@
     value: "true"
     create: yes
     no_extra_spaces: yes
+  register: result_ini
+  changed_when: result_ini.changed
 
 - name: "Prevent user modification of GNOME idle-activation-enabled"
   ansible.builtin.lineinfile:
@@ -18,6 +20,9 @@
     regexp: '^/org/gnome/desktop/screensaver/idle-activation-enabled$'
     line: '/org/gnome/desktop/screensaver/idle-activation-enabled'
     create: yes
+  register: result_lineinfile
+  changed_when: result_lineinfile.changed
 
 - name: Dconf Update
   ansible.builtin.command: dconf update
+  when: result_ini.changed or result_lineinfile.changed

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/ansible/shared.yml
@@ -9,6 +9,9 @@
     regexp: '^/org/gnome/desktop/screensaver/idle-activation-enabled$'
     line: '/org/gnome/desktop/screensaver/idle-activation-enabled'
     create: yes
+  register: result_lineinfile
+  changed_when: result_lineinfile.changed
 
 - name: Dconf Update
   ansible.builtin.command: dconf update
+  when: result_lineinfile.changed

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/ansible/shared.yml
@@ -13,6 +13,9 @@
     value: "uint32 {{ inactivity_timeout_value }}"
     create: yes
     no_extra_spaces: yes
+  register: result_ini
+  changed_when: result_ini.changed
 
 - name: Dconf Update
   ansible.builtin.command: dconf update
+  when: result_ini.changed

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/ansible/shared.yml
@@ -13,6 +13,9 @@
     value: "uint32 {{ var_screensaver_lock_delay }}"
     create: yes
     no_extra_spaces: yes
+  register: result_ini
+  changed_when: result_ini.changed
 
 - name: Dconf Update
   ansible.builtin.command: dconf update
+  when: result_ini.changed

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/ansible/shared.yml
@@ -9,6 +9,9 @@
     regexp: '^/org/gnome/desktop/screensaver/lock-enabled$'
     line: '/org/gnome/desktop/screensaver/lock-enabled'
     create: yes
+  register: result_lineinfile
+  changed_when: result_lineinfile.changed
 
 - name: Dconf Update
   ansible.builtin.command: dconf update
+  when: result_lineinfile.changed

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/ansible/shared.yml
@@ -11,6 +11,8 @@
     value: string ''
     create: yes
     no_extra_spaces: yes
+  register: result_ini
+  changed_when: result_ini.changed
 
 - name: "Prevent user modification of GNOME picture-uri"
   ansible.builtin.lineinfile:
@@ -18,6 +20,9 @@
     regexp: '^/org/gnome/desktop/screensaver/picture-uri$'
     line: '/org/gnome/desktop/screensaver/picture-uri'
     create: yes
+  register: result_lineinfile
+  changed_when: result_lineinfile.changed
 
 - name: Dconf Update
   ansible.builtin.command: dconf update
+  when: result_ini.changed or result_lineinfile.changed

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_info/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_info/ansible/shared.yml
@@ -11,6 +11,8 @@
     value: "false"
     create: yes
     no_extra_spaces: yes
+  register: result_ini
+  changed_when: result_ini.changed
 
 - name: "Prevent user modification of GNOME show-full-name-in-top-bar"
   ansible.builtin.lineinfile:
@@ -18,6 +20,9 @@
     regexp: '^/org/gnome/desktop/screensaver/show-full-name-in-top-bar$'
     line: '/org/gnome/desktop/screensaver/show-full-name-in-top-bar'
     create: yes
+  register: result_lineinfile
+  changed_when: result_lineinfile.changed
 
 - name: Dconf Update
   ansible.builtin.command: dconf update
+  when: result_ini.changed or result_lineinfile.changed

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/ansible/shared.yml
@@ -9,6 +9,9 @@
     regexp: '^/org/gnome/desktop/screensaver/lock-delay$'
     line: '/org/gnome/desktop/screensaver/lock-delay'
     create: yes
+  register: result_lineinfile
+  changed_when: result_lineinfile.changed
 
 - name: Dconf Update
   ansible.builtin.command: dconf update
+  when: result_lineinfile.changed

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/ansible/shared.yml
@@ -10,6 +10,9 @@
     regexp: '^/org/gnome/desktop/session/idle-delay$'
     line: '/org/gnome/desktop/session/idle-delay'
     create: yes
+  register: result_lineinfile
+  changed_when: result_lineinfile.changed
 
 - name: Dconf Update
   ansible.builtin.command: dconf update
+  when: result_lineinfile.changed

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/ansible/shared.yml
@@ -11,6 +11,8 @@
     value: "['']"
     create: yes
     no_extra_spaces: yes
+  register: result_ini
+  changed_when: result_ini.changed
 
 - name: "Prevent user modification of GNOME disablement of Ctrl-Alt-Del"
   ansible.builtin.lineinfile:
@@ -18,6 +20,9 @@
     regexp: '^/org/gnome/settings-daemon/plugins/media-keys/logout$'
     line: '/org/gnome/settings-daemon/plugins/media-keys/logout'
     create: yes
+  register: result_lineinfile
+  changed_when: result_lineinfile.changed
 
 - name: Dconf Update
   ansible.builtin.command: dconf update
+  when: result_ini.changed or result_lineinfile.changed

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_geolocation/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_geolocation/ansible/shared.yml
@@ -11,6 +11,8 @@
     value: "false"
     create: yes
     no_extra_spaces: yes
+  register: result_ini1
+  changed_when: result_ini1.changed
 
 - name: "Disable Geolocation in GNOME3 - clock location tracking"
   community.general.ini_file:
@@ -19,6 +21,8 @@
     option: gelocation
     value: "false"
     create: yes
+  register: result_ini2
+  changed_when: result_ini2.changed
 
 - name: "Prevent user modification of GNOME geolocation - location tracking"
   ansible.builtin.lineinfile:
@@ -26,6 +30,8 @@
     regexp: '^/org/gnome/system/location/enabled$'
     line: '/org/gnome/system/location/enabled'
     create: yes
+  register: result_lineinfile1
+  changed_when: result_lineinfile1.changed
 
 - name: "Prevent user modification of GNOME geolocation - clock location tracking"
   ansible.builtin.lineinfile:
@@ -33,6 +39,9 @@
     regexp: '^/org/gnome/clocks/geolocation$'
     line: '/org/gnome/clocks/geolocation'
     create: yes
+  register: result_lineinfile2
+  changed_when: result_lineinfile2.changed
 
 - name: Dconf Update
   ansible.builtin.command: dconf update
+  when: result_ini1.changed or result_ini2.changed or result_lineinfile1.changed or result_lineinfile2.changed


### PR DESCRIPTION
#### Description:

- Only run dconf when there is an actual change in previous tasks for dconf gnome ansible remediations
