### PR TITLE
Remove rule sshd_use_strong_kex from CIS profiles

### DIFF
--- a/products/rhel10/controls/cis_rhel10.yml
+++ b/products/rhel10/controls/cis_rhel10.yml
@@ -1695,13 +1695,11 @@ controls:
       levels:
           - l1_server
           - l1_workstation
-      status: pending
+      status: not applicable
       notes: |-
-          The status was automated but we need to double check the approach used in this rule.
-          Therefore I moved it to pending until deeper investigation.
-      rules:
-          - sshd_use_strong_kex
-          - sshd_strong_kex=cis_rhel10
+          This CIS requirement shall be notapplicable on RHEL 10. The CIS
+          Benchmark requires disabling the weak SHA1 key exchange algorithms,
+          but RHEL 10 doesn't provide these algorithms.
 
     - id: 5.1.13
       title: Ensure sshd LoginGraceTime is configured (Automated)

--- a/products/rhel10/profiles/default.profile
+++ b/products/rhel10/profiles/default.profile
@@ -12,6 +12,7 @@ description: |-
     this profile is to keep a rule in the product's XCCDF Benchmark.
 
 selections:
+    - sshd_use_strong_kex
     - grub2_nousb_argument
     - audit_rules_kernel_module_loading_create
     - grub2_uefi_admin_username

--- a/products/rhel8/controls/cis_rhel8.yml
+++ b/products/rhel8/controls/cis_rhel8.yml
@@ -1545,9 +1545,13 @@ controls:
           - l1_server
           - l1_workstation
       status: automated
+      notes: |-
+          We don't select rule sshd_use_strong_kex because the CIS Benchmark
+          recommends using system-wide crypto policies to disable the weak
+          SHA1 key exchange algorithms instead of configuring KexAlgorithms
+          in sshd configuration.
       rules:
-          - sshd_use_strong_kex
-          - sshd_strong_kex=cis_rhel8
+          - configure_custom_crypto_policy_cis
 
     - id: 4.2.12
       title: Ensure sshd LoginGraceTime is configured (Automated)

--- a/products/rhel9/controls/cis_rhel9.yml
+++ b/products/rhel9/controls/cis_rhel9.yml
@@ -1517,13 +1517,14 @@ controls:
       levels:
           - l1_server
           - l1_workstation
-      status: pending
+      status: automated
       notes: |-
-          The status was automated but we need to double check the approach used in this rule.
-          Therefore I moved it to pending until deeper investigation.
+          We don't select rule sshd_use_strong_kex because the CIS Benchmark
+          recommends using system-wide crypto policies to disable the weak
+          SHA1 key exchange algorithms instead of configuring KexAlgorithms
+          in sshd configuration.
       rules:
-          - sshd_use_strong_kex
-          - sshd_strong_kex=cis_rhel9
+          - configure_custom_crypto_policy_cis
 
     - id: 5.1.6
       title: Ensure sshd MACs are configured (Automated)

--- a/products/rhel9/profiles/default.profile
+++ b/products/rhel9/profiles/default.profile
@@ -13,6 +13,7 @@ description: |-
     is to keep a rule in the product's XCCDF Benchmark.
 
 selections:
+    - sshd_use_strong_kex
     - sebool_nfsd_anon_write
     - sebool_squid_connect_any
     - sebool_polipo_connect_all_unreserved

--- a/tests/data/profile_stability/rhel10/cis.profile
+++ b/tests/data/profile_stability/rhel10/cis.profile
@@ -395,8 +395,6 @@ sshd_set_loglevel_verbose
 sshd_set_max_auth_tries
 sshd_set_max_sessions
 sshd_set_maxstartups
-sshd_strong_kex=cis_rhel10
-sshd_use_strong_kex
 sudo_add_use_pty
 sudo_custom_logfile
 sudo_remove_no_authenticate

--- a/tests/data/profile_stability/rhel10/cis_server_l1.profile
+++ b/tests/data/profile_stability/rhel10/cis_server_l1.profile
@@ -286,8 +286,6 @@ sshd_set_loglevel_verbose
 sshd_set_max_auth_tries
 sshd_set_max_sessions
 sshd_set_maxstartups
-sshd_strong_kex=cis_rhel10
-sshd_use_strong_kex
 sudo_add_use_pty
 sudo_custom_logfile
 sudo_remove_no_authenticate

--- a/tests/data/profile_stability/rhel10/cis_workstation_l1.profile
+++ b/tests/data/profile_stability/rhel10/cis_workstation_l1.profile
@@ -279,8 +279,6 @@ sshd_set_loglevel_verbose
 sshd_set_max_auth_tries
 sshd_set_max_sessions
 sshd_set_maxstartups
-sshd_strong_kex=cis_rhel10
-sshd_use_strong_kex
 sudo_add_use_pty
 sudo_custom_logfile
 sudo_remove_no_authenticate

--- a/tests/data/profile_stability/rhel10/cis_workstation_l2.profile
+++ b/tests/data/profile_stability/rhel10/cis_workstation_l2.profile
@@ -391,8 +391,6 @@ sshd_set_loglevel_verbose
 sshd_set_max_auth_tries
 sshd_set_max_sessions
 sshd_set_maxstartups
-sshd_strong_kex=cis_rhel10
-sshd_use_strong_kex
 sudo_add_use_pty
 sudo_custom_logfile
 sudo_remove_no_authenticate

--- a/tests/data/profile_stability/rhel8/cis.profile
+++ b/tests/data/profile_stability/rhel8/cis.profile
@@ -369,8 +369,6 @@ sshd_set_loglevel_verbose
 sshd_set_max_auth_tries
 sshd_set_max_sessions
 sshd_set_maxstartups
-sshd_strong_kex=cis_rhel8
-sshd_use_strong_kex
 sudo_add_use_pty
 sudo_custom_logfile
 sudo_require_authentication

--- a/tests/data/profile_stability/rhel8/cis_server_l1.profile
+++ b/tests/data/profile_stability/rhel8/cis_server_l1.profile
@@ -270,8 +270,6 @@ sshd_set_loglevel_verbose
 sshd_set_max_auth_tries
 sshd_set_max_sessions
 sshd_set_maxstartups
-sshd_strong_kex=cis_rhel8
-sshd_use_strong_kex
 sudo_add_use_pty
 sudo_custom_logfile
 sudo_require_authentication

--- a/tests/data/profile_stability/rhel8/cis_workstation_l1.profile
+++ b/tests/data/profile_stability/rhel8/cis_workstation_l1.profile
@@ -265,8 +265,6 @@ sshd_set_loglevel_verbose
 sshd_set_max_auth_tries
 sshd_set_max_sessions
 sshd_set_maxstartups
-sshd_strong_kex=cis_rhel8
-sshd_use_strong_kex
 sudo_add_use_pty
 sudo_custom_logfile
 sudo_require_authentication

--- a/tests/data/profile_stability/rhel8/cis_workstation_l2.profile
+++ b/tests/data/profile_stability/rhel8/cis_workstation_l2.profile
@@ -365,8 +365,6 @@ sshd_set_loglevel_verbose
 sshd_set_max_auth_tries
 sshd_set_max_sessions
 sshd_set_maxstartups
-sshd_strong_kex=cis_rhel8
-sshd_use_strong_kex
 sudo_add_use_pty
 sudo_custom_logfile
 sudo_require_authentication

--- a/tests/data/profile_stability/rhel9/cis.profile
+++ b/tests/data/profile_stability/rhel9/cis.profile
@@ -366,8 +366,6 @@ sshd_set_loglevel_verbose
 sshd_set_max_auth_tries
 sshd_set_max_sessions
 sshd_set_maxstartups
-sshd_strong_kex=cis_rhel9
-sshd_use_strong_kex
 sudo_add_use_pty
 sudo_custom_logfile
 sudo_require_authentication

--- a/tests/data/profile_stability/rhel9/cis_server_l1.profile
+++ b/tests/data/profile_stability/rhel9/cis_server_l1.profile
@@ -263,8 +263,6 @@ sshd_set_loglevel_verbose
 sshd_set_max_auth_tries
 sshd_set_max_sessions
 sshd_set_maxstartups
-sshd_strong_kex=cis_rhel9
-sshd_use_strong_kex
 sudo_add_use_pty
 sudo_custom_logfile
 sudo_require_reauthentication

--- a/tests/data/profile_stability/rhel9/cis_workstation_l1.profile
+++ b/tests/data/profile_stability/rhel9/cis_workstation_l1.profile
@@ -257,8 +257,6 @@ sshd_set_loglevel_verbose
 sshd_set_max_auth_tries
 sshd_set_max_sessions
 sshd_set_maxstartups
-sshd_strong_kex=cis_rhel9
-sshd_use_strong_kex
 sudo_add_use_pty
 sudo_custom_logfile
 sudo_require_reauthentication

--- a/tests/data/profile_stability/rhel9/cis_workstation_l2.profile
+++ b/tests/data/profile_stability/rhel9/cis_workstation_l2.profile
@@ -362,8 +362,6 @@ sshd_set_loglevel_verbose
 sshd_set_max_auth_tries
 sshd_set_max_sessions
 sshd_set_maxstartups
-sshd_strong_kex=cis_rhel9
-sshd_use_strong_kex
 sudo_add_use_pty
 sudo_custom_logfile
 sudo_require_authentication


### PR DESCRIPTION
We will remove rule sshd_use_strong_kex from RHEL 8, 9 and 10 CIS profiles.

The reason for RHEL 8 and 9 is the CIS Benchmark recommends using system-wide crypto policies to disable the weak SHA1 key exchange algorithms instead of configuring KexAlgorithms in sshd configuration. This is already fully covered in our profiles by
configure_custom_crypto_policy_cis.

The reason for RHEL 10 is different. This CIS requirement shall be notapplicable on RHEL 10. The CIS Benchmark requires disabling the weak SHA1 key exchange algorithms, but RHEL 10 doesn't provide these algorithms. Consequently, the rule configure_custom_crypto_policy_cis doesn't disable them and selecting it would make no difference.

This change is done according to these CIS Benchmarks:
- CIS RHEL 8 v4.0.0
- CIS RHEL 9 v2.0.0
- CIS RHEL 10 v1.0.1

Resolves: https://issues.redhat.com/browse/RHEL-62941