### PR TITLE
[stabilization] Prevent Ansible fail in check mode

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/ansible/shared.yml
@@ -43,4 +43,6 @@
     dest: {{{ aide_stage_dest }}}
     backup: yes
     remote_src: yes
-  when: aide_database_init is changed
+  when:
+    - aide_database_init is changed
+    - not ansible_check_mode


### PR DESCRIPTION
Fixes failing /scanning/host-os/ansible-check/check-mode tests.

Addressing:
{"changed": false, "msg": "Source /var/lib/aide/aide.db.new.gz not found"}


