### PR TITLE
Fix tests for no_dirs_unowned_by_root

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/root_paths/no_dirs_unowned_by_root/tests/wrong.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/no_dirs_unowned_by_root/tests/wrong.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# remediation = none
 
 ( IFS=:
   for p in $PATH; do


### PR DESCRIPTION


#### Description:
Fix tests for `no_dirs_unowned_by_root`.
Add `remediation = none` so that tests don't expect fixed

#### Rationale:

Fix productization failure.
#### Review Hints:
`./automatus.py rule --datastream ../build/ssg-rhel9-ds.xml --libvirt qemu:///system automatus_rhel9_7 --remediate-using oscap no_dirs_unowned_by_root` should run with no warnings or errors.
