### PR TITLE
Make Ansible in file_etc_security_opasswd idempotent

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_etc_security_opasswd/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_etc_security_opasswd/ansible/shared.yml
@@ -4,10 +4,12 @@
 # complexity = low
 # disruption = low
 
-- name: Ensure /etc/security/opasswd exist and has the correct permissions
+- name: {{{ rule_title }}}
   ansible.builtin.file:
     path: /etc/security/opasswd
     owner: root
     group: root
     mode: 0600
     state: touch
+    modification_time: preserve
+    access_time: preserve


### PR DESCRIPTION
The Ansible remediation for rule file_etc_security_opasswd wasn't idempotent because the "state: touch" in "lineinfile" task updates the file modification time each time the task is run.

Resolves: https://issues.redhat.com/browse/OPENSCAP-6254



#### Review Hints:


- `./build_product --playbook-per-rule rhel9`
- manually replace hosts by `hosts: all` in build/rhel9/playbooks/all/file_etc_security_opasswd.yml
- run `ansible-playbook -u root -i YOUR_IP, build/rhel9/playbooks/all/file_etc_security_opasswd.yml at least twice and compare the output of the first run with the second run and so on, verify that the second and next runs don't change anything and that the output contains only "ok" or "skipping"

