### PR TITLE
Bump version to 0.1.80

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ include(SSGCommon)
 # Define Version values
 set(SSG_MAJOR_VERSION 0)
 set(SSG_MINOR_VERSION 1)
-set(SSG_PATCH_VERSION 79)
+set(SSG_PATCH_VERSION 80)
 set(SSG_VERSION "${SSG_MAJOR_VERSION}.${SSG_MINOR_VERSION}.${SSG_PATCH_VERSION}")
 
 set(SSG_VENDOR "ssgproject" CACHE STRING "Specify the XCCDF 1.2 vendor string.")


### PR DESCRIPTION
#### Description:

- Bump version to 0.1.80

#### Rationale:

- This is done right after the new stabilization branch is created.

- Fixes [OPENSCAP-6342](https://issues.redhat.com/browse/OPENSCAP-6342)
