### PR TITLE
Use the right workflow name for the Compare DS job

### DIFF
--- a/.github/workflows/compare-ds.yaml
+++ b/.github/workflows/compare-ds.yaml
@@ -1,9 +1,10 @@
 name: Compare DS
 on:
   workflow_run:
-    workflows: ["Compare DS Build Content"]
+    workflows: ["Compare DS Build"]
     types:
       - completed
+    branches: [master, 'stabilization*']
 permissions:
     pull-requests: write
     contents: read
@@ -56,7 +57,7 @@ jobs:
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         uses: actions/download-artifact@v6
         with:
-            name: pr-artifact-${{ github.event.workflow_run.head_sha }}
+            name: pr-artifacts-${{ github.event.workflow_run.head_sha }}
             path: pr_artifacts
       - name: Unpack built artifacts
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}


### PR DESCRIPTION
#### Description:
- Use the right workflow name for the Compare DS job
  - The job was never being triggered.

Change from this PR: https://github.com/ComplianceAsCode/content/pull/13535