### PR TITLE
Remove all codecs.open

### DIFF
--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -5,7 +5,6 @@ Common functions for processing YAML in SSG
 from __future__ import absolute_import
 from __future__ import print_function
 
-import codecs
 import re
 import sys
 import yaml
@@ -234,7 +233,7 @@ def open_raw(yaml_file):
     See also:
         _open_yaml: The function used to parse the YAML contents.
     """
-    with codecs.open(yaml_file, "r", "utf8") as stream:
+    with open(yaml_file, "r", encoding="utf8") as stream:
         yaml_contents = _open_yaml(stream, original_file=yaml_file)
     return yaml_contents
 

--- a/utils/generate_contributors.py
+++ b/utils/generate_contributors.py
@@ -2,7 +2,6 @@
 
 import argparse
 import os.path
-import codecs
 import ssg
 import ssg.contributors
 
@@ -23,11 +22,11 @@ def main():
         exit(0)
 
     root_dir = os.path.dirname(os.path.dirname(__file__))
-    with codecs.open(os.path.join(root_dir, "Contributors.md"),
+    with open(os.path.join(root_dir, "Contributors.md"),
                      mode="w", encoding="utf-8") as f:
         f.write(contributors_md)
 
-    with codecs.open(os.path.join(root_dir, "Contributors.xml"),
+    with open(os.path.join(root_dir, "Contributors.xml"),
                      mode="w", encoding="utf-8") as f:
         f.write(contributors_xml)
 


### PR DESCRIPTION


#### Description:
Remove all codecs.open

#### Rationale:

It is deprecated, just use open.
