### PR TITLE
CMP-3540: Remove version filter from insecure port rule

### DIFF
--- a/applications/openshift/api-server/api_server_insecure_port/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_port/rule.yml
@@ -37,7 +37,7 @@ rationale: |-
 identifiers:
   cce@ocp4: CCE-83813-6
 
-platform: (ocp4.6 or ocp4.7 or ocp4.8 or ocp4.9 or ocp4.10) and not ocp4-on-hypershift-hosted
+platform: not ocp4-on-hypershift-hosted
 
 severity: medium
 


### PR DESCRIPTION
We were filtering this using old OCP versions that are no longer
supported. Let's remove the filter so we continue to check this rule on
newer OpenShift versions. Even though OpenShift uses secure ports by
default, it's still good to check.
