### PR TITLE
Add a warning about hashing algorithms

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: "Set PAM''s Password Hashing Algorithm - password-auth"
+title: "Set PAM Password Hashing Algorithm - password-auth"
 
 description: |-
     The PAM system service can be configured to only store encrypted representations of passwords.
@@ -82,3 +82,10 @@ warnings:
         defined and is aligned to the "var_password_hashing_algorithm_pam" variable. The
         remediation will ensure the correct option and remove any other extra hashing algorithm
         option.
+{{% if "rhel" in product %}}
+    - general: |-
+        The CIS {{{ full_name }}} Benchmark permits both "sha512" and "yescrypt" algorithms for password hashing.
+        This profile is configured to check for "{{{ xccdf_value("var_password_hashing_algorithm_pam") }}}",
+        but a system using either algorithm is compliant with the CIS Benchmark requirements.
+        To use a different algorithm, create a tailored profile and select your preferred value for the <tt>var_password_hashing_algorithm_pam</tt> variable.
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: "Set PAM''s Password Hashing Algorithm"
+title: "Set PAM Password Hashing Algorithm - system-auth"
 
 {{% if product in ["sle12", "sle15", "slmicro5", "slmicro6"] or 'ubuntu' in product or 'debian' in product %}}
 {{% set pam_passwd_file_path = "/etc/pam.d/common-password" %}}
@@ -117,3 +117,10 @@ warnings:
         defined and is aligned to the "var_password_hashing_algorithm_pam" variable. The
         remediation will ensure the correct option and remove any other extra hashing algorithm
         option.
+{{% if "rhel" in product %}}
+    - general: |-
+        The CIS {{{ full_name }}} Benchmark permits both "sha512" and "yescrypt" algorithms for password hashing.
+        This profile is configured to check for "{{{ xccdf_value("var_password_hashing_algorithm_pam") }}}",
+        but a system using either algorithm is compliant with the CIS Benchmark requirements.
+        To use a different algorithm, create a tailored profile and select your preferred value for the <tt>var_password_hashing_algorithm_pam</tt> variable.
+{{% endif %}}


### PR DESCRIPTION
CIS Benchmarks for all RHEL versions (8, 9, 10) permit using both sha512 and yescrypt algorithms for password hashing. However, users shouldn't mix them to use both at once. Users should choose one of them and use it consistently.  Therefore, our rules need to specify a single specific algortihm. Users can switch to the other one in their profiles by changing the value of the `var_password_hashing_algorithm_pam` variable in tailoring files. We will add a warning to these rules to explain users this situation.

Resolves: https://issues.redhat.com/browse/OPENSCAP-6100

