### PR TITLE
[Ubuntu] Enable remediation of file_groupownerships_var_log on jammy

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupownerships_var_log/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupownerships_var_log/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Ubuntu 24.04
+# platform = multi_platform_ubuntu
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupownerships_var_log/tests/excluded_files.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupownerships_var_log/tests/excluded_files.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Ubuntu 24.04
+# platform = multi_platform_ubuntu
 # packages = rsyslog
 
 chgrp root -R /var/log/*
@@ -69,4 +69,3 @@ touch /var/log/sssd/sssd
 touch /var/log/sssd/SSSD
 chgrp nogroup /var/log/sssd/sssd
 chgrp nogroup /var/log/sssd/SSSD
-

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupownerships_var_log/tests/owned_by_adm.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupownerships_var_log/tests/owned_by_adm.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Ubuntu 24.04
+# platform = multi_platform_ubuntu
 # packages = rsyslog
 
 chgrp root -R /var/log/*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupownerships_var_log/tests/owned_by_nobody.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupownerships_var_log/tests/owned_by_nobody.fail.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
-# platform = Ubuntu 24.04
+# platform = multi_platform_ubuntu
 # packages = rsyslog
 
 chgrp root -R /var/log/*
 
 touch /var/log/test.log
 chgrp nogroup /var/log/test.log
+{{%- if product == 'ubuntu2204' %}}
+#make sure nogroup has members
+usermod -aG nogroup nobody
+chown nobody /var/log/test.log
+{{%- endif %}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupownerships_var_log/tests/owned_by_non_sys_acc_grp.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupownerships_var_log/tests/owned_by_non_sys_acc_grp.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Ubuntu 22.04
+# platform = multi_platform_ubuntu
 # packages = rsyslog
 
 chown root -R /var/log/*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupownerships_var_log/tests/owned_by_root.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupownerships_var_log/tests/owned_by_root.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Ubuntu 24.04
+# platform = multi_platform_ubuntu
 # packages = rsyslog
 
 chgrp root -R /var/log/*

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupownerships_var_log/tests/symlink.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupownerships_var_log/tests/symlink.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Ubuntu 24.04
+# platform = multi_platform_ubuntu
 
 chgrp root -R /var/log/*
 


### PR DESCRIPTION
#### Description:

- Enable remediation of file_groupownerships_var_log on jammy
- Enable tests

#### Rationale:
