### PR TITLE
Fix Ansible accounts_passwords_pam_faillock_dir in check mode

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/ansible/shared.yml
@@ -23,10 +23,12 @@
     setype: 'faillog_t'
 
 - name: '{{{ rule_title }}} - Get SELinux context for faillock directory'
-  ansible.builtin.command: "ls -dZ {{ var_accounts_passwords_pam_faillock_dir }}"
+  ansible.builtin.command:
+    cmd: "ls -dZ {{ var_accounts_passwords_pam_faillock_dir }}"
   register: faillock_selinux_context
   changed_when: false
   check_mode: false
+  failed_when: false
 
 - name: '{{{ rule_title }}} - Ensure SELinux file context is permanently set'
   ansible.builtin.command:


### PR DESCRIPTION
This commit fixes Ansible failing in check mode. The command task fails if the /var/log/faillock doesn't exist. In normal mode, this directory is created by the task above, but in check mode no directory is created. The fail has been revealed by productization test: /scanning/host-os/ansible-check/check-mode/stig

Addressing:

ERROR playbook: Lock Accounts Must Persist - Get SELinux context for faillock directory ({"changed": false, "cmd": ["ls", "-dZ", "/var/log/faillock"], "delta": "0:00:00.002322", "end": "2025-10-14 10:56:44.914993", "msg": "non-zero return code", "rc": 2, "start": "2025-10-14 10:56:44.912671", "stderr": "ls: cannot access '/var/log/faillock': No such file or directory", "stderr_lines": ["ls: cannot access '/var/log/faillock': No such file or directory"], "stdout": "", "stdout_lines": []})
