### PR TITLE
#14093 - script for checking iptable rules

### DIFF
--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_loopback_traffic/sce/shared.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_loopback_traffic/sce/shared.sh
@@ -26,3 +26,4 @@ if [[ ! "$rules" =~ "-A INPUT -s 127.0.0.0/8 -j DROP" ]]; then
 fi
 
 exit "$XCCDF_RESULT_PASS"
+


### PR DESCRIPTION
#### Description:

- Uses output from `iptables -S` to get current settings and compare using bash builtin function instead of using regex and external grep command.

#### Rationale:

- Current script misses output for ubuntu and servers which have lots of pkts count

- Fixes #14093
