### PR TITLE
Adjust rsyslog_logfiles_attributes_modify to better match the default file in RHEL

### DIFF
--- a/shared/templates/rsyslog_logfiles_attributes_modify/oval.template
+++ b/shared/templates/rsyslog_logfiles_attributes_modify/oval.template
@@ -84,7 +84,7 @@
             * the chunk was retrieved from a row not starting with space, '#', or '$' characters
       -->
     <ind:pattern
-      operation="pattern match">^\s*[^(\s|#|\$)]+\s+.*(?:\bFile="|\s|\/|-)(\/[^:;\s"]+).*$</ind:pattern>
+      operation="pattern match">^\s*[^(\s|#|\$)]+\s+.*(?:\b[Ff]ile="|\s|\/|-)(\/[^:;\s"]+).*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
     <filter action="exclude">state_{{{ _RULE_ID }}}_ignore_include_paths</filter>
   </ind:textfilecontent54_object>

--- a/shared/templates/rsyslog_logfiles_attributes_modify/tests/rainer_correct_lower_attr.pass.sh
+++ b/shared/templates/rsyslog_logfiles_attributes_modify/tests/rainer_correct_lower_attr.pass.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle,multi_platform_almalinux
+
+# Declare variables used for the tests and define the create_rsyslog_test_logs function
+source $SHARED/rsyslog_log_utils.sh
+
+{{% if ATTRIBUTE == "owner" %}}
+CHATTR="chown"
+ATTR_VALUE="root"
+{{% elif ATTRIBUTE == "groupowner" %}}
+CHATTR="chgrp"
+ATTR_VALUE="root"
+{{% else %}}
+CHATTR="chmod"
+ATTR_VALUE="0640"
+{{% endif %}}
+
+# create one test log file
+create_rsyslog_test_logs 1
+
+# setup test log file property
+$CHATTR $ATTR_VALUE ${RSYSLOG_TEST_LOGS[0]}
+
+# add rule with test log file
+cat <<EOF >$RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+*.*     action(type="omfile" FileCreateMode="0640" fileOwner="root" fileGroup="hoiadm" file="${RSYSLOG_TEST_LOGS[0]}")
+
+EOF


### PR DESCRIPTION


#### Description:

Allow for `file=` in template rsyslog_logfiles_attributes_modify
#### Rationale:

Align with default config.
