### PR TITLE
Add RHEL 10  to ./utils/ansible_playbook_to_role.py

### DIFF
--- a/utils/ansible_playbook_to_role.py
+++ b/utils/ansible_playbook_to_role.py
@@ -65,6 +65,7 @@ yaml.add_constructor(_mapping_tag, dict_constructor)
 PRODUCT_ALLOWLIST = set([
     "rhel8",
     "rhel9",
+    "rhel10",
 ])
 
 PROFILE_ALLOWLIST = set([


### PR DESCRIPTION
#### Description:

Add RHEL 10  to ./utils/ansible_playbook_to_role.py
#### Rationale:
So we publish the RHEL 10 updates as well.