### PR TITLE
Align OL8 to STIG V2R6

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/rule.yml
@@ -44,7 +44,6 @@ references:
     ospp: FCS_CKM.1,FCS_CKM.1.1,FCS_CKM.2,FCS_COP.1/ENCRYPT,FCS_COP.1/HASH,FCS_COP.1/SIGN,FCS_COP.1/KEYHMAC,FCS_TLSC_EXT.1,FCS_TLSC_EXT.1.1
     pcidss: Req-2.2
     srg: SRG-OS-000250-GPOS-00093
-    stigid@ol8: OL08-00-010293
 
 ocil_clause: |-
     the OpenSSL config file doesn't contain the whole section,

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/rule.yml
@@ -56,7 +56,7 @@ references:
     nist: CM-3(6),SC-12(2),SC-12(3),IA-7,SC-13,CM-6(a),SC-12
     ospp: FCS_COP.1(1),FCS_COP.1(2),FCS_COP.1(3),FCS_COP.1(4),FCS_CKM.1,FCS_CKM.2,FCS_TLSC_EXT.1,FCS_RBG_EXT.1
     srg: SRG-OS-000478-GPOS-00223,SRG-OS-000396-GPOS-00176
-    stigid@ol8: OL08-00-010020
+    stigid@ol8: OL08-00-010020,OL08-00-010293
 
 ocil_clause: 'FIPS mode is not enabled'
 

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -65,6 +65,7 @@ selections:
     - var_multiple_time_servers=stig
 
     ### Enable / Configure FIPS
+    # OL08-00-010293, OL08-00-010020
     - enable_fips_mode
     - var_system_crypto_policy=fips
     - configure_crypto_policy
@@ -72,6 +73,7 @@ selections:
     - configure_libreswan_crypto_policy
     - configure_kerberos_crypto_policy
     - enable_dracut_fips_module
+    - sysctl_crypto_fips_enabled
 
     # Other needed rules
     - enable_authselect
@@ -85,9 +87,6 @@ selections:
 
     # OL08-00-010019
     - ensure_oracle_gpgkey_installed
-
-    # OL08-00-010020
-    - sysctl_crypto_fips_enabled
 
     # OL08-00-010030
     - encrypt_partitions
@@ -202,9 +201,6 @@ selections:
 
     # OL08-00-010292
     - sshd_use_strong_rng
-
-    # OL08-00-010293
-    - configure_openssl_crypto_policy
 
     # OL08-00-010294
     - configure_openssl_tls_crypto_policy
@@ -965,7 +961,7 @@ selections:
     - grub2_pti_argument
 
     # OL08-00-040010
-    - package_rsh-server_removed
+    - ensure_epel_repos_disabled
 
     # OL08-00-040020
     - kernel_module_uvcvideo_disabled


### PR DESCRIPTION
#### Description:

Update rule selection for OL8 STIG V2R6

#### Rationale:

Be aligned to DISA standard