### PR TITLE
Fix invariant return type on utils/create_scap_delta_tailoring.py:main

### DIFF
--- a/utils/create_scap_delta_tailoring.py
+++ b/utils/create_scap_delta_tailoring.py
@@ -244,7 +244,7 @@ def parse_args():
 parse_args.__annotations__ = {'return': argparse.Namespace}
 
 
-def main():
+def main() -> int:
     args = parse_args()
     ET.register_namespace('xccdf-1.2', ssg.constants.XCCDF12_NS)
     tailoring_root = create_tailoring(args)
@@ -253,7 +253,7 @@ def main():
     if manual_version is None:
         sys.stderr.write("Unable to find version from file name.\n")
         sys.stderr.write("The string v[NUM]r[NUM] must be in the filename.\n")
-        exit(1)
+        return 1
 
     if args.dry_run:
         return 0
@@ -272,4 +272,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())


### PR DESCRIPTION
#### Description:
Fix invariant return type on utils/create_scap_delta_tailoring.py:main

#### Rationale:
Methods should always return the same type.
