### PR TITLE
Show CCE identifiers in the HTML rendered control files

### DIFF
--- a/utils/rendering/controls-template.html
+++ b/utils/rendering/controls-template.html
@@ -30,7 +30,11 @@ based on <a href="{{{ policy.source }}}">{{{ policy.source }}}</a>
     {{%- endif -%}}
     {{%- else %}}
     {{%- if selection in rules %}}
-    <li><a href="https://github.com/ComplianceAsCode/content/tree/master/{{{ rules[selection].relative_definition_location }}}">{{{ selection }}}</a>: {{{ rules[selection].title }}}</li>
+    <li><a href="https://github.com/ComplianceAsCode/content/tree/master/{{{ rules[selection].relative_definition_location }}}"> {{{ selection }}}</a>: {{{ rules[selection].title }}}
+      {{%- if rules[selection].identifiers and rules[selection].identifiers.get('cce') %}}
+      <ul><li>{{{ rules[selection].identifiers['cce'] }}}</li></ul>
+      {{%- endif %}}
+    </li>
     {{%- else %}}
     <li>{{{ selection }}} - not available for this product</li>
     {{%- endif -%}}


### PR DESCRIPTION
#### Description:

- Show CCE identifiers in the HTML rendered control files.

#### Rationale:

- CCE are good to uniquely identify rules.
- Supersedes #13890

#### Review Hints:

- ./build_product rhel9
- cd build
- ninja render-policies
- firefox rhel9/rendered-policies/cis_rhel9.html

#### Preview
<img width="1232" height="1293" alt="Screenshot From 2025-10-22 15-11-26" src="https://github.com/user-attachments/assets/dececb34-9ea8-46df-843d-1acea282c6f5" />
