### PR TITLE
Updates ansible_playbook_to_role.py to support RHEL 10 and fix github auth error

### DIFF
--- a/utils/ansible_playbook_to_role.py
+++ b/utils/ansible_playbook_to_role.py
@@ -583,11 +583,10 @@ def main():
             print("Input your GitHub credentials:")
             username = input("username or token: ")
             password = getpass.getpass("password (or empty for token): ")
+            github = Github(username, password)
         else:
-            username = args.token
-            password = ""
+            github = Github(args.token)
 
-        github = Github(username, password)
         github_org = github.get_organization(args.organization)
         github_repositories = [repo.name for repo in github_org.get_repos()]
 


### PR DESCRIPTION
#### Description:

Updates ansible_playbook_to_role.py to support RHEL 10 and fix github auth error

#### Rationale:

When creating new RHEL 10 repos, need the primary branch to be "main" instead of the legacy "master"
When using a github auth token, commits would fail

#### Review Hints:

Here is what I would see before the changes to the GitHub session initialization code

```
PYTHONPATH=. python3 utils/ansible_playbook_to_role.py  --build-playbooks-dir ./build/ansible/ --profile cis  --product rhel8 --tag-release --token "${GIT_TOKEN}"

Traceback (most recent call last):
  File "/home/danclark/workspace/content-ansible-updates/content-1.79/utils/ansible_playbook_to_role.py", line 613, in <module>
    main()
    ~~~~^^
  File "/home/danclark/workspace/content-ansible-updates/content-1.79/utils/ansible_playbook_to_role.py", line 586, in main
    github = Github(username, password)
  File "/usr/lib/python3.13/site-packages/github/MainClass.py", line 226, in __init__
    auth = github.Auth.Login(login_or_token, password)  # type: ignore
  File "/usr/lib/python3.13/site-packages/github/Auth.py", line 131, in __init__
    assert len(password) > 0
           ^^^^^^^^^^^^^^^^^
AssertionError
```

The changes that I made allow the commits to work correctly. I have tested them recently including today.