### PR TITLE
Install ATEX version 0.11 specifically in the Github workflow

### DIFF
--- a/.github/workflows/atex-test.yaml
+++ b/.github/workflows/atex-test.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Install test dependencies
         run: |
           dnf -y install python3-pip git rsync
-          pip install fmf atex
+          pip install fmf atex==0.11
 
       - name: Run tests on Testing Farm
         env:
@@ -135,7 +135,7 @@ jobs:
         if: always()
         run: |
           dnf -y install python3-pip git rsync
-          pip install fmf atex
+          pip install fmf atex==0.11
 
       - name: Checkout ATEX results repository
         if: always()


### PR DESCRIPTION
#### Description:

Always install the 0.11 ATEX release from PyPI, for now.

#### Rationale:

ATEX is still under development and API breakages will happen (at least 1-2 are planned, there might be more unplanned) before the 1.0 version is released.

Using a fixed version in the workflow allows us to update the API-using code in the same PR that bumps the version - the main benefit is that **other PRs are not impacted by any ATEX-related changes** because they either

1. use the old version with old API
2. use the new version with the new API

so they don't need to worry about rebasing.

I know @ggbecker wanted the version-less approach, but I still think it would be more trouble than it's worth at this stage of ATEX development.
