### PR TITLE
Add test scenario to cover case where user has nologin defined in usr

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/tests/interactive_user_usr_nologin_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/tests/interactive_user_usr_nologin_ignored.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m -s /usr/sbin/nologin $USER
+sed -i "s/\($USER:x:[0-9]*:[0-9]*:.*:\).*\(:.*\)$/\1\2/g" /etc/passwd


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/OPENSCAP-6327

#### Description:

- Add test scenario to cover case where user has nologin defined in usr.

#### Rationale:

- Test scenario to cover recently modified OVAL

#### Review Hints:

Build the rhel9 content then run automatus

tests/automatus.py rule --libvirt qemu:///system rhel9 --debug --datastream build/ssg-rhel9-ds.xml --dontclean --scenarios interactive_user_usr_nologin_ignored.pass accounts_user_interactive_home_directory_defined


- To check that the test fails, remove the code from https://github.com/ComplianceAsCode/content/pull/13962 and build the datastream and run the test again, it should fail.


