### PR TITLE
Rewrite Ansible remediation in accounts_user_dot_user_ownership

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/ansible/shared.yml
@@ -4,7 +4,39 @@
 # complexity = low
 # disruption = low
 
-- name: Ensure interactive local users are the owners of their respective initialization files
-  ansible.builtin.shell:
-    cmd: |
-      awk -F: '{if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) print $3":"$6}' /etc/passwd | while IFS=: read -r uid home; do find -P "$home" -maxdepth 1 -type f -name "\.[^.]*" -exec chown -f --no-dereference -- $uid "{}" \;; done
+- name: {{{ rule_title }}} - Get interactive users from passwd file
+  ansible.builtin.getent:
+    database: passwd
+  register: passwd_entries
+
+- name: {{{ rule_title }}} - Create list of interactive users with UID and home directory
+  ansible.builtin.set_fact:
+    interactive_users: "{{ interactive_users | default([]) + [{'uid': item.value[1], 'home': item.value[4], 'username': item.key}] }}"
+  loop: "{{ passwd_entries.ansible_facts.getent_passwd | dict2items }}"
+  when:
+    - item.value[1] | int >= {{{ uid_min }}} | int
+    - item.value[1] | int != {{{ nobody_uid }}} | int
+    - item.value[4] != ""
+
+- name: {{{ rule_title }}} - Find dot files in interactive user home directories
+  ansible.builtin.find:
+    paths: "{{ item.home }}"
+    patterns: ".*"
+    file_type: file
+    hidden: yes
+    depth: 1
+    follow: no
+  register: user_dotfiles
+  loop: "{{ interactive_users | default([]) }}"
+  failed_when: false
+  when: item.home != ""
+
+- name: {{{ rule_title }}} - Set correct ownership for user initialization files
+  ansible.builtin.file:
+    path: "{{ item.1.path }}"
+    owner: "{{ item.0.item.username }}"
+    follow: no
+  loop: "{{ user_dotfiles.results | subelements('files', skip_missing=True) }}"
+  when:
+    - item.0 is not skipped
+    - item.1.path is defined


### PR DESCRIPTION
Rewrite the remediation by using specialized modules instead of the shell module. Consequently, the remediation becomes idempotent.

Resolves: https://issues.redhat.com/browse/OPENSCAP-6250

#### Review Hints:

- `./build_product --playbook-per-rule rhel9`
- manually replace hosts by `hosts: all` in build/rhel9/playbooks/cis/accounts_user_dot_user_ownership.yml 
- run `ansible-playbook -u root -i YOUR_IP, build/rhel9/playbooks/cis/accounts_user_dot_user_ownership.yml` at least twice and compare the output of the first run with the second run and so on, verify that the second and next runs don't change anything and that the output contains only "ok" or "skipping"

- apart from that, run automatus Tss with `--remediate-using ansible`
