### PR TITLE
CMP-3540: Remove api-server-tls-cipher-suites assertion from CIS assertion files

### DIFF
--- a/tests/assertions/ocp4/ocp4-cis-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.12.yml
@@ -113,9 +113,6 @@ rule_results:
   ocp4-cis-api-server-tls-cert:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-tls-cipher-suites:
-    default_result: PASS
-    result_after_remediation: PASS
   ocp4-cis-api-server-tls-private-key:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-cis-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.13.yml
@@ -111,9 +111,6 @@ rule_results:
   ocp4-cis-api-server-tls-cert:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-tls-cipher-suites:
-    default_result: PASS
-    result_after_remediation: PASS
   ocp4-cis-api-server-tls-private-key:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-cis-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.14.yml
@@ -111,9 +111,6 @@ rule_results:
   ocp4-cis-api-server-tls-cert:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-tls-cipher-suites:
-    default_result: PASS
-    result_after_remediation: PASS
   ocp4-cis-api-server-tls-private-key:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-cis-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.15.yml
@@ -113,9 +113,6 @@ rule_results:
   ocp4-cis-api-server-tls-cert:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-tls-cipher-suites:
-    default_result: PASS
-    result_after_remediation: PASS
   ocp4-cis-api-server-tls-private-key:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-cis-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.16.yml
@@ -108,9 +108,6 @@ rule_results:
   ocp4-cis-api-server-tls-cert:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-tls-cipher-suites:
-    default_result: PASS
-    result_after_remediation: PASS
   ocp4-cis-api-server-tls-private-key:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-cis-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.17.yml
@@ -110,9 +110,6 @@ rule_results:
   ocp4-cis-api-server-tls-cert:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-tls-cipher-suites:
-    default_result: PASS
-    result_after_remediation: PASS
   ocp4-cis-api-server-tls-private-key:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-cis-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.18.yml
@@ -110,9 +110,6 @@ rule_results:
   ocp4-cis-api-server-tls-cert:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-tls-cipher-suites:
-    default_result: PASS
-    result_after_remediation: PASS
   ocp4-cis-api-server-tls-private-key:
     default_result: PASS
     result_after_remediation: PASS


### PR DESCRIPTION
This rule was removed in
https://github.com/ComplianceAsCode/content/pull/12863/commits/510f13f80a82e93ea12726812c6d1824cec746ca
but the assertion files for the CIS profile were never updated. This
commit updates those assertion files so that CI isn't failing because
the rule was removed.
