### PR TITLE
Update pci-dss profile for OL8

### DIFF
--- a/products/ol8/profiles/pci-dss.profile
+++ b/products/ol8/profiles/pci-dss.profile
@@ -50,6 +50,8 @@ selections:
     - '!package_cryptsetup-luks_installed'
     - '!audit_rules_file_deletion_events_renameat2'
     - '!audit_rules_dac_modification_fchmodat2'
+    - '!enable_dconf_user_profile'
+    - '!audit_rules_mac_modification_etc_selinux'
     # Use Oracle gpgkey rule
     - '!ensure_redhat_gpgkey_installed'
     - '!ensure_suse_gpgkey_installed'


### PR DESCRIPTION
#### Description:

Remove `audit_rules_mac_modification_etc_selinux` and `enable_dconf_user_profile` from `pci-dss` profile for OL8

#### Rationale:

Update pci-dss profile for OL8