### PR TITLE
Fix /etc/cron.allow permissions

### DIFF
--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_cron_allow_exists/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_cron_allow_exists/rule.yml
@@ -37,4 +37,4 @@ template:
         filepath: /etc/cron.allow
         exists: true
         fileuid: "0"
-        filemode: "0600"
+        filemode: "0640"

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_permissions_cron_allow/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_permissions_cron_allow/rule.yml
@@ -3,13 +3,8 @@ documentation_complete: true
 
 title: 'Verify Permissions on /etc/cron.allow file'
 
-{{%  if 'rhel' not in product %}}
-    {{% set target_perms_octal="0640" %}}
-    {{% set target_perms="-rw-r-----" %}}
-{{% else %}}
-    {{% set target_perms_octal="0600" %}}
-    {{% set target_perms="-rw-------" %}}
-{{% endif %}}
+{{% set target_perms_octal="0640" %}}
+{{% set target_perms="-rw-r-----" %}}
 
 description: |-
     If <tt>/etc/cron.allow</tt> exists, it must have permissions <tt>{{{ target_perms_octal }}}</tt>


### PR DESCRIPTION
Align the mode of /etc/cron.allow with CIS requirements. CIS Benchmarks for RHEL 8, RHEL 9 and RHEL 10 require mode 0640.

Resolves: https://issues.redhat.com/browse/OPENSCAP-6085

