### PR TITLE
CMP-3540: Remove OCP pre 4.9 tls and kubelet rule assertions

### DIFF
--- a/tests/assertions/ocp4/ocp4-cis-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.12.yml
@@ -80,15 +80,9 @@ rule_results:
   ocp4-cis-api-server-kubelet-client-cert:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-kubelet-client-cert-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-api-server-kubelet-client-key:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-kubelet-client-key-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-kubelet-configure-tls-cipher-suites-ingresscontroller:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-cis-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.13.yml
@@ -78,15 +78,9 @@ rule_results:
   ocp4-cis-api-server-kubelet-client-cert:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-kubelet-client-cert-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-api-server-kubelet-client-key:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-kubelet-client-key-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-kubelet-configure-tls-cipher-suites-ingresscontroller:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-cis-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.14.yml
@@ -78,15 +78,9 @@ rule_results:
   ocp4-cis-api-server-kubelet-client-cert:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-kubelet-client-cert-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-api-server-kubelet-client-key:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-kubelet-client-key-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-kubelet-configure-tls-cipher-suites-ingresscontroller:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-cis-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.15.yml
@@ -80,15 +80,9 @@ rule_results:
   ocp4-cis-api-server-kubelet-client-cert:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-kubelet-client-cert-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-api-server-kubelet-client-key:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-kubelet-client-key-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-kubelet-configure-tls-cipher-suites-ingresscontroller:
     default_result: FAIL
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-cis-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.16.yml
@@ -78,15 +78,9 @@ rule_results:
   ocp4-cis-api-server-kubelet-client-cert:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-kubelet-client-cert-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-api-server-kubelet-client-key:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-kubelet-client-key-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-api-server-oauth-https-serving-cert:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-cis-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.17.yml
@@ -80,15 +80,9 @@ rule_results:
   ocp4-cis-api-server-kubelet-client-cert:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-kubelet-client-cert-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-api-server-kubelet-client-key:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-kubelet-client-key-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-api-server-oauth-https-serving-cert:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-cis-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.18.yml
@@ -80,15 +80,9 @@ rule_results:
   ocp4-cis-api-server-kubelet-client-cert:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-kubelet-client-cert-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-api-server-kubelet-client-key:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-kubelet-client-key-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-api-server-oauth-https-serving-cert:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.12.yml
@@ -80,15 +80,9 @@ rule_results:
   ocp4-pci-dss-api-server-kubelet-client-cert:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-api-server-kubelet-client-cert-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-api-server-kubelet-client-key:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-api-server-kubelet-client-key-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-api-server-oauth-https-serving-cert:
     default_result: PASS
     result_after_remediation: PASS
@@ -218,15 +212,9 @@ rule_results:
   ocp4-pci-dss-kubelet-configure-tls-cert:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-kubelet-configure-tls-cert-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-kubelet-configure-tls-key:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-kubelet-configure-tls-key-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-kubelet-disable-readonly-port:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.13.yml
@@ -80,15 +80,9 @@ rule_results:
   ocp4-pci-dss-api-server-kubelet-client-cert:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-api-server-kubelet-client-cert-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-api-server-kubelet-client-key:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-api-server-kubelet-client-key-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-api-server-oauth-https-serving-cert:
     default_result: PASS
     result_after_remediation: PASS
@@ -217,15 +211,9 @@ rule_results:
   ocp4-pci-dss-kubelet-configure-tls-cert:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-kubelet-configure-tls-cert-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-kubelet-configure-tls-key:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-kubelet-configure-tls-key-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-kubelet-disable-readonly-port:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.14.yml
@@ -80,15 +80,9 @@ rule_results:
   ocp4-pci-dss-api-server-kubelet-client-cert:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-api-server-kubelet-client-cert-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-api-server-kubelet-client-key:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-api-server-kubelet-client-key-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-api-server-oauth-https-serving-cert:
     default_result: PASS
     result_after_remediation: PASS
@@ -217,15 +211,9 @@ rule_results:
   ocp4-pci-dss-kubelet-configure-tls-cert:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-kubelet-configure-tls-cert-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-kubelet-configure-tls-key:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-kubelet-configure-tls-key-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-kubelet-disable-readonly-port:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.15.yml
@@ -80,15 +80,9 @@ rule_results:
   ocp4-pci-dss-api-server-kubelet-client-cert:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-api-server-kubelet-client-cert-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-api-server-kubelet-client-key:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-api-server-kubelet-client-key-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-api-server-oauth-https-serving-cert:
     default_result: PASS
     result_after_remediation: PASS
@@ -217,15 +211,9 @@ rule_results:
   ocp4-pci-dss-kubelet-configure-tls-cert:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-kubelet-configure-tls-cert-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-kubelet-configure-tls-key:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-kubelet-configure-tls-key-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-kubelet-disable-readonly-port:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.16.yml
@@ -80,15 +80,9 @@ rule_results:
   ocp4-pci-dss-api-server-kubelet-client-cert:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-api-server-kubelet-client-cert-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-api-server-kubelet-client-key:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-api-server-kubelet-client-key-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-api-server-oauth-https-serving-cert:
     default_result: PASS
     result_after_remediation: PASS
@@ -217,15 +211,9 @@ rule_results:
   ocp4-pci-dss-kubelet-configure-tls-cert:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-kubelet-configure-tls-cert-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-kubelet-configure-tls-key:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-kubelet-configure-tls-key-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-kubelet-disable-readonly-port:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.17.yml
@@ -80,15 +80,9 @@ rule_results:
   ocp4-pci-dss-api-server-kubelet-client-cert:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-api-server-kubelet-client-cert-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-api-server-kubelet-client-key:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-api-server-kubelet-client-key-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-api-server-oauth-https-serving-cert:
     default_result: PASS
     result_after_remediation: PASS
@@ -218,15 +212,9 @@ rule_results:
   ocp4-pci-dss-kubelet-configure-tls-cert:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-kubelet-configure-tls-cert-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-kubelet-configure-tls-key:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-kubelet-configure-tls-key-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-kubelet-disable-readonly-port:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.18.yml
@@ -80,15 +80,9 @@ rule_results:
   ocp4-pci-dss-api-server-kubelet-client-cert:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-api-server-kubelet-client-cert-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-api-server-kubelet-client-key:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-api-server-kubelet-client-key-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-api-server-oauth-https-serving-cert:
     default_result: PASS
     result_after_remediation: PASS
@@ -218,15 +212,9 @@ rule_results:
   ocp4-pci-dss-kubelet-configure-tls-cert:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-kubelet-configure-tls-cert-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-kubelet-configure-tls-key:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-kubelet-configure-tls-key-pre-4-9:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-kubelet-disable-readonly-port:
     default_result: PASS
     result_after_remediation: PASS


### PR DESCRIPTION
These rules were updated in
https://github.com/ComplianceAsCode/content/pull/12863 but we missed the
assertions. This commit updates the assertion files so that CI doesn't
trip on old rules we removed.
