### PR TITLE
Make Ansible in file_groupownership_system_commands_dirs idempotent

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/ansible/shared.yml
@@ -4,13 +4,24 @@
 # complexity = medium
 # disruption = medium
 
-- name: "Retrieve the system command files and set their group ownership to root"
-{{% if 'ubuntu' in product %}}
-  ansible.builtin.command: "find -P {{ item }} ! -gid -{{{ gid_min }}} -type f -exec chgrp root '{}' \\;"
-{{% else %}}
-  ansible.builtin.command: "find -P {{ item }} ! -group root -type f -exec chgrp root '{}' \\;"
-{{% endif %}}
+- name: "{{{ rule_title }}} - Find system command files with incorrect group ownership"
+  ansible.builtin.find:
+    paths: "{{ item }}"
+    file_type: file
+    follow: no
+    recurse: no
+  register: system_command_files_found
   with_items: ['/bin', '/sbin', '/usr/bin', '/usr/sbin', '/usr/local/bin', '/usr/local/sbin']
-  changed_when: False
-  failed_when: False
-  check_mode: no
+  changed_when: false
+
+- name: "{{{ rule_title }}} - Set group ownership to root for system command files"
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    group: root
+{{% if 'ubuntu' in product %}}
+  with_items: '{{ system_command_files_found.results | map(attribute=''files'')
+      | flatten | rejectattr(''gid'', ''lesserthan'', {{{ gid_min }}}) | list }}'
+{{% else %}}
+  with_items: '{{ system_command_files_found.results | map(attribute=''files'')
+      | flatten | rejectattr(''gr_name'', ''equalto'', ''root'') | list }}'
+{{% endif %}}


### PR DESCRIPTION
Replace the shell command by specialized modules and ensure the Ansible Tasks are idempotent.

Resolves: https://issues.redhat.com/browse/OPENSCAP-6234


#### Review Hints:

- `./build_product --playbook-per-rule rhel9`
- manually replace hosts by `hosts: all` in `build/rhel9/playbooks/stig/file_groupownership_system_commands_dirs.yml`
- ssh to YOUR_IP and create an offending file there
 ```
 [root@localhost ~]# touch /usr/sbin/testme
[root@localhost ~]# groupadd group_test
[root@localhost ~]# chgrp group_test /usr/sbin/testme
```
- Back on the host, run `ansible-playbook -u root -i YOUR_IP, build/rhel9/playbooks/stig/file_groupownership_system_commands_dirs.yml` at least twice and compare the output of the first run with the second run and so on, verify that the second and next runs don't change anything and that the output contains only "ok" or "skipping"
- apart from that, run automatus Tss with `--remediate-using ansible`