### PR TITLE
Update rule has_nonlocal_mta for latest CIS

### DIFF
--- a/controls/cis_rhel10.yml
+++ b/controls/cis_rhel10.yml
@@ -978,10 +978,7 @@ controls:
       levels:
           - l1_server
           - l1_workstation
-      status: partial
-      notes: |-
-          The rule has_nonlocal_mta currently checks for services listening only on port 25,
-          but the policy checks also for ports 465 and 587
+      status: automated
       rules:
           - postfix_network_listening_disabled
           - var_postfix_inet_interfaces=loopback-only

--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -994,10 +994,7 @@ controls:
       levels:
           - l1_server
           - l1_workstation
-      status: partial
-      notes: |-
-          The rule has_nonlocal_mta currently checks for services listening only on
-          port 25, but the policy checks also for ports 465 and 587
+      status: automated
       rules:
           - postfix_network_listening_disabled
           - var_postfix_inet_interfaces=loopback-only

--- a/linux_os/guide/services/mail/has_nonlocal_mta/oval/shared.xml
+++ b/linux_os/guide/services/mail/has_nonlocal_mta/oval/shared.xml
@@ -8,7 +8,7 @@
     {{{ oval_metadata("Verify MTA is not listening on any non-loopback address", rule_title=rule_title) }}}
     <criteria operator="AND">
       {{{ generate_criteria_listening_port("25")}}}
-{{% if 'ubuntu' in product %}}
+{{% if 'ubuntu' in product or 'rhel' in product %}}
       {{{ generate_criteria_listening_port("465")}}}
       {{{ generate_criteria_listening_port("587")}}}
 {{% endif %}}
@@ -42,7 +42,7 @@
   {{% endmacro %}}
 
   {{{ generate_test_listening_port("25") }}}
-  {{% if 'ubuntu' in product %}}
+  {{% if 'ubuntu' in product or 'rhel' in product %}}
   {{{ generate_test_listening_port("465")}}}
   {{{ generate_test_listening_port("587")}}}
   {{% endif %}}

--- a/products/rhel9/controls/cis_rhel9.yml
+++ b/products/rhel9/controls/cis_rhel9.yml
@@ -998,10 +998,7 @@ controls:
       levels:
           - l1_server
           - l1_workstation
-      status: partial
-      notes: |-
-          The rule has_nonlocal_mta currently checks for services listening only on port 25,
-          but the policy checks also for ports 465 and 587
+      status: automated
       rules:
           - postfix_network_listening_disabled
           - var_postfix_inet_interfaces=loopback-only


### PR DESCRIPTION
The rule has_nonlocal_mta currently checks for services listening only on port 25, but the policy checks also for ports 465 and 587.  The content was already updated for other distro to include this extra criteria, so we simply enable that part of the code to RHEL.

This change aligns our CIS profiles with latest CIS Benchmarks on RHEL 8, 9 and 10.

Resolves: https://issues.redhat.com/browse/OPENSCAP-6083

