### PR TITLE
Fix compare ds artifacts retrieval

### DIFF
--- a/.github/workflows/compare-ds.yaml
+++ b/.github/workflows/compare-ds.yaml
@@ -73,6 +73,7 @@ jobs:
         with:
             name: pr-artifacts-${{ github.event.workflow_run.head_sha }}
             path: pr_artifacts
+            run-id: ${{ github.event.workflow_run.id }}
       - name: Unpack built artifacts
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: tar -xvzf pr_artifacts/artifacts.tar.gz -C pr_artifacts/unpacked_artifacts


### PR DESCRIPTION
#### Description:
- Fix compare ds artifacts retrieval
 - We have to use the run-id of the workflow that triggered the compare ds workflow.
   - the same as in https://github.com/ComplianceAsCode/content/blob/3f33c8ccbbf00f7e3f954299f985d2086414dcf8/.github/workflows/compare-ds.yaml#L26
