### PR TITLE
Make Ansible in dconf_db_up_to_date idempotent

### DIFF
--- a/linux_os/guide/system/software/gnome/dconf_db_up_to_date/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/dconf_db_up_to_date/ansible/shared.yml
@@ -3,6 +3,25 @@
 # strategy = unknown
 # complexity = low
 # disruption = medium
-- name: "Run dconf update"
+
+{{% macro check_db_is_up_to_date(db_name) %}}
+- name: "{{{ rule_title }}} - Get database modification time for {{{ db_name }}}"
+  ansible.builtin.stat:
+    path: '/etc/dconf/db/{{{ db_name }}}'
+  register: '{{{ db_name }}}_db'
+
+- name: "{{{ rule_title }}} - Get keyfiles for {{{ db_name }}}"
+  ansible.builtin.find:
+    paths: '/etc/dconf/db/{{{ db_name }}}.d/'
+  register: '{{{ db_name }}}_keyfiles'
+
+- name: "{{{ rule_title }}} - Run dconf update for {{{ db_name }}}"
   ansible.builtin.command:
     cmd: dconf update
+  when: "not {{{ db_name }}}_db.stat.exists or {{{ db_name }}}_keyfiles.files | length > 0 and {{{ db_name }}}_keyfiles.files | map(attribute='mtime') | max > {{{ db_name }}}_db.stat.mtime"
+{{% endmacro %}}
+
+{{{ check_db_is_up_to_date(dconf_gdm_dir.split(".")[0]) }}}
+{{% if dconf_gdm_dir.split(".")[0] != "local" %}}
+  {{{ check_db_is_up_to_date("local") }}}
+{{% endif %}}


### PR DESCRIPTION
This change will make the Ansible remediation for rule dconf_db_up_to_date idempotent. The solution is inspired by OVAL check in this rule. The Ansible remediation will update the dconf database only if some key file is newer than the database.

Resolves: https://issues.redhat.com/browse/OPENSCAP-6229



#### Review Hints:
- `./build_product --playbook-per-rule rhel9`
- manually replace hosts by `hosts: all` in `build/rhel9/playbooks/all/dconf_db_up_to_date.yml` 
- ssh to your VM and install the `gdm` RPM package there
- run this script there to make the system incompliant with the rule:  [test.sh](https://github.com/user-attachments/files/22762905/test.sh)
- run `ansible-playbook -u root -i YOUR_IP, build/rhel9/playbooks/all/dconf_db_up_to_date.yml` at least twice and compare the output of the first run with the second run and so on, verify that the second and next runs don't change anything and that the output contains only "ok" or "skipping"
- apart from that, run automatus Tss with `--remediate-using ansible`
