### PR TITLE
[Ubuntu] Enable nouser sce for Ubuntu 22.04

### DIFF
--- a/linux_os/guide/system/permissions/files/no_files_unowned_by_user/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/no_files_unowned_by_user/oval/shared.xml
@@ -1,4 +1,4 @@
-{{% if product not in ['ubuntu2404'] %}}
+{{% if 'ubuntu' not in product %}}
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("All files should be owned by a user", rule_title=rule_title) }}}

--- a/linux_os/guide/system/permissions/files/no_files_unowned_by_user/sce/shared.sh
+++ b/linux_os/guide/system/permissions/files/no_files_unowned_by_user/sce/shared.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# platform = multi_platform_fedora,multi_platform_rhel,Ubuntu 24.04
+# platform = multi_platform_fedora,multi_platform_rhel,multi_platform_ubuntu
 # check-import = stdout
 
 {{{ find_files(find_parameters="-nouser", fail_message="Found unowned files") }}}


### PR DESCRIPTION
#### Description:

- Disable oval for Ubuntu2204 as we did in Ubuntu2404
- Enable nouser sce for Ubuntu 22.04

#### Rationale:

- kvm result:
```
Setting console output to log level INFO
INFO - The base image option has not been specified, choosing libvirt-based test environment.
INFO - Logging into /home/am/git-pulls/content/logs/rule-custom-2025-09-25-1507/test_suite.log
INFO - xccdf_org.ssgproject.content_rule_no_files_unowned_by_user
INFO - Script unowned_file_tmp.fail.sh using profile (all) OK
INFO - Script unowned_file.fail.sh using profile (all) OK
INFO - Script all_owned.pass.sh using profile (all) OK
```