### PR TITLE
CMP-3540: Remove API server insecure port and gateway assertions

### DIFF
--- a/tests/assertions/ocp4/ocp4-cis-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.12.yml
@@ -26,9 +26,6 @@ rule_results:
   ocp4-cis-api-server-anonymous-auth:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -71,9 +68,6 @@ rule_results:
   ocp4-cis-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-cis-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.13.yml
@@ -24,9 +24,6 @@ rule_results:
   ocp4-cis-api-server-anonymous-auth:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -69,9 +66,6 @@ rule_results:
   ocp4-cis-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-cis-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.14.yml
@@ -24,9 +24,6 @@ rule_results:
   ocp4-cis-api-server-anonymous-auth:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -69,9 +66,6 @@ rule_results:
   ocp4-cis-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-cis-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.15.yml
@@ -26,9 +26,6 @@ rule_results:
   ocp4-cis-api-server-anonymous-auth:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -71,9 +68,6 @@ rule_results:
   ocp4-cis-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-cis-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.16.yml
@@ -24,9 +24,6 @@ rule_results:
   ocp4-cis-api-server-anonymous-auth:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -69,9 +66,6 @@ rule_results:
   ocp4-cis-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-cis-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.17.yml
@@ -26,9 +26,6 @@ rule_results:
   ocp4-cis-api-server-anonymous-auth:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -71,9 +68,6 @@ rule_results:
   ocp4-cis-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-cis-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.18.yml
@@ -26,9 +26,6 @@ rule_results:
   ocp4-cis-api-server-anonymous-auth:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -71,9 +68,6 @@ rule_results:
   ocp4-cis-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.12.yml
@@ -35,9 +35,6 @@ rule_results:
   ocp4-high-api-server-api-priority-flowschema-catch-all:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-high-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-high-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -83,9 +80,6 @@ rule_results:
   ocp4-high-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-high-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-high-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.13.yml
@@ -32,9 +32,6 @@ rule_results:
   ocp4-high-api-server-api-priority-flowschema-catch-all:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-high-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-high-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -80,9 +77,6 @@ rule_results:
   ocp4-high-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-high-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-high-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.14.yml
@@ -32,9 +32,6 @@ rule_results:
   ocp4-high-api-server-api-priority-flowschema-catch-all:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-high-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-high-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -80,9 +77,6 @@ rule_results:
   ocp4-high-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-high-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-high-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.15.yml
@@ -35,9 +35,6 @@ rule_results:
   ocp4-high-api-server-api-priority-flowschema-catch-all:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-high-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-high-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -83,9 +80,6 @@ rule_results:
   ocp4-high-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-high-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-high-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.16.yml
@@ -35,9 +35,6 @@ rule_results:
   ocp4-high-api-server-api-priority-flowschema-catch-all:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-high-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-high-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -83,9 +80,6 @@ rule_results:
   ocp4-high-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-high-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-high-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.17.yml
@@ -35,9 +35,6 @@ rule_results:
   ocp4-high-api-server-api-priority-flowschema-catch-all:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-high-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-high-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -83,9 +80,6 @@ rule_results:
   ocp4-high-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-high-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-high-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.18.yml
@@ -35,9 +35,6 @@ rule_results:
   ocp4-high-api-server-api-priority-flowschema-catch-all:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-high-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-high-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -83,9 +80,6 @@ rule_results:
   ocp4-high-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-high-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-high-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.12.yml
@@ -32,9 +32,6 @@ rule_results:
   ocp4-moderate-api-server-api-priority-flowschema-catch-all:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-moderate-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-moderate-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -80,9 +77,6 @@ rule_results:
   ocp4-moderate-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-moderate-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-moderate-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.13.yml
@@ -32,9 +32,6 @@ rule_results:
   ocp4-moderate-api-server-api-priority-flowschema-catch-all:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-moderate-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-moderate-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -80,9 +77,6 @@ rule_results:
   ocp4-moderate-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-moderate-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-moderate-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.14.yml
@@ -32,9 +32,6 @@ rule_results:
   ocp4-moderate-api-server-api-priority-flowschema-catch-all:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-moderate-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-moderate-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -80,9 +77,6 @@ rule_results:
   ocp4-moderate-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-moderate-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-moderate-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.15.yml
@@ -30,9 +30,6 @@ rule_results:
   ocp4-moderate-api-server-api-priority-flowschema-catch-all:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-moderate-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-moderate-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -78,9 +75,6 @@ rule_results:
   ocp4-moderate-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-moderate-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-moderate-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.16.yml
@@ -32,9 +32,6 @@ rule_results:
   ocp4-moderate-api-server-api-priority-flowschema-catch-all:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-moderate-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-moderate-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -80,9 +77,6 @@ rule_results:
   ocp4-moderate-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-moderate-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-moderate-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.17.yml
@@ -32,9 +32,6 @@ rule_results:
   ocp4-moderate-api-server-api-priority-flowschema-catch-all:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-moderate-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-moderate-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -80,9 +77,6 @@ rule_results:
   ocp4-moderate-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-moderate-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-moderate-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.18.yml
@@ -32,9 +32,6 @@ rule_results:
   ocp4-moderate-api-server-api-priority-flowschema-catch-all:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-moderate-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-moderate-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -80,9 +77,6 @@ rule_results:
   ocp4-moderate-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-moderate-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-moderate-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.12.yml
@@ -26,9 +26,6 @@ rule_results:
   ocp4-pci-dss-api-server-anonymous-auth:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -71,9 +68,6 @@ rule_results:
   ocp4-pci-dss-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.13.yml
@@ -26,9 +26,6 @@ rule_results:
   ocp4-pci-dss-api-server-anonymous-auth:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -71,9 +68,6 @@ rule_results:
   ocp4-pci-dss-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.14.yml
@@ -26,9 +26,6 @@ rule_results:
   ocp4-pci-dss-api-server-anonymous-auth:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -71,9 +68,6 @@ rule_results:
   ocp4-pci-dss-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.15.yml
@@ -26,9 +26,6 @@ rule_results:
   ocp4-pci-dss-api-server-anonymous-auth:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -71,9 +68,6 @@ rule_results:
   ocp4-pci-dss-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.16.yml
@@ -26,9 +26,6 @@ rule_results:
   ocp4-pci-dss-api-server-anonymous-auth:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -71,9 +68,6 @@ rule_results:
   ocp4-pci-dss-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.17.yml
@@ -26,9 +26,6 @@ rule_results:
   ocp4-pci-dss-api-server-anonymous-auth:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -71,9 +68,6 @@ rule_results:
   ocp4-pci-dss-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.18.yml
@@ -26,9 +26,6 @@ rule_results:
   ocp4-pci-dss-api-server-anonymous-auth:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -71,9 +68,6 @@ rule_results:
   ocp4-pci-dss-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-stig-4.12.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.12.yml
@@ -32,9 +32,6 @@ rule_results:
   ocp4-stig-api-server-api-priority-flowschema-catch-all:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-stig-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-stig-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -74,9 +71,6 @@ rule_results:
   ocp4-stig-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-stig-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-stig-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-stig-4.13.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.13.yml
@@ -32,9 +32,6 @@ rule_results:
   ocp4-stig-api-server-api-priority-flowschema-catch-all:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-stig-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-stig-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -74,9 +71,6 @@ rule_results:
   ocp4-stig-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-stig-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-stig-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-stig-4.14.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.14.yml
@@ -32,9 +32,6 @@ rule_results:
   ocp4-stig-api-server-api-priority-flowschema-catch-all:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-stig-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-stig-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -74,9 +71,6 @@ rule_results:
   ocp4-stig-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-stig-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-stig-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-stig-4.15.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.15.yml
@@ -32,9 +32,6 @@ rule_results:
   ocp4-stig-api-server-api-priority-flowschema-catch-all:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-stig-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-stig-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -74,9 +71,6 @@ rule_results:
   ocp4-stig-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-stig-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-stig-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-stig-4.16.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.16.yml
@@ -32,9 +32,6 @@ rule_results:
   ocp4-stig-api-server-api-priority-flowschema-catch-all:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-stig-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-stig-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -74,9 +71,6 @@ rule_results:
   ocp4-stig-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-stig-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-stig-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-stig-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.17.yml
@@ -32,9 +32,6 @@ rule_results:
   ocp4-stig-api-server-api-priority-flowschema-catch-all:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-stig-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-stig-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -74,9 +71,6 @@ rule_results:
   ocp4-stig-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-stig-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-stig-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-stig-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.18.yml
@@ -32,9 +32,6 @@ rule_results:
   ocp4-stig-api-server-api-priority-flowschema-catch-all:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-stig-api-server-api-priority-gate-enabled:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-stig-api-server-audit-log-maxbackup:
     default_result: PASS
     result_after_remediation: PASS
@@ -74,9 +71,6 @@ rule_results:
   ocp4-stig-api-server-insecure-bind-address:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-stig-api-server-insecure-port:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-stig-api-server-kubelet-certificate-authority:
     default_result: PASS
     result_after_remediation: PASS


### PR DESCRIPTION
These rules were removed from various profiles in
https://github.com/ComplianceAsCode/content/commit/f4bcb76deb68ec3ca06a072e1530e0d441243b79
because they only applied to older OpenShift versions. This rule is
inherently met on newer versions of OpenShift.
