### PR TITLE
Fix macro 'create_interactive_users_list_object' to also ignore users having /usr/sbin/nologin shell

### DIFF
--- a/shared/macros/10-oval.jinja
+++ b/shared/macros/10-oval.jinja
@@ -1168,7 +1168,7 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
 
 {{#
   Extract from system password database a list composed of password objects related to non-system UIDs.
-  This list is then filtered to exclude some special usernames and users with /sbin/nologin shell.
+  This list is then filtered to exclude some special usernames and users with /sbin/nologin or /usr/sbin/nologin shell.
   The list includes non-local (LDAP) users, because the implementation of "unix:password_object" in OpenSCAP makes use of getpwent(), which browses all users provided by the NSS.
 
   The macro receives a string as parameter, which is used as the password_object id in the rule.
@@ -1213,7 +1213,7 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
   </unix:password_state>
 
   <unix:password_state id="state_{{{ rule_id }}}_users_nologin_shell" version="1">
-    <unix:login_shell datatype="string" operation="pattern match">^/sbin/nologin$</unix:login_shell>
+    <unix:login_shell datatype="string" operation="pattern match">^(?:/usr)?/sbin/nologin$</unix:login_shell>
   </unix:password_state>
 {{%- endmacro %}}
 


### PR DESCRIPTION
#### Description:

The `create_interactive_users_list_object` macro doesn't exclude users having `/usr/sbin/nologin` as their shell.
On RHEL, users may get `/sbin/nologin` or `/usr/sbin/nologin`, depending on the package name, and for Dynamic Users, they seem to always get `/usr/sbin/nologin`.

#### Rationale:

See Red Hat issue [RHEL-118647](https://issues.redhat.com/browse/RHEL-118647)

#### Review Hints:

Reproducer on RHEL9 is:

1. Install a system with STIG profile
2. Start `cockpit.socket` unit and log into cockpit
3. Execute a scan with `xccdf_org.ssgproject.content_rule_accounts_user_interactive_home_directory_defined` rule

Result is failure because of dynamic users having a different shell:
~~~
[root@vm-stig9 ~]# getent passwd 
[...]
cockpit-systemd-service:x:61789:61789:Dynamic User:/:/usr/sbin/nologin
cockpit-session-socket:x:63205:63205:Dynamic User:/:/usr/sbin/nologin
cockpit-wsinstance-https:x:63714:63714:Dynamic User:/:/usr/sbin/nologin
cockpit-wsinstance-socket:x:62764:62764:Dynamic User:/:/usr/sbin/nologin
~~~