### PR TITLE
Fixing idempotency of require_singleuser_auth bash remediation script

### DIFF
--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -2287,7 +2287,7 @@ for f in $(echo -n "{{{ files }}}"); do
         if ! grep -qPz "{{{ key }}}={{{ value }}}" "$f"; then
 {{% if no_quotes %}}    
             sed -i "s/{{{ key }}}[^(\n)]*/{{{ key }}}={{{ value | replace("/", "\/") }}}/" "$f"
-{{% else %}}    
+{{% else %}}
             sed -i 's/{{{ key }}}[^(\n)]*/{{{ key }}}="{{{ value | replace("/", "\/") }}}"/' "$f"
 {{% endif %}}    
         fi

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -2284,12 +2284,15 @@ for f in $(echo -n "{{{ files }}}"); do
 
     # find key in section and change value
     if grep -qzosP "[[:space:]]*\[{{{ section }}}\]([^\n\[]*\n+)+?[[:space:]]*{{{ key }}}" "$f"; then
-{{% if no_quotes %}}
+        if ! grep -qPz "{{{ key }}}={{{ value }}}" "$f"; then
+{{% if no_quotes %}}    
             sed -i "s/{{{ key }}}[^(\n)]*/{{{ key }}}={{{ value | replace("/", "\/") }}}/" "$f"
-{{% else %}}
+{{% else %}}    
             sed -i 's/{{{ key }}}[^(\n)]*/{{{ key }}}="{{{ value | replace("/", "\/") }}}"/' "$f"
-{{% endif %}}
-            found=true
+{{% endif %}}    
+        fi
+
+        found=true
 
     # find section and add key = value to it
     elif grep -qs "[[:space:]]*\[{{{ section }}}\]" "$f"; then


### PR DESCRIPTION
#### Description:

-  Fixing a macro that causes rule's idempotency

#### Rationale:

- `sed` command in `bash_ensure_ini_config` in this particular rule causes replacement of ALL `ExecStart` with `ExecStart=\nExecStart=-/usr/lib/systemd/systemd-sulogin-shell rescue`
- additionally `/etc/systemd/system/rescue.service.d/10-oscap.conf` is being checked more than a single time during the remediation
- in result multiple duplicated `ExecStart` entries are appended to a file and amount of the additional duplicates is increased after every single run of the remediation script
- this macro should probably not be used to replace multiple entries across the entire file 

- Fixes https://issues.redhat.com/browse/RHEL-106811

#### Review Hints:

- fix in `bash_ensure_ini_config` is suppose to prevent file changes, in case  `key`=`value` already exists in the file
