### PR TITLE
Check if IPV6_PRIVACY=rfc3041 configuration is already in a file

### DIFF
--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_privacy_extensions/bash/shared.sh
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/network_ipv6_privacy_extensions/bash/shared.sh
@@ -1,7 +1,13 @@
 # platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_ol,multi_platform_almalinux
 
+APPLY_STRING="IPV6_PRIVACY=rfc3041"
+
 # enable randomness in ipv6 address generation
 for interface in /etc/sysconfig/network-scripts/ifcfg-*
 do
-    echo "IPV6_PRIVACY=rfc3041" >> $interface
+    if ! grep -q "^IPV6_PRIVACY=" "$interface"; then
+        echo "$APPLY_STRING" >> "$interface"
+    else
+        sed -i "s/^IPV6_PRIVACY=.*/$APPLY_STRING/" "$interface"
+    fi
 done


### PR DESCRIPTION
#### Description:

- Changes were made in response to remediation script of `network_ipv6_privacy_extensions` not being idempotent. Adding a check that is suppose to prevent duplicate lines in a configuration file, when remediation script is ran.

#### Rationale:

- Fixes [RHEL-106813](https://issues.redhat.com/browse/RHEL-106813)

#### Fixed remediation was tested on local machine with multiple cases:

- File didn't contain required line at all - line appeared in a file after remediation (passed :heavy_check_mark:)
- File contained required key, but incorrect value - line was corrected after remediation (passed :heavy_check_mark:) 
- File already already contained required line - no changes (passed :heavy_check_mark:) 
