### PR TITLE
Fixing add-cce option in fix_rules.py, while "identifiers" section in rule.yml is missing

### DIFF
--- a/utils/fix_rules.py
+++ b/utils/fix_rules.py
@@ -328,7 +328,7 @@ def add_to_the_section(file_contents, yaml_contents, section, new_keys):
     template_line = str(file_contents[end - 1])
     leading_whitespace = re.match(r"^\s*", template_line).group()
     if leading_whitespace in ['', '\n']:
-        leading_whitespace += ' '*4
+        leading_whitespace += ' ' * 4
     for key, value in new_keys.items():
         to_insert.append(leading_whitespace + key + ": " + value)
 

--- a/utils/fix_rules.py
+++ b/utils/fix_rules.py
@@ -303,6 +303,17 @@ def rewrite_value_remove_prefix(line):
     return key + ": " + new_value
 
 
+def add_section(file_contents, yaml_contents, section):
+    severity_index = list(yaml_contents.keys()).index('severity')
+    yaml_items = list(yaml_contents.items())
+    yaml_items.insert(severity_index, (section, {}))
+    new_yaml_contents = dict(yaml_items)
+    severity_start, _ = find_section_lines(file_contents, "severity")[0]
+    file_contents.insert(severity_start-1, '')
+    file_contents.insert(severity_start, f"{section}:")
+    return file_contents, new_yaml_contents
+
+
 def add_to_the_section(file_contents, yaml_contents, section, new_keys):
     to_insert = []
 
@@ -316,6 +327,8 @@ def add_to_the_section(file_contents, yaml_contents, section, new_keys):
     assert end > begin, "We need at least one identifier there already"
     template_line = str(file_contents[end - 1])
     leading_whitespace = re.match(r"^\s*", template_line).group()
+    if leading_whitespace in ['', '\n']:
+        leading_whitespace += ' '*4
     for key, value in new_keys.items():
         to_insert.append(leading_whitespace + key + ": " + value)
 
@@ -442,7 +455,7 @@ def add_product_cce(file_contents, yaml_contents, product, cce):
     section = 'identifiers'
 
     if section not in yaml_contents:
-        return file_contents
+        file_contents, yaml_contents = add_section(file_contents, yaml_contents, section)
 
     new_contents = add_to_the_section(
         file_contents, yaml_contents, section, {"cce@{product}".format(product=product): cce})


### PR DESCRIPTION
#### Description:

- Adding `add-section` function to fix `add-cce` option in `fix_rules.py`, while `identifiers` section in `rule.yml` is missing.

#### Rationale:

- When `fix_rules.py` is ran with `add-cce` option, the script should add the missing cce identifier to the description of the specified rule. However, the execution ends without result if the `rule.yml` file does not contain the `identifiers` section.

- Fixes #13708

#### Review Hints:

- The `add_section` function has been added. In the future, it can be potentially used to fix similar cases.  

- The results after running the command `python utils/fix_rules.py --product products/rhel9/product.yml add-cce --cce-pool redhat only_allow_dod_certs` can be seen in the screenshot (left side - before execution, right side - after execution):

<img width="2071" height="581" alt="image" src="https://github.com/user-attachments/assets/a04c8ddd-84b2-423e-8fb0-6a688a286043" />




