### PR TITLE
Make Ansible in aide_build_database idempotent

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/ansible/shared.yml
@@ -26,15 +26,16 @@
   with_items:
     - aide
 
-- name: "{{{ rule_title }}} - Build and Test AIDE Database"
-  ansible.builtin.command: {{{ aide_init_command }}}
-  changed_when: True
-
-# mainly to allow ansible's check mode to work
 - name: "{{{ rule_title }}} - Check Whether the Stock AIDE Database Exists"
   ansible.builtin.stat:
      path: {{{ aide_stage_src }}}
   register: aide_database_stat
+
+- name: "{{{ rule_title }}} - Build and Test AIDE Database"
+  ansible.builtin.command: {{{ aide_init_command }}}
+  changed_when: True
+  when: not (aide_database_stat.stat.exists is defined and aide_database_stat.stat.exists)
+  register: aide_database_init
 
 - name: "{{{ rule_title }}} - Stage AIDE Database"
   ansible.builtin.copy:
@@ -42,4 +43,4 @@
     dest: {{{ aide_stage_dest }}}
     backup: yes
     remote_src: yes
-  when: (aide_database_stat.stat.exists is defined and aide_database_stat.stat.exists)
+  when: aide_database_init is changed


### PR DESCRIPTION
Initialize AIDE database only if it hasn't been initialized yet.

Resolves: https://issues.redhat.com/browse/OPENSCAP-6233


#### Review Hints:

- `./build_product --playbook-per-rule rhel9`
- manually replace hosts by `hosts: all` in `build/rhel9/playbooks/stig/aide_build_database.yml`
- run `ansible-playbook -u root -i YOUR_IP, build/rhel9/playbooks/stig/aide_build_database.yml` at least twice and compare the output of the first run with the second run and so on, verify that the second and next runs don't change anything and that the output contains only "ok" or "skipping"
- apart from that, run automatus Tss with `--remediate-using ansible`