### PR TITLE
Make Ansible in dconf_ini_file idempotent

### DIFF
--- a/shared/templates/dconf_ini_file/ansible.template
+++ b/shared/templates/dconf_ini_file/ansible.template
@@ -19,6 +19,7 @@
     value: "{{{ VALUE }}}"
     create: yes
   when: {{{ rule_id }}}_config_files is defined and {{{ rule_id }}}_config_files.matched == 0
+  register: default_file
 
 - name: "Configure {{{ PARAMETER }}} - existing files"
   community.general.ini_file:
@@ -29,6 +30,7 @@
     create: yes
   with_items: "{{ {{{ rule_id }}}_config_files.files }}"
   when: {{{ rule_id }}}_config_files is defined and {{{ rule_id }}}_config_files.matched > 0
+  register: existing_files
 
 - name: "Detect if lock for {{{ PARAMETER }}} can be found on {{{ PATH }}}"
   ansible.builtin.find:
@@ -55,3 +57,4 @@
 
 - name: "Dconf Update - {{{ PARAMETER }}}"
   ansible.builtin.command: dconf update
+  when: default_file is changed or existing_files is changed


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/OPENSCAP-6252

#### Review Hints:

- `./build_product --playbook-per-rule rhel9`
- manually replace hosts by `hosts: all` in `/build/rhel9/playbooks/stig/dconf_gnome_lock_screen_on_smartcard_removal.yml` 
- install a VM with a `gdm` package installed.
- run `ansible-playbook -u root -i YOUR_IP, /build/rhel9/playbooks/stig/dconf_gnome_lock_screen_on_smartcard_removal.yml` at least twice and compare the output of the first run with the second run and so on, verify that the second and next runs don't change anything and that the output contains only "ok" or "skipping"

- apart from that, run automatus Tss with `--remediate-using ansible`
