### PR TITLE
[Ubuntu] Override the service name

### DIFF
--- a/linux_os/guide/services/smb/disabling_samba/service_smb_disabled/rule.yml
+++ b/linux_os/guide/services/smb/disabling_samba/service_smb_disabled/rule.yml
@@ -1,7 +1,6 @@
 documentation_complete: true
 
-
-title: 'Disable Samba'
+title: "Disable Samba"
 
 description: |-
     {{{ describe_service_disable(service="smb") }}}
@@ -35,5 +34,6 @@ template:
     name: service_disabled
     vars:
         servicename: smb
+        servicename@ubuntu2204: smbd
         servicename@ubuntu2404: smbd
         packagename: samba


### PR DESCRIPTION
#### Description:

- Override the service name for Ubuntu 2204

#### Rationale:

- kvm result
```
Setting console output to log level INFO
INFO - The base image option has not been specified, choosing libvirt-based test environment.
INFO - Logging into /home/am/git-pulls/content/logs/rule-custom-2025-09-25-1443/test_suite.log
INFO - xccdf_org.ssgproject.content_rule_service_smb_disabled
INFO - Script service_enabled.fail.sh using profile (all) OK
INFO - Script service_disabled.pass.sh using profile (all) OK
```