### PR TITLE
Align rule description with checks and remediations

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner_net/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner_net/rule.yml
@@ -5,7 +5,7 @@ title: 'Enable SSH Warning Banner'
 description: |-
     To enable the warning banner and ensure it is consistent
     across the system, add or correct the following line in
-    {{% if product in ['fedora', 'ol9', 'rhel9'] %}}
+    {{% if sshd_distributed_config == "true" %}}
     <tt>/etc/ssh/sshd_config.d/00-complianceascode-hardening.conf</tt>:
     {{% else %}}
     <tt>/etc/ssh/sshd_config</tt>:


### PR DESCRIPTION
The checks and remediations in rule `sshd_enable_warning_banner_net` can check and configure SSHD using distributed configuration file `/etc/ssh/sshd_config.d/00-complianceascode-hardening.conf`, depending on the product. This is defined by the `sshd_distributed_config` product property. However, the rule description didn't use this in the condition in the rule description. As a result, the description didn't correspond to actual contents of checks and remediations on RHEL 10.

This change is a part of aligning our content with RHEL 10 CIS Benchmark v1.0.1.

Resolves: https://issues.redhat.com/browse/OPENSCAP-6091

