### PR TITLE
Make Ansible in fips_custom_stig_sub_policy idempotent

### DIFF
--- a/linux_os/guide/system/software/integrity/fips/fips_custom_stig_sub_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/fips/fips_custom_stig_sub_policy/ansible/shared.yml
@@ -24,6 +24,14 @@
         create: true
         regexp: "^mac@SSH="
 
+-   name: "{{{ rule_title }}} - Check current crypto policy"
+    ansible.builtin.command: update-crypto-policies --show
+    register: current_crypto_policy
+    changed_when: false
+    failed_when: false
+    check_mode: false
+
 -   name: "{{{ rule_title }}} - Update crypto-policies"
     ansible.builtin.command: update-crypto-policies --set FIPS:STIG
+    when: current_crypto_policy.stdout.strip() != "FIPS:STIG"
 


### PR DESCRIPTION
The update-crypto-policies command shouldn't be executed if the crypto policy is already set to "FIPS:STIG".

Resolves: https://issues.redhat.com/browse/OPENSCAP-6232


#### Review Hints:

- `./build_product --playbook-per-rule rhel9`
- manually replace hosts by `hosts: all` in build/rhel9/playbooks/stig/fips_custom_stig_sub_policy.yml
- run `ansible-playbook -u root -i YOUR_IP, build/rhel9/playbooks/stig/fips_custom_stig_sub_policy.yml` at least twice and compare the output of the first run with the second run and so on, verify that the second and next runs don't change anything and that the output contains only "ok" or "skipping"
- apart from that, run automatus Tss with `--remediate-using ansible`
