### PR TITLE
[stabilization] Fix XCCDF value type

### DIFF
--- a/linux_os/guide/auditing/var_audit_backlog_limit.var
+++ b/linux_os/guide/auditing/var_audit_backlog_limit.var
@@ -7,7 +7,7 @@ description: |-
     The audit_backlog_limit parameter determines how auditd records can
     be held in the auditd backlog.
 
-type: number
+type: string
 
 operator: equals
 


### PR DESCRIPTION
Fixes failing SCAPVal requirement SRC-38.

Addressing:
Values of XCCDF datatype 'number', when bound to OVAL variables, the OVAL variables must be of the following OVAL types: int, float.
