### PR TITLE
Add 60s timeout for acquiring the APT lock

### DIFF
--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -460,7 +460,7 @@ if ! rpm -q --quiet "{{{ package }}}" ; then
     {{{ pkg_manager }}} install -y "{{{ package }}}"
 fi
 {{%- elif pkg_manager == "apt_get" -%}}
-DEBIAN_FRONTEND=noninteractive apt-get install -y "{{{ package }}}"
+DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=60 install -y "{{{ package }}}"
 {{%- elif pkg_manager == "zypper" -%}}
 zypper install -y "{{{ package }}}"
 {{%- else -%}}
@@ -498,7 +498,7 @@ if rpm -q --quiet "{{{ package }}}" ; then
 {{% endif %}}
 fi
 {{%- elif pkg_manager == "apt_get" -%}}
-DEBIAN_FRONTEND=noninteractive apt-get remove -y "{{{ package }}}"
+DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=60 remove -y "{{{ package }}}"
 {{%- elif pkg_manager == "zypper" -%}}
 zypper remove -y "{{{ package }}}"
 {{%- else -%}}


### PR DESCRIPTION
#### Description:

- Add 60s lock timeout to apt-get commands

#### Rationale:

- This largely mitigates the issue of packages failing to install due to other apt processes (unattended-upgrades) running in the background at the same time.
- By default, apt-get fails immediately if another apt process holds the lock, and there's no good way to acquire the lock from a bash script.