### PR TITLE
Enable profile in CO content image

### DIFF
--- a/Dockerfiles/compliance-operator-content-konflux.Containerfile
+++ b/Dockerfiles/compliance-operator-content-konflux.Containerfile
@@ -60,8 +60,13 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then \
     sed -i 's/\(documentation_complete: \).*/\1true/' products/ocp4/profiles/bsi-2022.profile && \
     sed -i 's/\(documentation_complete: \).*/\1true/' products/ocp4/profiles/bsi-node-2022.profile &&  \
     sed -i 's/\(documentation_complete: \).*/\1true/' products/ocp4/profiles/stig-v2r2.profile && \
+    sed -i 's/\(documentation_complete: \).*/\1true/' products/ocp4/profiles/stig-v2r3.profile && \
     sed -i 's/\(documentation_complete: \).*/\1true/' products/ocp4/profiles/stig-node-v2r2.profile && \
+    sed -i 's/\(documentation_complete: \).*/\1true/' products/ocp4/profiles/stig-node-v2r3.profile && \
+    sed -i 's/\(documentation_complete: \).*/\1true/' products/rhcos4/profiles/bsi.profile && \
+    sed -i 's/\(documentation_complete: \).*/\1true/' products/rhcos4/profiles/bsi-2022.profile && \
     sed -i 's/\(documentation_complete: \).*/\1true/' products/rhcos4/profiles/stig-v2r2.profile; \
+    sed -i 's/\(documentation_complete: \).*/\1true/' products/rhcos4/profiles/stig-v2r3.profile; \
     fi
 
 # Enable the DISA-STIG profiles for ppc64le


### PR DESCRIPTION


#### Description:

- Add RHCOS4 BSI profiles
- Add STIG V2R3 profiles

#### Rationale:

- These profiles are missing in content image because they were not  added to the Containerfile.