### PR TITLE
Adding a note on a FIPS compliance for RHEL-09-672020

### DIFF
--- a/products/rhel9/controls/stig_rhel9.yml
+++ b/products/rhel9/controls/stig_rhel9.yml
@@ -3859,7 +3859,7 @@ controls:
           Furthermore, running sudo 'update-crypto-policies --set FIPS' is not a reliable way to ensure FIPS compliance. Customers should
           refer to the official Red Hat Documentation and use the 'fips=1' kernel option during system installation to ensure the system is
           in FIPS mode.
-          More information can be found at: https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/security_hardening/switching-rhel-to-fips-mode_security-hardening
+          More information can be found at https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/security_hardening/switching-rhel-to-fips-mode_security-hardening
       status: pending
 
     - id: RHEL-09-672025


### PR DESCRIPTION
#### Description:

- These changes add a comment explaining why we don't have a rule implemented for [RHEL-09-672020](https://stigaview.com/products/rhel9/v2r4/RHEL-09-672020/).

#### Rationale:

- Fixes [RHEL-104411](https://issues.redhat.com/browse/RHEL-104411)
- After a brief discussion with @Mab879, @ggbecker, and @jan-cerny, we concluded that the best resolution is to add this comment (both to control file and to  JIRA ticket) explaining the proper usage of FIPS mode
- An addition of a specific rule would cause further confusion, since for SCE-only mode most users would get `notchecked` result in their reports
