### PR TITLE
Use ATEX from PyPI + compress uploaded files

### DIFF
--- a/.github/workflows/atex-test.yaml
+++ b/.github/workflows/atex-test.yaml
@@ -114,7 +114,7 @@ jobs:
         with:
           name: test-results-centos-stream${{ matrix.centos_stream_major }}
           path: |
-            results-centos-stream-${{ matrix.centos_stream_major }}-x86_64.json.gz
+            results-centos-stream-${{ matrix.centos_stream_major }}-x86_64.json.xz
             files-centos-stream-${{ matrix.centos_stream_major }}-x86_64/
             atex_debug.log.gz
           retention-days: ${{ env.ARTIFACT_RETENTION_DAYS }}
@@ -212,7 +212,7 @@ jobs:
 
           # Process and merge results for all CentOS Stream versions
           for version in 8 9 10; do
-            results_file="test-results/cs${version}/results-centos-stream-${version}-x86_64.json.gz"
+            results_file="test-results/cs${version}/results-centos-stream-${version}-x86_64.json.xz"
             files_dir="test-results/cs${version}/files-centos-stream-${version}-x86_64"
 
             if [ -f "${results_file}" ]; then
@@ -220,12 +220,12 @@ jobs:
               rm -f "${results_file}"
               [ -d "${files_dir}" ] && cp -r "${files_dir}"/* atex-results-testing-farm/files_dir/
             fi
-          done > results.json.gz
+          done > results.json.xz
 
       - name: Convert results to SQLite database
         if: always()
         run: |
-          python atex-html/json2db.py results.json.gz atex-results-testing-farm/results.sqlite.gz
+          python atex-html/json2db.py results.json.xz atex-results-testing-farm/results.sqlite.gz
 
       - name: Prepare HTML results viewer
         if: always()

--- a/tests/run_tests_testingfarm.py
+++ b/tests/run_tests_testingfarm.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from atex.provisioner.testingfarm import TestingFarmProvisioner
 from atex.orchestrator.contest import ContestOrchestrator
-from atex.aggregator.json import JSONAggregator
+from atex.aggregator.json import LZMAJSONAggregator
 from atex.fmf import FMFTests
 
 logger = logging.getLogger("ATEX")
@@ -87,10 +87,10 @@ def main():
             logger.info(f"    {test}")
 
         # Setup result aggregator
-        output_results = f"results-centos-stream-{args.os_major_version}-{args.arch}.json.gz"
+        output_results = f"results-centos-stream-{args.os_major_version}-{args.arch}.json.xz"
         output_files = f"files-centos-stream-{args.os_major_version}-{args.arch}"
         partial_runs = Path(output_files) / "old_runs"
-        aggregator = JSONAggregator(output_results, output_files)
+        aggregator = LZMAJSONAggregator(output_results, output_files)
         stack.enter_context(aggregator)
 
         partial_runs.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
#### Description:

This extends #14203 by using `atex` from PyPI directly (instead of using git), hopefully resulting in a more stable version.

It also takes advantage of the (new) `LZMAJSONAggregator` that transparently on-the-fly compresses both the `results.json.xz` and all files uploaded by tests. This is less critical now (with just STIG), but once we start extending the workflow to all profiles and (later) to run the full "daily productization" set of tests, it will be super useful to keep Testing Farm artifact storage within reasonable limits.

Yes, mixing `gz` / `xz` in the code is a bit weird now (eg. using `.gz` for `results.sqlite.gz`), but that's just a result of the project separation:
* `*.xz` comes from an `Aggregator` (results + uploaded files)
* `.sqlite.gz` comes from `atex-html`, a separate project that requires Gzip compression, because web browsers don't support LZMA

Also note `atex-html/json2db.py` [has been updated](https://github.com/RHSecurityCompliance/atex-html/commit/82b926e0cc4fb4d448d78d0b8a9eab1ebbb021f0) to support `.xz` inputs, and (from my testing) seems to work well with all of `.json` / `.json.gz` / `json.xz`.

#### Rationale:

Some rough Gzip / LZMA estimates show about 20% to 400% improvements in compressed size differences, indicating that LZMA does make sense, especially when https://github.com/RHSecurityCompliance/contest/pull/497 is merged and ALL test uploaded files are uncompressed.

#### Review Hints:

Note that I am intentionally keeping https://github.com/RHSecurityCompliance/atex (`main` branch) **behind the current 0.11 ATEX release** (on PyPI, and tagged on Github) to prevent existing CaC/content PRs breaking on the API change.  
But a few days after this PR gets merged, I'll update Github too, so hopefully everyone has rebased by then.

Unfortunately, as indicated by @ggbecker , I don't think we can test this PR using existing Github workflows, so review + blind merge might be needed here.