### PR TITLE
Replacing systemd_service with systemd module in Ansible playbooks

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_rules_enable_syscall_auditing/ansible/shared.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_rules_enable_syscall_auditing/ansible/shared.yml
@@ -53,7 +53,7 @@
   register: auditctl_syscall_auditing_rule_update_result
 
 - name: Restart auditd.service
-  ansible.builtin.systemd_service:
+  ansible.builtin.systemd:
     name: auditd.service
     state: restarted
   when:

--- a/linux_os/guide/services/ftp/ftp_configure_vsftpd/ftp_present_banner/ansible/shared.yml
+++ b/linux_os/guide/services/ftp/ftp_configure_vsftpd/ftp_present_banner/ansible/shared.yml
@@ -17,7 +17,7 @@
   when: ansible_facts.services["vsftpd.service"] is defined
 
 - name: Restart vsftpd
-  ansible.builtin.systemd_service:
+  ansible.builtin.systemd:
     name: vsftpd.service
     state: restarted
   when: banner_file_update_result.changed and ansible_facts.services["vsftpd.service"].state == "running"

--- a/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/ansible/shared.yml
@@ -9,7 +9,7 @@
 
 {{%- if init_system == "systemd" %}}
 - name: Start ntpd service if ntp installed
-  ansible.builtin.systemd_service:
+  ansible.builtin.systemd:
     name: "ntpd"
     enabled: "yes"
     state: "started"
@@ -18,7 +18,7 @@
 
 
 - name: Start chronyd service if chrony or chronyd installed
-  ansible.builtin.systemd_service:
+  ansible.builtin.systemd:
     name: "chronyd"
     enabled: "yes"
     state: "started"

--- a/linux_os/guide/services/obsolete/tftp/tftp_uses_secure_mode_systemd/ansible/shared.yml
+++ b/linux_os/guide/services/obsolete/tftp/tftp_uses_secure_mode_systemd/ansible/shared.yml
@@ -74,7 +74,7 @@
                 ExecStart=/usr/sbin/in.tftpd -s {{ var_tftpd_secure_directory }}
 
     -   name: "Reload systemd and restart tftp service"
-        ansible.builtin.systemd_service:
+        ansible.builtin.systemd:
             daemon_reload: true
             name: tftp
             state: restarted

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/ansible/shared.yml
@@ -22,7 +22,7 @@
     content: '{{{ ansible_deregexify_banner_etc_issue("login_banner_text") }}}'
 
 - name: "{{{ rule_title }}} - Restart issue-generator Service on Issue Configuration Change"
-  ansible.builtin.systemd_service:
+  ansible.builtin.systemd:
     name: "issue-generator"
     enabled: "yes"
     state: "restarted"

--- a/linux_os/guide/system/apparmor/apparmor_configured/ansible/shared.yml
+++ b/linux_os/guide/system/apparmor/apparmor_configured/ansible/shared.yml
@@ -1,7 +1,7 @@
 # platform = multi_platform_sle,multi_platform_debian
 
 - name: Start apparmor.service
-  ansible.builtin.systemd_service:
+  ansible.builtin.systemd:
     name: apparmor.service
     state: started
     enabled: yes

--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/ansible/shared.yml
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/ansible/shared.yml
@@ -22,7 +22,7 @@
 
 {{% if 'sle' in product or product == 'slmicro5' %}}
 - name: Enable timer logrotate
-  ansible.builtin.systemd_service:
+  ansible.builtin.systemd:
     name: "logrotate.timer"
     enabled: "yes"
     state: "started"


### PR DESCRIPTION
#### Description:

- This commit updates 7 Ansible playbooks across the `linux_os` security configuration rules to replace the `ansible.builtin.systemd_service` module with the `ansible.builtin.systemd` module.

- The changes affect the following rules: 
   - Auditing: `audit_rules_enable_syscall_auditing`
   - FTP services: `ftp_present_banner`
   - NTP services: `service_chronyd_or_ntpd_enabled`
   - TFTP services: `tftp_uses_secure_mode_systemd`
   - System banners: `banner_etc_issue`
   - AppArmor: `apparmor_configured`
   - Log rotation: `ensure_logrotate_activated`

#### Rationale:

- All functionality remains identical. `systemd` is simply a redirect to `systemd_service` and preserves all parameters (`name`, `state`, `enabled`, `daemon_reload`, `etc`.).

- Fixes # [RHEL-117141](https://issues.redhat.com/browse/RHEL-117141)

#### Review hints:
- original PR: https://github.com/ComplianceAsCode/content/pull/13829