### PR TITLE
extend the bootc platform to cover both online and offline cases

### DIFF
--- a/shared/applicability/bootc.yml
+++ b/shared/applicability/bootc.yml
@@ -20,5 +20,5 @@ check_id: bootc
 {{% else %}}
 {{% set kernel_package = "kernel" %}}
 {{% endif %}}
-bash_conditional: "{ rpm --quiet -q {{{ kernel_package }}} ;} && { rpm --quiet -q rpm-ostree ;} && { rpm --quiet -q bootc ;} && { ! rpm --quiet -q openshift-kubelet ;} && [ -f /run/ostree-booted ]"
+bash_conditional: "{ rpm --quiet -q {{{ kernel_package }}} ;} && { rpm --quiet -q rpm-ostree ;} && { rpm --quiet -q bootc ;} && { ! rpm --quiet -q openshift-kubelet ;} && ([ -f /run/ostree-booted ] || [ -L /ostree ])"
 ansible_conditional: '"{{{ kernel_package }}}" in ansible_facts.packages and "rpm-ostree" in ansible_facts.packages and "bootc" in ansible_facts.packages and not "openshift-kubelet" in ansible_facts.packages and "ostree" in ansible_proc_cmdline'

--- a/shared/applicability/oval/bootc.xml
+++ b/shared/applicability/oval/bootc.xml
@@ -5,7 +5,10 @@
       <criterion comment="kernel is installed" test_ref="bootc_platform_test_kernel_installed" />
       <criterion comment="rpm-ostree is installed" test_ref="bootc_platform_test_rpm_ostree_installed" />
       <criterion comment="bootc is installed" test_ref="bootc_platform_test_bootc_installed" />
-      <criterion comment="/run/ostree-booted exists" test_ref="bootc_platform_test_run_ostree_booted_exists" />
+      <criteria operator="OR">
+        <criterion comment="/run/ostree-booted exists, suggesting that we are in a running bootc environment" test_ref="bootc_platform_test_run_ostree_booted_exists" />
+        <criterion comment="/ostree symlink exists, suggesting that we are in a bootc environment being built and hardened" test_ref="bootc_platform_test_ostree_symlink_exists" />
+      </criteria>
       <criterion comment="openshift-kubelet is not installed" test_ref="bootc_platform_test_openshift_kubelet_removed" />
     </criteria>
   </definition>
@@ -26,5 +29,19 @@
   <unix:file_object id="bootc_platform_obj_run_ostree_booted_exists" comment="The file /run/ostree-booted exists" version="1">
     <unix:filepath operation="equals">/run/ostree-booted</unix:filepath>
   </unix:file_object>
+
+  <unix:file_test id="bootc_platform_test_ostree_symlink_exists" check="all" check_existence="all_exist" comment="The file /ostree is a symlink" version="1">
+    <unix:object object_ref="bootc_platform_obj_ostree_symlink_exists" />
+    <unix:state state_ref="bootc_platform_ste_ostree_symlink_exists" />
+  </unix:file_test>
+
+  <unix:file_object id="bootc_platform_obj_ostree_symlink_exists" comment="The file /ostree exists" version="1">
+    <unix:filepath operation="equals">/ostree</unix:filepath>
+  </unix:file_object>
+
+  <unix:file_state id="bootc_platform_ste_ostree_symlink_exists" comment="The file /ostree is a symlink" version="1">
+    <unix:filepath operation="equals">/ostree</unix:filepath>
+<unix:type operation="equals">symbolic link</unix:type>
+  </unix:file_state>
 
 </def-group>

--- a/shared/checks/oval/bootc.xml
+++ b/shared/checks/oval/bootc.xml
@@ -5,7 +5,10 @@
       <criterion comment="kernel is installed" test_ref="bootc_platform_test_kernel_installed" />
       <criterion comment="rpm-ostree is installed" test_ref="bootc_platform_test_rpm_ostree_installed" />
       <criterion comment="bootc is installed" test_ref="bootc_platform_test_bootc_installed" />
-      <criterion comment="/run/ostree-booted exists" test_ref="bootc_platform_test_run_ostree_booted_exists" />
+      <criteria operator="OR">
+        <criterion comment="/run/ostree-booted exists, suggesting that we are in a running bootc environment" test_ref="bootc_platform_test_run_ostree_booted_exists" />
+        <criterion comment="/ostree symlink exists, suggesting that we are in a bootc environment being built and hardened" test_ref="bootc_platform_test_ostree_symlink_exists" />
+      </criteria>
       <criterion comment="openshift-kubelet is not installed" test_ref="bootc_platform_test_openshift_kubelet_removed" />
     </criteria>
   </definition>
@@ -26,5 +29,19 @@
   <unix:file_object id="bootc_platform_obj_run_ostree_booted_exists" comment="The file /run/ostree-booted exists" version="1">
     <unix:filepath operation="equals">/run/ostree-booted</unix:filepath>
   </unix:file_object>
+
+  <unix:file_test id="bootc_platform_test_ostree_symlink_exists" check="all" check_existence="all_exist" comment="The file /ostree is a symlink" version="1">
+    <unix:object object_ref="bootc_platform_obj_ostree_symlink_exists" />
+    <unix:state state_ref="bootc_platform_ste_ostree_symlink_exists" />
+  </unix:file_test>
+
+  <unix:file_object id="bootc_platform_obj_ostree_symlink_exists" comment="The file /ostree exists" version="1">
+    <unix:filepath operation="equals">/ostree</unix:filepath>
+  </unix:file_object>
+
+  <unix:file_state id="bootc_platform_ste_ostree_symlink_exists" comment="The file /ostree is a symlink" version="1">
+    <unix:filepath operation="equals">/ostree</unix:filepath>
+<unix:type operation="equals">symbolic link</unix:type>
+  </unix:file_state>
 
 </def-group>


### PR DESCRIPTION
#### Description:

- extend the platform by checking either for /ostree symlink or presence of /run/ostree-booted regular file

#### Rationale:

it was discovered that there are two distint cases when we can be in the bootc environment. The first one is while the bootc image is actually hardened during its creation. This is manifested by presence of /ostree symlink. The second case is when we are in already booted bootc image. This was already covered before, but the file /run/ostree-booted is not present when building the image. Switching only to check for the /ostree symlink does not work as well, because in case of running bootc image, the /ostree is a directory, not a symlink. I think this covers both cases well and with reasonable accuracy.


#### Review Hints:

Try hardening a bootc image and also anaconda rpmostree installation case.