### PR TITLE
CMP-3566: Ensure a CLF exists and check for secure URLs

### DIFF
--- a/applications/openshift/logging/audit_log_forwarding_uses_tls/rule.yml
+++ b/applications/openshift/logging/audit_log_forwarding_uses_tls/rule.yml
@@ -37,7 +37,8 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting() | indent(4) }}}
+    {{{ openshift_cluster_setting(
+            "/apis/observability.openshift.io/v1/namespaces/openshift-logging/clusterlogforwarders") | indent(4) }}}
     {{{ openshift_filtered_cluster_setting_suppressed({
             "/apis/logging.openshift.io/v1/namespaces/openshift-logging/clusterlogforwarders/instance": 'try [.spec.outputs[].url] catch []',
             "/apis/observability.openshift.io/v1/namespaces/openshift-logging/clusterlogforwarders": 'try [.items[].spec.outputs[][]|objects|select(.url != null).url] catch []',

--- a/applications/openshift/logging/audit_log_forwarding_uses_tls_observability_api/oval/shared.xml
+++ b/applications/openshift/logging/audit_log_forwarding_uses_tls_observability_api/oval/shared.xml
@@ -1,0 +1,75 @@
+{{% set clf_path = '/apis/observability.openshift.io/v1/namespaces/openshift-logging/clusterlogforwarders' %}}
+{{% set clf_filter = 'try [.items[].spec.outputs[][]|objects|select(.url != null).url] catch []' %}}
+
+<def-group>
+  <definition class="compliance" id="audit_log_forwarding_uses_tls_observability_api" version="1">
+    {{{ oval_metadata("Ensure that Autidt Log Forwarding Uses TLS", rule_title=rule_title) }}}
+
+    <criteria>
+      <criterion  comment="In the YAML/JSON file {{{ clf_path }}}; ensure at least one clusterlogforwarder exists"
+        test_ref="test_audit_log_forwarding_exists_observability_api"/>
+      <criterion  comment="In the YAML/JSON file {{{ clf_path }}}; at path &#39;[:]&#39; all"
+        test_ref="test_audit_log_forwarding_uses_tls_observability_api"/>
+      <criterion comment="Make sure that the file '{{{ clf_path }}}' exists."
+        test_ref="test_file_for_audit_log_forwarding_uses_tls_observability_api"/>
+    </criteria>
+  </definition>
+
+  <local_variable id="audit_log_forwarding_uses_tls_observability_api_file_location" datatype="string" 
+    comment="The actual path of the file to scan." version="1">
+    <concat>
+      <variable_component var_ref="ocp_data_root"/>
+      <literal_component>{{{ clf_path }}}</literal_component>
+    </concat>
+  </local_variable>
+
+  <local_variable id="audit_log_forwarding_uses_tls_observability_api_filtered_file_location" datatype="string" 
+    comment="The actual path of the filtered object file to scan." version="1">
+    <concat>
+      <variable_component var_ref="ocp_data_root"/>
+      <literal_component>{{{ openshift_filtered_path(clf_path, clf_filter) }}}</literal_component>
+    </concat>
+  </local_variable>
+
+
+  <ind:yamlfilecontent_test id="test_audit_log_forwarding_exists_observability_api" check="all" check_existence="at_least_one_exists"
+     comment="In the file {{{ clf_path }}}; find only one object at path &#39;[:]&#39;." version="1">
+    <ind:object object_ref="object_audit_log_forwarding_exists_observability_api"/>
+  </ind:yamlfilecontent_test>
+
+  <ind:yamlfilecontent_object id="object_audit_log_forwarding_exists_observability_api" version="1">
+    <ind:filepath var_ref="audit_log_forwarding_uses_tls_observability_api_file_location"/>
+    <ind:yamlpath>.items[].spec.outputs[].name</ind:yamlpath>
+  </ind:yamlfilecontent_object>
+
+
+  <ind:yamlfilecontent_test id="test_audit_log_forwarding_uses_tls_observability_api" check="all" check_existence="any_exist"
+     comment="In the file {{{ clf_path }}}; find only one object at path &#39;[:]&#39;." version="1">
+    <ind:object object_ref="object_audit_log_forwarding_uses_tls_observability_api"/>
+    <ind:state state_ref="state_audit_log_forwarding_uses_tls_observability_api"/>
+  </ind:yamlfilecontent_test>
+
+  <ind:yamlfilecontent_object id="object_audit_log_forwarding_uses_tls_observability_api" version="1">
+    <ind:filepath var_ref="audit_log_forwarding_uses_tls_observability_api_filtered_file_location"/>
+    <ind:yamlpath>[:]</ind:yamlpath>
+  </ind:yamlfilecontent_object>
+
+  <ind:yamlfilecontent_state id="state_audit_log_forwarding_uses_tls_observability_api" version="1">
+    <ind:value datatype="record" entity_check="all">
+      <field  name="#" operation="pattern match" entity_check="all">^(https|tls)://.*$</field>
+    </ind:value>
+  </ind:yamlfilecontent_state>
+
+
+  <unix:file_test id="test_file_for_audit_log_forwarding_uses_tls_observability_api" check="all" check_existence="only_one_exists"
+    comment="Find the file to be checked ('{{{ clf_path }}}')." version="1">
+    <unix:object object_ref="object_file_for_audit_log_forwarding_uses_tls_observability_api"/>
+  </unix:file_test>
+
+  <unix:file_object id="object_file_for_audit_log_forwarding_uses_tls_observability_api" version="1">
+    <unix:filepath var_ref="audit_log_forwarding_uses_tls_observability_api_file_location"/>
+  </unix:file_object>
+
+
+  <external_variable comment="Root of OCP data dump" datatype="string" id="ocp_data_root" version="1" />
+</def-group>

--- a/applications/openshift/logging/audit_log_forwarding_uses_tls_observability_api/oval/shared.xml
+++ b/applications/openshift/logging/audit_log_forwarding_uses_tls_observability_api/oval/shared.xml
@@ -43,8 +43,8 @@
   </ind:yamlfilecontent_object>
 
 
-  <ind:yamlfilecontent_test id="test_audit_log_forwarding_uses_tls_observability_api" check="all" check_existence="any_exist"
-     comment="In the file {{{ clf_path }}}; find only one object at path &#39;[:]&#39;." version="1">
+  <ind:yamlfilecontent_test id="test_audit_log_forwarding_uses_tls_observability_api" check="all" check_existence="all_exist"
+     comment="In the file {{{ clf_path }}}; ensure no insecure protocols are used at path &#39;[:]&#39;." version="1">
     <ind:object object_ref="object_audit_log_forwarding_uses_tls_observability_api"/>
     <ind:state state_ref="state_audit_log_forwarding_uses_tls_observability_api"/>
   </ind:yamlfilecontent_test>
@@ -56,7 +56,7 @@
 
   <ind:yamlfilecontent_state id="state_audit_log_forwarding_uses_tls_observability_api" version="1">
     <ind:value datatype="record" entity_check="all">
-      <field  name="#" operation="pattern match" entity_check="all">^(https|tls)://.*$</field>
+      <field  name="#" operation="pattern match" datatype="string" entity_check="none satisfy">^(http|tcp|udp)://.*$</field>
     </ind:value>
   </ind:yamlfilecontent_state>
 

--- a/applications/openshift/logging/audit_log_forwarding_uses_tls_observability_api/rule.yml
+++ b/applications/openshift/logging/audit_log_forwarding_uses_tls_observability_api/rule.yml
@@ -37,24 +37,26 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting() | indent(4) }}}
+    {{{ openshift_cluster_setting(
+            "/apis/observability.openshift.io/v1/namespaces/openshift-logging/clusterlogforwarders"
+        ) | indent(4) }}}
     {{{ openshift_filtered_cluster_setting_suppressed({
             "/apis/observability.openshift.io/v1/namespaces/openshift-logging/clusterlogforwarders": 'try [.items[].spec.outputs[][]|objects|(select(.url != null).url] catch []',
         }) | indent(4) }}}
 
-template:
-  name: yamlfile_value
-  vars:
-    ocp_data: "true"
-    # A list of clusterlogforwarders is available at https://docs.openshift.com/container-platform/4.16/observability/logging/logging-6.0/log6x-clf.html#outputs
-    # The log forwarder outputs consist of an object and two strings (name and type).
-    # The url is part of the object and its name will vary depending on its type.
-    # By using the objects filter we ensure we are getting the object to query for its url.
-    filepath: "{{{ openshift_filtered_path('/apis/observability.openshift.io/v1/namespaces/openshift-logging/clusterlogforwarders', 'try [.items[].spec.outputs[][]|objects|select(.url != null).url] catch []') }}}"
-    yamlpath: "[:]"
-    check_existence: any_exist
-    entity_check: "all"
-    values:
-    - value: "^(https|tls)://.*$"
-      entity_check: "all"
-      operation: "pattern match"
+# template:
+#   name: yamlfile_value
+#   vars:
+#     ocp_data: "true"
+#     # A list of clusterlogforwarders is available at https://docs.openshift.com/container-platform/4.16/observability/logging/logging-6.0/log6x-clf.html#outputs
+#     # The log forwarder outputs consist of an object and two strings (name and type).
+#     # The url is part of the object and its name will vary depending on its type.
+#     # By using the objects filter we ensure we are getting the object to query for its url.
+#     filepath: "{{{ openshift_filtered_path('/apis/observability.openshift.io/v1/namespaces/openshift-logging/clusterlogforwarders', 'try [.items[].spec.outputs[][]|objects|select(.url != null).url] catch []') }}}"
+#     yamlpath: "[:]"
+#     check_existence: any_exist
+#     entity_check: "all"
+#     values:
+#     - value: "^(https|tls)://.*$"
+#       entity_check: "all"
+#       operation: "pattern match"

--- a/applications/openshift/logging/audit_log_forwarding_uses_tls_observability_api/rule.yml
+++ b/applications/openshift/logging/audit_log_forwarding_uses_tls_observability_api/rule.yml
@@ -52,6 +52,7 @@ template:
     # By using the objects filter we ensure we are getting the object to query for its url.
     filepath: "{{{ openshift_filtered_path('/apis/observability.openshift.io/v1/namespaces/openshift-logging/clusterlogforwarders', 'try [.items[].spec.outputs[][]|objects|select(.url != null).url] catch []') }}}"
     yamlpath: "[:]"
+    check_existence: any_exist
     entity_check: "all"
     values:
     - value: "^(https|tls)://.*$"


### PR DESCRIPTION
#### Description:

- Add an unfiltered yamlpath to check for existence of ClusterLogForwarders.
- Copy the existing check and add the check for CLF existence

#### Rationale:

- The cluster can be configured with log forwarders that are by default secure and use TLS, for example the AzureMonitor log forwarder. They don't have an URL key.
- The existing check only checks the `url` of CLF that have it. If a CLF doesn't have it, we don't check it.
- Problem is that we cannot differentiate between non-existent CLF, and CLF without `url` key. So we need to add a check for CLF existence.

- Fixes https://issues.redhat.com/browse/CMP-3566

