### PR TITLE
Move back to dhcp on RHEL 8 CIS

### DIFF
--- a/products/rhel8/controls/cis_rhel8.yml
+++ b/products/rhel8/controls/cis_rhel8.yml
@@ -825,7 +825,7 @@ controls:
           - l1_workstation
       status: automated
       rules:
-          - package_kea_removed
+          - package_dhcp_removed
       related_rules:
           - service_dhcpd_disabled
 

--- a/tests/data/profile_stability/rhel8/cis.profile
+++ b/tests/data/profile_stability/rhel8/cis.profile
@@ -320,13 +320,13 @@ package_bind_removed
 package_chrony_installed
 package_cron_installed
 package_cyrus-imapd_removed
+package_dhcp_removed
 package_dnsmasq_removed
 package_dovecot_removed
 package_firewalld_installed
 package_ftp_removed
 package_gdm_removed
 package_httpd_removed
-package_kea_removed
 package_libselinux_installed
 package_mcstrans_removed
 package_net-snmp_removed

--- a/tests/data/profile_stability/rhel8/cis_server_l1.profile
+++ b/tests/data/profile_stability/rhel8/cis_server_l1.profile
@@ -234,12 +234,12 @@ package_bind_removed
 package_chrony_installed
 package_cron_installed
 package_cyrus-imapd_removed
+package_dhcp_removed
 package_dnsmasq_removed
 package_dovecot_removed
 package_firewalld_installed
 package_ftp_removed
 package_httpd_removed
-package_kea_removed
 package_libselinux_installed
 package_mcstrans_removed
 package_net-snmp_removed

--- a/tests/data/profile_stability/rhel8/cis_workstation_l1.profile
+++ b/tests/data/profile_stability/rhel8/cis_workstation_l1.profile
@@ -231,12 +231,12 @@ package_bind_removed
 package_chrony_installed
 package_cron_installed
 package_cyrus-imapd_removed
+package_dhcp_removed
 package_dnsmasq_removed
 package_dovecot_removed
 package_firewalld_installed
 package_ftp_removed
 package_httpd_removed
-package_kea_removed
 package_libselinux_installed
 package_mcstrans_removed
 package_net-snmp_removed

--- a/tests/data/profile_stability/rhel8/cis_workstation_l2.profile
+++ b/tests/data/profile_stability/rhel8/cis_workstation_l2.profile
@@ -320,12 +320,12 @@ package_bind_removed
 package_chrony_installed
 package_cron_installed
 package_cyrus-imapd_removed
+package_dhcp_removed
 package_dnsmasq_removed
 package_dovecot_removed
 package_firewalld_installed
 package_ftp_removed
 package_httpd_removed
-package_kea_removed
 package_libselinux_installed
 package_mcstrans_removed
 package_net-snmp_removed


### PR DESCRIPTION
#### Description:

Move back to dhcp on RHEL 8 CIS
#### Rationale:
Partly addresses #14289

kea doesn't exist on RHEL 8.

#### Review hints:
Shouldn't need to add default since this hasn't been released.