### PR TITLE
[stabilization] Fix test scenarios metadata

### DIFF
--- a/linux_os/guide/services/sssd/sssd_enable_user_cert/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_user_cert/tests/correct_value.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# remediation = none
 # packages = sssd
 
 CONF="/etc/sssd/sssd.conf"

--- a/linux_os/guide/services/sssd/sssd_enable_user_cert/tests/multiple_in_section_and_correct_value.pass.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_user_cert/tests/multiple_in_section_and_correct_value.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# remediation = none
 # packages = sssd
 
 CONF="/etc/sssd/sssd.conf"

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/prevent_direct_root_logins/tests/asterisk.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/prevent_direct_root_logins/tests/asterisk.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # packages = passwd
 # platform = multi_platform_all
-# remediation = none
 
 sed -i "s/^root:[^:]*/root:*/" /etc/shadow


### PR DESCRIPTION
During stabilization we discovered that these scenarios fail the `/static-checks/unit-tests-metadata` test because `remediation=none` doesn't make sense for a `.pass.sh` test.

