### PR TITLE
Make Ansible in dconf_gnome_screensaver_lock_enabled idempotent

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/ansible/shared.yml
@@ -4,11 +4,7 @@
 # complexity = low
 # disruption = medium
 
-- name: Dconf Update
-  ansible.builtin.command: dconf update
-  when: ansible_distribution == 'SLES'
-
-- name: "Enable GNOME3 Screensaver Lock After Idle Period"
+- name: "{{{ rule_title }}} - Enable GNOME3 Screensaver Lock After Idle Period"
   community.general.ini_file:
     dest: "/etc/dconf/db/local.d/00-security-settings"
     section: "org/gnome/desktop/screensaver"
@@ -17,16 +13,18 @@
     create: yes
     no_extra_spaces: yes
   when: ansible_distribution != 'SLES'
+  register: screensaver_config
 
-- name: "Prevent user modification of GNOME lock-enabled"
+- name: "{{{ rule_title }}} - Prevent user modification of GNOME lock-enabled"
   ansible.builtin.lineinfile:
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
     regexp: '^/org/gnome/desktop/screensaver/lock-enabled$'
     line: '/org/gnome/desktop/screensaver/lock-enabled'
     create: yes
   when: ansible_distribution != 'SLES'
+  register: screensaver_lock
 
-- name: "Enable GNOME3 Screensaver Lock After Idle Period"
+- name: "{{{ rule_title }}} - Enable GNOME3 Screensaver Lock After Idle Period"
   community.general.ini_file:
     dest: "/etc/dconf/db/local.d/00-security-settings"
     section: "org/gnome/desktop/lockdown"
@@ -35,23 +33,37 @@
     create: yes
     no_extra_spaces: yes
   when: ansible_distribution == 'SLES'
+  register: lockdown_config
 
-- name: "Prevent user modification of GNOME disable-lock-screen"
+- name: "{{{ rule_title }}} - Prevent user modification of GNOME disable-lock-screen"
   ansible.builtin.lineinfile:
     path: /etc/dconf/db/local.d/locks/00-security-settings-lock
     regexp: '^/org/gnome/desktop/lockdown/disable-lock-screen$'
     line: '/org/gnome/desktop/lockdown/disable-lock-screen'
     create: yes
   when: ansible_distribution == 'SLES'
+  register: lockdown_lock
 
-- name: "Check GNOME3 screenserver disable-lock-screen false"
+- name: "{{{ rule_title }}} - Check GNOME3 screenserver disable-lock-screen false"
   ansible.builtin.command: gsettings get org.gnome.desktop.lockdown disable-lock-screen
   register: cmd_out
   when: ansible_distribution == 'SLES'
+  changed_when: false
 
-- name: "Update GNOME3 screenserver disable-lock-screen false"
+- name: "{{{ rule_title }}} - Update GNOME3 screenserver disable-lock-screen false"
   ansible.builtin.command: gsettings set org.gnome.desktop.lockdown disable-lock-screen false
-  when: ansible_distribution == 'SLES'
+  when:
+    - ansible_distribution == 'SLES'
+    - cmd_out.stdout != 'false'
 
-- name: Dconf Update
+- name: "{{{ rule_title }}} - Update dconf database for non-SLES systems"
   ansible.builtin.command: dconf update
+  when:
+    - ansible_distribution != 'SLES'
+    - (screensaver_config is changed or screensaver_lock is changed)
+
+- name: "{{{ rule_title }}} - Update dconf database for SLES systems"
+  ansible.builtin.command: dconf update
+  when:
+    - ansible_distribution == 'SLES'
+    - (lockdown_config is changed or lockdown_lock is changed)


### PR DESCRIPTION
This change ensures that the "dconf update" command will be executed only if some of the configuration files have been modified by the Ansible Tasks.

Resolves: https://issues.redhat.com/browse/OPENSCAP-6228

#### Review Hints:
- `./build_product --playbook-per-rule rhel9`
- manually replace hosts by `hosts: all` in `build/rhel9/playbooks/stig/dconf_gnome_screensaver_lock_enabled.yml` 
- ssh to your VM and install the `gdm` RPM package there
- run `ansible-playbook -u root -i YOUR_IP, build/rhel9/playbooks/stig/dconf_gnome_screensaver_lock_enabled.yml` at least twice and compare the output of the first run with the second run and so on, verify that the second and next runs don't change anything and that the output contains only "ok" or "skipping"
- apart from that, run automatus Tss with `--remediate-using ansible`
