### PR TITLE
Fix audit_rules_privileged_commands_unix_chkpwd misalignment with DISA

### DIFF
--- a/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/rule.yml
+++ b/linux_os/guide/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/rule.yml
@@ -1,6 +1,7 @@
-{{%- set unix_chkpwd_binary="/usr/sbin/unix_chkpwd" %}}
-{{%- if product in ["fedora", "rhcos4", "ubuntu2204", "ubuntu2404"] or 'ol' in families or 'rhel' in product or 'sle' in product or 'slmicro' in product %}}
+{{%- if 'sle' in product or 'slmicro' in product %}}
     {{%- set unix_chkpwd_binary="/sbin/unix_chkpwd" %}}
+{{%- else %}}
+    {{%- set unix_chkpwd_binary="/usr/sbin/unix_chkpwd" %}}
 {{%- endif %}}
 
 documentation_complete: true


### PR DESCRIPTION
The daily productization run on 2026-01-13 discovered that the rule audit_rules_privileged_commands_unix_chkpwd is misaligned with DISA on both RHEL 8 and RHEL 9. The reason is that our rule sets the path of the binary to `/sbin/unix_chkpwd` but DISA requires `/usr/sbin/unix_chkpwd`. The issue is caused by 33270232f367909eb528b956fefe5620e6495584. That commit fixed the inconsistency between rule description and template parameter. However, on most systems including RHEL, the `/sbin` is only a symlink to `/usr/sbin`. Audit rules should use the canonical path.


#### Review Hints:

Run contest tests `/scanning/disa-alignment/.*` on RHEL 8.10 and 9.8.