### PR TITLE
Shadow test scenario - service_systemd-journal-upload_enabled

### DIFF
--- a/linux_os/guide/system/logging/journald/service_systemd-journal-upload_enabled/tests/service_disabled.fail.sh
+++ b/linux_os/guide/system/logging/journald/service_systemd-journal-upload_enabled/tests/service_disabled.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# packages = systemd-journal-remote
+
+cat > /etc/systemd/journal-upload.conf << EOM
+[Upload]
+URL=http://example.com
+EOM
+
+SYSTEMCTL_EXEC='/usr/bin/systemctl'
+"$SYSTEMCTL_EXEC" stop 'systemd-journal-upload.service'
+"$SYSTEMCTL_EXEC" disable 'systemd-journal-upload.service'


### PR DESCRIPTION
Replace templated test scenario service_disabled.fail.sh by a rule-specific test scenario of the same file name in rule service_systemd-journal-upload_enabled. The reason is that the systemd-journal-upload service fails to start if a remote logging URL isn't configured on the system. The new test scenario configures this URL and is very similar to already shadowing pass test scenario in this rule.

Resolves: https://github.com/ComplianceAsCode/content/issues/14210



#### Review Hints:

```
python3 tests/automatus.py rule --libvirt qemu:///system ssgts_rhel10 service_systemd-journal-upload_enabled
```