### PR TITLE
Make Ansible in GRUB rules idempotent

### DIFF
--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1527,8 +1527,21 @@ Part of the grub2_bootloader_argument template.
 - name: Update grub defaults and the bootloader menu
   ansible.builtin.command: /usr/sbin/update-grub
 {{% else %}}
+- name: Check if {{{ arg_name }}} argument is already present in /etc/default/grub
+  ansible.builtin.slurp:
+    src: /etc/default/grub
+  register: etc_default_grub
+
+- name: Check if {{{ arg_name }}} argument is already present
+  ansible.builtin.command: /sbin/grubby --info=ALL
+  register: grubby_info
+  check_mode: False
+  changed_when: False
+  failed_when: False
+
 - name: Update grub defaults and the bootloader menu
   ansible.builtin.command: /sbin/grubby --update-kernel=ALL --args="{{{ arg_name_value }}}"
+  when: (grubby_info.stdout is not search('{{{ arg_name_value }}}')) or ((etc_default_grub['content'] | b64decode) is not search('{{{ arg_name_value }}}'))
 {{% endif -%}}
 {{%- endmacro -%}}
 


### PR DESCRIPTION
This commit changes the Ansible remediation in the grub2_bootloader_argument template to become idempotent.

Resolves: https://issues.redhat.com/browse/OPENSCAP-6256

#### Review Hints:

- `./build_product --playbook-per-rule rhel9`
- manually replace hosts by `hosts: all` in `build/rhel9/playbooks/all/grub2_nousb_argument.yml`
- run `ansible-playbook -u root -i YOUR_IP, build/rhel9/playbooks/all/grub2_nousb_argument.yml` at least twice and compare the output of the first run with the second run and so on, verify that the second and next runs don't change anything and that the output contains only "ok" or "skipping"
- apart from that, run automatus Tss with `--remediate-using ansible`

