### PR TITLE
CMP-3756: Configure MintMaker updates on RPM lockfiles

### DIFF
--- a/Dockerfiles/konflux/redhat.repo
+++ b/Dockerfiles/konflux/redhat.repo
@@ -1,0 +1,55 @@
+[rhel-9-for-$basearch-baseos-rpms]
+name = Red Hat Enterprise Linux 9 - BaseOS (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9/$basearch/baseos/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = $SSL_CLIENT_KEY
+sslclientcert = $SSL_CLIENT_CERT
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-baseos-source-rpms]
+name = Red Hat Enterprise Linux 9 - BaseOS (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9/$basearch/baseos/source/SRPMS
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = $SSL_CLIENT_KEY
+sslclientcert = $SSL_CLIENT_CERT
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-rpms]
+name = Red Hat Enterprise Linux 9 - AppStream (RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9/$basearch/appstream/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = $SSL_CLIENT_KEY
+sslclientcert = $SSL_CLIENT_CERT
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0
+
+[rhel-9-for-$basearch-appstream-source-rpms]
+name = Red Hat Enterprise Linux 9 - AppStream (Source RPMs)
+baseurl = https://cdn.redhat.com/content/dist/rhel9/9/$basearch/appstream/source/SRPMS
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+sslverify = 1
+sslcacert = /etc/rhsm/ca/redhat-uep.pem
+sslclientkey = $SSL_CLIENT_KEY
+sslclientcert = $SSL_CLIENT_CERT
+sslverifystatus = 1
+metadata_expire = 86400
+enabled_metadata = 0

--- a/Dockerfiles/konflux/rpms.in.yaml
+++ b/Dockerfiles/konflux/rpms.in.yaml
@@ -1,6 +1,6 @@
 contentOrigin:
   repofiles:
-     - ./redhat.repo
+    - ./redhat.repo
 
 packages:
   - python3
@@ -17,4 +17,4 @@ arches:
   - ppc64le
 
 context:
-    containerfile: Dockerfiles/compliance-operator-content-konflux.Containerfile
+  containerfile: ../compliance-operator-content-konflux.Containerfile


### PR DESCRIPTION


#### Description:

- Add a repo file so that `rpms.lock.file` can be properly maintained.

#### Rationale:

- MintMaker requires a repo file to keep rpms.lock.yaml up to date. 
  The repo file is also configured with SSL variables so that RPMs behind a subscription are accessible.

- Fixes [CMP-3756](https://issues.redhat.com/browse/CMP-3756)

#### Review Hints:

- https://konflux.pages.redhat.com/docs/users/mintmaker/rpm-lockfile.html#rpm-lockfile-with-rpms-that-require-subscription
- https://konflux.pages.redhat.com/docs/users/building/activation-keys-subscription.html#configuring-an-rpm-lockfile-for-hermetic-builds
- If nothing seems utterly wrong, we kinda need to merge and wait to see if MintMaker proposes a PR, 😅 


[CMP-3756]: https://redhat.atlassian.net/browse/CMP-3756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ