### PR TITLE
Make Ansible in grub2_argument_absent template idempotent

### DIFF
--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1578,8 +1578,21 @@ Part of the grub2_bootloader_argument_absent template.
 - name: Update grub defaults and the bootloader menu
   ansible.builtin.command: /usr/sbin/update-grub
 {{% else %}}
+- name: Check if {{{ arg_name }}} argument is already present in /etc/default/grub
+  ansible.builtin.slurp:
+    src: /etc/default/grub
+  register: etc_default_grub
+
+- name: Check if {{{ arg_name }}} argument is present
+  ansible.builtin.command: /sbin/grubby --info=ALL
+  register: grubby_info
+  check_mode: False
+  changed_when: False
+  failed_when: False
+
 - name: Update grub defaults and the bootloader menu
   ansible.builtin.command: /sbin/grubby --update-kernel=ALL --remove-args="{{{ arg_name }}}"
+  when: (grubby_info.stdout is search('{{{ arg_name }}}')) or ((etc_default_grub['content'] | b64decode) is search('{{{ arg_name }}}'))
 {{% endif -%}}
 {{%- endmacro -%}}
 


### PR DESCRIPTION
This commit will make Ansible remediations in the grub2_argument_absent template idempotent. The grubby command will be executed only if the GRUB2 argument is present in /etc/default/grub or is present in the /boot/loader/entries.

Resolves: https://issues.redhat.com/browse/OPENSCAP-6251



#### Review Hints:

- `./build_product --playbook-per-rule rhel9`
- manually replace hosts by `hosts: all` in rhel9/playbooks/anssi_bp28_high/grub2_nosmap_argument_absent.yml`
- ssh to YOUR_IP and run there: `grubby --update-kernel=ALL --args="nosmap"`
- Back on the host, run `ansible-playbook -u root -i YOUR_IP, rhel9/playbooks/anssi_bp28_high/grub2_nosmap_argument_absent.yml` at least twice and compare the output of the first run with the second run and so on, verify that the second and next runs don't change anything and that the output contains only "ok" or "skipping"
- apart from that, run automatus Tss with `--remediate-using ansible`