### PR TITLE
Add support for RHCOS4 nodes based on RHEL8

### DIFF
--- a/shared/applicability/rhcos4-rhel8.yml
+++ b/shared/applicability/rhcos4-rhel8.yml
@@ -1,0 +1,3 @@
+name: "cpe:/o:redhat:rhcos4:8"
+title: "Red Hat Enterprise Linux CoreOS 4 RHEL8 Based"
+check_id: installed_OS_is_rhcos4_rhel8

--- a/shared/checks/oval/installed_OS_is_rhcos4.xml
+++ b/shared/checks/oval/installed_OS_is_rhcos4.xml
@@ -16,6 +16,10 @@
       </criteria>
       <criteria operator="AND">
         <criterion comment="RHCOS is installed (ID='rhcos')" test_ref="test_rhcos" />
+        <criterion comment="RHEL_VERSION is 8" test_ref="test_rhcos4_rhel8_rhel_version" />
+      </criteria>
+      <criteria operator="AND">
+        <criterion comment="RHCOS is installed (ID='rhcos')" test_ref="test_rhcos" />
         <criterion comment="RHEL_VERSION is 9" test_ref="test_rhcos4_rhel9_rhel_version" />
       </criteria>
       <criteria operator="AND">
@@ -97,6 +101,37 @@
 </def-group>
 
 <def-group>
+  <definition class="inventory" id="installed_OS_is_rhcos4_rhel8" version="1">
+    <metadata>
+      <title>Red Hat Enterprise Linux CoreOS RHEL8 Based</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <reference ref_id="cpe:/o:redhat:rhcos4:8" source="CPE" />
+      <description>The operating system installed on the system is
+      Red Hat Enterprise Linux CoreOS RHEL8 Based</description>
+    </metadata>
+    <criteria operator="AND" comment="Old format: ID=rhcos with RHEL_VERSION=8.x">
+      <criterion comment="ID is rhcos" test_ref="test_rhcos" />
+      <criterion comment="RHEL_VERSION is 8" test_ref="test_rhcos4_rhel8_rhel_version" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" comment="rhcoreos RHEL_VERSION is 8 (old format)" id="test_rhcos4_rhel8_rhel_version" version="1">
+    <ind:object object_ref="obj_rhcos4_rhel8_rhel_version" />
+    <ind:state state_ref="state_rhcos4_rhel8_rhel_version" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_rhcos4_rhel8_rhel_version" version="1">
+    <ind:filepath>/etc/os-release</ind:filepath>
+    <ind:pattern operation="pattern match">^RHEL_VERSION=&quot;?(\d+\.?\d*)&quot;?$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_rhcos4_rhel8_rhel_version" version="1">
+    <ind:subexpression operation="pattern match">^8\.</ind:subexpression>
+  </ind:textfilecontent54_state>
+</def-group>
+
+<def-group>
   <definition class="inventory" id="installed_OS_is_rhcos4_rhel9" version="1">
     <metadata>
       <title>Red Hat Enterprise Linux CoreOS RHEL9 Based</title>
@@ -139,7 +174,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_rhcos4_rhel9_rhel_version" version="1">
     <ind:filepath>/etc/os-release</ind:filepath>
-    <ind:pattern operation="pattern match">^RHEL_VERSION=(\d+\.?\d*)$</ind:pattern>
+    <ind:pattern operation="pattern match">^RHEL_VERSION=&quot;?(\d+\.?\d*)&quot;?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_state id="state_rhcos4_rhel9_rhel_version" version="1">


### PR DESCRIPTION
#### Description:

1. Add support for RHCOS4 nodes based on RHEL8
2. Update the regex patterns to make the quotes optional for REAL_VERSION

#### Rationale:

For clusters based on different platforms, you can see the quotes is optional
```
$ oc debug node/xiyun414updateovn-011-dhgjp-master-0 -- chroot /host cat /etc/os-release
Starting pod/xiyun414updateovn-011-dhgjp-master-0-debug ...
To use host binaries, run `chroot /host`
NAME="Red Hat Enterprise Linux CoreOS"
ID="rhcos"
ID_LIKE="rhel fedora"
VERSION="414.92.202511122212-0"
VERSION_ID="4.14"
VARIANT="CoreOS"
VARIANT_ID=coreos
PLATFORM_ID="platform:el9"
PRETTY_NAME="Red Hat Enterprise Linux CoreOS 414.92.202511122212-0 (Plow)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:redhat:enterprise_linux:9::coreos"
HOME_URL="https://www.redhat.com/"
DOCUMENTATION_URL="https://docs.openshift.com/container-platform/4.14/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"
REDHAT_BUGZILLA_PRODUCT="OpenShift Container Platform"
REDHAT_BUGZILLA_PRODUCT_VERSION="4.14"
REDHAT_SUPPORT_PRODUCT="OpenShift Container Platform"
REDHAT_SUPPORT_PRODUCT_VERSION="4.14"
OPENSHIFT_VERSION="4.14"
RHEL_VERSION="9.2"
OSTREE_VERSION="414.92.202511122212-0"

Removing debug pod ...
$ oc debug node/ip-10-0-50-231.us-east-2.compute.internal -- chroot /host cat /etc/os-release
Starting pod/ip-10-0-50-231us-east-2computeinternal-debug ...
To use host binaries, run `chroot /host`
NAME="Red Hat Enterprise Linux CoreOS"
ID="rhcos"
ID_LIKE="rhel fedora"
VERSION="417.94.202601080818-0"
VERSION_ID="4.17"
VARIANT="CoreOS"
VARIANT_ID=coreos
PLATFORM_ID="platform:el9"
PRETTY_NAME="Red Hat Enterprise Linux CoreOS 417.94.202601080818-0"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:redhat:enterprise_linux:9::baseos::coreos"
HOME_URL="https://www.redhat.com/"
DOCUMENTATION_URL="https://docs.okd.io/latest/welcome/index.html"
BUG_REPORT_URL="https://access.redhat.com/labs/rhir/"
REDHAT_BUGZILLA_PRODUCT="OpenShift Container Platform"
REDHAT_BUGZILLA_PRODUCT_VERSION="4.17"
REDHAT_SUPPORT_PRODUCT="OpenShift Container Platform"
REDHAT_SUPPORT_PRODUCT_VERSION="4.17"
OPENSHIFT_VERSION="4.17"
RHEL_VERSION=9.4
OSTREE_VERSION="417.94.202601080818-0"

Removing debug pod ...
```

#### Review Hints:


