### PR TITLE
Update test scenario to make sure there are no compliant state

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/tests/invalid_username.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/tests/invalid_username.fail.sh
@@ -7,4 +7,13 @@
 
 make_grub_password
 
+{{% if 'ubuntu' in product %}}
+test -n "$GRUB_CFG_ROOT" || GRUB_CFG_ROOT=/boot/grub
+{{% else %}}
+test -n "$GRUB_CFG_ROOT" || GRUB_CFG_ROOT=/boot/grub2
+{{% endif %}}
+
+# replace all occurrences of superusers = root
+sed -i 's/set superusers="root"/set superusers="use r"/g' "$GRUB_CFG_ROOT/grub.cfg"
+
 set_superusers "use r"


### PR DESCRIPTION


#### Description:
- Update test scenario to make sure there are no compliant state.
  - The default file might contain compliant configuration that trips the test scenario setup. We force all config values to deviate from compliance state.

#### Rationale:

- Fixes #13982

#### Review Hints:

- Build the RHEL9 product
- tests/automatus.py rule --libvirt qemu:///system rhel9 --debug --datastream build/ssg-rhel9-ds.xml --remediate-using bash --scenarios invalid_username.fail.sh grub2_password


