### PR TITLE
CMP-3915: Update SCC variable to include new SCCs for 4.20

### DIFF
--- a/applications/openshift/scc/var_sccs_with_allowed_capabilities_regex.var
+++ b/applications/openshift/scc/var_sccs_with_allowed_capabilities_regex.var
@@ -11,4 +11,4 @@ operator: equals
 interactive: false
 
 options:
-  default: "^privileged$|^hostnetwork-v2$|^restricted-v2$|^nonroot-v2$|^insights-runtime-extractor-scc$"
+  default: "^privileged$|^hostnetwork-v2$|^restricted-v2$|^restricted-v3$|^nonroot-v2$|^insights-runtime-extractor-scc|^nested-container$"


### PR DESCRIPTION
4.20 ships with two new SCCs that allow additional capabilities. Let's
add them to the variable so we don't get false positives on scans
running on OCP 4.20.
