### PR TITLE
Fix help text formatting in build_ds_container.py

### DIFF
--- a/utils/build_ds_container.py
+++ b/utils/build_ds_container.py
@@ -47,7 +47,7 @@ parser.add_argument(
     '-np', '--no-upstream-prefix',
     help=(
         'The prefix for bundle names. The default is "upstream" if not specified. '
-        'To disable prefix, use --no-upstream-prefix.',
+        'To disable prefix, use --no-upstream-prefix. '
         'This option is ignored when building content in the cluster using '
         '--build-in-cluster.'),
     action='store_true',


### PR DESCRIPTION
#### Description:

Fix help text formatting in build_ds_container.py. The wrong formate  will bring an error when trying to deploy the profiles on a ocp cluster.

#### Rationale:
without the fix, you will get error below:
```
$ ./utils/build_ds_container.py -c -p
...
TypeError: can only concatenate tuple (not "str") to tuple
Traceback (most recent call last):
  File "/home/xiyuan/isc/content/./utils/build_ds_container.py", line 46, in <module>
    parser.add_argument(
    ~~~~~~~~~~~~~~~~~~~^
        '-np', '--no-upstream-prefix',
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<5 lines>...
        action='store_true',
        ^^^^^^^^^^^^^^^^^^^^
        default=False)
        ^^^^^^^^^^^^^^
  File "/usr/lib64/python3.14/argparse.py", line 1561, in add_argument
    self._check_help(action)

```



