### PR TITLE
Renaming test for accounts_root_gid_zero 

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_root_gid_zero/tests/other_user_gid_0.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_root_gid_zero/tests/other_user_gid_0.fail.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_fedora,multi_platform_rhel,multi_platform_ubuntu
-# Remediation doesn't fix the rule, only locks passwords
-# of non-root accounts with uid 0.
 # remediation = none
 
 useradd --gid 0 root2


### PR DESCRIPTION
#### Description:

- Name of the test didn't reflect it's content. No other changes are required

#### Rationale:

- Fixes [OPENSCAP-6104](https://issues.redhat.com/browse/OPENSCAP-6104)
