### PR TITLE
Align some sudo rules with RHEL 10 CIS Benchmark

### DIFF
--- a/controls/cis_rhel10.yml
+++ b/controls/cis_rhel10.yml
@@ -1844,7 +1844,7 @@ controls:
           - l2_workstation
       status: automated
       rules:
-          - sudo_require_authentication
+          - sudo_remove_nopasswd
 
     - id: 5.2.5
       title: Ensure re-authentication for privilege escalation is not disabled globally (Automated)
@@ -1853,7 +1853,7 @@ controls:
           - l1_workstation
       status: automated
       rules:
-          - sudo_require_authentication
+          - sudo_remove_no_authenticate
 
     - id: 5.2.6
       title: Ensure sudo timestamp_timeout is configured (Automated)
@@ -1863,6 +1863,7 @@ controls:
       status: automated
       rules:
           - sudo_require_reauthentication
+          - var_sudo_timestamp_timeout=15_minutes
 
     - id: 5.2.7
       title: Ensure access to the su command is restricted (Automated)

--- a/tests/data/profile_stability/rhel10/cis.profile
+++ b/tests/data/profile_stability/rhel10/cis.profile
@@ -365,7 +365,8 @@ sshd_use_strong_kex
 sshd_use_strong_macs
 sudo_add_use_pty
 sudo_custom_logfile
-sudo_require_authentication
+sudo_remove_no_authenticate
+sudo_remove_nopasswd
 sudo_require_reauthentication
 sysctl_fs_protected_hardlinks
 sysctl_fs_protected_symlinks
@@ -457,6 +458,7 @@ var_sshd_max_sessions=10
 var_sshd_set_keepalive=1
 var_sshd_set_login_grace_time=60
 var_sshd_set_maxstartups=10:30:60
+var_sudo_timestamp_timeout=15_minutes
 var_system_crypto_policy=default_policy
 var_user_initialization_files_regex=all_dotfiles
 wireless_disable_interfaces

--- a/tests/data/profile_stability/rhel10/cis_server_l1.profile
+++ b/tests/data/profile_stability/rhel10/cis_server_l1.profile
@@ -267,7 +267,7 @@ sshd_use_strong_kex
 sshd_use_strong_macs
 sudo_add_use_pty
 sudo_custom_logfile
-sudo_require_authentication
+sudo_remove_no_authenticate
 sudo_require_reauthentication
 sysctl_fs_protected_hardlinks
 sysctl_fs_suid_dumpable
@@ -347,6 +347,7 @@ var_sshd_max_sessions=10
 var_sshd_set_keepalive=1
 var_sshd_set_login_grace_time=60
 var_sshd_set_maxstartups=10:30:60
+var_sudo_timestamp_timeout=15_minutes
 var_system_crypto_policy=default_policy
 var_user_initialization_files_regex=all_dotfiles
 wireless_disable_interfaces

--- a/tests/data/profile_stability/rhel10/cis_workstation_l1.profile
+++ b/tests/data/profile_stability/rhel10/cis_workstation_l1.profile
@@ -260,7 +260,7 @@ sshd_use_strong_kex
 sshd_use_strong_macs
 sudo_add_use_pty
 sudo_custom_logfile
-sudo_require_authentication
+sudo_remove_no_authenticate
 sudo_require_reauthentication
 sysctl_fs_protected_hardlinks
 sysctl_fs_suid_dumpable
@@ -341,5 +341,6 @@ var_sshd_max_sessions=10
 var_sshd_set_keepalive=1
 var_sshd_set_login_grace_time=60
 var_sshd_set_maxstartups=10:30:60
+var_sudo_timestamp_timeout=15_minutes
 var_system_crypto_policy=default_policy
 var_user_initialization_files_regex=all_dotfiles

--- a/tests/data/profile_stability/rhel10/cis_workstation_l2.profile
+++ b/tests/data/profile_stability/rhel10/cis_workstation_l2.profile
@@ -362,7 +362,8 @@ sshd_use_strong_kex
 sshd_use_strong_macs
 sudo_add_use_pty
 sudo_custom_logfile
-sudo_require_authentication
+sudo_remove_no_authenticate
+sudo_remove_nopasswd
 sudo_require_reauthentication
 sysctl_fs_protected_hardlinks
 sysctl_fs_protected_symlinks
@@ -454,5 +455,6 @@ var_sshd_max_sessions=10
 var_sshd_set_keepalive=1
 var_sshd_set_login_grace_time=60
 var_sshd_set_maxstartups=10:30:60
+var_sudo_timestamp_timeout=15_minutes
 var_system_crypto_policy=default_policy
 var_user_initialization_files_regex=all_dotfiles


### PR DESCRIPTION
This commit aligns our CIS profiles with RHEL 10 CIS Benchmark version v1.0.1 requirements 5.2.4, 5.2.5 and 5.2.6.

Requirement 5.2.4 is only about removal of `NOPASSWD` directive, but the currently selected rule `sudo_require_authentication` removes both `NOPASSWD` and `!authenticate` directives. We will replace this rule by `sudo_remove_nopasswd` which only removes `NOPASSWD` and therefore better fits this requirement.

Requirement 5.2.5 is only about removal of `!authenticate` directive, but the currently selected rule `sudo_require_authentication` removes both `NOPASSWD` and `!authenticate` directives. We will replace this rule by `sudo_remove_no_authenticate` which only removes `!authenticate` and therefore better fits this requirement.

Requirement 5.2.6 needs an explicit variable selection of variable `var_sudo_timestamp_timeout` used by rule `sudo_require_reauthentication`.

Resolves: https://issues.redhat.com/browse/OPENSCAP-6138
