### PR TITLE
Make Ansible in SELinux rules idempotent

### DIFF
--- a/linux_os/guide/system/selinux/selinux_not_disabled/ansible/shared.yml
+++ b/linux_os/guide/system/selinux/selinux_not_disabled/ansible/shared.yml
@@ -4,9 +4,19 @@
 # complexity = low
 # disruption = low
 
+- name: "{{{ rule_title }}} - Check current SELinux state"
+  ansible.builtin.command:
+    cmd: getenforce
+  register: selinux_state
+  check_mode: false
+  changed_when: false
+
 {{{ ansible_selinux_config_set(parameter="SELINUX", value="permissive", rule_title=rule_title) }}}
 
-- name: "{{{ RULE_TITLE }}} - Mark system to relabel SELinux on next boot"
+- name: "{{{ rule_title }}} - Mark system to relabel SELinux on next boot"
   ansible.builtin.file:
     path: /.autorelabel
     state: touch
+    access_time: preserve
+    modification_time: preserve
+  when: selinux_state.stdout | lower != "permissive"

--- a/linux_os/guide/system/selinux/selinux_state/ansible/shared.yml
+++ b/linux_os/guide/system/selinux/selinux_state/ansible/shared.yml
@@ -5,9 +5,19 @@
 # disruption = low
 {{{ ansible_instantiate_variables("var_selinux_state") }}}
 
+- name: "{{{ rule_title }}} - Check current SELinux state"
+  ansible.builtin.command:
+    cmd: getenforce
+  register: selinux_state
+  check_mode: false
+  changed_when: false
+
 {{{ ansible_selinux_config_set(parameter="SELINUX", value="{{ var_selinux_state }}", rule_title=rule_title) }}}
 
-- name: "{{{ RULE_TITLE }}} - Mark system to relabel SELinux on next boot"
+- name: "{{{ rule_title }}} - Mark system to relabel SELinux on next boot"
   ansible.builtin.file:
     path: /.autorelabel
     state: touch
+    access_time: preserve
+    modification_time: preserve
+  when: selinux_state.stdout | lower != var_selinux_state


### PR DESCRIPTION
There were 2 problems:
1. the .autorelabel file was created even if SELinux state was correct
2. the .autorelabel file was changed even if it existed because the task uses "touch" which always modified the file modification time

Resolves: https://issues.redhat.com/browse/OPENSCAP-6255



#### Review Hints:
- `./build_product --playbook-per-rule rhel9`
- manually replace hosts by `hosts: all` in `build/rhel9/playbooks/stig/selinux_state.yml` and `build/rhel9/playbooks/all/selinux_not_disabled.yml`
- run `ansible-playbook -u root -i YOUR_IP, build/rhel9/playbooks/stig/selinux_state.yml` at least twice and compare the output of the first run with the second run and so on, verify that the second and next runs don't change anything and that the output contains only "ok" or "skipping"
- dtto for the `build/rhel9/playbooks/all/selinux_not_disabled.yml`
- apart from that, run automatus Tss with `--remediate-using ansible`

