### PR TITLE
Add firewalld-backend to RHEL 10 CIS profile

### DIFF
--- a/controls/cis_rhel10.yml
+++ b/controls/cis_rhel10.yml
@@ -1520,7 +1520,10 @@ controls:
       levels:
           - l1_server
           - l1_workstation
-      status: pending
+      status: automated
+      rules:
+          - firewalld-backend
+
 
     - id: 4.1.3
       title: Ensure firewalld.service is configured (Automated)

--- a/tests/data/profile_stability/rhel10/cis.profile
+++ b/tests/data/profile_stability/rhel10/cis.profile
@@ -254,6 +254,7 @@ file_permissions_sshd_pub_key
 file_permissions_unauthorized_world_writable
 file_permissions_user_cfg
 file_permissions_var_log_audit
+firewalld-backend
 firewalld_loopback_traffic_trusted
 gid_passwd_group_same
 group_unique_id

--- a/tests/data/profile_stability/rhel10/cis_server_l1.profile
+++ b/tests/data/profile_stability/rhel10/cis_server_l1.profile
@@ -166,6 +166,7 @@ file_permissions_sshd_private_key
 file_permissions_sshd_pub_key
 file_permissions_unauthorized_world_writable
 file_permissions_user_cfg
+firewalld-backend
 firewalld_loopback_traffic_trusted
 gid_passwd_group_same
 group_unique_id

--- a/tests/data/profile_stability/rhel10/cis_workstation_l1.profile
+++ b/tests/data/profile_stability/rhel10/cis_workstation_l1.profile
@@ -164,6 +164,7 @@ file_permissions_sshd_private_key
 file_permissions_sshd_pub_key
 file_permissions_unauthorized_world_writable
 file_permissions_user_cfg
+firewalld-backend
 firewalld_loopback_traffic_trusted
 gid_passwd_group_same
 group_unique_id

--- a/tests/data/profile_stability/rhel10/cis_workstation_l2.profile
+++ b/tests/data/profile_stability/rhel10/cis_workstation_l2.profile
@@ -254,6 +254,7 @@ file_permissions_sshd_pub_key
 file_permissions_unauthorized_world_writable
 file_permissions_user_cfg
 file_permissions_var_log_audit
+firewalld-backend
 firewalld_loopback_traffic_trusted
 gid_passwd_group_same
 group_unique_id


### PR DESCRIPTION
#### Description:
Add firewalld-backend to RHEL 10 CIS profile

#### Rationale:
Help fill out the profiles.