### PR TITLE
Postfix: Use systemd to restart

### DIFF
--- a/linux_os/guide/services/mail/has_nonlocal_mta/tests/correct.pass.sh
+++ b/linux_os/guide/services/mail/has_nonlocal_mta/tests/correct.pass.sh
@@ -2,4 +2,4 @@
 # packages = postfix
 
 echo "inet_interfaces = localhost" > /etc/postfix/main.cf
-postfix stop || postfix start
+systemctl restart postfix

--- a/linux_os/guide/services/mail/has_nonlocal_mta/tests/wrong.fail.sh
+++ b/linux_os/guide/services/mail/has_nonlocal_mta/tests/wrong.fail.sh
@@ -3,4 +3,4 @@
 # remediation = none
 
 echo "inet_interfaces = all" > /etc/postfix/main.cf
-postfix stop || postfix start
+systemctl restart postfix


### PR DESCRIPTION
#### Description:

- Use systemd to restart postfix service so that the config could take effect properly

#### Rationale:
