### PR TITLE
Make Ansible in account_password_selinux_faillock_dir idempotent

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/ansible/shared.yml
@@ -28,18 +28,32 @@
   with_items: "{{ list_faillock_dir }}"
   when: item != ""
 
-- name: {{{ rule_title }}} - Set up SELinux context for faillock
-  ansible.builtin.shell: |-
-    if ! semanage fcontext -a -t faillog_t "{{ item }}(/.*)?"; then
-      semanage fcontext -m -t faillog_t "{{ item }}(/.*)?"
-    fi
-  with_items: "{{ list_faillock_dir }}"
+- name: {{{ rule_title}}} - Get SELinux context for faillock directories
+  ansible.builtin.command: ls -dZ "{{ item }}"
+  register: faillock_selinux_context
+  changed_when: false
+  check_mode: false
+  with_items: '{{ list_faillock_dir }}'
   when: item != ""
 
+- name: {{{ rule_title }}} - Set up SELinux context for faillock
+  ansible.builtin.shell: |-
+    if ! semanage fcontext -a -t faillog_t "{{ item.item }}(/.*)?"; then
+      semanage fcontext -m -t faillog_t "{{ item.item }}(/.*)?"
+    fi
+  with_items: "{{ faillock_selinux_context.results }}"
+  when:
+    - item.item != ""
+    - item.stdout is defined
+    - '"faillog_t" not in item.stdout'
+
 - name: {{{ rule_title }}} - Restore SELinux context
-  ansible.builtin.command: restorecon -R -v "{{ item }}"
-  with_items: "{{ list_faillock_dir }}"
-  when: item != ""
+  ansible.builtin.command: restorecon -R -v "{{ item.item }}"
+  with_items: "{{ faillock_selinux_context.results }}"
+  when:
+    - item.item != ""
+    - item.stdout is defined
+    - '"faillog_t" not in item.stdout'
 
 - name: {{{ rule_title }}} - Verify pam_faillock.so configuration
   ansible.builtin.debug:


### PR DESCRIPTION
Change the faillock directory SELinux context only if the context is incorrect.

Resolves: https://issues.redhat.com/browse/OPENSCAP-6239



#### Review Hints:
- `./build_product --playbook-per-rule rhel9`
- manually replace hosts by `hosts: all` in `build/rhel9/playbooks/stig/account_password_selinux_faillock_dir.yml`
- ssh to your VM and run `linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/wrong_value.fail.sh` there
- run `ansible-playbook -u root -i YOUR_IP, build/rhel9/playbooks/stig/account_password_selinux_faillock_dir.yml` at least twice and compare the output of the first run with the second run and so on, verify that the second and next runs don't change anything and that the output contains only "ok" or "skipping"
- apart from that, run automatus Tss with `--remediate-using ansible`
