### PR TITLE
Fix Ansible sysctl template

### DIFF
--- a/shared/templates/sysctl/ansible.template
+++ b/shared/templates/sysctl/ansible.template
@@ -39,7 +39,7 @@
 {{%- if SYSCTLVAL == "" or SYSCTLVAL is not string  %}}
     cmd: find -L {{ sysctl_paths | join(" ") }} -type f -name '*.conf' | xargs grep -HP '^\s*{{{ SYSCTLVAR }}}\s*=\s*{{ sysctl_{{{ SYSCTLID }}}_value }}$'
 {{%- else %}}
-    cmd: find -L {{ sysctl_paths | join(" ") }} -type f -name '*.conf' | xargs grep -HP '^\s*{{{ SYSCTLVAR }}}\s*=\s*{{{ SYSCTLVAL }}}$'
+    cmd: find -L {{ sysctl_paths | join(" ") }} -type f -name '*.conf' | xargs grep -HP '^\s*{{{ SYSCTLVAR }}}\s*=\s*{{{ SYSCTLVAL | escape_regex }}}$'
 {{%- endif %}}
   register: find_correct_value
   check_mode: false


### PR DESCRIPTION
If the value of the sysctl item contains a special character it needs to be escaped before using it in a regular expression or the regular expression won't work correctly. This happens in rule sysctl_kernel_core_pattern where the value is `|/bin/false` which contains the `|` character.

This fixes multiple failing test scenarios for Ansible remediation in rule sysctl_kernel_core_pattern.

