### PR TITLE
Fix sle16 full platform name

### DIFF
--- a/products/sle16/product.yml
+++ b/products/sle16/product.yml
@@ -1,5 +1,5 @@
 product: sle16
-full_name: SUSE Linux Enterprise Server 16
+full_name: SUSE Linux Enterprise 16
 type: platform
 
 families:


### PR DESCRIPTION
#### Description:

- The partial match of the expected and declared platform full name leads to inconsistencies when refering to sle16 platform

#### Rationale:

Observed issues when using shared templates for:
- platform_ipv6_state
- platform_mount 
CPE OVAL checks
- as well the inconsistency confuses ssg/utils.py product_to_name method

