### PR TITLE
[Ubuntu] Apparmor variable switch to enforce

### DIFF
--- a/controls/cis_ubuntu2204.yml
+++ b/controls/cis_ubuntu2204.yml
@@ -371,7 +371,7 @@ controls:
           - l1_server
           - l1_workstation
       rules:
-          - var_apparmor_mode=keep_existing_mode
+          - var_apparmor_mode=enforce
           - all_apparmor_profiles_in_enforce_complain_mode
       status: automated
 


### PR DESCRIPTION
#### Description:

- Apparmor variable switch to enforce

#### Rationale:

- Ubuntu 22.04 doesn't have unconfined profile by default