### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for CO

### DIFF
--- a/Dockerfiles/compliance-operator-content-konflux.Containerfile
+++ b/Dockerfiles/compliance-operator-content-konflux.Containerfile
@@ -94,7 +94,8 @@ LABEL \
         description="OpenSCAP content for the compliance-operator" \
         maintainer="Red Hat ISC <isc-team@redhat.com>" \
         License="GPLv2+" \
-        name="openshift-compliance-content" \
+        name="compliance/openshift-compliance-content-rhel8" \
+        cpe="cpe:/a:redhat:openshift_compliance_operator:1::el9" \
         com.redhat.component="openshift-compliance-content-container" \
         io.openshift.maintainer.product="OpenShift Container Platform" \
         io.openshift.maintainer.component="Compliance Operator"


### PR DESCRIPTION
#### Description:

- Add `name` and `cpe` labels to CO's content image

#### Rationale:

- For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also https://github.com/release-engineering/rhtap-ec-policy/pull/149