### PR TITLE
Make Ansible in audit_rules_immutable idempotent

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_immutable/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_immutable/ansible/shared.yml
@@ -50,7 +50,7 @@
   ansible.builtin.file:
     path: "{{ item | dirname }}"
     state: directory
-    mode: '0755'
+    mode: '0750'
   loop:
     - "/etc/audit/audit.rules"
     - "/etc/audit/rules.d/immutable.rules"


### PR DESCRIPTION
The current solution executed lineinfile task even if the correct line is present in the file. We will change the code to make the remediation idempotent.

Resolves: https://issues.redhat.com/browse/OPENSCAP-6257



#### Review Hints:

- `./build_product --playbook-per-rule rhel9`
- manually replace hosts by `hosts: all` in `build/rhel9/playbooks/stig/audit_rules_immutable.yml`
- run `ansible-playbook -u root -i YOUR_IP, build/rhel9/playbooks/stig/audit_rules_immutable.yml` at least twice and compare the output of the first run with the second run and so on, verify that the second and next runs don't change anything and that the output contains only "ok" or "skipping"
- apart from that, run automatus Tss with `--remediate-using ansible`