### PR TITLE
Add enable_authselect back to RHEL 8 CIS

### DIFF
--- a/products/rhel8/controls/cis_rhel8.yml
+++ b/products/rhel8/controls/cis_rhel8.yml
@@ -30,6 +30,19 @@ controls:
       rules:
           - dconf_db_up_to_date
 
+    - id: enable_authselect
+      title: Enable Authselect
+      levels:
+          - l1_server
+          - l1_workstation
+      notes: |-
+          We need this in all CIS versions, but the policy doesn't have any section where this
+          would fit better.
+      status: automated
+      rules:
+          - var_authselect_profile=sssd
+          - enable_authselect
+
     - id: 1.1.1.1
       title: Ensure cramfs kernel module is not available (Automated)
       levels:

--- a/products/rhel8/profiles/cis.profile
+++ b/products/rhel8/profiles/cis.profile
@@ -22,4 +22,3 @@ description: |-
 
 selections:
     - cis_rhel8:all:l2_server
-    - var_authselect_profile=local

--- a/products/rhel8/profiles/cis_server_l1.profile
+++ b/products/rhel8/profiles/cis_server_l1.profile
@@ -22,4 +22,3 @@ description: |-
 
 selections:
     - cis_rhel8:all:l1_server
-    - var_authselect_profile=local

--- a/products/rhel8/profiles/cis_workstation_l1.profile
+++ b/products/rhel8/profiles/cis_workstation_l1.profile
@@ -22,4 +22,3 @@ description: |-
 
 selections:
     - cis_rhel8:all:l1_workstation
-    - var_authselect_profile=local

--- a/products/rhel8/profiles/cis_workstation_l2.profile
+++ b/products/rhel8/profiles/cis_workstation_l2.profile
@@ -22,4 +22,3 @@ description: |-
 
 selections:
     - cis_rhel8:all:l2_workstation
-    - var_authselect_profile=local

--- a/tests/data/profile_stability/rhel8/cis.profile
+++ b/tests/data/profile_stability/rhel8/cis.profile
@@ -134,6 +134,7 @@ directory_permissions_var_log_audit
 disable_host_auth
 disable_users_coredumps
 disable_weak_deps
+enable_authselect
 ensure_gpgcheck_globally_activated
 ensure_gpgcheck_never_disabled
 ensure_pam_wheel_group_empty
@@ -478,7 +479,7 @@ var_auditd_disk_full_action=cis_rhel8
 var_auditd_max_log_file=8
 var_auditd_max_log_file_action=keep_logs
 var_auditd_space_left_action=cis_rhel8
-var_authselect_profile=local
+var_authselect_profile=sssd
 var_multiple_time_servers=rhel
 var_pam_wheel_group_for_su=cis
 var_password_hashing_algorithm=cis_rhel8

--- a/tests/data/profile_stability/rhel8/cis_server_l1.profile
+++ b/tests/data/profile_stability/rhel8/cis_server_l1.profile
@@ -65,6 +65,7 @@ dconf_gnome_session_idle_user_locks
 dir_perms_world_writable_sticky_bits
 disable_host_auth
 disable_users_coredumps
+enable_authselect
 ensure_gpgcheck_globally_activated
 ensure_gpgcheck_never_disabled
 ensure_pam_wheel_group_empty
@@ -368,7 +369,7 @@ var_accounts_passwords_pam_faillock_deny=5
 var_accounts_passwords_pam_faillock_unlock_time=900
 var_accounts_tmout=15_min
 var_accounts_user_umask=027
-var_authselect_profile=local
+var_authselect_profile=sssd
 var_multiple_time_servers=rhel
 var_pam_wheel_group_for_su=cis
 var_password_hashing_algorithm=cis_rhel8

--- a/tests/data/profile_stability/rhel8/cis_workstation_l1.profile
+++ b/tests/data/profile_stability/rhel8/cis_workstation_l1.profile
@@ -63,6 +63,7 @@ dconf_gnome_session_idle_user_locks
 dir_perms_world_writable_sticky_bits
 disable_host_auth
 disable_users_coredumps
+enable_authselect
 ensure_gpgcheck_globally_activated
 ensure_gpgcheck_never_disabled
 ensure_pam_wheel_group_empty
@@ -363,7 +364,7 @@ var_accounts_passwords_pam_faillock_deny=5
 var_accounts_passwords_pam_faillock_unlock_time=900
 var_accounts_tmout=15_min
 var_accounts_user_umask=027
-var_authselect_profile=local
+var_authselect_profile=sssd
 var_multiple_time_servers=rhel
 var_pam_wheel_group_for_su=cis
 var_password_hashing_algorithm=cis_rhel8

--- a/tests/data/profile_stability/rhel8/cis_workstation_l2.profile
+++ b/tests/data/profile_stability/rhel8/cis_workstation_l2.profile
@@ -134,6 +134,7 @@ directory_permissions_var_log_audit
 disable_host_auth
 disable_users_coredumps
 disable_weak_deps
+enable_authselect
 ensure_gpgcheck_globally_activated
 ensure_gpgcheck_never_disabled
 ensure_pam_wheel_group_empty
@@ -474,7 +475,7 @@ var_auditd_disk_full_action=cis_rhel8
 var_auditd_max_log_file=8
 var_auditd_max_log_file_action=keep_logs
 var_auditd_space_left_action=cis_rhel8
-var_authselect_profile=local
+var_authselect_profile=sssd
 var_multiple_time_servers=rhel
 var_pam_wheel_group_for_su=cis
 var_password_hashing_algorithm=cis_rhel8


### PR DESCRIPTION
Add enable_authselect back to RHEL 8 CIS. The rule used to be there, however, the new CIS is more similar to RHEL 10 CIS where this rule isn't select. The difference is that after clean installation the authselect check command fails on RHEL 8 whereas on RHEL 10  where the rule isn't selected this command passes. The "authselect check" command is a part of remediations in multiple rules. If this command fails the remediation terminates and doesn't perform the required configuration. Enabling authselect will prevent the "authselect check" fail.



#### Review Hints:

Contest tests like /hardening/host-os/oscap/cis on RHEL 8.10
