### PR TITLE
Improve RHEL 10 CIS requirement 6.1.2

### DIFF
--- a/controls/cis_rhel10.yml
+++ b/controls/cis_rhel10.yml
@@ -2334,6 +2334,8 @@ controls:
       status: automated
       rules:
           - aide_periodic_cron_checking
+      related_rules:
+          - aide_periodic_checking_systemd_timer
 
     - id: 6.1.3
       title: Ensure cryptographic mechanisms are used to protect the integrity of audit tools (Automated)


### PR DESCRIPTION
Regular periodic file integrity checking can be implemented either by cron or by a systemd timer. The RHEL 10 CIS Benchmark v1.0.1 requirement 6.1.2 allows both ways. But, they are mutually exclusive, we can't have rules for both ways in the profile. Therefore we will pick one and we will add the other to related_rules section.

Resolves: https://issues.redhat.com/browse/OPENSCAP-6107

