### PR TITLE
Fix controleval_metrics.py for having per product controls 

### DIFF
--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -984,9 +984,9 @@ class ControlsManager:
         """
         try:
             policy = self.policies[policy_id]
-        except KeyError:
-            msg = "policy '%s' doesn't exist" % policy_id
-            raise ValueError(msg)
+        except KeyError as e:
+            msg = f"policy '{policy_id}' doesn't exist"
+            raise ValueError(msg) from e
         return policy
 
     def get_all_controls_of_level(self, policy_id: str, level_id: str) -> List[Control]:
@@ -1033,7 +1033,7 @@ class ControlsManager:
         Remove specified variables from a control object.
 
         Args:
-            variables_to_remove (set): A list of variable names to be removed from the control.
+            variables_to_remove (set): A set of variable names to be removed from the control.
             control (object): The control object from which variables will be removed.
 
         Returns:

--- a/utils/controleval.py
+++ b/utils/controleval.py
@@ -92,22 +92,23 @@ def get_parameter_from_yaml(yaml_file: str, section: str) -> Optional[List]:
 
 
 def get_controls_from_profiles(controls: List[controls.Control], profiles_files: List[str],
-                               used_controls: set) -> Set[str]:
+                               used_controls: Set) -> Set[str]:
     for file in profiles_files:
         selections = get_parameter_from_yaml(file, 'selections')
-        for selection in selections:
-            if any(selection.startswith(control) for control in controls):
-                used_controls.add(selection.split(':')[0])
+        if selections:
+            for selection in selections:
+                if any(selection.startswith(control) for control in controls):
+                    used_controls.add(selection.split(':')[0])
     return used_controls
 
 
-def get_controls_used_by_products(ctrls_mgr: controls.ControlsManager, products: List[str]) -> list:
-    used_controls = set()
-    controls = ctrls_mgr.policies.keys()
+def get_policies_used_by_products(ctrls_mgr: controls.ControlsManager, products: List[str]) -> Set[str]:
+    used_policies = set()
+    policies = ctrls_mgr.policies.keys()
     for product in products:
         profiles_files = get_product_profiles_files(product)
-        used_controls = get_controls_from_profiles(controls, profiles_files, used_controls)
-    return used_controls
+        used_policies = get_controls_from_profiles(policies, profiles_files, used_policies)
+    return used_policies
 
 
 def get_policy_levels(ctrls_mgr: controls.ControlsManager, control_id: str) -> List[str]:
@@ -154,7 +155,7 @@ def get_formatted_name(text_name: str) -> str:
     return text_name
 
 
-def count_implicit_status(ctrls: List[controls.Control], status_count: Dict[str, int]):
+def count_implicit_status(ctrls: List[controls.Control], status_count: Dict[str, int]) -> Dict[str, int]:
     automated = status_count[controls.Status.AUTOMATED]
     documentation = status_count[controls.Status.DOCUMENTATION]
     inherently_met = status_count[controls.Status.INHERENTLY_MET]

--- a/utils/controleval_metrics.py
+++ b/utils/controleval_metrics.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python3
 import argparse
+import os
+import sys
 
 from prometheus_client import CollectorRegistry, Gauge, generate_latest, write_to_textfile
 from utils.controleval import (
     count_controls_by_status,
     count_rules_and_vars,
-    get_controls_used_by_products,
+    get_policies_used_by_products,
     get_policy_levels,
-    load_controls_manager
+    load_controls_manager,
+    load_product_yaml
 )
 
 try:
@@ -77,10 +80,35 @@ def get_prometheus_metrics_registry(
     return registry
 
 
-def prometheus(args):
-    ctrls_mgr = load_controls_manager(args.controls_dir, args.products[0])
-    used_controls = get_controls_used_by_products(ctrls_mgr, args.products)
-    registry = get_prometheus_metrics_registry(used_controls, ctrls_mgr)
+def prometheus(args: argparse.Namespace) -> None:
+    """
+    Generate Prometheus metrics for control policies across products.
+
+    Creates a single ControlsManager with all controls directories (root + all products)
+    to ensure all policies are visible. Product-specific controls override root controls
+    following the same precedence as the build system.
+    """
+    registry = CollectorRegistry()
+
+    # Build a single ControlsManager with all control directories
+    all_controls_dirs = [args.controls_dir]
+    for product in sorted(args.products):
+        product_yaml = load_product_yaml(product)
+        product_controls_dir = os.path.join(product_yaml['product_dir'], 'controls')
+        all_controls_dirs.append(product_controls_dir)
+
+    # Use the first product's yaml for env_yaml (required by ControlsManager)
+    # This is arbitrary since we're loading all controls
+    first_product_yaml = load_product_yaml(sorted(args.products)[0])
+    ctrls_mgr = controls.ControlsManager(all_controls_dirs, dict(first_product_yaml))
+    ctrls_mgr.load()
+
+    # Find all policies used across all products
+    used_policies = get_policies_used_by_products(ctrls_mgr, args.products)
+
+    for policy_id in sorted(used_policies):
+        registry = get_prometheus_metrics(ctrls_mgr, policy_id, registry)
+
     if args.output_file:
         write_to_textfile(args.output_file, registry)
     else:
@@ -108,7 +136,9 @@ def parse_arguments() -> argparse.Namespace:
         help="calculate and return benchmarks metrics in Prometheus format")
     prometheus_parser.add_argument(
         '-p', '--products', nargs='+', required=True,
-        help="list of products to process the respective controls files")
+        help=("list of products to process the respective controls files. "
+              "Metrics are aggregated across all specified products by building "
+              "a single ControlsManager from all control directories"))
     prometheus_parser.add_argument(
         '-f', '--output-file',
         help="save policy metrics in a file instead of showing in stdout")


### PR DESCRIPTION
#### Description:

* Fix `controleval_metrics.py` for having per product controls 

#### Rationale:

Fix metrics

#### Review Hints:

Run and check the output of `./utils/controleval_metrics.py prometheus -p fedora ocp4 rhcos4 rhel10 rhel9 rhel8 sle12 sle15 -f ./build/policies_metrics`
