### PR TITLE
Fix `mount_option_boot_efi_nosuid` test scenarios

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/tests/vfat_with_nosuid.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/tests/vfat_with_nosuid.pass.sh
@@ -3,6 +3,8 @@
 # This test verifies that the rule passes when /boot/efi is mounted with vfat filesystem
 # Even with nosuid set, vfat is excluded from the requirement (nosuid has no effect on vfat)
 
+# packages = dosfstools
+
 . $SHARED/partition.sh
 
 clean_up_partition /boot/efi
@@ -14,7 +16,11 @@ mkfs.vfat $VFAT_PARTITION
 
 # Add to fstab with nosuid option (should still pass because vfat is excluded)
 mkdir -p /boot/efi
-echo "$VFAT_PARTITION /boot/efi vfat rw,nosuid,relatime 0 0" >> /etc/fstab
+echo "$VFAT_PARTITION /boot/efi vfat rw,nosuid,relatime,loop 0 0" >> /etc/fstab
 
 # Mount the partition
 mount /boot/efi
+
+# Add verification step to ensure the mount is active and correct
+# This helps the script exit with a failure if mount failed unexpectedly
+findmnt --target /boot/efi > /dev/null 2>&1

--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/tests/vfat_without_nosuid.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/tests/vfat_without_nosuid.pass.sh
@@ -3,6 +3,8 @@
 # This test verifies that the rule passes when /boot/efi is mounted with vfat filesystem
 # The nosuid requirement is not applicable to vfat filesystems
 
+# packages = dosfstools
+
 . $SHARED/partition.sh
 
 clean_up_partition /boot/efi
@@ -14,7 +16,7 @@ mkfs.vfat $VFAT_PARTITION
 
 # Add to fstab without nosuid option (should pass because vfat is excluded)
 mkdir -p /boot/efi
-echo "$VFAT_PARTITION /boot/efi vfat rw,relatime 0 0" >> /etc/fstab
+echo "$VFAT_PARTITION /boot/efi vfat rw,relatime,loop 0 0" >> /etc/fstab
 
 # Mount the partition
 mount /boot/efi


### PR DESCRIPTION
#### Description:

- Fix mount_option_boot_efi_nosuid test scenarios.

#### Rationale:

RHEL9 automatus tests.
```
Setting console output to log level INFO
INFO - The base image option has not been specified, choosing libvirt-based test environment.
INFO - Logging into /home/ggasparb/workspace/github/content/logs/rule-custom-2025-12-10-1328/test_suite.log
INFO - xccdf_org.ssgproject.content_rule_mount_option_boot_efi_nosuid
INFO - Script fstab_commented_correct_then_uncommented_wrong.fail.sh using profile (all) OK
INFO - Script separate.pass.sh using profile (all) OK
INFO - Script fstab.fail.sh using profile (all) OK
INFO - Script runtime.pass.sh using profile (all) OK
INFO - Script fstab_comment.pass.sh using profile (all) OK
INFO - Script ext2_with_nosuid.pass.sh using profile (all) OK
INFO - Script ext2_without_nosuid.fail.sh using profile (all) OK
INFO - Script vfat_with_nosuid.pass.sh using profile (all) OK
INFO - Script vfat_without_nosuid.pass.sh using profile (all) OK
```