### PR TITLE
Update list of profiles in the ansible roles generation

### DIFF
--- a/utils/ansible_playbook_to_role.py
+++ b/utils/ansible_playbook_to_role.py
@@ -89,7 +89,9 @@ PROFILE_ALLOWLIST = set([
     "rhvh-stig",
     "rhvh-vpp",
     "e8",
-    "ism",
+    "ism_o",
+    "ism_o_secret",
+    "ism_o_top_secret",
 ])
 
 


### PR DESCRIPTION
#### Description:

- Update list of profiles in the ansible roles generation

#### Rationale:

- Profile with id "ism" does not exist in the project.
- it rendered a blank ansible role for example https://galaxy.ansible.com/ui/standalone/roles/RedHatOfficial/rhel9-ism/
- with a "blank" github repo: https://github.com/RedHatOfficial/ansible-role-rhel9-ism

#### Review Hints

- Build RHEL9/8 content and run
- `python utils/ansible_playbook_to_role.py --dry-run roles`