### PR TITLE
Prevent Ansible errors in accounts_user_dot_user_ownership

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/ansible/shared.yml
@@ -39,4 +39,7 @@
   loop: "{{ user_dotfiles.results | subelements('files', skip_missing=True) }}"
   when:
     - item.0 is not skipped
+    - item.0 is not failed
+    - item.0.item is defined
+    - item.0.item.username is defined
     - item.1.path is defined


### PR DESCRIPTION
This PR aims to resolve the CI fails currently happening in our PR gating.

The subelements filter might create incomplete data structures if some tasks in the loop are failed or skipped.

Addressing:

{"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'username'. 'dict object' has no attribute 'username'\n\nThe error appears to be in '/usr/share/scap-security-guide/ansible/centos8-playbook-anssi_bp28_high.yml': line 7892, column 5, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n - name: User Initialization Files Must Be Owned By the Primary User - Set correct\n ^ here\n"}

