### PR TITLE
Improving regexes in aide_check_audit_tools

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/bash/shared.sh
@@ -7,25 +7,25 @@
 {{{ bash_package_install("aide") }}}
 
 {{% set auditfiles = [
-      "/usr/sbin/auditctl",
-      "/usr/sbin/auditd",
-      "/usr/sbin/ausearch",
-      "/usr/sbin/aureport",
-      "/usr/sbin/autrace",
-      "/usr/sbin/augenrules" ] %}}
+      "auditctl",
+      "auditd",
+      "ausearch",
+      "aureport",
+      "autrace",
+      "augenrules" ] %}}
 
 {{% if aide_also_checks_audispd == "yes" %}}
-{{% set auditfiles = auditfiles + ["/usr/sbin/audispd"] %}}
+{{% set auditfiles = auditfiles + ["audispd"] %}}
 {{% endif %}}
 
 {{% if aide_also_checks_rsyslog == "yes" %}}
-{{% set auditfiles = auditfiles + ["/usr/sbin/rsyslogd"] %}}
+{{% set auditfiles = auditfiles + ["rsyslogd"] %}}
 {{% endif %}}
 
 {{% for file in auditfiles %}}
-if grep -i '^.*{{{file}}}.*$' {{{ aide_conf_path }}}; then
-sed -i "s#.*{{{file}}}.*#{{{file}}} {{{ aide_string() }}}#" {{{ aide_conf_path }}}
+if grep -i -E '^.*(/usr)?/sbin/{{{file}}}.*$' {{{ aide_conf_path }}}; then
+sed -i -r "s#.*(/usr)?/sbin/{{{file}}}.*#/usr/sbin/{{{file}}} {{{ aide_string() }}}#" {{{ aide_conf_path }}}
 else
-echo "{{{ file }}} {{{ aide_string() }}}" >> {{{ aide_conf_path }}}
+echo "/usr/sbin/{{{ file }}} {{{ aide_string() }}}" >> {{{ aide_conf_path }}}
 fi
 {{% endfor %}}

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/oval/shared.xml
@@ -26,112 +26,13 @@
     {{% endif %}}
   </ind:textfilecontent54_state>
 
-  <ind:textfilecontent54_test id="test_aide_verify_auditctl"
-  comment="auditctl is checked in {{{ aide_conf_path }}}" check="all"
-  check_existence="all_exist" version="1">
-    <ind:object object_ref="object_aide_verify_auditctl" />
-    <ind:state state_ref="state_aide_check_attributes" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_aide_verify_auditctl"
-  version="1">
-    <ind:filepath>{{{ aide_conf_path }}}</ind:filepath>
-    <ind:pattern operation="pattern match">^\/usr\/sbin\/auditctl\s+([^\n]+)$</ind:pattern>
-    <ind:instance datatype="int" operation="equals">1</ind:instance>
-  </ind:textfilecontent54_object>
-
-  <ind:textfilecontent54_test id="test_aide_verify_auditd"
-  comment="auditd is checked in {{{ aide_conf_path }}}" check="all"
-  check_existence="all_exist" version="1">
-    <ind:object object_ref="object_aide_verify_auditd" />
-    <ind:state state_ref="state_aide_check_attributes" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_aide_verify_auditd"
-  version="1">
-    <ind:filepath>{{{ aide_conf_path }}}</ind:filepath>
-    <ind:pattern operation="pattern match">^/usr/sbin/auditd\s+([^\n]+)$</ind:pattern>
-    <ind:instance datatype="int" operation="equals">1</ind:instance>
-  </ind:textfilecontent54_object>
-
-  <ind:textfilecontent54_test id="test_aide_verify_ausearch"
-  comment="ausearch is checked in {{{ aide_conf_path }}}" check="all"
-  check_existence="all_exist" version="1">
-    <ind:object object_ref="object_aide_verify_ausearch" />
-    <ind:state state_ref="state_aide_check_attributes" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_aide_verify_ausearch"
-  version="1">
-    <ind:filepath>{{{ aide_conf_path }}}</ind:filepath>
-    <ind:pattern operation="pattern match">^/usr/sbin/ausearch\s+([^\n]+)$</ind:pattern>
-    <ind:instance datatype="int" operation="equals">1</ind:instance>
-  </ind:textfilecontent54_object>
-
-  <ind:textfilecontent54_test id="test_aide_verify_aureport"
-  comment="aureport is checked in {{{ aide_conf_path }}}" check="all"
-  check_existence="all_exist" version="1">
-    <ind:object object_ref="object_aide_verify_aureport" />
-    <ind:state state_ref="state_aide_check_attributes" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_aide_verify_aureport"
-  version="1">
-    <ind:filepath>{{{ aide_conf_path }}}</ind:filepath>
-    <ind:pattern operation="pattern match">^/usr/sbin/aureport\s+([^\n]+)$</ind:pattern>
-    <ind:instance datatype="int" operation="equals">1</ind:instance>
-  </ind:textfilecontent54_object>
-
-  <ind:textfilecontent54_test id="test_aide_verify_autrace"
-  comment="autrace is checked in {{{ aide_conf_path }}}" check="all"
-  check_existence="all_exist" version="1">
-    <ind:object object_ref="object_aide_verify_autrace" />
-    <ind:state state_ref="state_aide_check_attributes" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_aide_verify_autrace"
-  version="1">
-    <ind:filepath>{{{ aide_conf_path }}}</ind:filepath>
-    <ind:pattern operation="pattern match">^/usr/sbin/autrace\s+([^\n]+)$</ind:pattern>
-    <ind:instance datatype="int" operation="equals">1</ind:instance>
-  </ind:textfilecontent54_object>
-
-{{% if aide_also_checks_audispd == "yes" %}}
-  <ind:textfilecontent54_test id="test_aide_verify_audispd"
-  comment="audispd is checked in {{{ aide_conf_path }}}" check="all"
-  check_existence="all_exist" version="1">
-    <ind:object object_ref="object_aide_verify_audispd" />
-    <ind:state state_ref="state_aide_check_attributes" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_aide_verify_audispd"
-  version="1">
-    <ind:filepath>{{{ aide_conf_path }}}</ind:filepath>
-    <ind:pattern operation="pattern match">^/usr/sbin/audispd\s+([^\n]+)$</ind:pattern>
-    <ind:instance datatype="int" operation="equals">1</ind:instance>
-  </ind:textfilecontent54_object>
-{{% endif %}}
-
-{{% if aide_also_checks_rsyslog == "yes" %}}
-  <ind:textfilecontent54_test id="test_aide_verify_rsyslogd"
-  comment="rsyslogd is checked in {{{ aide_conf_path }}}" check="all"
-  check_existence="all_exist" version="1">
-    <ind:object object_ref="object_aide_verify_rsyslogd" />
-    <ind:state state_ref="state_aide_check_attributes" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_aide_verify_rsyslogd"
-  version="1">
-    <ind:filepath>{{{ aide_conf_path }}}</ind:filepath>
-    <ind:pattern operation="pattern match">^/usr/sbin/rsyslogd\s+([^\n]+)$</ind:pattern>
-    <ind:instance datatype="int" operation="equals">1</ind:instance>
-  </ind:textfilecontent54_object>
-{{% endif %}}
-
-  <ind:textfilecontent54_test id="test_aide_verify_augenrules"
-  comment="augenrules is checked in {{{ aide_conf_path }}}" check="all"
-  check_existence="all_exist" version="1">
-    <ind:object object_ref="object_aide_verify_augenrules" />
-    <ind:state state_ref="state_aide_check_attributes" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_aide_verify_augenrules"
-  version="1">
-    <ind:filepath>{{{ aide_conf_path }}}</ind:filepath>
-    <ind:pattern operation="pattern match">^/usr/sbin/augenrules\s+([^\n]+)$</ind:pattern>
-    <ind:instance datatype="int" operation="equals">1</ind:instance>
-  </ind:textfilecontent54_object>
+  {{{ oval_test_aide_audit_tools(audit_tool='auditctl') }}}
+  {{{ oval_test_aide_audit_tools(audit_tool='auditd') }}}
+  {{{ oval_test_aide_audit_tools(audit_tool='ausearch') }}}
+  {{{ oval_test_aide_audit_tools(audit_tool='aureport') }}}
+  {{{ oval_test_aide_audit_tools(audit_tool='autrace') }}}
+  {{{ oval_test_aide_audit_tools(audit_tool='audispd') }}}
+  {{{ oval_test_aide_audit_tools(audit_tool='rsyslogd') }}}
+  {{{ oval_test_aide_audit_tools(audit_tool='augenrules') }}}
 
 </def-group>

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/except_sbin_path.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/except_sbin_path.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_ubuntu,multi_platform_almalinux
+# packages = aide
+
+declare -a bins
+bins=('/sbin/auditctl' '/sbin/auditd' '/sbin/augenrules' '/sbin/aureport' '/sbin/ausearch' '/sbin/autrace' '/sbin/rsyslogd' '/sbin/audispd')
+
+for theFile in "${bins[@]}"
+do
+    echo "$theFile p+i+n+u+g+s+b+acl+xattrs+sha512"  >> {{{ aide_conf_path }}}
+done

--- a/shared/macros/10-oval.jinja
+++ b/shared/macros/10-oval.jinja
@@ -1803,3 +1803,30 @@ Macro to check if external variable is set to value
 
   <external_variable comment="External variable {{{ variable }}}" datatype="string" id="{{{ variable }}}" version="1" />
 {{%- endmacro -%}}
+
+{{#
+  Macro which generates the OVAL metadata section
+
+:param description: The text to place in the description section
+:type description: str
+:param title: Optional, the associated rule title is used by default
+:type title: str
+:param affected_platforms: Optional, list of unix platform strings (e.g. "Fedora") to put under the affected element. Uses the oval_affected macro by default under the hood.
+:type affected_platforms: list[str]
+
+#}}
+{{%- macro oval_test_aide_audit_tools(audit_tool) -%}}
+  <ind:textfilecontent54_test id="test_aide_verify_{{{ audit_tool }}}"
+  comment="{{{ audit_tool }}} is checked in {{{ aide_conf_path }}}" check="all"
+  check_existence="all_exist" version="1">
+    <ind:object object_ref="object_aide_verify_{{{ audit_tool }}}" />
+    <ind:state state_ref="state_aide_check_attributes" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_aide_verify_{{{ audit_tool }}}"
+  version="1">
+    <ind:filepath>{{{ aide_conf_path }}}</ind:filepath>
+    <ind:pattern operation="pattern match">^(?:/usr)?/sbin/{{{ audit_tool }}}\s+([^\n]+)$</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+{{%- endmacro -%}}


### PR DESCRIPTION
#### Description:

- Changes were made in response to this [issue ](https://github.com/ComplianceAsCode/content/issues/13770)

#### Rationale:

- The `xccdf_org.ssgproject.content_rule_aide_check_audit_tools` rule does not comply with the Amazon Linux 2023 CIS Benchmark (section 1.3.3). The benchmark requires audit tools to be located in `/sbin/`, while most modern distributions use `/usr/sbin/`.

This change updates the rule to accept both `/sbin/` and `/usr/sbin/` as valid paths, resolving the compliance failure.

- Fixes #13770

#### Review Hints:

- Matching range of all regular expressions in `shared.xml` OVAL test has been extended to accept both '/usr/sbin' and '/sbin/' location of audit tools binaries.

- Additional macro was created to remove code duplication and increase readability 
