### PR TITLE
Fix aide_build_database

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/oval/shared.xml
@@ -19,7 +19,10 @@
       <ind:pattern operation="pattern match">^database=file:/([/a-z.]+)$</ind:pattern>
     {{% elif product == 'slmicro6' %}}
       <ind:pattern operation="pattern match">^database_in=file:/([/a-z.]+)$</ind:pattern>
-    {{% elif product in [ 'ol10', 'rhel10', 'fedora' ] %}}
+    {{% elif product == "rhel9" %}}
+      <!-- RHEL 9.8 (aide-0.19.2-2.el9 and newer) uses _in suffix for database_in line -->
+      <ind:pattern operation="pattern match">^database(?:_in)?=file:(?:@@{DBDIR})?/(?:[a-z.]+/)*([a-z.]+)$</ind:pattern>
+    {{% elif product in ['ol10', 'rhel10', 'fedora' ] %}}
       <ind:pattern operation="pattern match">^database_in=file:(?:@@{DBDIR})?/(?:[a-z.]+/)*([a-z.]+)$</ind:pattern>
     {{% else %}}
       <ind:pattern operation="pattern match">^database=file:(?:@@{DBDIR})?/(?:[a-z.]+/)*([a-z.]+)$</ind:pattern>


### PR DESCRIPTION
On CentOS Stream 9, aide-0.19.2-2.el9.x86_64 starts using the modern format of the configuration file where they use `database_in` instead of database.

Addressing:

Failing tests /hardening/host-os/oscap and /hardening/host-os/ansible on CentOS Stream 9.

