### PR TITLE
Make Ansible file_existence template idempotent

### DIFF
--- a/shared/templates/file_existence/ansible.template
+++ b/shared/templates/file_existence/ansible.template
@@ -6,12 +6,12 @@
 
 
 {{% if not EXISTS %}}
-- name: Remove {{{ FILEPATH }}}
+- name: {{{ rule_title }}} - Remove {{{ FILEPATH }}}
   ansible.builtin.file:
       path: {{{ FILEPATH }}}
       state: absent
 {{% else %}}
-- name: Add empty {{{ FILEPATH }}}
+- name: {{{ rule_title }}} - Add empty {{{ FILEPATH }}}
   ansible.builtin.file:
       path: {{{ FILEPATH }}}
       state: touch
@@ -21,4 +21,6 @@
     {{%- if FILEMODE %}}
       mode: "{{{ FILEMODE }}}"
     {{%- endif %}}
+      modification_time: preserve
+      access_time: preserve
 {{% endif %}}


### PR DESCRIPTION
This will fix idempotency for rules like file_cron_allow_exists. The reason why the Ansible remediation in this rule wasn't idempotent is that it uses the "state: touch" which causes that the file modification time is always modified when the task is run.

Resolves: https://issues.redhat.com/browse/OPENSCAP-6258




#### Review Hints:

- `./build_product --playbook-per-rule rhel9`
- manually replace hosts by `hosts: all` in `build/rhel9/playbooks/cis/file_cron_allow_exists.yml`
- run `ansible-playbook -u root -i YOUR_IP, build/rhel9/playbooks/cis/file_cron_allow_exists.yml` at least twice and compare the output of the first run with the second run and so on, verify that the second and next runs don't change anything and that the output contains only "ok" or "skipping"
- apart from that, run automatus Tss with `--remediate-using ansible`
