### PR TITLE
Remove the branches from the compare-ds workflow_run target

### DIFF
--- a/.github/workflows/compare-ds.yaml
+++ b/.github/workflows/compare-ds.yaml
@@ -4,7 +4,6 @@ on:
     workflows: ["Compare DS Build"]
     types:
       - completed
-    branches: [master, 'stabilization*']
 permissions:
     pull-requests: write
     contents: read


### PR DESCRIPTION
#### Description:
- Remove the branches from the compare-ds workflow_run target.

#### Rationale:

- The branches are not supposed to be there since we want to run this job on pull requests that will come from any branch from any fork of the project.

- This should finally make the compare-ds job working again for pull requests

Follow up of #14094 

Similar to https://github.com/ComplianceAsCode/content/pull/14203/files#diff-9addf9274c6b364d0b93589020922ee3e9bceb41b6a9e51d987edffde000d386R4-R7
