### PR TITLE
[Ubuntu] Fix _guard var for package_iptables_installed

### DIFF
--- a/linux_os/guide/system/network/network-iptables/package_iptables_installed/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/package_iptables_installed/rule.yml
@@ -33,7 +33,7 @@ ocil_clause: 'the package is not installed'
 
 ocil: '{{{ ocil_package(package="iptables") }}}'
 
-{{%- if product in [ "sle12", "sle15", "ubuntu2404" ] %}}
+{{%- if product in [ "sle12", "sle15" ] or 'ubuntu' in product %}}
 template:
     name: package_installed_guard_var
     vars:


### PR DESCRIPTION
#### Description:

- Fix _guard var for package_iptables_installed

#### Rationale: