### PR TITLE
Add note to RHEL 10 CIS 4.1.4

### DIFF
--- a/controls/cis_rhel10.yml
+++ b/controls/cis_rhel10.yml
@@ -1540,6 +1540,9 @@ controls:
           - l1_server
           - l1_workstation
       status: pending
+      notes: |-
+        There is not an easy way to do this for only active zones using OVAL.
+        For now, there are are no rules for this control.
 
     - id: 4.1.5
       title: Ensure firewalld loopback traffic is configured (Automated)


### PR DESCRIPTION
#### Description:

Add note to RHEL 10 CIS 4.1.4 as there isn't an easy way to do this with OVAL

#### Rationale:

Keep profile up-to-date.