### PR TITLE
CMP-3916: Fix sshd_disable_gssapi_auth remediation for Kubernetes

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_gssapi_auth/kubernetes/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_gssapi_auth/kubernetes/shared.yml
@@ -3,6 +3,6 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-{{{ kubernetes_sshd_set() }}}
+{{{ kubernetes_disable_sshd_config_option('GSSAPIAuthentication') }}}
 ---
-{{{ kubernetes_sshd_dropin('GSSAPIAuthentication no', config_basename='00-complianceascode-sshd_disable_gssapi_auth.conf') }}}
+{{{ kubernetes_disable_sshd_config_option_dropin('GSSAPIAuthentication') }}}

--- a/shared/macros/10-kubernetes.jinja
+++ b/shared/macros/10-kubernetes.jinja
@@ -248,6 +248,29 @@ spec:
 {{{ kubernetes_machine_config_file(path='/etc/ssh/sshd_config.d/' + config_basename, file_permissions_mode='0600', source=sshd_dropin_content, ocp_version_range=ocp_version_range) }}}
 {{%- endmacro -%}}
 
+{{#
+  Disable SSH options in existing configuration files.
+
+  GSSAPI authentication is enabled by default in
+  `/etc/ssh/sshd_config.d/50-redhat.conf`. Using a drop-in file for another
+  parameter in the same directory breaks the rule. Even if the drop-in file is
+  placed correctly, and disables the GSSAPI, the rule still detects that there
+  is a string in `/etc/ssh/sshd_config.d/50-redhat.conf` that has
+  `GSSAPIAuthentication yes`.
+
+  We need this specific macro so that we can override the setting in
+  `/etc/ssh/sshd_config.d/50-redhat.conf` on 4.13+ and `/etc/ssh/sshd_config` on
+  4.12.
+
+#}}
+{{%- macro kubernetes_disable_sshd_config_option(parameter) -%}}
+{{{ kubernetes_machine_config_file(path='/etc/ssh/sshd_config', file_permissions_mode='0600', source=parameter + ' no' , ocp_version_range='<4.13.0') }}}
+{{%- endmacro -%}}
+
+{{%- macro kubernetes_disable_sshd_config_option_dropin(parameter) -%}}
+{{{ kubernetes_machine_config_file(path='/etc/ssh/sshd_config.d/50-redhat.conf', file_permissions_mode='0600', source=parameter + ' no' , ocp_version_range='>=4.13.0') }}}
+{{%- endmacro -%}}
+
 
 {{% macro usbguard_config_source() %}}
 #


### PR DESCRIPTION
Add shared Kubernetes configuration that disables GSSAPI authentication in SSHD by setting GSSAPIAuthentication to 'no' with higher priority. This is necessary because the default `50-redhat.conf` file contains GSSAPIAuthentication set to 'yes', which must be overridden for compliance requirements.

```
sh-5.1# cd /etc/ssh/ssh_config.d/
sh-5.1# ls
50-redhat.conf
sh-5.1# cat 50-redhat.conf 
# The options here are in the "Match final block" to be applied as the last
# options and could be potentially overwritten by the user configuration
Match final all
        # Follow system-wide Crypto Policy, if defined:
        Include /etc/crypto-policies/back-ends/openssh.config

        GSSAPIAuthentication yes

# If this option is set to yes then remote X11 clients will have full access
# to the original X11 display. As virtually no X11 client supports the untrusted
# mode correctly we set this to yes.
        ForwardX11Trusted yes

# Uncomment this if you want to use .local domain
# Host *.local
sh-5.1# 
```