### PR TITLE
Override auditd_kmod OVAL to allow old watch format on Ubuntu

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/oval/ubuntu.xml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/oval/ubuntu.xml
@@ -1,0 +1,68 @@
+<def-group>
+  <definition class="compliance" id="audit_rules_privileged_commands_kmod" version="1">
+    {{{ oval_metadata("Ensure audit rule for all uses of the kmod command is enabled.", rule_title=rule_title) }}}
+
+    <criteria operator="OR">
+
+      <!-- Test the augenrules case -->
+      <criteria operator="AND">
+        <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
+        <criteria operator="OR">
+          <criterion comment="audit augenrules kmod old format" test_ref="test_kmod_augenrules_old_format" />
+          <criterion comment="audit augenrules kmod new format" test_ref="test_audit_rules_privileged_commands_kmod_augenrules" />
+        </criteria>
+      </criteria>
+
+      <!-- Test the auditctl case -->
+      <criteria operator="AND">
+        <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
+        <criteria operator="OR">
+          <criterion comment="audit auditctl kmod old format" test_ref="test_kmod_auditctl_old_format" />
+          <criterion comment="audit auditctl kmod new format" test_ref="test_audit_rules_privileged_commands_kmod_auditctl" />
+        </criteria>
+      </criteria>
+
+    </criteria>
+  </definition>
+
+  <!-- Old auditd watch format -->
+
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists" comment="audit augenrules kmod old format" id="test_kmod_augenrules_old_format" version="1">
+    <ind:object object_ref="object_kmod_augenrules_old_format" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_kmod_augenrules_old_format" version="1">
+    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-w[\s]+/bin/kmod[\s]+-p[\s]+x([\s]+-k[\s]+[\S]+)?[\s]*$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists" comment="audit auditctl kmod old format" id="test_kmod_auditctl_old_format" version="1">
+    <ind:object object_ref="object_kmod_auditctl_old_format" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_kmod_auditctl_old_format" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-w[\s]+/bin/kmod[\s]+-p[\s]+x([\s]+-k[\s]+[\S]+)?[\s]*$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- New auditd watch format -->
+
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists" comment="audit augenrules kmod" id="test_audit_rules_privileged_commands_kmod_augenrules" version="1">
+    <ind:object object_ref="object_audit_rules_privileged_commands_kmod_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_audit_rules_privileged_commands_kmod_augenrules" version="1">
+    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+path=\/usr\/bin\/kmod(?:[\s]+-F[\s]+perm=x)[\s]+-F[\s]+auid>={{{ auid }}}[\s]+-F[\s]+auid!=(?:4294967295|unset|-1)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists" comment="audit auditctl kmod" id="test_audit_rules_privileged_commands_kmod_auditctl" version="1">
+    <ind:object object_ref="object_audit_rules_privileged_commands_kmod_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_audit_rules_privileged_commands_kmod_auditctl" version="1">
+    <ind:filepath operation="pattern match">/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+path=\/usr\/bin\/kmod(?:[\s]+-F[\s]+perm=x)[\s]+-F[\s]+auid>={{{ auid }}}[\s]+-F[\s]+auid!=(?:4294967295|unset|-1)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/tests/auditctl_correct_old_format.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/tests/auditctl_correct_old_format.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = audit
+
+echo "-w /bin/kmod -p x -k privileged" >> /etc/audit/audit.rules
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/tests/augenrules_correct_old_format.pass.sh
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/tests/augenrules_correct_old_format.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = audit
+
+echo "-w /bin/kmod -p x -k privileged" >> /etc/audit/rules.d/privileged.rules


### PR DESCRIPTION
#### Description:

The rule `audit_rules_privileged_commands_kmod` uses the template `audit_rules_privileged_commands` which uses the new watch format (-a always,exit -F path=/bin/kmod ...) whereas Ubuntu STIGs suggest the old format (-w /bin/kmod ...).

This change aligns the content to the Ubuntu STIGs by allowing both formats.

#### Rationale:

- Fixes #14099 

#### Automatus results

```
$ python3 tests/automatus.py rule --libvirt qemu:///system sec-noble-amd64  --datastream build/ssg-ubuntu2404-ds.xml --remove-fips-certified --remediate-using bash --profile "(all)" --dontclean audit_rules_privileged_commands_kmod

Setting console output to log level INFO
INFO - The base image option has not been specified, choosing libvirt-based test environment.
WARNING - Script 'auditctl_missing_arch.fail.sh' is not applicable on 'ubuntu2404' target because its platform is 'Red Hat Enterprise Linux 10'
WARNING - Script 'augenrules_missing_arch.fail.sh' is not applicable on 'ubuntu2404' target because its platform is 'Red Hat Enterprise Linux 10'
INFO - xccdf_org.ssgproject.content_rule_audit_rules_privileged_commands_kmod
INFO - Script auditctl_comented_value.fail.sh using profile (all) OK
INFO - Script auditctl_missing_auid.fail.sh using profile (all) OK
INFO - Script augenrules_missing_auid.fail.sh using profile (all) OK
INFO - Script auditctl_missing_perm_x.fail.sh using profile (all) OK
INFO - Script augenrules_missing_perm_x.fail.sh using profile (all) OK
INFO - Script augenrules_comented_value.fail.sh using profile (all) OK
INFO - Script auditctl_correct_value.pass.sh using profile (all) OK
INFO - Script augenrules_correct_value.pass.sh using profile (all) OK
INFO - Script augenrules_correct_old_format.pass.sh using profile (all) OK
INFO - Script auditctl_correct_old_format.pass.sh using profile (all) OK
```