### PR TITLE
Removing aide_periodic_cron_checking rule from RHEL-09-651015

### DIFF
--- a/controls/stig_rhel9.yml
+++ b/controls/stig_rhel9.yml
@@ -2987,7 +2987,6 @@ controls:
       title: RHEL 9 must routinely check the baseline configuration for unauthorized changes and notify
           the system administrator when anomalies in the operation of any security functions are discovered.
       rules:
-          - aide_periodic_cron_checking
           - aide_scan_notification
       status: automated
 

--- a/tests/data/profile_stability/rhel9/stig.profile
+++ b/tests/data/profile_stability/rhel9/stig.profile
@@ -48,7 +48,6 @@ accounts_user_interactive_home_directory_defined
 accounts_user_interactive_home_directory_exists
 aide_build_database
 aide_check_audit_tools
-aide_periodic_cron_checking
 aide_scan_notification
 aide_use_fips_hashes
 aide_verify_acls

--- a/tests/data/profile_stability/rhel9/stig_gui.profile
+++ b/tests/data/profile_stability/rhel9/stig_gui.profile
@@ -48,7 +48,6 @@ accounts_user_interactive_home_directory_defined
 accounts_user_interactive_home_directory_exists
 aide_build_database
 aide_check_audit_tools
-aide_periodic_cron_checking
 aide_scan_notification
 aide_use_fips_hashes
 aide_verify_acls


### PR DESCRIPTION
#### Description:

- The remediation script of `aide_scan_notification` rule currently checks for `/usr/sbin/aide --check | /bin/mail` line in a crontab file and ignores the presence of baseline `/usr/sbin/aide --check`, which could be added there by a remediation of `aide_periodic_cron_checking` rule. This causes the existence of **two** similar crontab entries:

  - `05 4 * * * root /usr/sbin/aide --check` provides file integrity scan
  - `0 5 * * * root /usr/sbin/aide  --check | /bin/mail -s "$(hostname) - AIDE Integrity Check" root@localhost` provides the same scan and notifies appropriate personnel of the results

#### Rationale:

- As suggested by @vojtapolasek, rule `aide_periodic_cron_checking` may be removed from RHEL-09-651015, since `aide_scan_notification` already covers all of the required functionality.

- Fixes [RHEL-100924](https://issues.redhat.com/browse/RHEL-100924)

- [RHEL-09-651015 STIG reference](https://stigaview.com/products/rhel9/v2r5/RHEL-09-651015/)
