### PR TITLE
CMP-3540: Remove SDN proxy kubeconfig assertions from 4.17+ assertion files

### DIFF
--- a/tests/assertions/ocp4/ocp4-cis-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.17.yml
@@ -164,15 +164,6 @@ rule_results:
   ocp4-cis-etcd-peer-key-file:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-file-groupowner-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
-  ocp4-cis-file-owner-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
-  ocp4-cis-file-permissions-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-general-apply-scc:
     default_result: MANUAL
     result_after_remediation: MANUAL

--- a/tests/assertions/ocp4/ocp4-cis-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-cis-4.18.yml
@@ -164,15 +164,6 @@ rule_results:
   ocp4-cis-etcd-peer-key-file:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-cis-file-groupowner-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
-  ocp4-cis-file-owner-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
-  ocp4-cis-file-permissions-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-cis-general-apply-scc:
     default_result: MANUAL
     result_after_remediation: MANUAL

--- a/tests/assertions/ocp4/ocp4-high-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.17.yml
@@ -221,21 +221,12 @@ rule_results:
   ocp4-high-etcd-peer-key-file:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-high-file-groupowner-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-high-file-integrity-exists:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   ocp4-high-file-integrity-notification-enabled:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
-  ocp4-high-file-owner-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
-  ocp4-high-file-permissions-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-high-fips-mode-enabled-on-all-nodes:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-high-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-high-4.18.yml
@@ -221,21 +221,12 @@ rule_results:
   ocp4-high-etcd-peer-key-file:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-high-file-groupowner-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-high-file-integrity-exists:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   ocp4-high-file-integrity-notification-enabled:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
-  ocp4-high-file-owner-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
-  ocp4-high-file-permissions-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-high-fips-mode-enabled-on-all-nodes:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.17.yml
@@ -215,21 +215,12 @@ rule_results:
   ocp4-moderate-etcd-peer-key-file:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-moderate-file-groupowner-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-moderate-file-integrity-exists:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   ocp4-moderate-file-integrity-notification-enabled:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
-  ocp4-moderate-file-owner-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
-  ocp4-moderate-file-permissions-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-moderate-fips-mode-enabled-on-all-nodes:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-moderate-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-moderate-4.18.yml
@@ -215,21 +215,12 @@ rule_results:
   ocp4-moderate-etcd-peer-key-file:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-moderate-file-groupowner-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-moderate-file-integrity-exists:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   ocp4-moderate-file-integrity-notification-enabled:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
-  ocp4-moderate-file-owner-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
-  ocp4-moderate-file-permissions-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-moderate-fips-mode-enabled-on-all-nodes:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.17.yml
@@ -188,21 +188,12 @@ rule_results:
   ocp4-pci-dss-4-0-etcd-peer-key-file:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-4-0-file-groupowner-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-4-0-file-integrity-exists:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   ocp4-pci-dss-4-0-file-integrity-notification-enabled:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
-  ocp4-pci-dss-4-0-file-owner-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
-  ocp4-pci-dss-4-0-file-permissions-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-4-0-general-apply-scc:
     default_result: MANUAL
     result_after_remediation: MANUAL

--- a/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4-0-4.18.yml
@@ -188,21 +188,12 @@ rule_results:
   ocp4-pci-dss-4-0-etcd-peer-key-file:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-4-0-file-groupowner-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-4-0-file-integrity-exists:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   ocp4-pci-dss-4-0-file-integrity-notification-enabled:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
-  ocp4-pci-dss-4-0-file-owner-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
-  ocp4-pci-dss-4-0-file-permissions-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-4-0-general-apply-scc:
     default_result: MANUAL
     result_after_remediation: MANUAL

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.17.yml
@@ -170,21 +170,12 @@ rule_results:
   ocp4-pci-dss-etcd-peer-key-file:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-file-groupowner-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-file-integrity-exists:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   ocp4-pci-dss-file-integrity-notification-enabled:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
-  ocp4-pci-dss-file-owner-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
-  ocp4-pci-dss-file-permissions-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-general-apply-scc:
     default_result: MANUAL
     result_after_remediation: MANUAL

--- a/tests/assertions/ocp4/ocp4-pci-dss-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-pci-dss-4.18.yml
@@ -170,21 +170,12 @@ rule_results:
   ocp4-pci-dss-etcd-peer-key-file:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-pci-dss-file-groupowner-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-file-integrity-exists:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
   ocp4-pci-dss-file-integrity-notification-enabled:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
-  ocp4-pci-dss-file-owner-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
-  ocp4-pci-dss-file-permissions-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-pci-dss-general-apply-scc:
     default_result: MANUAL
     result_after_remediation: MANUAL

--- a/tests/assertions/ocp4/ocp4-stig-4.17.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.17.yml
@@ -185,18 +185,9 @@ rule_results:
   ocp4-stig-etcd-peer-client-cert-auth:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-stig-file-groupowner-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-stig-file-integrity-exists:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
-  ocp4-stig-file-owner-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
-  ocp4-stig-file-permissions-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-stig-fips-mode-enabled-on-all-nodes:
     default_result: PASS
     result_after_remediation: PASS

--- a/tests/assertions/ocp4/ocp4-stig-4.18.yml
+++ b/tests/assertions/ocp4/ocp4-stig-4.18.yml
@@ -185,18 +185,9 @@ rule_results:
   ocp4-stig-etcd-peer-client-cert-auth:
     default_result: PASS
     result_after_remediation: PASS
-  ocp4-stig-file-groupowner-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-stig-file-integrity-exists:
     default_result: FAIL or NOT-APPLICABLE
     result_after_remediation: PASS or NOT-APPLICABLE
-  ocp4-stig-file-owner-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
-  ocp4-stig-file-permissions-proxy-kubeconfig:
-    default_result: NOT-APPLICABLE
-    result_after_remediation: NOT-APPLICABLE
   ocp4-stig-fips-mode-enabled-on-all-nodes:
     default_result: PASS
     result_after_remediation: PASS


### PR DESCRIPTION
OpenShift uses OVN Kubernetes on 4.17, and the SDN rules are not
applicable in those versions such that they're not run in profiles that
use them. This commit removes the assertions that expect them to be
there on those versions.
