### PR TITLE
Fix Ansible remediation in network_sniffer_disabled

### DIFF
--- a/linux_os/guide/system/network/network_sniffer_disabled/ansible/shared.yml
+++ b/linux_os/guide/system/network/network_sniffer_disabled/ansible/shared.yml
@@ -13,5 +13,5 @@
   ansible.builtin.command:
     cmd: ip link set dev {{ (item.split(':')[1] | trim).split('@')[0] }} multicast off promisc off
   loop: "{{ network_interfaces.stdout_lines }}"
-  when: network_interfaces.stdout_lines is defined and item.split(':') | length == 3
+  when: network_interfaces.stdout_lines is defined and item.split(':') | length >= 3
 


### PR DESCRIPTION
The rule network_sniffer_disabled failed the test scenario promisc_interface_exists.fail.sh with Ansible remeditaion. The task condition is wrong because the `ip -o link show` command output typically contains more colons than 3 colons because it typically contains MAC addresses where colons are user as separators. This problem has been discovered during stabilization run on RHEL 10.0.

