### PR TITLE
Enable testing of bsi and ism_o_top_secret profiles on CentOS Stream

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -45,6 +45,11 @@ jobs:
   identifier: /hardening/host-os/ansible/anssi_bp28_high
   tmt_plan: /plans/contest/hardening/host-os/ansible/anssi_bp28_high$
 - <<: *test-static-checks
+  identifier: /hardening/host-os/ansible/bsi
+  tmt_plan: /plans/contest/hardening/host-os/ansible/bsi$
+  targets:
+    centos-stream-9: {}
+- <<: *test-static-checks
   identifier: /hardening/host-os/ansible/ccn_advanced
   tmt_plan: /plans/contest/hardening/host-os/ansible/ccn_advanced$
   targets:
@@ -77,6 +82,11 @@ jobs:
   identifier: /hardening/host-os/ansible/ism_o
   tmt_plan: /plans/contest/hardening/host-os/ansible/ism_o$
 - <<: *test-static-checks
+  identifier: /hardening/host-os/ansible/ism_o_top_secret
+  tmt_plan: /plans/contest/hardening/host-os/ansible/ism_o_top_secret$
+  targets:
+    centos-stream-10: {}
+- <<: *test-static-checks
   identifier: /hardening/host-os/ansible/ospp
   tmt_plan: /plans/contest/hardening/host-os/ansible/ospp$
 - <<: *test-static-checks
@@ -89,6 +99,11 @@ jobs:
 - <<: *test-static-checks
   identifier: /hardening/host-os/oscap/anssi_bp28_high
   tmt_plan: /plans/contest/hardening/host-os/oscap/anssi_bp28_high$
+- <<: *test-static-checks
+  identifier: /hardening/host-os/oscap/bsi
+  tmt_plan: /plans/contest/hardening/host-os/oscap/bsi$
+  targets:
+    centos-stream-9: {}
 - <<: *test-static-checks
   identifier: /hardening/host-os/oscap/ccn_advanced
   tmt_plan: /plans/contest/hardening/host-os/oscap/ccn_advanced$
@@ -121,6 +136,11 @@ jobs:
 - <<: *test-static-checks
   identifier: /hardening/host-os/oscap/ism_o
   tmt_plan: /plans/contest/hardening/host-os/oscap/ism_o$
+- <<: *test-static-checks
+  identifier: /hardening/host-os/oscap/ism_o_top_secret
+  tmt_plan: /plans/contest/hardening/host-os/oscap/ism_o_top_secret$
+  targets:
+    centos-stream-10: {}
 - <<: *test-static-checks
   identifier: /hardening/host-os/oscap/ospp
   tmt_plan: /plans/contest/hardening/host-os/oscap/ospp$

--- a/tests/tmt/plans/contest.fmf
+++ b/tests/tmt/plans/contest.fmf
@@ -16,6 +16,9 @@ report:
 /hardening/host-os/ansible/anssi_bp28_high:
     discover+: {test: /hardening/host-os/ansible/anssi_bp28_high$}
 
+/hardening/host-os/ansible/bsi:
+    discover+: {test: /hardening/host-os/ansible/bsi$}
+
 /hardening/host-os/ansible/ccn_advanced:
     discover+: {test: /hardening/host-os/ansible/ccn_advanced$}
 
@@ -43,6 +46,9 @@ report:
 /hardening/host-os/ansible/ism_o:
     discover+: {test: /hardening/host-os/ansible/ism_o$}
 
+/hardening/host-os/ansible/ism_o_top_secret:
+    discover+: {test: /hardening/host-os/ansible/ism_o_top_secret$}
+
 /hardening/host-os/ansible/ospp:
     discover+: {test: /hardening/host-os/ansible/ospp$}
 
@@ -58,6 +64,9 @@ report:
 
 /hardening/host-os/oscap/anssi_bp28_high:
     discover+: {test: /hardening/host-os/oscap/anssi_bp28_high$}
+
+/hardening/host-os/oscap/bsi:
+    discover+: {test: /hardening/host-os/oscap/bsi$}
 
 /hardening/host-os/oscap/ccn_advanced:
     discover+: {test: /hardening/host-os/oscap/ccn_advanced$}
@@ -85,6 +94,9 @@ report:
 
 /hardening/host-os/oscap/ism_o:
     discover+: {test: /hardening/host-os/oscap/ism_o$}
+
+/hardening/host-os/oscap/ism_o_top_secret:
+    discover+: {test: /hardening/host-os/oscap/ism_o_top_secret$}
 
 /hardening/host-os/oscap/ospp:
     discover+: {test: /hardening/host-os/oscap/ospp$}


### PR DESCRIPTION
Add testing of new RHEL profiles:
* BSI is currently only available on RHEL 9
* ISM Official Top Secret (based on control file) is a superset of the base ISM Official (available only on RHEL 10+)