### PR TITLE
Make Ansible in accounts_passwords_pam_faillock_dir idempotent

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/ansible/shared.yml
@@ -16,11 +16,17 @@
     - python3-policycoreutils
     - policycoreutils-python-utils
 
-- name: '{{{ rule_title }}} - Create the tally directory if it does not exist'
+- name: '{{{ rule_title }}} - Create the faillock directory if it does not exist'
   ansible.builtin.file:
     path: "{{ var_accounts_passwords_pam_faillock_dir }}"
     state: directory
     setype: 'faillog_t'
+
+- name: '{{{ rule_title }}} - Get SELinux context for faillock directory'
+  ansible.builtin.command: "ls -dZ {{ var_accounts_passwords_pam_faillock_dir }}"
+  register: faillock_selinux_context
+  changed_when: false
+  check_mode: false
 
 - name: '{{{ rule_title }}} - Ensure SELinux file context is permanently set'
   ansible.builtin.command:
@@ -29,8 +35,10 @@
   failed_when: false
   changed_when:
     - result_accounts_passwords_pam_faillock_dir_semanage.rc == 0
+  when: '"faillog_t" not in faillock_selinux_context.stdout'
 
 - name: '{{{ rule_title }}} - Ensure SELinux file context is applied'
   ansible.builtin.command:
     cmd: restorecon -R "{{ var_accounts_passwords_pam_faillock_dir }}"
   register: result_accounts_passwords_pam_faillock_dir_restorecon
+  when: '"faillog_t" not in faillock_selinux_context.stdout'


### PR DESCRIPTION
Change the SELinux context of /var/log/faillock only if the current context isn't correct.

Resolves: https://issues.redhat.com/browse/OPENSCAP-6240

#### Review Hints:

- `./build_product --playbook-per-rule rhel9`
- manually replace hosts by `hosts: all` in `build/rhel9/playbooks/stig/accounts_passwords_pam_faillock_dir.yml`
- Connect by ssh to your VM and ensure an authselect profile is selected before running any Ansible Playbook.
- run `ansible-playbook -u root -i YOUR_IP, build/rhel9/playbooks/stig/accounts_passwords_pam_faillock_dir.yml` at least twice and compare the output of the first run with the second run and so on, verify that the second and next runs don't change anything and that the output contains only "ok" or "skipping"
- apart from that, run automatus Tss with `--remediate-using ansible`
