### PR TITLE
[Ubuntu] Override tftp name for Ubuntu release

### DIFF
--- a/linux_os/guide/services/obsolete/tftp/package_tftp-server_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/tftp/package_tftp-server_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-{{% if product in ['ubuntu2404'] %}}
+{{% if 'ubuntu' in product %}}
 {{% set package_name = "tftpd-hpa" %}}
 {{% else %}}
 {{% set package_name = "tftp-server" %}}

--- a/linux_os/guide/services/obsolete/tftp/service_tftp_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/tftp/service_tftp_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-{{% if product in ['ubuntu2404'] %}}
+{{% if 'ubuntu' in product %}}
 {{% set service_name = "tftpd-hpa" %}}
 {{% set package_name = "tftpd-hpa" %}}
 {{% else %}}


### PR DESCRIPTION
#### Description:

- Override tftp name for Ubuntu release

#### Rationale:

- This tftp package name is consistent 