### PR TITLE
Fix linux disable network sniffer ansible syntax for non-standard interfaces

### DIFF
--- a/linux_os/guide/system/network/network_sniffer_disabled/ansible/shared.yml
+++ b/linux_os/guide/system/network/network_sniffer_disabled/ansible/shared.yml
@@ -13,5 +13,5 @@
   ansible.builtin.command:
     cmd: ip link set dev {{ (item.split(':')[1] | trim).split('@')[0] }} multicast off promisc off
   loop: "{{ network_interfaces.stdout_lines }}"
-  when: network_interfaces.stdout_lines is defined and "item.split(':') | length == 3"
+  when: network_interfaces.stdout_lines is defined and item.split(':') | length == 3
 


### PR DESCRIPTION
#### Description:

- Fixes issue with Linux Ansible syntax when ran against systems with interfaces such as `bond.70@bond0`.

#### Rationale:

- Enhance existing Jinja filtering to ensure proper handling of non-standard interfaces by further refining registered item.

Fixes #11901

#### Review Hints:

- Existing filters will reduce registered item to only the interface name by extracting the content between two `:` delimiters. The enhancements will take the output of that and further reduce the item by extracting the content left of the first `@` delimiter. This results in the `bond.70@bond0` becoming `bond.70` as that is the first item (0) in this delimited list.

- Example registered item: `3: bond.70@bond0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP mode DEFAULT group default qlen 1000\    link/ether ab:cd:ef:12:34:56 brd ff:ff:ff:ff:ff:ff\    altname enxabcdef123456`
- Existing jinja template filter results: `bond.70@bond0`
- Enhanced jinja template filter results: `bond.70`


- _Good examples are useful commands, if it is better to review all commits together or in a suggested sequence, any relevant discussion in other PRs or issues, etc._
