### PR TITLE
Fix conditional in no_shelllogin_for_systemaccounts remediation

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/bash/shared.sh
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = medium
 
-readarray -t systemaccounts < <(awk -F: '($3 < {{{ uid_min }}} && $3 != root \
+readarray -t systemaccounts < <(awk -F: '($3 < {{{ uid_min }}} && $1 != "root" \
   && $7 != "\/sbin\/shutdown" && $7 != "\/sbin\/halt" && $7 != "\/bin\/sync") \
   { print $1 }' /etc/passwd)
 


### PR DESCRIPTION
#### Description:

- Fix conditional in the awk command of `no_shelllogin_for_systemaccounts` remediation.

#### Rationale:

- Fixes https://bugs.launchpad.net/usg/+bug/2133747
