### PR TITLE
Update ccn profile for OL9

### DIFF
--- a/controls/ccn_ol9.yml
+++ b/controls/ccn_ol9.yml
@@ -52,7 +52,9 @@ controls:
           - advanced
       status: automated
       rules:
-          - audit_rules_session_events
+          - audit_rules_session_events_utmp
+          - audit_rules_session_events_btmp
+          - audit_rules_session_events_wtmp
           - audit_rules_login_events_faillock
           - audit_rules_login_events_lastlog
 


### PR DESCRIPTION
#### Description:

Replace `audit_rules_session_events` with `audit_rules_session_events_btmp`, `audit_rules_session_events_utmp`  and `audit_rules_session_events_wtmp`

#### Rationale:

Update ccn profile for OL9 