### PR TITLE
Make rule enable_authselect notapplicable in containers

### DIFF
--- a/linux_os/guide/system/accounts/enable_authselect/rule.yml
+++ b/linux_os/guide/system/accounts/enable_authselect/rule.yml
@@ -35,6 +35,8 @@ ocil: |-
     <pre>authselect current</pre>
     If authselect is enabled on the system, the output should show the ID of the profile which is currently in use.
 
+platform: system_with_kernel
+
 fixtext: |-
     Configure {{{ full_name }}} to select an authselect profile if one is not already selected.
     Use the following command to enable the {{{ xccdf_value("var_authselect_profile") }}} profile:


### PR DESCRIPTION
The rule enable_authselect shouldn't be applicable when scanning a container image such as ubi8 using oscap-podman. At the same time I think it should be applicable when building a bootable container image using oscap-im. Therefore, I assign the system_with_kernel platform.

Resolves: https://issues.redhat.com/browse/RHEL-84439

