### PR TITLE
Set owners for tests/assertions/ocp4

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,6 +7,7 @@
 
 # Products
 
+/tests/assertions/ocp4/ @rhmdnd @Vincent056 @yuumasato
 /tests/data/product_stability/rhel*.yml @ComplianceAsCode/red-hatters
 /tests/data/product_stability/ol*.yml @ComplianceAsCode/oracle-maintainers
 /tests/data/product_stability/sle*.yml @ComplianceAsCode/suse-maintainers


### PR DESCRIPTION

#### Description:

- Set OCP team members as owners of OCP4 assertion files

#### Rationale:

- Less noise to core maintainers when we need to update OCP4 assertions.
- For example:
  - https://github.com/ComplianceAsCode/content/pull/13886
  - https://github.com/ComplianceAsCode/content/pull/13951 
