### PR TITLE
[stabilization] Fix CIS reference

### DIFF
--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -547,7 +547,7 @@ controls:
       status: automated
       notes: |-
           This requirement is already satisfied by 1.6.1.
-      related_rules:
+      rules:
           - configure_custom_crypto_policy_cis
 
     - id: 1.6.3


### PR DESCRIPTION
This change fixes incomplete references in rule
`configure_custom_crypto_policy_cis` in RHEL 8 CIS profiles.  The rule is present in the CIS profiles because it's selected by multiple other requirements. However, the rule is missing a reference to requirement 1.6.2, which is confusing for users of HTML reports and guides.  To add the reference we need to add the selection to the rules key.

Related to: https://issues.redhat.com/browse/RHEL-76009


