### PR TITLE
Add changed_when and check_mode keys

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/directory_permissions_var_log_audit/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/directory_permissions_var_log_audit/ansible/shared.yml
@@ -8,6 +8,7 @@
   ansible.builtin.command: grep -iw ^log_file /etc/audit/auditd.conf
   check_mode: False
   failed_when: false
+  changed_when: false
   register: log_file_exists
 
 - name: "{{{ rule_title }}} - Set audit log file fact"
@@ -28,6 +29,7 @@
   ansible.builtin.command: grep -iw ^log_group /etc/audit/auditd.conf
   check_mode: False
   failed_when: false
+  changed_when: false
   register: log_group_exists
 
 - name: "{{{ rule_title }}} - Set audit log directory mode to 0700"

--- a/linux_os/guide/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/ansible/shared.yml
@@ -7,6 +7,8 @@
 - name: "{{{ rule_title }}} - Get Audit Log Files"
   ansible.builtin.command: grep -iw ^log_file /etc/audit/auditd.conf
   failed_when: false
+  changed_when: false
+  check_mode: false
   register: log_file_exists
 
 - name: "{{{ rule_title }}} - Set Log File Facts"
@@ -33,6 +35,8 @@
 - name: "{{{ rule_title }}} - Get Audit Log Group"
   ansible.builtin.command: grep -iw ^log_group /etc/audit/auditd.conf
   failed_when: false
+  changed_when: false
+  check_mode: false
   register: log_group_exists
 
 - name: "{{{ rule_title }}} - Set Log Group Facts"

--- a/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/ansible/shared.yml
@@ -8,6 +8,7 @@
   ansible.builtin.command: grep -iw ^log_file /etc/audit/auditd.conf
   check_mode: False
   failed_when: false
+  changed_when: false
   register: log_file_exists
 
 - name: "{{{ rule_title }}} - Set audit log file fact"

--- a/linux_os/guide/auditing/auditd_configure_rules/file_permissions_var_log_audit/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/file_permissions_var_log_audit/ansible/shared.yml
@@ -7,11 +7,15 @@
 - name: Get audit log files
   ansible.builtin.command: grep -iw ^log_file /etc/audit/auditd.conf
   failed_when: false
+  changed_when: false
+  check_mode: false
   register: log_file_exists
 
 - name: Parse log file line
   ansible.builtin.command: awk -F '=' '/^log_file/ {print $2}' /etc/audit/auditd.conf
   register: log_file_line
+  changed_when: false
+  check_mode: false
   when: log_file_exists is not skipped and (log_file_exists.stdout | length > 0)
 
 - name: Set default log_file if not set
@@ -28,10 +32,14 @@
 - name: Get log files group
   ansible.builtin.command: grep -m 1 ^log_group /etc/audit/auditd.conf
   failed_when: false
+  changed_when: false
+  check_mode: false
   register: log_group_line
 
 - name: Parse log group line
   ansible.builtin.command: awk -F '=' '/log_group/ {print $2}' /etc/audit/auditd.conf
+  changed_when: false
+  check_mode: false
   register: log_group
   when: (log_group_line is not skipped) and (log_group_line.stdout | length > 0)
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/ansible/shared.yml
@@ -8,6 +8,8 @@
   ansible.builtin.shell: |-
     grep -oP '^\s*(?:auth.*pam_faillock.so.*)?dir\s*=\s*(\S+)' "{{ item }}" | sed -r 's/.*=\s*(\S+)/\1/'
   register: faillock_output
+  changed_when: false
+  check_mode: false
   with_items:
     - /etc/security/faillock.conf
     {{% if 'ol' not in families %}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/ansible/shared.yml
@@ -9,6 +9,8 @@
   ansible.builtin.command:
     cmd: awk -F':' '(/^[^:]+:[^!*]/ && ($5 > {{ var_accounts_maximum_age_login_defs }} || $5 == "")) {print $1}' /etc/shadow
   register: user_names
+  changed_when: false
+  check_mode: false
 
 - name: Change the maximum time period between password changes
 {{% if product in ["ol7"] %}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/ansible/shared.yml
@@ -10,6 +10,8 @@
   ansible.builtin.command: >
     awk -F':' '(/^[^:]+:[^!*]/ && ($4 < {{ var_accounts_minimum_age_login_defs }} || $4 == "")) {print $1}' /etc/shadow
   register: user_names
+  changed_when: false
+  check_mode: false
 
 - name: Change the minimum time period between password changes
 {{% if product in ["sle12", "sle15", "slmicro6"] %}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/ansible/shared.yml
@@ -24,6 +24,8 @@
   ansible.builtin.shell: |
     find / -xdev -type f -perm -0002 2> /dev/null
   register: world_writable_files
+  changed_when: false
+  check_mode: false
 
 - name: {{{ rule_title }}} - Find referenced_files in init files
   ansible.builtin.find:

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/ansible/shared.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/ansible/shared.yml
@@ -12,6 +12,8 @@
     {{% endif %}}
     register: cron_log_config_exists
     failed_when: false
+    changed_when: false
+    check_mode: false
 
 -   name: "{{{ rule_title }}} - Ensure the /etc/rsyslog.d directory exists"
     ansible.builtin.file:

--- a/linux_os/guide/system/logging/ensure_rtc_utc_configuration/ansible/shared.yml
+++ b/linux_os/guide/system/logging/ensure_rtc_utc_configuration/ansible/shared.yml
@@ -5,6 +5,8 @@
     timedatectl status | grep -i 'Time zone'| grep -iv 'UTC\|GMT' || true
   register: check_tz
   failed_when: "check_tz.rc not in [ 0 , 1 ]"
+  changed_when: false
+  check_mode: false
 
 - name: Configure OS to use 'UTC' timezone
   ansible.builtin.command: timedatectl set-timezone UTC

--- a/linux_os/guide/system/network/network-nftables/set_nftables_loopback_traffic/ansible/shared.yml
+++ b/linux_os/guide/system/network/network-nftables/set_nftables_loopback_traffic/ansible/shared.yml
@@ -14,6 +14,8 @@
   ansible.builtin.shell: |
     [ -z "$(grep "^\s*linux" /boot/grub2/grub.cfg | grep -v ipv6.disabled=1)" ]
   register: ipv6_status
+  changed_when: false
+  check_mode: false
 
 - name: Check sysctl value of net.ipv6.conf.all.disable_ipv6
   ansible.posix.sysctl:

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/ansible/shared.yml
@@ -14,6 +14,8 @@
     LC_ALL=C grep "^[A-Z][A-Za-z_]*" /etc/aide.conf | grep -v "^ALLXTRAHASHES" | cut -f1 -d '=' | tr -d ' ' | sort -u || true
   when: "'aide' in ansible_facts.packages"
   register: find_rules_groups_results
+  changed_when: false
+  check_mode: false
 
 - name: Ensure the acl rule is present when aide is installed.
   ansible.builtin.replace:

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/ansible/shared.yml
@@ -14,6 +14,8 @@
     LC_ALL=C grep "^[A-Z][A-Za-z_]*" /etc/aide.conf | grep -v "^ALLXTRAHASHES" | cut -f1 -d '=' | tr -d ' ' | sort -u || true
   when: "'aide' in ansible_facts.packages"
   register: find_rules_groups_results
+  changed_when: false
+  check_mode: false
 
 - name: Ensure the xattrs rule is present when aide is installed.
   ansible.builtin.replace:

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1487,12 +1487,14 @@ Part of the grub2_bootloader_argument template.
   ansible.builtin.command: grep '^\s*GRUB_CMDLINE_LINUX=.*{{{ arg_name }}}=' /etc/default/grub
   check_mode: False
   failed_when: False
+  changed_when: False
   register: argcheck
 
 - name: Check {{{ arg_name }}} argument exists
   ansible.builtin.command: grep '^\s*GRUB_CMDLINE_LINUX=' /etc/default/grub
   check_mode: False
   failed_when: False
+  changed_when: False
   register: linecheck
 
 - name: Add {{{ arg_name }}} argument
@@ -1560,6 +1562,7 @@ Part of the grub2_bootloader_argument_absent template.
   ansible.builtin.command: grep '^GRUB_CMDLINE_LINUX=.*{{{ arg_name }}}=.*"' /etc/default/grub
   check_mode: False
   failed_when: False
+  changed_when: False
   register: argcheck
 
 - name: Replace existing {{{ arg_name }}} argument

--- a/shared/templates/mount_option/ansible.template
+++ b/shared/templates/mount_option/ansible.template
@@ -19,6 +19,7 @@
   register: device_name
   failed_when: device_name.rc > 1
   changed_when: False
+  check_mode: False
 
 - name: "{{{ rule_title }}}: Create mount_info dictionary variable"
   set_fact:

--- a/shared/templates/socket_disabled/ansible.template
+++ b/shared/templates/socket_disabled/ansible.template
@@ -10,6 +10,7 @@
     cmd: systemctl -q list-unit-files --type socket
   register: result_systemd_unit_files
   changed_when: false
+  check_mode: false
 
 - name: "{{{ rule_title }}} - Ensure {{{ SOCKETNAME }}}.socket is Masked"
   ansible.builtin.systemd:


### PR DESCRIPTION
This change adds "check_mode: false" and/or "changed_when: false" to Ansible Tasks that use the shell or command modules.

Resolves: https://issues.redhat.com/browse/OPENSCAP-6246


