### PR TITLE
NetworkManager package and PAM stat files fixes

### DIFF
--- a/Dockerfiles/test_suite-ubi
+++ b/Dockerfiles/test_suite-ubi
@@ -21,4 +21,3 @@ RUN true \
         && chmod og-rw /root/.ssh "$AUTH_KEYS" \
         && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
 && true
-

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/ansible/shared.yml
@@ -12,7 +12,7 @@
 - name: '{{{ rule_title }}} - Check if {{{ pam_file }}} File is Present'
   ansible.builtin.stat:
     path: {{{ pam_file }}}
-  register: result_pam_file_present
+  register: result_pam_password_auth_file_present
 
 - name: '{{{ rule_title }}} - Check The Proper Remediation For The System'
   block:
@@ -46,4 +46,4 @@
         - result_authselect_present.stat.exists
         - result_pam_hashing_options_removal is changed
   when:
-    - result_pam_file_present.stat.exists
+    - result_pam_password_auth_file_present.stat.exists

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/ansible/shared.yml
@@ -18,7 +18,7 @@
 - name: '{{{ rule_title }}} - Check if {{{ pam_file }}} File is Present'
   ansible.builtin.stat:
     path: {{{ pam_file }}}
-  register: result_pam_file_present
+  register: result_pam_auth_file_present
 
 - name: '{{{ rule_title }}} - Check The Proper Remediation For The System'
   block:
@@ -52,4 +52,4 @@
         - result_authselect_present.stat.exists
         - result_pam_hashing_options_removal is changed
   when:
-    - result_pam_file_present.stat.exists
+    - result_pam_auth_file_present.stat.exists

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/ansible/shared.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/ansible/shared.yml
@@ -4,19 +4,19 @@
 # complexity = low
 # disruption = medium
 
-- name: Service facts
+- name: "{{{ rule_title }}} - Service facts"
   ansible.builtin.service_facts:
 
 {{% if product in ["sle12", "sle15", "slmicro5"] %}}
 
-- name: Wicked Deactivate Wireless Network Interfaces
+- name: "{{{ rule_title }}} - Wicked Deactivate Wireless Network Interfaces"
   ansible.builtin.command: wicked ifdown {{ item }}
   loop: '{{ ansible_facts.interfaces }}'
   when:
     - ansible_facts.services['wickedd.service'].state == 'running'
     - 'item.startswith("wl")'
 
-- name: Wicked Disable Wireless Network Interfaces
+- name: "{{{ rule_title }}} - Wicked Disable Wireless Network Interfaces"
   ansible.builtin.lineinfile:
     path: /etc/sysconfig/network/ifcfg-{{ item }}
     regexp: '^STARTMODE='
@@ -27,7 +27,7 @@
     - 'item.startswith("wl")'
 {{%- else %}}
 
-- name: Ensure NetworkManager is installed
+- name: "{{{ rule_title }}} - Ensure NetworkManager is installed"
   ansible.builtin.package:
     name: "{{ item }}"
     state: present
@@ -36,7 +36,7 @@
 
 {{%- endif %}}
 
-- name: NetworkManager Deactivate Wireless Network Interfaces
+- name: "{{{ rule_title }}} - NetworkManager Deactivate Wireless Network Interfaces"
   ansible.builtin.command: nmcli radio wifi off
   when:
     - "'NetworkManager' in ansible_facts.packages"

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/ansible/ubuntu.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/ansible/ubuntu.yml
@@ -1,0 +1,49 @@
+# platform = multi_platform_ubuntu
+# reboot = false
+# strategy = unknown
+# complexity = low
+# disruption = medium
+
+- name: "{{{ rule_title }}} - Find wireless marker directories"
+  ansible.builtin.find:
+    paths: "/sys/class/net"
+    file_type: directory
+    patterns: "wireless"
+    recurse: yes
+  register: wireless_paths
+
+- name: "{{{ rule_title }}} - Extract interface names from directory paths"
+  ansible.builtin.set_fact:
+    wireless_interfaces: >-
+      {{ wireless_paths.files | map('dirname') | map('basename') | list }}
+
+- name: "{{{ rule_title }}} - Bring wireless interfaces down"
+  ansible.builtin.command:
+    cmd: "ip link set dev {{ item }} down"
+  with_items: "{{ wireless_interfaces }}"
+  when: wireless_interfaces | length > 0
+
+- name: "{{{ rule_title }}} - Get driver name for each interface"
+  ansible.builtin.command:
+    cmd: "basename $(readlink -f /sys/class/net/{{ item }}/device/driver)"
+  register: wireless_drivers
+  with_items: "{{ wireless_interfaces }}"
+  changed_when: false
+  check_mode: false
+  when: wireless_interfaces | length > 0
+
+- name: "{{{ rule_title }}} - Create disable wireless driver modprobe config"
+  ansible.builtin.blockinfile:
+    path: /etc/modprobe.d/disable_wireless.conf
+    create: yes
+    block: |
+      {% for r in wireless_drivers.results %}
+      install {{ r.stdout }} /bin/false
+      {% endfor %}
+  when: wireless_interfaces | length > 0
+
+- name: "{{{ rule_title }}} - Unload wireless kernel modules"
+  ansible.builtin.command:
+    cmd: "modprobe -r {{ item.stdout }}"
+  with_items: "{{ wireless_drivers.results }}"
+  when: wireless_interfaces | length > 0

--- a/shared/applicability/package.yml
+++ b/shared/applicability/package.yml
@@ -69,7 +69,11 @@ args:
       pkgname: snmp
     {{% endif %}}
   networkmanager:
+    {{% if product in ["ubuntu2204", "ubuntu2404"] %}}
+    pkgname: network-manager
+    {{% else %}}
     pkgname: NetworkManager
+    {{% endif %}}
   nftables:
       pkgname: nftables
   nss-pam-ldapd:

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1836,7 +1836,13 @@ Part of the grub2_bootloader_argument_absent template.
 - name: '{{{ rule_title }}} - Check if {{{ pam_file }}} file is present'
   ansible.builtin.stat:
     path: "{{{ pam_file }}}"
+  {{%- if pam_file == "/etc/pam.d/password-auth" %}}
+  register: result_pam_password_auth_file_present
+  {{%- elif pam_file in ["/etc/pam.d/common-password", "/etc/pam.d/system-auth"] %}}
+  register: result_pam_auth_file_present
+  {{%- else %}}
   register: result_pam_file_present
+  {{%- endif %}}
 
 - name: '{{{ rule_title }}} - Ensure the "{{{ option }}}" option from "{{{ module }}}" is not present in {{{ pam_file }}}'
   ansible.builtin.replace:
@@ -1848,7 +1854,14 @@ Part of the grub2_bootloader_argument_absent template.
     {{%- endif %}}
     replace: '\1\2'
   register: result_pam_option_removal
-  when: result_pam_file_present.stat.exists
+  when:
+  {{%- if pam_file == "/etc/pam.d/password-auth" %}}
+    - result_pam_password_auth_file_present.stat.exists
+  {{%- elif pam_file in ["/etc/pam.d/common-password", "/etc/pam.d/system-auth"] %}}
+    - result_pam_auth_file_present.stat.exists
+  {{%- else %}}
+    - result_pam_file_present.stat.exists
+  {{%- endif %}}
 {{%- endmacro -%}}
 
 
@@ -2016,7 +2029,13 @@ Part of the grub2_bootloader_argument_absent template.
 - name: '{{{ rule_title }}} - Check if {{{ pam_file }}} file is present'
   ansible.builtin.stat:
     path: {{{ pam_file }}}
+  {{%- if pam_file == "/etc/pam.d/password-auth" %}}
+  register: result_pam_password_auth_file_present
+  {{%- elif pam_file in ["/etc/pam.d/common-password", "/etc/pam.d/system-auth"] %}}
+  register: result_pam_auth_file_present
+  {{%- else %}}
   register: result_pam_file_present
+  {{%- endif %}}
 
 - name: '{{{ rule_title }}} - Check the proper remediation for the system'
   block:
@@ -2035,7 +2054,13 @@ Part of the grub2_bootloader_argument_absent template.
           (result_pam_{{{ rule_id }}}_add is defined and result_pam_{{{ rule_id }}}_add.changed)
            or (result_pam_{{{ rule_id }}}_edit is defined and result_pam_{{{ rule_id }}}_edit.changed)
   when:
+  {{%- if pam_file == "/etc/pam.d/password-auth" %}}
+    - result_pam_password_auth_file_present.stat.exists
+  {{%- elif pam_file in ["/etc/pam.d/common-password", "/etc/pam.d/system-auth"] %}}
+    - result_pam_auth_file_present.stat.exists
+  {{%- else %}}
     - result_pam_file_present.stat.exists
+  {{%- endif %}}
 {{%- endmacro -%}}
 
 
@@ -2060,7 +2085,13 @@ Part of the grub2_bootloader_argument_absent template.
 - name: '{{{ rule_title }}} - Check if {{{ pam_file }}} file is present'
   ansible.builtin.stat:
     path: {{{ pam_file }}}
+  {{%- if pam_file == "/etc/pam.d/password-auth" %}}
+  register: result_pam_password_auth_file_present
+  {{%- elif pam_file in ["/etc/pam.d/common-password", "/etc/pam.d/system-auth"] %}}
+  register: result_pam_auth_file_present
+  {{%- else %}}
   register: result_pam_file_present
+  {{%- endif %}}
 
 - name: '{{{ rule_title }}} - Check the proper remediation for the system'
   block:
@@ -2073,7 +2104,13 @@ Part of the grub2_bootloader_argument_absent template.
         - result_authselect_present.stat.exists
         - result_pam_option_removal is changed
   when:
+  {{%- if pam_file == "/etc/pam.d/password-auth" %}}
+    - result_pam_password_auth_file_present.stat.exists
+  {{%- elif pam_file in ["/etc/pam.d/common-password", "/etc/pam.d/system-auth"] %}}
+    - result_pam_auth_file_present.stat.exists
+  {{%- else %}}
     - result_pam_file_present.stat.exists
+  {{%- endif %}}
 {{%- endmacro -%}}
 
 


### PR DESCRIPTION
NetworkManager package and PAM stat files fixes

- Fixed NetworkManager package issue for ubuntu2204 and ubuntu2404.
  - ubuntu didn't need Network manager so this created a custom wirless_disable_interfaces for ubuntu for ansible, similar to how it was done in bash.
- Resolved issue where using the same register variable outside and inside the block were causing failures.
- Add rule_title to all tasks for wireless_disable_interfactes ansible.

#### Description:

- Update logic so that the NetworkManager package didn't need to be installed for ubuntu2204 and ubuntu2404.
  - The updated logic does the same thing as the bash remediation for disabling wireless interfaces.
- Resolved issue where using the same register variable outside and inside the block was causing failures.

#### Rationale:

- When testing the Ansible playbook for ubuntu2404 I ran into two issues:
  - The playbook was trying to install and look for the NetworkManager package called `NetworkManager`, however for ubuntu2204 and ubuntu2404 the correct package name is `network-manager`. This was noted in the product files, it just was not being overriden.
  - When only the register variable of `result_pam_file_present` was being used for both inside and outside of a block it would cause strange errors.

- Fixes https://github.com/ComplianceAsCode/content/issues/14038
