### PR TITLE
sysctl_kernel_exec_shield: make applicable only on x86_64

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/rule.yml
@@ -25,7 +25,9 @@ rationale: |-
 
 severity: medium
 
-platform: system_with_kernel  # The oscap sysctl probe doesn't support offline mode
+# The oscap sysctl probe doesn't support offline mode
+# the execshield is relevant only to x86_64 platform
+platform: system_with_kernel and x86_64_arch
 
 identifiers:
     cce@rhel8: CCE-80914-5


### PR DESCRIPTION
### Description:

- extend the rule's applicability platform to restrict the rule to x86_64 platform only

#### Rationale:

- The execshield feature is available only on x86_64 platform.


#### Review Hints:

Try to scan / remediate rule on x86_64 platform and ideally also non x86_64 platform.