### PR TITLE
Group system calls in audit_rules_kernel_module_loading template

### DIFF
--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -57,6 +57,8 @@
 
     -   **key** - audit key. If this isn't specified then the default value `perm_mod` is used.
 
+    -   **syscall_grouping** - a list of syscalls that can be grouped together in a single audit rule
+
 -   Languages: Ansible, Bash, OVAL, Kubernetes
 
 #### audit_rules_file_deletion_events
@@ -66,6 +68,8 @@
 
     -   **name** - value of `-S` argument in Audit rule, eg. `unlink`
 
+    -   **syscall_grouping** - a list of syscalls that can be grouped together in a single audit rule
+
 -   Languages: Ansible, Bash, OVAL
 
 #### audit_rules_kernel_module_loading
@@ -74,6 +78,8 @@
 -   Parameters:
 
     -   **name** - value of `-S` argument in Audit rule, eg. `create_module`
+
+    -   **syscall_grouping** - a list of syscalls that can be grouped together in a single audit rule
 
 -   Languages: Ansible, Bash, Kubernetes, OVAL
 
@@ -133,6 +139,8 @@
 -   Parameters:
 
     -   **name** - name of the unsuccessful system call, eg. `creat`
+
+    -   **syscall_grouping** - a list of syscalls that can be grouped together in a single audit rule
 
 -   Languages: Ansible, Bash, OVAL
 

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_create/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_create/rule.yml
@@ -36,3 +36,9 @@ template:
     name: audit_rules_kernel_module_loading
     vars:
         name: create_module
+        syscall_grouping:
+          - create_module
+          - delete_module
+          - finit_module
+          - init_module
+          - query_module

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/rule.yml
@@ -54,3 +54,9 @@ template:
     name: audit_rules_kernel_module_loading
     vars:
         name: delete_module
+        syscall_grouping:
+          - create_module
+          - delete_module
+          - finit_module
+          - init_module
+          - query_module

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/rule.yml
@@ -52,3 +52,9 @@ template:
     name: audit_rules_kernel_module_loading
     vars:
         name: finit_module
+        syscall_grouping:
+          - create_module
+          - delete_module
+          - finit_module
+          - init_module
+          - query_module

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/rule.yml
@@ -53,3 +53,9 @@ template:
     name: audit_rules_kernel_module_loading
     vars:
         name: init_module
+        syscall_grouping:
+          - create_module
+          - delete_module
+          - finit_module
+          - init_module
+          - query_module

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_query/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_query/rule.yml
@@ -32,3 +32,9 @@ template:
     name: audit_rules_kernel_module_loading
     vars:
         name: query_module
+        syscall_grouping:
+          - create_module
+          - delete_module
+          - finit_module
+          - init_module
+          - query_module

--- a/shared/templates/audit_rules_kernel_module_loading/ansible.template
+++ b/shared/templates/audit_rules_kernel_module_loading/ansible.template
@@ -28,17 +28,17 @@
       action_arch_filters="-a always,exit -F arch=b32",
       other_filters="",
       auid_filters=auid_filters,
-      syscalls=[NAME],
+      syscalls=NAME,
       key="modules",
-      syscall_grouping=[],
+      syscall_grouping=SYSCALL_GROUPING,
       )|indent(4) }}}
     {{{ ansible_audit_auditctl_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b32",
       other_filters="",
       auid_filters=auid_filters,
-      syscalls=[NAME],
+      syscalls=NAME,
       key="modules",
-      syscall_grouping=[],
+      syscall_grouping=SYSCALL_GROUPING,
       )|indent(4) }}}
 
 - name: {{{ rule_title }}} - Perform remediation of Audit rules for {{{ NAME }}} for 64bit platform
@@ -47,16 +47,16 @@
       action_arch_filters="-a always,exit -F arch=b64",
       other_filters="",
       auid_filters=auid_filters,
-      syscalls=[NAME],
+      syscalls=NAME,
       key="modules",
-      syscall_grouping=[],
+      syscall_grouping=SYSCALL_GROUPING,
       )|indent(4) }}}
     {{{ ansible_audit_auditctl_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b64",
       other_filters="",
       auid_filters=auid_filters,
-      syscalls=[NAME],
+      syscalls=NAME,
       key="modules",
-      syscall_grouping=[],
+      syscall_grouping=SYSCALL_GROUPING,
       )|indent(4) }}}
   when: audit_arch == "b64"

--- a/shared/templates/audit_rules_kernel_module_loading/bash.template
+++ b/shared/templates/audit_rules_kernel_module_loading/bash.template
@@ -19,7 +19,7 @@ do
 	{{% endif %}}
 	SYSCALL="{{{ NAME }}}"
 	KEY="modules"
-	SYSCALL_GROUPING="{{{ NAME }}}"
+	SYSCALL_GROUPING="{{{ SYSCALL_GROUPING }}}"
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 	{{{ bash_fix_audit_syscall_rule("augenrules", "$ACTION_ARCH_FILTERS", "$OTHER_FILTERS", "$AUID_FILTERS", "$SYSCALL", "$SYSCALL_GROUPING", "$KEY") }}}
 	{{{ bash_fix_audit_syscall_rule("auditctl", "$ACTION_ARCH_FILTERS", "$OTHER_FILTERS", "$AUID_FILTERS", "$SYSCALL", "$SYSCALL_GROUPING", "$KEY") }}}

--- a/shared/templates/audit_rules_kernel_module_loading/template.py
+++ b/shared/templates/audit_rules_kernel_module_loading/template.py
@@ -1,0 +1,18 @@
+def _audit_rules_kernel_module_loading(data, lang):
+    if lang == "bash":
+        if "syscall_grouping" in data:
+            # Make it easier to transform the syscall_grouping into a Bash array
+            data["syscall_grouping"] = " ".join(data["syscall_grouping"])
+    elif lang == "ansible":
+        if "name" in data:
+            # Transform the syscall into a Ansible list
+            # The syscall is under 'name'
+            data["name"] = [data["name"]]
+        if "syscall_grouping" not in data:
+            # Ensure that syscall_grouping is a list
+            data["syscall_grouping"] = []
+    return data
+
+
+def preprocess(data, lang):
+    return _audit_rules_kernel_module_loading(data, lang)


### PR DESCRIPTION
Add a new parameter `syscall_grouping` that contains a list of system calls for which audit rules can be grouped together in a single audit rule.

This commit also fixes missing documentation for the syscall_grouping parameter of other templates that have this parameter.

Fixes: #14055



#### Review Hints:
Run Contest test "/scanning/audit-rules-syscalls-grouping" with master and with this PR. For example:

```
./autocontest.sh test --content-path /home/jcerny/work/git/scap-security-guide/ -t "/scanning/audit-rules-syscalls-grouping" -c qemu:///system -n ac_rhel96
```

Also, run automatus tests for any of the rules that use this template, eg.
```
python3 tests/automatus.py rule --libvirt qemu:///system ssgts_rhel9 audit_rules_kernel_module_loading_create
```