### PR TITLE
service_systemd-journald_enabled: add specific test scenario

### DIFF
--- a/linux_os/guide/system/logging/journald/service_systemd-journal-upload_enabled/tests/service_enabled.pass.sh
+++ b/linux_os/guide/system/logging/journald/service_systemd-journal-upload_enabled/tests/service_enabled.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# packages = systemd-journal-remote
+
+cat > /etc/systemd/journal-upload.conf << EOM
+[Upload]
+URL=http://example.com
+EOM
+
+SYSTEMCTL_EXEC='/usr/bin/systemctl'
+"$SYSTEMCTL_EXEC" unmask 'systemd-journal-upload.service'
+"$SYSTEMCTL_EXEC" start 'systemd-journal-upload.service'
+"$SYSTEMCTL_EXEC" enable 'systemd-journal-upload.service'


### PR DESCRIPTION
#### Description:

- add a specific test scenario overriding the templated one

#### Rationale:

- The service can be enabled successfully only if properly configured
- see man journal-upload.conf


#### Review Hints:

Use Automatus.